### PR TITLE
Add support for HIP Graph

### DIFF
--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -1,0 +1,166 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_HIP_GRAPHNODEKERNEL_HPP
+#define KOKKOS_HIP_GRAPHNODEKERNEL_HPP
+
+#include <Kokkos_Graph_fwd.hpp>
+
+#include <impl/Kokkos_GraphImpl.hpp>
+#include <impl/Kokkos_SharedAlloc.hpp>
+
+#include <Kokkos_Parallel.hpp>
+#include <Kokkos_Parallel_Reduce.hpp>
+#include <Kokkos_PointerOwnership.hpp>
+
+#include <HIP/Kokkos_HIP_SharedAllocationRecord.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+template <class CombinedFunctorReducer, class PolicyType>
+struct PatternImplSpecializationFromTag<
+    Kokkos::ParallelReduceTag, CombinedFunctorReducer, PolicyType, Kokkos::HIP>
+    : type_identity<
+          ParallelReduce<CombinedFunctorReducer, PolicyType, Kokkos::HIP>> {};
+
+template <typename PolicyType, typename Functor, typename PatternTag,
+          typename... Args>
+class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
+    : public PatternImplSpecializationFromTag<PatternTag, Functor, PolicyType,
+                                              Args..., Kokkos::HIP>::type {
+ public:
+  using Policy       = PolicyType;
+  using graph_kernel = GraphNodeKernelImpl;
+  using base_t =
+      typename PatternImplSpecializationFromTag<PatternTag, Functor, Policy,
+                                                Args..., Kokkos::HIP>::type;
+  using Record = Kokkos::Impl::SharedAllocationRecord<Kokkos::HIPSpace, void>;
+
+  // TODO use the name and executionspace
+  template <typename PolicyDeduced, typename... ArgsDeduced>
+  GraphNodeKernelImpl(std::string, Kokkos::HIP const&, Functor arg_functor,
+                      PolicyDeduced&& arg_policy, ArgsDeduced&&... args)
+      : base_t(std::move(arg_functor), (PolicyDeduced &&) arg_policy,
+               (ArgsDeduced &&) args...) {}
+
+  template <typename PolicyDeduced>
+  GraphNodeKernelImpl(Kokkos::HIP const& exec_space, Functor arg_functor,
+                      PolicyDeduced&& arg_policy)
+      : GraphNodeKernelImpl("", exec_space, std::move(arg_functor),
+                            (PolicyDeduced &&) arg_policy) {}
+
+  ~GraphNodeKernelImpl() {
+    if (m_driver_storage) {
+      Record::decrement(Record::get_record(m_driver_storage));
+    }
+  }
+
+  void set_hip_graph_ptr(hipGraph_t* arg_graph_ptr) {
+    m_graph_ptr = arg_graph_ptr;
+  }
+
+  void set_hip_graph_node_ptr(hipGraphNode_t* arg_node_ptr) {
+    m_graph_node_ptr = arg_node_ptr;
+  }
+
+  hipGraphNode_t* get_hip_graph_node_ptr() const { return m_graph_node_ptr; }
+
+  hipGraph_t const* get_hip_graph_ptr() const { return m_graph_ptr; }
+
+  Kokkos::ObservingRawPtr<base_t> allocate_driver_memory_buffer() const {
+    KOKKOS_EXPECTS(m_driver_storage == nullptr);
+
+    auto* record = Record::allocate(
+        Kokkos::HIPSpace{}, "GraphNodeKernel global memory functor storage",
+        sizeof(base_t));
+
+    Record::increment(record);
+    m_driver_storage = reinterpret_cast<base_t*>(record->data());
+    KOKKOS_ENSURES(m_driver_storage != nullptr);
+
+    return m_driver_storage;
+  }
+
+ private:
+  Kokkos::ObservingRawPtr<const hipGraph_t> m_graph_ptr    = nullptr;
+  Kokkos::ObservingRawPtr<hipGraphNode_t> m_graph_node_ptr = nullptr;
+  Kokkos::OwningRawPtr<base_t> m_driver_storage            = nullptr;
+};
+
+struct HIPGraphNodeAggregateKernel {
+  using graph_kernel = HIPGraphNodeAggregateKernel;
+
+  // Aggregates don't need a policy, but for the purposes of checking the static
+  // assertions about graph kerenls,
+  struct Policy {
+    using is_graph_kernel = std::true_type;
+  };
+};
+
+template <typename KernelType,
+          typename Tag =
+              typename PatternTagFromImplSpecialization<KernelType>::type>
+struct get_graph_node_kernel_type
+    : type_identity<
+          GraphNodeKernelImpl<Kokkos::HIP, typename KernelType::Policy,
+                              typename KernelType::functor_type, Tag>> {};
+
+template <typename KernelType>
+struct get_graph_node_kernel_type<KernelType, Kokkos::ParallelReduceTag>
+    : type_identity<GraphNodeKernelImpl<
+          Kokkos::HIP, typename KernelType::Policy,
+          CombinedFunctorReducer<typename KernelType::functor_type,
+                                 typename KernelType::reducer_type>,
+          Kokkos::ParallelReduceTag>> {};
+
+template <typename KernelType>
+auto* allocate_driver_storage_for_kernel(KernelType const& kernel) {
+  using graph_node_kernel_t =
+      typename get_graph_node_kernel_type<KernelType>::type;
+  auto const& kernel_as_graph_kernel =
+      static_cast<graph_node_kernel_t const&>(kernel);
+
+  return kernel_as_graph_kernel.allocate_driver_memory_buffer();
+}
+
+template <typename KernelType>
+auto const& get_hip_graph_from_kernel(KernelType const& kernel) {
+  using graph_node_kernel_t =
+      typename get_graph_node_kernel_type<KernelType>::type;
+  auto const& kernel_as_graph_kernel =
+      static_cast<graph_node_kernel_t const&>(kernel);
+  hipGraph_t const* graph_ptr = kernel_as_graph_kernel.get_hip_graph_ptr();
+  KOKKOS_EXPECTS(graph_ptr != nullptr);
+
+  return *graph_ptr;
+}
+
+template <typename KernelType>
+auto& get_hip_graph_node_from_kernel(KernelType const& kernel) {
+  using graph_node_kernel_t =
+      typename get_graph_node_kernel_type<KernelType>::type;
+  auto const& kernel_as_graph_kernel =
+      static_cast<graph_node_kernel_t const&>(kernel);
+  auto* graph_node_ptr = kernel_as_graph_kernel.get_hip_graph_node_ptr();
+  KOKKOS_EXPECTS(graph_node_ptr != nullptr);
+
+  return *graph_node_ptr;
+}
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif

