### PR TITLE
Create cudaAPI function wrappers

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -43,7 +43,8 @@
 cudaStream_t Kokkos::Impl::cuda_get_deep_copy_stream() {
   static cudaStream_t s = nullptr;
   if (s == nullptr) {
-    cudaStreamCreate(&s);
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (CudaInternal::singleton().cuda_stream_create_wrapper(&s)));
   }
   return s;
 }
@@ -66,19 +67,22 @@ static std::atomic<int> num_uvm_allocations(0);
 }  // namespace
 
 void DeepCopyCuda(void *dst, const void *src, size_t n) {
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemcpy(dst, src, n, cudaMemcpyDefault));
+  KOKKOS_IMPL_CUDA_SAFE_CALL((CudaInternal::singleton().cuda_memcpy_wrapper(
+      dst, src, n, cudaMemcpyDefault)));
 }
 
 void DeepCopyAsyncCuda(const Cuda &instance, void *dst, const void *src,
                        size_t n) {
   KOKKOS_IMPL_CUDA_SAFE_CALL(
-      cudaMemcpyAsync(dst, src, n, cudaMemcpyDefault, instance.cuda_stream()));
+      (instance.impl_internal_space_instance()->cuda_memcpy_async_wrapper(
+          dst, src, n, cudaMemcpyDefault, instance.cuda_stream())));
 }
 
 void DeepCopyAsyncCuda(void *dst, const void *src, size_t n) {
   cudaStream_t s = cuda_get_deep_copy_stream();
   KOKKOS_IMPL_CUDA_SAFE_CALL(
-      cudaMemcpyAsync(dst, src, n, cudaMemcpyDefault, s));
+      (CudaInternal::singleton().cuda_memcpy_async_wrapper(
+          dst, src, n, cudaMemcpyDefault, s)));
   Impl::cuda_stream_synchronize(
       s,
       Kokkos::Tools::Experimental::SpecialSynchronizationCases::
@@ -171,25 +175,36 @@ void *impl_allocate_common(const Cuda &exec_space, const char *arg_label,
   if (arg_alloc_size >= memory_threshold_g) {
     if (exec_space_provided) {
       cudaStream_t stream = exec_space.cuda_stream();
-      error_code          = cudaMallocAsync(&ptr, arg_alloc_size, stream);
+      error_code =
+          exec_space.impl_internal_space_instance()->cuda_malloc_async_wrapper(
+              &ptr, arg_alloc_size, stream);
       exec_space.fence("Kokkos::Cuda: backend fence after async malloc");
     } else {
-      error_code = cudaMallocAsync(&ptr, arg_alloc_size, 0);
+      error_code =
+          exec_space.impl_internal_space_instance()->cuda_malloc_async_wrapper(
+              &ptr, arg_alloc_size, 0);
       Impl::cuda_device_synchronize(
           "Kokkos::Cuda: backend fence after async malloc");
     }
   } else {
-    error_code = cudaMalloc(&ptr, arg_alloc_size);
+    error_code = exec_space.impl_internal_space_instance()->cuda_malloc_wrapper(
+        &ptr, arg_alloc_size);
   }
 #else
-  (void)exec_space;
-  (void)exec_space_provided;
-  auto error_code = cudaMalloc(&ptr, arg_alloc_size);
+  cudaError_t error_code;
+  if (exec_space_provided) {
+    error_code = exec_space.impl_internal_space_instance()->cuda_malloc_wrapper(
+        &ptr, arg_alloc_size);
+  } else {
+    error_code = Impl::CudaInternal::singleton().cuda_malloc_wrapper(
+        &ptr, arg_alloc_size);
+  }
 #endif
   if (error_code != cudaSuccess) {  // TODO tag as unlikely branch
-    cudaGetLastError();  // This is the only way to clear the last error, which
-                         // we should do here since we're turning it into an
-                         // exception here
+    // This is the only way to clear the last error, which
+    // we should do here since we're turning it into an
+    // exception here
+    exec_space.impl_internal_space_instance()->cuda_get_last_error_wrapper();
     throw Experimental::CudaRawMemoryAllocationFailure(
         arg_alloc_size, error_code,
         Experimental::RawMemoryAllocationFailure::AllocationMechanism::
@@ -240,18 +255,22 @@ void *CudaUVMSpace::impl_allocate(
     Kokkos::Impl::num_uvm_allocations++;
 
     auto error_code =
-        cudaMallocManaged(&ptr, arg_alloc_size, cudaMemAttachGlobal);
+        Impl::CudaInternal::singleton().cuda_malloc_managed_wrapper(
+            &ptr, arg_alloc_size, cudaMemAttachGlobal);
 
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_PIN_UVM_TO_HOST
     if (Kokkos::CudaUVMSpace::cuda_pin_uvm_to_host())
-      cudaMemAdvise(ptr, arg_alloc_size, cudaMemAdviseSetPreferredLocation,
-                    cudaCpuDeviceId);
+      KOKKOS_IMPL_CUDA_SAFE_CALL(
+          (Impl::CudaInternal::singleton().cuda_mem_advise_wrapper(
+              ptr, arg_alloc_size, cudaMemAdviseSetPreferredLocation,
+              cudaCpuDeviceId)));
 #endif
 
     if (error_code != cudaSuccess) {  // TODO tag as unlikely branch
-      cudaGetLastError();  // This is the only way to clear the last error,
-                           // which we should do here since we're turning it
-                           // into an exception here
+      // This is the only way to clear the last error, which
+      // we should do here since we're turning it into an
+      // exception here
+      Impl::CudaInternal::singleton().cuda_get_last_error_wrapper();
       throw Experimental::CudaRawMemoryAllocationFailure(
           arg_alloc_size, error_code,
           Experimental::RawMemoryAllocationFailure::AllocationMechanism::
@@ -281,11 +300,13 @@ void *CudaHostPinnedSpace::impl_allocate(
     const Kokkos::Tools::SpaceHandle arg_handle) const {
   void *ptr = nullptr;
 
-  auto error_code = cudaHostAlloc(&ptr, arg_alloc_size, cudaHostAllocDefault);
+  auto error_code = Impl::CudaInternal::singleton().cuda_host_alloc_wrapper(
+      &ptr, arg_alloc_size, cudaHostAllocDefault);
   if (error_code != cudaSuccess) {  // TODO tag as unlikely branch
-    cudaGetLastError();  // This is the only way to clear the last error, which
-                         // we should do here since we're turning it into an
-                         // exception here
+    // This is the only way to clear the last error, which
+    // we should do here since we're turning it into an
+    // exception here
+    Impl::CudaInternal::singleton().cuda_get_last_error_wrapper();
     throw Experimental::CudaRawMemoryAllocationFailure(
         arg_alloc_size, error_code,
         Experimental::RawMemoryAllocationFailure::AllocationMechanism::
@@ -327,14 +348,18 @@ void CudaSpace::impl_deallocate(
     if (arg_alloc_size >= memory_threshold_g) {
       Impl::cuda_device_synchronize(
           "Kokkos::Cuda: backend fence before async free");
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeAsync(arg_alloc_ptr, 0));
+      KOKKOS_IMPL_CUDA_SAFE_CALL(
+          (Impl::CudaInternal::singleton().cuda_free_async_wrapper(
+              arg_alloc_ptr, 0)));
       Impl::cuda_device_synchronize(
           "Kokkos::Cuda: backend fence after async free");
     } else {
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(arg_alloc_ptr));
+      KOKKOS_IMPL_CUDA_SAFE_CALL(
+          (Impl::CudaInternal::singleton().cuda_free_wrapper(arg_alloc_ptr)));
     }
 #else
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(arg_alloc_ptr));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (Impl::CudaInternal::singleton().cuda_free_wrapper(arg_alloc_ptr)));
 #endif
   } catch (...) {
   }
@@ -353,10 +378,7 @@ void CudaUVMSpace::deallocate(const char *arg_label, void *const arg_alloc_ptr,
 }
 void CudaUVMSpace::impl_deallocate(
     const char *arg_label, void *const arg_alloc_ptr,
-    const size_t arg_alloc_size
-
-    ,
-    const size_t arg_logical_size,
+    const size_t arg_alloc_size, const size_t arg_logical_size,
     const Kokkos::Tools::SpaceHandle arg_handle) const {
   Cuda::impl_static_fence(
       "Kokkos::CudaUVMSpace::impl_deallocate: Pre UVM Deallocation");
@@ -369,7 +391,8 @@ void CudaUVMSpace::impl_deallocate(
   try {
     if (arg_alloc_ptr != nullptr) {
       Kokkos::Impl::num_uvm_allocations--;
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(arg_alloc_ptr));
+      KOKKOS_IMPL_CUDA_SAFE_CALL(
+          (Impl::CudaInternal::singleton().cuda_free_wrapper(arg_alloc_ptr)));
     }
   } catch (...) {
   }
@@ -399,7 +422,8 @@ void CudaHostPinnedSpace::impl_deallocate(
                                       reported_size);
   }
   try {
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeHost(arg_alloc_ptr));
+    KOKKOS_IMPL_CUDA_SAFE_CALL((
+        Impl::CudaInternal::singleton().cuda_free_host_wrapper(arg_alloc_ptr)));
   } catch (...) {
   }
 }
@@ -570,7 +594,9 @@ void cuda_prefetch_pointer(const Cuda &space, const void *ptr, size_t bytes,
                            bool to_device) {
   if ((ptr == nullptr) || (bytes == 0)) return;
   cudaPointerAttributes attr;
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaPointerGetAttributes(&attr, ptr));
+  KOKKOS_IMPL_CUDA_SAFE_CALL((
+      space.impl_internal_space_instance()->cuda_pointer_get_attributes_wrapper(
+          &attr, ptr)));
   // I measured this and it turns out prefetching towards the host slows
   // DualView syncs down. Probably because the latency is not too bad in the
   // first place for the pull down. If we want to change that provde
@@ -578,8 +604,9 @@ void cuda_prefetch_pointer(const Cuda &space, const void *ptr, size_t bytes,
   bool is_managed = attr.type == cudaMemoryTypeManaged;
   if (to_device && is_managed &&
       space.cuda_device_prop().concurrentManagedAccess) {
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemPrefetchAsync(
-        ptr, bytes, space.cuda_device(), space.cuda_stream()));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (space.impl_internal_space_instance()->cuda_mem_prefetch_async_wrapper(
+            ptr, bytes, space.cuda_device(), space.cuda_stream())));
   }
 }
 

--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -31,7 +31,6 @@
 #include <Kokkos_PointerOwnership.hpp>
 
 #include <Cuda/Kokkos_Cuda.hpp>
-#include <cuda_runtime_api.h>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/Cuda/Kokkos_Cuda_GraphNode_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNode_Impl.hpp
@@ -26,7 +26,6 @@
 #include <impl/Kokkos_GraphImpl.hpp>  // GraphAccess needs to be complete
 
 #include <Cuda/Kokkos_Cuda.hpp>
-#include <cuda_runtime_api.h>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -167,8 +167,7 @@ struct GraphImpl<Kokkos::Cuda> {
     }
     KOKKOS_IMPL_CUDA_SAFE_CALL(
         (m_execution_space.impl_internal_space_instance()
-             ->cuda_graph_launch_wrapper(m_graph_exec,
-                                         m_execution_space.cuda_stream())));
+             ->cuda_graph_launch_wrapper(m_graph_exec)));
   }
 
   execution_space const& get_execution_space() const noexcept {

--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -31,7 +31,6 @@
 #include <Cuda/Kokkos_Cuda_GraphNode_Impl.hpp>
 
 #include <Cuda/Kokkos_Cuda.hpp>
-#include <cuda_runtime_api.h>
 #include <Cuda/Kokkos_Cuda_Error.hpp>
 #include <Cuda/Kokkos_Cuda_Instance.hpp>
 

--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -33,6 +33,7 @@
 #include <Cuda/Kokkos_Cuda.hpp>
 #include <cuda_runtime_api.h>
 #include <Cuda/Kokkos_Cuda_Error.hpp>
+#include <Cuda/Kokkos_Cuda_Instance.hpp>
 
 namespace Kokkos {
 namespace Impl {
@@ -55,8 +56,11 @@ struct GraphImpl<Kokkos::Cuda> {
     constexpr size_t error_log_size = 256;
     cudaGraphNode_t error_node      = nullptr;
     char error_log[error_log_size];
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGraphInstantiate(
-        &m_graph_exec, m_graph, &error_node, error_log, error_log_size));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (m_execution_space.impl_internal_space_instance()
+             ->cuda_graph_instantiate_wrapper(&m_graph_exec, m_graph,
+                                              &error_node, error_log,
+                                              error_log_size)));
     // TODO @graphs print out errors
   }
 
@@ -83,24 +87,31 @@ struct GraphImpl<Kokkos::Cuda> {
     m_execution_space.fence("Kokkos::GraphImpl::~GraphImpl: Graph Destruction");
     KOKKOS_EXPECTS(bool(m_graph))
     if (bool(m_graph_exec)) {
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGraphExecDestroy(m_graph_exec));
+      KOKKOS_IMPL_CUDA_SAFE_CALL(
+          (m_execution_space.impl_internal_space_instance()
+               ->cuda_graph_exec_destroy_wrapper(m_graph_exec)));
     }
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGraphDestroy(m_graph));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (m_execution_space.impl_internal_space_instance()
+             ->cuda_graph_destroy_wrapper(m_graph)));
   };
 
   explicit GraphImpl(Kokkos::Cuda arg_instance)
       : m_execution_space(std::move(arg_instance)) {
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaGraphCreate(&m_graph, cuda_graph_flags_t{0}));
+        (m_execution_space.impl_internal_space_instance()
+             ->cuda_graph_create_wrapper(&m_graph, cuda_graph_flags_t{0})));
   }
 
   void add_node(std::shared_ptr<aggregate_node_impl_t> const& arg_node_ptr) {
     // All of the predecessors are just added as normal, so all we need to
     // do here is add an empty node
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaGraphAddEmptyNode(&(arg_node_ptr->node_details_t::node), m_graph,
-                              /* dependencies = */ nullptr,
-                              /* numDependencies = */ 0));
+        (m_execution_space.impl_internal_space_instance()
+             ->cuda_graph_add_empty_node_wrapper(
+                 &(arg_node_ptr->node_details_t::node), m_graph,
+                 /* dependencies = */ nullptr,
+                 /* numDependencies = */ 0)));
   }
 
   template <class NodeImpl>
