### PR TITLE
Use `/usr/bin/env bash` in `nvcc_wrapper` and `kokkos_launch_compiler` for portability

### DIFF
--- a/bin/kokkos_launch_compiler
+++ b/bin/kokkos_launch_compiler
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 #   This script allows CMAKE_CXX_COMPILER to be a standard
 #   C++ compiler and Kokkos sets RULE_LAUNCH_COMPILE and
@@ -12,6 +12,8 @@
 #   the original command. Examples of when $2 will not equal
 #   $1 are 'ar', 'cmake', etc. during the linking phase
 #
+
+set -e
 
 # emit a message about the underlying command executed
 : ${DEBUG:=0}

--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This shell script (nvcc_wrapper) wraps both the host compiler and
 # NVCC, if you are building legacy C or C++ code with CUDA enabled.


### PR DESCRIPTION
This is useful e.g. on NixOS where `bash` is not in `/bin`. As far as I know there's no downside to using `/usr/bin/env bash` as it should be strictly more portable, but am I missing some reason for keeping `/bin/bash` hardcoded in `kokkos_launch_compiler` and `nvcc_wrapper`?