### PR TITLE
Adding is_scoped_enum & to_underlying

### DIFF
--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -79,35 +79,11 @@ template <class T>
 using remove_cvref_t = typename remove_cvref<T>::type;
 #endif
 
-#if __cplusplus >= 202002
-// C++20 version of std::underlying_type
-//
-// If T is a complete enumeration (enum) type, provides a member typedef type
-// that names the underlying type of T.
-// Otherwise, if T is not an enumeration type, there is no member type.
-// Otherwise (T is an incomplete enumeration type), the program is ill-formed.
-using std::underlying_type;
-using std::underlying_type_t;
-#else
-template <typename E, bool = std::is_enum_v<E>>
-struct underlying_type_impl {};
-
-template <typename E>
-struct underlying_type_impl<E, true> {
-  using type = std::underlying_type_t<E>;
-};
-
-template <typename E>
-using underlying_type = underlying_type_impl<E>;
-
-template <typename E>
-using underlying_type_t = typename underlying_type<E>::type;
-#endif
-
 // same as C++23 std::to_underlying but with __host__ __device__ annotations
 template <typename E>
-KOKKOS_FUNCTION constexpr underlying_type_t<E> to_underlying(E e) noexcept {
-  return static_cast<underlying_type_t<E>>(e);
+KOKKOS_FUNCTION constexpr std::underlying_type_t<E> to_underlying(
+    E e) noexcept {
+  return static_cast<std::underlying_type_t<E>>(e);
 }
 
 #if defined(__cpp_lib_is_scoped_enum)
@@ -120,7 +96,8 @@ struct is_scoped_enum_impl : std::false_type {};
 
 template <typename E>
 struct is_scoped_enum_impl<E, true>
-    : std::bool_constant<!std::is_convertible_v<E, underlying_type_t<E>>> {};
+    : std::bool_constant<!std::is_convertible_v<E, std::underlying_type_t<E>>> {
+};
 
 template <typename E>
 struct is_scoped_enum : is_scoped_enum_impl<E>::type {};

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -106,7 +106,7 @@ using underlying_type_t = typename underlying_type<E>::type;
 
 // same as C++23 std::to_underlying but with __host__ __device__ annotations
 template <typename E>
-KOKKOS_INLINE_FUNCTION constexpr underlying_type_t<E> to_underlying(
+KOKKOS_FUNCTION constexpr underlying_type_t<E> to_underlying(
     E e) noexcept {
   return static_cast<underlying_type_t<E>>(e);
 }

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -106,8 +106,7 @@ using underlying_type_t = typename underlying_type<E>::type;
 
 // same as C++23 std::to_underlying but with __host__ __device__ annotations
 template <typename E>
-KOKKOS_FUNCTION constexpr underlying_type_t<E> to_underlying(
-    E e) noexcept {
+KOKKOS_FUNCTION constexpr underlying_type_t<E> to_underlying(E e) noexcept {
   return static_cast<underlying_type_t<E>>(e);
 }
 

--- a/core/unit_test/TestUtilities.hpp
+++ b/core/unit_test/TestUtilities.hpp
@@ -48,23 +48,6 @@ enum class ScopedEnum { SEZero, SEOne };
 enum class ScopedEnumShort : short { SESZero, SESOne };
 }  // namespace
 
-void test_cpp20_underlying_type() {
-  using Kokkos::Impl::underlying_type;
-  using Kokkos::Impl::underlying_type_t;
-
-  static_assert(std::is_integral_v<underlying_type<Enum>::type>);
-  static_assert(std::is_integral_v<underlying_type_t<Enum>>);
-
-  static_assert(std::is_same_v<bool, underlying_type<EnumBool>::type>);
-  static_assert(std::is_same_v<bool, underlying_type_t<EnumBool>>);
-
-  static_assert(std::is_integral_v<underlying_type<ScopedEnum>::type>);
-  static_assert(std::is_integral_v<underlying_type_t<ScopedEnum>>);
-
-  static_assert(std::is_same_v<short, underlying_type<ScopedEnumShort>::type>);
-  static_assert(std::is_same_v<short, underlying_type_t<ScopedEnumShort>>);
-}
-
 void test_to_underlying() {
   using Kokkos::Impl::to_underlying;
 

--- a/core/unit_test/TestUtilities.hpp
+++ b/core/unit_test/TestUtilities.hpp
@@ -41,4 +41,89 @@ void test_is_specialization_of() {
                 "");
 }
 
+namespace {
+enum Enum { EZero, EOne };
+enum EnumBool : bool { EBFalse, EBTrue };
+enum class ScopedEnum { SEZero, SEOne };
+enum class ScopedEnumShort : short { SESZero, SESOne };
+}  // namespace
+
+void test_cpp20_underlying_type() {
+  using Kokkos::Impl::underlying_type;
+  using Kokkos::Impl::underlying_type_t;
+
+  static_assert(std::is_integral_v<underlying_type<Enum>::type>);
+  static_assert(std::is_integral_v<underlying_type_t<Enum>>);
+
+  static_assert(std::is_same_v<bool, underlying_type<EnumBool>::type>);
+  static_assert(std::is_same_v<bool, underlying_type_t<EnumBool>>);
+
+  static_assert(std::is_integral_v<underlying_type<ScopedEnum>::type>);
+  static_assert(std::is_integral_v<underlying_type_t<ScopedEnum>>);
+
+  static_assert(std::is_same_v<short, underlying_type<ScopedEnumShort>::type>);
+  static_assert(std::is_same_v<short, underlying_type_t<ScopedEnumShort>>);
+}
+
+void test_to_underlying() {
+  using Kokkos::Impl::to_underlying;
+
+  constexpr auto e0 = to_underlying(EZero);
+  static_assert(e0 == 0);
+
+  constexpr auto e1 = to_underlying(EOne);
+  static_assert(e1 == 1);
+
+  constexpr auto eb0 = to_underlying(EBFalse);
+  constexpr bool b0  = false;
+  static_assert(std::is_same_v<decltype(eb0), decltype(b0)>);
+  static_assert(eb0 == b0);
+
+  constexpr auto eb1 = to_underlying(EBTrue);
+  constexpr bool b1  = true;
+  static_assert(std::is_same_v<decltype(eb1), decltype(b1)>);
+  static_assert(eb1 == b1);
+
+  constexpr auto se0 = to_underlying(ScopedEnum::SEZero);
+  static_assert(se0 == 0);
+
+  constexpr auto se1 = to_underlying(ScopedEnum::SEOne);
+  static_assert(se1 == 1);
+
+  constexpr auto ses0 = to_underlying(ScopedEnumShort::SESZero);
+  constexpr short s0  = 0;
+  static_assert(std::is_same_v<decltype(ses0), decltype(s0)>);
+  static_assert(ses0 == s0);
+
+  constexpr auto ses1 = to_underlying(ScopedEnumShort::SESOne);
+  constexpr short s1  = 1;
+  static_assert(std::is_same_v<decltype(ses1), decltype(s1)>);
+  static_assert(ses1 == s1);
+}
+
+void test_is_scoped_enum() {
+  using Kokkos::Impl::is_scoped_enum;
+  using Kokkos::Impl::is_scoped_enum_v;
+
+  static_assert(!is_scoped_enum<int>{});
+  static_assert(!is_scoped_enum<int>::value);
+  static_assert(!is_scoped_enum_v<int>);
+
+  static_assert(!is_scoped_enum<Enum>{});
+  static_assert(!is_scoped_enum<Enum>::value);
+  static_assert(!is_scoped_enum_v<Enum>);
+
+  static_assert(!is_scoped_enum<EnumBool>{});
+  static_assert(!is_scoped_enum<EnumBool>::value);
+  static_assert(!is_scoped_enum_v<EnumBool>);
+
+  static_assert(is_scoped_enum<ScopedEnum>{});
+  static_assert(is_scoped_enum<ScopedEnum>::value);
+  static_assert(is_scoped_enum_v<ScopedEnum>);
+
+  static_assert(is_scoped_enum<ScopedEnumShort>{});
+  static_assert(is_scoped_enum<ScopedEnumShort>::value);
+  static_assert(is_scoped_enum_v<ScopedEnumShort>);
+}
+
 }  // namespace Test

--- a/core/unit_test/TestUtilities.hpp
+++ b/core/unit_test/TestUtilities.hpp
@@ -92,26 +92,39 @@ void test_is_scoped_enum() {
   static_assert(!is_scoped_enum<int>{});
   static_assert(!is_scoped_enum<int>::value);
   static_assert(!is_scoped_enum_v<int>);
-
-  static_assert(!is_scoped_enum<Enum>{});
-  static_assert(!is_scoped_enum<Enum>::value);
-  static_assert(!is_scoped_enum_v<Enum>);
-
-  static_assert(!is_scoped_enum<EnumBool>{});
-  static_assert(!is_scoped_enum<EnumBool>::value);
-  static_assert(!is_scoped_enum_v<EnumBool>);
-
-  static_assert(is_scoped_enum<ScopedEnum>{});
-  static_assert(is_scoped_enum<ScopedEnum>::value);
-  static_assert(is_scoped_enum_v<ScopedEnum>);
-
-  static_assert(is_scoped_enum<ScopedEnumShort>{});
-  static_assert(is_scoped_enum<ScopedEnumShort>::value);
-  static_assert(is_scoped_enum_v<ScopedEnumShort>);
+  static_assert(std::is_base_of_v<std::false_type, is_scoped_enum<int>> &&
+                !std::is_same_v<std::false_type, is_scoped_enum<int>>);
 
   static_assert(!is_scoped_enum<Class>{});
   static_assert(!is_scoped_enum<Class>::value);
   static_assert(!is_scoped_enum_v<Class>);
+  static_assert(std::is_base_of_v<std::false_type, is_scoped_enum<Class>> &&
+                !std::is_same_v<std::false_type, is_scoped_enum<Class>>);
+
+  static_assert(!is_scoped_enum<Enum>{});
+  static_assert(!is_scoped_enum<Enum>::value);
+  static_assert(!is_scoped_enum_v<Enum>);
+  static_assert(std::is_base_of_v<std::false_type, is_scoped_enum<Enum>> &&
+                !std::is_same_v<std::false_type, is_scoped_enum<Enum>>);
+
+  static_assert(!is_scoped_enum<EnumBool>{});
+  static_assert(!is_scoped_enum<EnumBool>::value);
+  static_assert(!is_scoped_enum_v<EnumBool>);
+  static_assert(std::is_base_of_v<std::false_type, is_scoped_enum<EnumBool>> &&
+                !std::is_same_v<std::false_type, is_scoped_enum<EnumBool>>);
+
+  static_assert(is_scoped_enum<ScopedEnum>{});
+  static_assert(is_scoped_enum<ScopedEnum>::value);
+  static_assert(is_scoped_enum_v<ScopedEnum>);
+  static_assert(std::is_base_of_v<std::true_type, is_scoped_enum<ScopedEnum>> &&
+                !std::is_same_v<std::true_type, is_scoped_enum<ScopedEnum>>);
+
+  static_assert(is_scoped_enum<ScopedEnumShort>{});
+  static_assert(is_scoped_enum<ScopedEnumShort>::value);
+  static_assert(is_scoped_enum_v<ScopedEnumShort>);
+  static_assert(
+      std::is_base_of_v<std::true_type, is_scoped_enum<ScopedEnumShort>> &&
+      !std::is_same_v<std::true_type, is_scoped_enum<ScopedEnumShort>>);
 }
 
 }  // namespace Test