@@ -146,7 +157,9 @@ struct GraphImpl<Kokkos::Cuda> {
     KOKKOS_EXPECTS(bool(cuda_node))
 
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaGraphAddDependencies(m_graph, &pred_cuda_node, &cuda_node, 1));
+        (m_execution_space.impl_internal_space_instance()
+             ->cuda_graph_add_dependencies_wrapper(m_graph, &pred_cuda_node,
+                                                   &cuda_node, 1)));
   }
 
   void submit() {
@@ -154,7 +167,9 @@ struct GraphImpl<Kokkos::Cuda> {
       _instantiate_graph();
     }
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaGraphLaunch(m_graph_exec, m_execution_space.cuda_stream()));
+        (m_execution_space.impl_internal_space_instance()
+             ->cuda_graph_launch_wrapper(m_graph_exec,
+                                         m_execution_space.cuda_stream())));
   }
 
   execution_space const& get_execution_space() const noexcept {
@@ -167,9 +182,11 @@ struct GraphImpl<Kokkos::Cuda> {
     auto rv = std::make_shared<root_node_impl_t>(
         get_execution_space(), _graph_node_is_root_ctor_tag{});
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaGraphAddEmptyNode(&(rv->node_details_t::node), m_graph,
-                              /* dependencies = */ nullptr,
-                              /* numDependencies = */ 0));
+        (m_execution_space.impl_internal_space_instance()
+             ->cuda_graph_add_empty_node_wrapper(&(rv->node_details_t::node),
+                                                 m_graph,
+                                                 /* dependencies = */ nullptr,
+                                                 /* numDependencies = */ 0)));
     KOKKOS_ENSURES(bool(rv->node_details_t::node))
     return rv;
   }

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -21,6 +21,7 @@
 #include <impl/Kokkos_Tools.hpp>
 #include <atomic>
 #include <Cuda/Kokkos_Cuda_Error.hpp>
