### PR TITLE
 SYCL: Use sycl::bit_cast from oneAPI 2024.0.0 on 

### DIFF
--- a/core/src/Kokkos_BitManipulation.hpp
+++ b/core/src/Kokkos_BitManipulation.hpp
@@ -100,12 +100,9 @@ inline constexpr bool is_standard_unsigned_integer_type_v =
 namespace Kokkos {
 
 //<editor-fold desc="[bit.cast], bit_cast">
-#ifdef KOKKOS_ENABLE_SYCL
-#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20240000
-using sycl::bit_cast;
-#else
+#if defined(KOKKOS_ENABLE_SYCL) && defined(__INTEL_LLVM_COMPILER) && \
+    __INTEL_LLVM_COMPILER < 20240000
 using sycl::detail::bit_cast;
-#endif
 #else
 template <class To, class From>
 KOKKOS_FUNCTION std::enable_if_t<sizeof(To) == sizeof(From) &&
@@ -113,9 +110,14 @@ KOKKOS_FUNCTION std::enable_if_t<sizeof(To) == sizeof(From) &&
                                      std::is_trivially_copyable_v<From>,
                                  To>
 bit_cast(From const& from) noexcept {
+#if defined(KOKKOS_ENABLE_SYCL) && defined(__INTEL_LLVM_COMPILER) && \
+    __INTEL_LLVM_COMPILER >= 20240000
+  return sycl::bit_cast<To>(from);
+#else
   To to;
   memcpy(&to, &from, sizeof(To));
   return to;
+#endif
 }
 #endif
 //</editor-fold>

--- a/core/src/Kokkos_BitManipulation.hpp
+++ b/core/src/Kokkos_BitManipulation.hpp
@@ -100,10 +100,12 @@ inline constexpr bool is_standard_unsigned_integer_type_v =
 namespace Kokkos {
 
 //<editor-fold desc="[bit.cast], bit_cast">
-// FIXME_SYCL intel/llvm has unqualified calls to bit_cast which are ambiguous
-// if we declare our own bit_cast function
 #ifdef KOKKOS_ENABLE_SYCL
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20240000
+using sycl::bit_cast;
+#else
 using sycl::detail::bit_cast;
+#endif
 #else
 template <class To, class From>
 KOKKOS_FUNCTION std::enable_if_t<sizeof(To) == sizeof(From) &&

--- a/core/unit_test/TestBitManipulation.cpp
+++ b/core/unit_test/TestBitManipulation.cpp
@@ -500,8 +500,8 @@ constexpr X test_bit_cast(...) {
   return {};
 }
 
-// FIXME_SYCL The SYCL implementation is unconstrained
-#ifndef KOKKOS_ENABLE_SYCL
+#if !defined(KOKKOS_ENABLE_SYCL) || \
+    (defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20240000)
 namespace TypesNotTheSameSize {
 struct To {
   char a;


### PR DESCRIPTION
Follow-up to #6121 and #6137. 
https://github.com/intel/llvm/pull/10215 removes `sycl::detail::biit_cast` which we needed before https://github.com/intel/llvm/pull/9398 to fix ambiguities between `Kokkos::bit_cast` and `sycl::bit_cast` due to some unconstrained calls. This latter pull request will be included in the `oneAPI 2024.0.0` release.
After https://github.com/intel/llvm/pull/9398, we can also enable all the `Kokos::bit_cast` tests for `SYCL` since that pull request also constrained `sycl::bit_cast` properly.
An alternative to importing `sycl::bit_cast` into the `Kokkos` namespace would be to call it inside `Kokkos::bit_cast` of course but it's not obvious to me that this would be better and this way it's (slightly) easier to support multiple `oneAPI` versions. 