--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -31,12 +31,6 @@
 namespace Kokkos {
 namespace Impl {
 
-template <class CombinedFunctorReducer, class PolicyType>
-struct PatternImplSpecializationFromTag<
-    Kokkos::ParallelReduceTag, CombinedFunctorReducer, PolicyType, Kokkos::HIP>
-    : type_identity<
-          ParallelReduce<CombinedFunctorReducer, PolicyType, Kokkos::HIP>> {};
-
 template <typename PolicyType, typename Functor, typename PatternTag,
           typename... Args>
 class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
@@ -105,7 +99,7 @@ struct HIPGraphNodeAggregateKernel {
   using graph_kernel = HIPGraphNodeAggregateKernel;
 
   // Aggregates don't need a policy, but for the purposes of checking the static
-  // assertions about graph kerenls,
+  // assertions about graph kernels,
   struct Policy {
     using is_graph_kernel = std::true_type;
   };

--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -27,6 +27,7 @@
 #include <Kokkos_PointerOwnership.hpp>
 
 #include <HIP/Kokkos_HIP_SharedAllocationRecord.hpp>
+#include <HIP/Kokkos_HIP_GraphNode_Impl.hpp>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/HIP/Kokkos_HIP_GraphNode_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNode_Impl.hpp
@@ -1,0 +1,56 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_HIP_GRAPHNODE_IMPL_HPP
+#define KOKKOS_HIP_GRAPHNODE_IMPL_HPP
+
+#include <Kokkos_Graph_fwd.hpp>
+
+#include <impl/Kokkos_GraphImpl.hpp>
+
+#include <HIP/Kokkos_HIP.hpp>
+
+namespace Kokkos {
+namespace Impl {
+template <>
+struct GraphNodeBackendSpecificDetails<Kokkos::HIP> {
+  hipGraphNode_t node = nullptr;
+
+  explicit GraphNodeBackendSpecificDetails() = default;
+
+  explicit GraphNodeBackendSpecificDetails(
+      _graph_node_is_root_ctor_tag) noexcept {}
+};
+
+template <typename Kernel, typename PredecessorRef>
+struct GraphNodeBackendDetailsBeforeTypeErasure<Kokkos::HIP, Kernel,
+                                                PredecessorRef> {
+ protected:
+  GraphNodeBackendDetailsBeforeTypeErasure(
+      Kokkos::HIP const &, Kernel &, PredecessorRef const &,
+      GraphNodeBackendSpecificDetails<Kokkos::HIP> &) noexcept {}
+
+  GraphNodeBackendDetailsBeforeTypeErasure(
+      Kokkos::HIP const &, _graph_node_is_root_ctor_tag,
+      GraphNodeBackendSpecificDetails<Kokkos::HIP> &) noexcept {}
+};
+
+}  // namespace Impl
+}  // namespace Kokkos
+
+#include <HIP/Kokkos_HIP_GraphNodeKernel.hpp>
+
+#endif

--- a/core/src/HIP/Kokkos_HIP_GraphNode_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNode_Impl.hpp
@@ -51,6 +51,4 @@ struct GraphNodeBackendDetailsBeforeTypeErasure<Kokkos::HIP, Kernel,
 }  // namespace Impl
 }  // namespace Kokkos
 
-#include <HIP/Kokkos_HIP_GraphNodeKernel.hpp>
-
 #endif

--- a/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
@@ -19,9 +19,6 @@
 
 #include <Kokkos_Macros.hpp>
 
-#if defined(KOKKOS_ENABLE_HIP)
-#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR > 2)
-
 #include <Kokkos_Graph_fwd.hpp>
 
 #include <impl/Kokkos_GraphImpl.hpp>
@@ -187,6 +184,4 @@ auto GraphImpl<Kokkos::HIP>::create_aggregate_ptr(PredecessorRefs&&...) {
 }  // namespace Impl
 }  // namespace Kokkos
 