+#include <cuda_runtime_api.h>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -193,6 +193,326 @@ class CudaInternal {
     }
   }
 
+  // Using cudaAPI function/objects will be w.r.t. device 0 unless
+  // cudaSetDevice(device_id) is called with the correct device_id.
+  // The correct device_id is stored in the static variable
+  // CudaInternal::m_cudaDev set in Cuda::impl_initialize(). It is not
+  // sufficient to call cudaSetDevice(m_cudaDev) during cuda initialization
+  // only, however, since if a user creates a new thread, that thread will be
+  // given the default cuda env with device_id=0, causing errors when
+  // device_id!=0 is requested by the user. To ensure against this, almost all
+  // cudaAPI calls, as well as using cudaStream_t variables, must be proceeded
+  // by cudaSetDevice(device_id).
+
+  // This function sets device in cudaAPI to device requested at runtime (set in
+  // m_cudaDev).
+  void set_cuda_device() const {
+    verify_is_initialized("set_cuda_device");
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(m_cudaDev));
+  }
+
+  // The following are wrappers for cudaAPI functions (C and C++ routines) which
+  // set the correct device id directly before the cudaAPI call (unless
+  // explicitly disabled by providing setCudaDevice=false template).
+  // setCudaDevice=true should be used for all calls which take a stream unless
+  // it is guarenteed to be from a cuda instance with the correct device set
+  // already (e.g., back-to-back cudaAPI calls in a single function). All
+  // cudaAPI calls should be wrapped in these interface functions to ensure
+  // safety when using threads.
+
+  // C API routines
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_device_get_limit_wrapper(size_t* pValue,
+                                            cudaLimit limit) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaDeviceGetLimit(pValue, limit);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_device_set_limit_wrapper(cudaLimit limit,
+                                            size_t value) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaDeviceSetLimit(limit, value);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_device_synchronize_wrapper() const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaDeviceSynchronize();
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_event_create_wrapper(cudaEvent_t* event) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaEventCreate(event);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_event_destroy_wrapper(cudaEvent_t event) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaEventDestroy(event);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_event_record_wrapper(cudaEvent_t event,
+                                        cudaStream_t stream = 0) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaEventRecord(event, stream);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_event_synchronize_wrapper(cudaEvent_t event) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaEventSynchronize(event);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_free_wrapper(void* devPtr) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaFree(devPtr);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_free_async_wrapper(void* devPtr,
+                                      cudaStream_t hStream) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaFreeAsync(devPtr, hStream);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_free_host_wrapper(void* ptr) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaFreeHost(ptr);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_get_device_count_wrapper(int* count) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaGetDeviceCount(count);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_get_device_properties_wrapper(cudaDeviceProp* prop,
+                                                 int device) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaGetDeviceProperties(prop, device);
+  }
+
+  template <bool setCudaDevice = true>
+  const char* cuda_get_error_name_wrapper(cudaError_t error) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaGetErrorName(error);
+  }
+
+  template <bool setCudaDevice = true>
+  const char* cuda_get_error_string_wrapper(cudaError_t error) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaGetErrorString(error);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_get_last_error_wrapper() const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaGetLastError();
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_graph_add_dependencies_wrapper(
+      cudaGraph_t graph, const cudaGraphNode_t* from, const cudaGraphNode_t* to,
+      size_t numDependencies) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaGraphAddDependencies(graph, from, to, numDependencies);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_graph_add_empty_node_wrapper(
+      cudaGraphNode_t* pGraphNode, cudaGraph_t graph,
+      const cudaGraphNode_t* pDependencies, size_t numDependencies) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaGraphAddEmptyNode(pGraphNode, graph, pDependencies,
+                                 numDependencies);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_graph_add_kernel_node_wrapper(
+      cudaGraphNode_t* pGraphNode, cudaGraph_t graph,
+      const cudaGraphNode_t* pDependencies, size_t numDependencies,
+      const cudaKernelNodeParams* pNodeParams) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaGraphAddKernelNode(pGraphNode, graph, pDependencies,
+                                  numDependencies, pNodeParams);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_graph_create_wrapper(cudaGraph_t* pGraph,
+                                        unsigned int flags) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaGraphCreate(pGraph, flags);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_graph_destroy_wrapper(cudaGraph_t graph) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaGraphDestroy(graph);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_graph_exec_destroy_wrapper(cudaGraphExec_t graphExec) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaGraphExecDestroy(graphExec);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_graph_launch_wrapper(cudaGraphExec_t graphExec,
+                                        cudaStream_t stream) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaGraphLaunch(graphExec, stream);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_host_alloc_wrapper(void** pHost, size_t size,
+                                      unsigned int flags) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaHostAlloc(pHost, size, flags);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_malloc_wrapper(void** devPtr, size_t size) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaMalloc(devPtr, size);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_malloc_async_wrapper(void** devPtr, size_t size,
+                                        cudaStream_t hStream) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaMallocAsync(devPtr, size, hStream);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_malloc_host_wrapper(void** ptr, size_t size) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaMallocHost(ptr, size);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_malloc_managed_wrapper(
+      void** devPtr, size_t size,
+      unsigned int flags = cudaMemAttachGlobal) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaMallocManaged(devPtr, size, flags);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_mem_advise_wrapper(const void* devPtr, size_t count,
+                                      cudaMemoryAdvise advice,
+                                      int device) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaMemAdvise(devPtr, count, advice, device);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_mem_prefetch_async_wrapper(const void* devPtr, size_t count,
+                                              int dstDevice,
+                                              cudaStream_t stream = 0) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaMemPrefetchAsync(devPtr, count, dstDevice, stream);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_memcpy_wrapper(void* dst, const void* src, size_t count,
+                                  cudaMemcpyKind kind) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaMemcpy(dst, src, count, kind);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_memcpy_async_wrapper(void* dst, const void* src,
+                                        size_t count, cudaMemcpyKind kind,
+                                        cudaStream_t stream = 0) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaMemcpyAsync(dst, src, count, kind, stream);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_memcpy_to_symbol_async_wrapper(
+      const void* symbol, const void* src, size_t count, size_t offset,
+      cudaMemcpyKind kind, cudaStream_t stream = 0) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaMemcpyToSymbolAsync(symbol, src, count, offset, kind, stream);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_memset_wrapper(void* devPtr, int value, size_t count) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaMemset(devPtr, value, count);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_memset_async_wrapper(void* devPtr, int value, size_t count,
+                                        cudaStream_t stream = 0) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaMemsetAsync(devPtr, value, count, stream);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_pointer_get_attributes_wrapper(
+      cudaPointerAttributes* attributes, const void* ptr) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaPointerGetAttributes(attributes, ptr);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_stream_create_wrapper(cudaStream_t* pStream) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaStreamCreate(pStream);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_stream_destroy_wrapper(cudaStream_t stream) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaStreamDestroy(stream);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_stream_synchronize_wrapper(cudaStream_t stream) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaStreamSynchronize(stream);
+  }
+
+  // C++ API routines
+  template <typename T, bool setCudaDevice = true>
+  cudaError_t cuda_func_get_attributes_wrapper(cudaFuncAttributes* attr,
+                                               T* entry) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaFuncGetAttributes(attr, entry);
+  }
+
+  template <typename T, bool setCudaDevice = true>
+  cudaError_t cuda_func_set_attributes_wrapper(T* entry, cudaFuncAttribute attr,
+                                               int value) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaFuncSetAttributes(entry, attr, value);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_graph_instantiate_wrapper(cudaGraphExec_t* pGraphExec,
+                                             cudaGraph_t graph,
+                                             cudaGraphNode_t* pErrorNode,
+                                             char* pLogBuffer,
+                                             size_t bufferSize) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaGraphInstantiate(pGraphExec, graph, pErrorNode, pLogBuffer,
+                                bufferSize);
+  }
+
+  // Using the m_stream variable can also cause issues when device_id!=0.
+  template <bool setCudaDevice = true>
+  cudaStream_t get_stream() const {
+    if (setCudaDevice) set_cuda_device();
+    return m_stream;
+  }
+
   // Resizing of reduction related scratch spaces
   size_type* scratch_space(const std::size_t size) const;
   size_type* scratch_flags(const std::size_t size) const;
