### PR TITLE
Fix #6336: capturing `this` implicitly is deprecated in C++20

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsTeamAdjacentFind.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamAdjacentFind.cpp
@@ -55,7 +55,7 @@ struct TestFunctorA {
       case 0: {
         const auto it = KE::adjacent_find(member, KE::cbegin(myRowViewFrom),
                                           KE::cend(myRowViewFrom));
-        Kokkos::single(Kokkos::PerTeam(member), [=, this]() {
+        Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
           m_distancesView(myRowIndex) =
               KE::distance(KE::cbegin(myRowViewFrom), it);
         });
@@ -64,7 +64,7 @@ struct TestFunctorA {
 
       case 1: {
         const auto it = KE::adjacent_find(member, myRowViewFrom);
-        Kokkos::single(Kokkos::PerTeam(member), [=, this]() {
+        Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
           m_distancesView(myRowIndex) =
               KE::distance(KE::begin(myRowViewFrom), it);
         });
@@ -75,7 +75,7 @@ struct TestFunctorA {
         const auto it =
             KE::adjacent_find(member, KE::cbegin(myRowViewFrom),
                               KE::cend(myRowViewFrom), m_binaryPred);
-        Kokkos::single(Kokkos::PerTeam(member), [=, this]() {
+        Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
           m_distancesView(myRowIndex) =
               KE::distance(KE::cbegin(myRowViewFrom), it);
         });
@@ -84,7 +84,7 @@ struct TestFunctorA {
 
       case 3: {
         const auto it = KE::adjacent_find(member, myRowViewFrom, m_binaryPred);
-        Kokkos::single(Kokkos::PerTeam(member), [=, this]() {
+        Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
           m_distancesView(myRowIndex) =
               KE::distance(KE::begin(myRowViewFrom), it);
         });

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamAdjacentFind.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamAdjacentFind.cpp
@@ -55,7 +55,7 @@ struct TestFunctorA {
       case 0: {
         const auto it = KE::adjacent_find(member, KE::cbegin(myRowViewFrom),
                                           KE::cend(myRowViewFrom));
-        Kokkos::single(Kokkos::PerTeam(member), [=]() {
+        Kokkos::single(Kokkos::PerTeam(member), [=, this]() {
           m_distancesView(myRowIndex) =
               KE::distance(KE::cbegin(myRowViewFrom), it);
         });
@@ -64,7 +64,7 @@ struct TestFunctorA {
 
       case 1: {
         const auto it = KE::adjacent_find(member, myRowViewFrom);
-        Kokkos::single(Kokkos::PerTeam(member), [=]() {
+        Kokkos::single(Kokkos::PerTeam(member), [=, this]() {
           m_distancesView(myRowIndex) =
               KE::distance(KE::begin(myRowViewFrom), it);
         });
@@ -75,7 +75,7 @@ struct TestFunctorA {
         const auto it =
             KE::adjacent_find(member, KE::cbegin(myRowViewFrom),
                               KE::cend(myRowViewFrom), m_binaryPred);
-        Kokkos::single(Kokkos::PerTeam(member), [=]() {
+        Kokkos::single(Kokkos::PerTeam(member), [=, this]() {
           m_distancesView(myRowIndex) =
               KE::distance(KE::cbegin(myRowViewFrom), it);
         });
@@ -84,7 +84,7 @@ struct TestFunctorA {
 
       case 3: {
         const auto it = KE::adjacent_find(member, myRowViewFrom, m_binaryPred);
-        Kokkos::single(Kokkos::PerTeam(member), [=]() {
+        Kokkos::single(Kokkos::PerTeam(member), [=, this]() {
           m_distancesView(myRowIndex) =
               KE::distance(KE::begin(myRowViewFrom), it);
         });

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamCount.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamCount.cpp
@@ -47,7 +47,7 @@ struct TestFunctorA {
         auto result =
             KE::count(member, KE::cbegin(rowView), KE::cend(rowView), value);
         Kokkos::single(Kokkos::PerTeam(member),
-                       [=]() { m_countsView(rowIndex) = result; });
+                       [=, this]() { m_countsView(rowIndex) = result; });
 
         break;
       }
@@ -55,7 +55,7 @@ struct TestFunctorA {
       case 1: {
         auto result = KE::count(member, rowView, value);
         Kokkos::single(Kokkos::PerTeam(member),
-                       [=]() { m_countsView(rowIndex) = result; });
+                       [=, this]() { m_countsView(rowIndex) = result; });
 
         break;
       }

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamCount.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamCount.cpp
@@ -47,7 +47,7 @@ struct TestFunctorA {
         auto result =
             KE::count(member, KE::cbegin(rowView), KE::cend(rowView), value);
         Kokkos::single(Kokkos::PerTeam(member),
-                       [=, this]() { m_countsView(rowIndex) = result; });
+                       [=, *this]() { m_countsView(rowIndex) = result; });
 
         break;
       }
@@ -55,7 +55,7 @@ struct TestFunctorA {
       case 1: {
         auto result = KE::count(member, rowView, value);
         Kokkos::single(Kokkos::PerTeam(member),
-                       [=, this]() { m_countsView(rowIndex) = result; });
+                       [=, *this]() { m_countsView(rowIndex) = result; });
 
         break;
       }

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamCountIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamCountIf.cpp
@@ -58,11 +58,11 @@ struct TestFunctorA {
                                   KE::end(myRowView), predicate);
 
       Kokkos::single(Kokkos::PerTeam(member),
-                     [=]() { m_countsView(myRowIndex) = myCount; });
+                     [=, this]() { m_countsView(myRowIndex) = myCount; });
     } else if (m_apiPick == 1) {
       auto myCount = KE::count_if(member, myRowView, predicate);
       Kokkos::single(Kokkos::PerTeam(member),
-                     [=]() { m_countsView(myRowIndex) = myCount; });
+                     [=, this]() { m_countsView(myRowIndex) = myCount; });
     }
   }
 };

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamCountIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamCountIf.cpp
@@ -58,11 +58,11 @@ struct TestFunctorA {
                                   KE::end(myRowView), predicate);
 
       Kokkos::single(Kokkos::PerTeam(member),
-                     [=, this]() { m_countsView(myRowIndex) = myCount; });
+                     [=, *this]() { m_countsView(myRowIndex) = myCount; });
     } else if (m_apiPick == 1) {
       auto myCount = KE::count_if(member, myRowView, predicate);
       Kokkos::single(Kokkos::PerTeam(member),
-                     [=, this]() { m_countsView(myRowIndex) = myCount; });
+                     [=, *this]() { m_countsView(myRowIndex) = myCount; });
     }
   }
 };

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamLexicographicalCompare.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamLexicographicalCompare.cpp
@@ -67,7 +67,7 @@ struct TestFunctorA {
         const bool result = KE::lexicographical_compare(
             member, dataBegin, dataEnd, compBegin, compEnd);
         Kokkos::single(Kokkos::PerTeam(member),
-                       [=, this]() { m_resultsView(rowIndex) = result; });
+                       [=, *this]() { m_resultsView(rowIndex) = result; });
         break;
       }
 
@@ -75,7 +75,7 @@ struct TestFunctorA {
         const bool result =
             KE::lexicographical_compare(member, rowData, rowComp);
         Kokkos::single(Kokkos::PerTeam(member),
-                       [=, this]() { m_resultsView(rowIndex) = result; });
+                       [=, *this]() { m_resultsView(rowIndex) = result; });
         break;
       }
 
@@ -83,7 +83,7 @@ struct TestFunctorA {
         const bool result = KE::lexicographical_compare(
             member, dataBegin, dataEnd, compBegin, compEnd, m_binaryComp);
         Kokkos::single(Kokkos::PerTeam(member),
-                       [=, this]() { m_resultsView(rowIndex) = result; });
+                       [=, *this]() { m_resultsView(rowIndex) = result; });
         break;
       }
 
@@ -91,7 +91,7 @@ struct TestFunctorA {
         const bool result =
             KE::lexicographical_compare(member, rowData, rowComp, m_binaryComp);
         Kokkos::single(Kokkos::PerTeam(member),
-                       [=, this]() { m_resultsView(rowIndex) = result; });
+                       [=, *this]() { m_resultsView(rowIndex) = result; });
         break;
       }
     }

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamLexicographicalCompare.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamLexicographicalCompare.cpp
@@ -67,7 +67,7 @@ struct TestFunctorA {
         const bool result = KE::lexicographical_compare(
             member, dataBegin, dataEnd, compBegin, compEnd);
         Kokkos::single(Kokkos::PerTeam(member),
-                       [=]() { m_resultsView(rowIndex) = result; });
+                       [=, this]() { m_resultsView(rowIndex) = result; });
         break;
       }
 
@@ -75,7 +75,7 @@ struct TestFunctorA {
         const bool result =
             KE::lexicographical_compare(member, rowData, rowComp);
         Kokkos::single(Kokkos::PerTeam(member),
-                       [=]() { m_resultsView(rowIndex) = result; });
+                       [=, this]() { m_resultsView(rowIndex) = result; });
         break;
       }
 
@@ -83,7 +83,7 @@ struct TestFunctorA {
         const bool result = KE::lexicographical_compare(
             member, dataBegin, dataEnd, compBegin, compEnd, m_binaryComp);
         Kokkos::single(Kokkos::PerTeam(member),
-                       [=]() { m_resultsView(rowIndex) = result; });
+                       [=, this]() { m_resultsView(rowIndex) = result; });
         break;
       }
 
@@ -91,7 +91,7 @@ struct TestFunctorA {
         const bool result =
             KE::lexicographical_compare(member, rowData, rowComp, m_binaryComp);
         Kokkos::single(Kokkos::PerTeam(member),
-                       [=]() { m_resultsView(rowIndex) = result; });
+                       [=, this]() { m_resultsView(rowIndex) = result; });
         break;
       }
     }

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamMismatch.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamMismatch.cpp
@@ -67,7 +67,7 @@ struct TestFunctorA {
 
         const auto dataDist = KE::distance(dataBegin, dataIt);
         const auto compDist = KE::distance(compBegin, compIt);
-        Kokkos::single(Kokkos::PerTeam(member), [=, this]() {
+        Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
           m_resultsView(rowIndex) = Kokkos::make_pair(dataDist, compDist);
         });
 
@@ -80,7 +80,7 @@ struct TestFunctorA {
 
         const auto dataDist = KE::distance(dataBegin, dataIt);
         const auto compDist = KE::distance(compBegin, compIt);
-        Kokkos::single(Kokkos::PerTeam(member), [=, this]() {
+        Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
           m_resultsView(rowIndex) = Kokkos::make_pair(dataDist, compDist);
         });
 
@@ -92,7 +92,7 @@ struct TestFunctorA {
 
         const std::size_t dataDist = KE::distance(dataBegin, dataIt);
         const std::size_t compDist = KE::distance(compBegin, compIt);
-        Kokkos::single(Kokkos::PerTeam(member), [=, this]() {
+        Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
           m_resultsView(rowIndex) = Kokkos::make_pair(dataDist, compDist);
         });
 
@@ -105,7 +105,7 @@ struct TestFunctorA {
 
         const std::size_t dataDist = KE::distance(dataBegin, dataIt);
         const std::size_t compDist = KE::distance(compBegin, compIt);
-        Kokkos::single(Kokkos::PerTeam(member), [=, this]() {
+        Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
           m_resultsView(rowIndex) = Kokkos::make_pair(dataDist, compDist);
         });
 

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamMismatch.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamMismatch.cpp
@@ -67,7 +67,7 @@ struct TestFunctorA {
 
         const auto dataDist = KE::distance(dataBegin, dataIt);
         const auto compDist = KE::distance(compBegin, compIt);
-        Kokkos::single(Kokkos::PerTeam(member), [=]() {
+        Kokkos::single(Kokkos::PerTeam(member), [=, this]() {
           m_resultsView(rowIndex) = Kokkos::make_pair(dataDist, compDist);
         });
 
@@ -80,7 +80,7 @@ struct TestFunctorA {
 
         const auto dataDist = KE::distance(dataBegin, dataIt);
         const auto compDist = KE::distance(compBegin, compIt);
-        Kokkos::single(Kokkos::PerTeam(member), [=]() {
+        Kokkos::single(Kokkos::PerTeam(member), [=, this]() {
           m_resultsView(rowIndex) = Kokkos::make_pair(dataDist, compDist);
         });
 
@@ -92,7 +92,7 @@ struct TestFunctorA {
 
         const std::size_t dataDist = KE::distance(dataBegin, dataIt);
         const std::size_t compDist = KE::distance(compBegin, compIt);
-        Kokkos::single(Kokkos::PerTeam(member), [=]() {
+        Kokkos::single(Kokkos::PerTeam(member), [=, this]() {
           m_resultsView(rowIndex) = Kokkos::make_pair(dataDist, compDist);
         });
 
@@ -105,7 +105,7 @@ struct TestFunctorA {
 
         const std::size_t dataDist = KE::distance(dataBegin, dataIt);
         const std::size_t compDist = KE::distance(compBegin, compIt);
-        Kokkos::single(Kokkos::PerTeam(member), [=]() {
+        Kokkos::single(Kokkos::PerTeam(member), [=, this]() {
           m_resultsView(rowIndex) = Kokkos::make_pair(dataDist, compDist);
         });
 


### PR DESCRIPTION
implicit capture of 'this' via '[=]' is deprecated in C++20 , so making it explicit anyway. 