### PR TITLE
simd: make mask and condition unit test to check with all data types

### DIFF
--- a/simd/unit_tests/include/TestSIMD_MaskOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MaskOps.hpp
@@ -72,13 +72,13 @@ KOKKOS_INLINE_FUNCTION void device_check_mask_ops() {
   for (std::size_t i = 0; i < mask_type::size(); ++i) {
     mask_type test_mask([&](std::size_t j) { return i == j; });
 
-    EXPECT_TRUE(any_of(test_mask));
-    EXPECT_FALSE(none_of(test_mask));
+    checker.truth(any_of(test_mask));
+    checker.truth(!none_of(test_mask));
 
     if constexpr (mask_type::size() > 1) {
-      EXPECT_FALSE(all_of(test_mask));
+      checker.truth(!all_of(test_mask));
     } else {
-      EXPECT_TRUE(all_of(test_mask));
+      checker.truth(all_of(test_mask));
     }
   }
 }

--- a/simd/unit_tests/include/TestSIMD_MaskOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MaskOps.hpp
@@ -20,35 +20,80 @@
 #include <Kokkos_SIMD.hpp>
 #include <SIMDTesting_Utilities.hpp>
 
-template <typename Abi>
+template <typename Abi, typename DataType>
 inline void host_check_mask_ops() {
-  using mask_type = Kokkos::Experimental::simd_mask<double, Abi>;
+  using mask_type = Kokkos::Experimental::simd_mask<DataType, Abi>;
+
   EXPECT_FALSE(none_of(mask_type(true)));
   EXPECT_TRUE(none_of(mask_type(false)));
   EXPECT_TRUE(all_of(mask_type(true)));
   EXPECT_FALSE(all_of(mask_type(false)));
+  EXPECT_TRUE(any_of(mask_type(true)));
+  EXPECT_FALSE(any_of(mask_type(false)));
+
+  for (std::size_t i = 0; i < mask_type::size(); ++i) {
+    mask_type test_mask([&](std::size_t j) { return i == j; });
+
+    EXPECT_TRUE(any_of(test_mask));
+    EXPECT_FALSE(none_of(test_mask));
+
+    if constexpr (mask_type::size() > 1) {
+      EXPECT_FALSE(all_of(test_mask));
+    } else {
+      EXPECT_TRUE(all_of(test_mask));
+    }
+  }
+}
+
+template <typename Abi, typename... DataTypes>
+inline void host_check_mask_ops_all_types(
+    Kokkos::Experimental::Impl::data_types<DataTypes...>) {
+  (host_check_mask_ops<Abi, DataTypes>(), ...);
 }
 
 template <typename... Abis>
 inline void host_check_mask_ops_all_abis(
     Kokkos::Experimental::Impl::abi_set<Abis...>) {
-  (host_check_mask_ops<Abis>(), ...);
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (host_check_mask_ops_all_types<Abis>(DataTypes()), ...);
 }
 
-template <typename Abi>
+template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_mask_ops() {
-  using mask_type = Kokkos::Experimental::simd_mask<double, Abi>;
+  using mask_type = Kokkos::Experimental::simd_mask<DataType, Abi>;
   kokkos_checker checker;
   checker.truth(!none_of(mask_type(true)));
   checker.truth(none_of(mask_type(false)));
   checker.truth(all_of(mask_type(true)));
   checker.truth(!all_of(mask_type(false)));
+  checker.truth(any_of(mask_type(true)));
+  checker.truth(!any_of(mask_type(false)));
+
+  for (std::size_t i = 0; i < mask_type::size(); ++i) {
+    mask_type test_mask([&](std::size_t j) { return i == j; });
+
+    EXPECT_TRUE(any_of(test_mask));
+    EXPECT_FALSE(none_of(test_mask));
+
+    if constexpr (mask_type::size() > 1) {
+      EXPECT_FALSE(all_of(test_mask));
+    } else {
+      EXPECT_TRUE(all_of(test_mask));
+    }
+  }
+}
+
+template <typename Abi, typename... DataTypes>
+KOKKOS_INLINE_FUNCTION void device_check_mask_ops_all_types(
+    Kokkos::Experimental::Impl::data_types<DataTypes...>) {
+  (device_check_mask_ops<Abi, DataTypes>(), ...);
 }
 
 template <typename... Abis>
 KOKKOS_INLINE_FUNCTION void device_check_mask_ops_all_abis(
     Kokkos::Experimental::Impl::abi_set<Abis...>) {
-  (device_check_mask_ops<Abis>(), ...);
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (device_check_mask_ops_all_types<Abis>(DataTypes()), ...);
 }
 
 class simd_device_mask_ops_functor {


### PR DESCRIPTION
Follow on from https://github.com/kokkos/kokkos/pull/6278#discussion_r1275517329.

This PR modifies `simd_mask` ops and `condition` unit tests to test with all supported data types for:

- `bool any_of(const simd_mask&)`
- `simd condition(const mask_type& mask, const simd& a, const simd& b)`

This addition to the tests ensures that `simd_mask` and `condition` are defined properly per supported simd backend.