### PR TITLE
Update to HIP TeamPolicy Block number heuristic

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -585,7 +585,7 @@ class ParallelReduce<CombinedFunctorReducerType,
   using pointer_type   = typename ReducerType::pointer_type;
   using reference_type = typename ReducerType::reference_type;
   using value_type     = typename ReducerType::value_type;
-  
+
  public:
   using size_type = HIP::size_type;
 
@@ -780,7 +780,7 @@ class ParallelReduce<CombinedFunctorReducerType,
         block_max = 65536;
       }
       constexpr int preferred_block_min = 1024;
-      int block_count_tmp = m_league_size;
+      int block_count_tmp               = m_league_size;
       if (block_count_tmp < preferred_block_min) {
         // keep blocks as is, already low parallelism
       } else if (block_count_tmp >= block_max) {

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -656,7 +656,7 @@ class ParallelReduce<CombinedFunctorReducerType,
     }
   }
 
-  int compute_block_count() {
+  int compute_block_count() const {
     constexpr auto light_weight =
         Kokkos::Experimental::WorkItemProperty::HintLightWeight;
     constexpr typename Policy::work_item_property property;

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -755,11 +755,25 @@ class ParallelReduce<CombinedFunctorReducerType,
                                  !m_result_ptr_host_accessible ||
                                  !std::is_same<ReducerType, InvalidType>::value;
     if (!is_empty_range || need_device_set) {
-      const int block_count =
-          UseShflReduction
-              ? std::min(m_league_size, size_type(1024 * HIPTraits::WarpSize))
-              : std::min(static_cast<int>(m_league_size), m_team_size);
-
+      constexpr int block_max           = 65536;
+      constexpr int preferred_block_min = 1024;
+      int block_count_tmp = m_league_size;
+      if(block_count_tmp < preferred_block_min){
+        //keep blocks as is, already low parallelism
+      } else if (block_count_tmp >= block_max){
+        block_count_tmp = block_max;
+      } else {
+        int nwork = m_league_size * m_team_size;
+	int items_per_thread = (nwork + block_count_tmp * m_team_size - 1)/(block_count_tmp * m_team_size);
+	if (items_per_thread < 4){
+	  int ratio = std::min(
+	       (block_count_tmp + preferred_block_min - 1) / preferred_block_min,
+	       (4 + items_per_thread - 1) / items_per_thread);
+	  block_count_tmp /= ratio;
+	}
+      }
+      const int block_count = block_count_tmp;
+      
       m_scratch_space = hip_internal_scratch_space(
           m_policy.space(), reducer.value_size() * block_count);
       m_scratch_flags =

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -599,7 +599,6 @@ class ParallelReduce<CombinedFunctorReducerType,
   struct ShflReductionTag {};
   struct SHMEMReductionTag {};
 
-
   // Algorithmic constraints: blockDim.y is a power of two AND
   // blockDim.y == blockDim.z == 1 shared memory utilization:
   //

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -593,8 +593,10 @@ class ParallelReduce<CombinedFunctorReducerType,
   // FIXME_HIP This should be disabled unconditionally for best performance, but
   // it currently causes tests to fail.
   static constexpr int UseShflReduction =
+      (ReducerType::static_value_size() != 0);
 
-      private : struct ShflReductionTag {};
+ private:
+  struct ShflReductionTag {};
   struct SHMEMReductionTag {};
 
   // Conditionally set word_size_type to int16_t or int8_t if value_type is

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -599,18 +599,6 @@ class ParallelReduce<CombinedFunctorReducerType,
   struct ShflReductionTag {};
   struct SHMEMReductionTag {};
 
-  // Conditionally set word_size_type to int16_t or int8_t if value_type is
-  // smaller than int32_t (Kokkos::HIP::size_type)
-  // word_size_type is used to determine the word count, shared memory buffer
-  // size, and global memory buffer size before the scan is performed.
-  // Within the scan, the word count is recomputed based on word_size_type
-  // and when calculating indexes into the shared/global memory buffers for
-  // performing the scan, word_size_type is used again.
-  // For scalars > 4 bytes in size, indexing into shared/global memory relies
-  // on the block and grid dimensions to ensure that we index at the correct
-  // offset rather than at every 4 byte word; such that, when the join is
-  // performed, we have the correct data that was copied over in chunks of 4
-  // bytes.
 
   // Algorithmic constraints: blockDim.y is a power of two AND
   // blockDim.y == blockDim.z == 1 shared memory utilization:


### PR DESCRIPTION
This work is related to https://github.com/kokkos/kokkos/issues/6255. We have updated the heuristic that sets the block count inside TeamPolicy's parallel_reduce implementation. We have profiled the resulting performance of the new heuristic on a dot product workload and a yAx workload, and we have ensured that performance is at least as good as the previous heuristic. We want to explicitly note that **this is the first step in an ongoing effort to improve HIP parallel_reduce**.

In the plots shown our heuristic is labeled "kokkos-change", with kokkos 4.0.00 as "kokkos-4.0.00", and the develop branch as "kokkos-dev"

Plot showing bandwidth vs. # array elements for a dot product workload:
![image](https://github.com/kokkos/kokkos/assets/107126280/8d4ba38f-76de-4b0b-ae33-352c5488a87b)
There is an obvious dip in performance that happens where we revert back to the old heuristic. This is due to effects that could seen on the yAx workload:
![image](https://github.com/kokkos/kokkos/assets/107126280/4afe06c3-59a7-43df-a0e9-1740c2d316fd)
The "mesa" of performance seen for larger values of N would be narrower had we fixed the dip in the dot performance by simply changing the switchover point. This would represent a fairly sizable performance regression in the yAx case, so with the current heuristic we attempt to be at least as good as the previous heuristic. 

We have ideas for further optimizations, but they will require more development effort on our end. This PR is meant to serve as a starting point towards a more optimized heuristic for HIP block count selection in TeamPolicies.
