### PR TITLE
SIMD: convert binary operators to hidden friends

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -472,70 +472,67 @@ class simd<double, simd_abi::avx2_fixed_size<4>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(_mm256_cmp_pd(m_value, other.m_value, _CMP_LT_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(
+        _mm256_sub_pd(_mm256_set1_pd(0.0), static_cast<__m256d>(m_value)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(_mm256_cmp_pd(m_value, other.m_value, _CMP_GT_OS));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm256_mul_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return mask_type(_mm256_cmp_pd(m_value, other.m_value, _CMP_LE_OS));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm256_div_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return mask_type(_mm256_cmp_pd(m_value, other.m_value, _CMP_GE_OS));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm256_add_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(_mm256_cmp_pd(m_value, other.m_value, _CMP_EQ_OS));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm256_sub_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return mask_type(_mm256_cmp_pd(m_value, other.m_value, _CMP_NEQ_OS));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
+                                   static_cast<__m256d>(rhs), _CMP_LT_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
+                                   static_cast<__m256d>(rhs), _CMP_GT_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
+                                   static_cast<__m256d>(rhs), _CMP_LE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
+                                   static_cast<__m256d>(rhs), _CMP_GE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
+                                   static_cast<__m256d>(rhs), _CMP_EQ_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
+                                   static_cast<__m256d>(rhs), _CMP_NEQ_OS));
   }
 };
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx2_fixed_size<4>>
-    operator*(simd<double, simd_abi::avx2_fixed_size<4>> const& lhs,
-              simd<double, simd_abi::avx2_fixed_size<4>> const& rhs) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_mul_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx2_fixed_size<4>>
-    operator/(simd<double, simd_abi::avx2_fixed_size<4>> const& lhs,
-              simd<double, simd_abi::avx2_fixed_size<4>> const& rhs) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_div_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx2_fixed_size<4>>
-    operator+(simd<double, simd_abi::avx2_fixed_size<4>> const& lhs,
-              simd<double, simd_abi::avx2_fixed_size<4>> const& rhs) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_add_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx2_fixed_size<4>>
-    operator-(simd<double, simd_abi::avx2_fixed_size<4>> const& lhs,
-              simd<double, simd_abi::avx2_fixed_size<4>> const& rhs) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_sub_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx2_fixed_size<4>>
-    operator-(simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_sub_pd(_mm256_set1_pd(0.0), static_cast<__m256d>(a)));
-}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<double, simd_abi::avx2_fixed_size<4>> copysign(
@@ -680,85 +677,70 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(_mm_cmpeq_epi32(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        _mm_cmpeq_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(_mm_cmpgt_epi32(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        _mm_cmpgt_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(_mm_cmplt_epi32(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        _mm_cmplt_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return ((*this) < other) || ((*this) == other);
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return (lhs < rhs) || (lhs == rhs);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return ((*this) > other) || ((*this) == other);
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return (lhs > rhs) || (lhs == rhs);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return !((*this) == other);
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return !(lhs == rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm_sub_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm_add_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int32_t, simd_abi::avx2_fixed_size<4>>
-  operator>>(simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-             int rhs) noexcept {
-    return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
-        _mm_srai_epi32(static_cast<__m128i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm_srai_epi32(static_cast<__m128i>(lhs), rhs));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int32_t, simd_abi::avx2_fixed_size<4>>
-  operator>>(
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
-    return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
         _mm_srav_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int32_t, simd_abi::avx2_fixed_size<4>>
-  operator<<(simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-             int rhs) noexcept {
-    return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
-        _mm_slli_epi32(static_cast<__m128i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm_slli_epi32(static_cast<__m128i>(lhs), rhs));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int32_t, simd_abi::avx2_fixed_size<4>>
-  operator<<(
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
-    return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
         _mm_sllv_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
 };
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
-    operator-(simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-              simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) {
-  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
-      _mm_sub_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
-    operator+(simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-              simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) {
-  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
-      _mm_add_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
-    abs(simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx2_fixed_size<4>> abs(
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a) {
   __m128i const rhs = static_cast<__m128i>(a);
   return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(_mm_abs_epi32(rhs));
 }
@@ -838,90 +820,75 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       const {
     return m_value;
   }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(
+        _mm256_sub_epi64(_mm256_set1_epi64x(0), static_cast<__m256i>(m_value)));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+
   // AVX2 only has eq and gt comparisons for int64
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(_mm256_cmpeq_epi64(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpeq_epi64(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(_mm256_cmpgt_epi64(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpgt_epi64(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return other > (*this);
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return rhs > lhs;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return ((*this) < other) || ((*this) == other);
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return (lhs < rhs) || (lhs == rhs);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return ((*this) > other) || ((*this) == other);
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return (lhs > rhs) || (lhs == rhs);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return !((*this) == other);
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return !(lhs == rhs);
   }
 
   // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
-  // KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend
-  // simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator>>(
-  //     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-  //     int rhs) noexcept {
-  //   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
-  //       _mm256_srai_epi64(static_cast<__m256i>(lhs), rhs));
+  // [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd(
+  //     simd const& lhs, int rhs) noexcept {
+  //   return simd(_mm256_srai_epi64(static_cast<__m256i>(lhs), rhs));
   // }
 
-  // KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend
-  // simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator>>(
-  //     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-  //     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
-  //   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
-  //       _mm256_srav_epi64(static_cast<__m256i>(lhs),
-  //       _mm256_cvtepi32_epi64(static_cast<__m128i>(static_cast<__m128i>(rhs))));
+  // [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd(
+  //     simd const& lhs, simd const& rhs) noexcept {
+  //   return simd(_mm256_srav_epi64(static_cast<__m256i>(lhs),
+  //                                 static_cast<__m256i>(rhs))));
   // }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int64_t, simd_abi::avx2_fixed_size<4>>
-  operator<<(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-             int rhs) noexcept {
-    return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
-        _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int64_t, simd_abi::avx2_fixed_size<4>>
-  operator<<(
-      simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
-    return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
-        _mm256_sllv_epi64(static_cast<__m256i>(lhs),
-                          _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_sllv_epi64(static_cast<__m256i>(lhs),
+                                  static_cast<__m256i>(rhs)));
   }
 };
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
-    operator-(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-              simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& rhs) {
-  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
-      _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
-    operator-(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a) {
-  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(0) - a;
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
-    operator+(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-              simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& rhs) {
-  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
-      _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
 
 // Manually computing absolute values, because _mm256_abs_epi64
 // is not in AVX2; it's available in AVX512.
@@ -997,59 +964,56 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                     static_cast<__m256i>(mask_type(true)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator&(simd const& other) const {
-    return _mm256_and_si256(m_value, other.m_value);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator|(simd const& other) const {
-    return _mm256_or_si256(m_value, other.m_value);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(_mm256_cmpeq_epi64(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return !((*this) == other);
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::uint64_t, simd_abi::avx2_fixed_size<4>>
-  operator>>(simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-             int rhs) noexcept {
-    return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
-        _mm256_srli_epi64(static_cast<__m256i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return _mm256_srli_epi64(static_cast<__m256i>(lhs), rhs);
   }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::uint64_t, simd_abi::avx2_fixed_size<4>>
-  operator>>(
-      simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-      simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
-    return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(_mm256_srlv_epi64(
-        static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
+    return _mm256_srlv_epi64(static_cast<__m256i>(lhs),
+                             static_cast<__m256i>(rhs));
   }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::uint64_t, simd_abi::avx2_fixed_size<4>>
-  operator<<(simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-             int rhs) noexcept {
-    return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
-        _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs);
   }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::uint64_t, simd_abi::avx2_fixed_size<4>>
-  operator<<(
-      simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-      simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
-    return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(_mm256_sllv_epi64(
-        static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return _mm256_sllv_epi64(static_cast<__m256i>(lhs),
+                             static_cast<__m256i>(rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator&(
+      simd const& lhs, simd const& rhs) noexcept {
+    return _mm256_and_si256(static_cast<__m256i>(lhs),
+                            static_cast<__m256i>(rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator|(
+      simd const& lhs, simd const& rhs) noexcept {
+    return _mm256_or_si256(static_cast<__m256i>(lhs),
+                           static_cast<__m256i>(rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpeq_epi64(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return !(lhs == rhs);
   }
 };
 
@@ -1058,25 +1022,9 @@ simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::simd(
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other)
     : m_value(static_cast<__m256i>(other)) {}
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
-    operator+(simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-              simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& rhs) {
-  return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
-      _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
-    operator-(simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-              simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& rhs) {
-  return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
-      _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
-    abs(simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> abs(
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a) {
   return a;
 }
 

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -200,92 +200,77 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(_mm256_cmplt_epi32_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(_mm256_cmplt_epi32_mask(other.m_value, m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return mask_type(_mm256_cmple_epi32_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return mask_type(_mm256_cmple_epi32_mask(other.m_value, m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(_mm256_cmpeq_epi32_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return mask_type(_mm256_cmpneq_epi32_mask(m_value, other.m_value));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(_mm256_sub_epi32(_mm256_set1_epi32(0), m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int32_t, simd_abi::avx512_fixed_size<8>>
-  operator>>(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-             int rhs) noexcept {
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
+                                   static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
     return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
-        _mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
+        _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int32_t, simd_abi::avx512_fixed_size<8>>
-  operator>>(
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
-    return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(_mm256_srav_epi32(
-        static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int32_t, simd_abi::avx512_fixed_size<8>>
-  operator<<(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-             int rhs) noexcept {
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
     return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
-        _mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+        _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int32_t, simd_abi::avx512_fixed_size<8>>
-  operator<<(
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
-    return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(_mm256_sllv_epi32(
-        static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmplt_epi32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmplt_epi32_mask(static_cast<__m256i>(rhs),
+                                             static_cast<__m256i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmple_epi32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmple_epi32_mask(static_cast<__m256i>(rhs),
+                                             static_cast<__m256i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpeq_epi32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpneq_epi32_mask(static_cast<__m256i>(lhs),
+                                              static_cast<__m256i>(rhs)));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_srav_epi32(static_cast<__m256i>(lhs),
+                                  static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+                                  static_cast<__m256i>(rhs)));
   }
 };
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
-    operator*(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_mullo_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
-    operator+(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(0) - a;
-}
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
@@ -372,88 +357,73 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(_mm256_cmplt_epu32_mask(m_value, other.m_value));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
+                                   static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(_mm256_cmplt_epu32_mask(other.m_value, m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return mask_type(_mm256_cmple_epu32_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return mask_type(_mm256_cmple_epu32_mask(other.m_value, m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(_mm256_cmpeq_epu32_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return mask_type(_mm256_cmpneq_epu32_mask(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::uint32_t, simd_abi::avx512_fixed_size<8>>
-  operator>>(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-             int rhs) noexcept {
-    return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-        _mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::uint32_t, simd_abi::avx512_fixed_size<8>>
-  operator>>(
-      simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-      simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
-    return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-        _mm256_srlv_epi32(static_cast<__m256i>(lhs),
-                          static_cast<__m256i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(rhs),
+                                             static_cast<__m256i>(lhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::uint32_t, simd_abi::avx512_fixed_size<8>>
-  operator<<(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-             int rhs) noexcept {
-    return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-        _mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::uint32_t, simd_abi::avx512_fixed_size<8>>
-  operator<<(
-      simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-      simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
-    return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-        _mm256_sllv_epi32(static_cast<__m256i>(lhs),
-                          static_cast<__m256i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(rhs),
+                                             static_cast<__m256i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpeq_epu32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpneq_epu32_mask(static_cast<__m256i>(lhs),
+                                              static_cast<__m256i>(rhs)));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_srlv_epi32(static_cast<__m256i>(lhs),
+                                  static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+                                  static_cast<__m256i>(rhs)));
   }
 };
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
-    operator*(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_mullo_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
-    operator+(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
@@ -536,94 +506,83 @@ class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(_mm512_cmplt_epi64_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(_mm512_cmplt_epi64_mask(other.m_value, m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return mask_type(_mm512_cmple_epi64_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return mask_type(_mm512_cmple_epi64_mask(other.m_value, m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(_mm512_cmpeq_epi64_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return mask_type(_mm512_cmpneq_epi64_mask(m_value, other.m_value));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(_mm512_sub_epi64(_mm512_set1_epi64(0), m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int64_t, simd_abi::avx512_fixed_size<8>>
-  operator>>(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-             int rhs) {
-    return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
-        _mm512_srai_epi64(static_cast<__m512i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
+                                   static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int64_t, simd_abi::avx512_fixed_size<8>>
-  operator>>(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-             simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-    return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(_mm512_srav_epi64(
-        static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int64_t, simd_abi::avx512_fixed_size<8>>
-  operator<<(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-             int rhs) {
-    return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
-        _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int64_t, simd_abi::avx512_fixed_size<8>>
-  operator<<(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-             simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-    return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(_mm512_sllv_epi64(
-        static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epi64_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epi64_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epi64_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epi64_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmpeq_epi64_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmpneq_epi64_mask(static_cast<__m512i>(lhs),
+                                              static_cast<__m512i>(rhs)));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) {
+    return simd(_mm512_srai_epi64(static_cast<__m512i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) {
+    return simd(_mm512_srav_epi64(static_cast<__m512i>(lhs),
+                                  static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) {
+    return simd(_mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) {
+    return simd(_mm512_sllv_epi64(static_cast<__m512i>(lhs),
+                                  static_cast<__m512i>(rhs)));
   }
 };
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
-    operator*(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_mullo_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
-    operator+(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(0) - a;
-}
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::avx512_fixed_size<8>> abs(
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a) {
+    abs(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a) {
   __m512i const rhs = static_cast<__m512i>(a);
   return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_abs_epi64(rhs));
@@ -702,101 +661,90 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
       value_type* ptr, element_aligned_tag) const {
     _mm512_storeu_si512(ptr, m_value);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator&(simd const& other) const {
-    return _mm512_and_epi64(m_value, other.m_value);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator|(simd const& other) const {
-    return _mm512_or_epi64(m_value, other.m_value);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(_mm512_cmplt_epu64_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(_mm512_cmplt_epu64_mask(other.m_value, m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return mask_type(_mm512_cmple_epu64_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return mask_type(_mm512_cmple_epu64_mask(other.m_value, m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(_mm512_cmpeq_epu64_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return mask_type(_mm512_cmpneq_epu64_mask(m_value, other.m_value));
-  }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::uint64_t, simd_abi::avx512_fixed_size<8>>
-  operator>>(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-             int rhs) {
-    return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
-        _mm512_srli_epi64(static_cast<__m512i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
+                                   static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::uint64_t, simd_abi::avx512_fixed_size<8>>
-  operator>>(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-             simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return _mm512_srli_epi64(static_cast<__m512i>(lhs), rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
     return _mm512_srlv_epi64(static_cast<__m512i>(lhs),
                              static_cast<__m512i>(rhs));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::uint64_t, simd_abi::avx512_fixed_size<8>>
-  operator<<(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-             int rhs) {
-    return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
-        _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::uint64_t, simd_abi::avx512_fixed_size<8>>
-  operator<<(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-             simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-    return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
-        _mm512_sllv_epi64(static_cast<__m512i>(lhs),
-                          static_cast<__m512i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return _mm512_sllv_epi64(static_cast<__m512i>(lhs),
+                             static_cast<__m512i>(rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator&(
+      simd const& lhs, simd const& rhs) noexcept {
+    return _mm512_and_epi64(static_cast<__m512i>(lhs),
+                            static_cast<__m512i>(rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator|(
+      simd const& lhs, simd const& rhs) noexcept {
+    return _mm512_or_epi64(static_cast<__m512i>(lhs),
+                           static_cast<__m512i>(rhs));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epu64_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epu64_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epu64_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epu64_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmpeq_epu64_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmpneq_epu64_mask(static_cast<__m512i>(lhs),
+                                              static_cast<__m512i>(rhs)));
   }
 };
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
-    operator*(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_mullo_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
-    operator+(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-}
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> abs(
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a) {
+    abs(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a) {
   return a;
 }
 
@@ -881,75 +829,67 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_LT_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(_mm512_sub_pd(_mm512_set1_pd(0.0), m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_GT_OS));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm512_mul_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_LE_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm512_div_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_GE_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm512_add_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_EQ_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm512_sub_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_NEQ_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
+                                        static_cast<__m512d>(rhs), _CMP_LT_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(rhs),
+                                        static_cast<__m512d>(lhs), _CMP_GT_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
+                                        static_cast<__m512d>(rhs), _CMP_LE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(rhs),
+                                        static_cast<__m512d>(lhs), _CMP_GE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
+                                        static_cast<__m512d>(rhs), _CMP_EQ_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_pd_mask(
+        static_cast<__m512d>(lhs), static_cast<__m512d>(rhs), _CMP_NEQ_OS));
   }
 };
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<double, simd_abi::avx512_fixed_size<8>>
-    operator*(simd<double, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<double, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_mul_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    operator/(simd<double, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<double, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_div_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    operator+(simd<double, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<double, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_add_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<double, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<double, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_sub_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_sub_pd(_mm512_set1_pd(0.0), static_cast<__m512d>(a)));
-}
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> copysign(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<double, simd_abi::avx512_fixed_size<8>> const& b) {
+    copysign(simd<double, simd_abi::avx512_fixed_size<8>> const& a,
+             simd<double, simd_abi::avx512_fixed_size<8>> const& b) {
   static const __m512i sign_mask = reinterpret_cast<__m512i>(
       static_cast<__m512d>(simd<double, simd_abi::avx512_fixed_size<8>>(-0.0)));
   return simd<double, simd_abi::avx512_fixed_size<8>>(
@@ -960,9 +900,9 @@ simd<double, simd_abi::avx512_fixed_size<8>> copysign(
               sign_mask, reinterpret_cast<__m512i>(static_cast<__m512d>(b))))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> abs(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::avx512_fixed_size<8>>
+    abs(simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
   __m512d const rhs = static_cast<__m512d>(a);
 #if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 830)
   return simd<double, simd_abi::avx512_fixed_size<8>>((__m512d)_mm512_and_epi64(
@@ -972,69 +912,69 @@ simd<double, simd_abi::avx512_fixed_size<8>> abs(
 #endif
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> sqrt(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::avx512_fixed_size<8>>
+    sqrt(simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
   return simd<double, simd_abi::avx512_fixed_size<8>>(
       _mm512_sqrt_pd(static_cast<__m512d>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> cbrt(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::avx512_fixed_size<8>>
+    cbrt(simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
   return simd<double, simd_abi::avx512_fixed_size<8>>(
       _mm512_cbrt_pd(static_cast<__m512d>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> exp(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::avx512_fixed_size<8>>
+    exp(simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
   return simd<double, simd_abi::avx512_fixed_size<8>>(
       _mm512_exp_pd(static_cast<__m512d>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> log(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::avx512_fixed_size<8>>
+    log(simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
   return simd<double, simd_abi::avx512_fixed_size<8>>(
       _mm512_log_pd(static_cast<__m512d>(a)));
 }
 
 #endif
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> fma(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<double, simd_abi::avx512_fixed_size<8>> const& b,
-    simd<double, simd_abi::avx512_fixed_size<8>> const& c) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::avx512_fixed_size<8>>
+    fma(simd<double, simd_abi::avx512_fixed_size<8>> const& a,
+        simd<double, simd_abi::avx512_fixed_size<8>> const& b,
+        simd<double, simd_abi::avx512_fixed_size<8>> const& c) {
   return simd<double, simd_abi::avx512_fixed_size<8>>(
       _mm512_fmadd_pd(static_cast<__m512d>(a), static_cast<__m512d>(b),
                       static_cast<__m512d>(c)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> max(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<double, simd_abi::avx512_fixed_size<8>> const& b) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::avx512_fixed_size<8>>
+    max(simd<double, simd_abi::avx512_fixed_size<8>> const& a,
+        simd<double, simd_abi::avx512_fixed_size<8>> const& b) {
   return simd<double, simd_abi::avx512_fixed_size<8>>(
       _mm512_max_pd(static_cast<__m512d>(a), static_cast<__m512d>(b)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> min(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<double, simd_abi::avx512_fixed_size<8>> const& b) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::avx512_fixed_size<8>>
+    min(simd<double, simd_abi::avx512_fixed_size<8>> const& a,
+        simd<double, simd_abi::avx512_fixed_size<8>> const& b) {
   return simd<double, simd_abi::avx512_fixed_size<8>>(
       _mm512_min_pd(static_cast<__m512d>(a), static_cast<__m512d>(b)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> condition(
-    simd_mask<double, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<double, simd_abi::avx512_fixed_size<8>> const& b,
-    simd<double, simd_abi::avx512_fixed_size<8>> const& c) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::avx512_fixed_size<8>>
+    condition(simd_mask<double, simd_abi::avx512_fixed_size<8>> const& a,
+              simd<double, simd_abi::avx512_fixed_size<8>> const& b,
+              simd<double, simd_abi::avx512_fixed_size<8>> const& c) {
   return simd<double, simd_abi::avx512_fixed_size<8>>(
       _mm512_mask_blend_pd(static_cast<__mmask8>(a), static_cast<__m512d>(c),
                            static_cast<__m512d>(b)));

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -366,70 +366,63 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
   operator float64x2_t() const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(vcltq_f64(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  operator-(simd const& a) const noexcept {
+    return simd(vnegq_f64(static_cast<float64x2_t>(a)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(vcgtq_f64(m_value, other.m_value));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vmulq_f64(static_cast<float64x2_t>(lhs),
+                          static_cast<float64x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return mask_type(vcleq_f64(m_value, other.m_value));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vdivq_f64(static_cast<float64x2_t>(lhs),
+                          static_cast<float64x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return mask_type(vcgeq_f64(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vaddq_f64(static_cast<float64x2_t>(lhs),
+                          static_cast<float64x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(vceqq_f64(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vsubq_f64(static_cast<float64x2_t>(lhs),
+                          static_cast<float64x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return !(operator==(other));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vcltq_f64(static_cast<float64x2_t>(lhs),
+                               static_cast<float64x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vcgtq_f64(static_cast<float64x2_t>(lhs),
+                               static_cast<float64x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vcleq_f64(static_cast<float64x2_t>(lhs),
+                               static_cast<float64x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vcgeq_f64(static_cast<float64x2_t>(lhs),
+                               static_cast<float64x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vceqq_f64(static_cast<float64x2_t>(lhs),
+                               static_cast<float64x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return !(operator==(lhs, rhs));
   }
 };
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::neon_fixed_size<2>>
-    operator*(simd<double, simd_abi::neon_fixed_size<2>> const& lhs,
-              simd<double, simd_abi::neon_fixed_size<2>> const& rhs) {
-  return simd<double, simd_abi::neon_fixed_size<2>>(
-      vmulq_f64(static_cast<float64x2_t>(lhs), static_cast<float64x2_t>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::neon_fixed_size<2>>
-    operator/(simd<double, simd_abi::neon_fixed_size<2>> const& lhs,
-              simd<double, simd_abi::neon_fixed_size<2>> const& rhs) {
-  return simd<double, simd_abi::neon_fixed_size<2>>(
-      vdivq_f64(static_cast<float64x2_t>(lhs), static_cast<float64x2_t>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::neon_fixed_size<2>>
-    operator+(simd<double, simd_abi::neon_fixed_size<2>> const& lhs,
-              simd<double, simd_abi::neon_fixed_size<2>> const& rhs) {
-  return simd<double, simd_abi::neon_fixed_size<2>>(
-      vaddq_f64(static_cast<float64x2_t>(lhs), static_cast<float64x2_t>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::neon_fixed_size<2>>
-    operator-(simd<double, simd_abi::neon_fixed_size<2>> const& lhs,
-              simd<double, simd_abi::neon_fixed_size<2>> const& rhs) {
-  return simd<double, simd_abi::neon_fixed_size<2>>(
-      vsubq_f64(static_cast<float64x2_t>(lhs), static_cast<float64x2_t>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::neon_fixed_size<2>>
-    operator-(simd<double, simd_abi::neon_fixed_size<2>> const& a) {
-  return simd<double, simd_abi::neon_fixed_size<2>>(
-      vnegq_f64(static_cast<float64x2_t>(a)));
-}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<double, simd_abi::neon_fixed_size<2>> abs(
@@ -572,89 +565,78 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(vceq_s32(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(vcgt_s32(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(vclt_s32(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return mask_type(vcle_s32(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return mask_type(vcge_s32(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return !((*this) == other);
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  operator-(simd const& a) const noexcept {
+    return simd(vneg_s32(static_cast<int32x2_t>(a)));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int32_t, simd_abi::neon_fixed_size<2>>
-  operator>>(simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
-             const int rhs) noexcept {
-    return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(vshl_s32(
-        static_cast<int32x2_t>(lhs), vneg_s32(vmov_n_s32(std::int32_t(rhs)))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        vsub_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int32_t, simd_abi::neon_fixed_size<2>>
-  operator>>(
-      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
-      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
-    return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(vshl_s32(
-        static_cast<int32x2_t>(lhs), vneg_s32(static_cast<int32x2_t>(rhs))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        vadd_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int32_t, simd_abi::neon_fixed_size<2>>
-  operator<<(simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
-             const int rhs) noexcept {
-    return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        vceq_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        vcgt_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        vclt_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        vcle_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        vcge_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return !(lhs == rhs);
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return simd(vshl_s32(static_cast<int32x2_t>(lhs),
+                         vneg_s32(vmov_n_s32(std::int32_t(rhs)))));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vshl_s32(static_cast<int32x2_t>(lhs),
+                         vneg_s32(static_cast<int32x2_t>(rhs))));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return simd(
         vshl_s32(static_cast<int32x2_t>(lhs), vmov_n_s32(std::int32_t(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int32_t, simd_abi::neon_fixed_size<2>>
-  operator<<(
-      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
-      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
-    return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
         vshl_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
 };
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>>
-    operator-(simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& a) {
-  return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
-      vneg_s32(static_cast<int32x2_t>(a)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>>
-    operator-(simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
-              simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) {
-  return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
-      vsub_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>>
-    operator+(simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
-              simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) {
-  return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
-      vadd_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>>
-    abs(simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::neon_fixed_size<2>> abs(
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& a) {
   return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
       vabs_s32(static_cast<int32x2_t>(a)));
 }
@@ -749,90 +731,78 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(vceqq_s64(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(vcgtq_s64(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(vcltq_s64(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return mask_type(vcleq_s64(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return mask_type(vcgeq_s64(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return !((*this) == other);
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  operator-(simd const& a) const noexcept {
+    return simd(vnegq_s64(static_cast<int64x2_t>(a)));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int64_t, simd_abi::neon_fixed_size<2>>
-  operator>>(simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-             const int rhs) noexcept {
-    return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
-        vshlq_s64(static_cast<int64x2_t>(lhs),
-                  vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        vsubq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int64_t, simd_abi::neon_fixed_size<2>>
-  operator>>(
-      simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-      simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
-    return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(vshlq_s64(
-        static_cast<int64x2_t>(lhs), vnegq_s64(static_cast<int64x2_t>(rhs))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        vaddq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int64_t, simd_abi::neon_fixed_size<2>>
-  operator<<(simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-             const int rhs) noexcept {
-    return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        vceqq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        vcgtq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        vcltq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        vcleq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        vcgeq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return !(lhs == rhs);
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return simd(vshlq_s64(static_cast<int64x2_t>(lhs),
+                          vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vshlq_s64(static_cast<int64x2_t>(lhs),
+                          vnegq_s64(static_cast<int64x2_t>(rhs))));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return simd(
         vshlq_s64(static_cast<int64x2_t>(lhs), vmovq_n_s64(std::int64_t(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::int64_t, simd_abi::neon_fixed_size<2>>
-  operator<<(
-      simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-      simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
-    return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
         vshlq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
 };
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::neon_fixed_size<2>>
-    operator-(simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& a) {
-  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
-      vnegq_s64(static_cast<int64x2_t>(a)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::neon_fixed_size<2>>
-    operator-(simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-              simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& rhs) {
-  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
-      vsubq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::neon_fixed_size<2>>
-    operator+(simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-              simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& rhs) {
-  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
-      vaddq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::neon_fixed_size<2>>
-    abs(simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::neon_fixed_size<2>> abs(
+    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& a) {
   return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
       vabsq_s64(static_cast<int64x2_t>(a)));
 }
@@ -921,77 +891,64 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
                                                        element_aligned_tag) {
     m_value = vld1q_u64(ptr);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator&(simd const& other) const {
-    return simd(vandq_u64(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator|(simd const& other) const {
-    return simd(vorrq_u64(m_value, other.m_value));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator uint64x2_t()
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(vceqq_u64(m_value, other.m_value));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        vsubq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return !((*this) == other);
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        vaddq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::uint64_t, simd_abi::neon_fixed_size<2>>
-  operator>>(simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-             const int rhs) noexcept {
-    return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
-        vshlq_u64(static_cast<uint64x2_t>(lhs),
-                  vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator&(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        vandq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::uint64_t, simd_abi::neon_fixed_size<2>>
-  operator>>(
-      simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-      simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
-    return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(vshlq_u64(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator|(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        vorrq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        vceqq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return !(lhs == rhs);
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return simd(vshlq_u64(static_cast<uint64x2_t>(lhs),
+                          vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vshlq_u64(
         static_cast<uint64x2_t>(lhs),
         vnegq_s64(vreinterpretq_s64_u64(static_cast<uint64x2_t>(rhs)))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::uint64_t, simd_abi::neon_fixed_size<2>>
-  operator<<(simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-             const int rhs) noexcept {
-    return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(vshlq_u64(
-        static_cast<uint64x2_t>(lhs), vmovq_n_s64(std::int64_t(rhs))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return simd(vshlq_u64(static_cast<uint64x2_t>(lhs),
+                          vmovq_n_s64(std::int64_t(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
-      std::uint64_t, simd_abi::neon_fixed_size<2>>
-  operator<<(
-      simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-      simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
-    return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
-        vshlq_u64(static_cast<uint64x2_t>(lhs),
-                  vreinterpretq_s64_u64(static_cast<uint64x2_t>(rhs))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vshlq_u64(static_cast<uint64x2_t>(lhs),
+                          vreinterpretq_s64_u64(static_cast<uint64x2_t>(rhs))));
   }
 };
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>>
-    operator-(simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-              simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) {
-  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
-      vsubq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>>
-    operator+(simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-              simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) {
-  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
-      vaddq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
-}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::neon_fixed_size<2>>::simd(

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -366,9 +366,9 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
   operator float64x2_t() const {
     return m_value;
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator-(simd const& a) const noexcept {
-    return simd(vnegq_f64(static_cast<float64x2_t>(a)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(vnegq_f64(m_value));
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
@@ -393,32 +393,32 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
                           static_cast<float64x2_t>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator<(simd const& lhs, simd const& rhs) noexcept {
     return mask_type(vcltq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator>(simd const& lhs, simd const& rhs) noexcept {
     return mask_type(vcgtq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator<=(simd const& lhs, simd const& rhs) noexcept {
     return mask_type(vcleq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator>=(simd const& lhs, simd const& rhs) noexcept {
     return mask_type(vcgeq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator==(simd const& lhs, simd const& rhs) noexcept {
     return mask_type(vceqq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator!=(simd const& lhs, simd const& rhs) noexcept {
     return !(operator==(lhs, rhs));
   }
@@ -566,9 +566,9 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator-(simd const& a) const noexcept {
-    return simd(vneg_s32(static_cast<int32x2_t>(a)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(vneg_s32(m_value));
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
@@ -732,9 +732,9 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator-(simd const& a) const noexcept {
-    return simd(vnegq_s64(static_cast<int64x2_t>(a)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(vnegq_s64(m_value));
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -157,7 +157,7 @@ class simd<T, simd_abi::scalar> {
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator>>(
       simd const& lhs, simd const& rhs) noexcept {
-    return simd(lhs.m_value >> static_cast<value_type>(rhs));
+    return simd(lhs.m_value >> rhs.m_value);
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator<<(
       simd const& lhs, int rhs) noexcept {
@@ -165,7 +165,7 @@ class simd<T, simd_abi::scalar> {
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator<<(
       simd const& lhs, simd const& rhs) noexcept {
-    return simd(lhs.m_value << static_cast<value_type>(rhs));
+    return simd(lhs.m_value << rhs.m_value);
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator&(
       simd const& lhs, simd const& rhs) noexcept {

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -115,33 +115,8 @@ class simd<T, simd_abi::scalar> {
                 bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit simd(G&& gen) noexcept
       : m_value(gen(std::integral_constant<std::size_t, 0>())) {}
-  KOKKOS_FORCEINLINE_FUNCTION simd operator-() const { return simd(-m_value); }
-  KOKKOS_FORCEINLINE_FUNCTION simd operator&(simd const& other) const {
-    return m_value & other.m_value;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION simd operator|(simd const& other) const {
-    return m_value | other.m_value;
-  }
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator T() const {
     return m_value;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION mask_type operator<(simd const& other) const {
-    return mask_type(m_value < other.m_value);
-  }
-  KOKKOS_FORCEINLINE_FUNCTION mask_type operator>(simd const& other) const {
-    return mask_type(m_value > other.m_value);
-  }
-  KOKKOS_FORCEINLINE_FUNCTION mask_type operator<=(simd const& other) const {
-    return mask_type(m_value <= other.m_value);
-  }
-  KOKKOS_FORCEINLINE_FUNCTION mask_type operator>=(simd const& other) const {
-    return mask_type(m_value >= other.m_value);
-  }
-  KOKKOS_FORCEINLINE_FUNCTION mask_type operator==(simd const& other) const {
-    return mask_type(m_value == other.m_value);
-  }
-  KOKKOS_FORCEINLINE_FUNCTION mask_type operator!=(simd const& other) const {
-    return mask_type(m_value != other.m_value);
   }
   KOKKOS_FORCEINLINE_FUNCTION void copy_from(T const* ptr,
                                              element_aligned_tag) {
@@ -156,52 +131,75 @@ class simd<T, simd_abi::scalar> {
   KOKKOS_FORCEINLINE_FUNCTION value_type operator[](std::size_t) const {
     return m_value;
   }
+  KOKKOS_FORCEINLINE_FUNCTION simd operator-() const noexcept {
+    return simd(-m_value);
+  }
 
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator>>(
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(lhs.m_value * rhs.m_value);
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator/(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(lhs.m_value / rhs.m_value);
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(lhs.m_value + rhs.m_value);
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(lhs.m_value - rhs.m_value);
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator>>(
       simd const& lhs, int rhs) noexcept {
     return simd(lhs.m_value >> rhs);
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator>>(
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator>>(
       simd const& lhs, simd const& rhs) noexcept {
-    return simd(lhs.m_value >> static_cast<int>(rhs[0]));
+    return simd(lhs.m_value >> static_cast<value_type>(rhs));
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator<<(
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator<<(
       simd const& lhs, int rhs) noexcept {
     return simd(lhs.m_value << rhs);
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator<<(
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator<<(
       simd const& lhs, simd const& rhs) noexcept {
-    return simd(lhs.m_value << static_cast<int>(rhs[0]));
+    return simd(lhs.m_value << static_cast<value_type>(rhs));
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator&(
+      simd const& lhs, simd const& rhs) noexcept {
+    return lhs.m_value & rhs.m_value;
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator|(
+      simd const& lhs, simd const& rhs) noexcept {
+    return lhs.m_value | rhs.m_value;
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(lhs.m_value < rhs.m_value);
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(lhs.m_value > rhs.m_value);
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(lhs.m_value <= rhs.m_value);
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(lhs.m_value >= rhs.m_value);
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(lhs.m_value == rhs.m_value);
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(lhs.m_value != rhs.m_value);
   }
 };
-
-template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> operator*(
-    simd<T, simd_abi::scalar> const& lhs,
-    simd<T, simd_abi::scalar> const& rhs) {
-  return simd<T, simd_abi::scalar>(static_cast<T>(lhs) * static_cast<T>(rhs));
-}
-
-template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> operator/(
-    simd<T, simd_abi::scalar> const& lhs,
-    simd<T, simd_abi::scalar> const& rhs) {
-  return simd<T, simd_abi::scalar>(static_cast<T>(lhs) / static_cast<T>(rhs));
-}
-
-template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> operator+(
-    simd<T, simd_abi::scalar> const& lhs,
-    simd<T, simd_abi::scalar> const& rhs) {
-  return simd<T, simd_abi::scalar>(static_cast<T>(lhs) + static_cast<T>(rhs));
-}
-
-template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> operator-(
-    simd<T, simd_abi::scalar> const& lhs,
-    simd<T, simd_abi::scalar> const& rhs) {
-  return simd<T, simd_abi::scalar>(static_cast<T>(lhs) - static_cast<T>(rhs));
-}
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> abs(


### PR DESCRIPTION
Follow up from https://github.com/kokkos/kokkos/pull/6109#discussion_r1276669755.

Converted binary operators to hidden friends and modified operator signatures to stay consistent with class overview provided in [P1928R6](https://wg21.link/P1928R6).