-#endif
-#endif
 #endif

--- a/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
@@ -22,9 +22,9 @@
 #include <Kokkos_Graph_fwd.hpp>
 
 #include <impl/Kokkos_GraphImpl.hpp>
-
 #include <impl/Kokkos_GraphNodeImpl.hpp>
-#include <HIP/Kokkos_HIP_GraphNode_Impl.hpp>
+
+#include <HIP/Kokkos_HIP_GraphNodeKernel.hpp>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
@@ -1,0 +1,190 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_HIP_GRAPH_IMPL_HPP
+#define KOKKOS_HIP_GRAPH_IMPL_HPP
+
+#include <Kokkos_Macros.hpp>
+
+#if defined(KOKKOS_ENABLE_HIP)
+
+#include <Kokkos_Graph_fwd.hpp>
+
+#include <impl/Kokkos_GraphImpl.hpp>
+
+#include <impl/Kokkos_GraphNodeImpl.hpp>
+#include <HIP/Kokkos_HIP_GraphNode_Impl.hpp>
+
+namespace Kokkos {
+namespace Impl {
+template <>
+class GraphImpl<Kokkos::HIP> {
+ public:
+  using node_details_t = GraphNodeBackendSpecificDetails<Kokkos::HIP>;
+  using root_node_impl_t =
+      GraphNodeImpl<Kokkos::HIP, Kokkos::Experimental::TypeErasedTag,
+                    Kokkos::Experimental::TypeErasedTag>;
+  using aggregate_kernel_impl_t = HIPGraphNodeAggregateKernel;
+  using aggregate_node_impl_t =
+      GraphNodeImpl<Kokkos::HIP, aggregate_kernel_impl_t,
+                    Kokkos::Experimental::TypeErasedTag>;
+
+  // Not moveable or copyable; it spends its whole life as a shared_ptr in the
+  // Graph object.
+  GraphImpl()                 = delete;
+  GraphImpl(GraphImpl const&) = delete;
+  GraphImpl(GraphImpl&&)      = delete;
+  GraphImpl& operator=(GraphImpl const&) = delete;
+  GraphImpl& operator=(GraphImpl&&) = delete;
+
+  ~GraphImpl();
+
+  explicit GraphImpl(Kokkos::HIP instance);
+
+  void add_node(std::shared_ptr<aggregate_node_impl_t> const& arg_node_ptr);
+
+  template <class NodeImpl>
+  void add_node(std::shared_ptr<NodeImpl> const& arg_node_ptr);
+
+  template <class NodeImplPtr, class PredecessorRef>
+  void add_predecessor(NodeImplPtr arg_node_ptr, PredecessorRef arg_pred_ref);
+
+  void submit();
+
+  Kokkos::HIP const& get_execution_space() const noexcept;
+
+  auto create_root_node_ptr();
+
+  template <class... PredecessorRefs>
+  auto create_aggregate_ptr(PredecessorRefs&&...);
+
+ private:
+  void instantiate_graph() {
+    constexpr size_t error_log_size = 256;
+    hipGraphNode_t error_node       = nullptr;
+    char error_log[error_log_size];
+    KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphInstantiate(
+        &m_graph_exec, m_graph, &error_node, error_log, error_log_size));
+  }
+
+  Kokkos::HIP m_execution_space;
+  hipGraph_t m_graph          = nullptr;
+  hipGraphExec_t m_graph_exec = nullptr;
+};
+
+GraphImpl<Kokkos::HIP>::~GraphImpl() {
+  m_execution_space.fence("Kokkos::GraphImpl::~GraphImpl: Graph Destruction");
+  KOKKOS_EXPECTS(m_graph);
+  if (m_graph_exec) {
+    KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphExecDestroy(m_graph_exec));
+  }
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphDestroy(m_graph));
+}
+
+GraphImpl<Kokkos::HIP>::GraphImpl(Kokkos::HIP instance)
+    : m_execution_space(std::move(instance)) {
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphCreate(&m_graph, 0));
+}
+
+void GraphImpl<Kokkos::HIP>::add_node(
+    std::shared_ptr<aggregate_node_impl_t> const& arg_node_ptr) {
+  // All of the predecessors are just added as normal, so all we need to
+  // do here is add an empty node
+  KOKKOS_IMPL_HIP_SAFE_CALL(
+      hipGraphAddEmptyNode(&(arg_node_ptr->node_details_t::node), m_graph,
+                           /* dependencies = */ nullptr,
+                           /* numDependencies = */ 0));
+}
+
+// Requires NodeImplPtr is a shared_ptr to specialization of GraphNodeImpl
+// Also requires that the kernel has the graph node tag in it's policy
+template <class NodeImpl>
+void GraphImpl<Kokkos::HIP>::add_node(
+    std::shared_ptr<NodeImpl> const& arg_node_ptr) {
+  static_assert(NodeImpl::kernel_type::Policy::is_graph_kernel::value);
+  KOKKOS_EXPECTS(arg_node_ptr);
+  // The Kernel launch from the execute() method has been shimmed to insert
+  // the node into the graph
+  auto& kernel = arg_node_ptr->get_kernel();
+  auto& node   = static_cast<node_details_t*>(arg_node_ptr.get())->node;
+  KOKKOS_EXPECTS(!node);
+  kernel.set_hip_graph_ptr(&m_graph);
+  kernel.set_hip_graph_node_ptr(&node);
+  kernel.execute();
+  KOKKOS_ENSURES(node);
+}
+
+// Requires PredecessorRef is a specialization of GraphNodeRef that has
+// already been added to this graph and NodeImpl is a specialization of
+// GraphNodeImpl that has already been added to this graph.
+template <class NodeImplPtr, class PredecessorRef>
+void GraphImpl<Kokkos::HIP>::add_predecessor(NodeImplPtr arg_node_ptr,
+                                             PredecessorRef arg_pred_ref) {
+  KOKKOS_EXPECTS(arg_node_ptr);
+  auto pred_ptr = GraphAccess::get_node_ptr(arg_pred_ref);
+  KOKKOS_EXPECTS(pred_ptr);
+
+  auto const& pred_node = pred_ptr->node_details_t::node;
+  KOKKOS_EXPECTS(pred_node);
+
+  auto const& node = arg_node_ptr->node_details_t::node;
+  KOKKOS_EXPECTS(node);
+
+  KOKKOS_IMPL_HIP_SAFE_CALL(
+      hipGraphAddDependencies(m_graph, &pred_node, &node, 1));
+}
+
+void GraphImpl<Kokkos::HIP>::submit() {
+  if (!m_graph_exec) {
+    instantiate_graph();
+  }
+  KOKKOS_IMPL_HIP_SAFE_CALL(
+      hipGraphLaunch(m_graph_exec, m_execution_space.hip_stream()));
+}
+
+Kokkos::HIP const& GraphImpl<Kokkos::HIP>::get_execution_space() const
+    noexcept {
+  return m_execution_space;
+}
+
+auto GraphImpl<Kokkos::HIP>::create_root_node_ptr() {
+  KOKKOS_EXPECTS(m_graph);
+  KOKKOS_EXPECTS(!m_graph_exec);
+  auto rv = std::make_shared<root_node_impl_t>(get_execution_space(),
+                                               _graph_node_is_root_ctor_tag{});
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphAddEmptyNode(&(rv->node_details_t::node),
+                                                 m_graph,
+                                                 /* dependencies = */ nullptr,
+                                                 /* numDependencies = */ 0));
+  KOKKOS_ENSURES(rv->node_details_t::node);
+  return rv;
+}
+
+template <class... PredecessorRefs>
+auto GraphImpl<Kokkos::HIP>::create_aggregate_ptr(PredecessorRefs&&...) {
+  // The attachment to predecessors, which is all we really need, happens
+  // in the generic layer, which calls through to add_predecessor for
+  // each predecessor ref, so all we need to do here is create the (trivial)
+  // aggregate node.
+  return std::make_shared<aggregate_node_impl_t>(m_execution_space,
+                                                 _graph_node_kernel_ctor_tag{},
+                                                 aggregate_kernel_impl_t{});
+}
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif
+#endif