--- a/core/unit_test/TestUtilities.hpp
+++ b/core/unit_test/TestUtilities.hpp
@@ -47,6 +47,10 @@ enum EnumBool : bool { EBFalse, EBTrue };
 enum class ScopedEnum { SEZero, SEOne };
 enum class ScopedEnumShort : short { SESZero, SESOne };
 class Class {};
+
+template <typename Base, typename Derived>
+inline constexpr bool is_public_unambiguous_base_of_v =
+    std::is_convertible_v<Derived*, Base*> && !std::is_same_v<Derived, Base>;
 }  // namespace
 
 void test_to_underlying() {
@@ -92,39 +96,39 @@ void test_is_scoped_enum() {
   static_assert(!is_scoped_enum<int>{});
   static_assert(!is_scoped_enum<int>::value);
   static_assert(!is_scoped_enum_v<int>);
-  static_assert(std::is_base_of_v<std::false_type, is_scoped_enum<int>> &&
-                !std::is_same_v<std::false_type, is_scoped_enum<int>>);
+  static_assert(
+      is_public_unambiguous_base_of_v<std::false_type, is_scoped_enum<int>>);
 
   static_assert(!is_scoped_enum<Class>{});
   static_assert(!is_scoped_enum<Class>::value);
   static_assert(!is_scoped_enum_v<Class>);
-  static_assert(std::is_base_of_v<std::false_type, is_scoped_enum<Class>> &&
-                !std::is_same_v<std::false_type, is_scoped_enum<Class>>);
+  static_assert(
+      is_public_unambiguous_base_of_v<std::false_type, is_scoped_enum<Class>>);
 
   static_assert(!is_scoped_enum<Enum>{});
   static_assert(!is_scoped_enum<Enum>::value);
   static_assert(!is_scoped_enum_v<Enum>);
-  static_assert(std::is_base_of_v<std::false_type, is_scoped_enum<Enum>> &&
-                !std::is_same_v<std::false_type, is_scoped_enum<Enum>>);
+  static_assert(
+      is_public_unambiguous_base_of_v<std::false_type, is_scoped_enum<Enum>>);
 
   static_assert(!is_scoped_enum<EnumBool>{});
   static_assert(!is_scoped_enum<EnumBool>::value);
   static_assert(!is_scoped_enum_v<EnumBool>);
-  static_assert(std::is_base_of_v<std::false_type, is_scoped_enum<EnumBool>> &&
-                !std::is_same_v<std::false_type, is_scoped_enum<EnumBool>>);
+  static_assert(is_public_unambiguous_base_of_v<std::false_type,
+                                                is_scoped_enum<EnumBool>>);
 
   static_assert(is_scoped_enum<ScopedEnum>{});
   static_assert(is_scoped_enum<ScopedEnum>::value);
   static_assert(is_scoped_enum_v<ScopedEnum>);
-  static_assert(std::is_base_of_v<std::true_type, is_scoped_enum<ScopedEnum>> &&
-                !std::is_same_v<std::true_type, is_scoped_enum<ScopedEnum>>);
+  static_assert(is_public_unambiguous_base_of_v<std::true_type,
+                                                is_scoped_enum<ScopedEnum>>);
 
   static_assert(is_scoped_enum<ScopedEnumShort>{});
   static_assert(is_scoped_enum<ScopedEnumShort>::value);
   static_assert(is_scoped_enum_v<ScopedEnumShort>);
   static_assert(
-      std::is_base_of_v<std::true_type, is_scoped_enum<ScopedEnumShort>> &&
-      !std::is_same_v<std::true_type, is_scoped_enum<ScopedEnumShort>>);
+      is_public_unambiguous_base_of_v<std::true_type,
+                                      is_scoped_enum<ScopedEnumShort>>);
 }
 
 }  // namespace Test

