### PR TITLE
Use aligned version of operator new instead of aligned_malloc

### DIFF
--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -208,11 +208,6 @@ void HPX::impl_initialize(InitializationSettings const &settings) {
   hpx::runtime *rt = hpx::get_runtime_ptr();
   if (rt == nullptr) {
     hpx::local::init_params i;
-    i.cfg = {
-#ifdef KOKKOS_ENABLE_DEBUG
-        "--hpx:attach-debugger=exception",
-#endif
-    };
     if (settings.has_num_threads()) {
       i.cfg.emplace_back("hpx.os_threads=" +
                          std::to_string(settings.get_num_threads()));


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/6367. ~~Apparently, `aligned_malloc` is not available on Mac OS X before 10.15 and I don't see much of a problem using `posix_memalign` for Mac OS X unconditionally until we don't support 10.15 anymore.~~
The aligned version of operator new seems to work better (icpc needs some non-standard include file, though.).