--- a/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
@@ -20,6 +20,7 @@
 #include <Kokkos_Macros.hpp>
 
 #if defined(KOKKOS_ENABLE_HIP)
+#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR > 2)
 
 #include <Kokkos_Graph_fwd.hpp>
 
@@ -186,5 +187,6 @@ auto GraphImpl<Kokkos::HIP>::create_aggregate_ptr(PredecessorRefs&&...) {
 }  // namespace Impl
 }  // namespace Kokkos
 
+#endif
 #endif
 #endif

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -25,7 +25,7 @@
 #include <HIP/Kokkos_HIP_Instance.hpp>
 #include <HIP/Kokkos_HIP_Space.hpp>
 
-#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR > 2)
+#if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 2))
 #include <HIP/Kokkos_HIP_GraphNodeKernel.hpp>
 #include <impl/Kokkos_GraphImpl_fwd.hpp>
 #endif
@@ -380,7 +380,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
         driver);
   }
 
-#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR > 2)
+#if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 2))
   static void create_parallel_launch_graph_node(
       DriverType const &driver, dim3 const &grid, dim3 const &block, int shmem,
       HIPInternal const * /*hip_instance*/) {
@@ -438,7 +438,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
         driver_ptr);
   }
 
-#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR > 2)
+#if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 2))
   static void create_parallel_launch_graph_node(
       DriverType const &driver, dim3 const &grid, dim3 const &block, int shmem,
       HIPInternal const *hip_instance) {
@@ -581,7 +581,7 @@ void hip_parallel_launch(const DriverType &driver, const dim3 &grid,
                          const dim3 &block, const int shmem,
                          const HIPInternal *hip_instance,
                          const bool prefer_shmem) {
-#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR > 2)
+#if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 2))
   if constexpr (DoGraph) {
     // Graph launch
     using base_t = HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -24,8 +24,11 @@
 #include <HIP/Kokkos_HIP_Error.hpp>
 #include <HIP/Kokkos_HIP_Instance.hpp>
 #include <HIP/Kokkos_HIP_Space.hpp>
+
+#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR > 2)
 #include <HIP/Kokkos_HIP_GraphNodeKernel.hpp>
 #include <impl/Kokkos_GraphImpl_fwd.hpp>
+#endif
 
 // Must use global variable on the device with HIP-Clang
 #ifdef __HIP__
@@ -377,6 +380,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
         driver);
   }
 
+#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR > 2)
   static void create_parallel_launch_graph_node(
       DriverType const &driver, dim3 const &grid, dim3 const &block, int shmem,
       HIPInternal const * /*hip_instance*/) {
@@ -410,6 +414,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
     }
     KOKKOS_ENSURES(graph_node);
   }
