### PR TITLE
HIP: Update print_configuration

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -97,10 +97,14 @@ void HIPInternal::print_configuration(std::ostream &s) const {
     KOKKOS_IMPL_HIP_SAFE_CALL(hipGetDeviceProperties(&hipProp, i));
 
     s << "Kokkos::HIP[ " << i << " ] "
-      << "gcnArch " << hipProp.gcnArch << ", Total Global Memory: "
+      << "gcnArch " << hipProp.gcnArchName << ", Total Global Memory: "
       << ::Kokkos::Impl::human_memory_size(hipProp.totalGlobalMem)
       << ", Shared Memory per Block: "
-      << ::Kokkos::Impl::human_memory_size(hipProp.sharedMemPerBlock);
+      << ::Kokkos::Impl::human_memory_size(hipProp.sharedMemPerBlock)
+      << ", APU: " << hipProp.integrated
+      << ", Is Large Bar: " << hipProp.isLargeBar
+      << ", Support Managed Memory: " << hipProp.managedMemory
+      << ", Wavefront Size: " << hipProp.warpSize;
     if (m_hipDev == i) s << " : Selected";
     s << '\n';
   }

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -95,15 +95,16 @@ void HIPInternal::print_configuration(std::ostream &s) const {
   for (int i = 0; i < hipDevCount; ++i) {
     hipDeviceProp_t hipProp;
     KOKKOS_IMPL_HIP_SAFE_CALL(hipGetDeviceProperties(&hipProp, i));
+    std::string gpu_type = hipProp.integrated == 1 ? "APU" : "dGPU";
 
     s << "Kokkos::HIP[ " << i << " ] "
       << "gcnArch " << hipProp.gcnArchName << ", Total Global Memory: "
       << ::Kokkos::Impl::human_memory_size(hipProp.totalGlobalMem)
       << ", Shared Memory per Block: "
       << ::Kokkos::Impl::human_memory_size(hipProp.sharedMemPerBlock)
-      << ", APU: " << hipProp.integrated
+      << ", APU or dGPU: " << gpu_type
       << ", Is Large Bar: " << hipProp.isLargeBar
-      << ", Support Managed Memory: " << hipProp.managedMemory
+      << ", Supports Managed Memory: " << hipProp.managedMemory
       << ", Wavefront Size: " << hipProp.warpSize;
     if (m_hipDev == i) s << " : Selected";
     s << '\n';


### PR DESCRIPTION
This PR does the following:
 - replace `gcnArch` with `gcnArchName` because `gcnArch` is deprecated
 - return if the chip is an APU or a discrete GPU: this could be useful for MI300 GPUs
 - return if the chips is large bar, i.e., if we can access the CPU memory from the GPU without copying the data
 - return if managed memory is supported
 - return the size of the wave front

Here is the output, I get on crusher
```
 Kokkos Version: 4.1.99
Compiler:
  KOKKOS_COMPILER_CLANG: 1600
Architecture:
  CPU architecture: AMD_ZEN3
  Default Device: N6Kokkos3HIPE
  GPU architecture: AMD_GFX90A
  platform: 64bit
Atomics:
Vectorization:
  KOKKOS_ENABLE_PRAGMA_IVDEP: no
  KOKKOS_ENABLE_PRAGMA_LOOPCOUNT: no
  KOKKOS_ENABLE_PRAGMA_UNROLL: no
  KOKKOS_ENABLE_PRAGMA_VECTOR: no
Memory:
  KOKKOS_ENABLE_HBWSPACE: no
  KOKKOS_ENABLE_INTEL_MM_ALLOC: no
Options:
  KOKKOS_ENABLE_ASM: no
  KOKKOS_ENABLE_CXX17: yes
  KOKKOS_ENABLE_CXX20: no
  KOKKOS_ENABLE_CXX23: no
  KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK: no
  KOKKOS_ENABLE_HWLOC: no
  KOKKOS_ENABLE_LIBDL: yes
  KOKKOS_ENABLE_LIBRT: no
Host Serial Execution Space:
  KOKKOS_ENABLE_SERIAL: yes

Serial Runtime Configuration:
Device Execution Space:
  KOKKOS_ENABLE_HIP: yes
HIP Options:
  KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE: no

Runtime Configuration:
macro  KOKKOS_ENABLE_HIP : defined
macro  HIP_VERSION = 50530202 = version 5.5.30202
Kokkos::HIP[ 0 ] gcnArch gfx90a:sramecc+:xnack+, Total Global Memory: 63.98 G, Shared Memory per Block: 64 K, APU: 0, Is Large Bar: 1, Support Managed Memory: 1, Wavefront Size: 64 : Selected
Kokkos::HIP[ 1 ] gcnArch gfx90a:sramecc+:xnack+, Total Global Memory: 63.98 G, Shared Memory per Block: 64 K, APU: 0, Is Large Bar: 1, Support Managed Memory: 1, Wavefront Size: 64
Kokkos::HIP[ 2 ] gcnArch gfx90a:sramecc+:xnack+, Total Global Memory: 63.98 G, Shared Memory per Block: 64 K, APU: 0, Is Large Bar: 1, Support Managed Memory: 1, Wavefront Size: 64
Kokkos::HIP[ 3 ] gcnArch gfx90a:sramecc+:xnack+, Total Global Memory: 63.98 G, Shared Memory per Block: 64 K, APU: 0, Is Large Bar: 1, Support Managed Memory: 1, Wavefront Size: 64
Kokkos::HIP[ 4 ] gcnArch gfx90a:sramecc+:xnack+, Total Global Memory: 63.98 G, Shared Memory per Block: 64 K, APU: 0, Is Large Bar: 1, Support Managed Memory: 1, Wavefront Size: 64
Kokkos::HIP[ 5 ] gcnArch gfx90a:sramecc+:xnack+, Total Global Memory: 63.98 G, Shared Memory per Block: 64 K, APU: 0, Is Large Bar: 1, Support Managed Memory: 1, Wavefront Size: 64
Kokkos::HIP[ 6 ] gcnArch gfx90a:sramecc+:xnack+, Total Global Memory: 63.98 G, Shared Memory per Block: 64 K, APU: 0, Is Large Bar: 1, Support Managed Memory: 1, Wavefront Size: 64
Kokkos::HIP[ 7 ] gcnArch gfx90a:sramecc+:xnack+, Total Global Memory: 63.98 G, Shared Memory per Block: 64 K, APU: 0, Is Large Bar: 1, Support Managed Memory: 1, Wavefront Size: 64
```