@@ -218,7 +538,9 @@ namespace Impl {
 inline void create_Cuda_instances(std::vector<Cuda>& instances) {
   for (int s = 0; s < int(instances.size()); s++) {
     cudaStream_t stream;
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamCreate(&stream));
+    KOKKOS_IMPL_CUDA_SAFE_CALL((
+        instances[s].impl_internal_space_instance()->cuda_stream_create_wrapper(
+            &stream)));
     instances[s] = Cuda(stream, true);
   }
 }

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -274,13 +274,6 @@ class CudaInternal {
   }
 
   template <bool setCudaDevice = true>
-  cudaError_t cuda_free_async_wrapper(void* devPtr,
-                                      cudaStream_t hStream) const {
-    if (setCudaDevice) set_cuda_device();
-    return cudaFreeAsync(devPtr, hStream);
-  }
-
-  template <bool setCudaDevice = true>
   cudaError_t cuda_free_host_wrapper(void* ptr) const {
     if (setCudaDevice) set_cuda_device();
     return cudaFreeHost(ptr);
@@ -384,13 +377,6 @@ class CudaInternal {
   }
 
   template <bool setCudaDevice = true>
-  cudaError_t cuda_malloc_async_wrapper(void** devPtr, size_t size,
-                                        cudaStream_t hStream) const {
-    if (setCudaDevice) set_cuda_device();
-    return cudaMallocAsync(devPtr, size, hStream);
-  }
-
-  template <bool setCudaDevice = true>
   cudaError_t cuda_malloc_host_wrapper(void** ptr, size_t size) const {
     if (setCudaDevice) set_cuda_device();
     return cudaMallocHost(ptr, size);
@@ -480,6 +466,23 @@ class CudaInternal {
     if (setCudaDevice) set_cuda_device();
     return cudaStreamSynchronize(stream);
   }
+
+  // The following are only available for cuda 11.2 and greater
+#if (defined(KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC) && CUDART_VERSION >= 11020)
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_malloc_async_wrapper(void** devPtr, size_t size,
+                                        cudaStream_t hStream) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaMallocAsync(devPtr, size, hStream);
+  }
+
+  template <bool setCudaDevice = true>
+  cudaError_t cuda_free_async_wrapper(void* devPtr,
+                                      cudaStream_t hStream) const {
+    if (setCudaDevice) set_cuda_device();
+    return cudaFreeAsync(devPtr, hStream);
+  }
+#endif
 
   // C++ API routines
   template <typename T, bool setCudaDevice = true>

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -256,7 +256,7 @@ class CudaInternal {
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_event_record_wrapper(cudaEvent_t event,
-                                        cudaStream_t stream = 0) const {
+                                        cudaStream_t stream = nullptr) const {
     if (setCudaDevice) set_cuda_device();
     return cudaEventRecord(event, stream);
   }
@@ -399,9 +399,9 @@ class CudaInternal {
   }
 
   template <bool setCudaDevice = true>
-  cudaError_t cuda_mem_prefetch_async_wrapper(const void* devPtr, size_t count,
-                                              int dstDevice,
-                                              cudaStream_t stream = 0) const {
+  cudaError_t cuda_mem_prefetch_async_wrapper(
+      const void* devPtr, size_t count, int dstDevice,
+      cudaStream_t stream = nullptr) const {
     if (setCudaDevice) set_cuda_device();
     return cudaMemPrefetchAsync(devPtr, count, dstDevice, stream);
   }
@@ -416,7 +416,7 @@ class CudaInternal {
   template <bool setCudaDevice = true>
   cudaError_t cuda_memcpy_async_wrapper(void* dst, const void* src,
                                         size_t count, cudaMemcpyKind kind,
-                                        cudaStream_t stream = 0) const {
+                                        cudaStream_t stream = nullptr) const {
     if (setCudaDevice) set_cuda_device();
     return cudaMemcpyAsync(dst, src, count, kind, stream);
   }
@@ -424,7 +424,7 @@ class CudaInternal {
   template <bool setCudaDevice = true>
   cudaError_t cuda_memcpy_to_symbol_async_wrapper(
       const void* symbol, const void* src, size_t count, size_t offset,
-      cudaMemcpyKind kind, cudaStream_t stream = 0) const {
+      cudaMemcpyKind kind, cudaStream_t stream = nullptr) const {
     if (setCudaDevice) set_cuda_device();
     return cudaMemcpyToSymbolAsync(symbol, src, count, offset, kind, stream);
   }
@@ -437,7 +437,7 @@ class CudaInternal {
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_memset_async_wrapper(void* devPtr, int value, size_t count,
-                                        cudaStream_t stream = 0) const {
+                                        cudaStream_t stream = nullptr) const {
     if (setCudaDevice) set_cuda_device();
     return cudaMemsetAsync(devPtr, value, count, stream);
   }

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -215,7 +215,7 @@ class CudaInternal {
   // Return the class stream, optionally setting the device id.
   template <bool setCudaDevice = true>
   cudaStream_t get_stream() const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return m_stream;
   }
 
@@ -239,88 +239,88 @@ class CudaInternal {
   template <bool setCudaDevice = true>
   cudaError_t cuda_device_get_limit_wrapper(size_t* pValue,
                                             cudaLimit limit) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaDeviceGetLimit(pValue, limit);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_device_set_limit_wrapper(cudaLimit limit,
                                             size_t value) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaDeviceSetLimit(limit, value);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_device_synchronize_wrapper() const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaDeviceSynchronize();
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_event_create_wrapper(cudaEvent_t* event) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaEventCreate(event);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_event_destroy_wrapper(cudaEvent_t event) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaEventDestroy(event);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_event_record_wrapper(cudaEvent_t event,
                                         cudaStream_t stream = nullptr) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaEventRecord(event, get_input_stream(stream));
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_event_synchronize_wrapper(cudaEvent_t event) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaEventSynchronize(event);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_free_wrapper(void* devPtr) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaFree(devPtr);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_free_host_wrapper(void* ptr) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaFreeHost(ptr);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_get_device_count_wrapper(int* count) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaGetDeviceCount(count);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_get_device_properties_wrapper(cudaDeviceProp* prop,
                                                  int device) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaGetDeviceProperties(prop, device);
   }
 
   template <bool setCudaDevice = true>
   const char* cuda_get_error_name_wrapper(cudaError_t error) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaGetErrorName(error);
   }
 
   template <bool setCudaDevice = true>
   const char* cuda_get_error_string_wrapper(cudaError_t error) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaGetErrorString(error);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_get_last_error_wrapper() const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaGetLastError();
   }
 
@@ -328,7 +328,7 @@ class CudaInternal {
   cudaError_t cuda_graph_add_dependencies_wrapper(
       cudaGraph_t graph, const cudaGraphNode_t* from, const cudaGraphNode_t* to,
       size_t numDependencies) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaGraphAddDependencies(graph, from, to, numDependencies);
   }
 
@@ -336,7 +336,7 @@ class CudaInternal {
   cudaError_t cuda_graph_add_empty_node_wrapper(
       cudaGraphNode_t* pGraphNode, cudaGraph_t graph,
       const cudaGraphNode_t* pDependencies, size_t numDependencies) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaGraphAddEmptyNode(pGraphNode, graph, pDependencies,
                                  numDependencies);
   }
@@ -346,7 +346,7 @@ class CudaInternal {
       cudaGraphNode_t* pGraphNode, cudaGraph_t graph,
       const cudaGraphNode_t* pDependencies, size_t numDependencies,
       const cudaKernelNodeParams* pNodeParams) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaGraphAddKernelNode(pGraphNode, graph, pDependencies,
                                   numDependencies, pNodeParams);
   }
@@ -354,45 +354,45 @@ class CudaInternal {
   template <bool setCudaDevice = true>
   cudaError_t cuda_graph_create_wrapper(cudaGraph_t* pGraph,
                                         unsigned int flags) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaGraphCreate(pGraph, flags);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_graph_destroy_wrapper(cudaGraph_t graph) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaGraphDestroy(graph);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_graph_exec_destroy_wrapper(cudaGraphExec_t graphExec) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaGraphExecDestroy(graphExec);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_graph_launch_wrapper(cudaGraphExec_t graphExec,
                                         cudaStream_t stream = nullptr) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaGraphLaunch(graphExec, get_input_stream(stream));
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_host_alloc_wrapper(void** pHost, size_t size,
                                       unsigned int flags) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaHostAlloc(pHost, size, flags);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_malloc_wrapper(void** devPtr, size_t size) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaMalloc(devPtr, size);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_malloc_host_wrapper(void** ptr, size_t size) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaMallocHost(ptr, size);
   }
 
@@ -400,7 +400,7 @@ class CudaInternal {
   cudaError_t cuda_malloc_managed_wrapper(
       void** devPtr, size_t size,
       unsigned int flags = cudaMemAttachGlobal) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaMallocManaged(devPtr, size, flags);
   }
 
@@ -408,7 +408,7 @@ class CudaInternal {
   cudaError_t cuda_mem_advise_wrapper(const void* devPtr, size_t count,
                                       cudaMemoryAdvise advice,
                                       int device) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaMemAdvise(devPtr, count, advice, device);
   }
 
@@ -416,7 +416,7 @@ class CudaInternal {
   cudaError_t cuda_mem_prefetch_async_wrapper(
       const void* devPtr, size_t count, int dstDevice,
       cudaStream_t stream = nullptr) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaMemPrefetchAsync(devPtr, count, dstDevice,
                                 get_input_stream(stream));
   }
@@ -424,7 +424,7 @@ class CudaInternal {
   template <bool setCudaDevice = true>
   cudaError_t cuda_memcpy_wrapper(void* dst, const void* src, size_t count,
                                   cudaMemcpyKind kind) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaMemcpy(dst, src, count, kind);
   }
 
@@ -432,7 +432,7 @@ class CudaInternal {
   cudaError_t cuda_memcpy_async_wrapper(void* dst, const void* src,
                                         size_t count, cudaMemcpyKind kind,
                                         cudaStream_t stream = nullptr) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaMemcpyAsync(dst, src, count, kind, get_input_stream(stream));
   }
 
@@ -440,46 +440,46 @@ class CudaInternal {
   cudaError_t cuda_memcpy_to_symbol_async_wrapper(
       const void* symbol, const void* src, size_t count, size_t offset,
       cudaMemcpyKind kind, cudaStream_t stream = nullptr) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaMemcpyToSymbolAsync(symbol, src, count, offset, kind,
                                    get_input_stream(stream));
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_memset_wrapper(void* devPtr, int value, size_t count) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaMemset(devPtr, value, count);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_memset_async_wrapper(void* devPtr, int value, size_t count,
                                         cudaStream_t stream = nullptr) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaMemsetAsync(devPtr, value, count, get_input_stream(stream));
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_pointer_get_attributes_wrapper(
       cudaPointerAttributes* attributes, const void* ptr) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaPointerGetAttributes(attributes, ptr);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_stream_create_wrapper(cudaStream_t* pStream) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaStreamCreate(pStream);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_stream_destroy_wrapper(cudaStream_t stream) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaStreamDestroy(stream);
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_stream_synchronize_wrapper(cudaStream_t stream) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaStreamSynchronize(stream);
   }
 
@@ -488,14 +488,14 @@ class CudaInternal {
   template <bool setCudaDevice = true>
   cudaError_t cuda_malloc_async_wrapper(void** devPtr, size_t size,
                                         cudaStream_t hStream == nullptr) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaMallocAsync(devPtr, size, get_input_stream(stream));
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_free_async_wrapper(void* devPtr,
                                       cudaStream_t hStream == nullptr) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaFreeAsync(devPtr, get_input_stream(stream));
   }
 #endif
@@ -504,14 +504,14 @@ class CudaInternal {
   template <typename T, bool setCudaDevice = true>
   cudaError_t cuda_func_get_attributes_wrapper(cudaFuncAttributes* attr,
                                                T* entry) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaFuncGetAttributes(attr, entry);
   }
 
   template <typename T, bool setCudaDevice = true>
   cudaError_t cuda_func_set_attributes_wrapper(T* entry, cudaFuncAttribute attr,
                                                int value) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaFuncSetAttributes(entry, attr, value);
   }
 
@@ -521,7 +521,7 @@ class CudaInternal {
                                              cudaGraphNode_t* pErrorNode,
                                              char* pLogBuffer,
                                              size_t bufferSize) const {
-    if (setCudaDevice) set_cuda_device();
+    if constexpr (setCudaDevice) set_cuda_device();
     return cudaGraphInstantiate(pGraphExec, graph, pErrorNode, pLogBuffer,
                                 bufferSize);
   }

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -196,7 +196,7 @@ class CudaInternal {
 
   // Using cudaAPI function/objects will be w.r.t. device 0 unless
   // cudaSetDevice(device_id) is called with the correct device_id.
-  // The correct device_id is stored in the static variable
+  // The correct device_id is stored in the variable
   // CudaInternal::m_cudaDev set in Cuda::impl_initialize(). It is not
   // sufficient to call cudaSetDevice(m_cudaDev) during cuda initialization
   // only, however, since if a user creates a new thread, that thread will be

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -464,8 +464,7 @@ struct CudaParallelLaunchKernelInvoker<
         cuda_instance->scratch_functor(sizeof(DriverType)));
 
     KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_memcpy_async_wrapper(
-        driver_ptr, &driver, sizeof(DriverType), cudaMemcpyDefault,
-        cuda_instance->get_stream())));
+        driver_ptr, &driver, sizeof(DriverType), cudaMemcpyDefault)));
     (base_t::get_kernel_func())<<<grid, block, shmem,
                                   cuda_instance->get_stream()>>>(driver_ptr);
   }
