### PR TITLE
Fix #6334: intel compiler does not like returning inside if constexpr

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -181,7 +181,7 @@ create_deep_copyable_compatible_view_with_same_extent(ViewType view) {
 }
 
 template <class ViewType, std::enable_if_t<ViewType::rank == 2, int> = 0>
-Kokkos::View<typename ViewType::value_type*, typename ViewType::execution_space>
+Kokkos::View<typename ViewType::value_type**, typename ViewType::execution_space>
 create_deep_copyable_compatible_view_with_same_extent(ViewType view) {
   using result_t         = Kokkos::View<typename ViewType::value_type**,
                                 typename ViewType::execution_space>;

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -194,14 +194,13 @@ auto create_deep_copyable_compatible_view_with_same_extent(ViewType view) {
 
 template <class ViewType>
 auto create_deep_copyable_compatible_clone(ViewType view) {
-  auto view_dc    = create_deep_copyable_compatible_view_with_same_extent(view);
-  using view_dc_t = decltype(view_dc);
+  auto view_dc = create_deep_copyable_compatible_view_with_same_extent(view);
   if constexpr (ViewType::rank == 1) {
-    CopyFunctor<ViewType, view_dc_t> F1(view, view_dc);
+    CopyFunctor F1(view, view_dc);
     Kokkos::parallel_for("copy", view.extent(0), F1);
   } else {
     static_assert(ViewType::rank == 2, "Only rank 1 or 2 supported.");
-    CopyFunctorRank2<ViewType, view_dc_t> F1(view, view_dc);
+    CopyFunctorRank2 F1(view, view_dc);
     Kokkos::parallel_for("copy", view.extent(0) * view.extent(1), F1);
   }
   return view_dc;

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -171,8 +171,11 @@ auto create_view(StridedThreeRowsTag, std::size_t ext0, std::size_t ext1,
   return view;
 }
 
-template <class ViewType, std::enable_if_t<ViewType::rank == 1, int> = 0>
-Kokkos::View<typename ViewType::value_type*, typename ViewType::execution_space>
+template <class ViewType>
+std::enable_if_t<
+  ViewType::rank == 1,
+  Kokkos::View<typename ViewType::value_type*, typename ViewType::execution_space>
+  >
 create_deep_copyable_compatible_view_with_same_extent(ViewType view) {
   using result_t         = Kokkos::View<typename ViewType::value_type*,
                                 typename ViewType::execution_space>;
@@ -180,8 +183,10 @@ create_deep_copyable_compatible_view_with_same_extent(ViewType view) {
   return result_t{"view_dc", ext0};
 }
 
-template <class ViewType, std::enable_if_t<ViewType::rank == 2, int> = 0>
-Kokkos::View<typename ViewType::value_type**, typename ViewType::execution_space>
+template <class ViewType>
+std::enable_if_t<ViewType::rank == 2,
+   Kokkos::View<typename ViewType::value_type**, typename ViewType::execution_space>
+		 >
 create_deep_copyable_compatible_view_with_same_extent(ViewType view) {
   using result_t         = Kokkos::View<typename ViewType::value_type**,
                                 typename ViewType::execution_space>;

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -200,13 +200,12 @@ create_deep_copyable_compatible_view_with_same_extent(ViewType view) {
 template <class ViewType>
 auto create_deep_copyable_compatible_clone(ViewType view) {
   auto view_dc    = create_deep_copyable_compatible_view_with_same_extent(view);
-  using view_dc_t = decltype(view_dc);
   if constexpr (ViewType::rank == 1) {
-    CopyFunctor<ViewType, view_dc_t> F1(view, view_dc);
+    CopyFunctor F1(view, view_dc);
     Kokkos::parallel_for("copy", view.extent(0), F1);
   } else {
     static_assert(ViewType::rank == 2, "Only rank 1 or 2 supported.");
-    CopyFunctorRank2<ViewType, view_dc_t> F1(view, view_dc);
+    CopyFunctorRank2 F1(view, view_dc);
     Kokkos::parallel_for("copy", view.extent(0) * view.extent(1), F1);
   }
   return view_dc;

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -197,17 +197,21 @@ create_deep_copyable_compatible_view_with_same_extent(ViewType view) {
   return result_t("view_dc", ext0, ext1);
 }
 
-template <class ViewType>
-auto create_deep_copyable_compatible_clone(ViewType view) {
+template <class ViewType, std::enable_if_t< ViewType::rank == 1, int > = 0 >
+auto create_deep_copyable_compatible_clone(ViewType view)
+{
   auto view_dc    = create_deep_copyable_compatible_view_with_same_extent(view);
-  if constexpr (ViewType::rank == 1) {
-    CopyFunctor F1(view, view_dc);
-    Kokkos::parallel_for("copy", view.extent(0), F1);
-  } else {
-    static_assert(ViewType::rank == 2, "Only rank 1 or 2 supported.");
-    CopyFunctorRank2 F1(view, view_dc);
-    Kokkos::parallel_for("copy", view.extent(0) * view.extent(1), F1);
-  }
+  CopyFunctor F1(view, view_dc);
+  Kokkos::parallel_for("copy", view.extent(0), F1);
+  return view_dc;
+}
+
+template <class ViewType, std::enable_if_t< ViewType::rank == 2, int > = 0 >
+auto create_deep_copyable_compatible_clone(ViewType view)
+{
+  auto view_dc    = create_deep_copyable_compatible_view_with_same_extent(view);
+  CopyFunctorRank2 F1(view, view_dc);
+  Kokkos::parallel_for("copy", view.extent(0) * view.extent(1), F1);
   return view_dc;
 }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -200,7 +200,8 @@ create_deep_copyable_compatible_view_with_same_extent(ViewType view) {
 template <class ViewType, std::enable_if_t< ViewType::rank == 1, int > = 0 >
 auto create_deep_copyable_compatible_clone(ViewType view)
 {
-  auto view_dc    = create_deep_copyable_compatible_view_with_same_extent(view);
+  Kokkos::View<typename ViewType::value_type*,
+	       typename ViewType::execution_space> view_dc("view_dc", view.extent(0));
   CopyFunctor F1(view, view_dc);
   Kokkos::parallel_for("copy", view.extent(0), F1);
   return view_dc;
@@ -209,7 +210,8 @@ auto create_deep_copyable_compatible_clone(ViewType view)
 template <class ViewType, std::enable_if_t< ViewType::rank == 2, int > = 0 >
 auto create_deep_copyable_compatible_clone(ViewType view)
 {
-  auto view_dc    = create_deep_copyable_compatible_view_with_same_extent(view);
+  Kokkos::View<typename ViewType::value_type**,
+	       typename ViewType::execution_space> view_dc("view_dc", view.extent(0), view.extent(1));
   CopyFunctorRank2 F1(view, view_dc);
   Kokkos::parallel_for("copy", view.extent(0) * view.extent(1), F1);
   return view_dc;

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -171,6 +171,7 @@ auto create_view(StridedThreeRowsTag, std::size_t ext0, std::size_t ext1,
   return view;
 }
 
+
 template <class ViewType>
 std::enable_if_t<
   ViewType::rank == 1,
@@ -178,9 +179,9 @@ std::enable_if_t<
   >
 create_deep_copyable_compatible_view_with_same_extent(ViewType view) {
   using result_t         = Kokkos::View<typename ViewType::value_type*,
-                                typename ViewType::execution_space>;
+					typename ViewType::execution_space>;
   const std::size_t ext0 = view.extent(0);
-  return result_t{"view_dc", ext0};
+  return result_t("view_dc", ext0);
 }
 
 template <class ViewType>
@@ -190,10 +191,10 @@ std::enable_if_t<
   >
 create_deep_copyable_compatible_view_with_same_extent(ViewType view) {
   using result_t         = Kokkos::View<typename ViewType::value_type**,
-                                typename ViewType::execution_space>;
+					typename ViewType::execution_space>;
   const std::size_t ext0 = view.extent(0);
   const std::size_t ext1 = view.extent(1);
-  return result_t{"view_dc", ext0, ext1};
+  return result_t("view_dc", ext0, ext1);
 }
 
 template <class ViewType>

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -174,25 +174,23 @@ auto create_view(StridedThreeRowsTag, std::size_t ext0, std::size_t ext1,
 // THERE MUST BE A BETTER WAY
 #if defined KOKKOS_COMPILER_INTEL
 template <class ViewType>
-std::enable_if_t<
-  ViewType::rank == 1,
-  Kokkos::View<typename ViewType::value_type*, typename ViewType::execution_space>
-  >
+std::enable_if_t<ViewType::rank == 1,
+                 Kokkos::View<typename ViewType::value_type*,
+                              typename ViewType::execution_space> >
 create_deep_copyable_compatible_view_with_same_extent(ViewType view) {
   using result_t         = Kokkos::View<typename ViewType::value_type*,
-					typename ViewType::execution_space>;
+                                typename ViewType::execution_space>;
   const std::size_t ext0 = view.extent(0);
   return result_t("view_dc", ext0);
 }
 
 template <class ViewType>
-std::enable_if_t<
-  ViewType::rank == 2,
-  Kokkos::View<typename ViewType::value_type**, typename ViewType::execution_space>
-  >
+std::enable_if_t<ViewType::rank == 2,
+                 Kokkos::View<typename ViewType::value_type**,
+                              typename ViewType::execution_space> >
 create_deep_copyable_compatible_view_with_same_extent(ViewType view) {
   using result_t         = Kokkos::View<typename ViewType::value_type**,
-					typename ViewType::execution_space>;
+                                typename ViewType::execution_space>;
   const std::size_t ext0 = view.extent(0);
   const std::size_t ext1 = view.extent(1);
   return result_t("view_dc", ext0, ext1);

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -171,20 +171,25 @@ auto create_view(StridedThreeRowsTag, std::size_t ext0, std::size_t ext1,
   return view;
 }
 
-template <class ViewType>
+template <class ViewType, std::enable_if_t<ViewType::rank == 1, int> = 0>
 auto create_deep_copyable_compatible_view_with_same_extent(ViewType view) {
-  using view_value_type  = typename ViewType::value_type;
-  using view_exespace    = typename ViewType::execution_space;
+  using view_value_type      = typename ViewType::value_type;
+  using view_exespace        = typename ViewType::execution_space;
+  using view_deep_copyable_t = Kokkos::View<view_value_type*, view_exespace>;
+
   const std::size_t ext0 = view.extent(0);
-  if constexpr (ViewType::rank == 1) {
-    using view_deep_copyable_t = Kokkos::View<view_value_type*, view_exespace>;
-    return view_deep_copyable_t{"view_dc", ext0};
-  } else {
-    static_assert(ViewType::rank == 2, "Only rank 1 or 2 supported.");
-    using view_deep_copyable_t = Kokkos::View<view_value_type**, view_exespace>;
-    const std::size_t ext1     = view.extent(1);
-    return view_deep_copyable_t{"view_dc", ext0, ext1};
-  }
+  return view_deep_copyable_t{"view_dc", ext0};
+}
+
+template <class ViewType, std::enable_if_t<ViewType::rank == 2, int> = 0>
+auto create_deep_copyable_compatible_view_with_same_extent(ViewType view) {
+  using view_value_type      = typename ViewType::value_type;
+  using view_exespace        = typename ViewType::execution_space;
+  using view_deep_copyable_t = Kokkos::View<view_value_type**, view_exespace>;
+
+  const std::size_t ext0 = view.extent(0);
+  const std::size_t ext1 = view.extent(1);
+  return view_deep_copyable_t{"view_dc", ext0, ext1};
 }
 
 template <class ViewType>


### PR DESCRIPTION
Fixes #6334 

Seems like intel did not like the constexpr and so was complaining about the return value because it was inside the else branch of the constexpr if. This provides a workaround using the native unreachable extension. 
Verified it compiles and runs correctly on dev-2.

@ndellingwood 

