### PR TITLE
Fix cudaAPI wrapper errors for CUDA_MALLOC_ASYNC

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -458,6 +458,7 @@ pipeline {
                                 -DKokkos_ENABLE_CUDA_LAMBDA=ON \
                                 -DKokkos_ENABLE_LIBDL=OFF \
                                 -DKokkos_ENABLE_IMPL_MDSPAN=ON \
+                                -DKokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=ON \
                               .. && \
                               make -j8 && ctest --verbose && \
                               cd ../example/build_cmake_in_tree && \

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -141,7 +141,7 @@ CudaUVMSpace::CudaUVMSpace() : m_device(Kokkos::Cuda().cuda_device()) {}
 
 CudaHostPinnedSpace::CudaHostPinnedSpace() {}
 
-int memory_threshold_g = 40000;  // 40 kB
+size_t memory_threshold_g = 40000;  // 40 kB
 
 //==============================================================================
 // <editor-fold desc="allocate()"> {{{1
@@ -172,7 +172,7 @@ void *impl_allocate_common(const Cuda &exec_space, const char *arg_label,
 #error CUDART_VERSION undefined!
 #elif (defined(KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC) && CUDART_VERSION >= 11020)
   cudaError_t error_code;
-  if (arg_alloc_size >= (size_t)memory_threshold_g) {
+  if (arg_alloc_size >= memory_threshold_g) {
     if (exec_space_provided) {
       error_code =
           exec_space.impl_internal_space_instance()->cuda_malloc_async_wrapper(
@@ -347,7 +347,7 @@ void CudaSpace::impl_deallocate(
 #ifndef CUDART_VERSION
 #error CUDART_VERSION undefined!
 #elif (defined(KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC) && CUDART_VERSION >= 11020)
-    if (arg_alloc_size >= (size_t)memory_threshold_g) {
+    if (arg_alloc_size >= memory_threshold_g) {
       Impl::cuda_device_synchronize(
           "Kokkos::Cuda: backend fence before async free");
       KOKKOS_IMPL_CUDA_SAFE_CALL(

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -172,7 +172,7 @@ void *impl_allocate_common(const Cuda &exec_space, const char *arg_label,
 #error CUDART_VERSION undefined!
 #elif (defined(KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC) && CUDART_VERSION >= 11020)
   cudaError_t error_code;
-  if (arg_alloc_size >= memory_threshold_g) {
+  if (arg_alloc_size >= (size_t)memory_threshold_g) {
     if (exec_space_provided) {
       error_code =
           exec_space.impl_internal_space_instance()->cuda_malloc_async_wrapper(
@@ -347,7 +347,7 @@ void CudaSpace::impl_deallocate(
 #ifndef CUDART_VERSION
 #error CUDART_VERSION undefined!
 #elif (defined(KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC) && CUDART_VERSION >= 11020)
-    if (arg_alloc_size >= memory_threshold_g) {
+    if (arg_alloc_size >= (size_t)memory_threshold_g) {
       Impl::cuda_device_synchronize(
           "Kokkos::Cuda: backend fence before async free");
       KOKKOS_IMPL_CUDA_SAFE_CALL(

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -487,16 +487,16 @@ class CudaInternal {
 #if (defined(KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC) && CUDART_VERSION >= 11020)
   template <bool setCudaDevice = true>
   cudaError_t cuda_malloc_async_wrapper(void** devPtr, size_t size,
-                                        cudaStream_t hStream == nullptr) const {
+                                        cudaStream_t hStream = nullptr) const {
     if constexpr (setCudaDevice) set_cuda_device();
-    return cudaMallocAsync(devPtr, size, get_input_stream(stream));
+    return cudaMallocAsync(devPtr, size, get_input_stream(hStream));
   }
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_free_async_wrapper(void* devPtr,
-                                      cudaStream_t hStream == nullptr) const {
+                                      cudaStream_t hStream = nullptr) const {
     if constexpr (setCudaDevice) set_cuda_device();
-    return cudaFreeAsync(devPtr, get_input_stream(stream));
+    return cudaFreeAsync(devPtr, get_input_stream(hStream));
   }
 #endif
 


### PR DESCRIPTION
Fixes build error uncovered in https://github.com/kokkos/kokkos/issues/6344. Uncovered an additional error (typo in input arg).

I verified the following config on Weaver V100:
```
Modules:
cuda11.8, gcc/9.3.0, cmake/3.25.1

CMake env: 
cmake -DKokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=ON \
      -DCMAKE_CXX_COMPILER=$KOKKOS_DIR/bin/nvcc_wrapper \
      -DKokkos_ENABLE_SERIAL=ON \
      -DKokkos_ENABLE_CUDA=ON \
      -DKokkos_ARCH_VOLTA70=ON \
      -DKokkos_ENABLE_TESTS=ON \
      -DCMAKE_BUILD_TYPE:STRING=Debug
      $KOKKOS_DIR

Test command:
ctest -R Cuda
``` 
Build fails on develop, but this branch builds successfully and all tests run and pass.

Closes https://github.com/kokkos/kokkos/issues/6344.