### PR TITLE
simd: use kokkos lambda to avoid host device function calling host only lambda

### DIFF
--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -51,7 +51,7 @@ class simd_mask<T, simd_abi::scalar> {
                            value_type, G, std::integral_constant<bool, false>>,
                        bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit simd_mask(G&& gen) noexcept
-      : m_value(gen(std::integral_constant<std::size_t, 0>())) {}
+      : m_value(gen(0)) {}
   template <class U>
   KOKKOS_FORCEINLINE_FUNCTION simd_mask(
       simd_mask<U, simd_abi::scalar> const& other)
@@ -114,7 +114,7 @@ class simd<T, simd_abi::scalar> {
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit simd(G&& gen) noexcept
-      : m_value(gen(std::integral_constant<std::size_t, 0>())) {}
+      : m_value(gen(0)) {}
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator T() const {
     return m_value;
   }

--- a/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
+++ b/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
@@ -36,15 +36,16 @@ inline void host_check_gen_ctor() {
     expected[i] = (init_mask[i]) ? init[i] * 9 : init[i];
   }
 
-  simd_type basic([&](std::size_t i) { return init[i]; });
-  mask_type mask([&](std::size_t i) { return init_mask[i]; });
+  simd_type basic(KOKKOS_LAMBDA(std::size_t i) { return init[i]; });
+  mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return init_mask[i]; });
 
   simd_type rhs;
   rhs.copy_from(init, Kokkos::Experimental::element_aligned_tag());
   host_check_equality(basic, rhs, lanes);
 
-  simd_type lhs([&](std::size_t i) { return init[i] * 9; });
-  simd_type result([&](std::size_t i) { return (mask[i]) ? lhs[i] : rhs[i]; });
+  simd_type lhs(KOKKOS_LAMBDA(std::size_t i) { return init[i] * 9; });
+  simd_type result(
+      KOKKOS_LAMBDA(std::size_t i) { return (mask[i]) ? lhs[i] : rhs[i]; });
 
   simd_type blend;
   blend.copy_from(expected, Kokkos::Experimental::element_aligned_tag());
@@ -80,13 +81,14 @@ KOKKOS_INLINE_FUNCTION void device_check_gen_ctor() {
     expected[i] = (mask[i]) ? init[i] * 9 : init[i];
   }
 
-  simd_type basic([&](std::size_t i) { return init[i]; });
+  simd_type basic(KOKKOS_LAMBDA(std::size_t i) { return init[i]; });
   simd_type rhs;
   rhs.copy_from(init, Kokkos::Experimental::element_aligned_tag());
   device_check_equality(basic, rhs, lanes);
 
-  simd_type lhs([&](std::size_t i) { return init[i] * 9; });
-  simd_type result([&](std::size_t i) { return (mask[i]) ? lhs[i] : rhs[i]; });
+  simd_type lhs(KOKKOS_LAMBDA(std::size_t i) { return init[i] * 9; });
+  simd_type result(
+      KOKKOS_LAMBDA(std::size_t i) { return (mask[i]) ? lhs[i] : rhs[i]; });
 
   simd_type blend;
   blend.copy_from(expected, Kokkos::Experimental::element_aligned_tag());

--- a/simd/unit_tests/include/TestSIMD_MaskOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MaskOps.hpp
@@ -32,7 +32,7 @@ inline void host_check_mask_ops() {
   EXPECT_FALSE(any_of(mask_type(false)));
 
   for (std::size_t i = 0; i < mask_type::size(); ++i) {
-    mask_type test_mask([&](std::size_t j) { return i == j; });
+    mask_type test_mask(KOKKOS_LAMBDA(std::size_t j) { return i == j; });
 
     EXPECT_TRUE(any_of(test_mask));
     EXPECT_FALSE(none_of(test_mask));
@@ -70,7 +70,7 @@ KOKKOS_INLINE_FUNCTION void device_check_mask_ops() {
   checker.truth(!any_of(mask_type(false)));
 
   for (std::size_t i = 0; i < mask_type::size(); ++i) {
-    mask_type test_mask([&](std::size_t j) { return i == j; });
+    mask_type test_mask(KOKKOS_LAMBDA(std::size_t j) { return i == j; });
 
     checker.truth(any_of(test_mask));
     checker.truth(!none_of(test_mask));


### PR DESCRIPTION
Recently merged in #6347 introduced a few occurrences of `calling a __host__ function from a __host__ __device__ function` problems.

This occurred in two places:
  - In generator ctors unit test where host lambdae are passed into host device generator ctors.
  - Calling a constexpr std::size_t operator in host device lambda (by a generator constructor).
  
because non-scalar backend simds interfaces are strictly host-only, only `Scalar` simd is affected.