### PR TITLE
Update CMakeLists for unit tests with OpenMPTarget, OpenACC with NVHPC

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -828,8 +828,6 @@ endif()
 # FIXME_OPENMPTARGET, FIXME_OPENACC - Comment non-passing tests with the NVIDIA HPC compiler nvc++
 if ((KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_OPENACC) AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
   LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES
-    TestSharedSpace.cpp
-    TestSharedHostPinnedSpace.cpp
     TestCompilerMacros.cpp
     default/TestDefaultDeviceType_a1.cpp
     default/TestDefaultDeviceType_b1.cpp

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -827,12 +827,21 @@ endif()
 
 # FIXME_OPENMPTARGET, FIXME_OPENACC - Comment non-passing tests with the NVIDIA HPC compiler nvc++
 if ((KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_OPENACC) AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
-  SET(DEFAULT_DEVICE_SOURCES
-    UnitTestMainInit.cpp
-    TestInitializationSettings.cpp
-    TestParseCmdLineArgsAndEnvVars.cpp
-    default/TestDefaultDeviceType.cpp
-  )
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedSpace.cpp)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedHostPinnedSpace.cpp)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestCompilerMacros.cpp)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_a1.cpp)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_b1.cpp)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_c1.cpp)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_a2.cpp)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_b2.cpp)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_c2.cpp)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_a3.cpp)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_b3.cpp)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_c3.cpp)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_d.cpp)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceTypeResize.cpp)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceTypeViewAPI.cpp)
 endif()
 
 KOKKOS_ADD_EXECUTABLE_AND_TEST(

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -827,21 +827,23 @@ endif()
 
 # FIXME_OPENMPTARGET, FIXME_OPENACC - Comment non-passing tests with the NVIDIA HPC compiler nvc++
 if ((KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_OPENACC) AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedSpace.cpp)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedHostPinnedSpace.cpp)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestCompilerMacros.cpp)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_a1.cpp)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_b1.cpp)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_c1.cpp)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_a2.cpp)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_b2.cpp)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_c2.cpp)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_a3.cpp)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_b3.cpp)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_c3.cpp)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceType_d.cpp)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceTypeResize.cpp)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES default/TestDefaultDeviceTypeViewAPI.cpp)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES
+    TestSharedSpace.cpp
+    TestSharedHostPinnedSpace.cpp
+    TestCompilerMacros.cpp
+    default/TestDefaultDeviceType_a1.cpp
+    default/TestDefaultDeviceType_b1.cpp
+    default/TestDefaultDeviceType_c1.cpp
+    default/TestDefaultDeviceType_a2.cpp
+    default/TestDefaultDeviceType_b2.cpp
+    default/TestDefaultDeviceType_c2.cpp
+    default/TestDefaultDeviceType_a3.cpp
+    default/TestDefaultDeviceType_b3.cpp
+    default/TestDefaultDeviceType_c3.cpp
+    default/TestDefaultDeviceType_d.cpp
+    default/TestDefaultDeviceTypeResize.cpp
+    default/TestDefaultDeviceTypeViewAPI.cpp
+  )
 endif()
 
 KOKKOS_ADD_EXECUTABLE_AND_TEST(


### PR DESCRIPTION
The PR updates CMakeLists for OpenMPTarget and OpenACC with NVHPC compiler to use `remove_item` instead of updating target sources. 