### PR TITLE
Update to NVHPC-23.7 for testing

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -27,17 +27,18 @@ pipeline {
         }
         stage('Build') {
             parallel {
-                stage('OPENACC-NVHPC-CUDA-11.6') {
+                stage('OPENACC-NVHPC-CUDA-12.2') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.nvhpc'
                             dir 'scripts/docker'
+                            additionalBuildArgs '--build-arg BASE=nvcr.io/nvidia/nvhpc:23.7-devel-cuda12.2-ubuntu20.04'
                             label 'nvidia-docker && volta && large_images'
                             args '--env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }
                     }
                     environment {
-                        CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/22.3/cuda/11.6'
+                        NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2'
                     }
                     steps {
                         sh '''rm -rf build && mkdir -p build && cd build && \

--- a/.jenkins
+++ b/.jenkins
@@ -53,12 +53,12 @@ pipeline {
                               make -j8 && ctest --verbose'''
                     }
                 }
-                stage('CUDA-11.7-NVHPC') {
+                stage('CUDA-12.2-NVHPC') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.nvhpc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=nvcr.io/nvidia/nvhpc:22.9-devel-cuda11.7-ubuntu20.04'
+                            additionalBuildArgs '--build-arg BASE=nvcr.io/nvidia/nvhpc:23.7-devel-cuda12.2-ubuntu20.04'
                             label 'nvidia-docker && large_images && volta'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }
@@ -70,7 +70,7 @@ pipeline {
                         OMP_MAX_ACTIVE_LEVELS = 1
                         OMP_PLACES = 'threads'
                         OMP_PROC_BIND = 'spread'
-                        NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/22.9/cuda/11.7'
+                        NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2'
                     }
                     steps {
                         sh '''rm -rf build && mkdir -p build && cd build && \

--- a/.jenkins
+++ b/.jenkins
@@ -32,7 +32,6 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.nvhpc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=nvcr.io/nvidia/nvhpc:23.7-devel-cuda12.2-ubuntu20.04'
                             label 'nvidia-docker && volta && large_images'
                             args '--env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }
@@ -59,7 +58,6 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.nvhpc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=nvcr.io/nvidia/nvhpc:23.7-devel-cuda12.2-ubuntu20.04'
                             label 'nvidia-docker && large_images && volta'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }

--- a/algorithms/src/sorting/Kokkos_BinSortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_BinSortPublicAPI.hpp
@@ -61,8 +61,7 @@ class BinSort {
         Kokkos::View<typename SrcViewType::const_data_type,
                      typename SrcViewType::array_layout,
                      typename SrcViewType::device_type,
-                     Kokkos::MemoryTraits<Kokkos::RandomAccess>
-                     >,
+                     Kokkos::MemoryTraits<Kokkos::RandomAccess> >,
         typename SrcViewType::const_type>;
 
     using perm_view_type = typename PermuteViewType::const_type;

--- a/algorithms/src/sorting/Kokkos_BinSortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_BinSortPublicAPI.hpp
@@ -60,8 +60,12 @@ class BinSort {
         Kokkos::is_view<SrcViewType>::value,
         Kokkos::View<typename SrcViewType::const_data_type,
                      typename SrcViewType::array_layout,
-                     typename SrcViewType::device_type,
-                     Kokkos::MemoryTraits<Kokkos::RandomAccess> >,
+                     typename SrcViewType::device_type
+#if !defined(KOKKOS_COMPILER_NVHPC) || (KOKKOS_COMPILER_NVHPC >= 230700)
+                     ,
+                     Kokkos::MemoryTraits<Kokkos::RandomAccess>
+#endif
+                     >,
         typename SrcViewType::const_type>;
 
     using perm_view_type = typename PermuteViewType::const_type;

--- a/algorithms/src/sorting/Kokkos_BinSortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_BinSortPublicAPI.hpp
@@ -60,11 +60,8 @@ class BinSort {
         Kokkos::is_view<SrcViewType>::value,
         Kokkos::View<typename SrcViewType::const_data_type,
                      typename SrcViewType::array_layout,
-                     typename SrcViewType::device_type
-#if not defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-                     ,
+                     typename SrcViewType::device_type,
                      Kokkos::MemoryTraits<Kokkos::RandomAccess>
-#endif
                      >,
         typename SrcViewType::const_type>;
 

--- a/algorithms/unit_tests/TestBinSortA.hpp
+++ b/algorithms/unit_tests/TestBinSortA.hpp
@@ -223,18 +223,8 @@ TEST(TEST_CATEGORY, BinSortGenericTests) {
   using key_type       = unsigned;
   constexpr int N      = 171;
 
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if (!std::is_same_v<ExecutionSpace, Kokkos::Cuda>)
-#endif
-    BinSortSetA::test_3D_sort_impl<ExecutionSpace, key_type>(N);
-
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if (!std::is_same_v<ExecutionSpace, Kokkos::Cuda>)
-#endif
-    BinSortSetA::test_issue_1160_impl<ExecutionSpace>();
-
+  BinSortSetA::test_3D_sort_impl<ExecutionSpace, key_type>(N);
+  BinSortSetA::test_issue_1160_impl<ExecutionSpace>();
   BinSortSetA::test_sort_integer_overflow<ExecutionSpace, long long>();
   BinSortSetA::test_sort_integer_overflow<ExecutionSpace, unsigned long long>();
   BinSortSetA::test_sort_integer_overflow<ExecutionSpace, int>();

--- a/containers/performance_tests/TestCuda.cpp
+++ b/containers/performance_tests/TestCuda.cpp
@@ -44,10 +44,6 @@ TEST(TEST_CATEGORY, dynrankview_perf) {
 }
 
 TEST(TEST_CATEGORY, global_2_local) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  GTEST_SKIP() << "errors reported for all sizes";
-#endif
   std::cout << "Cuda" << std::endl;
   std::cout << "size, create, generate, fill, find" << std::endl;
   for (unsigned i = Performance::begin_id_size; i <= Performance::end_id_size;

--- a/containers/unit_tests/TestBitset.hpp
+++ b/containers/unit_tests/TestBitset.hpp
@@ -190,19 +190,8 @@ void test_bitset() {
     {
       Impl::TestBitsetTest<const_bitset_type> f(bitset);
       uint32_t count = f.testit();
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-      if constexpr (!std::is_same_v<typename Device::execution_space,
-                                    Kokkos::Cuda>) {
-        EXPECT_EQ(bitset.size(), count);
-        EXPECT_EQ(count, bitset.count());
-      } else {
-        (void)count;
-      }
-#else
       EXPECT_EQ(bitset.size(), count);
       EXPECT_EQ(count, bitset.count());
-#endif
     }
 
     // std::cout << "  Check reset() " << std::endl;

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -396,12 +396,6 @@ void test_deep_copy(uint32_t num_nodes) {
 
 #if !defined(_WIN32)
 TEST(TEST_CATEGORY, UnorderedMap_insert) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Cuda>) {
-    GTEST_SKIP() << "unit test is hanging from index 0";
-  }
-#endif
   for (int i = 0; i < 500; ++i) {
     test_inserts<TEST_EXECSPACE>(100000, 90000, 100, true);
     test_inserts<TEST_EXECSPACE>(100000, 90000, 100, false);
@@ -418,12 +412,6 @@ TEST(TEST_CATEGORY, UnorderedMap_failed_insert) {
 }
 
 TEST(TEST_CATEGORY, UnorderedMap_deep_copy) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Cuda>) {
-    GTEST_SKIP() << "unit test is hanging from index 0";
-  }
-#endif
   for (int i = 0; i < 2; ++i) test_deep_copy<TEST_EXECSPACE>(10000);
 }
 

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -286,7 +286,7 @@ KOKKOS_INLINE_FUNCTION int abs(int n) {
 }
 KOKKOS_INLINE_FUNCTION long abs(long n) {
 // FIXME_NVHPC ptxas fatal   : unresolved extern function 'labs'
-#ifdef KOKKOS_COMPILER_NVHPC
+#if defined(KOKKOS_COMPILER_NVHPC) && KOKKOS_COMPILER_NVHPC<230700
   return n > 0 ? n : -n;
 #else
   using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::abs;
@@ -295,7 +295,7 @@ KOKKOS_INLINE_FUNCTION long abs(long n) {
 }
 KOKKOS_INLINE_FUNCTION long long abs(long long n) {
 // FIXME_NVHPC ptxas fatal   : unresolved extern function 'labs'
-#ifdef KOKKOS_COMPILER_NVHPC
+#if defined(KOKKOS_COMPILER_NVHPC) && KOKKOS_COMPILER_NVHPC<230700
   return n > 0 ? n : -n;
 #else
   using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::abs;
@@ -345,9 +345,7 @@ KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED(
 // Exponential functions
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(exp)
 // FIXME_NVHPC nvc++ has issues with exp2
-#ifndef KOKKOS_COMPILER_NVHPC
-KOKKOS_IMPL_MATH_UNARY_FUNCTION(exp2)
-#else
+#if defined(KOKKOS_COMPILER_NVHPC) && KOKKOS_COMPILER_NVHPC<230700
 KOKKOS_INLINE_FUNCTION float exp2(float val) {
   constexpr float ln2 = 0.693147180559945309417232121458176568L;
   return exp(ln2 * val);
@@ -365,6 +363,8 @@ KOKKOS_INLINE_FUNCTION double exp2(T val) {
   constexpr double ln2 = 0.693147180559945309417232121458176568L;
   return exp(ln2 * static_cast<double>(val));
 }
+#else
+KOKKOS_IMPL_MATH_UNARY_FUNCTION(exp2)
 #endif
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(expm1)
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(log)

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -286,7 +286,7 @@ KOKKOS_INLINE_FUNCTION int abs(int n) {
 }
 KOKKOS_INLINE_FUNCTION long abs(long n) {
 // FIXME_NVHPC ptxas fatal   : unresolved extern function 'labs'
-#if defined(KOKKOS_COMPILER_NVHPC) && KOKKOS_COMPILER_NVHPC<230700
+#if defined(KOKKOS_COMPILER_NVHPC) && KOKKOS_COMPILER_NVHPC < 230700
   return n > 0 ? n : -n;
 #else
   using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::abs;
@@ -295,7 +295,7 @@ KOKKOS_INLINE_FUNCTION long abs(long n) {
 }
 KOKKOS_INLINE_FUNCTION long long abs(long long n) {
 // FIXME_NVHPC ptxas fatal   : unresolved extern function 'labs'
-#if defined(KOKKOS_COMPILER_NVHPC) && KOKKOS_COMPILER_NVHPC<230700
+#if defined(KOKKOS_COMPILER_NVHPC) && KOKKOS_COMPILER_NVHPC < 230700
   return n > 0 ? n : -n;
 #else
   using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::abs;
@@ -345,7 +345,7 @@ KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED(
 // Exponential functions
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(exp)
 // FIXME_NVHPC nvc++ has issues with exp2
-#if defined(KOKKOS_COMPILER_NVHPC) && KOKKOS_COMPILER_NVHPC<230700
+#if defined(KOKKOS_COMPILER_NVHPC) && KOKKOS_COMPILER_NVHPC < 230700
 KOKKOS_INLINE_FUNCTION float exp2(float val) {
   constexpr float ln2 = 0.693147180559945309417232121458176568L;
   return exp(ln2 * val);

--- a/core/src/Kokkos_Pair.hpp
+++ b/core/src/Kokkos_Pair.hpp
@@ -62,8 +62,7 @@ struct pair {
   ///
   /// This calls the copy constructors of T1 and T2.  It won't compile
   /// if those copy constructors are not defined and public.
-#ifdef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC bug in NVHPC regarding constexpr
-                              // constructors used in device code
+#if defined(KOKKOS_COMPILER_NVHPC) && KOKKOS_COMPILER_NVHPC<230700
   KOKKOS_FORCEINLINE_FUNCTION
 #else
   KOKKOS_FORCEINLINE_FUNCTION constexpr
@@ -75,8 +74,7 @@ struct pair {
   /// This calls the copy constructors of T1 and T2.  It won't compile
   /// if those copy constructors are not defined and public.
   template <class U, class V>
-#ifdef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC bug in NVHPC regarding constexpr
-                              // constructors used in device code
+#if defined(KOKKOS_COMPILER_NVHPC) && KOKKOS_COMPILER_NVHPC<230700
   KOKKOS_FORCEINLINE_FUNCTION
 #else
   KOKKOS_FORCEINLINE_FUNCTION constexpr

--- a/core/src/Kokkos_Pair.hpp
+++ b/core/src/Kokkos_Pair.hpp
@@ -62,7 +62,7 @@ struct pair {
   ///
   /// This calls the copy constructors of T1 and T2.  It won't compile
   /// if those copy constructors are not defined and public.
-#if defined(KOKKOS_COMPILER_NVHPC) && KOKKOS_COMPILER_NVHPC<230700
+#if defined(KOKKOS_COMPILER_NVHPC) && KOKKOS_COMPILER_NVHPC < 230700
   KOKKOS_FORCEINLINE_FUNCTION
 #else
   KOKKOS_FORCEINLINE_FUNCTION constexpr
@@ -74,7 +74,7 @@ struct pair {
   /// This calls the copy constructors of T1 and T2.  It won't compile
   /// if those copy constructors are not defined and public.
   template <class U, class V>
-#if defined(KOKKOS_COMPILER_NVHPC) && KOKKOS_COMPILER_NVHPC<230700
+#if defined(KOKKOS_COMPILER_NVHPC) && KOKKOS_COMPILER_NVHPC < 230700
   KOKKOS_FORCEINLINE_FUNCTION
 #else
   KOKKOS_FORCEINLINE_FUNCTION constexpr

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -155,10 +155,7 @@ class HostThreadTeamData {
 
   //----------------------------------------
 
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC bug in NVHPC regarding constexpr
-                               // constructors used in device code
   constexpr
-#endif
       HostThreadTeamData() noexcept
       : m_work_range(-1, -1),
         m_work_end(0),

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -155,7 +155,10 @@ class HostThreadTeamData {
 
   //----------------------------------------
 
-  constexpr HostThreadTeamData() noexcept
+#if !defined(KOKKOS_COMPILER_NVHPC) || (KOKKOS_COMPILER_NVHPC >= 230700)
+  constexpr
+#endif
+      HostThreadTeamData() noexcept
       : m_work_range(-1, -1),
         m_work_end(0),
         m_scratch(nullptr),
@@ -176,7 +179,8 @@ class HostThreadTeamData {
         m_work_chunk(0),
         m_steal_rank(0),
         m_pool_rendezvous_step(0),
-        m_team_rendezvous_step(0) {}
+        m_team_rendezvous_step(0) {
+  }
 
   //----------------------------------------
   // Organize array of members into a pool.

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -155,8 +155,7 @@ class HostThreadTeamData {
 
   //----------------------------------------
 
-  constexpr
-      HostThreadTeamData() noexcept
+  constexpr HostThreadTeamData() noexcept
       : m_work_range(-1, -1),
         m_work_end(0),
         m_scratch(nullptr),
@@ -177,8 +176,7 @@ class HostThreadTeamData {
         m_work_chunk(0),
         m_steal_rank(0),
         m_pool_rendezvous_step(0),
-        m_team_rendezvous_step(0) {
-  }
+        m_team_rendezvous_step(0) {}
 
   //----------------------------------------
   // Organize array of members into a pool.

--- a/core/unit_test/TestAbort.hpp
+++ b/core/unit_test/TestAbort.hpp
@@ -80,7 +80,13 @@ void test_abort_from_device() {
   } else {
     TestAbortCausingAbnormalProgramTerminationAndPrinting<ExecutionSpace>();
   }
-#elif defined(KOKKOS_ENABLE_SYCL)  // FIXME_SYCL
+#elif defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC
+  if (std::is_same<ExecutionSpace, Kokkos::Experimental::OpenACC>::value) {
+    TestAbortPrintingToStdout<ExecutionSpace>();
+  } else {
+    TestAbortCausingAbnormalProgramTerminationAndPrinting<ExecutionSpace>();
+  }
+#elif defined(KOKKOS_ENABLE_SYCL)     // FIXME_SYCL
   if (std::is_same<ExecutionSpace, Kokkos::Experimental::SYCL>::value) {
 #ifdef NDEBUG
     TestAbortPrintingToStdout<ExecutionSpace>();

--- a/core/unit_test/TestAbort.hpp
+++ b/core/unit_test/TestAbort.hpp
@@ -19,7 +19,6 @@
 #include <regex>
 #include <Kokkos_Core.hpp>
 
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC
 TEST(TEST_CATEGORY_DEATH, abort_from_host) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
@@ -100,4 +99,3 @@ TEST(TEST_CATEGORY_DEATH, abort_from_device) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   test_abort_from_device<TEST_EXECSPACE>();
 }
-#endif

--- a/core/unit_test/TestAtomics.hpp
+++ b/core/unit_test/TestAtomics.hpp
@@ -581,8 +581,6 @@ struct TpetraUseCase {
   }
 };
 
-TEST(TEST_CATEGORY, atomics_tpetra_max_abs) {
-  TpetraUseCase().check();
-}
+TEST(TEST_CATEGORY, atomics_tpetra_max_abs) { TpetraUseCase().check(); }
 
 }  // namespace Test

--- a/core/unit_test/TestAtomics.hpp
+++ b/core/unit_test/TestAtomics.hpp
@@ -563,7 +563,7 @@ struct TpetraUseCase {
   };
 
   using T = int;
-  Kokkos::View<T> d_{"lbl"};
+  Kokkos::View<T, TEST_EXECSPACE> d_{"lbl"};
   KOKKOS_FUNCTION void operator()(int i) const {
     // 0, -1, 2, -3, ...
     auto v_i = static_cast<T>(i);
@@ -572,7 +572,9 @@ struct TpetraUseCase {
                        AbsMaxHelper<T>{v_i});
   }
 
-  TpetraUseCase() { Kokkos::parallel_for(10, *this); }
+  TpetraUseCase() {
+    Kokkos::parallel_for(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 10), *this);
+  }
 
   void check() {
     T v;

--- a/core/unit_test/TestAtomics.hpp
+++ b/core/unit_test/TestAtomics.hpp
@@ -582,10 +582,6 @@ struct TpetraUseCase {
 };
 
 TEST(TEST_CATEGORY, atomics_tpetra_max_abs) {
-#ifdef KOKKOS_COMPILER_NVHPC
-  GTEST_SKIP() << "FIXME_NVHPC (?)";
-#endif
-
   TpetraUseCase().check();
 }
 

--- a/core/unit_test/TestBitManipulationBuiltins.hpp
+++ b/core/unit_test/TestBitManipulationBuiltins.hpp
@@ -828,7 +828,7 @@ struct TestBitCastFunction {
     }
 
 #if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
+    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC 23.7
     if constexpr (std::is_same_v<Space, Kokkos::Cuda>) {
       return;
     }

--- a/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
+++ b/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
@@ -108,12 +108,6 @@ TEST(TEST_CATEGORY, host_shared_ptr_dereference_on_device) {
       static_cast<T*>(Kokkos::kokkos_malloc<MemorySpace>(sizeof(T))),
       [](T* p) { Kokkos::kokkos_free<MemorySpace>(p); });
 
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Cuda>) {
-    GTEST_SKIP() << "FIXME wrong result";
-  }
-#endif
   check_access_stored_pointer_and_dereference_on_device(device_ptr);
 }
 

--- a/core/unit_test/TestJoinBackwardCompatibility.hpp
+++ b/core/unit_test/TestJoinBackwardCompatibility.hpp
@@ -19,13 +19,8 @@
 
 #ifndef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC - temporarily disabled due to
                                // unimplemented reduction features
-#ifndef KOKKOS_COMPILER_NVHPC // doesn't work with 23.1
 namespace {
 
-// FIXME_NVHPC 23.3 errors out when using enums here
-// NVC++-F-0000-Internal compiler error. process_acc_put_dinit: unexpected
-// datatype    5339
-#ifndef KOKKOS_COMPILER_NVHPC
 enum MyErrorCode {
   no_error                           = 0b000,
   error_operator_plus_equal          = 0b001,
@@ -39,17 +34,6 @@ KOKKOS_FUNCTION constexpr MyErrorCode operator|(MyErrorCode lhs,
   return static_cast<MyErrorCode>(static_cast<int>(lhs) |
                                   static_cast<int>(rhs));
 }
-
-#else
-
-using MyErrorCode                                        = unsigned;
-constexpr MyErrorCode no_error                           = 0b000;
-constexpr MyErrorCode error_operator_plus_equal          = 0b001;
-constexpr MyErrorCode error_operator_plus_equal_volatile = 0b010;
-constexpr MyErrorCode error_join_volatile                = 0b100;
-constexpr MyErrorCode expected_join_volatile             = 0b1000;
-
-#endif
 
 static_assert((no_error | error_operator_plus_equal_volatile) ==
                   error_operator_plus_equal_volatile,
@@ -138,14 +122,8 @@ void test_join_backward_compatibility() {
 }
 
 TEST(TEST_CATEGORY, join_backward_compatibility) {
-#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVHPC) && \
-    KOKKOS_COMPILER_NVHPC <                                          \
-        230300  // FIXME_NVHPC test passes with workaround in 23.3
-  GTEST_SKIP() << "FIXME wrong result";
-#endif
   test_join_backward_compatibility();
 }
 
 }  // namespace
-#endif
 #endif

--- a/core/unit_test/TestJoinBackwardCompatibility.hpp
+++ b/core/unit_test/TestJoinBackwardCompatibility.hpp
@@ -19,6 +19,7 @@
 
 #ifndef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC - temporarily disabled due to
                                // unimplemented reduction features
+#ifndef KOKKOS_COMPILER_NVHPC // doesn't work with 23.1
 namespace {
 
 // FIXME_NVHPC 23.3 errors out when using enums here
@@ -146,4 +147,5 @@ TEST(TEST_CATEGORY, join_backward_compatibility) {
 }
 
 }  // namespace
+#endif
 #endif

--- a/core/unit_test/TestJoinBackwardCompatibility.hpp
+++ b/core/unit_test/TestJoinBackwardCompatibility.hpp
@@ -96,7 +96,7 @@ struct ReducerWithJoinThatTakesVolatileQualifiedArgs {
 
 void test_join_backward_compatibility() {
   MyJoinBackCompatValueType result;
-  Kokkos::RangePolicy<> policy(0, 1);
+  Kokkos::RangePolicy<TEST_EXECSPACE> policy(0, 1);
 
   Kokkos::parallel_reduce(
       policy, ReducerWithJoinThatTakesBothVolatileAndNonVolatileQualifiedArgs{},

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -910,7 +910,8 @@ TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutleft) {
 #if defined(KOKKOS_ENABLE_CUDA) && \
     defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC 23.7
   if (std::is_same_v<ExecSpace, Kokkos::Cuda>)
-    GTEST_SKIP() << "FIXME_NVHPC (?)";
+    GTEST_SKIP()
+        << "FIXME_NVHPC : Compiler bug affecting subviews of high rank Views";
 #endif
   using ViewType = Kokkos::View<double********, Kokkos::LayoutLeft, ExecSpace>;
 
@@ -942,7 +943,8 @@ TEST(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutleft) {
 #if defined(KOKKOS_ENABLE_CUDA) && \
     defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC 23.7
   if (std::is_same_v<ExecSpace, Kokkos::Cuda>)
-    GTEST_SKIP() << "FIXME_NVHPC (?)";
+    GTEST_SKIP()
+        << "FIXME_NVHPC : Compiler bug affecting subviews of high rank Views";
 #endif
   using ViewType = Kokkos::View<double********, Kokkos::LayoutLeft, ExecSpace>;
 
@@ -974,7 +976,8 @@ TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutright) {
 #if defined(KOKKOS_ENABLE_CUDA) && \
     defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC 23.7
   if (std::is_same_v<ExecSpace, Kokkos::Cuda>)
-    GTEST_SKIP() << "FIXME_NVHPC (?)";
+    GTEST_SKIP()
+        << "FIXME_NVHPC : Compiler bug affecting subviews of high rank Views";
 #endif
   using ViewType = Kokkos::View<double********, Kokkos::LayoutRight, ExecSpace>;
 
@@ -1006,7 +1009,8 @@ TEST(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutright) {
 #if defined(KOKKOS_ENABLE_CUDA) && \
     defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC 23.7
   if (std::is_same_v<ExecSpace, Kokkos::Cuda>)
-    GTEST_SKIP() << "FIXME_NVHPC (?)";
+    GTEST_SKIP()
+        << "FIXME_NVHPC : Compiler bug affecting subviews of high rank Views";
 #endif
 
   using ViewType = Kokkos::View<double********, Kokkos::LayoutRight, ExecSpace>;

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -906,6 +906,10 @@ void impl_test_local_deepcopy_rangepolicy_rank_7(const int N) {
 
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutleft) {
+#ifdef KOKKOS_COMPILER_NVHPC // 23.7
+  GTEST_SKIP() << "FIXME_NVHPC (?)";
+#endif
+
   using ExecSpace = TEST_EXECSPACE;
   using ViewType  = Kokkos::View<double********, Kokkos::LayoutLeft, ExecSpace>;
 
@@ -933,6 +937,10 @@ TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutleft) {
 }
 //-------------------------------------------------------------------------------------------------------------
 TEST(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutleft) {
+#ifdef KOKKOS_COMPILER_NVHPC // 23.7
+  GTEST_SKIP() << "FIXME_NVHPC (?)";
+#endif
+
   using ExecSpace = TEST_EXECSPACE;
   using ViewType  = Kokkos::View<double********, Kokkos::LayoutLeft, ExecSpace>;
 
@@ -960,6 +968,10 @@ TEST(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutleft) {
 }
 //-------------------------------------------------------------------------------------------------------------
 TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutright) {
+#ifdef KOKKOS_COMPILER_NVHPC // 23.7
+  GTEST_SKIP() << "FIXME_NVHPC (?)";
+#endif
+
   using ExecSpace = TEST_EXECSPACE;
   using ViewType = Kokkos::View<double********, Kokkos::LayoutRight, ExecSpace>;
 
@@ -987,6 +999,10 @@ TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutright) {
 }
 //-------------------------------------------------------------------------------------------------------------
 TEST(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutright) {
+#ifdef KOKKOS_COMPILER_NVHPC //23.7
+  GTEST_SKIP() << "FIXME_NVHPC (?)";
+#endif
+
   using ExecSpace = TEST_EXECSPACE;
   using ViewType = Kokkos::View<double********, Kokkos::LayoutRight, ExecSpace>;
 

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -906,7 +906,7 @@ void impl_test_local_deepcopy_rangepolicy_rank_7(const int N) {
 
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutleft) {
-#ifdef KOKKOS_COMPILER_NVHPC // 23.7
+#ifdef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
   GTEST_SKIP() << "FIXME_NVHPC (?)";
 #endif
 
@@ -937,7 +937,7 @@ TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutleft) {
 }
 //-------------------------------------------------------------------------------------------------------------
 TEST(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutleft) {
-#ifdef KOKKOS_COMPILER_NVHPC // 23.7
+#ifdef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
   GTEST_SKIP() << "FIXME_NVHPC (?)";
 #endif
 
@@ -968,7 +968,7 @@ TEST(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutleft) {
 }
 //-------------------------------------------------------------------------------------------------------------
 TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutright) {
-#ifdef KOKKOS_COMPILER_NVHPC // 23.7
+#ifdef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
   GTEST_SKIP() << "FIXME_NVHPC (?)";
 #endif
 
@@ -999,7 +999,7 @@ TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutright) {
 }
 //-------------------------------------------------------------------------------------------------------------
 TEST(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutright) {
-#ifdef KOKKOS_COMPILER_NVHPC //23.7
+#ifdef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
   GTEST_SKIP() << "FIXME_NVHPC (?)";
 #endif
 

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -906,12 +906,13 @@ void impl_test_local_deepcopy_rangepolicy_rank_7(const int N) {
 
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutleft) {
-#ifdef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
-  GTEST_SKIP() << "FIXME_NVHPC (?)";
-#endif
-
   using ExecSpace = TEST_EXECSPACE;
-  using ViewType  = Kokkos::View<double********, Kokkos::LayoutLeft, ExecSpace>;
+#if defined(KOKKOS_ENABLE_CUDA) && \
+    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC 23.7
+  if (std::is_same_v<ExecSpace, Kokkos::Cuda>)
+    GTEST_SKIP() << "FIXME_NVHPC (?)";
+#endif
+  using ViewType = Kokkos::View<double********, Kokkos::LayoutLeft, ExecSpace>;
 
   {  // Rank-1
     impl_test_local_deepcopy_teampolicy_rank_1<ExecSpace, ViewType>(8);
@@ -937,12 +938,13 @@ TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutleft) {
 }
 //-------------------------------------------------------------------------------------------------------------
 TEST(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutleft) {
-#ifdef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
-  GTEST_SKIP() << "FIXME_NVHPC (?)";
-#endif
-
   using ExecSpace = TEST_EXECSPACE;
-  using ViewType  = Kokkos::View<double********, Kokkos::LayoutLeft, ExecSpace>;
+#if defined(KOKKOS_ENABLE_CUDA) && \
+    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC 23.7
+  if (std::is_same_v<ExecSpace, Kokkos::Cuda>)
+    GTEST_SKIP() << "FIXME_NVHPC (?)";
+#endif
+  using ViewType = Kokkos::View<double********, Kokkos::LayoutLeft, ExecSpace>;
 
   {  // Rank-1
     impl_test_local_deepcopy_rangepolicy_rank_1<ExecSpace, ViewType>(8);
@@ -968,11 +970,12 @@ TEST(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutleft) {
 }
 //-------------------------------------------------------------------------------------------------------------
 TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutright) {
-#ifdef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
-  GTEST_SKIP() << "FIXME_NVHPC (?)";
-#endif
-
   using ExecSpace = TEST_EXECSPACE;
+#if defined(KOKKOS_ENABLE_CUDA) && \
+    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC 23.7
+  if (std::is_same_v<ExecSpace, Kokkos::Cuda>)
+    GTEST_SKIP() << "FIXME_NVHPC (?)";
+#endif
   using ViewType = Kokkos::View<double********, Kokkos::LayoutRight, ExecSpace>;
 
   {  // Rank-1
@@ -999,11 +1002,13 @@ TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutright) {
 }
 //-------------------------------------------------------------------------------------------------------------
 TEST(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutright) {
-#ifdef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
-  GTEST_SKIP() << "FIXME_NVHPC (?)";
+  using ExecSpace = TEST_EXECSPACE;
+#if defined(KOKKOS_ENABLE_CUDA) && \
+    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC 23.7
+  if (std::is_same_v<ExecSpace, Kokkos::Cuda>)
+    GTEST_SKIP() << "FIXME_NVHPC (?)";
 #endif
 
-  using ExecSpace = TEST_EXECSPACE;
   using ViewType = Kokkos::View<double********, Kokkos::LayoutRight, ExecSpace>;
 
   {  // Rank-1

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -81,7 +81,6 @@ TEST(TEST_CATEGORY, md_range_policy_construction_from_arrays) {
   construct_mdrange_policy_variable_type<std::int64_t>();
 }
 
-#ifndef KOKKOS_COMPILER_NVHPC       // FIXME_NVHPC
 #ifndef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET
 TEST(TEST_CATEGORY_DEATH, policy_bounds_unsafe_narrowing_conversions) {
   using Policy = Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>,
@@ -94,7 +93,6 @@ TEST(TEST_CATEGORY_DEATH, policy_bounds_unsafe_narrowing_conversions) {
       },
       "unsafe narrowing conversion");
 }
-#endif
 #endif
 
 }  // namespace

--- a/core/unit_test/TestMathematicalConstants.hpp
+++ b/core/unit_test/TestMathematicalConstants.hpp
@@ -63,7 +63,7 @@ struct TestMathematicalConstants {
 
   KOKKOS_FUNCTION void use_on_device() const {
 #if defined(KOKKOS_COMPILER_NVCC) || defined(KOKKOS_ENABLE_OPENMPTARGET) || \
-    defined(KOKKOS_ENABLE_OPENACC) || defined(KOKKOS_COMPILER_NVHPC)
+    defined(KOKKOS_ENABLE_OPENACC) || defined(KOKKOS_COMPILER_NVHPC) // FIXME_NVHPC 23.7
     take_by_value(Trait::value);
 #else
     (void)take_address_of(Trait::value);

--- a/core/unit_test/TestMathematicalConstants.hpp
+++ b/core/unit_test/TestMathematicalConstants.hpp
@@ -63,7 +63,8 @@ struct TestMathematicalConstants {
 
   KOKKOS_FUNCTION void use_on_device() const {
 #if defined(KOKKOS_COMPILER_NVCC) || defined(KOKKOS_ENABLE_OPENMPTARGET) || \
-    defined(KOKKOS_ENABLE_OPENACC) || defined(KOKKOS_COMPILER_NVHPC) // FIXME_NVHPC 23.7
+    defined(KOKKOS_ENABLE_OPENACC) ||                                       \
+    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC 23.7
     take_by_value(Trait::value);
 #else
     (void)take_address_of(Trait::value);

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -314,12 +314,7 @@ struct math_function_name;
 // https://www.gnu.org/software/libc/manual/html_node/Errors-in-Math-Functions.html
 // For now 1s largely seem to work ...
 DEFINE_UNARY_FUNCTION_EVAL(exp, 2);
-#ifdef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC exp2 not device callable,
-                              // workaround computes it via exp
-DEFINE_UNARY_FUNCTION_EVAL(exp2, 30);
-#else
 DEFINE_UNARY_FUNCTION_EVAL(exp2, 2);
-#endif
 DEFINE_UNARY_FUNCTION_EVAL(expm1, 2);
 DEFINE_UNARY_FUNCTION_EVAL(log, 2);
 DEFINE_UNARY_FUNCTION_EVAL(log10, 2);
@@ -1151,7 +1146,7 @@ struct TestIsNaN {
       Kokkos::printf("failed isnan(float)\n");
     }
     if (isnan(3.)
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
         || !isnan(quiet_NaN<double>::value) ||
         !isnan(signaling_NaN<double>::value)
 #endif

--- a/core/unit_test/TestMinMaxClamp.hpp
+++ b/core/unit_test/TestMinMaxClamp.hpp
@@ -174,10 +174,6 @@ TEST(TEST_CATEGORY, minmax) {
   EXPECT_EQ(r2.first, 2);
   EXPECT_EQ(r2.second, 3);
 
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC nvhpc can't deal with device side
-                               // constexpr constructors so I removed the
-                               // constexpr in pair, which makes static_assert
-                               // here fail
   static_assert((Kokkos::pair<float, float>(Kokkos::minmax(3.f, 2.f)) ==
                  Kokkos::make_pair(2.f, 3.f)));
   static_assert(
@@ -208,7 +204,6 @@ TEST(TEST_CATEGORY, minmax) {
                                    ::Test::PairIntCompareFirst{0, 5},
                                })
                     .second.second == 4);  // rightmost
-#endif
 }
 
 template <class ViewType>

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -41,7 +41,6 @@ struct extrema {
   DEFINE_EXTREMA(float, -FLT_MAX, FLT_MAX);
   DEFINE_EXTREMA(double, -DBL_MAX, DBL_MAX);
 
-// FIXME_NVHPC: with 23.3 using long double in KOKKOS_FUNCTION is hard error
 #if !defined(KOKKOS_ENABLE_CUDA) || \
     !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double
   DEFINE_EXTREMA(long double, -LDBL_MAX, LDBL_MAX);
@@ -208,7 +207,8 @@ TEST(TEST_CATEGORY, numeric_traits_infinity) {
   TestNumericTraits<TEST_EXECSPACE, float, Infinity>();
   TestNumericTraits<TEST_EXECSPACE, double, Infinity>();
   // FIXME_NVHPC long double not supported
-#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double
+#if !defined(KOKKOS_ENABLE_CUDA) || \
+    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double
   TestNumericTraits<TEST_EXECSPACE, long double, Infinity>();
 #endif
 }
@@ -217,7 +217,8 @@ TEST(TEST_CATEGORY, numeric_traits_epsilon) {
   TestNumericTraits<TEST_EXECSPACE, float, Epsilon>();
   TestNumericTraits<TEST_EXECSPACE, double, Epsilon>();
   // FIXME_NVHPC long double not supported
-#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
+#if !defined(KOKKOS_ENABLE_CUDA) || \
+    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, Epsilon>();
 #endif
 }
@@ -226,7 +227,8 @@ TEST(TEST_CATEGORY, numeric_traits_round_error) {
   TestNumericTraits<TEST_EXECSPACE, float, RoundError>();
   TestNumericTraits<TEST_EXECSPACE, double, RoundError>();
   // FIXME_NVHPC long double not supported
-#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
+#if !defined(KOKKOS_ENABLE_CUDA) || \
+    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, RoundError>();
 #endif
 }
@@ -235,7 +237,8 @@ TEST(TEST_CATEGORY, numeric_traits_norm_min) {
   TestNumericTraits<TEST_EXECSPACE, float, NormMin>();
   TestNumericTraits<TEST_EXECSPACE, double, NormMin>();
   // FIXME_NVHPC long double not supported
-#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
+#if !defined(KOKKOS_ENABLE_CUDA) || \
+    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, NormMin>();
 #endif
 }
@@ -244,7 +247,8 @@ TEST(TEST_CATEGORY, numeric_traits_denorm_min) {
   TestNumericTraits<TEST_EXECSPACE, float, DenormMin>();
   TestNumericTraits<TEST_EXECSPACE, double, DenormMin>();
   // FIXME_NVHPC long double not supported
-#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
+#if !defined(KOKKOS_ENABLE_CUDA) || \
+    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, DenormMin>();
 #endif
 }
@@ -281,8 +285,8 @@ TEST(TEST_CATEGORY, numeric_traits_finite_min_max) {
   TestNumericTraits<TEST_EXECSPACE, float, FiniteMax>();
   TestNumericTraits<TEST_EXECSPACE, double, FiniteMin>();
   TestNumericTraits<TEST_EXECSPACE, double, FiniteMax>();
-  // FIXME_NVHPC long double not supported
-#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
+#if !defined(KOKKOS_ENABLE_CUDA) || \
+    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, FiniteMin>();
   TestNumericTraits<TEST_EXECSPACE, long double, FiniteMax>();
 #endif
@@ -303,8 +307,8 @@ TEST(TEST_CATEGORY, numeric_traits_digits) {
   TestNumericTraits<TEST_EXECSPACE, unsigned long long int, Digits>();
   TestNumericTraits<TEST_EXECSPACE, float, Digits>();
   TestNumericTraits<TEST_EXECSPACE, double, Digits>();
-  // FIXME_NVHPC long double not supported
-#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
+#if !defined(KOKKOS_ENABLE_CUDA) || \
+    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, Digits>();
 #endif
 }
@@ -324,8 +328,8 @@ TEST(TEST_CATEGORY, numeric_traits_digits10) {
   TestNumericTraits<TEST_EXECSPACE, unsigned long long int, Digits10>();
   TestNumericTraits<TEST_EXECSPACE, float, Digits10>();
   TestNumericTraits<TEST_EXECSPACE, double, Digits10>();
-  // FIXME_NVHPC long double not supported
-#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
+#if !defined(KOKKOS_ENABLE_CUDA) || \
+    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, Digits10>();
 #endif
 }
@@ -333,8 +337,8 @@ TEST(TEST_CATEGORY, numeric_traits_digits10) {
 TEST(TEST_CATEGORY, numeric_traits_max_digits10) {
   TestNumericTraits<TEST_EXECSPACE, float, MaxDigits10>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxDigits10>();
-  // FIXME_NVHPC long double not supported
-#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
+#if !defined(KOKKOS_ENABLE_CUDA) || \
+    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, MaxDigits10>();
 #endif
 }
@@ -353,8 +357,8 @@ TEST(TEST_CATEGORY, numeric_traits_radix) {
   TestNumericTraits<TEST_EXECSPACE, unsigned long long int, Radix>();
   TestNumericTraits<TEST_EXECSPACE, float, Radix>();
   TestNumericTraits<TEST_EXECSPACE, double, Radix>();
-  // FIXME_NVHPC long double not supported
-#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
+#if !defined(KOKKOS_ENABLE_CUDA) || \
+    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, Radix>();
 #endif
 }
@@ -364,8 +368,8 @@ TEST(TEST_CATEGORY, numeric_traits_min_max_exponent) {
   TestNumericTraits<TEST_EXECSPACE, float, MaxExponent>();
   TestNumericTraits<TEST_EXECSPACE, double, MinExponent>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxExponent>();
-  // FIXME_NVHPC long double not supported
-#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
+#if !defined(KOKKOS_ENABLE_CUDA) || \
+    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, MinExponent>();
   TestNumericTraits<TEST_EXECSPACE, long double, MaxExponent>();
 #endif
@@ -376,8 +380,8 @@ TEST(TEST_CATEGORY, numeric_traits_min_max_exponent10) {
   TestNumericTraits<TEST_EXECSPACE, float, MaxExponent10>();
   TestNumericTraits<TEST_EXECSPACE, double, MinExponent10>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxExponent10>();
-  // FIXME_NVHPC long double not supported
-#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
+#if !defined(KOKKOS_ENABLE_CUDA) || \
+    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, MinExponent10>();
   TestNumericTraits<TEST_EXECSPACE, long double, MaxExponent10>();
 #endif
@@ -387,8 +391,8 @@ TEST(TEST_CATEGORY, numeric_traits_quiet_and_signaling_nan) {
   TestNumericTraits<TEST_EXECSPACE, float, SignalingNaN>();
   TestNumericTraits<TEST_EXECSPACE, double, QuietNaN>();
   TestNumericTraits<TEST_EXECSPACE, double, SignalingNaN>();
-  // FIXME_NVHPC long double not supported
-#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
+#if !defined(KOKKOS_ENABLE_CUDA) || \
+    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, QuietNaN>();
   TestNumericTraits<TEST_EXECSPACE, long double, SignalingNaN>();
 #endif

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -42,7 +42,7 @@ struct extrema {
   DEFINE_EXTREMA(double, -DBL_MAX, DBL_MAX);
 
 // FIXME_NVHPC: with 23.3 using long double in KOKKOS_FUNCTION is hard error
-#if !defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)
+#if !defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC) // 23.7 long double
   DEFINE_EXTREMA(long double, -LDBL_MAX, LDBL_MAX);
 #else
   static long double min(long double) { return -LDBL_MAX; }
@@ -145,7 +145,7 @@ struct TestNumericTraits {
   KOKKOS_FUNCTION void operator()(MaxExponent10, int, int&) const { use_on_device(); }
   // clang-format on
   KOKKOS_FUNCTION void operator()(QuietNaN, int, int& e) const {
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7 nan
     using Kokkos::Experimental::quiet_NaN;
     constexpr auto nan  = quiet_NaN<T>::value;
     constexpr auto zero = T(0);
@@ -157,7 +157,7 @@ struct TestNumericTraits {
     use_on_device();
   }
   KOKKOS_FUNCTION void operator()(SignalingNaN, int, int& e) const {
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC  23.7 nan
     using Kokkos::Experimental::signaling_NaN;
     constexpr auto nan  = signaling_NaN<T>::value;
     constexpr auto zero = T(0);
@@ -207,7 +207,7 @@ TEST(TEST_CATEGORY, numeric_traits_infinity) {
   TestNumericTraits<TEST_EXECSPACE, float, Infinity>();
   TestNumericTraits<TEST_EXECSPACE, double, Infinity>();
   // FIXME_NVHPC long double not supported
-#if !defined(KOKKOS_COMPILER_NVHPC)
+#ifndef KOKKOS_COMPILER_NVHPC // 23.7 long double
   TestNumericTraits<TEST_EXECSPACE, long double, Infinity>();
 #endif
 }
@@ -216,7 +216,7 @@ TEST(TEST_CATEGORY, numeric_traits_epsilon) {
   TestNumericTraits<TEST_EXECSPACE, float, Epsilon>();
   TestNumericTraits<TEST_EXECSPACE, double, Epsilon>();
   // FIXME_NVHPC long double not supported
-#if !defined(KOKKOS_COMPILER_NVHPC)
+#ifndef KOKKOS_COMPILER_NVHPC // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, Epsilon>();
 #endif
 }
@@ -224,9 +224,8 @@ TEST(TEST_CATEGORY, numeric_traits_epsilon) {
 TEST(TEST_CATEGORY, numeric_traits_round_error) {
   TestNumericTraits<TEST_EXECSPACE, float, RoundError>();
   TestNumericTraits<TEST_EXECSPACE, double, RoundError>();
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC:
-  // nvc++-Fatal-/home/projects/x86-64/nvidia/hpc_sdk/Linux_x86_64/22.3/compilers/bin/tools/cpp2
-  // TERMINATED by signal 11
+  // FIXME_NVHPC long double not supported
+#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, RoundError>();
 #endif
 }
@@ -234,9 +233,8 @@ TEST(TEST_CATEGORY, numeric_traits_round_error) {
 TEST(TEST_CATEGORY, numeric_traits_norm_min) {
   TestNumericTraits<TEST_EXECSPACE, float, NormMin>();
   TestNumericTraits<TEST_EXECSPACE, double, NormMin>();
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC:
-  // nvc++-Fatal-/home/projects/x86-64/nvidia/hpc_sdk/Linux_x86_64/22.3/compilers/bin/tools/cpp2
-  // TERMINATED by signal 11
+  // FIXME_NVHPC long double not supported
+#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, NormMin>();
 #endif
 }
@@ -244,9 +242,8 @@ TEST(TEST_CATEGORY, numeric_traits_norm_min) {
 TEST(TEST_CATEGORY, numeric_traits_denorm_min) {
   TestNumericTraits<TEST_EXECSPACE, float, DenormMin>();
   TestNumericTraits<TEST_EXECSPACE, double, DenormMin>();
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC:
-  // nvc++-Fatal-/home/projects/x86-64/nvidia/hpc_sdk/Linux_x86_64/22.3/compilers/bin/tools/cpp2
-  // TERMINATED by signal 11
+  // FIXME_NVHPC long double not supported
+#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, DenormMin>();
 #endif
 }
@@ -283,9 +280,8 @@ TEST(TEST_CATEGORY, numeric_traits_finite_min_max) {
   TestNumericTraits<TEST_EXECSPACE, float, FiniteMax>();
   TestNumericTraits<TEST_EXECSPACE, double, FiniteMin>();
   TestNumericTraits<TEST_EXECSPACE, double, FiniteMax>();
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC:
-  // nvc++-Fatal-/home/projects/x86-64/nvidia/hpc_sdk/Linux_x86_64/22.3/compilers/bin/tools/cpp2
-  // TERMINATED by signal 11
+  // FIXME_NVHPC long double not supported
+#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, FiniteMin>();
   TestNumericTraits<TEST_EXECSPACE, long double, FiniteMax>();
 #endif
@@ -306,9 +302,8 @@ TEST(TEST_CATEGORY, numeric_traits_digits) {
   TestNumericTraits<TEST_EXECSPACE, unsigned long long int, Digits>();
   TestNumericTraits<TEST_EXECSPACE, float, Digits>();
   TestNumericTraits<TEST_EXECSPACE, double, Digits>();
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC:
-  // nvc++-Fatal-/home/projects/x86-64/nvidia/hpc_sdk/Linux_x86_64/22.3/compilers/bin/tools/cpp2
-  // TERMINATED by signal 11
+  // FIXME_NVHPC long double not supported
+#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, Digits>();
 #endif
 }
@@ -328,9 +323,8 @@ TEST(TEST_CATEGORY, numeric_traits_digits10) {
   TestNumericTraits<TEST_EXECSPACE, unsigned long long int, Digits10>();
   TestNumericTraits<TEST_EXECSPACE, float, Digits10>();
   TestNumericTraits<TEST_EXECSPACE, double, Digits10>();
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC:
-  // nvc++-Fatal-/home/projects/x86-64/nvidia/hpc_sdk/Linux_x86_64/22.3/compilers/bin/tools/cpp2
-  // TERMINATED by signal 11
+  // FIXME_NVHPC long double not supported
+#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, Digits10>();
 #endif
 }
@@ -338,9 +332,8 @@ TEST(TEST_CATEGORY, numeric_traits_digits10) {
 TEST(TEST_CATEGORY, numeric_traits_max_digits10) {
   TestNumericTraits<TEST_EXECSPACE, float, MaxDigits10>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxDigits10>();
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC:
-  // nvc++-Fatal-/home/projects/x86-64/nvidia/hpc_sdk/Linux_x86_64/22.3/compilers/bin/tools/cpp2
-  // TERMINATED by signal 11
+  // FIXME_NVHPC long double not supported
+#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, MaxDigits10>();
 #endif
 }
@@ -359,9 +352,8 @@ TEST(TEST_CATEGORY, numeric_traits_radix) {
   TestNumericTraits<TEST_EXECSPACE, unsigned long long int, Radix>();
   TestNumericTraits<TEST_EXECSPACE, float, Radix>();
   TestNumericTraits<TEST_EXECSPACE, double, Radix>();
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC:
-  // nvc++-Fatal-/home/projects/x86-64/nvidia/hpc_sdk/Linux_x86_64/22.3/compilers/bin/tools/cpp2
-  // TERMINATED by signal 11
+  // FIXME_NVHPC long double not supported
+#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, Radix>();
 #endif
 }
@@ -371,9 +363,8 @@ TEST(TEST_CATEGORY, numeric_traits_min_max_exponent) {
   TestNumericTraits<TEST_EXECSPACE, float, MaxExponent>();
   TestNumericTraits<TEST_EXECSPACE, double, MinExponent>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxExponent>();
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC:
-  // nvc++-Fatal-/home/projects/x86-64/nvidia/hpc_sdk/Linux_x86_64/22.3/compilers/bin/tools/cpp2
-  // TERMINATED by signal 11
+  // FIXME_NVHPC long double not supported
+#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, MinExponent>();
   TestNumericTraits<TEST_EXECSPACE, long double, MaxExponent>();
 #endif
@@ -384,9 +375,8 @@ TEST(TEST_CATEGORY, numeric_traits_min_max_exponent10) {
   TestNumericTraits<TEST_EXECSPACE, float, MaxExponent10>();
   TestNumericTraits<TEST_EXECSPACE, double, MinExponent10>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxExponent10>();
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC:
-  // nvc++-Fatal-/home/projects/x86-64/nvidia/hpc_sdk/Linux_x86_64/22.3/compilers/bin/tools/cpp2
-  // TERMINATED by signal 11
+  // FIXME_NVHPC long double not supported
+#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, MinExponent10>();
   TestNumericTraits<TEST_EXECSPACE, long double, MaxExponent10>();
 #endif
@@ -396,12 +386,8 @@ TEST(TEST_CATEGORY, numeric_traits_quiet_and_signaling_nan) {
   TestNumericTraits<TEST_EXECSPACE, float, SignalingNaN>();
   TestNumericTraits<TEST_EXECSPACE, double, QuietNaN>();
   TestNumericTraits<TEST_EXECSPACE, double, SignalingNaN>();
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC:
-  // Unsupported unknown data type 38.
-  // Unsupported unknown data type 38.
-  // Unsupported unknown data type 38.
-  // nvc++-Fatal-/home/projects/x86-64/nvidia/hpc_sdk/Linux_x86_64/22.3/compilers/bin/tools/cpp2
-  // TERMINATED by signal 11
+  // FIXME_NVHPC long double not supported
+#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, QuietNaN>();
   TestNumericTraits<TEST_EXECSPACE, long double, SignalingNaN>();
 #endif

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -42,7 +42,8 @@ struct extrema {
   DEFINE_EXTREMA(double, -DBL_MAX, DBL_MAX);
 
 // FIXME_NVHPC: with 23.3 using long double in KOKKOS_FUNCTION is hard error
-#if !defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC) // 23.7 long double
+#if !defined(KOKKOS_ENABLE_CUDA) || \
+    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double
   DEFINE_EXTREMA(long double, -LDBL_MAX, LDBL_MAX);
 #else
   static long double min(long double) { return -LDBL_MAX; }
@@ -207,7 +208,7 @@ TEST(TEST_CATEGORY, numeric_traits_infinity) {
   TestNumericTraits<TEST_EXECSPACE, float, Infinity>();
   TestNumericTraits<TEST_EXECSPACE, double, Infinity>();
   // FIXME_NVHPC long double not supported
-#ifndef KOKKOS_COMPILER_NVHPC // 23.7 long double
+#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double
   TestNumericTraits<TEST_EXECSPACE, long double, Infinity>();
 #endif
 }
@@ -216,7 +217,7 @@ TEST(TEST_CATEGORY, numeric_traits_epsilon) {
   TestNumericTraits<TEST_EXECSPACE, float, Epsilon>();
   TestNumericTraits<TEST_EXECSPACE, double, Epsilon>();
   // FIXME_NVHPC long double not supported
-#ifndef KOKKOS_COMPILER_NVHPC // 23.7 long double:
+#ifndef KOKKOS_COMPILER_NVHPC  // 23.7 long double:
   TestNumericTraits<TEST_EXECSPACE, long double, Epsilon>();
 #endif
 }

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -157,7 +157,7 @@ struct TestNumericTraits {
     use_on_device();
   }
   KOKKOS_FUNCTION void operator()(SignalingNaN, int, int& e) const {
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC  23.7 nan
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7 nan
     using Kokkos::Experimental::signaling_NaN;
     constexpr auto nan  = signaling_NaN<T>::value;
     constexpr auto zero = T(0);

--- a/core/unit_test/TestOther.hpp
+++ b/core/unit_test/TestOther.hpp
@@ -17,12 +17,7 @@
 #ifndef KOKKOS_TEST_OTHER_HPP
 #define KOKKOS_TEST_OTHER_HPP
 #include <TestAggregate.hpp>
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC:
-// NVC++-F-0000-Internal compiler error. Basic LLVM base data type required 23
-// (/ascldap/users/crtrott/Kokkos/kokkos/build/core/unit_test/cuda/TestCuda_Other.cpp:
-// 204) NVC++/x86-64 Linux 22.3-0: compilation aborted
 #include <TestMemoryPool.hpp>
-#endif
 #include <TestCXX11.hpp>
 
 #include <TestViewCtorPropEmbeddedDim.hpp>

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -1233,7 +1233,6 @@ struct TestReducers {
 #if !defined(KOKKOS_ENABLE_OPENACC)
     // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_minloc(10003);
-#if defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC misaligned memory
 #if defined(KOKKOS_ENABLE_CUDA)
     if (!std::is_same_v<ExecSpace, Kokkos::Cuda>)
 #endif
@@ -1242,19 +1241,16 @@ struct TestReducers {
       test_minloc_2d(100);
 #endif
 #endif
-#endif
     test_max(10007);
 #if !defined(KOKKOS_ENABLE_OPENACC)
     // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_maxloc(10007);
-#if !defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC misaligned memory
 #if defined(KOKKOS_ENABLE_CUDA)
     if (!std::is_same_v<ExecSpace, Kokkos::Cuda>)
 #endif
 // FIXME_OPENMPTARGET requires custom reductions.
 #if !defined(KOKKOS_ENABLE_OPENMPTARGET)
       test_maxloc_2d(100);
-#endif
 #endif
 #endif
 // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -952,10 +952,7 @@ struct checkScan {
 TEST(TEST_CATEGORY, team_vector) {
   ASSERT_TRUE((TestTeamVector::Test<TEST_EXECSPACE>(0)));
   ASSERT_TRUE((TestTeamVector::Test<TEST_EXECSPACE>(1)));
-#if !(defined(KOKKOS_ENABLE_CUDA) && \
-      defined(KOKKOS_COMPILER_NVHPC))  // FIXME_NVHPC
   ASSERT_TRUE((TestTeamVector::Test<TEST_EXECSPACE>(2)));
-#endif
   ASSERT_TRUE((TestTeamVector::Test<TEST_EXECSPACE>(3)));
   ASSERT_TRUE((TestTeamVector::Test<TEST_EXECSPACE>(4)));
   ASSERT_TRUE((TestTeamVector::Test<TEST_EXECSPACE>(5)));
@@ -1003,7 +1000,7 @@ TEST(TEST_CATEGORY, parallel_scan_with_reducers) {
   constexpr int n_vector_range = 100;
 
 #if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
+    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC 23.7
   if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Cuda>) {
     GTEST_SKIP() << "All but max inclusive scan differ at index 101";
   }

--- a/core/unit_test/TestTeamVectorRange.hpp
+++ b/core/unit_test/TestTeamVectorRange.hpp
@@ -437,7 +437,7 @@ namespace Test {
 TEST(TEST_CATEGORY, team_teamvector_range) {
   ASSERT_TRUE((TestTeamVectorRange::Test<TEST_EXECSPACE>(0)));
 #if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
+    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC 23.7
   if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Cuda>) {
     GTEST_SKIP() << "Disabling 2/3rd of the test for now";
   }

--- a/core/unit_test/TestViewCtorDimMatch.hpp
+++ b/core/unit_test/TestViewCtorDimMatch.hpp
@@ -49,9 +49,7 @@ using DType = int;
 
 // Skip test execution when KOKKOS_ENABLE_OPENMPTARGET is enabled until
 // Kokkos::abort() aborts properly on that backend
-// Skip test execution when KOKKOS_COMPILER_NVHPC until fixed in GTEST
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) || (KOKKOS_COMPILER_NVHPC)
-#else
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
 TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_dyn) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 

--- a/core/unit_test/TestViewLayoutStrideAssignment.hpp
+++ b/core/unit_test/TestViewLayoutStrideAssignment.hpp
@@ -582,7 +582,6 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
   }
 }
 
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC
 TEST(TEST_CATEGORY_DEATH, view_layoutstride_right_to_layoutleft_assignment) {
   using exec_space = TEST_EXECSPACE;
 
@@ -886,7 +885,6 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_left_to_layoutright_assignment) {
                  "View assignment must have compatible layouts");
   }
 }
-#endif
 
 }  // namespace Test
 

--- a/core/unit_test/TestViewMemoryAccessViolation.hpp
+++ b/core/unit_test/TestViewMemoryAccessViolation.hpp
@@ -18,7 +18,6 @@
 
 #include <gtest/gtest.h>
 
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC
 template <class View, class ExecutionSpace>
 struct TestViewMemoryAccessViolation {
   View v;
@@ -185,4 +184,3 @@ TEST(TEST_CATEGORY_DEATH, view_memory_access_violations_from_device) {
 
   test_view_memory_access_violations_from_device<ExecutionSpace>();
 }
-#endif

--- a/core/unit_test/TestViewMemoryAccessViolation.hpp
+++ b/core/unit_test/TestViewMemoryAccessViolation.hpp
@@ -181,6 +181,12 @@ TEST(TEST_CATEGORY_DEATH, view_memory_access_violations_from_device) {
                     "able to abort from the device";
   }
 #endif
+#if defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC
+  if (std::is_same<ExecutionSpace, Kokkos::Experimental::OpenACC>::value) {
+    GTEST_SKIP() << "skipping because OpenACC backend is currently not "
+                    "able to abort from the device";
+  }
+#endif
 
   test_view_memory_access_violations_from_device<ExecutionSpace>();
 }

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -338,11 +338,6 @@ struct TestViewCudaTexture {
 };
 
 TEST(cuda, impl_view_texture) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  GTEST_SKIP()
-      << "Getting error_count of 1000 meaning all assertions are failing";
-#endif
   TestViewCudaTexture<Kokkos::CudaSpace>::run();
   TestViewCudaTexture<Kokkos::CudaUVMSpace>::run();
 }
@@ -407,11 +402,6 @@ void test_view_subview_const_randomaccess() {
 }  // namespace issue_5594
 
 TEST(cuda, view_subview_const_randomaccess) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC (similar failure to
-                                    // TestViewCudaTexture?)
-  GTEST_SKIP() << "RandomAccess view not working on NVHPC?";
-#endif
   issue_5594::test_view_subview_const_randomaccess<Kokkos::Cuda,
                                                    Kokkos::CudaSpace>();
   issue_5594::test_view_subview_const_randomaccess<Kokkos::Cuda,

--- a/scripts/docker/Dockerfile.nvhpc
+++ b/scripts/docker/Dockerfile.nvhpc
@@ -1,4 +1,4 @@
-ARG BASE=nvcr.io/nvidia/nvhpc:22.3-devel-cuda11.6-ubuntu20.04
+ARG BASE=nvcr.io/nvidia/nvhpc:23.7-devel-cuda12.2-ubuntu20.04
 FROM $BASE
 
 RUN KEYDUMP_URL=https://cloud.cees.ornl.gov/download && \


### PR DESCRIPTION
I went through all the places where we ifdef for NVHPC and checked whether its needed with 23.7. In the tests I unconditionally removed places where the special casing is not needed, in the source code I did a version based check. 

All in all we are going down from over 30 places with issues to 11 FIXME places for NVHPC - 4 of which are a regression in 23.x compared to 22.9.