### PR TITLE
SIMD: suppress a uninitialized variable warning

### DIFF
--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -192,8 +192,8 @@ void host_check_math_op_one_loader(UnaryOp unary_op, std::size_t n,
     bool const loaded_arg = loader.host_load(args + i, nlanes, arg);
     if (!loaded_arg) continue;
     simd_type expected_result;
-    // gcc 8.4.0 warns if using nlanes as upper bound about first_arg and/or
-    // second_arg being uninitialized
+    // gcc 8.4.0 warns if using nlanes as upper bound about arg
+    // being uninitialized
     for (std::size_t lane = 0; lane < simd_type::size(); ++lane) {
       if (lane < nlanes)
         expected_result[lane] = unary_op.on_host_serial(T(arg[lane]));

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -192,8 +192,11 @@ void host_check_math_op_one_loader(UnaryOp unary_op, std::size_t n,
     bool const loaded_arg = loader.host_load(args + i, nlanes, arg);
     if (!loaded_arg) continue;
     simd_type expected_result;
-    for (std::size_t lane = 0; lane < nlanes; ++lane) {
-      expected_result[lane] = unary_op.on_host_serial(T(arg[lane]));
+    // gcc 8.4.0 warns if using nlanes as upper bound about first_arg and/or
+    // second_arg being uninitialized
+    for (std::size_t lane = 0; lane < simd_type::size(); ++lane) {
+      if (lane < nlanes)
+        expected_result[lane] = unary_op.on_host_serial(T(arg[lane]));
     }
     simd_type const computed_result = unary_op.on_host(arg);
     host_check_equality(expected_result, computed_result, nlanes);


### PR DESCRIPTION
Fixes #6277.

Related to the 4th bullet in #6223.

Added an extra branching operation that suppresses a seemingly spurious uninitialized variable warnings from gcc and included the same comment about this from #6223.