### PR TITLE
Fix compiling SIMD libraray with NEON and gcc-13

### DIFF
--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -914,7 +914,8 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
       simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
       simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
     return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(vshlq_u64(
-        static_cast<uint64x2_t>(lhs), vnegq_s64(static_cast<uint64x2_t>(rhs))));
+        static_cast<uint64x2_t>(lhs),
+        vnegq_s64(vreinterpretq_s64_u64(static_cast<uint64x2_t>(rhs)))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
       std::uint64_t, simd_abi::neon_fixed_size<2>>
@@ -929,7 +930,8 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
       simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
       simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
     return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
-        vshlq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
+        vshlq_u64(static_cast<uint64x2_t>(lhs),
+                  vreinterpretq_s64_u64(static_cast<uint64x2_t>(rhs))));
   }
 };
 


### PR DESCRIPTION
Trying to compile `Kokkos` on a M1 using `g++13` currently errors out with:
```
In file included from /tmp/kokkos/simd/src/Kokkos_SIMD.hpp:33,
                 from /tmp/kokkos/simd/unit_tests/include/TestSIMD_MathOps.hpp:20,
                 from /tmp/kokkos/simd/unit_tests/TestSIMD.cpp:17:
/tmp/kokkos/simd/src/Kokkos_SIMD_NEON.hpp: In function 'Kokkos::Experimental::simd<long long unsigned int, Kokkos::Experimental::simd_abi::neon_fixed_size<2> > Kokkos::Experimental::operator>>(const simd<long long unsigned int, simd_abi::neon_fixed_size<2> >&, const simd<long long unsigned int, simd_abi::neon_fixed_size<2> >&)':
/tmp/kokkos/simd/src/Kokkos_SIMD_NEON.hpp:917:48: note: use '-flax-vector-conversions' to permit conversions between vectors with differing element types or numbers of subparts
  917 |         static_cast<uint64x2_t>(lhs), vnegq_s64(static_cast<uint64x2_t>(rhs))));
      |                                       ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/kokkos/simd/src/Kokkos_SIMD_NEON.hpp:917:49: error: cannot convert 'uint64x2_t' to 'int64x2_t'
  917 |         static_cast<uint64x2_t>(lhs), vnegq_s64(static_cast<uint64x2_t>(rhs))));
      |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                 |
      |                                                 uint64x2_t
In file included from /tmp/kokkos/simd/src/Kokkos_SIMD_NEON.hpp:25:
/opt/homebrew/Cellar/gcc/13.1.0/lib/gcc/current/gcc/aarch64-apple-darwin21/13/include/arm_neon.h:17503:22: note:   initializing argument 1 of 'int64x2_t vnegq_s64(int64x2_t)'
17503 | vnegq_s64 (int64x2_t __a)
      |            ~~~~~~~~~~^~~
/tmp/kokkos/simd/src/Kokkos_SIMD_NEON.hpp: In function 'Kokkos::Experimental::simd<long long unsigned int, Kokkos::Experimental::simd_abi::neon_fixed_size<2> > Kokkos::Experimental::operator<<(const simd<long long unsigned int, simd_abi::neon_fixed_size<2> >&, const simd<long long unsigned int, simd_abi::neon_fixed_size<2> >&)':
/tmp/kokkos/simd/src/Kokkos_SIMD_NEON.hpp:932:49: error: cannot convert 'uint64x2_t' to 'int64x2_t'
  932 |         vshlq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
      |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                 |
      |                                                 uint64x2_t
/opt/homebrew/Cellar/gcc/13.1.0/lib/gcc/current/gcc/aarch64-apple-darwin21/13/include/arm_neon.h:21105:38: note:   initializing argument 2 of 'uint64x2_t vshlq_u64(uint64x2_t, int64x2_t)'
21105 | vshlq_u64 (uint64x2_t __a, int64x2_t __b)
      |                            ~~~~~~~~~~^~~
```
It seems we need to `reinterpret_cast` from `uint64x2_t` to `int64x2_t` in some places to make the compiler happy. According to https://developer.arm.com/architectures/instruction-sets/intrinsics/[__arm_]vreinterpretq_u64[_s8], this is a no-op anyway.