### PR TITLE
Fully qualify Experimental::SYCL in algorithms to avoid conflicting namespaces

### DIFF
--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -183,10 +183,10 @@ void sort_cudathrust(const Cuda& space,
 
 #if defined(KOKKOS_ENABLE_ONEDPL)
 template <class DataType, class... Properties>
-void sort_onedpl(const Experimental::SYCL& space,
+void sort_onedpl(const Kokkos::Experimental::SYCL& space,
                  const Kokkos::View<DataType, Properties...>& view) {
   using ViewType = Kokkos::View<DataType, Properties...>;
-  static_assert(SpaceAccessibility<Experimental::SYCL,
+  static_assert(SpaceAccessibility<Kokkos::Experimental::SYCL,
                                    typename ViewType::memory_space>::accessible,
                 "SYCL execution space is not able to access the memory space "
                 "of the View argument!");
@@ -227,7 +227,7 @@ void sort_device_view_without_comparator(
 #if defined(KOKKOS_ENABLE_ONEDPL)
 template <class DataType, class... Properties>
 void sort_device_view_without_comparator(
-    const Experimental::SYCL& exec,
+    const Kokkos::Experimental::SYCL& exec,
     const Kokkos::View<DataType, Properties...>& view) {
   sort_onedpl(exec, view);
 }


### PR DESCRIPTION
Some users reported errors like
```
In file included from /tmp/kokkos-install/include/Kokkos_Sort.hpp:25:
In file included from /tmp/kokkos-install/include/sorting/Kokkos_SortPublicAPI.hpp:20:
/tmp/kokkos-install/include/sorting/./impl/Kokkos_SortImpl.hpp:189:50: error: no member named 'SYCL' in namespace 'Kokkos::Impl::Experimental'
  static_assert(SpaceAccessibility<Experimental::SYCL,
                                   ~~~~~~~~~~~~~~^
/tmp/kokkos-install/include/sorting/./impl/Kokkos_SortImpl.hpp:230:11: error: no type named 'SYCL' in namespace 'Kokkos::Impl::Experimental'; did you mean '::Kokkos::Experimental::SYCL'?
    const Experimental::SYCL& exec,
          ^~~~~~~~~~~~~~~~~~
          ::Kokkos::Experimental::SYCL
/tmp/kokkos-install/include/SYCL/Kokkos_SYCL.hpp:49:7: note: '::Kokkos::Experimental::SYCL' declared here
class SYCL {
```
We are in `Impl` at that place and there exists `namespace Experimental::Impl` in `algorithms/src/sorting/impl/Kokkos_NestedSortImpl.hpp`. I'm not quite sure why we don't see this error anywhere else, though.

Anyway, qualifying the namespace we want some more should help.