### PR TITLE
Only set KOKKOS_ARCH_AMD_GPU if a AMD GPU architecture is enabled

### DIFF
--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -994,8 +994,8 @@ ENDFOREACH()
 
 #Regardless of version, make sure we define the general architecture name
 FOREACH(ARCH IN LISTS SUPPORTED_AMD_ARCHS)
-  SET(KOKKOS_ARCH_AMD_GPU ON)
   IF (KOKKOS_ARCH_${ARCH})
+    SET(KOKKOS_ARCH_AMD_GPU ON)
     STRING(REGEX MATCH "(VEGA)" IS_VEGA ${ARCH})
     IF(IS_VEGA)
       SET(KOKKOS_ARCH_VEGA ON)


### PR DESCRIPTION
As reported in https://github.com/kokkos/kokkos/pull/6364#issuecomment-1682460296, we are currently enabling `KOKKOS_ARCH_AMD_GPU` unconditionally. This pull request fixes that by only enabling `KOKKOS_ARCH_AMD_GPU` if a AMD GPU architecture has been enabled.