### PR TITLE
Kokkos::Array deduction guide

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -320,6 +320,9 @@ struct Array<T, KOKKOS_INVALID_INDEX, Array<>::strided> {
       : m_elem(arg_ptr), m_size(arg_size), m_stride(arg_stride) {}
 };
 
+template <typename T, typename... Us>
+Array(T, Us...)->Array<T, 1 + sizeof...(Us)>;
+
 }  // namespace Kokkos
 
 //<editor-fold desc="Support for structured binding">

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -49,4 +49,25 @@ KOKKOS_FUNCTION constexpr bool test_array_structured_binding_support() {
 
 static_assert(test_array_structured_binding_support());
 
+template <typename L, typename R>
+constexpr bool is_equal(L const& l, R const& r) {
+  if (std::size(l) != std::size(r)) return false;
+
+  for (size_t i = 0; i != std::size(l); ++i) {
+    if (l[i] != r[i]) return false;
+  }
+
+  return true;
+}
+
+KOKKOS_FUNCTION constexpr bool test_array_ctad() {
+  constexpr int x = 10;
+  constexpr Kokkos::Array a{1, 2, 3, 5, x};
+  constexpr Kokkos::Array<int, 5> b{1, 2, 3, 5, x};
+
+  return std::is_same_v<decltype(a), decltype(b)> && is_equal(a, b);
+}
+
+static_assert(test_array_ctad());
+
 }  // namespace

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -50,7 +50,7 @@ KOKKOS_FUNCTION constexpr bool test_array_structured_binding_support() {
 static_assert(test_array_structured_binding_support());
 
 template <typename L, typename R>
-constexpr bool is_equal(L const& l, R const& r) {
+KOKKOS_FUNCTION constexpr bool is_equal(L const& l, R const& r) {
   if (std::size(l) != std::size(r)) return false;
 
   for (size_t i = 0; i != std::size(l); ++i) {


### PR DESCRIPTION
(Part of issue #6355, intended to be applied after #6372, as that contains the initial unit tests for `std::array`.)

This adds a deduction guide for `Kokkos::Array<T, N, void>` (where `0<N`) analogous to the one for `std::array`, along with unit tests.