### PR TITLE
#5635: Serial/OpenMP: Parallel_scan with return value for ThreadVectorRange

### DIFF
--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -893,16 +893,21 @@ KOKKOS_INLINE_FUNCTION
   }
 }
 
-template <typename iType, class ClosureType, class Member>
+template <typename iType, class ClosureType, class Member, typename ValueType>
 KOKKOS_INLINE_FUNCTION
-    std::enable_if_t<Impl::is_host_thread_team_member<Member>::value>
+    std::enable_if_t<!Kokkos::is_reducer<ValueType>::value &&
+                     Impl::is_host_thread_team_member<Member>::value>
     parallel_scan(Impl::ThreadVectorRangeBoundariesStruct<iType, Member> const&
                       loop_boundaries,
-                  ClosureType const& closure) {
-  using value_type = typename Kokkos::Impl::FunctorAnalysis<
-      Impl::FunctorPatternInterface::SCAN, void, ClosureType, void>::value_type;
+                  ClosureType const& closure, ValueType& return_val) {
+  // Extract ValueType from the Closure
+  using ClosureValueType = typename Kokkos::Impl::FunctorAnalysis<
+      Kokkos::Impl::FunctorPatternInterface::SCAN, void, ClosureType,
+      void>::value_type;
+  static_assert(std::is_same<ClosureValueType, ValueType>::value,
+                "Non-matching value types of closure and return type");
 
-  value_type scan_val = value_type();
+  ValueType scan_val = ValueType();
 
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
 #pragma ivdep
@@ -911,6 +916,22 @@ KOKKOS_INLINE_FUNCTION
        i += loop_boundaries.increment) {
     closure(i, scan_val, true);
   }
+
+  return_val = scan_val;
+}
+
+template <typename iType, class ClosureType, class Member>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<Impl::is_host_thread_team_member<Member>::value>
+    parallel_scan(Impl::ThreadVectorRangeBoundariesStruct<iType, Member> const&
+                      loop_boundaries,
+                  ClosureType const& closure) {
+  // Extract ValueType from the closure
+  using ValueType = typename Kokkos::Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::SCAN, void, ClosureType, void>::value_type;
+
+  ValueType scan_val;
+  parallel_scan(loop_boundaries, closure, scan_val);
 }
 
 template <typename iType, class Lambda, typename ReducerType, typename Member>

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -618,13 +618,12 @@ struct functor_vec_scan_ret_val {
   using execution_space = ExecutionSpace;
   using view_type       = Kokkos::View<Scalar **, execution_space>;
 
-  Kokkos::View<int, Kokkos::LayoutLeft, ExecutionSpace> flag;
+  Kokkos::View<int, ExecutionSpace> flag;
   view_type return_values;
   int team_size;
 
-  functor_vec_scan_ret_val(
-      Kokkos::View<int, Kokkos::LayoutLeft, ExecutionSpace> flag_, int nteams,
-      int tsize)
+  functor_vec_scan_ret_val(Kokkos::View<int, ExecutionSpace> flag_, int nteams,
+                           int tsize)
       : flag(flag_), team_size(tsize) {
     return_values = view_type("return_values", nteams, tsize);
   }


### PR DESCRIPTION
Related to #5635 