### PR TITLE
Adding `Kokkos::to_array`

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -356,6 +356,32 @@ struct KOKKOS_DEPRECATED
 template <typename T, typename... Us>
 Array(T, Us...)->Array<T, 1 + sizeof...(Us)>;
 
+namespace Impl {
+
+template <typename T, size_t N, size_t... I>
+KOKKOS_INLINE_FUNCTION constexpr Array<std::remove_cv_t<T>, N> to_Array_impl(
+    T (&a)[N], std::index_sequence<I...>) {
+  return {{a[I]...}};
+}
+
+template <typename T, size_t N, size_t... I>
+KOKKOS_INLINE_FUNCTION constexpr Array<std::remove_cv_t<T>, N> to_Array_impl(
+    T(&&a)[N], std::index_sequence<I...>) {
+  return {{std::move(a[I])...}};
+}
+
+}  // namespace Impl
+
+template <class T, size_t N>
+KOKKOS_INLINE_FUNCTION constexpr auto to_Array(T (&a)[N]) {
+  return Impl::to_Array_impl(a, std::make_index_sequence<N>{});
+}
+
+template <class T, size_t N>
+KOKKOS_INLINE_FUNCTION constexpr auto to_Array(T(&&a)[N]) {
+  return Impl::to_Array_impl(std::move(a), std::make_index_sequence<N>{});
+}
+
 }  // namespace Kokkos
 
 //<editor-fold desc="Support for structured binding">

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -373,12 +373,12 @@ KOKKOS_FUNCTION constexpr Array<std::remove_cv_t<T>, N> to_Array_impl(
 }  // namespace Impl
 
 template <typename T, size_t N>
