### PR TITLE
Add deprecated attribute to `HostSpace(AllocationMechanism)` definition

### DIFF
--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -56,7 +56,8 @@
 namespace Kokkos {
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-HostSpace::HostSpace(const HostSpace::AllocationMechanism &) : HostSpace() {}
+KOKKOS_DEPRECATED HostSpace::HostSpace(const HostSpace::AllocationMechanism &)
+    : HostSpace() {}
 #endif
 
 void *HostSpace::allocate(const size_t arg_alloc_size) const {


### PR DESCRIPTION
This is an attempt to silent a deprecated declaration warning when building Kokkos.
The warning shows in the ArborX nightly GCC 13.1 build.

The declaration had the deprecated attribute since #6341
https://github.com/kokkos/kokkos/blob/b26a6c620b4e89d8a842a662fb6547abef105719/core/src/Kokkos_HostSpace.hpp#L85-L86