@@ -500,8 +499,7 @@ struct CudaParallelLaunchKernelInvoker<
       // destroyed, where there should be a fence ensuring that the allocation
       // associated with this kernel on the device side isn't deleted.
       KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_memcpy_async_wrapper(
-          driver_ptr, &driver, sizeof(DriverType), cudaMemcpyDefault,
-          cuda_instance->get_stream())));
+          driver_ptr, &driver, sizeof(DriverType), cudaMemcpyDefault)));
 
       void const* args[] = {&driver_ptr};
 
@@ -591,8 +589,7 @@ struct CudaParallelLaunchKernelInvoker<
     KOKKOS_IMPL_CUDA_SAFE_CALL(
         (cuda_instance->cuda_memcpy_to_symbol_async_wrapper(
             kokkos_impl_cuda_constant_memory_buffer, staging,
-            sizeof(DriverType), 0, cudaMemcpyHostToDevice,
-            cudaStream_t(cuda_instance->get_stream()))));
+            sizeof(DriverType), 0, cudaMemcpyHostToDevice)));
 
     // Invoke the driver function on the device
     (base_t::get_kernel_func())<<<grid, block, shmem,
@@ -600,8 +597,7 @@ struct CudaParallelLaunchKernelInvoker<
 
     // Record an event that says when the constant buffer can be reused
     KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_event_record_wrapper(
-        CudaInternal::constantMemReusable,
-        cudaStream_t(cuda_instance->get_stream()))));
+        CudaInternal::constantMemReusable)));
   }
 
   inline static void create_parallel_launch_graph_node(

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -128,7 +128,7 @@ inline void check_shmem_request(CudaInternal const* cuda_instance, int shmem) {
 // These functions need to be templated on DriverType and LaunchBounds
 // so that the static bool is unique for each type combo
 // KernelFuncPtr does not necessarily contain that type information.
-
+// FIXME_CUDA_MULTIPLE_DEVICES
 template <class DriverType, class LaunchBounds, class KernelFuncPtr>
 const cudaFuncAttributes& get_cuda_kernel_func_attributes(
     const KernelFuncPtr& func) {
@@ -136,7 +136,9 @@ const cudaFuncAttributes& get_cuda_kernel_func_attributes(
   // by leveraging static variable initialization rules
   auto wrap_get_attributes = [&]() -> cudaFuncAttributes {
     cudaFuncAttributes attr;
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFuncGetAttributes(&attr, func));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (CudaInternal::singleton().cuda_func_get_attributes_wrapper(&attr,
+                                                                    func)));
     return attr;
   };
   static cudaFuncAttributes func_attr = wrap_get_attributes();
@@ -217,9 +219,11 @@ inline void configure_shmem_preference(const KernelFuncPtr& func,
   if (carveout > 100) carveout = 100;
 
   // Set the carveout, but only call it once per kernel or when it changes
+  // FIXME_CUDA_MULTIPLE_DEVICES
   auto set_cache_config = [&] {
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFuncSetAttribute(
-        func, cudaFuncAttributePreferredSharedMemoryCarveout, carveout));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (CudaInternal::singleton().cuda_func_set_attributes_wrapper(
+            func, cudaFuncAttributePreferredSharedMemoryCarveout, carveout)));
     return carveout;
   };
   // Store the value in a static variable so we only reset if needed
@@ -361,9 +365,8 @@ struct CudaParallelLaunchKernelInvoker<
   static void invoke_kernel(DriverType const& driver, dim3 const& grid,
                             dim3 const& block, int shmem,
                             CudaInternal const* cuda_instance) {
-    (base_t::
-         get_kernel_func())<<<grid, block, shmem, cuda_instance->m_stream>>>(
-        driver);
+    (base_t::get_kernel_func())<<<grid, block, shmem,
+                                  cuda_instance->get_stream()>>>(driver);
   }
 
   inline static void create_parallel_launch_graph_node(
@@ -399,15 +402,17 @@ struct CudaParallelLaunchKernelInvoker<
       params.kernelParams   = (void**)args;
       params.extra          = nullptr;
 
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGraphAddKernelNode(
-          &graph_node, graph, /* dependencies = */ nullptr,
-          /* numDependencies = */ 0, &params));
+      KOKKOS_IMPL_CUDA_SAFE_CALL(
+          (cuda_instance->cuda_graph_add_kernel_node_wrapper(
+              &graph_node, graph, /* dependencies = */ nullptr,
+              /* numDependencies = */ 0, &params)));
     } else {
       // We still need an empty node for the dependency structure
       KOKKOS_IMPL_CUDA_SAFE_CALL(
-          cudaGraphAddEmptyNode(&graph_node, graph,
-                                /* dependencies = */ nullptr,
-                                /* numDependencies = */ 0));
+          (cuda_instance->cuda_graph_add_empty_node_wrapper(
+              &graph_node, graph,
+              /* dependencies = */ nullptr,
+              /* numDependencies = */ 0)));
     }
     KOKKOS_ENSURES(bool(graph_node))
   }
