### PR TITLE
Remove deprecated code 3 support for volatile join

### DIFF
--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -631,11 +631,9 @@ struct FunctorAnalysis {
                         detected_volatile_join_no_tag<F>::value)>>
       : public has_volatile_join_no_tag_function<F> {
     enum : bool { value = true };
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_3
     static_assert(Impl::dependent_false_v<F>,
                   "Reducer with a join() operator taking "
                   "volatile-qualified parameters is no longer supported");
-#endif
   };
 
   template <class F = Functor, typename = void>
@@ -654,11 +652,9 @@ struct FunctorAnalysis {
                                          detected_volatile_join_tag<F>::value)>>
       : public has_volatile_join_tag_function<F> {
     enum : bool { value = true };
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_3
     static_assert(Impl::dependent_false_v<F>,
                   "Reducer with a join() operator taking "
                   "volatile-qualified parameters is no longer supported");
-#endif
   };
 
   //----------------------------------------

--- a/core/unit_test/TestJoinBackwardCompatibility.hpp
+++ b/core/unit_test/TestJoinBackwardCompatibility.hpp
@@ -134,13 +134,6 @@ void test_join_backward_compatibility() {
   ReducerWithJoinThatTakesVolatileQualifiedArgs my_red;
   my_red.join(vol_result, result2);
   ASSERT_EQ(vol_result.err, expected_join_volatile);
-
-#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_3)
-  MyJoinBackCompatValueType result3;
-  Kokkos::parallel_reduce(
-      policy, ReducerWithJoinThatTakesVolatileQualifiedArgs{}, result3);
-  ASSERT_EQ(result3.err, expected_join_volatile);
-#endif
 }
 
 TEST(TEST_CATEGORY, join_backward_compatibility) {


### PR DESCRIPTION
This wasn't working in Serial and Threads anymore anyway. We just didn't test those guys.