### PR TITLE
#5635: Threads: Add Overloads for parallel_scan with return value for TeamThreadRange

### DIFF
--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -985,7 +985,7 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
   using closure_value_type = typename Kokkos::Impl::FunctorAnalysis<
       Kokkos::Impl::FunctorPatternInterface::SCAN, void, FunctorType,
       void>::value_type;
-  static_assert(std::is_same<closure_value_type, ValueType>::value,
+  static_assert(std::is_same_v<closure_value_type, ValueType>,
                 "Non-matching value types of closure and return type");
 
   auto scan_val = ValueType{};

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -976,16 +976,19 @@ parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
  * lambda(iType i, ValueType & val, bool final) for each i=0..N-1.
  *
  */
-template <typename iType, class FunctorType>
+template <typename iType, class FunctorType, typename ValueType>
 KOKKOS_INLINE_FUNCTION void parallel_scan(
     const Impl::TeamThreadRangeBoundariesStruct<
         iType, Impl::ThreadsExecTeamMember>& loop_bounds,
-    const FunctorType& lambda) {
-  using value_type = typename Kokkos::Impl::FunctorAnalysis<
+    const FunctorType& lambda, ValueType& return_val) {
+  // Extract ValueType from the Closure
+  using closure_value_type = typename Kokkos::Impl::FunctorAnalysis<
       Kokkos::Impl::FunctorPatternInterface::SCAN, void, FunctorType,
       void>::value_type;
+  static_assert(std::is_same<closure_value_type, ValueType>::value,
+                "Non-matching value types of closure and return type");
 
-  auto scan_val = value_type{};
+  auto scan_val = ValueType{};
 
   // Intra-member scan
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
@@ -1006,6 +1009,21 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
        i += loop_bounds.increment) {
     lambda(i, scan_val, true);
   }
+
+  return_val = scan_val;
+}
+
+template <typename iType, class FunctorType>
+KOKKOS_INLINE_FUNCTION void parallel_scan(
+    const Impl::TeamThreadRangeBoundariesStruct<
+        iType, Impl::ThreadsExecTeamMember>& loop_bounds,
+    const FunctorType& lambda) {
+  using value_type = typename Kokkos::Impl::FunctorAnalysis<
+      Kokkos::Impl::FunctorPatternInterface::SCAN, void, FunctorType,
+      void>::value_type;
+
+  value_type scan_val;
+  parallel_scan(loop_bounds, lambda, scan_val);
 }
 
 /** \brief  Intra-thread vector parallel exclusive prefix sum. Executes

--- a/core/unit_test/TestTeamScan.hpp
+++ b/core/unit_test/TestTeamScan.hpp
@@ -185,16 +185,9 @@ struct TestTeamScanRetVal {
     a_r = view_2d_type("a_r", M, N);
     a_s = view_1d_type("a_s", M);
 
-    // Set team size explicitly to check whether non-power-of-two team sizes can
-    // be used.
-    if (ExecutionSpace().concurrency() > 10000)
-      Kokkos::parallel_for(policy_type(M, 127), *this);
-    else if (ExecutionSpace().concurrency() > 2)
-      Kokkos::parallel_for(policy_type(M, 3), *this);
-    else
-      Kokkos::parallel_for(policy_type(M, 1), *this);
-    Kokkos::fence();
+    Kokkos::parallel_for(policy_type(M, Kokkos::AUTO), *this);
 
+    Kokkos::fence();
     auto a_i  = Kokkos::create_mirror_view(a_d);
     auto a_o  = Kokkos::create_mirror_view(a_r);
     auto a_os = Kokkos::create_mirror_view(a_s);

--- a/core/unit_test/TestTeamScan.hpp
+++ b/core/unit_test/TestTeamScan.hpp
@@ -132,7 +132,7 @@ TEST(TEST_CATEGORY, team_scan) {
 
 // Temporary: This condition will progressively be reduced when parallel_scan
 // with return value will be implemented for more backends.
-#if !defined(KOKKOS_ENABLE_OPENACC) && !defined(KOKKOS_ENABLE_SYCL) &&         \
+#if !defined(KOKKOS_ENABLE_OPENACC) && !defined(KOKKOS_ENABLE_SYCL) && \
     !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(KOKKOS_ENABLE_HPX)
 template <class ExecutionSpace, class DataType>
 struct TestTeamScanRetVal {

--- a/core/unit_test/TestTeamScan.hpp
+++ b/core/unit_test/TestTeamScan.hpp
@@ -133,8 +133,7 @@ TEST(TEST_CATEGORY, team_scan) {
 // Temporary: This condition will progressively be reduced when parallel_scan
 // with return value will be implemented for more backends.
 #if !defined(KOKKOS_ENABLE_OPENACC) && !defined(KOKKOS_ENABLE_SYCL) &&         \
-    !defined(KOKKOS_ENABLE_THREADS) && !defined(KOKKOS_ENABLE_OPENMPTARGET) && \
-    !defined(KOKKOS_ENABLE_HPX)
+    !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(KOKKOS_ENABLE_HPX)
 template <class ExecutionSpace, class DataType>
 struct TestTeamScanRetVal {
   using execution_space = ExecutionSpace;
@@ -186,10 +185,16 @@ struct TestTeamScanRetVal {
     a_r = view_2d_type("a_r", M, N);
     a_s = view_1d_type("a_s", M);
 
-    // Execute calculations
-    Kokkos::parallel_for(policy_type(M, Kokkos::AUTO), *this);
-
+    // Set team size explicitly to check whether non-power-of-two team sizes can
+    // be used.
+    if (ExecutionSpace().concurrency() > 10000)
+      Kokkos::parallel_for(policy_type(M, 127), *this);
+    else if (ExecutionSpace().concurrency() > 2)
+      Kokkos::parallel_for(policy_type(M, 3), *this);
+    else
+      Kokkos::parallel_for(policy_type(M, 1), *this);
     Kokkos::fence();
+
     auto a_i  = Kokkos::create_mirror_view(a_d);
     auto a_o  = Kokkos::create_mirror_view(a_r);
     auto a_os = Kokkos::create_mirror_view(a_s);


### PR DESCRIPTION
Related to #5635 #6453

~Depends on https://github.com/kokkos/kokkos/pull/6302~ (merged)