@@ -458,11 +463,11 @@ struct CudaParallelLaunchKernelInvoker<
     DriverType* driver_ptr = reinterpret_cast<DriverType*>(
         cuda_instance->scratch_functor(sizeof(DriverType)));
 
-    cudaMemcpyAsync(driver_ptr, &driver, sizeof(DriverType), cudaMemcpyDefault,
-                    cuda_instance->m_stream);
-    (base_t::
-         get_kernel_func())<<<grid, block, shmem, cuda_instance->m_stream>>>(
-        driver_ptr);
+    KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_memcpy_async_wrapper(
+        driver_ptr, &driver, sizeof(DriverType), cudaMemcpyDefault,
+        cuda_instance->get_stream())));
+    (base_t::get_kernel_func())<<<grid, block, shmem,
+                                  cuda_instance->get_stream()>>>(driver_ptr);
   }
 
   inline static void create_parallel_launch_graph_node(
@@ -494,8 +499,9 @@ struct CudaParallelLaunchKernelInvoker<
       // which is guaranteed to be alive until the graph instance itself is
       // destroyed, where there should be a fence ensuring that the allocation
       // associated with this kernel on the device side isn't deleted.
-      cudaMemcpyAsync(driver_ptr, &driver, sizeof(DriverType),
-                      cudaMemcpyDefault, cuda_instance->m_stream);
+      KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_memcpy_async_wrapper(
+          driver_ptr, &driver, sizeof(DriverType), cudaMemcpyDefault,
+          cuda_instance->get_stream())));
 
       void const* args[] = {&driver_ptr};
 
