### PR TITLE
Add default ParallelFor copy constructor for HIP

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -40,10 +40,11 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
   const FunctorType m_functor;
   const Policy m_policy;
 
-  ParallelFor()        = delete;
+ public:
+  ParallelFor()                   = delete;
+  ParallelFor(ParallelFor const&) = default;
   ParallelFor& operator=(ParallelFor const&) = delete;
 
- public:
   inline __device__ void operator()() const {
     Kokkos::Impl::DeviceIterateTile<Policy::rank, Policy, FunctorType,
                                     typename Policy::work_tag>(m_policy,

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -43,9 +43,6 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::HIP> {
   const FunctorType m_functor;
   const Policy m_policy;
 
-  ParallelFor()        = delete;
-  ParallelFor& operator=(const ParallelFor&) = delete;
-
   template <class TagType>
   inline __device__ std::enable_if_t<std::is_void<TagType>::value> exec_range(
       const Member i) const {
@@ -60,6 +57,10 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::HIP> {
 
  public:
   using functor_type = FunctorType;
+
+  ParallelFor()                   = delete;
+  ParallelFor(ParallelFor const&) = default;
+  ParallelFor& operator=(ParallelFor const&) = delete;
 
   inline __device__ void operator()() const {
     const Member work_stride = blockDim.y * gridDim.x;

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -466,6 +466,10 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>, HIP> {
   }
 
  public:
+  ParallelFor()                   = delete;
+  ParallelFor(ParallelFor const&) = default;
+  ParallelFor& operator=(ParallelFor const&) = delete;
+
   __device__ inline void operator()() const {
     // Iterate this block through the league
     int64_t threadid = 0;


### PR DESCRIPTION
With ROCm 5.6 and the Cray compiler, we get a lot of warnings because we are using an implicitly define copy constructor. This PR explicitly create the copy constructor. The copy constructor is used  when using local memory [here](https://github.com/kokkos/kokkos/blob/f050fbc66dd15410f26fda1db2a1678075fc9fda/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp#L68-L80).

This PR also makes the deleted default constructor and assignment operator public. They were private before which is not necessary since they are deleted. 