### PR TITLE
Use `desul::atomic_load` to read `m_ready_count` in task queue implementations

### DIFF
--- a/core/src/HPX/Kokkos_HPX_Task.hpp
+++ b/core/src/HPX/Kokkos_HPX_Task.hpp
@@ -164,7 +164,9 @@ class TaskQueueSpecializationConstrained<
         team_queue.complete(task);
       }
 
-      if (*((volatile int *)&team_queue.m_ready_count) > 0) {
+      if (desul::atomic_load(&team_queue.m_ready_count,
+                             desul::MemoryOrderAcquire(),
+                             desul::MemoryScopeDevice()) > 0) {
         task = end;
         for (int i = 0; i < queue_type::NumQueue && end == task; ++i) {
           for (int j = 0; j < 2 && end == task; ++j) {

--- a/core/src/HPX/Kokkos_HPX_Task.hpp
+++ b/core/src/HPX/Kokkos_HPX_Task.hpp
@@ -20,6 +20,7 @@
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_HPX) && defined(KOKKOS_ENABLE_TASKDAG)
 
+#include <Kokkos_Atomic.hpp>
 #include <Kokkos_TaskScheduler_fwd.hpp>
 
 #include <HPX/Kokkos_HPX.hpp>

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
@@ -287,7 +287,9 @@ class TaskQueueSpecializationConstrained<
 
               // If 0 == m_ready_count then set task = 0
 
-              if (*((volatile int*)&team_queue.m_ready_count) > 0) {
+              if (desul::atomic_load(&team_queue.m_ready_count,
+                                     desul::MemoryOrderAcquire(),
+                                     desul::MemoryScopeDevice()) > 0) {
                 task = end;
                 // Attempt to acquire a task
                 // Loop by priority and then type

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
@@ -20,6 +20,7 @@
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_OPENMP) && defined(KOKKOS_ENABLE_TASKDAG)
 
+#include <Kokkos_Atomic.hpp>
 #include <Kokkos_TaskScheduler_fwd.hpp>
 
 #include <impl/Kokkos_HostThreadTeam.hpp>

--- a/core/src/impl/Kokkos_TaskQueueCommon.hpp
+++ b/core/src/impl/Kokkos_TaskQueueCommon.hpp
@@ -143,14 +143,14 @@ class TaskQueueCommonMixin {
  public:
   KOKKOS_INLINE_FUNCTION
   bool is_done() const noexcept {
-    // TODO @tasking @memory_order DSH Memory order, instead of volatile
-    return (*(volatile int*)(&m_ready_count)) == 0;
+    return desul::atomic_load(&m_ready_count, desul::MemoryOrderAcquire(),
+                              desul::MemoryScopeDevice()) == 0;
   }
 
   KOKKOS_INLINE_FUNCTION
   int32_t ready_count() const noexcept {
-    // TODO @tasking @memory_order DSH Memory order, instead of volatile
-    return (*(volatile int*)(&m_ready_count));
+    return desul::atomic_load(&m_ready_count, desul::MemoryOrderAcquire(),
+                              desul::MemoryScopeDevice());
   }
 
   template <class TaskQueueTraits, class TeamSchedulerInfo>

--- a/core/src/impl/Kokkos_TaskQueueMultiple.hpp
+++ b/core/src/impl/Kokkos_TaskQueueMultiple.hpp
@@ -119,7 +119,9 @@ class TaskQueueMultiple : public TaskQueue<ExecSpace, MemorySpace> {
         for (int iteam = 0; iteam < m_other_queues->size(); ++iteam) {
           if (iteam == m_league_rank) continue;
           auto& steal_from = get_team_queue(iteam);
-          if (*((volatile int*)&steal_from.m_ready_count) > 0) {
+          if (desul::atomic_load(&steal_from.m_ready_count,
+                                 desul::MemoryOrderAcquire(),
+                                 desul::MemoryScopeDevice()) > 0) {
             // we've found at least one queue that's not done, so even if we
             // can't pop something off of it we shouldn't return a nullptr
             // indicating completion.  rv will be end_tag when the pop fails


### PR DESCRIPTION
Fixes #5748?

I've only changed the loads for `HPX` and `OpenMP`. I don't dare touch the ones for `CUDA` and `OpenMPTarget`, but if someone says it's safe to change those similarly I'll update this. I'm also not going to touch the many other volatile loads/stores and variables (at least in this PR...).

I've made the loads `MemoryOrderAcquire` which I'm ~90% sure is ok here instead of `SeqCst`, but if you want to be on the safe side I'll make those `SeqCst` as well.