### PR TITLE
fix refcount exception safety

### DIFF
--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -137,9 +137,9 @@ inline void parallel_for(const std::string& str, const ExecPolicy& policy,
   ExecPolicy inner_policy = policy;
   Kokkos::Tools::Impl::begin_parallel_for(inner_policy, functor, str, kpID);
 
-  Kokkos::Impl::shared_allocation_tracking_disable();
-  Impl::ParallelFor<FunctorType, ExecPolicy> closure(functor, inner_policy);
-  Kokkos::Impl::shared_allocation_tracking_enable();
+  auto closure = Kokkos::Impl::with_shared_allocation_tracking_disabled([&]() {
+    return Impl::ParallelFor<FunctorType, ExecPolicy>(functor, inner_policy);
+  });
 
   closure.execute();
 
@@ -352,10 +352,10 @@ inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
   ExecutionPolicy inner_policy = policy;
   Kokkos::Tools::Impl::begin_parallel_scan(inner_policy, functor, str, kpID);
 
-  Kokkos::Impl::shared_allocation_tracking_disable();
-  Impl::ParallelScan<FunctorType, ExecutionPolicy> closure(functor,
-                                                           inner_policy);
-  Kokkos::Impl::shared_allocation_tracking_enable();
+  auto closure = Kokkos::Impl::with_shared_allocation_tracking_disabled([&]() {
+    return Impl::ParallelScan<FunctorType, ExecutionPolicy>(functor,
+                                                            inner_policy);
+  });
 
   closure.execute();
 
@@ -398,18 +398,21 @@ inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
   Kokkos::Tools::Impl::begin_parallel_scan(inner_policy, functor, str, kpID);
 
   if constexpr (Kokkos::is_view<ReturnType>::value) {
-    Kokkos::Impl::shared_allocation_tracking_disable();
-    Impl::ParallelScanWithTotal<FunctorType, ExecutionPolicy,
-                                typename ReturnType::value_type>
-        closure(functor, inner_policy, return_value);
-    Kokkos::Impl::shared_allocation_tracking_enable();
+    auto closure =
+        Kokkos::Impl::with_shared_allocation_tracking_disabled([&]() {
+          return Impl::ParallelScanWithTotal<FunctorType, ExecutionPolicy,
+                                             typename ReturnType::value_type>(
+              functor, inner_policy, return_value);
+        });
     closure.execute();
   } else {
-    Kokkos::Impl::shared_allocation_tracking_disable();
-    Kokkos::View<ReturnType, Kokkos::HostSpace> view(&return_value);
-    Impl::ParallelScanWithTotal<FunctorType, ExecutionPolicy, ReturnType>
-        closure(functor, inner_policy, view);
-    Kokkos::Impl::shared_allocation_tracking_enable();
+    auto closure =
+        Kokkos::Impl::with_shared_allocation_tracking_disabled([&]() {
+          Kokkos::View<ReturnType, Kokkos::HostSpace> view(&return_value);
+          return Impl::ParallelScanWithTotal<FunctorType, ExecutionPolicy,
+                                             ReturnType>(functor, inner_policy,
+                                                         view);
+        });
     closure.execute();
   }
 

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1514,7 +1514,7 @@ struct ParallelReduceAdaptor {
 
     CombinedFunctorReducer functor_reducer(
         functor, typename Analysis::Reducer(
-                      ReducerSelector::select(functor, return_value)));
+                     ReducerSelector::select(functor, return_value)));
     auto closure = construct_with_shared_allocation_tracking_disabled<
         Impl::ParallelReduce<decltype(functor_reducer), PolicyType,
                              typename Impl::FunctorPolicyExecutionSpace<

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1512,14 +1512,16 @@ struct ParallelReduceAdaptor {
                                      PolicyType, typename ReducerSelector::type,
                                      typename return_value_adapter::value_type>;
 
-    CombinedFunctorReducer functor_reducer(
-        functor, typename Analysis::Reducer(
-                     ReducerSelector::select(functor, return_value)));
+    using CombinedFunctorReducerType =
+        CombinedFunctorReducer<FunctorType, typename Analysis::Reducer>;
     auto closure = construct_with_shared_allocation_tracking_disabled<
-        Impl::ParallelReduce<decltype(functor_reducer), PolicyType,
+        Impl::ParallelReduce<CombinedFunctorReducerType, PolicyType,
                              typename Impl::FunctorPolicyExecutionSpace<
                                  FunctorType, PolicyType>::execution_space>>(
-        functor_reducer, inner_policy,
+        CombinedFunctorReducerType(
+            functor, typename Analysis::Reducer(
+                         ReducerSelector::select(functor, return_value))),
+        inner_policy,
         return_value_adapter::return_value(return_value, functor));
     closure.execute();
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1919,46 +1919,6 @@ KOKKOS_INLINE_FUNCTION bool operator!=(const View<LT, LP...>& lhs,
 
 namespace Kokkos {
 namespace Impl {
-struct SharedAllocationDisableTrackingGuard {
-  SharedAllocationDisableTrackingGuard() {
-    assert(
-        (Kokkos::Impl::SharedAllocationRecord<void, void>::tracking_enabled()));
-    Kokkos::Impl::SharedAllocationRecord<void, void>::tracking_disable();
-  }
-
-  SharedAllocationDisableTrackingGuard(
-      const SharedAllocationDisableTrackingGuard&) = delete;
-  SharedAllocationDisableTrackingGuard(
-      SharedAllocationDisableTrackingGuard&&) noexcept = delete;
-
-  ~SharedAllocationDisableTrackingGuard() {
-    Kokkos::Impl::SharedAllocationRecord<void, void>::tracking_enable();
-  }
-
-  // clang-format off
-  // The old version of clang format we use is particularly egregious here
-  SharedAllocationDisableTrackingGuard& operator=(
-      const SharedAllocationDisableTrackingGuard&) = delete;
-  SharedAllocationDisableTrackingGuard& operator=(
-      SharedAllocationDisableTrackingGuard&&) noexcept = delete;
-  // clang-format on
-};
-
-template <class FunctorType, class... Args>
-inline FunctorType construct_with_shared_allocation_tracking_disabled(
-    Args&&... args) {
-  [[maybe_unused]] auto guard = SharedAllocationDisableTrackingGuard{};
-  return {std::forward<Args>(args)...};
-}
-
-} /* namespace Impl */
-} /* namespace Kokkos */
-
-//----------------------------------------------------------------------------
-//----------------------------------------------------------------------------
-
-namespace Kokkos {
-namespace Impl {
 
 template <class Specialize, typename A, typename B>
 struct CommonViewValueType;

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1935,10 +1935,13 @@ struct SharedAllocationDisableTrackingGuard {
     Kokkos::Impl::SharedAllocationRecord<void, void>::tracking_enable();
   }
 
+  // clang-format off
+  // The old version of clang format we use is particularly egregious here
   SharedAllocationDisableTrackingGuard& operator=(
       const SharedAllocationDisableTrackingGuard&) = delete;
   SharedAllocationDisableTrackingGuard& operator=(
       SharedAllocationDisableTrackingGuard&&) noexcept = delete;
+  // clang-format on
 };
 
 template <class FunctorType, class... Args>

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1921,17 +1921,29 @@ namespace Kokkos {
 namespace Impl {
 struct SharedAllocationDisableTrackingGuard {
   SharedAllocationDisableTrackingGuard() {
-    assert( ( Kokkos::Impl::SharedAllocationRecord< void, void >::tracking_enabled() ) );
+    assert(
+        (Kokkos::Impl::SharedAllocationRecord<void, void>::tracking_enabled()));
     Kokkos::Impl::SharedAllocationRecord<void, void>::tracking_disable();
   }
+
+  SharedAllocationDisableTrackingGuard(
+      const SharedAllocationDisableTrackingGuard&) = delete;
+  SharedAllocationDisableTrackingGuard(
+      SharedAllocationDisableTrackingGuard&&) noexcept = delete;
 
   ~SharedAllocationDisableTrackingGuard() {
     Kokkos::Impl::SharedAllocationRecord<void, void>::tracking_enable();
   }
+
+  SharedAllocationDisableTrackingGuard& operator=(
+      const SharedAllocationDisableTrackingGuard&) = delete;
+  SharedAllocationDisableTrackingGuard& operator=(
+      SharedAllocationDisableTrackingGuard&&) noexcept = delete;
 };
 
 template <class FunctorType, class... Args>
-inline FunctorType construct_with_shared_allocation_tracking_disabled(Args&&... args) {
+inline FunctorType construct_with_shared_allocation_tracking_disabled(
+    Args&&... args) {
   [[maybe_unused]] auto guard = SharedAllocationDisableTrackingGuard{};
   return {std::forward<Args>(args)...};
 }

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -26,8 +26,6 @@ static_assert(false,
 #include <string>
 #include <algorithm>
 #include <initializer_list>
-#include <functional>
-#include <cassert>
 
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_HostSpace.hpp>

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -27,6 +27,7 @@ static_assert(false,
 #include <algorithm>
 #include <initializer_list>
 #include <functional>
+#include <cassert>
 
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_HostSpace.hpp>
@@ -1920,6 +1921,7 @@ namespace Kokkos {
 namespace Impl {
 struct SharedAllocationDisableTrackingGuard {
   SharedAllocationDisableTrackingGuard() {
+    assert( ( Kokkos::Impl::SharedAllocationRecord< void, void >::tracking_enabled() ) );
     Kokkos::Impl::SharedAllocationRecord<void, void>::tracking_disable();
   }
 
@@ -1928,10 +1930,10 @@ struct SharedAllocationDisableTrackingGuard {
   }
 };
 
-template <class F>
-inline decltype(auto) with_shared_allocation_tracking_disabled(F&& fun) {
+template <class FunctorType, class... Args>
+inline FunctorType construct_with_shared_allocation_tracking_disabled(Args&&... args) {
   [[maybe_unused]] auto guard = SharedAllocationDisableTrackingGuard{};
-  return std::invoke(std::forward<F>(fun));
+  return {std::forward<Args>(args)...};
 }
 
 } /* namespace Impl */

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -657,6 +657,8 @@ struct SharedAllocationDisableTrackingGuard {
       delete;
 
   ~SharedAllocationDisableTrackingGuard() {
+    KOKKOS_ASSERT((
+        !Kokkos::Impl::SharedAllocationRecord<void, void>::tracking_enabled()));
     Kokkos::Impl::SharedAllocationRecord<void, void>::tracking_enable();
   }
   // clang-format off

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -644,6 +644,34 @@ union SharedAllocationTracker {
 #undef KOKKOS_IMPL_SHARED_ALLOCATION_TRACKER_DECREMENT
 };
 
+struct SharedAllocationDisableTrackingGuard {
+  SharedAllocationDisableTrackingGuard() {
+    KOKKOS_ASSERT(
+        (Kokkos::Impl::SharedAllocationRecord<void, void>::tracking_enabled()));
+    Kokkos::Impl::SharedAllocationRecord<void, void>::tracking_disable();
+  }
+
+  SharedAllocationDisableTrackingGuard(
+      const SharedAllocationDisableTrackingGuard&) = delete;
+  SharedAllocationDisableTrackingGuard(SharedAllocationDisableTrackingGuard&&) =
+      delete;
+
+  ~SharedAllocationDisableTrackingGuard() {
+    Kokkos::Impl::SharedAllocationRecord<void, void>::tracking_enable();
+  }
+
+  SharedAllocationDisableTrackingGuard& operator=(
+      const SharedAllocationDisableTrackingGuard&) = delete;
+  SharedAllocationDisableTrackingGuard& operator=(
+      SharedAllocationDisableTrackingGuard&&) = delete;
+};
+
+template <class FunctorType, class... Args>
+inline FunctorType construct_with_shared_allocation_tracking_disabled(
+    Args&&... args) {
+  [[maybe_unused]] auto guard = SharedAllocationDisableTrackingGuard{};
+  return {std::forward<Args>(args)...};
+}
 } /* namespace Impl */
 } /* namespace Kokkos */
 #endif

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -659,11 +659,13 @@ struct SharedAllocationDisableTrackingGuard {
   ~SharedAllocationDisableTrackingGuard() {
     Kokkos::Impl::SharedAllocationRecord<void, void>::tracking_enable();
   }
-
+  // clang-format off
+  // The old version of clang format we use is particularly egregious here
   SharedAllocationDisableTrackingGuard& operator=(
       const SharedAllocationDisableTrackingGuard&) = delete;
   SharedAllocationDisableTrackingGuard& operator=(
       SharedAllocationDisableTrackingGuard&&) = delete;
+  // clang-format on
 };
 
 template <class FunctorType, class... Args>

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1349,7 +1349,7 @@ class TestViewAPI {
       throw std::bad_alloc();
     }
 
-    KOKKOS_INLINE_FUNCTION void operator()(int i) const { view(i) = i; }
+    KOKKOS_INLINE_FUNCTION void operator()(int i) const {}
 
     view_type view;
   };
@@ -1361,7 +1361,9 @@ class TestViewAPI {
 
     // test_refcount_poison_copy_functor throws during copy construction
     try {
-      Kokkos::parallel_for(N0, test_refcount_poison_copy_functor(original));
+      Kokkos::parallel_for(
+          Kokkos::RangePolicy<typename DeviceType::execution_space>(0, N0),
+          test_refcount_poison_copy_functor(original));
     } catch (const std::bad_alloc &) {
     }
 

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1349,7 +1349,7 @@ class TestViewAPI {
       throw std::bad_alloc();
     }
 
-    void operator()(int i) const { view(i) = i; }
+    KOKKOS_INLINE_FUNCTION void operator()(int i) const { view(i) = i; }
 
     view_type view;
   };

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1339,6 +1339,38 @@ class TestViewAPI {
     ASSERT_EQ(dz.data(), nullptr);
   }
 
+  struct test_refcount_poison_copy_functor {
+    using view_type = Kokkos::View<double *>;
+    explicit test_refcount_poison_copy_functor(view_type v) : view(v) {}
+
+    test_refcount_poison_copy_functor(
+        const test_refcount_poison_copy_functor &other)
+        : view(other.view) {
+      throw std::bad_alloc();
+    }
+
+    void operator()(int i) const { view(i) = i; }
+
+    view_type view;
+  };
+
+  static void run_test_refcount_exception() {
+    using view_type = typename test_refcount_poison_copy_functor::view_type;
+    view_type original("original", N0);
+    ASSERT_EQ(original.use_count(), 1);
+
+    // test_refcount_poison_copy_functor throws during copy construction
+    try {
+      Kokkos::parallel_for(N0, test_refcount_poison_copy_functor(original));
+    } catch (const std::bad_alloc &) {
+    }
+
+    // Ensure refcounting is enabled, we should increment here
+    auto copy = original;
+    ASSERT_EQ(original.use_count(), 2);
+    ASSERT_EQ(copy.use_count(), 2);
+  }
+
   static void run_test_deep_copy_empty() {
     // Check Deep Copy of LayoutLeft to LayoutRight
     {

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1349,7 +1349,7 @@ class TestViewAPI {
       throw std::bad_alloc();
     }
 
-    KOKKOS_INLINE_FUNCTION void operator()(int i) const {}
+    KOKKOS_INLINE_FUNCTION void operator()(int) const {}
 
     view_type view;
   };

--- a/core/unit_test/TestViewAPI_c.hpp
+++ b/core/unit_test/TestViewAPI_c.hpp
@@ -19,6 +19,7 @@
 namespace Test {
 
 TEST(TEST_CATEGORY, view_api_c) {
+  TestViewAPI<double, TEST_EXECSPACE>::run_test_refcount_exception();
   TestViewAPI<double, TEST_EXECSPACE>::run_test_deep_copy_empty();
   TestViewAPI<double, TEST_EXECSPACE>::run_test_view_operator_b();
 }


### PR DESCRIPTION
We currently toggle refcounting before and after copying functors in `parallel_*` operations. This isn't exception safe and a functor that throws in its copy constructor can break refcounting until the next `parallel_*` operation. This PR fixes the issue and provides tests.

Note this bug affects all backends.