### PR TITLE
`Kokkos::sort` support custom comparator

### DIFF
--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -28,7 +28,6 @@ namespace Kokkos {
 // basic overloads
 // ---------------------------------------------------------------
 
-// clang-format off
 template <class ExecutionSpace, class DataType, class... Properties>
 void sort([[maybe_unused]] const ExecutionSpace& exec,
           const Kokkos::View<DataType, Properties...>& view) {
@@ -46,7 +45,7 @@ void sort([[maybe_unused]] const ExecutionSpace& exec,
     return;
   }
 
-  if constexpr (Impl::better_off_calling_std_sort_v<ExecutionSpace>){
+  if constexpr (Impl::better_off_calling_std_sort_v<ExecutionSpace>) {
     auto first = ::Kokkos::Experimental::begin(view);
     auto last  = ::Kokkos::Experimental::end(view);
     std::sort(first, last);
@@ -79,8 +78,7 @@ template <class ExecutionSpace, class ComparatorType, class DataType,
           class... Properties>
 void sort([[maybe_unused]] const ExecutionSpace& exec,
           const Kokkos::View<DataType, Properties...>& view,
-          const ComparatorType & comparator)
-{
+          const ComparatorType& comparator) {
   // constraints
   using ViewType = Kokkos::View<DataType, Properties...>;
   using MemSpace = typename ViewType::memory_space;
@@ -88,8 +86,9 @@ void sort([[maybe_unused]] const ExecutionSpace& exec,
       ViewType::rank == 1 &&
           (std::is_same_v<typename ViewType::array_layout, LayoutRight> ||
            std::is_same_v<typename ViewType::array_layout, LayoutLeft> ||
-	   std::is_same_v<typename ViewType::array_layout, LayoutStride>),
-      "Kokkos::sort with comparator: supports 1D Views with LayoutRight, LayoutLeft or LayoutStride.");
+           std::is_same_v<typename ViewType::array_layout, LayoutStride>),
+      "Kokkos::sort with comparator: supports 1D Views with LayoutRight, "
+      "LayoutLeft or LayoutStride.");
 
   static_assert(SpaceAccessibility<ExecutionSpace, MemSpace>::accessible,
                 "Kokkos::sort: execution space instance is not able to access "
@@ -99,7 +98,7 @@ void sort([[maybe_unused]] const ExecutionSpace& exec,
     return;
   }
 
-  if constexpr (Impl::better_off_calling_std_sort_v<ExecutionSpace>){
+  if constexpr (Impl::better_off_calling_std_sort_v<ExecutionSpace>) {
     auto first = ::Kokkos::Experimental::begin(view);
     auto last  = ::Kokkos::Experimental::end(view);
     std::sort(first, last, comparator);
@@ -110,15 +109,15 @@ void sort([[maybe_unused]] const ExecutionSpace& exec,
 
 template <class ComparatorType, class DataType, class... Properties>
 void sort(const Kokkos::View<DataType, Properties...>& view,
-          const ComparatorType & comparator)
-{
+          const ComparatorType& comparator) {
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(
       ViewType::rank == 1 &&
           (std::is_same_v<typename ViewType::array_layout, LayoutRight> ||
            std::is_same_v<typename ViewType::array_layout, LayoutLeft> ||
-	   std::is_same_v<typename ViewType::array_layout, LayoutStride>),
-      "Kokkos::sort with comparator: supports 1D Views with LayoutRight, LayoutLeft or LayoutStride.");
+           std::is_same_v<typename ViewType::array_layout, LayoutStride>),
+      "Kokkos::sort with comparator: supports 1D Views with LayoutRight, "
+      "LayoutLeft or LayoutStride.");
 
   Kokkos::fence("Kokkos::sort with comparator: before");
 
@@ -130,7 +129,6 @@ void sort(const Kokkos::View<DataType, Properties...>& view,
   sort(exec, view, comparator);
   exec.fence("Kokkos::sort with comparator: fence after sorting");
 }
-
 
 // ---------------------------------------------------------------
 // overloads for sorting a view with a subrange

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -93,8 +93,7 @@ void sort([[maybe_unused]] const ExecutionSpace& exec,
 
   static_assert(SpaceAccessibility<ExecutionSpace, MemSpace>::accessible,
                 "Kokkos::sort: execution space instance is not able to access "
-                "the memory space of the "
-                "View argument!");
+                "the memory space of the View argument!");
 
   if (view.extent(0) <= 1) {
     return;

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -79,7 +79,7 @@ template <class ExecutionSpace, class ComparatorType, class DataType,
           class... Properties>
 void sort([[maybe_unused]] const ExecutionSpace& exec,
           const Kokkos::View<DataType, Properties...>& view,
-          ComparatorType const& comparator)
+          const ComparatorType & comparator)
 {
   // constraints
   using ViewType = Kokkos::View<DataType, Properties...>;
@@ -110,7 +110,7 @@ void sort([[maybe_unused]] const ExecutionSpace& exec,
 
 template <class ComparatorType, class DataType, class... Properties>
 void sort(const Kokkos::View<DataType, Properties...>& view,
-          ComparatorType const& comparator)
+          const ComparatorType & comparator)
 {
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -224,21 +224,7 @@ void copy_to_host_run_stdsort_copy_back(
   namespace KE = ::Kokkos::Experimental;
 
   using ViewType = Kokkos::View<DataType, Properties...>;
-  using MemSpace = typename ViewType::memory_space;
   using layout   = typename ViewType::array_layout;
-  static_assert(
-      ViewType::rank == 1 &&
-          (std::is_same_v<typename ViewType::array_layout, LayoutRight> ||
-           std::is_same_v<typename ViewType::array_layout, LayoutLeft> ||
-           std::is_same_v<typename ViewType::array_layout, LayoutStride>),
-      "Impl::copy_to_host_run_stdsort_copy_back: supports 1D Views with "
-      "LayoutRight, LayoutLeft or LayoutStride.");
-
-  static_assert(
-      SpaceAccessibility<ExecutionSpace, MemSpace>::accessible,
-      "Impl::copy_to_host_run_stdsort_copy_back: execution space instance is "
-      "not able to access the memory space of the  View argument!");
-
   if constexpr (std::is_same_v<LayoutStride, layout>) {
     // for strided views we cannot just deep_copy from device to host,
     // so we need to do a few more jumps

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -339,7 +339,7 @@ sort_device_view_with_comparator(
     const ExecutionSpace& exec,
     const Kokkos::View<DataType, Properties...>& view,
     ComparatorType const& comparator) {
-  // This is a fallback case if a more specialized overload does not exists:
+  // This is a fallback case if a more specialized overload does not exist:
   // for now, this fallback copies data to host, runs std::sort
   // and then copies data back. Potentially, this can later be changed
   // with a better solution like our own quicksort on device or similar.

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -294,7 +294,7 @@ sort_device_view_without_comparator(
 template <class ComparatorType, class DataType, class... Properties>
 void sort_device_view_with_comparator(
     const Cuda& exec, const Kokkos::View<DataType, Properties...>& view,
-    ComparatorType const& comparator) {
+    const ComparatorType& comparator) {
   sort_cudathrust(exec, view, comparator);
 }
 #endif
@@ -304,7 +304,7 @@ template <class ComparatorType, class DataType, class... Properties>
 void sort_device_view_with_comparator(
     const Experimental::SYCL& exec,
     const Kokkos::View<DataType, Properties...>& view,
-    ComparatorType const& comparator) {
+    const ComparatorType& comparator) {
   using ViewType = Kokkos::View<DataType, Properties...>;
   constexpr bool strided =
       std::is_same_v<LayoutStride, typename ViewType::array_layout>;
@@ -323,7 +323,7 @@ std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value>
 sort_device_view_with_comparator(
     const ExecutionSpace& exec,
     const Kokkos::View<DataType, Properties...>& view,
-    ComparatorType const& comparator) {
+    const ComparatorType& comparator) {
   // This is a fallback case if a more specialized overload does not exist:
   // for now, this fallback copies data to host, runs std::sort
   // and then copies data back. Potentially, this can later be changed

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -325,9 +325,9 @@ void sort_device_view_with_comparator(
       std::is_same_v<LayoutStride, typename ViewType::array_layout>;
   if constexpr (strided) {
     // strided views not supported in dpl so use the most generic case
-    copy_to_host_run_stdsort_copy_back_fence_exec(exec, view, comparator);
+    copy_to_host_run_stdsort_copy_back(exec, view, comparator);
   } else {
-    sort_onedpl_and_fence_exec(exec, view, comparator);
+    sort_onedpl(exec, view, comparator);
   }
 }
 #endif

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -233,7 +233,6 @@ void copy_to_host_run_stdsort_copy_back(
     using view_deep_copyable_t = Kokkos::View<view_value_type*, view_exespace>;
     view_deep_copyable_t view_dc("view_dc", view.extent(0));
     KE::copy(exec, view, view_dc);
-    exec.fence();
 
     // run sort on the mirror of view_dc
     auto mv_h  = create_mirror_view_and_copy(Kokkos::HostSpace(), view_dc);

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -20,6 +20,7 @@
 #include "../Kokkos_BinOpsPublicAPI.hpp"
 #include "../Kokkos_BinSortPublicAPI.hpp"
 #include <std_algorithms/Kokkos_BeginEnd.hpp>
+#include <std_algorithms/Kokkos_Copy.hpp>
 #include <Kokkos_Core.hpp>
 
 #if defined(KOKKOS_ENABLE_CUDA)
@@ -164,9 +165,10 @@ void sort_via_binsort(const ExecutionSpace& exec,
 }
 
 #if defined(KOKKOS_ENABLE_CUDA)
-template <class DataType, class... Properties>
+template <class DataType, class... Properties, class... MaybeComparator>
 void sort_cudathrust(const Cuda& space,
-                     const Kokkos::View<DataType, Properties...>& view) {
+                     const Kokkos::View<DataType, Properties...>& view,
+                     MaybeComparator&&... maybeComparator) {
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
                 "Kokkos::sort: currently only supports rank-1 Views.");
@@ -177,14 +179,16 @@ void sort_cudathrust(const Cuda& space,
   const auto exec = thrust::cuda::par.on(space.cuda_stream());
   auto first      = ::Kokkos::Experimental::begin(view);
   auto last       = ::Kokkos::Experimental::end(view);
-  thrust::sort(exec, first, last);
+  thrust::sort(exec, first, last,
+               std::forward<MaybeComparator>(maybeComparator)...);
 }
 #endif
 
 #if defined(KOKKOS_ENABLE_ONEDPL)
-template <class DataType, class... Properties>
+template <class DataType, class... Properties, class... MaybeComparator>
 void sort_onedpl(const Kokkos::Experimental::SYCL& space,
-                 const Kokkos::View<DataType, Properties...>& view) {
+                 const Kokkos::View<DataType, Properties...>& view,
+                 MaybeComparator&&... maybeComparator) {
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(SpaceAccessibility<Kokkos::Experimental::SYCL,
                                    typename ViewType::memory_space>::accessible,
@@ -206,9 +210,62 @@ void sort_onedpl(const Kokkos::Experimental::SYCL& space,
   auto queue  = space.sycl_queue();
   auto policy = oneapi::dpl::execution::make_device_policy(queue);
   const int n = view.extent(0);
-  oneapi::dpl::sort(policy, view.data(), view.data() + n);
+  oneapi::dpl::sort(policy, view.data(), view.data() + n,
+                    std::forward<MaybeComparator>(maybeComparator)...);
 }
 #endif
+
+template <class ExecutionSpace, class DataType, class... Properties,
+          class... MaybeComparator>
+void copy_to_host_run_stdsort_copy_back(
+    const ExecutionSpace& exec,
+    const Kokkos::View<DataType, Properties...>& view,
+    MaybeComparator&&... maybeComparator) {
+  namespace KE = ::Kokkos::Experimental;
+
+  using ViewType = Kokkos::View<DataType, Properties...>;
+  using MemSpace = typename ViewType::memory_space;
+  using layout   = typename ViewType::array_layout;
+  static_assert(
+      ViewType::rank == 1 &&
+          (std::is_same_v<typename ViewType::array_layout, LayoutRight> ||
+           std::is_same_v<typename ViewType::array_layout, LayoutLeft> ||
+           std::is_same_v<typename ViewType::array_layout, LayoutStride>),
+      "Impl::copy_to_host_run_stdsort_copy_back: supports 1D Views with "
+      "LayoutRight, LayoutLeft or LayoutStride.");
+
+  static_assert(
+      SpaceAccessibility<ExecutionSpace, MemSpace>::accessible,
+      "Impl::copy_to_host_run_stdsort_copy_back: execution space instance is "
+      "not able to access the memory space of the  View argument!");
+
+  if constexpr (std::is_same_v<LayoutStride, layout>) {
+    // for strided views we cannot just deep_copy from device to host,
+    // so we need to do a few more jumps
+    using view_value_type      = typename ViewType::non_const_value_type;
+    using view_exespace        = typename ViewType::execution_space;
+    using view_deep_copyable_t = Kokkos::View<view_value_type*, view_exespace>;
+    view_deep_copyable_t view_dc("view_dc", view.extent(0));
+    KE::copy(exec, view, view_dc);
+    exec.fence();
+
+    // run sort on the mirror of view_dc
+    auto mv_h  = create_mirror_view_and_copy(Kokkos::HostSpace(), view_dc);
+    auto first = KE::begin(mv_h);
+    auto last  = KE::end(mv_h);
+    std::sort(first, last, std::forward<MaybeComparator>(maybeComparator)...);
+    Kokkos::deep_copy(exec, view_dc, mv_h);
+
+    // copy back to argument view
+    KE::copy(exec, KE::cbegin(view_dc), KE::cend(view_dc), KE::begin(view));
+  } else {
+    auto view_h = create_mirror_view_and_copy(Kokkos::HostSpace(), view);
+    auto first  = KE::begin(view_h);
+    auto last   = KE::end(view_h);
+    std::sort(first, last, std::forward<MaybeComparator>(maybeComparator)...);
+    Kokkos::deep_copy(exec, view, view_h);
+  }
+}
 
 // --------------------------------------------------
 //
@@ -240,6 +297,60 @@ sort_device_view_without_comparator(
     const ExecutionSpace& exec,
     const Kokkos::View<DataType, Properties...>& view) {
   sort_via_binsort(exec, view);
+}
+
+// --------------------------------------------------
+//
+// specialize cases for sorting with comparator
+//
+// --------------------------------------------------
+
+#if defined(KOKKOS_ENABLE_CUDA)
+template <class ComparatorType, class DataType, class... Properties>
+void sort_device_view_with_comparator(
+    const Cuda& exec, const Kokkos::View<DataType, Properties...>& view,
+    ComparatorType const& comparator) {
+  sort_cudathrust(exec, view, comparator);
+}
+#endif
+
+#if defined(KOKKOS_ENABLE_ONEDPL)
+template <class ComparatorType, class DataType, class... Properties>
+void sort_device_view_with_comparator(
+    const Experimental::SYCL& exec,
+    const Kokkos::View<DataType, Properties...>& view,
+    ComparatorType const& comparator) {
+  using ViewType = Kokkos::View<DataType, Properties...>;
+  constexpr bool strided =
+      std::is_same_v<LayoutStride, typename ViewType::array_layout>;
+  if constexpr (strided) {
+    // strided views not supported in dpl so use the most generic case
+    copy_to_host_run_stdsort_copy_back_fence_exec(exec, view, comparator);
+  } else {
+    sort_onedpl_and_fence_exec(exec, view, comparator);
+  }
+}
+#endif
+
+template <class ExecutionSpace, class ComparatorType, class DataType,
+          class... Properties>
+std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value>
+sort_device_view_with_comparator(
+    const ExecutionSpace& exec,
+    const Kokkos::View<DataType, Properties...>& view,
+    ComparatorType const& comparator) {
+  // This is a fallback case if a more specialized overload does not exists:
+  // for now, this fallback copies data to host, runs std::sort
+  // and then copies data back. Potentially, this can later be changed
+  // with a better solution like our own quicksort on device or similar.
+
+  using ViewType = Kokkos::View<DataType, Properties...>;
+  using MemSpace = typename ViewType::memory_space;
+  static_assert(!SpaceAccessibility<HostSpace, MemSpace>::accessible,
+                "Impl::sort_device_view_with_comparator: should not be called "
+                "on a view that is already accessible on the host");
+
+  copy_to_host_run_stdsort_copy_back(exec, view, comparator);
 }
 
 }  // namespace Impl

--- a/algorithms/unit_tests/CMakeLists.txt
+++ b/algorithms/unit_tests/CMakeLists.txt
@@ -25,6 +25,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;HIP;SYCL;OpenMPTarget)
     set(ALGO_SORT_SOURCES)
     foreach(SOURCE_Input
 	TestSort
+	TestSortCustomComp
 	TestBinSortA
 	TestBinSortB
 	TestNestedSort
@@ -164,6 +165,7 @@ if(NOT (KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM
     UnitTest_Sort
     SOURCES
     UnitTestMain.cpp
+    TestStdAlgorithmsCommon.cpp
     ${ALGO_SORT_SOURCES}
   )
 

--- a/algorithms/unit_tests/TestSortCustomComp.hpp
+++ b/algorithms/unit_tests/TestSortCustomComp.hpp
@@ -31,7 +31,7 @@ auto create_random_view_and_host_clone(
     LayoutTagType LayoutTag, std::size_t n,
     Kokkos::pair<ValueType, ValueType> bounds, const std::string& label,
     std::size_t seedIn = 12371) {
-  using namespace ::Test::stdalgos;
+  using namespace Test::stdalgos;
 
   // construct in memory space associated with default exespace
   auto dataView = create_view<ValueType>(LayoutTag, n, label);
@@ -113,7 +113,7 @@ void run_all_scenarios(int api)
 
 TEST(TEST_CATEGORY, SortWithCustomComparator) {
   using ExeSpace = TEST_EXECSPACE;
-  using namespace ::Test::stdalgos;
+  using namespace Test::stdalgos;
   for (int api = 0; api < 2; api++) {
     run_all_scenarios<ExeSpace, DynamicTag, int>(api);
     run_all_scenarios<ExeSpace, DynamicTag, double>(api);

--- a/algorithms/unit_tests/TestSortCustomComp.hpp
+++ b/algorithms/unit_tests/TestSortCustomComp.hpp
@@ -14,8 +14,8 @@
 //
 //@HEADER
 
-#ifndef KOKKOS_ALGORITHMS_SORTING_CUSTOM_COMP_HPP
-#define KOKKOS_ALGORITHMS_SORTING_CUSTOM_COMP_HPP
+#ifndef KOKKOS_ALGORITHMS_UNITTESTS_TEST_SORT_CUSTOM_COMP_HPP
+#define KOKKOS_ALGORITHMS_UNITTESTS_TEST_SORT_CUSTOM_COMP_HPP
 
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
@@ -36,7 +36,7 @@ auto create_random_view_and_host_clone(
   // construct in memory space associated with default exespace
   auto dataView = create_view<ValueType>(LayoutTag, n, label);
 
-  // dataView might not deep copyable (e.g. strided layout) so to
+  // dataView might not be deep copyable (e.g. strided layout) so to
   // randomize it, we make a new view that is for sure deep copyable,
   // modify it on the host, deep copy to device and then launch
   // a kernel to copy to dataView
@@ -102,9 +102,10 @@ void run_all_scenarios(int api)
     // To actually check that Kokkos::sort used the custom
     // comparator MyComp, we should have a result in non-ascending order.
     // We can verify this by running std::is_sorted and if that returns
-    // false, then it means everything ran as expected
-    if (api <= 1 && N >= 2){
-      namespace KE = Kokkos::Experimental;
+    // false, then it means everything ran as expected.
+    // Note: std::is_sorted returns true for ranges of length one,
+    // so this check makes sense only when N >= 2.
+    if (N >= 2){
       ASSERT_FALSE(std::is_sorted( KE::cbegin(dataView_h), KE::cend(dataView_h)));
     }
   }
@@ -115,9 +116,11 @@ TEST(TEST_CATEGORY, SortWithCustomComparator) {
   for (int api = 0; api < 2; api++) {
     run_all_scenarios<ExeSpace, stdalgos::DynamicTag, int>(api);
     run_all_scenarios<ExeSpace, stdalgos::DynamicTag, double>(api);
-    run_all_scenarios<ExeSpace, stdalgos::StridedTwoTag, int>(api);
+    run_all_scenarios<ExeSpace, stdalgos::DynamicLayoutLeftTag, int>(api);
+    run_all_scenarios<ExeSpace, stdalgos::DynamicLayoutLeftTag, double>(api);
+    run_all_scenarios<ExeSpace, stdalgos::DynamicLayoutRightTag, int>(api);
+    run_all_scenarios<ExeSpace, stdalgos::DynamicLayoutRightTag, double>(api);
     run_all_scenarios<ExeSpace, stdalgos::StridedThreeTag, int>(api);
-    run_all_scenarios<ExeSpace, stdalgos::StridedTwoTag, double>(api);
     run_all_scenarios<ExeSpace, stdalgos::StridedThreeTag, double>(api);
   }
 }  // namespace SortWithComp

--- a/algorithms/unit_tests/TestSortCustomComp.hpp
+++ b/algorithms/unit_tests/TestSortCustomComp.hpp
@@ -23,7 +23,7 @@
 #include <Kokkos_Sort.hpp>
 #include <TestStdAlgorithmsCommon.hpp>
 
-namespace Test {
+namespace {
 namespace SortWithComp {
 
 template <class LayoutTagType, class ValueType>
@@ -96,8 +96,8 @@ void run_all_scenarios(int api)
       exespace.fence();
     }
 
-    auto dataView_h = stdalgos::create_host_space_copy(dataView);
-    stdalgos::compare_views(dataViewBeforeOp_h, dataView_h);
+    auto dataView_h = Test::stdalgos::create_host_space_copy(dataView);
+    Test::stdalgos::compare_views(dataViewBeforeOp_h, dataView_h);
 
     // To actually check that Kokkos::sort used the custom
     // comparator MyComp, we should have a result in non-ascending order.
@@ -113,18 +113,19 @@ void run_all_scenarios(int api)
 
 TEST(TEST_CATEGORY, SortWithCustomComparator) {
   using ExeSpace = TEST_EXECSPACE;
+  using namespace ::Test::stdalgos;
   for (int api = 0; api < 2; api++) {
-    run_all_scenarios<ExeSpace, stdalgos::DynamicTag, int>(api);
-    run_all_scenarios<ExeSpace, stdalgos::DynamicTag, double>(api);
-    run_all_scenarios<ExeSpace, stdalgos::DynamicLayoutLeftTag, int>(api);
-    run_all_scenarios<ExeSpace, stdalgos::DynamicLayoutLeftTag, double>(api);
-    run_all_scenarios<ExeSpace, stdalgos::DynamicLayoutRightTag, int>(api);
-    run_all_scenarios<ExeSpace, stdalgos::DynamicLayoutRightTag, double>(api);
-    run_all_scenarios<ExeSpace, stdalgos::StridedThreeTag, int>(api);
-    run_all_scenarios<ExeSpace, stdalgos::StridedThreeTag, double>(api);
+    run_all_scenarios<ExeSpace, DynamicTag, int>(api);
+    run_all_scenarios<ExeSpace, DynamicTag, double>(api);
+    run_all_scenarios<ExeSpace, DynamicLayoutLeftTag, int>(api);
+    run_all_scenarios<ExeSpace, DynamicLayoutLeftTag, double>(api);
+    run_all_scenarios<ExeSpace, DynamicLayoutRightTag, int>(api);
+    run_all_scenarios<ExeSpace, DynamicLayoutRightTag, double>(api);
+    run_all_scenarios<ExeSpace, StridedThreeTag, int>(api);
+    run_all_scenarios<ExeSpace, StridedThreeTag, double>(api);
   }
-}  // namespace SortWithComp
+}
 
 }  // namespace SortWithComp
-}  // namespace Test
+}  // namespace anonym
 #endif

--- a/algorithms/unit_tests/TestSortCustomComp.hpp
+++ b/algorithms/unit_tests/TestSortCustomComp.hpp
@@ -1,0 +1,127 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_ALGORITHMS_SORTING_CUSTOM_COMP_HPP
+#define KOKKOS_ALGORITHMS_SORTING_CUSTOM_COMP_HPP
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+#include <Kokkos_Sort.hpp>
+#include <TestStdAlgorithmsCommon.hpp>
+
+namespace Test {
+namespace SortWithComp {
+
+template <class LayoutTagType, class ValueType>
+auto create_random_view_and_host_clone(
+    LayoutTagType LayoutTag, std::size_t n,
+    Kokkos::pair<ValueType, ValueType> bounds, const std::string& label,
+    std::size_t seedIn = 12371) {
+  using namespace ::Test::stdalgos;
+
+  // construct in memory space associated with default exespace
+  auto dataView = create_view<ValueType>(LayoutTag, n, label);
+
+  // dataView might not deep copyable (e.g. strided layout) so to
+  // randomize it, we make a new view that is for sure deep copyable,
+  // modify it on the host, deep copy to device and then launch
+  // a kernel to copy to dataView
+  auto dataView_dc =
+      create_deep_copyable_compatible_view_with_same_extent(dataView);
+  auto dataView_dc_h = create_mirror_view(Kokkos::HostSpace(), dataView_dc);
+
+  // randomly fill the view
+  Kokkos::Random_XorShift64_Pool<Kokkos::DefaultHostExecutionSpace> pool(
+      seedIn);
+  Kokkos::fill_random(dataView_dc_h, pool, bounds.first, bounds.second);
+
+  // copy to dataView_dc and then to dataView
+  Kokkos::deep_copy(dataView_dc, dataView_dc_h);
+  // use CTAD
+  CopyFunctor F1(dataView_dc, dataView);
+  Kokkos::parallel_for("copy", dataView.extent(0), F1);
+
+  return std::make_pair(dataView, dataView_dc_h);
+}
+
+template <class T>
+struct MyComp {
+  KOKKOS_FUNCTION
+  bool operator()(T a, T b) const {
+    // we return a>b on purpose here, rather than doing a<b
+    return a > b;
+  }
+};
+
+// clang-format off
+template <class ExecutionSpace, class Tag, class ValueType>
+void run_all_scenarios(int api)
+{
+  using comp_t = MyComp<ValueType>;
+
+  const std::vector<std::size_t> my_scenarios = {0, 1, 2, 9, 1003, 51513};
+  for (std::size_t N : my_scenarios)
+  {
+    auto [dataView, dataViewBeforeOp_h] = create_random_view_and_host_clone(
+        Tag{}, N, Kokkos::pair<ValueType, ValueType>{-1045, 565},
+        "dataView");
+
+    namespace KE = Kokkos::Experimental;
+
+    if (api == 0) {
+      Kokkos::sort(dataView, comp_t{});
+      std::sort(KE::begin(dataViewBeforeOp_h), KE::end(dataViewBeforeOp_h),
+                comp_t{});
+    }
+
+    else if (api == 1) {
+      auto exespace = ExecutionSpace();
+      Kokkos::sort(exespace, dataView, comp_t{});
+      std::sort(KE::begin(dataViewBeforeOp_h), KE::end(dataViewBeforeOp_h),
+                comp_t{});
+      exespace.fence();
+    }
+
+    auto dataView_h = stdalgos::create_host_space_copy(dataView);
+    stdalgos::compare_views(dataViewBeforeOp_h, dataView_h);
+
+    // To actually check that Kokkos::sort used the custom
+    // comparator MyComp, we should have a result in non-ascending order.
+    // We can verify this by running std::is_sorted and if that returns
+    // false, then it means everything ran as expected
+    if (api <= 1 && N >= 2){
+      namespace KE = Kokkos::Experimental;
+      ASSERT_FALSE(std::is_sorted( KE::cbegin(dataView_h), KE::cend(dataView_h)));
+    }
+  }
+}
+
+TEST(TEST_CATEGORY, SortWithCustomComparator) {
+  using ExeSpace = TEST_EXECSPACE;
+  for (int api = 0; api < 2; api++) {
+    run_all_scenarios<ExeSpace, stdalgos::DynamicTag, int>(api);
+    run_all_scenarios<ExeSpace, stdalgos::DynamicTag, double>(api);
+    run_all_scenarios<ExeSpace, stdalgos::StridedTwoTag, int>(api);
+    run_all_scenarios<ExeSpace, stdalgos::StridedThreeTag, int>(api);
+    run_all_scenarios<ExeSpace, stdalgos::StridedTwoTag, double>(api);
+    run_all_scenarios<ExeSpace, stdalgos::StridedThreeTag, double>(api);
+  }
+}  // namespace SortWithComp
+
+}  // namespace SortWithComp
+}  // namespace Test
+#endif

--- a/algorithms/unit_tests/TestSortCustomComp.hpp
+++ b/algorithms/unit_tests/TestSortCustomComp.hpp
@@ -31,7 +31,7 @@ auto create_random_view_and_host_clone(
     LayoutTagType LayoutTag, std::size_t n,
     Kokkos::pair<ValueType, ValueType> bounds, const std::string& label,
     std::size_t seedIn = 12371) {
-  using namespace Test::stdalgos;
+  using namespace ::Test::stdalgos;
 
   // construct in memory space associated with default exespace
   auto dataView = create_view<ValueType>(LayoutTag, n, label);
@@ -113,7 +113,7 @@ void run_all_scenarios(int api)
 
 TEST(TEST_CATEGORY, SortWithCustomComparator) {
   using ExeSpace = TEST_EXECSPACE;
-  using namespace Test::stdalgos;
+  using namespace ::Test::stdalgos;
   for (int api = 0; api < 2; api++) {
     run_all_scenarios<ExeSpace, DynamicTag, int>(api);
     run_all_scenarios<ExeSpace, DynamicTag, double>(api);

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.cpp
@@ -21,6 +21,14 @@ namespace stdalgos {
 
 std::string view_tag_to_string(DynamicTag) { return "dynamic_view"; }
 
+std::string view_tag_to_string(DynamicLayoutLeftTag) {
+  return "dynamic_layout_left_view";
+}
+
+std::string view_tag_to_string(DynamicLayoutRightTag) {
+  return "dynamic_layout_right_view";
+}
+
 std::string view_tag_to_string(StridedTwoTag) { return "stride2_view"; }
 
 std::string view_tag_to_string(StridedThreeTag) { return "stride3_view"; }

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -35,6 +35,8 @@ using exespace = Kokkos::DefaultExecutionSpace;
 // tags
 //
 struct DynamicTag {};
+struct DynamicLayoutLeftTag {};
+struct DynamicLayoutRightTag {};
 
 // these are for rank-1
 struct StridedTwoTag {};
@@ -61,6 +63,8 @@ const std::map<std::string, std::size_t> default_scenarios = {
 
 // see cpp file for these functions
 std::string view_tag_to_string(DynamicTag);
+std::string view_tag_to_string(DynamicLayoutLeftTag);
+std::string view_tag_to_string(DynamicLayoutRightTag);
 std::string view_tag_to_string(StridedTwoTag);
 std::string view_tag_to_string(StridedThreeTag);
 std::string view_tag_to_string(StridedTwoRowsTag);
@@ -75,6 +79,24 @@ template <class ValueType>
 auto create_view(DynamicTag, std::size_t ext, const std::string label) {
   using view_t = Kokkos::View<ValueType*>;
   view_t view{label + "_" + view_tag_to_string(DynamicTag{}), ext};
+  return view;
+}
+
+// dynamic layout left
+template <class ValueType>
+auto create_view(DynamicLayoutLeftTag, std::size_t ext,
+                 const std::string label) {
+  using view_t = Kokkos::View<ValueType*, Kokkos::LayoutLeft>;
+  view_t view{label + "_" + view_tag_to_string(DynamicLayoutLeftTag{}), ext};
+  return view;
+}
+
+// dynamic layout right
+template <class ValueType>
+auto create_view(DynamicLayoutRightTag, std::size_t ext,
+                 const std::string label) {
+  using view_t = Kokkos::View<ValueType*, Kokkos::LayoutRight>;
+  view_t view{label + "_" + view_tag_to_string(DynamicLayoutRightTag{}), ext};
   return view;
 }
 
@@ -106,6 +128,26 @@ auto create_view(DynamicTag, std::size_t ext0, std::size_t ext1,
                  const std::string label) {
   using view_t = Kokkos::View<ValueType**>;
   view_t view{label + "_" + view_tag_to_string(DynamicTag{}), ext0, ext1};
+  return view;
+}
+
+// dynamic layout left
+template <class ValueType>
+auto create_view(DynamicLayoutLeftTag, std::size_t ext0, std::size_t ext1,
+                 const std::string label) {
+  using view_t = Kokkos::View<ValueType**, Kokkos::LayoutLeft>;
+  view_t view{label + "_" + view_tag_to_string(DynamicLayoutLeftTag{}), ext0,
+              ext1};
+  return view;
+}
+
+// dynamic layout right
+template <class ValueType>
+auto create_view(DynamicLayoutRightTag, std::size_t ext0, std::size_t ext1,
+                 const std::string label) {
+  using view_t = Kokkos::View<ValueType**, Kokkos::LayoutRight>;
+  view_t view{label + "_" + view_tag_to_string(DynamicLayoutRightTag{}), ext0,
+              ext1};
   return view;
 }
 


### PR DESCRIPTION
Adds 2 overloads to `Kokkos::sort` to support a custom comparator.

```cpp
template <class ExecutionSpace, class CompType, class DataType, class... Properties>
template <class ExecutionSpace, class ComparatorType, class DataType, class... Properties>
void sort([[maybe_unused]] const ExecutionSpace& exec,
          const Kokkos::View<DataType, Properties...>& view,
          ComparatorType const& comparator)
{
   /* view must be rank-1 with layout{left,right,stride} */

  if constexpr (Impl::better_off_calling_std_sort_v<ExecutionSpace>){
    auto first = ::Kokkos::Experimental::begin(view);
    auto last  = ::Kokkos::Experimental::end(view);
    std::sort(first, last, comparator);
  } else {
    Impl::sort_device_view_with_comparator(exec, view, comparator);
  }
}

template <class ComparatorType, class DataType, class... Properties>
void sort(const Kokkos::View<DataType, Properties...>& view, ComparatorType const& comparator){
  // calls overload above using the view execution space
}
```
where:
```
Impl::sort_device_view_with_comparator(exec, view, comparator) 
```
calls cuda thrust for cuda, onedpl and the fallback case (for now) copies view to host, calls std::sort and copies back. 
This solution is based on a discussion with @crtrott  and @dalg24. 

Note that this is potentially the place where we can later optimize for example implementing our own quicksort or what not.