### PR TITLE
Enable Serial backend in HPX build

### DIFF
--- a/.github/workflows/continuous-integration-workflow-hpx.yml
+++ b/.github/workflows/continuous-integration-workflow-hpx.yml
@@ -80,7 +80,7 @@ jobs:
             -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF \
             -DKokkos_ENABLE_EXAMPLES=ON \
             -DKokkos_ENABLE_HPX=ON \
-            -DKokkos_ENABLE_SERIAL=OFF \
+            -DKokkos_ENABLE_SERIAL=ON \
             -DKokkos_ENABLE_TESTS=ON \
             ..
 

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1227,7 +1227,7 @@ class TestViewAPI {
       Kokkos::deep_copy(typename hView4::execution_space(), dx, hx);
       Kokkos::deep_copy(typename hView4::execution_space(), dy, dx);
       Kokkos::deep_copy(typename hView4::execution_space(), hy, dy);
-      typename dView4::execution_space().fence();
+      typename hView4::execution_space().fence();
 
       for (size_t ip = 0; ip < N0; ++ip)
         for (size_t i1 = 0; i1 < N1; ++i1)
@@ -1238,7 +1238,7 @@ class TestViewAPI {
 
       Kokkos::deep_copy(typename hView4::execution_space(), dx, T(0));
       Kokkos::deep_copy(typename hView4::execution_space(), hx, dx);
-      typename dView4::execution_space().fence();
+      typename hView4::execution_space().fence();
 
       for (size_t ip = 0; ip < N0; ++ip)
         for (size_t i1 = 0; i1 < N1; ++i1)


### PR DESCRIPTION
`Kokkos_CoreUnitTest_Serial2` fails when kokkos is built with both HPX and Serial enabled:
```
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from serial
[ RUN      ] serial.view_api_a
/home/cz4rs/Kokkos/kokkos/core/unit_test/TestViewAPI.hpp:1236: Failure
Expected equality of these values:
  hx(ip, i1, i2, i3)
    Which is: 1
  hy(ip, i1, i2, i3)
    Which is: 0
[  FAILED  ] serial.view_api_a (16 ms)
[----------] 1 test from serial (16 ms total)
```

This went unnoticed because HPX build had Serial disabled.

---
- enable Serial backend in HPX build
- fix failing test