### PR TITLE
std_algos: fix wrong corner case for `is_partitioned`

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_IsPartitioned.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_IsPartitioned.hpp
@@ -107,14 +107,27 @@ bool is_partitioned_impl(const std::string& label, const ExecutionSpace& ex,
   constexpr index_type red_id_max =
       ::Kokkos::reduction_identity<index_type>::max();
 
+  // clang-format off
   if (red_result.max_loc_true != red_id_max &&
-      red_result.min_loc_false != red_id_min) {
+      red_result.min_loc_false != red_id_min){
+    // this occurs when the reduction yields nontrivial values
     return red_result.max_loc_true < red_result.min_loc_false;
-  } else if (first + red_result.max_loc_true == --last) {
+  }
+  else if (red_result.max_loc_true == red_id_max &&
+	   red_result.min_loc_false == 0){
+    // this occurs when all values do NOT satisfy
+    // the predicate, and this corner case should also be true
     return true;
-  } else {
+  }
+  else if (first + red_result.max_loc_true == --last) {
+    // this occurs when all values DO satisfy the predicate,
+    // this corner case should also be true
+    return true;
+  }
+  else {
     return false;
   }
+  // clang-format on
 }
 
 }  // namespace Impl

--- a/algorithms/src/std_algorithms/impl/Kokkos_IsPartitioned.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_IsPartitioned.hpp
@@ -107,27 +107,22 @@ bool is_partitioned_impl(const std::string& label, const ExecutionSpace& ex,
   constexpr index_type red_id_max =
       ::Kokkos::reduction_identity<index_type>::max();
 
-  // clang-format off
   if (red_result.max_loc_true != red_id_max &&
-      red_result.min_loc_false != red_id_min){
+      red_result.min_loc_false != red_id_min) {
     // this occurs when the reduction yields nontrivial values
     return red_result.max_loc_true < red_result.min_loc_false;
-  }
-  else if (red_result.max_loc_true == red_id_max &&
-	   red_result.min_loc_false == 0){
+  } else if (red_result.max_loc_true == red_id_max &&
+             red_result.min_loc_false == 0) {
     // this occurs when all values do NOT satisfy
     // the predicate, and this corner case should also be true
     return true;
-  }
-  else if (first + red_result.max_loc_true == --last) {
+  } else if (first + red_result.max_loc_true == --last) {
     // this occurs when all values DO satisfy the predicate,
     // this corner case should also be true
     return true;
-  }
-  else {
+  } else {
     return false;
   }
-  // clang-format on
 }
 
 }  // namespace Impl

--- a/algorithms/unit_tests/TestStdAlgorithmsPartitioningOps.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsPartitioningOps.cpp
@@ -127,7 +127,7 @@ struct std_algorithms_partitioning_test : public std_algorithms_test {
       case Mixed: return false;
       case NegativeFirst: return true;
       case AllNegative: return true;
-      case AllPositive: return false;
+      case AllPositive: return true;
       case NegativeLast: return false;
       case SingleNegative: return true;
       default: return false;


### PR DESCRIPTION
Fix wrong behavior for corner case in `Kokkos::Experimental::is_partitioned`. 

Currently, if we were to do: 
```cpp
template <class ValueType>
struct IsNegativeFunctor {
  KOKKOS_INLINE_FUNCTION
  bool operator()(const ValueType val) const { return (val < 0); }
};

Kokkos::View<int*> v = {11, 3, 17, 9, 3};
auto res = KE::is_partitioned(exespace(), KE::cbegin(v), KE::cend(v), p);
```
we get `res == false`. 
However, this is wrong wrt std library [see godbolt here](https://godbolt.org/z/3rao6GW3K) and should return `true`.
This PR fixes this and the test that was wrongly set to false. 

Note that the std library documentation `https://en.cppreference.com/w/cpp/algorithm/is_partitioned` is not super clear about this, in the sense that when none of the elements satisfy the predicate one could misinterpret it.

Comment: this bug was found when implementing the team-level api in #6256 