+#endif
 };
 
 // HIPLaunchMechanism::GlobalMemory specialization
@@ -433,6 +438,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
         driver_ptr);
   }
 
+#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR > 2)
   static void create_parallel_launch_graph_node(
       DriverType const &driver, dim3 const &grid, dim3 const &block, int shmem,
       HIPInternal const *hip_instance) {
@@ -476,6 +482,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
     }
     KOKKOS_ENSURES(bool(graph_node))
   }
+#endif
 };
 
 // HIPLaunchMechanism::ConstantMemory specializations
@@ -574,13 +581,16 @@ void hip_parallel_launch(const DriverType &driver, const dim3 &grid,
                          const dim3 &block, const int shmem,
                          const HIPInternal *hip_instance,
                          const bool prefer_shmem) {
+#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR > 2)
   if constexpr (DoGraph) {
     // Graph launch
     using base_t = HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
                                                   LaunchMechanism>;
     base_t::create_parallel_launch_graph_node(driver, grid, block, shmem,
                                               hip_instance);
-  } else {
+  } else
+#endif
+  {
     // Regular kernel launch
 #ifndef KOKKOS_ENABLE_HIP_MULTIPLE_KERNEL_INSTANTIATIONS
     HIPParallelLaunch<DriverType, LaunchBounds, LaunchMechanism>(

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -24,6 +24,8 @@
 #include <HIP/Kokkos_HIP_Error.hpp>
 #include <HIP/Kokkos_HIP_Instance.hpp>
 #include <HIP/Kokkos_HIP_Space.hpp>
+#include <HIP/Kokkos_HIP_GraphNodeKernel.hpp>
+#include <impl/Kokkos_GraphImpl_fwd.hpp>
 
 // Must use global variable on the device with HIP-Clang
 #ifdef __HIP__
@@ -192,6 +194,13 @@ struct HIPParallelLaunchKernelFuncData {
     return attr;
   }
 };
+
+//---------------------------------------------------------------//
+// Helper function                                               //
+//---------------------------------------------------------------//
+inline bool is_empty_launch(dim3 const &grid, dim3 const &block) {
+  return (grid.x == 0) || ((block.x * block.y * block.z) == 0);
+}
 
 //---------------------------------------------------------------//
 // HIPParallelLaunchKernelFunc structure and its specializations //
@@ -367,6 +376,40 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
     (base_t::get_kernel_func())<<<grid, block, shmem, hip_instance->m_stream>>>(
         driver);
   }
+
+  static void create_parallel_launch_graph_node(
+      DriverType const &driver, dim3 const &grid, dim3 const &block, int shmem,
+      HIPInternal const * /*hip_instance*/) {
+    auto const &graph = Impl::get_hip_graph_from_kernel(driver);
+    KOKKOS_EXPECTS(graph);
+    auto &graph_node = Impl::get_hip_graph_node_from_kernel(driver);
+    // Expect node not yet initialized
+    KOKKOS_EXPECTS(!graph_node);
+
+    if (!Impl::is_empty_launch(grid, block)) {
+      void const *args[] = {&driver};
+
+      hipKernelNodeParams params = {};
+
+      params.blockDim       = block;
+      params.gridDim        = grid;
+      params.sharedMemBytes = shmem;
+      params.func           = (void *)base_t::get_kernel_func();
+      params.kernelParams   = (void **)args;
+      params.extra          = nullptr;
+
+      KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphAddKernelNode(
+          &graph_node, graph, /* dependencies = */ nullptr,
+          /* numDependencies = */ 0, &params));
+    } else {
+      // We still need an empty node for the dependency structure
+      KOKKOS_IMPL_HIP_SAFE_CALL(
+          hipGraphAddEmptyNode(&graph_node, graph,
+                               /* dependencies = */ nullptr,
+                               /* numDependencies = */ 0));
+    }
+    KOKKOS_ENSURES(graph_node);
+  }
 };
 
 // HIPLaunchMechanism::GlobalMemory specialization
