### PR TITLE
Fully qualify Experimental::SYCL in algorithms to avoid conflicting namspaces

### DIFF
--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -302,7 +302,7 @@ void sort_device_view_with_comparator(
 #if defined(KOKKOS_ENABLE_ONEDPL)
 template <class ComparatorType, class DataType, class... Properties>
 void sort_device_view_with_comparator(
-    const Experimental::SYCL& exec,
+    const Kokkos::Experimental::SYCL& exec,
     const Kokkos::View<DataType, Properties...>& view,
     const ComparatorType& comparator) {
   using ViewType = Kokkos::View<DataType, Properties...>;


### PR DESCRIPTION
Follow-up to #6283. I believe we merged the comparator support after #6283.
We are in `Impl` at that place and there exists namespace `Experimental::Impl` in `algorithms/src/sorting/impl/Kokkos_NestedSortImpl.hpp`.