### PR TITLE
Fix SIMD tests on NEON

### DIFF
--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -193,7 +193,7 @@ void host_check_math_op_one_loader(UnaryOp unary_op, std::size_t n,
     if (!loaded_arg) continue;
     simd_type expected_result;
     for (std::size_t lane = 0; lane < nlanes; ++lane) {
-      expected_result[lane] = unary_op.on_host_serial(arg[lane]);
+      expected_result[lane] = unary_op.on_host_serial(T(arg[lane]));
     }
     simd_type const computed_result = unary_op.on_host(arg);
     host_check_equality(expected_result, computed_result, nlanes);


### PR DESCRIPTION
https://github.com/kokkos/kokkos/pull/6069 broke compiling the unit tests for NEON with error messages like:
```
/tmp/kokkos/simd/unit_tests/TestSIMD.cpp:196:29: error: object of type 'Kokkos::Experimental::simd<double, Kokkos::Experimental::simd_abi::neon_fixed_size<2>>::reference' cannot be assigned because its copy assignment operator is implicitly deleted
      expected_result[lane] = unary_op.on_host_serial(arg[lane]);
                            ^
/tmp/kokkos/simd/unit_tests/TestSIMD.cpp:256:3: note: in instantiation of function template specialization 'host_check_math_op_one_loader<Kokkos::Experimental::simd_abi::neon_fixed_size<2>, load_element_aligned, absolutes, double>' requested here
  host_check_math_op_one_loader<Abi, load_element_aligned>(op, n, args...);
  ^
/tmp/kokkos/simd/unit_tests/TestSIMD.cpp:357:3: note: in instantiation of function template specialization 'host_check_math_op_all_loaders<Kokkos::Experimental::simd_abi::neon_fixed_size<2>, absolutes, double>' requested here
  host_check_math_op_all_loaders<Abi>(absolutes(), n, first_args);
  ^
/tmp/kokkos/simd/unit_tests/TestSIMD.cpp:376:5: note: in instantiation of function template specialization 'host_check_all_math_ops<Kokkos::Experimental::simd_abi::neon_fixed_size<2>, double, 11UL>' requested here
    host_check_all_math_ops<Abi>(first_args, second_args);
    ^
/tmp/kokkos/simd/unit_tests/TestSIMD.cpp:558:4: note: in instantiation of function template specialization 'host_check_math_ops<Kokkos::Experimental::simd_abi::neon_fixed_size<2>, double>' requested here
  (host_check_math_ops<Abi, DataTypes>(), ...);
   ^
/tmp/kokkos/simd/unit_tests/TestSIMD.cpp:565:3: note: in instantiation of function template specialization 'host_check_math_ops_all_types<Kokkos::Experimental::simd_abi::neon_fixed_size<2>, int, long long, unsigned long long, double>' requested here
  host_check_math_ops_all_types<Abi>(DataTypes());
  ^
/tmp/kokkos/simd/unit_tests/TestSIMD.cpp:597:3: note: in instantiation of function template specialization 'host_check_abi<Kokkos::Experimental::simd_abi::neon_fixed_size<2>>' requested here
  host_check_abi<FirstAbi>();
  ^
/tmp/kokkos/simd/unit_tests/TestSIMD.cpp:598:3: note: in instantiation of function template specialization 'host_check_abis<Kokkos::Experimental::simd_abi::neon_fixed_size<2>>' requested here
  host_check_abis(Kokkos::Experimental::Impl::abi_set<RestAbis...>());
  ^
/tmp/kokkos/simd/unit_tests/TestSIMD.cpp:609:3: note: in instantiation of function template specialization 'host_check_abis<Kokkos::Experimental::simd_abi::scalar, Kokkos::Experimental::simd_abi::neon_fixed_size<2>>' requested here
  host_check_abis(Kokkos::Experimental::Impl::host_abi_set());
  ^
/tmp/kokkos/simd/src/Kokkos_SIMD_NEON.hpp:260:18: note: copy assignment operator of 'reference' is implicitly deleted because field 'm_value' is of reference type 'float64x2_t &'
    float64x2_t& m_value;
                 ^
```
The change here mirrors what we do for the `host_check_math_op_one_loader` and fixes the issue.