@@ -508,15 +514,17 @@ struct CudaParallelLaunchKernelInvoker<
       params.kernelParams   = (void**)args;
       params.extra          = nullptr;
 
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGraphAddKernelNode(
-          &graph_node, graph, /* dependencies = */ nullptr,
-          /* numDependencies = */ 0, &params));
+      KOKKOS_IMPL_CUDA_SAFE_CALL(
+          (cuda_instance->cuda_graph_add_kernel_node_wrapper(
+              &graph_node, graph, /* dependencies = */ nullptr,
+              /* numDependencies = */ 0, &params)));
     } else {
       // We still need an empty node for the dependency structure
       KOKKOS_IMPL_CUDA_SAFE_CALL(
-          cudaGraphAddEmptyNode(&graph_node, graph,
-                                /* dependencies = */ nullptr,
-                                /* numDependencies = */ 0));
+          (cuda_instance->cuda_graph_add_empty_node_wrapper(
+              &graph_node, graph,
+              /* dependencies = */ nullptr,
+              /* numDependencies = */ 0)));
     }
     KOKKOS_ENSURES(bool(graph_node))
   }
@@ -572,26 +580,28 @@ struct CudaParallelLaunchKernelInvoker<
                             CudaInternal const* cuda_instance) {
     // Wait until the previous kernel that uses the constant buffer is done
     std::lock_guard<std::mutex> lock(CudaInternal::constantMemMutex);
-    KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaEventSynchronize(CudaInternal::constantMemReusable));
+    KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_event_synchronize_wrapper(
+        CudaInternal::constantMemReusable)));
 
     // Copy functor (synchronously) to staging buffer in pinned host memory
     unsigned long* staging = cuda_instance->constantMemHostStaging;
     memcpy(staging, &driver, sizeof(DriverType));
 
     // Copy functor asynchronously from there to constant memory on the device
-    cudaMemcpyToSymbolAsync(kokkos_impl_cuda_constant_memory_buffer, staging,
-                            sizeof(DriverType), 0, cudaMemcpyHostToDevice,
-                            cudaStream_t(cuda_instance->m_stream));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (cuda_instance->cuda_memcpy_to_symbol_async_wrapper(
+            kokkos_impl_cuda_constant_memory_buffer, staging,
+            sizeof(DriverType), 0, cudaMemcpyHostToDevice,
+            cudaStream_t(cuda_instance->get_stream()))));
 
     // Invoke the driver function on the device
-    (base_t::
-         get_kernel_func())<<<grid, block, shmem, cuda_instance->m_stream>>>();
+    (base_t::get_kernel_func())<<<grid, block, shmem,
+                                  cuda_instance->get_stream()>>>();
 
     // Record an event that says when the constant buffer can be reused
-    KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaEventRecord(CudaInternal::constantMemReusable,
-                        cudaStream_t(cuda_instance->m_stream)));
+    KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_event_record_wrapper(
+        CudaInternal::constantMemReusable,
+        cudaStream_t(cuda_instance->get_stream()))));
   }
 
   inline static void create_parallel_launch_graph_node(
@@ -669,7 +679,8 @@ struct CudaParallelLaunchImpl<
       base_t::invoke_kernel(driver, grid, block, shmem, cuda_instance);
 
 #if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetLastError());
+      KOKKOS_IMPL_CUDA_SAFE_CALL(
+          (cuda_instance->cuda_get_last_error_wrapper()));
       cuda_instance->fence(
           "Kokkos::Impl::launch_kernel: Debug Only Check for Execution Error");
 #endif

--- a/core/src/Cuda/Kokkos_Cuda_Task.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Task.hpp
@@ -222,6 +222,7 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::Cuda, QueueType>> {
     }
   }
 
