### PR TITLE
allow sorting via native oneDPL  to support views with stride = 1

### DIFF
--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -34,8 +34,14 @@ void sort([[maybe_unused]] const ExecutionSpace& exec,
   // constraints
   using ViewType = Kokkos::View<DataType, Properties...>;
   using MemSpace = typename ViewType::memory_space;
-  static_assert(ViewType::rank == 1,
-                "Kokkos::sort: currently only supports rank-1 Views.");
+  static_assert(
+      ViewType::rank == 1 &&
+          (std::is_same_v<typename ViewType::array_layout, LayoutRight> ||
+           std::is_same_v<typename ViewType::array_layout, LayoutLeft> ||
+           std::is_same_v<typename ViewType::array_layout, LayoutStride>),
+      "Kokkos::sort without comparator: supports 1D Views with LayoutRight, "
+      "LayoutLeft or LayoutStride.");
+
   static_assert(SpaceAccessibility<ExecutionSpace, MemSpace>::accessible,
                 "Kokkos::sort: execution space instance is not able to access "
                 "the memory space of the "

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -198,7 +198,7 @@ void sort_onedpl(const Kokkos::Experimental::SYCL& space,
   static_assert(
       (ViewType::rank == 1) &&
           (std::is_same_v<typename ViewType::array_layout, LayoutRight> ||
-               std::is_same_v<typename ViewType::array_layout, LayoutLeft>,
+           std::is_same_v<typename ViewType::array_layout, LayoutLeft> ||
            std::is_same_v<typename ViewType::array_layout, LayoutStride>),
       "SYCL sort only supports contiguous rank-1 Views with LayoutLeft, "
       "LayoutRight or LayoutStride"

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -285,8 +285,8 @@ void sort_device_view_without_comparator(
           (std::is_same_v<typename ViewType::array_layout, LayoutRight> ||
            std::is_same_v<typename ViewType::array_layout, LayoutLeft> ||
            std::is_same_v<typename ViewType::array_layout, LayoutStride>),
-      "sort_device_view_without_comparator: support rank-1 Views "
-      " with LayoutLeft, LayoutRight or LayoutStride");
+      "sort_device_view_without_comparator: supports rank-1 Views "
+      "with LayoutLeft, LayoutRight or LayoutStride");
 
   if (view.stride(0) == 1) {
     sort_onedpl(exec, view);
@@ -332,8 +332,8 @@ void sort_device_view_with_comparator(
           (std::is_same_v<typename ViewType::array_layout, LayoutRight> ||
            std::is_same_v<typename ViewType::array_layout, LayoutLeft> ||
            std::is_same_v<typename ViewType::array_layout, LayoutStride>),
-      "sort_device_view_with_comparator: support rank-1 Views "
-      " with LayoutLeft, LayoutRight or LayoutStride");
+      "sort_device_view_with_comparator: supports rank-1 Views "
+      "with LayoutLeft, LayoutRight or LayoutStride");
 
   if (view.stride(0) == 1) {
     sort_onedpl(exec, view, comparator);

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -313,7 +313,15 @@ void sort_device_view_with_comparator(
     const Experimental::SYCL& exec,
     const Kokkos::View<DataType, Properties...>& view,
     const ComparatorType& comparator) {
-  if (view.stride(0) == 1) {
+  using ViewType = Kokkos::View<DataType, Properties...>;
+
+  static_assert(ViewType::rank == 1,
+                "sort_device_view_with_comparator: currently only supports "
+                "rank-1 Views.");
+
+  if constexpr (std::is_same_v<typename ViewType::array_layout, LayoutRight> ||
+                std::is_same_v<typename ViewType::array_layout, LayoutLeft> ||
+                std::is_same_v<typename ViewType::array_layout, LayoutStride>) {
     sort_onedpl(exec, view, comparator);
   } else {
     copy_to_host_run_stdsort_copy_back(exec, view, comparator);

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -313,19 +313,7 @@ void sort_device_view_with_comparator(
     const Experimental::SYCL& exec,
     const Kokkos::View<DataType, Properties...>& view,
     const ComparatorType& comparator) {
-  using ViewType = Kokkos::View<DataType, Properties...>;
-
-  static_assert(ViewType::rank == 1,
-                "sort_device_view_with_comparator: currently only supports "
-                "rank-1 Views.");
-
-  if constexpr (std::is_same_v<typename ViewType::array_layout, LayoutRight> ||
-                std::is_same_v<typename ViewType::array_layout, LayoutLeft> ||
-                std::is_same_v<typename ViewType::array_layout, LayoutStride>) {
-    sort_onedpl(exec, view, comparator);
-  } else {
-    copy_to_host_run_stdsort_copy_back(exec, view, comparator);
-  }
+  sort_onedpl(exec, view, comparator);
 }
 #endif
 

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -197,7 +197,7 @@ void sort_onedpl(const Kokkos::Experimental::SYCL& space,
 
   static_assert(ViewType::rank == 1, "SYCL sort only supports rank-1 Views");
   if (view.stride(0) != 1) {
-    Kokkos::abort("SYCL sort on supports rank-1 Views with stride = 1".);
+    Kokkos::abort("SYCL sort only supports rank-1 Views with stride = 1".);
   }
 
   if (view.extent(0) <= 1) {

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -195,9 +195,18 @@ void sort_onedpl(const Kokkos::Experimental::SYCL& space,
                 "SYCL execution space is not able to access the memory space "
                 "of the View argument!");
 
-  static_assert(ViewType::rank == 1, "SYCL sort only supports rank-1 Views");
+  static_assert(
+      (ViewType::rank == 1) &&
+          (std::is_same_v<typename ViewType::array_layout, LayoutRight> ||
+               std::is_same_v<typename ViewType::array_layout, LayoutLeft>,
+           std::is_same_v<typename ViewType::array_layout, LayoutStride>),
+      "SYCL sort only supports contiguous rank-1 Views with LayoutLeft, "
+      "LayoutRight or LayoutStride"
+      "For the latter, this means the View must have stride(0) = 1, enforced "
+      "at runtime.");
+
   if (view.stride(0) != 1) {
-    Kokkos::abort("SYCL sort only supports rank-1 Views with stride = 1".);
+    Kokkos::abort("SYCL sort only supports rank-1 Views with stride(0) = 1".);
   }
 
   if (view.extent(0) <= 1) {

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -206,7 +206,7 @@ void sort_onedpl(const Kokkos::Experimental::SYCL& space,
       "at runtime.");
 
   if (view.stride(0) != 1) {
-    Kokkos::abort("SYCL sort only supports rank-1 Views with stride(0) = 1".);
+    Kokkos::abort("SYCL sort only supports rank-1 Views with stride(0) = 1.");
   }
 
   if (view.extent(0) <= 1) {


### PR DESCRIPTION
Before this PR, the call to native sort in oneDPL was guarded with static asserts for views to have layoutRight and layoutLeft. 
Since technically oneDPL can support stride = 1, this PR also allows for LayoutStride but adds a runtime check that stride ==1. 