-KOKKOS_INLINE_FUNCTION constexpr auto to_Array(T (&a)[N]) {
+KOKKOS_FUNCTION constexpr auto to_Array(T (&a)[N]) {
   return Impl::to_Array_impl(a, std::make_index_sequence<N>{});
 }
 
 template <typename T, size_t N>
-KOKKOS_INLINE_FUNCTION constexpr auto to_Array(T(&&a)[N]) {
+KOKKOS_FUNCTION constexpr auto to_Array(T(&&a)[N]) {
   return Impl::to_Array_impl(std::move(a), std::make_index_sequence<N>{});
 }
 

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -359,25 +359,25 @@ Array(T, Us...)->Array<T, 1 + sizeof...(Us)>;
 namespace Impl {
 
 template <typename T, size_t N, size_t... I>
-KOKKOS_INLINE_FUNCTION constexpr Array<std::remove_cv_t<T>, N> to_Array_impl(
+KOKKOS_FUNCTION constexpr Array<std::remove_cv_t<T>, N> to_Array_impl(
     T (&a)[N], std::index_sequence<I...>) {
   return {{a[I]...}};
 }
 
 template <typename T, size_t N, size_t... I>
-KOKKOS_INLINE_FUNCTION constexpr Array<std::remove_cv_t<T>, N> to_Array_impl(
+KOKKOS_FUNCTION constexpr Array<std::remove_cv_t<T>, N> to_Array_impl(
     T(&&a)[N], std::index_sequence<I...>) {
   return {{std::move(a[I])...}};
 }
 
 }  // namespace Impl
 
-template <class T, size_t N>
+template <typename T, size_t N>
 KOKKOS_INLINE_FUNCTION constexpr auto to_Array(T (&a)[N]) {
   return Impl::to_Array_impl(a, std::make_index_sequence<N>{});
 }
 
-template <class T, size_t N>
+template <typename T, size_t N>
 KOKKOS_INLINE_FUNCTION constexpr auto to_Array(T(&&a)[N]) {
   return Impl::to_Array_impl(std::move(a), std::make_index_sequence<N>{});
 }

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -359,13 +359,13 @@ Array(T, Us...)->Array<T, 1 + sizeof...(Us)>;
 namespace Impl {
 
 template <typename T, size_t N, size_t... I>
-KOKKOS_FUNCTION constexpr Array<std::remove_cv_t<T>, N> to_Array_impl(
+KOKKOS_FUNCTION constexpr Array<std::remove_cv_t<T>, N> to_array_impl(
     T (&a)[N], std::index_sequence<I...>) {
   return {{a[I]...}};
 }
 
 template <typename T, size_t N, size_t... I>
-KOKKOS_FUNCTION constexpr Array<std::remove_cv_t<T>, N> to_Array_impl(
+KOKKOS_FUNCTION constexpr Array<std::remove_cv_t<T>, N> to_array_impl(
     T(&&a)[N], std::index_sequence<I...>) {
   return {{std::move(a[I])...}};
 }
@@ -373,13 +373,13 @@ KOKKOS_FUNCTION constexpr Array<std::remove_cv_t<T>, N> to_Array_impl(
 }  // namespace Impl
 
 template <typename T, size_t N>
-KOKKOS_FUNCTION constexpr auto to_Array(T (&a)[N]) {
-  return Impl::to_Array_impl(a, std::make_index_sequence<N>{});
+KOKKOS_FUNCTION constexpr auto to_array(T (&a)[N]) {
+  return Impl::to_array_impl(a, std::make_index_sequence<N>{});
 }
 
 template <typename T, size_t N>
-KOKKOS_FUNCTION constexpr auto to_Array(T(&&a)[N]) {
-  return Impl::to_Array_impl(std::move(a), std::make_index_sequence<N>{});
+KOKKOS_FUNCTION constexpr auto to_array(T(&&a)[N]) {
+  return Impl::to_array_impl(std::move(a), std::make_index_sequence<N>{});
 }
 
 }  // namespace Kokkos

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -160,4 +160,23 @@ constexpr bool test_array_specialization_kokkos_swap() {
 
 static_assert(test_array_specialization_kokkos_swap());
 
+KOKKOS_FUNCTION constexpr bool test_to_array() {
+  // copies a string literal
+  auto a1 = Kokkos::to_Array("foo");
+  static_assert(a1.size() == 4);
+
+  // deduces both element type and length
+  auto a2 = Kokkos::to_Array({0, 2, 1, 3});
+  static_assert(std::is_same_v<decltype(a2), Kokkos::Array<int, 4>>);
+
+  // deduces length with element type specified
+  // implicit conversion happens
+  auto a3 = Kokkos::to_Array<long>({0, 1, 3});
+  static_assert(std::is_same_v<decltype(a3), Kokkos::Array<long, 3>>);
+
+  return true;
+}
+
+static_assert(test_to_array());
+
 }  // namespace

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -160,7 +160,7 @@ constexpr bool test_array_specialization_kokkos_swap() {
 
 static_assert(test_array_specialization_kokkos_swap());
 
-KOKKOS_FUNCTION constexpr bool test_to_array() {
+constexpr bool test_to_array() {
   // copies a string literal
   auto a1 = Kokkos::to_Array("foo");
   static_assert(a1.size() == 4);

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -167,12 +167,12 @@ static_assert(test_array_specialization_kokkos_swap());
 
 constexpr bool test_to_array() {
   // copies a string literal
-  [[maybe_unused]] auto a1 = Kokkos::to_Array("foo");
+  [[maybe_unused]] auto a1 = Kokkos::to_array("foo");
   static_assert(a1.size() == 4);
   maybe_unused(a1);
 
   // deduces both element type and length
-  [[maybe_unused]] auto a2 = Kokkos::to_Array({0, 2, 1, 3});
+  [[maybe_unused]] auto a2 = Kokkos::to_array({0, 2, 1, 3});
   static_assert(std::is_same_v<decltype(a2), Kokkos::Array<int, 4>>);
   maybe_unused(a2);
 
@@ -180,7 +180,7 @@ constexpr bool test_to_array() {
 #if !defined(KOKKOS_COMPILER_GNU) || (KOKKOS_COMPILER_GNU >= 910)
   // deduces length with element type specified
   // implicit conversion happens
-  [[maybe_unused]] auto a3 = Kokkos::to_Array<long>({0, 1, 3});
+  [[maybe_unused]] auto a3 = Kokkos::to_array<long>({0, 1, 3});
   static_assert(std::is_same_v<decltype(a3), Kokkos::Array<long, 3>>);
   maybe_unused(a3);
 #endif

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -18,6 +18,9 @@
 
 namespace {
 
+template <typename... Ts>
+KOKKOS_FUNCTION constexpr void maybe_unused(Ts&&...) {}
+
 KOKKOS_FUNCTION constexpr bool test_array() {
   constexpr Kokkos::Array<int, 3> a{{1, 2}};
 
@@ -173,6 +176,8 @@ constexpr bool test_to_array() {
   // implicit conversion happens
   auto a3 = Kokkos::to_Array<long>({0, 1, 3});
   static_assert(std::is_same_v<decltype(a3), Kokkos::Array<long, 3>>);
+
+  maybe_unused(a1, a2, a3);
 
   return true;
 }


### PR DESCRIPTION
(Part of issue #6355, intended to be applied after #6372, as that contains the initial unit tests for `Kokkos::array`.)

Adding `Kokkos::to_Array` for `Kokkos::Array<T, N, void>`, analogous to `std::to_array` for `std::array`, as well as unit tests.