@@ -388,6 +431,50 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
             reinterpret_cast<void const *>(&driver), sizeof(DriverType)));
     (base_t::get_kernel_func())<<<grid, block, shmem, hip_instance->m_stream>>>(
         driver_ptr);
+  }
+
+  static void create_parallel_launch_graph_node(
+      DriverType const &driver, dim3 const &grid, dim3 const &block, int shmem,
+      HIPInternal const *hip_instance) {
+    auto const &graph = Impl::get_hip_graph_from_kernel(driver);
+    KOKKOS_EXPECTS(graph);
+    auto &graph_node = Impl::get_hip_graph_node_from_kernel(driver);
+    // Expect node not yet initialized
+    KOKKOS_EXPECTS(!graph_node);
+
+    if (!Impl::is_empty_launch(grid, block)) {
+      auto *driver_ptr = Impl::allocate_driver_storage_for_kernel(driver);
+
+      // Unlike in the non-graph case, we can get away with doing an async copy
+      // here because the `DriverType` instance is held in the GraphNodeImpl
+      // which is guaranteed to be alive until the graph instance itself is
+      // destroyed, where there should be a fence ensuring that the allocation
+      // associated with this kernel on the device side isn't deleted.
+      hipMemcpyAsync(driver_ptr, &driver, sizeof(DriverType), hipMemcpyDefault,
+                     hip_instance->m_stream);
+
+      void const *args[] = {&driver_ptr};
+
+      hipKernelNodeParams params = {};
+
+      params.blockDim       = block;
+      params.gridDim        = grid;
+      params.sharedMemBytes = shmem;
+      params.func           = (void *)base_t::get_kernel_func();
+      params.kernelParams   = (void **)args;
+      params.extra          = nullptr;
+
+      KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphAddKernelNode(
+          &graph_node, graph, /* dependencies = */ nullptr,
+          /* numDependencies = */ 0, &params));
+    } else {
+      // We still need an empty node for the dependency structure
+      KOKKOS_IMPL_HIP_SAFE_CALL(
+          hipGraphAddEmptyNode(&graph_node, graph,
+                               /* dependencies = */ nullptr,
+                               /* numDependencies = */ 0));
+    }
+    KOKKOS_ENSURES(bool(graph_node))
   }
 };
 
@@ -481,38 +568,48 @@ struct HIPParallelLaunch<
 // al.
 template <typename DriverType, typename LaunchBounds = Kokkos::LaunchBounds<>,
           HIPLaunchMechanism LaunchMechanism =
