### PR TITLE
Update Clang+Cuda CI from 10.1 to 11.0.3

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -305,7 +305,7 @@ pipeline {
                                 -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*" \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=clang++ \
-                                -DCMAKE_CXX_FLAGS=-Werror \
+                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unknown-cuda-version" \
                                 -DCMAKE_CXX_STANDARD=17 \
                                 -DKokkos_ARCH_NATIVE=ON \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \

--- a/.jenkins
+++ b/.jenkins
@@ -288,7 +288,7 @@ pipeline {
                         }
                     }
                 }
-                stage('CUDA-10.1-Clang-Tidy') {
+                stage('CUDA-11.0.3-Clang-Tidy') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.kokkosllvmproject'

--- a/scripts/docker/Dockerfile.kokkosllvmproject
+++ b/scripts/docker/Dockerfile.kokkosllvmproject
@@ -2,7 +2,7 @@ FROM nvidia/cuda:11.0.3-devel
 
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         bc \
         git \
         wget \
@@ -15,10 +15,10 @@ RUN apt-get update && apt-get install -y \
 
 # unbuntu18.04-based images have libstdc++ that is lacking filesystem support
 RUN apt-get update && \
-    apt-get install -y software-properties-common && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common && \
     add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
     apt-get update && \
-    apt-get install -y g++-9 && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y g++-9 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/scripts/docker/Dockerfile.kokkosllvmproject
+++ b/scripts/docker/Dockerfile.kokkosllvmproject
@@ -49,7 +49,7 @@ ARG NPROC=8
 
 # Clone Kokkos fork of the LLVM Project and build Clang
 ENV LLVM_DIR=/opt/llvm
-RUN LLVM_VERSION=55b3bcf643685c63fcc529d434bed112fdf03939 && \
+RUN LLVM_VERSION=65d206484c54177641d4b11d42cab1f1acc8c0c7 && \
     LLVM_URL=https://github.com/kokkos/llvm-project/archive/${LLVM_VERSION}.tar.gz &&\
     LLVM_ARCHIVE=llvm.tar.xz && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \

--- a/scripts/docker/Dockerfile.kokkosllvmproject
+++ b/scripts/docker/Dockerfile.kokkosllvmproject
@@ -49,7 +49,7 @@ ARG NPROC=8
 
 # Clone Kokkos fork of the LLVM Project and build Clang
 ENV LLVM_DIR=/opt/llvm
-RUN LLVM_VERSION=65d206484c54177641d4b11d42cab1f1acc8c0c7 && \
+RUN LLVM_VERSION=32413084ecbb5e739c6b35d8bf13ad972985acb3 && \
     LLVM_URL=https://github.com/kokkos/llvm-project/archive/${LLVM_VERSION}.tar.gz &&\
     LLVM_ARCHIVE=llvm.tar.xz && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \

--- a/scripts/docker/Dockerfile.kokkosllvmproject
+++ b/scripts/docker/Dockerfile.kokkosllvmproject
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.1-devel
+FROM nvidia/cuda:11.0.3-devel
 
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 


### PR DESCRIPTION
NVIDIA removed more images including 10.1, see https://gitlab.com/nvidia/container-images/cuda/-/issues/209 for a complete list. 11.0.3 is now the oldest image and this pull request proposes using that instead of 10.1.

Since we no longer have a good setup for testing Clang+Cuda 10, we could consider raising the minimum to 11 and be consistent with our requirement for `nvcc` (maybe in a follow-up).