### PR TITLE
Fix -Wformat-truncation warnings in CI

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -626,17 +626,11 @@ void initialize(const std::string& profileLibrary) {
     return;
   }
 
-  char* envProfileLibrary = const_cast<char*>(profileLibrary.c_str());
-
-  const size_t envProfileLen = strlen(envProfileLibrary) + 1;
-  const auto envProfileCopy  = std::make_unique<char[]>(envProfileLen);
-  snprintf(envProfileCopy.get(), envProfileLen, "%s", envProfileLibrary);
-
-  char* profileLibraryName = strtok(envProfileCopy.get(), ";");
-
-  if ((profileLibraryName != nullptr) &&
-      (strcmp(profileLibraryName, "") != 0)) {
-    firstProfileLibrary = dlopen(profileLibraryName, RTLD_NOW | RTLD_GLOBAL);
+  if (auto end_first_library = profileLibrary.find(';');
+      end_first_library != 0) {
+    auto profileLibraryName = profileLibrary.substr(0, end_first_library);
+    firstProfileLibrary =
+        dlopen(profileLibraryName.c_str(), RTLD_NOW | RTLD_GLOBAL);
 
     if (firstProfileLibrary == nullptr) {
       std::cerr << "Error: Unable to load KokkosP library: "

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -282,7 +282,7 @@ SharedAllocationRecord<void, void>* SharedAllocationRecord<
 // FIXME GCC warns that we truncate the output below.
 #ifdef KOKKOS_COMPILER_GNU
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
+#pragma GCC diagnostic ignored "-Wformat-truncation="
 #endif
 
 void SharedAllocationRecord<void, void>::print_host_accessible_records(

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -278,6 +278,13 @@ SharedAllocationRecord<void, void>* SharedAllocationRecord<
 }
 
 #ifdef KOKKOS_ENABLE_DEBUG
+
+// FIXME GCC warns that we truncate the output below.
+#ifdef KOKKOS_COMPILER_GNU
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
+
 void SharedAllocationRecord<void, void>::print_host_accessible_records(
     std::ostream& s, const char* const space_name,
     const SharedAllocationRecord* const root, const bool detail) {
@@ -331,6 +338,11 @@ void SharedAllocationRecord<void, void>::print_host_accessible_records(
     }
   }
 }
+
+#ifdef KOKKOS_COMPILER_GNU
+#pragma GCC diagnostic pop
+#endif
+
 #else
 void SharedAllocationRecord<void, void>::print_host_accessible_records(
     std::ostream&, const char* const, const SharedAllocationRecord* const,

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
+#include <iomanip>
 
 namespace Kokkos {
 namespace Impl {
@@ -285,22 +286,28 @@ void SharedAllocationRecord<void, void>::print_host_accessible_records(
   // allocation.
   const SharedAllocationRecord<void, void>* r = root->m_next;
 
+#define KOKKOS_PAD_HEX(ptr)                              \
+  "0x" << std::hex << std::setw(12) << std::setfill('0') \
+       << reinterpret_cast<uintptr_t>(ptr)
   if (detail) {
     while (r != root) {
-      s << space_name << " addr( " << r << " ) list ( " << r->m_prev << ' '
-        << r->m_next << " ) extent[ " << r->m_alloc_ptr << " + "
-        << r->m_alloc_size << " ] count(" << r->use_count() << ") dealloc("
-        << reinterpret_cast<void*>(r->m_dealloc) << ") "
+      s << space_name << " addr( " << KOKKOS_PAD_HEX(r) << " ) list ( "
+        << KOKKOS_PAD_HEX(r->m_prev) << ' ' << KOKKOS_PAD_HEX(r->m_next)
+        << " ) extent[ " << KOKKOS_PAD_HEX(r->m_alloc_ptr) << " + " << std::dec
+        << std::setw(8) << r->m_alloc_size << " ] count(" << r->use_count()
+        << ") dealloc(" << KOKKOS_PAD_HEX(r->m_dealloc) << ") "
         << r->m_alloc_ptr->m_label << '\n';
+
       r = r->m_next;
     }
   } else {
     while (r != root) {
-      s << space_name << " [ " << r->data() << " + " << r->size() << " ] "
-        << r->m_alloc_ptr->m_label << '\n';
+      s << space_name << " [ " << KOKKOS_PAD_HEX(r->data()) << " + " << std::dec
+        << r->size() << " ] " << r->m_alloc_ptr->m_label << '\n';
       r = r->m_next;
     }
   }
+#undef KOKKOS_PAD_HEX
 }
 #else
 void SharedAllocationRecord<void, void>::print_host_accessible_records(

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -286,6 +286,7 @@ void SharedAllocationRecord<void, void>::print_host_accessible_records(
   // allocation.
   const SharedAllocationRecord<void, void>* r = root->m_next;
 
+  std::ios_base::fmtflags saved_flags = s.flags();
 #define KOKKOS_PAD_HEX(ptr)                              \
   "0x" << std::hex << std::setw(12) << std::setfill('0') \
        << reinterpret_cast<uintptr_t>(ptr)
@@ -308,6 +309,7 @@ void SharedAllocationRecord<void, void>::print_host_accessible_records(
     }
   }
 #undef KOKKOS_PAD_HEX
+  s.flags(saved_flags);
 }
 #else
 void SharedAllocationRecord<void, void>::print_host_accessible_records(


### PR DESCRIPTION
This attempts to fix https://github.com/kokkos/kokkos/issues/6349. 
Instead of using a fixed-size buffer, this pull request ~~makes sure that we resize the buffer to be at least big enough to hold the full formatted output.~~ directly uses `operator<<`.

Trying enabling `-Wformat-truncation` locally also flagged `Kokkos_Profiling.cpp`, so this is simplified using fewer `C` functions.
```
/tmp/kokkos/core/src/impl/Kokkos_Profiling.cpp: In function 'void Kokkos::Tools::initialize(const std::string&)':
/tmp/kokkos/core/src/impl/Kokkos_Profiling.cpp:633:52: error: 'snprintf' output may be truncated before the last format character [-Werror=format-truncation=]
  633 |   snprintf(envProfileCopy.get(), envProfileLen, "%s", envProfileLibrary);
      |                                                    ^
/tmp/kokkos/core/src/impl/Kokkos_Profiling.cpp:633:11: note: 'snprintf' output 1 or more bytes (assuming 2) into a destination of size 1
  633 |   snprintf(envProfileCopy.get(), envProfileLen, "%s", envProfileLibrary);
      |   ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```