### PR TITLE
add helper variable templates `are_*_iterators_v`

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_Constraints.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Constraints.hpp
@@ -72,7 +72,7 @@ struct are_iterators<T> {
 template <class Head, class... Tail>
 struct are_iterators<Head, Tail...> {
   static constexpr bool value =
-      are_iterators<Head>::value && are_iterators<Tail...>::value;
+      are_iterators<Head>::value && (are_iterators<Tail>::value && ... && true);
 };
 
 template <class... Ts>
@@ -93,8 +93,9 @@ struct are_random_access_iterators<T> {
 
 template <class Head, class... Tail>
 struct are_random_access_iterators<Head, Tail...> {
-  static constexpr bool value = are_random_access_iterators<Head>::value &&
-                                are_random_access_iterators<Tail...>::value;
+  static constexpr bool value =
+      are_random_access_iterators<Head>::value &&
+      (are_random_access_iterators<Tail>::value && ... && true);
 };
 
 template <class... Ts>

--- a/algorithms/src/std_algorithms/impl/Kokkos_Constraints.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Constraints.hpp
@@ -55,6 +55,9 @@ using iterator_category_t = typename T::iterator_category;
 template <class T>
 using is_iterator = Kokkos::is_detected<iterator_category_t, T>;
 
+template <class T>
+inline constexpr bool is_iterator_v = is_iterator<T>::value;
+
 //
 // are_iterators
 //
@@ -63,7 +66,7 @@ struct are_iterators;
 
 template <class T>
 struct are_iterators<T> {
-  static constexpr bool value = is_iterator<T>::value;
+  static constexpr bool value = is_iterator_v<T>;
 };
 
 template <class Head, class... Tail>
@@ -71,6 +74,9 @@ struct are_iterators<Head, Tail...> {
   static constexpr bool value =
       are_iterators<Head>::value && are_iterators<Tail...>::value;
 };
+
+template <class... Ts>
+inline constexpr bool are_iterators_v = are_iterators<Ts...>::value;
 
 //
 // are_random_access_iterators
@@ -81,9 +87,8 @@ struct are_random_access_iterators;
 template <class T>
 struct are_random_access_iterators<T> {
   static constexpr bool value =
-      is_iterator<T>::value &&
-      std::is_base_of<std::random_access_iterator_tag,
-                      typename T::iterator_category>::value;
+      is_iterator_v<T> && std::is_base_of<std::random_access_iterator_tag,
+                                          typename T::iterator_category>::value;
 };
 
 template <class Head, class... Tail>
@@ -91,6 +96,10 @@ struct are_random_access_iterators<Head, Tail...> {
   static constexpr bool value = are_random_access_iterators<Head>::value &&
                                 are_random_access_iterators<Tail...>::value;
 };
+
+template <class... Ts>
+inline constexpr bool are_random_access_iterators_v =
+    are_random_access_iterators<Ts...>::value;
 
 //
 // iterators_are_accessible_from

--- a/algorithms/unit_tests/TestRandomAccessIterator.cpp
+++ b/algorithms/unit_tests/TestRandomAccessIterator.cpp
@@ -217,5 +217,15 @@ TEST_F(random_access_iterator_test, distance) {
   ASSERT_EQ(m_dynamic_view.extent(0), size_t(KE::distance(first, last)));
 }
 
+TEST_F(random_access_iterator_test, traits_helpers) {
+  using T1_t = KE::Impl::RandomAccessIterator<static_view_t>;
+  using T2_t = KE::Impl::RandomAccessIterator<dyn_view_t>;
+  using T3_t = KE::Impl::RandomAccessIterator<strided_view_t>;
+
+  namespace KE = Kokkos::Experimental;
+  static_assert(KE::Impl::are_iterators_v<T1_t, T2_t, T3_t>);
+  static_assert(KE::Impl::are_random_access_iterators_v<T1_t, T2_t, T3_t>);
+}
+
 }  // namespace stdalgos
 }  // namespace Test

--- a/algorithms/unit_tests/TestRandomAccessIterator.cpp
+++ b/algorithms/unit_tests/TestRandomAccessIterator.cpp
@@ -225,6 +225,7 @@ TEST_F(random_access_iterator_test, traits_helpers) {
   namespace KE = Kokkos::Experimental;
   static_assert(KE::Impl::are_iterators_v<T1_t, T2_t, T3_t>);
   static_assert(KE::Impl::are_random_access_iterators_v<T1_t, T2_t, T3_t>);
+  static_assert(!KE::Impl::are_iterators_v<int, T2_t, T3_t>);
 }
 
 }  // namespace stdalgos


### PR DESCRIPTION
self-explanatory 

Why needed: for the team-level algorithms PRs, to address comments