-              DeduceHIPLaunchMechanism<DriverType>::launch_mechanism>
+              DeduceHIPLaunchMechanism<DriverType>::launch_mechanism,
+          bool DoGraph = DriverType::Policy::is_graph_kernel::value>
 void hip_parallel_launch(const DriverType &driver, const dim3 &grid,
                          const dim3 &block, const int shmem,
                          const HIPInternal *hip_instance,
                          const bool prefer_shmem) {
+  if constexpr (DoGraph) {
+    // Graph launch
+    using base_t = HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
+                                                  LaunchMechanism>;
+    base_t::create_parallel_launch_graph_node(driver, grid, block, shmem,
+                                              hip_instance);
+  } else {
+    // Regular kernel launch
 #ifndef KOKKOS_ENABLE_HIP_MULTIPLE_KERNEL_INSTANTIATIONS
-  HIPParallelLaunch<DriverType, LaunchBounds, LaunchMechanism>(
-      driver, grid, block, shmem, hip_instance, prefer_shmem);
-#else
-  if constexpr (!HIPParallelLaunch<DriverType, LaunchBounds,
-                                   LaunchMechanism>::default_launchbounds()) {
-    // for user defined, we *always* honor the request
     HIPParallelLaunch<DriverType, LaunchBounds, LaunchMechanism>(
         driver, grid, block, shmem, hip_instance, prefer_shmem);
-  } else {
-    // we can do what we like
-    const unsigned flat_block_size = block.x * block.y * block.z;
-    if (flat_block_size <= HIPTraits::ConservativeThreadsPerBlock) {
-      // we have to use the large blocksize
-      HIPParallelLaunch<
-          DriverType,
-          Kokkos::LaunchBounds<HIPTraits::ConservativeThreadsPerBlock, 1>,
-          LaunchMechanism>(driver, grid, block, shmem, hip_instance,
-                           prefer_shmem);
+#else
+    if constexpr (!HIPParallelLaunch<DriverType, LaunchBounds,
+                                     LaunchMechanism>::default_launchbounds()) {
+      // for user defined, we *always* honor the request
+      HIPParallelLaunch<DriverType, LaunchBounds, LaunchMechanism>(
+          driver, grid, block, shmem, hip_instance, prefer_shmem);
     } else {
-      HIPParallelLaunch<DriverType,
-                        Kokkos::LaunchBounds<HIPTraits::MaxThreadsPerBlock, 1>,
-                        LaunchMechanism>(driver, grid, block, shmem,
-                                         hip_instance, prefer_shmem);
+      // we can do what we like
+      const unsigned flat_block_size = block.x * block.y * block.z;
+      if (flat_block_size <= HIPTraits::ConservativeThreadsPerBlock) {
+        // we have to use the large blocksize
+        HIPParallelLaunch<
+            DriverType,
+            Kokkos::LaunchBounds<HIPTraits::ConservativeThreadsPerBlock, 1>,
+            LaunchMechanism>(driver, grid, block, shmem, hip_instance,
+                             prefer_shmem);
+      } else {
+        HIPParallelLaunch<
+            DriverType, Kokkos::LaunchBounds<HIPTraits::MaxThreadsPerBlock, 1>,
+            LaunchMechanism>(driver, grid, block, shmem, hip_instance,
+                             prefer_shmem);
+      }
     }
-  }
 #endif
+  }
 }
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -394,7 +394,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
     // Expect node not yet initialized
     KOKKOS_EXPECTS(!graph_node);
 
-    if (!Impl::is_empty_launch(grid, block)) {
+    if (!is_empty_launch(grid, block)) {
       void const *args[] = {&driver};
 
       hipKernelNodeParams params = {};

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -26,6 +26,10 @@
 #include <HIP/Kokkos_HIP_Space.hpp>
 
 #if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 2))
+#define KOKKOS_IMPL_HIP_GRAPH_ENABLED
+#endif
+
+#ifdef KOKKOS_IMPL_HIP_GRAPH_ENABLED
 #include <HIP/Kokkos_HIP_GraphNodeKernel.hpp>
 #include <impl/Kokkos_GraphImpl_fwd.hpp>
 #endif
@@ -380,13 +384,13 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
         driver);
   }
 
-#if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 2))
+#ifdef KOKKOS_IMPL_HIP_GRAPH_ENABLED
   static void create_parallel_launch_graph_node(
       DriverType const &driver, dim3 const &grid, dim3 const &block, int shmem,
       HIPInternal const * /*hip_instance*/) {
-    auto const &graph = Impl::get_hip_graph_from_kernel(driver);
+    auto const &graph = get_hip_graph_from_kernel(driver);
     KOKKOS_EXPECTS(graph);
-    auto &graph_node = Impl::get_hip_graph_node_from_kernel(driver);
+    auto &graph_node = get_hip_graph_node_from_kernel(driver);
     // Expect node not yet initialized
     KOKKOS_EXPECTS(!graph_node);
 
@@ -438,13 +442,13 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
         driver_ptr);
   }
 
