### PR TITLE
SYCL TeamPolicy: Fix sign comparison warning

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -681,7 +681,7 @@ class ParallelReduce<CombinedFunctorReducerType,
                 if constexpr (!use_shuffle_based_algorithm<ReducerType>) {
                   reference_type update =
                       reducer.init(&local_mem[local_id * value_count]);
-                  for (size_t league_rank = group_id; league_rank < league_size;
+                  for (int league_rank = group_id; league_rank < league_size;
                        league_rank += n_wgroups) {
                     const member_type team_member(
                         team_scratch_memory_L0.get_pointer(), shmem_begin,


### PR DESCRIPTION
We got a little unlucky that the combination of #6272 and #6270 resulted in a sign comparison warning that we didn't notice for the individual pull requests. It seems that we don't test array reductions for TeamPolicy in the CI.

The change matches what we do for the other (shuffle-based) code path.