### PR TITLE
Use checked arithmetic builtins for overflow detection

### DIFF
--- a/core/src/impl/Kokkos_CheckedIntegerOps.hpp
+++ b/core/src/impl/Kokkos_CheckedIntegerOps.hpp
@@ -29,9 +29,13 @@ std::enable_if_t<std::is_integral_v<T>, bool> constexpr multiply_overflow(
     T a, T b, T& res) {
   static_assert(std::is_unsigned_v<T>,
                 "Operation not implemented for signed integers.");
-#if defined(KOKKOS_COMPILER_CLANG) || defined(KOKKOS_COMPILER_GNU)
+
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_mul_overflow)
   return __builtin_mul_overflow(a, b, &res);
-#else
+#endif
+#endif
+
   auto product = a * b;
   if ((a == 0) || (b == 0) || (a == product / b)) {
     res = product;
@@ -39,7 +43,6 @@ std::enable_if_t<std::is_integral_v<T>, bool> constexpr multiply_overflow(
   } else {
     return true;
   }
-#endif
 }
 
 template <typename T>

--- a/core/src/impl/Kokkos_CheckedIntegerOps.hpp
+++ b/core/src/impl/Kokkos_CheckedIntegerOps.hpp
@@ -29,6 +29,9 @@ std::enable_if_t<std::is_integral_v<T>, bool> constexpr multiply_overflow(
     T a, T b, T& res) {
   static_assert(std::is_unsigned_v<T>,
                 "Operation not implemented for signed integers.");
+#if defined(KOKKOS_COMPILER_CLANG) || defined(KOKKOS_COMPILER_GNU)
+  return __builtin_mul_overflow(a, b, &res);
+#else
   auto product = a * b;
   if ((a == 0) || (b == 0) || (a == product / b)) {
     res = product;
@@ -36,6 +39,7 @@ std::enable_if_t<std::is_integral_v<T>, bool> constexpr multiply_overflow(
   } else {
     return true;
   }
+#endif
 }
 
 template <typename T>

--- a/core/src/impl/Kokkos_CheckedIntegerOps.hpp
+++ b/core/src/impl/Kokkos_CheckedIntegerOps.hpp
@@ -24,18 +24,21 @@
 namespace Kokkos {
 namespace Impl {
 
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_mul_overflow)
+#define KOKKOS_IMPL_USE_MUL_OVERFLOW_BUILTIN
+#endif
+#endif
+
 template <typename T>
 std::enable_if_t<std::is_integral_v<T>, bool> constexpr multiply_overflow(
     T a, T b, T& res) {
   static_assert(std::is_unsigned_v<T>,
                 "Operation not implemented for signed integers.");
 
-#if defined(__has_builtin)
-#if __has_builtin(__builtin_mul_overflow)
+#if defined(KOKKOS_IMPL_USE_MUL_OVERFLOW_BUILTIN)
   return __builtin_mul_overflow(a, b, &res);
-#endif
-#endif
-
+#else
   auto product = a * b;
   if ((a == 0) || (b == 0) || (a == product / b)) {
     res = product;
@@ -43,7 +46,10 @@ std::enable_if_t<std::is_integral_v<T>, bool> constexpr multiply_overflow(
   } else {
     return true;
   }
+#endif
 }
+
+#undef KOKKOS_IMPL_USE_MUL_OVERFLOW_BUILTIN
 
 template <typename T>
 T multiply_overflow_abort(T a, T b) {


### PR DESCRIPTION
Follow-up to #6159 and https://github.com/kokkos/kokkos/pull/6159#discussion_r1275548410.

Use checked arithmetic builtins when available. Both `clang` and `gcc` provide those:
- https://clang.llvm.org/docs/LanguageExtensions.html#checked-arithmetic-builtins
- https://gcc.gnu.org/onlinedocs/gcc/Integer-Overflow-Builtins.html


_Note: [Prior to Clang 10, `__has_builtin` could not be used to detect most builtin pseudo-functions](https://clang.llvm.org/docs/LanguageExtensions.html#has-builtin). This should not be an issue here, so I opted to use that instead of explicitly checking for compilers._




