### PR TITLE
Add a more comprehensive `kokkos_{malloc, free}` perf_test

### DIFF
--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -126,6 +126,7 @@ SET(
   PerfTest_CustomReduction.cpp
   PerfTest_ExecSpacePartitioning.cpp
   PerfTestHexGrad.cpp
+  PerfTest_MallocFree.cpp
   PerfTest_ViewAllocate.cpp
   PerfTest_ViewCopy_a123.cpp
   PerfTest_ViewCopy_b123.cpp

--- a/core/perf_test/PerfTest_MallocFree.cpp
+++ b/core/perf_test/PerfTest_MallocFree.cpp
@@ -1,0 +1,100 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+#include <benchmark/benchmark.h>
+#include "Benchmark_Context.hpp"
+
+namespace Benchmark {
+
+// when the time will be recorded
+enum class When { after_malloc, after_touch, after_free };
+
+static void Impl(benchmark::State& state, const bool touch, const When when) {
+  const size_t N = state.range(0);
+  for (auto _ : state) {
+    Kokkos::Timer timer;
+    char* a_ptr = static_cast<char*>(Kokkos::kokkos_malloc("A", N));
+    if (When::after_malloc == when) {
+      state.SetIterationTime(timer.seconds());
+    }
+    if (touch) {
+      constexpr size_t STRIDE = 1024;  // stride for touching the allocation.
+      // this is intended to be a safe value that would touch every "page", but
+      // not saturate the memory bandwidth
+      Kokkos::parallel_for(
+          N / STRIDE,
+          KOKKOS_LAMBDA(const size_t& i) { a_ptr[i * STRIDE] = i * STRIDE; });
+      Kokkos::fence();
+    }
+    if (When::after_touch == when) {
+      state.SetIterationTime(timer.seconds());
+    }
+    Kokkos::kokkos_free(a_ptr);
+    if (When::after_free == when) {
+      state.SetIterationTime(timer.seconds());
+    }
+  }
+
+  state.counters[KokkosBenchmark::benchmark_fom("rate")] =
+      benchmark::Counter(state.iterations(), benchmark::Counter::kIsRate);
+}
+
+static void Malloc(benchmark::State& state) {
+  Impl(state, false, When::after_malloc);
+}
+
+static void MallocFree(benchmark::State& state) {
+  Impl(state, false, When::after_free);
+}
+
+static void MallocTouch(benchmark::State& state) {
+  Impl(state, true, When::after_touch);
+}
+
+static void MallocTouchFree(benchmark::State& state) {
+  Impl(state, true, When::after_free);
+}
+
+BENCHMARK(Malloc)
+    ->ArgName("N")
+    ->RangeMultiplier(16)
+    ->Range(1, int64_t(1) << 32)
+    ->UseManualTime()
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK(MallocFree)
+    ->ArgName("N")
+    ->RangeMultiplier(16)
+    ->Range(1, int64_t(1) << 32)
+    ->UseManualTime()
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK(MallocTouch)
+    ->ArgName("N")
+    ->RangeMultiplier(16)
+    ->Range(1, int64_t(1) << 32)
+    ->UseManualTime()
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK(MallocTouchFree)
+    ->ArgName("N")
+    ->RangeMultiplier(16)
+    ->Range(1, int64_t(1) << 32)
+    ->UseManualTime()
+    ->Unit(benchmark::kMicrosecond);
+
+}  // namespace Benchmark


### PR DESCRIPTION
* Adds this new perf test with a few modes
* Removes the now-redundant benchmark from ViewAlloc

Command and sample output

```bash
$ ./Kokkos_PerformanceTest_Benchmark --benchmark_filter="Malloc"
```

```
Kokkos::Cuda::initialize WARNING: running kernels compiled for compute capability 8.0 on device with compute capability 8.6 , this will likely reduce potential performance.
2023-08-23T19:17:59+00:00
Running ./Kokkos_PerformanceTest_Benchmark
Run on (56 X 4600 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x28)
  L1 Instruction 32 KiB (x28)
  L2 Unified 2048 KiB (x28)
  L3 Unified 76800 KiB (x1)
Load Average: 0.20, 2.89, 10.79
CPU architecture: none
Default Device: N6Kokkos4CudaE
GIT_BRANCH: perf_test/malloc-free
GIT_CLEAN_STATUS: DIRTY
GIT_COMMIT_DATE: %cI
GIT_COMMIT_DESCRIPTION: Remove duplicate ViewAllocate_Raw (present in PerfTest_MallocFree)
GIT_COMMIT_HASH: 389c560
GPU architecture: AMPERE80
KOKKOS_COMPILER_GNU: 1220
KOKKOS_COMPILER_NVCC: 1220
KOKKOS_ENABLE_ASM: yes
KOKKOS_ENABLE_CUDA: yes
KOKKOS_ENABLE_CUDA_LAMBDA: yes
KOKKOS_ENABLE_CUDA_LDG_INTRINSIC: yes
KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE: no
KOKKOS_ENABLE_CUDA_UVM: no
KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA: yes
KOKKOS_ENABLE_CXX17: yes
KOKKOS_ENABLE_CXX20: no
KOKKOS_ENABLE_CXX23: no
KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK: no
KOKKOS_ENABLE_HBWSPACE: no
KOKKOS_ENABLE_HWLOC: no
KOKKOS_ENABLE_INTEL_MM_ALLOC: no
KOKKOS_ENABLE_LIBDL: yes
KOKKOS_ENABLE_LIBRT: no
KOKKOS_ENABLE_PRAGMA_IVDEP: no
KOKKOS_ENABLE_PRAGMA_LOOPCOUNT: no
KOKKOS_ENABLE_PRAGMA_UNROLL: no
KOKKOS_ENABLE_PRAGMA_VECTOR: no
KOKKOS_ENABLE_SERIAL: yes
Kokkos: Cuda[ 0 ] NVIDIA RTX A2000 12GB capability 8.6, Total Global Memory: 11.75 G, Shared Memory per Block: 48 K : Selected
Kokkos Version: 4.1.99
macro  KOKKOS_ENABLE_CUDA: defined
platform: 64bit
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
----------------------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------
Malloc/LOG2:0/manual_time                0.007 ms        0.015 ms        96958 FOM: GB/s=0/s MB=0
Malloc/LOG2:4/manual_time                0.005 ms        0.012 ms       123028 FOM: GB/s=0/s MB=0
Malloc/LOG2:8/manual_time                0.006 ms        0.012 ms       127470 FOM: GB/s=0/s MB=0
Malloc/LOG2:12/manual_time               0.005 ms        0.012 ms       127270 FOM: GB/s=0/s MB=0
Malloc/LOG2:16/manual_time               0.005 ms        0.012 ms       128348 FOM: GB/s=0/s MB=0
Malloc/LOG2:20/manual_time               0.006 ms        0.012 ms       128340 FOM: GB/s=180.604/s MB=1
Malloc/LOG2:24/manual_time               0.430 ms        0.469 ms         1518 FOM: GB/s=37.2177/s MB=16
Malloc/LOG2:28/manual_time                3.67 ms         4.35 ms          353 FOM: GB/s=72.9692/s MB=268
Malloc/LOG2:32/manual_time                99.3 ms         8.14 ms            8 FOM: GB/s=43.2517/s MB=4.294k
MallocFree/LOG2:0/manual_time            0.013 ms        0.013 ms        48081 FOM: GB/s=0/s MB=0
MallocFree/LOG2:4/manual_time            0.013 ms        0.013 ms        63699 FOM: GB/s=0/s MB=0
MallocFree/LOG2:8/manual_time            0.015 ms        0.015 ms        48123 FOM: GB/s=0/s MB=0
MallocFree/LOG2:12/manual_time           0.012 ms        0.012 ms        58934 FOM: GB/s=0/s MB=0
MallocFree/LOG2:16/manual_time           0.012 ms        0.012 ms        59990 FOM: GB/s=0/s MB=0
MallocFree/LOG2:20/manual_time           0.012 ms        0.012 ms        60445 FOM: GB/s=84.8584/s MB=1
MallocFree/LOG2:24/manual_time           0.469 ms        0.469 ms         1371 FOM: GB/s=34.1096/s MB=16
MallocFree/LOG2:28/manual_time            5.78 ms         4.27 ms          166 FOM: GB/s=46.3931/s MB=268
MallocFree/LOG2:32/manual_time             100 ms         7.96 ms            8 FOM: GB/s=42.7488/s MB=4.294k
MallocTouch/LOG2:0/manual_time           0.006 ms        0.012 ms       103922 FOM: GB/s=0/s MB=0
MallocTouch/LOG2:4/manual_time           0.006 ms        0.012 ms       121728 FOM: GB/s=0/s MB=0
MallocTouch/LOG2:8/manual_time           0.006 ms        0.013 ms       111126 FOM: GB/s=0/s MB=0
MallocTouch/LOG2:12/manual_time          0.012 ms        0.018 ms        60395 FOM: GB/s=0/s MB=0
MallocTouch/LOG2:16/manual_time          0.012 ms        0.018 ms        59416 FOM: GB/s=0/s MB=0
MallocTouch/LOG2:20/manual_time          0.012 ms        0.018 ms        58867 FOM: GB/s=83.8676/s MB=1
MallocTouch/LOG2:24/manual_time          0.441 ms        0.481 ms         1493 FOM: GB/s=36.2758/s MB=16
MallocTouch/LOG2:28/manual_time           3.79 ms         4.36 ms          335 FOM: GB/s=70.6594/s MB=268
MallocTouch/LOG2:32/manual_time           87.8 ms         8.97 ms            7 FOM: GB/s=48.8848/s MB=4.294k
MallocTouchFree/LOG2:0/manual_time       0.015 ms        0.016 ms        45183 FOM: GB/s=0/s MB=0
MallocTouchFree/LOG2:4/manual_time       0.015 ms        0.015 ms        45311 FOM: GB/s=0/s MB=0
MallocTouchFree/LOG2:8/manual_time       0.014 ms        0.014 ms        45324 FOM: GB/s=0/s MB=0
MallocTouchFree/LOG2:12/manual_time      0.018 ms        0.018 ms        39143 FOM: GB/s=0/s MB=0
MallocTouchFree/LOG2:16/manual_time      0.018 ms        0.018 ms        38604 FOM: GB/s=0/s MB=0
MallocTouchFree/LOG2:20/manual_time      0.018 ms        0.018 ms        38227 FOM: GB/s=55.0325/s MB=1
MallocTouchFree/LOG2:24/manual_time      0.535 ms        0.535 ms          957 FOM: GB/s=29.8856/s MB=16
MallocTouchFree/LOG2:28/manual_time       5.73 ms         4.30 ms          166 FOM: GB/s=46.7523/s MB=268
MallocTouchFree/LOG2:32/manual_time        112 ms         9.09 ms            9 FOM: GB/s=38.4532/s MB=4.294k
```

@simongdg