### PR TITLE
Remove stray Cuda graph pattern specialization from tag

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -35,13 +35,6 @@
 namespace Kokkos {
 namespace Impl {
 
-// FIXME Remove once all backends implement the new reduce interface
-template <class CombinedFunctorReducer, class PolicyType>
-struct PatternImplSpecializationFromTag<
-    Kokkos::ParallelReduceTag, CombinedFunctorReducer, PolicyType, Kokkos::Cuda>
-    : type_identity<
-          ParallelReduce<CombinedFunctorReducer, PolicyType, Kokkos::Cuda>> {};
-
 template <class PolicyType, class Functor, class PatternTag, class... Args>
 class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
                           Args...>


### PR DESCRIPTION
Was introduced in #5874 and we forgot to drop it after all backends got migrated to the new reduce interface