### PR TITLE
Decrease maximum memory available to ccache

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -3,7 +3,7 @@ pipeline {
 
     environment {
         CCACHE_DIR = '/tmp/ccache'
-        CCACHE_MAXSIZE = '10G'
+        CCACHE_MAXSIZE = '5G'
         CCACHE_CPP2 = 'true'
     }
 


### PR DESCRIPTION
The majority of the CI issues we have are due to ccache using too much memory. This PR should hopefully fix this.