-#if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 2))
+#ifdef KOKKOS_IMPL_HIP_GRAPH_ENABLED
   static void create_parallel_launch_graph_node(
       DriverType const &driver, dim3 const &grid, dim3 const &block, int shmem,
       HIPInternal const *hip_instance) {
-    auto const &graph = Impl::get_hip_graph_from_kernel(driver);
+    auto const &graph = get_hip_graph_from_kernel(driver);
     KOKKOS_EXPECTS(graph);
-    auto &graph_node = Impl::get_hip_graph_node_from_kernel(driver);
+    auto &graph_node = get_hip_graph_node_from_kernel(driver);
     // Expect node not yet initialized
     KOKKOS_EXPECTS(!graph_node);
 
@@ -581,7 +585,7 @@ void hip_parallel_launch(const DriverType &driver, const dim3 &grid,
                          const dim3 &block, const int shmem,
                          const HIPInternal *hip_instance,
                          const bool prefer_shmem) {
-#if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 2))
+#ifdef KOKKOS_IMPL_HIP_GRAPH_ENABLED
   if constexpr (DoGraph) {
     // Graph launch
     using base_t = HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
@@ -623,6 +627,8 @@ void hip_parallel_launch(const DriverType &driver, const dim3 &grid,
 }
 }  // namespace Impl
 }  // namespace Kokkos
+
+#undef KOKKOS_IMPL_HIP_GRAPH_ENABLED
 
 #endif
 

--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -30,7 +30,8 @@ namespace Impl {
 template <class FunctorType, class... Traits>
 class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
  public:
-  using Policy = Kokkos::MDRangePolicy<Traits...>;
+  using Policy       = Kokkos::MDRangePolicy<Traits...>;
+  using functor_type = FunctorType;
 
  private:
   using array_index_type = typename Policy::array_index_type;

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -121,6 +121,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   using value_type     = typename ReducerType::value_type;
   using reference_type = typename ReducerType::reference_type;
   using functor_type   = FunctorType;
+  using reducer_type   = ReducerType;
   using size_type      = Kokkos::HIP::size_type;
   using index_type     = typename Policy::index_type;
   // Conditionally set word_size_type to int16_t or int8_t if value_type is

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -425,7 +425,7 @@ __device__ inline void hip_release_scratch_index(int32_t* scratch_locks,
 template <typename FunctorType, typename... Properties>
 class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>, HIP> {
  public:
-  using Policy       = TeamPolicyInternal<HIP, Properties...>;
+  using Policy       = TeamPolicy<Properties...>;
   using functor_type = FunctorType;
   using size_type    = HIP::size_type;
 
@@ -587,7 +587,8 @@ class ParallelReduce<CombinedFunctorReducerType,
   using value_type     = typename ReducerType::value_type;
 
  public:
-  using size_type = HIP::size_type;
+  using functor_type = FunctorType;
+  using size_type    = HIP::size_type;
 
   static int constexpr UseShflReduction =
       (ReducerType::static_value_size() != 0);
@@ -753,6 +754,7 @@ class ParallelReduce<CombinedFunctorReducerType,
     const bool need_device_set = ReducerType::has_init_member_function() ||
                                  ReducerType::has_final_member_function() ||
                                  !m_result_ptr_host_accessible ||
+                                 Policy::is_graph_kernel::value ||
                                  !std::is_same<ReducerType, InvalidType>::value;
     if (!is_empty_range || need_device_set) {
       const int block_count =

--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -161,6 +161,7 @@ Graph<ExecutionSpace> create_graph(Closure&& arg_closure) {
 #include <impl/Kokkos_GraphNodeImpl.hpp>
 #include <impl/Kokkos_Default_Graph_Impl.hpp>
 #include <Cuda/Kokkos_Cuda_Graph_Impl.hpp>
+#include <HIP/Kokkos_HIP_Graph_Impl.hpp>
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_GRAPH
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_GRAPH

--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -161,7 +161,11 @@ Graph<ExecutionSpace> create_graph(Closure&& arg_closure) {
 #include <impl/Kokkos_GraphNodeImpl.hpp>
 #include <impl/Kokkos_Default_Graph_Impl.hpp>
 #include <Cuda/Kokkos_Cuda_Graph_Impl.hpp>
+#if defined(KOKKOS_ENABLE_HIP)
+#if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 2))
 #include <HIP/Kokkos_HIP_Graph_Impl.hpp>
+#endif
+#endif
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_GRAPH
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_GRAPH

--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -162,6 +162,7 @@ Graph<ExecutionSpace> create_graph(Closure&& arg_closure) {
 #include <impl/Kokkos_Default_Graph_Impl.hpp>
 #include <Cuda/Kokkos_Cuda_Graph_Impl.hpp>
 #if defined(KOKKOS_ENABLE_HIP)
+// The implementation of hipGraph in ROCm 5.2 is bugged, so we cannot use it.
 #if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 2))
 #include <HIP/Kokkos_HIP_Graph_Impl.hpp>
 #endif


### PR DESCRIPTION
Similar to CUDA, HIP has  a Graph library (as far as I can tell it was introduced in ROCm 4.5). The API is basically the same as the CUDA API and the new code is very close to CUDA code.