--- a/core/unit_test/TestUtilities.hpp
+++ b/core/unit_test/TestUtilities.hpp
@@ -46,6 +46,7 @@ enum Enum { EZero, EOne };
 enum EnumBool : bool { EBFalse, EBTrue };
 enum class ScopedEnum { SEZero, SEOne };
 enum class ScopedEnumShort : short { SESZero, SESOne };
+class Class {};
 }  // namespace
 
 void test_to_underlying() {
@@ -107,6 +108,10 @@ void test_is_scoped_enum() {
   static_assert(is_scoped_enum<ScopedEnumShort>{});
   static_assert(is_scoped_enum<ScopedEnumShort>::value);
   static_assert(is_scoped_enum_v<ScopedEnumShort>);
+
+  static_assert(!is_scoped_enum<Class>{});
+  static_assert(!is_scoped_enum<Class>::value);
+  static_assert(!is_scoped_enum_v<Class>);
 }
 
 }  // namespace Test


### PR DESCRIPTION
Adding to `Impl`:
- C++20 compatible version of `underlying_type` & `underlying_type_t`
- C++23 `to_underlying` (marked as a `KOKKOS_INLINE_FUNCTION`)
- C++23 `is_scoped_enum` & `is_scoped_enum_v`

Q:  Should these be made public?

(Needed as part of issue #6355)