+  // FIXME_CUDA_MULTIPLE_DEVICES
   static void execute(scheduler_type const& scheduler) {
     const int shared_per_warp = 2048;
     const dim3 grid(Kokkos::Impl::cuda_internal_multiprocessor_count(), 1, 1);
@@ -245,7 +246,8 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::Cuda, QueueType>> {
 
     size_t previous_stack_size = 0;
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaDeviceGetLimit(&previous_stack_size, cudaLimitStackSize));
+        (CudaInternal::singleton().cuda_device_get_limit_wrapper(
+            &previous_stack_size, cudaLimitStackSize)));
 
     // If not large enough then set the stack size, in bytes:
 
@@ -253,13 +255,15 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::Cuda, QueueType>> {
 
     if (previous_stack_size < larger_stack_size) {
       KOKKOS_IMPL_CUDA_SAFE_CALL(
-          cudaDeviceSetLimit(cudaLimitStackSize, larger_stack_size));
+          (CudaInternal::singleton().cuda_device_set_limit_wrapper(
+              cudaLimitStackSize, larger_stack_size)));
     }
 
     cuda_task_queue_execute<<<grid, block, shared_total, stream>>>(
         scheduler, shared_per_warp);
 
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetLastError());
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (CudaInternal::singleton().cuda_get_last_error_wrapper()));
 
     Impl::cuda_device_synchronize(
         "Kokkos::Impl::TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::"
@@ -267,7 +271,8 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::Cuda, QueueType>> {
 
     if (previous_stack_size < larger_stack_size) {
       KOKKOS_IMPL_CUDA_SAFE_CALL(
-          cudaDeviceSetLimit(cudaLimitStackSize, previous_stack_size));
+          (CudaInternal::singleton().cuda_device_set_limit_wrapper(
+              cudaLimitStackSize, previous_stack_size)));
     }
   }
 
@@ -295,7 +300,8 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::Cuda, QueueType>> {
     set_cuda_task_base_apply_function_pointer<TaskType>
         <<<1, 1>>>(ptr_ptr, dtor_ptr);
 
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetLastError());
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (CudaInternal::singleton().cuda_get_last_error_wrapper()));
     Impl::cuda_device_synchronize(
         "Kokkos::Impl::TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::"
         "Cuda>::execute: Post Get Function Pointer for Tasks");
@@ -456,6 +462,7 @@ class TaskQueueSpecializationConstrained<
     } while (1);
   }
 
+  // FIXME_CUDA_MULTIPLE_DEVICES
   static void execute(scheduler_type const& scheduler) {
     const int shared_per_warp = 2048;
     const int warps_per_block = 4;
@@ -476,7 +483,8 @@ class TaskQueueSpecializationConstrained<
 
     size_t previous_stack_size = 0;
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaDeviceGetLimit(&previous_stack_size, cudaLimitStackSize));
+        (CudaInternal::singleton().cuda_device_get_limit_wrapper(
+            &previous_stack_size, cudaLimitStackSize)));
 
     // If not large enough then set the stack size, in bytes:
 
@@ -484,13 +492,15 @@ class TaskQueueSpecializationConstrained<
 
     if (previous_stack_size < larger_stack_size) {
       KOKKOS_IMPL_CUDA_SAFE_CALL(
-          cudaDeviceSetLimit(cudaLimitStackSize, larger_stack_size));
+          (CudaInternal::singleton().cuda_device_set_limit_wrapper(
+              cudaLimitStackSize, larger_stack_size)));
     }
 
     cuda_task_queue_execute<<<grid, block, shared_total, stream>>>(
         scheduler, shared_per_warp);
 
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetLastError());
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (CudaInternal::singleton().cuda_get_last_error_wrapper()));
 
     Impl::cuda_device_synchronize(
         "Kokkos::Impl::TaskQueueSpecializationConstrained<SimpleTaskScheduler<"
@@ -498,7 +508,8 @@ class TaskQueueSpecializationConstrained<
 
     if (previous_stack_size < larger_stack_size) {
       KOKKOS_IMPL_CUDA_SAFE_CALL(
-          cudaDeviceSetLimit(cudaLimitStackSize, previous_stack_size));
+          (CudaInternal::singleton().cuda_device_set_limit_wrapper(
+              cudaLimitStackSize, previous_stack_size)));
     }
   }
 
@@ -521,7 +532,8 @@ class TaskQueueSpecializationConstrained<
     set_cuda_task_base_apply_function_pointer<TaskType>
         <<<1, 1>>>(ptr_ptr, dtor_ptr);
 
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetLastError());
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (CudaInternal::singleton().cuda_get_last_error_wrapper()));
     Impl::cuda_device_synchronize(
         "Kokkos::Impl::TaskQueueSpecializationConstrained<SimpleTaskScheduler<"
         "Kokkos::Cuda>::get_function_pointer: Post Get Function Pointer");

--- a/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
@@ -27,16 +27,21 @@ template <class T, class... P>
 struct ZeroMemset<Kokkos::Cuda, View<T, P...>> {
   ZeroMemset(const Kokkos::Cuda& exec_space_instance, const View<T, P...>& dst,
              typename View<T, P...>::const_value_type&) {
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemsetAsync(
-        dst.data(), 0, dst.size() * sizeof(typename View<T, P...>::value_type),
-        exec_space_instance.cuda_stream()));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (exec_space_instance.impl_internal_space_instance()
+             ->cuda_memset_async_wrapper(
+                 dst.data(), 0,
+                 dst.size() * sizeof(typename View<T, P...>::value_type),
+                 exec_space_instance.cuda_stream())));
   }
 
   ZeroMemset(const View<T, P...>& dst,
              typename View<T, P...>::const_value_type&) {
+    // FIXME_CUDA_MULTIPLE_DEVICES
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaMemset(dst.data(), 0,
-                   dst.size() * sizeof(typename View<T, P...>::value_type)));
+        (Kokkos::Impl::CudaInternal::singleton().cuda_memset_wrapper(
+            dst.data(), 0,
+            dst.size() * sizeof(typename View<T, P...>::value_type))));
   }
 };
 

--- a/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
@@ -31,8 +31,7 @@ struct ZeroMemset<Kokkos::Cuda, View<T, P...>> {
         (exec_space_instance.impl_internal_space_instance()
              ->cuda_memset_async_wrapper(
                  dst.data(), 0,
-                 dst.size() * sizeof(typename View<T, P...>::value_type),
-                 exec_space_instance.cuda_stream())));
+                 dst.size() * sizeof(typename View<T, P...>::value_type))));
   }
 
   ZeroMemset(const View<T, P...>& dst,


### PR DESCRIPTION
An alternative to https://github.com/kokkos/kokkos/pull/5989. Here I use individual wrappers for each cudaAPI call.

Benefits
- Much easier to read where wrapper is called (vs. function ptrs)
- Reading runtime errors give location of call with name matching cudaAPI function name (difference only in case)
- Less code where function is called (vs. function ptrs where type casts are required)

Negative
- Much more code in `Kokkos_Cuda_Instance.hpp` where wrappers are defined

Notes
- I did not use the wrappers in the unit tests
- A separate impl file could be added for the wrappers to make `CudaInternal` class much more readable (at the cost of more code lines)

Ping @crtrott.