### PR TITLE
Suppress NVCC attribute ignored warning on SIMD operators as hidden friends

### DIFF
--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -19,6 +19,13 @@
 
 #include <Kokkos_SIMD_Common.hpp>
 
+// suppress NVCC warnings with the [[nodiscard]] attribute on overloaded
+// operators implemented as hidden friends
+#if defined(KOKKOS_COMPILER_NVCC) && KOKKOS_COMPILER_NVCC < 1130
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
 #include <Kokkos_SIMD_Scalar.hpp>
 
 #ifdef KOKKOS_ARCH_AVX2
@@ -31,6 +38,10 @@
 
 #ifdef __ARM_NEON
 #include <Kokkos_SIMD_NEON.hpp>
+#endif
+
+#if defined(KOKKOS_COMPILER_NVCC) && KOKKOS_COMPILER_NVCC < 1130
+#pragma GCC diagnostic pop
 #endif
 
 namespace Kokkos {


### PR DESCRIPTION
Fix #6383 

The alternative would be to implement the operators out of class which yields less readable code IMO.
https://godbolt.org/z/sqn1WP9x1

I opted to suppress the warning before including the various SIMD implementation to avoid guarding everywhere.  I think it is OK because `<Kokkos_Core.hpp>` gets included prior to that.