### PR TITLE
Add nightly build using latest gcc and c++23

### DIFF
--- a/.jenkins_nightly
+++ b/.jenkins_nightly
@@ -70,6 +70,38 @@ pipeline {
                           '''
                     }      
                 }   
+                stage('GCC-13') {
+                    agent {
+                        dockerfile {
+                            image 'gcc:13.1'
+                            label 'docker'
+                        }
+                    }
+                    steps {
+                        sh '''
+                          DEBIAN_FRONTEND=noninteractive && \
+                          apt-get update && apt-get upgrade -y && apt-get install -y \
+                          cmake \
+                          && \
+                          apt-get clean && rm -rf /var/lib/apt/lists/*
+
+                          mkdir -p build && cd build && \
+                          cmake \
+                            -DCMAKE_BUILD_TYPE=Release \
+                            -DCMAKE_CXX_STANDARD=23 \
+                            -DCMAKE_CXX_FLAGS=-Werror \
+                            -DKokkos_ARCH_NATIVE=ON \
+                            -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
+                            -DKokkos_ENABLE_BENCHMARKS=ON \
+                            -DKokkos_ENABLE_EXAMPLES=ON \
+                            -DKokkos_ENABLE_TESTS=ON \
+                            -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
+                            -DKokkos_ENABLE_SERIAL=ON \
+                          .. && \
+                          make -j8 && ctest --verbose
+                          '''
+                    }
+                }
             }
         }
     }

--- a/example/tutorial/Hierarchical_Parallelism/03_vectorization/vectorization.cpp
+++ b/example/tutorial/Hierarchical_Parallelism/03_vectorization/vectorization.cpp
@@ -56,7 +56,8 @@ struct SomeCorrelation {
 
     // With each team run a parallel_for with its threads
     Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(thread, data.extent(1)), [=](const int& j) {
+        Kokkos::TeamThreadRange(thread, data.extent(1)),
+        [=, *this](const int& j) {
           int tsum;
           // Run a vector loop reduction over the inner dimension of data
           // Count how many values are multiples of 4
@@ -64,7 +65,7 @@ struct SomeCorrelation {
           // broadcast to all vector lanes
           Kokkos::parallel_reduce(
               Kokkos::ThreadVectorRange(thread, data.extent(2)),
-              [=](const int& k, int& vsum) {
+              [=, *this](const int& k, int& vsum) {
                 vsum += (data(i, j, k) % 4 == 0) ? 1 : 0;
               },
               tsum);
@@ -103,7 +104,7 @@ struct SomeCorrelation {
     // Add with one thread and vectorlane of the team the team_sum to the global
     // value
     Kokkos::single(Kokkos::PerTeam(thread),
-                   [=]() { Kokkos::atomic_add(&gsum(), team_sum); });
+                   [=, *this]() { Kokkos::atomic_add(&gsum(), team_sum); });
   }
 
   // The functor needs to define how much shared memory it requests given a


### PR DESCRIPTION
Add nightly build using gcc 13.1 with C++23 and fix warnings

```
 error: implicit capture of 'this' via '[=]' is deprecated in C++20 [-Werror=deprecated]
```