### PR TITLE
Run NVHPC CI only on V100

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -59,7 +59,7 @@ pipeline {
                             filename 'Dockerfile.nvhpc'
                             dir 'scripts/docker'
                             additionalBuildArgs '--build-arg BASE=nvcr.io/nvidia/nvhpc:22.9-devel-cuda11.7-ubuntu20.04'
-                            label 'nvidia-docker && large_images'
+                            label 'nvidia-docker && large_images && volta'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }
                     }


### PR DESCRIPTION
Since the problem with `for_each` and `NVHPC` only happens on waffle, we can force the ci to use fetnat instead.

Alternative to https://github.com/kokkos/kokkos/pull/6332