### PR TITLE
Update CI: use CUDA 11.6.2 instead of 11.6.0

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -433,7 +433,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.nvcc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.6.0-devel-ubuntu20.04'
+                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.6.2-devel-ubuntu20.04'
                             label 'nvidia-docker'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }


### PR DESCRIPTION
Nvidia removed the image we were using in the CI, just bumping the minor version to fix this.