### PR TITLE
Adopt (new) HIP cmake's way of finding clang-rt

### DIFF
--- a/cmake/Modules/FindTPLROCM.cmake
+++ b/cmake/Modules/FindTPLROCM.cmake
@@ -8,13 +8,22 @@ FIND_LIBRARY(HSA_RUNTIME_LIBRARY hsa-runtime64 PATHS ENV ROCM_PATH PATH_SUFFIXES
 # found.
 # clang_rt.builtins is necessary to use half precision. The following code to
 # find clang_rt.buitins is based on
-# https://github.com/ROCm-Developer-Tools/HIP/blob/develop/hip-lang-config.cmake.in#L99-L111
-file(GLOB_RECURSE CLANG_RT_DIR "$ENV{ROCM_PATH}/llvm/lib/clang/*/lib/*/*clang_rt.builtins*")
-FIND_LIBRARY(CLANG_RT_LIBRARY
-  NAMES
-  clang_rt.builtins
-  clang_rt.builtins-x86_64
-  PATHS "${CLANG_RT_DIR}/..")
+# https://github.com/ROCm-Developer-Tools/hipamd/blob/d1e0ee98a0f3d79f7bf43295f82d0053a69ec742/hip-config.cmake.in#L241
+# NOTE: Per the above, we still search for the clang-rt library,
+# but use the user's specified compiler to find the library to avoid use of
+# environment variables / relative paths.
+execute_process(
+  COMMAND ${CMAKE_CXX_COMPILER} -print-libgcc-file-name --rtlib=compiler-rt
+  OUTPUT_VARIABLE CLANG_RT_LIBRARY
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE CLANG_RT_CHECK)
+
+if( NOT "${CLANG_RT_CHECK}" STREQUAL "0" )
+  # if the above failed, we delete CLANG_RT_LIBRARY to make the args check
+  # below fail
+  unset(CLANG_RT_LIBRARY)
+endif()
+
 
 find_package_handle_standard_args(TPLROCM DEFAULT_MSG AMD_HIP_LIBRARY HSA_RUNTIME_LIBRARY CLANG_RT_LIBRARY)
 


### PR DESCRIPTION
This is not strictly necessary anymore (as of ROCm >= 5.5), but we have internally observed the Check for CLANG_RT_LIBRARY failing for newer LLVM versions. Historically, this sort of relative pathing in CMake has caused issues (e.g., major LLVM versions occaisonally change the exact path to the clang-rt builtins). A more robust solution was adopted in the HIP CMake (see e.g., https://github.com/ROCm-Developer-Tools/hipamd/blob/d1e0ee98a0f3d79f7bf43295f82d0053a69ec742/hip-config.cmake.in#L241) that asks the CXX compiler specified by the user to print out the path to the library. We check the return code of that compiler call, and unset CLANG_RT_LIBRARY to fail as a find_package_handle_standard_args.

Change-Id: If536364092db9c2bacc85c2f1bd15745efab9ada