### PR TITLE
simd: add floor, ceil, round, trunc operations

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1499,7 +1499,7 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   }
 };
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::simd(
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other)
     : m_value(static_cast<__m256i>(other)) {}

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -635,103 +635,139 @@ class simd<double, simd_abi::avx2_fixed_size<4>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> copysign(
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    copysign(Experimental::simd<
+                 double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+             Experimental::simd<
+                 double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
   __m256d const sign_mask = _mm256_set1_pd(-0.0);
   return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_xor_pd(_mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)),
                     _mm256_and_pd(sign_mask, static_cast<__m256d>(b))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> abs(
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    abs(Experimental::simd<
+        double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   __m256d const sign_mask = _mm256_set1_pd(-0.0);
   return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> sqrt(
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    floor(Experimental::simd<
+          double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm256_round_pd(static_cast<__m256d>(a),
+                      (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    ceil(Experimental::simd<
+         double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm256_round_pd(static_cast<__m256d>(a),
+                      (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    round(Experimental::simd<
+          double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm256_round_pd(static_cast<__m256d>(a),
+                      (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    trunc(Experimental::simd<
+          double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm256_round_pd(static_cast<__m256d>(a),
+                      (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    sqrt(Experimental::simd<
+         double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_sqrt_pd(static_cast<__m256d>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> cbrt(
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    cbrt(Experimental::simd<
+         double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cbrt_pd(static_cast<__m256d>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> exp(
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    exp(Experimental::simd<
+        double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_exp_pd(static_cast<__m256d>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> log(
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    log(Experimental::simd<
+        double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_log_pd(static_cast<__m256d>(a)));
 }
 
 #endif
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> fma(
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& b,
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& c) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    fma(Experimental::simd<double,
+                           Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+        Experimental::simd<double,
+                           Experimental::simd_abi::avx2_fixed_size<4>> const& b,
+        Experimental::simd<
+            double, Experimental::simd_abi::avx2_fixed_size<4>> const& c) {
   return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_fmadd_pd(static_cast<__m256d>(a), static_cast<__m256d>(b),
                       static_cast<__m256d>(c)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> max(
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    max(Experimental::simd<double,
+                           Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+        Experimental::simd<
+            double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
   return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_max_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> min(
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    min(Experimental::simd<double,
+                           Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+        Experimental::simd<
+            double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
   return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_min_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
 }
 
 namespace Experimental {
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> condition(
-    simd_mask<double, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<double, simd_abi::avx2_fixed_size<4>> const& b,
-    simd<double, simd_abi::avx2_fixed_size<4>> const& c) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::avx2_fixed_size<4>>
+    condition(simd_mask<double, simd_abi::avx2_fixed_size<4>> const& a,
+              simd<double, simd_abi::avx2_fixed_size<4>> const& b,
+              simd<double, simd_abi::avx2_fixed_size<4>> const& c) {
   return simd<double, simd_abi::avx2_fixed_size<4>>(
       _mm256_blendv_pd(static_cast<__m256d>(c), static_cast<__m256d>(b),
                        static_cast<__m256d>(a)));
@@ -838,8 +874,9 @@ class simd<float, simd_abi::avx2_fixed_size<4>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> copysign(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::avx2_fixed_size<4>>
+copysign(
     Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
         a,
     Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
@@ -850,54 +887,90 @@ Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> copysign(
                  _mm_and_ps(sign_mask, static_cast<__m128>(b))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> abs(
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
-        a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    abs(Experimental::simd<
+        float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   __m128 const sign_mask = _mm_set1_ps(-0.0);
   return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_andnot_ps(sign_mask, static_cast<__m128>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> sqrt(
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
-        a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    floor(Experimental::simd<
+          float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm_round_ps(static_cast<__m128>(a),
+                   (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    ceil(Experimental::simd<
+         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm_round_ps(static_cast<__m128>(a),
+                   (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    round(Experimental::simd<
+          float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm_round_ps(static_cast<__m128>(a),
+                   (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    trunc(Experimental::simd<
+          float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm_round_ps(static_cast<__m128>(a),
+                   (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    sqrt(Experimental::simd<
+         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_sqrt_ps(static_cast<__m128>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> cbrt(
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
-        a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    cbrt(Experimental::simd<
+         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_cbrt_ps(static_cast<__m128>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> exp(
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
-        a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    exp(Experimental::simd<
+        float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_exp_ps(static_cast<__m128>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> log(
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
-        a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    log(Experimental::simd<
+        float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_log_ps(static_cast<__m128>(a)));
 }
 
 #endif
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> fma(
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::avx2_fixed_size<4>>
+fma(Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
         a,
     Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
         b,
@@ -908,9 +981,9 @@ Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> fma(
                    static_cast<__m128>(c)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> max(
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::avx2_fixed_size<4>>
+max(Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
         a,
     Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
         b) {
@@ -918,9 +991,9 @@ Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> max(
       _mm_max_ps(static_cast<__m128>(a), static_cast<__m128>(b)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> min(
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::avx2_fixed_size<4>>
+min(Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
         a,
     Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
         b) {
@@ -930,11 +1003,11 @@ Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> min(
 
 namespace Experimental {
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx2_fixed_size<4>> condition(
-    simd_mask<float, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<float, simd_abi::avx2_fixed_size<4>> const& b,
-    simd<float, simd_abi::avx2_fixed_size<4>> const& c) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<float, simd_abi::avx2_fixed_size<4>>
+    condition(simd_mask<float, simd_abi::avx2_fixed_size<4>> const& a,
+              simd<float, simd_abi::avx2_fixed_size<4>> const& b,
+              simd<float, simd_abi::avx2_fixed_size<4>> const& c) {
   return simd<float, simd_abi::avx2_fixed_size<4>>(_mm_blendv_ps(
       static_cast<__m128>(c), static_cast<__m128>(b), static_cast<__m128>(a)));
 }
@@ -1064,14 +1137,46 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>>
-abs(Experimental::simd<std::int32_t,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>>
+    abs(Experimental::simd<
+        std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   __m128i const rhs = static_cast<__m128i>(a);
   return Experimental::simd<std::int32_t,
                             Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_abs_epi32(rhs));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    floor(Experimental::simd<
+          std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    ceil(Experimental::simd<
+         std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    round(Experimental::simd<
+          std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    trunc(Experimental::simd<
+          std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
 }
 
 namespace Experimental {
@@ -1238,6 +1343,38 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       [&](std::size_t i) { return (a[i] < 0) ? -a[i] : a[i]; });
 }
 
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    floor(Experimental::simd<
+          std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm256_setr_pd(a[0], a[1], a[2], a[3]));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    ceil(Experimental::simd<
+         std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm256_setr_pd(a[0], a[1], a[2], a[3]));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    round(Experimental::simd<
+          std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm256_setr_pd(a[0], a[1], a[2], a[3]));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    trunc(Experimental::simd<
+          std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm256_setr_pd(a[0], a[1], a[2], a[3]));
+}
+
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -1362,10 +1499,53 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   }
 };
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::simd(
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other)
     : m_value(static_cast<__m256i>(other)) {}
+
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>>
+abs(Experimental::simd<std::uint64_t,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return a;
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    floor(Experimental::simd<
+          std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm256_setr_pd(a[0], a[1], a[2], a[3]));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    ceil(Experimental::simd<
+         std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm256_setr_pd(a[0], a[1], a[2], a[3]));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    round(Experimental::simd<
+          std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm256_setr_pd(a[0], a[1], a[2], a[3]));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    trunc(Experimental::simd<
+          std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm256_setr_pd(a[0], a[1], a[2], a[3]));
+}
+
+namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
@@ -1385,17 +1565,6 @@ simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::simd(
     (*this)[i] = std::int32_t(other[i]);
   }
 }
-
-}  // namespace Experimental
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>>
-abs(Experimental::simd<std::uint64_t,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return a;
-}
-
-namespace Experimental {
 
 template <>
 class const_where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -141,661 +141,6 @@ class simd_mask<T, simd_abi::avx512_fixed_size<8>> {
 };
 
 template <>
-class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
-  __m256i m_value;
-
- public:
-  using value_type = std::int32_t;
-  using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 8;
-  }
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-      : m_value(_mm256_set1_epi32(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      __m256i const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::uint64_t, abi_type> const& other);
-  template <class G,
-            std::enable_if_t<
-                // basically, can you do { value_type r =
-                // gen(std::integral_constant<std::size_t, i>()); }
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      G&& gen) noexcept
-      : m_value(
-            _mm256_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
-                              gen(std::integral_constant<std::size_t, 1>()),
-                              gen(std::integral_constant<std::size_t, 2>()),
-                              gen(std::integral_constant<std::size_t, 3>()),
-                              gen(std::integral_constant<std::size_t, 4>()),
-                              gen(std::integral_constant<std::size_t, 5>()),
-                              gen(std::integral_constant<std::size_t, 6>()),
-                              gen(std::integral_constant<std::size_t, 7>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, element_aligned_tag) const {
-    _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
-                             m_value);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       element_aligned_tag) {
-    m_value = _mm256_mask_loadu_epi32(
-        _mm256_set1_epi32(0), static_cast<__mmask8>(mask_type(true)), ptr);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
-      const {
-    return m_value;
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
-      noexcept {
-    return simd(_mm256_sub_epi32(_mm256_set1_epi32(0), m_value));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
-                                   static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
-        _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
-        _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm256_cmplt_epi32_mask(static_cast<__m256i>(lhs),
-                                             static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm256_cmplt_epi32_mask(static_cast<__m256i>(rhs),
-                                             static_cast<__m256i>(lhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm256_cmple_epi32_mask(static_cast<__m256i>(lhs),
-                                             static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm256_cmple_epi32_mask(static_cast<__m256i>(rhs),
-                                             static_cast<__m256i>(lhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm256_cmpeq_epi32_mask(static_cast<__m256i>(lhs),
-                                             static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm256_cmpneq_epi32_mask(static_cast<__m256i>(lhs),
-                                              static_cast<__m256i>(rhs)));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_srav_epi32(static_cast<__m256i>(lhs),
-                                  static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
-                                  static_cast<__m256i>(rhs)));
-  }
-};
-
-}  // namespace Experimental
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>>
-abs(Experimental::simd<std::int32_t,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  __m256i const rhs = static_cast<__m256i>(a);
-  return Experimental::simd<std::int32_t,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
-      _mm256_abs_epi32(rhs));
-}
-
-namespace Experimental {
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
-    condition(simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a,
-              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& b,
-              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
-                              static_cast<__m256i>(b)));
-}
-
-template <>
-class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
-  __m256i m_value;
-
- public:
-  using value_type = std::uint32_t;
-  using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 8;
-  }
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-      : m_value(_mm256_set1_epi32(
-            Kokkos::bit_cast<std::int32_t>(value_type(value)))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      __m256i const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other)
-      : m_value(static_cast<__m256i>(other)) {}
-  template <class G,
-            std::enable_if_t<
-                // basically, can you do { value_type r =
-                // gen(std::integral_constant<std::size_t, i>()); }
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      G&& gen) noexcept
-      : m_value(
-            _mm256_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
-                              gen(std::integral_constant<std::size_t, 1>()),
-                              gen(std::integral_constant<std::size_t, 2>()),
-                              gen(std::integral_constant<std::size_t, 3>()),
-                              gen(std::integral_constant<std::size_t, 4>()),
-                              gen(std::integral_constant<std::size_t, 5>()),
-                              gen(std::integral_constant<std::size_t, 6>()),
-                              gen(std::integral_constant<std::size_t, 7>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, element_aligned_tag) const {
-    _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
-                             m_value);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       element_aligned_tag) {
-    m_value = _mm256_mask_loadu_epi32(
-        _mm256_set1_epi32(0), static_cast<__mmask8>(mask_type(true)), ptr);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
-      const {
-    return m_value;
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
-                                   static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
-        _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
-        _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(lhs),
-                                             static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(rhs),
-                                             static_cast<__m256i>(lhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(lhs),
-                                             static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(rhs),
-                                             static_cast<__m256i>(lhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm256_cmpeq_epu32_mask(static_cast<__m256i>(lhs),
-                                             static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm256_cmpneq_epu32_mask(static_cast<__m256i>(lhs),
-                                              static_cast<__m256i>(rhs)));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_srlv_epi32(static_cast<__m256i>(lhs),
-                                  static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
-                                  static_cast<__m256i>(rhs)));
-  }
-};
-
-}  // namespace Experimental
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>>
-abs(Experimental::simd<std::uint32_t,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return a;
-}
-
-namespace Experimental {
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
-    condition(simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a,
-              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& b,
-              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
-                              static_cast<__m256i>(b)));
-}
-
-template <>
-class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
-  __m512i m_value;
-
- public:
-  using value_type = std::int64_t;
-  using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 8;
-  }
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-      : m_value(_mm512_set1_epi64(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other)
-      : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other);
-  template <class G,
-            std::enable_if_t<
-                // basically, can you do { value_type r =
-                // gen(std::integral_constant<std::size_t, i>()); }
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      G&& gen) noexcept
-      : m_value(
-            _mm512_setr_epi64(gen(std::integral_constant<std::size_t, 0>()),
-                              gen(std::integral_constant<std::size_t, 1>()),
-                              gen(std::integral_constant<std::size_t, 2>()),
-                              gen(std::integral_constant<std::size_t, 3>()),
-                              gen(std::integral_constant<std::size_t, 4>()),
-                              gen(std::integral_constant<std::size_t, 5>()),
-                              gen(std::integral_constant<std::size_t, 6>()),
-                              gen(std::integral_constant<std::size_t, 7>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m512i const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       element_aligned_tag) {
-    m_value = _mm512_loadu_si512(ptr);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, element_aligned_tag) const {
-    _mm512_storeu_si512(ptr, m_value);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
-      const {
-    return m_value;
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
-      noexcept {
-    return simd(_mm512_sub_epi64(_mm512_set1_epi64(0), m_value));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
-                                   static_cast<__m512i>(rhs)));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
-        _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
-        _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm512_cmplt_epi64_mask(static_cast<__m512i>(lhs),
-                                             static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm512_cmplt_epi64_mask(static_cast<__m512i>(rhs),
-                                             static_cast<__m512i>(lhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm512_cmple_epi64_mask(static_cast<__m512i>(lhs),
-                                             static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm512_cmple_epi64_mask(static_cast<__m512i>(rhs),
-                                             static_cast<__m512i>(lhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm512_cmpeq_epi64_mask(static_cast<__m512i>(lhs),
-                                             static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm512_cmpneq_epi64_mask(static_cast<__m512i>(lhs),
-                                              static_cast<__m512i>(rhs)));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) {
-    return simd(_mm512_srai_epi64(static_cast<__m512i>(lhs), rhs));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) {
-    return simd(_mm512_srav_epi64(static_cast<__m512i>(lhs),
-                                  static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) {
-    return simd(_mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) {
-    return simd(_mm512_sllv_epi64(static_cast<__m512i>(lhs),
-                                  static_cast<__m512i>(rhs)));
-  }
-};
-
-}  // namespace Experimental
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>>
-abs(Experimental::simd<std::int64_t,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  __m512i const rhs = static_cast<__m512i>(a);
-  return Experimental::simd<std::int64_t,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
-      _mm512_abs_epi64(rhs));
-}
-
-namespace Experimental {
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
-    condition(simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a,
-              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& b,
-              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_mask_blend_epi64(static_cast<__mmask8>(a), static_cast<__m512i>(c),
-                              static_cast<__m512i>(b)));
-}
-
-template <>
-class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
-  __m512i m_value;
-
- public:
-  using value_type = std::uint64_t;
-  using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 8;
-  }
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-      : m_value(_mm512_set1_epi64(
-            Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m512i const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int32_t, abi_type> const& other)
-      : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
-  template <class G,
-            std::enable_if_t<
-                // basically, can you do { value_type r =
-                // gen(std::integral_constant<std::size_t, i>()); }
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      G&& gen) noexcept
-      : m_value(
-            _mm512_setr_epi64(gen(std::integral_constant<std::size_t, 0>()),
-                              gen(std::integral_constant<std::size_t, 1>()),
-                              gen(std::integral_constant<std::size_t, 2>()),
-                              gen(std::integral_constant<std::size_t, 3>()),
-                              gen(std::integral_constant<std::size_t, 4>()),
-                              gen(std::integral_constant<std::size_t, 5>()),
-                              gen(std::integral_constant<std::size_t, 6>()),
-                              gen(std::integral_constant<std::size_t, 7>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int64_t, abi_type> const& other)
-      : m_value(static_cast<__m512i>(other)) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       element_aligned_tag) {
-    m_value = _mm512_loadu_si512(ptr);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, element_aligned_tag) const {
-    _mm512_storeu_si512(ptr, m_value);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
-      const {
-    return m_value;
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
-                                   static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
-        _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
-        _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) noexcept {
-    return _mm512_srli_epi64(static_cast<__m512i>(lhs), rhs);
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
-    return _mm512_srlv_epi64(static_cast<__m512i>(lhs),
-                             static_cast<__m512i>(rhs));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) noexcept {
-    return _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs);
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
-    return _mm512_sllv_epi64(static_cast<__m512i>(lhs),
-                             static_cast<__m512i>(rhs));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator&(
-      simd const& lhs, simd const& rhs) noexcept {
-    return _mm512_and_epi64(static_cast<__m512i>(lhs),
-                            static_cast<__m512i>(rhs));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator|(
-      simd const& lhs, simd const& rhs) noexcept {
-    return _mm512_or_epi64(static_cast<__m512i>(lhs),
-                           static_cast<__m512i>(rhs));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm512_cmplt_epu64_mask(static_cast<__m512i>(lhs),
-                                             static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm512_cmplt_epu64_mask(static_cast<__m512i>(rhs),
-                                             static_cast<__m512i>(lhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm512_cmple_epu64_mask(static_cast<__m512i>(lhs),
-                                             static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm512_cmple_epu64_mask(static_cast<__m512i>(rhs),
-                                             static_cast<__m512i>(lhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm512_cmpeq_epu64_mask(static_cast<__m512i>(lhs),
-                                             static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm512_cmpneq_epu64_mask(static_cast<__m512i>(lhs),
-                                              static_cast<__m512i>(rhs)));
-  }
-};
-
-}  // namespace Experimental
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>>
-abs(Experimental::simd<std::uint64_t,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return a;
-}
-
-namespace Experimental {
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
-    condition(simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a,
-              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& b,
-              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_mask_blend_epi64(static_cast<__mmask8>(a), static_cast<__m512i>(c),
-                              static_cast<__m512i>(b)));
-}
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::simd(
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other)
-    : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::simd(
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other)
-    : m_value(static_cast<__m512i>(other)) {}
-
-template <>
 class simd<double, simd_abi::avx512_fixed_size<8>> {
   __m512d m_value;
 
@@ -950,6 +295,46 @@ copysign(
                             Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_abs_pd(rhs));
 #endif
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
+    floor(Experimental::simd<
+          double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  __m512d const val = static_cast<__m512d>(a);
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_roundscale_pd(val, _MM_FROUND_TO_NEG_INF));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
+    ceil(Experimental::simd<
+         double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  __m512d const val = static_cast<__m512d>(a);
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_roundscale_pd(val, _MM_FROUND_TO_POS_INF));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
+    round(Experimental::simd<
+          double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  __m512d const val = static_cast<__m512d>(a);
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_roundscale_pd(val, _MM_FROUND_TO_NEAREST_INT));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
+    trunc(Experimental::simd<
+          double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  __m512d const val = static_cast<__m512d>(a);
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_roundscale_pd(val, _MM_FROUND_TO_ZERO));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -1171,6 +556,46 @@ Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> abs(
       _mm256_andnot_ps(sign_mask, static_cast<__m256>(a)));
 }
 
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
+    floor(Experimental::simd<
+          float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  __m256 const val = static_cast<__m256>(a);
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm256_roundscale_ps(val, _MM_FROUND_TO_NEG_INF));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
+    ceil(Experimental::simd<
+         float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  __m256 const val = static_cast<__m256>(a);
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm256_roundscale_ps(val, _MM_FROUND_TO_POS_INF));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
+    round(Experimental::simd<
+          float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  __m256 const val = static_cast<__m256>(a);
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm256_roundscale_ps(val, _MM_FROUND_TO_NEAREST_INT));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
+    trunc(Experimental::simd<
+          float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  __m256 const val = static_cast<__m256>(a);
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm256_roundscale_ps(val, _MM_FROUND_TO_ZERO));
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> sqrt(
     Experimental::simd<float,
@@ -1258,6 +683,805 @@ simd<float, simd_abi::avx512_fixed_size<8>> condition(
       _mm256_mask_blend_ps(static_cast<__mmask8>(a), static_cast<__m256>(c),
                            static_cast<__m256>(b)));
 }
+
+template <>
+class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
+  __m256i m_value;
+
+ public:
+  using value_type = std::int32_t;
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm256_set1_epi32(value_type(value))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      __m256i const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint64_t, abi_type> const& other);
+  template <class G,
+            std::enable_if_t<
+                // basically, can you do { value_type r =
+                // gen(std::integral_constant<std::size_t, i>()); }
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      G&& gen) noexcept
+      : m_value(
+            _mm256_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
+                              gen(std::integral_constant<std::size_t, 1>()),
+                              gen(std::integral_constant<std::size_t, 2>()),
+                              gen(std::integral_constant<std::size_t, 3>()),
+                              gen(std::integral_constant<std::size_t, 4>()),
+                              gen(std::integral_constant<std::size_t, 5>()),
+                              gen(std::integral_constant<std::size_t, 6>()),
+                              gen(std::integral_constant<std::size_t, 7>()))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
+                             m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm256_mask_loadu_epi32(
+        _mm256_set1_epi32(0), static_cast<__mmask8>(mask_type(true)), ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
+      const {
+    return m_value;
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(_mm256_sub_epi32(_mm256_set1_epi32(0), m_value));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
+                                   static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+        _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+        _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmplt_epi32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmplt_epi32_mask(static_cast<__m256i>(rhs),
+                                             static_cast<__m256i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmple_epi32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmple_epi32_mask(static_cast<__m256i>(rhs),
+                                             static_cast<__m256i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpeq_epi32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpneq_epi32_mask(static_cast<__m256i>(lhs),
+                                              static_cast<__m256i>(rhs)));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_srav_epi32(static_cast<__m256i>(lhs),
+                                  static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+                                  static_cast<__m256i>(rhs)));
+  }
+};
+
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>>
+abs(Experimental::simd<std::int32_t,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  __m256i const rhs = static_cast<__m256i>(a);
+  return Experimental::simd<std::int32_t,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm256_abs_epi32(rhs));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+floor(Experimental::simd<
+      std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_cvtepi32_pd(static_cast<__m256i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
+    ceil(Experimental::simd<
+         std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_cvtepi32_pd(static_cast<__m256i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+round(Experimental::simd<
+      std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_cvtepi32_pd(static_cast<__m256i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+trunc(Experimental::simd<
+      std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_cvtepi32_pd(static_cast<__m256i>(a)));
+}
+
+namespace Experimental {
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
+    condition(simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a,
+              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& b,
+              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& c) {
+  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
+                              static_cast<__m256i>(b)));
+}
+
+template <>
+class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
+  __m256i m_value;
+
+ public:
+  using value_type = std::uint32_t;
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm256_set1_epi32(
+            Kokkos::bit_cast<std::int32_t>(value_type(value)))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      __m256i const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other)
+      : m_value(static_cast<__m256i>(other)) {}
+  template <class G,
+            std::enable_if_t<
+                // basically, can you do { value_type r =
+                // gen(std::integral_constant<std::size_t, i>()); }
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      G&& gen) noexcept
+      : m_value(
+            _mm256_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
+                              gen(std::integral_constant<std::size_t, 1>()),
+                              gen(std::integral_constant<std::size_t, 2>()),
+                              gen(std::integral_constant<std::size_t, 3>()),
+                              gen(std::integral_constant<std::size_t, 4>()),
+                              gen(std::integral_constant<std::size_t, 5>()),
+                              gen(std::integral_constant<std::size_t, 6>()),
+                              gen(std::integral_constant<std::size_t, 7>()))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
+                             m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm256_mask_loadu_epi32(
+        _mm256_set1_epi32(0), static_cast<__mmask8>(mask_type(true)), ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
+      const {
+    return m_value;
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
+                                   static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(rhs),
+                                             static_cast<__m256i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(rhs),
+                                             static_cast<__m256i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpeq_epu32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpneq_epu32_mask(static_cast<__m256i>(lhs),
+                                              static_cast<__m256i>(rhs)));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_srlv_epi32(static_cast<__m256i>(lhs),
+                                  static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+                                  static_cast<__m256i>(rhs)));
+  }
+};
+
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>>
+abs(Experimental::simd<std::uint32_t,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return a;
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+floor(Experimental::simd<
+      std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_cvtepu32_pd(static_cast<__m256i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+ceil(Experimental::simd<
+     std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_cvtepu32_pd(static_cast<__m256i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+round(Experimental::simd<
+      std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_cvtepu32_pd(static_cast<__m256i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+trunc(Experimental::simd<
+      std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_cvtepu32_pd(static_cast<__m256i>(a)));
+}
+
+namespace Experimental {
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
+    condition(simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a,
+              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& b,
+              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& c) {
+  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
+                              static_cast<__m256i>(b)));
+}
+
+template <>
+class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
+  __m512i m_value;
+
+ public:
+  using value_type = std::int64_t;
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm512_set1_epi64(value_type(value))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other)
+      : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other);
+  template <class G,
+            std::enable_if_t<
+                // basically, can you do { value_type r =
+                // gen(std::integral_constant<std::size_t, i>()); }
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      G&& gen) noexcept
+      : m_value(
+            _mm512_setr_epi64(gen(std::integral_constant<std::size_t, 0>()),
+                              gen(std::integral_constant<std::size_t, 1>()),
+                              gen(std::integral_constant<std::size_t, 2>()),
+                              gen(std::integral_constant<std::size_t, 3>()),
+                              gen(std::integral_constant<std::size_t, 4>()),
+                              gen(std::integral_constant<std::size_t, 5>()),
+                              gen(std::integral_constant<std::size_t, 6>()),
+                              gen(std::integral_constant<std::size_t, 7>()))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m512i const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm512_loadu_si512(ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm512_storeu_si512(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
+      const {
+    return m_value;
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(_mm512_sub_epi64(_mm512_set1_epi64(0), m_value));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
+                                   static_cast<__m512i>(rhs)));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epi64_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epi64_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epi64_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epi64_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmpeq_epi64_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmpneq_epi64_mask(static_cast<__m512i>(lhs),
+                                              static_cast<__m512i>(rhs)));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) {
+    return simd(_mm512_srai_epi64(static_cast<__m512i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) {
+    return simd(_mm512_srav_epi64(static_cast<__m512i>(lhs),
+                                  static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) {
+    return simd(_mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) {
+    return simd(_mm512_sllv_epi64(static_cast<__m512i>(lhs),
+                                  static_cast<__m512i>(rhs)));
+  }
+};
+
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>>
+abs(Experimental::simd<std::int64_t,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  __m512i const rhs = static_cast<__m512i>(a);
+  return Experimental::simd<std::int64_t,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_abs_epi64(rhs));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+floor(Experimental::simd<
+      std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_cvtepi64_pd(static_cast<__m512i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
+    ceil(Experimental::simd<
+         std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_cvtepi64_pd(static_cast<__m512i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+round(Experimental::simd<
+      std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_cvtepi64_pd(static_cast<__m512i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+trunc(Experimental::simd<
+      std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_cvtepi64_pd(static_cast<__m512i>(a)));
+}
+
+namespace Experimental {
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
+    condition(simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a,
+              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& b,
+              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& c) {
+  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_mask_blend_epi64(static_cast<__mmask8>(a), static_cast<__m512i>(c),
+                              static_cast<__m512i>(b)));
+}
+
+template <>
+class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
+  __m512i m_value;
+
+ public:
+  using value_type = std::uint64_t;
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm512_set1_epi64(
+            Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m512i const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int32_t, abi_type> const& other)
+      : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
+  template <class G,
+            std::enable_if_t<
+                // basically, can you do { value_type r =
+                // gen(std::integral_constant<std::size_t, i>()); }
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      G&& gen) noexcept
+      : m_value(
+            _mm512_setr_epi64(gen(std::integral_constant<std::size_t, 0>()),
+                              gen(std::integral_constant<std::size_t, 1>()),
+                              gen(std::integral_constant<std::size_t, 2>()),
+                              gen(std::integral_constant<std::size_t, 3>()),
+                              gen(std::integral_constant<std::size_t, 4>()),
+                              gen(std::integral_constant<std::size_t, 5>()),
+                              gen(std::integral_constant<std::size_t, 6>()),
+                              gen(std::integral_constant<std::size_t, 7>()))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int64_t, abi_type> const& other)
+      : m_value(static_cast<__m512i>(other)) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm512_loadu_si512(ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm512_storeu_si512(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
+      const {
+    return m_value;
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
+                                   static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return _mm512_srli_epi64(static_cast<__m512i>(lhs), rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
+    return _mm512_srlv_epi64(static_cast<__m512i>(lhs),
+                             static_cast<__m512i>(rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return _mm512_sllv_epi64(static_cast<__m512i>(lhs),
+                             static_cast<__m512i>(rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator&(
+      simd const& lhs, simd const& rhs) noexcept {
+    return _mm512_and_epi64(static_cast<__m512i>(lhs),
+                            static_cast<__m512i>(rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator|(
+      simd const& lhs, simd const& rhs) noexcept {
+    return _mm512_or_epi64(static_cast<__m512i>(lhs),
+                           static_cast<__m512i>(rhs));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epu64_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epu64_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epu64_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epu64_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmpeq_epu64_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmpneq_epu64_mask(static_cast<__m512i>(lhs),
+                                              static_cast<__m512i>(rhs)));
+  }
+};
+
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>>
+abs(Experimental::simd<std::uint64_t,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return a;
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+floor(Experimental::simd<
+      std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_cvtepu64_pd(static_cast<__m512i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+ceil(Experimental::simd<
+     std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_cvtepu64_pd(static_cast<__m512i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+round(Experimental::simd<
+      std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_cvtepu64_pd(static_cast<__m512i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+trunc(Experimental::simd<
+      std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_cvtepu64_pd(static_cast<__m512i>(a)));
+}
+
+namespace Experimental {
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
+    condition(simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a,
+              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& b,
+              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& c) {
+  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_mask_blend_epi64(static_cast<__mmask8>(a), static_cast<__m512i>(c),
+                              static_cast<__m512i>(b)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other)
+    : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other)
+    : m_value(static_cast<__m512i>(other)) {}
 
 template <>
 class const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -329,7 +329,6 @@ template <class T, class Abi>
 }
 
 }  // namespace Experimental
-
 }  // namespace Kokkos
 
 #endif

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -328,6 +328,20 @@ template <class T, class Abi>
   return a == simd_mask<T, Abi>(false);
 }
 
+// A temporary device-callable implemenation of round half to nearest even
+template <typename T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto round_half_to_nearest_even(
+    T const& x) {
+  auto ceil  = Kokkos::ceil(x);
+  auto floor = Kokkos::floor(x);
+
+  if (Kokkos::abs(ceil - x) == Kokkos::abs(floor - x)) {
+    auto rem = Kokkos::remainder(ceil, 2.0);
+    return (rem == 0) ? ceil : floor;
+  }
+  return Kokkos::round(x);
+}
+
 }  // namespace Experimental
 }  // namespace Kokkos
 

--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -69,23 +69,6 @@ reduce(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x, T,
   return result;
 }
 
-namespace Impl {
-
-// A temporary device-callable implemenation of round half to nearest even
-template <typename T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto round_half_to_nearest_even(
-    T const& x) {
-  auto ceil  = Kokkos::ceil(x);
-  auto floor = Kokkos::floor(x);
-
-  if (Kokkos::abs(ceil - x) == Kokkos::abs(floor - x)) {
-    auto rem = Kokkos::remainder(ceil, 2.0);
-    return (rem == 0) ? ceil : floor;
-  }
-  return Kokkos::round(x);
-}
-
-}  // namespace Impl
 }  // namespace Experimental
 
 template <class T, class Abi>

--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -69,6 +69,23 @@ reduce(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x, T,
   return result;
 }
 
+namespace Impl {
+
+// A temporary device-callable implemenation of round half to nearest even
+template <typename T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto round_half_to_nearest_even(
+    T const& x) {
+  auto ceil  = Kokkos::ceil(x);
+  auto floor = Kokkos::floor(x);
+
+  if (Kokkos::abs(ceil - x) == Kokkos::abs(floor - x)) {
+    auto rem = Kokkos::remainder(ceil, 2.0);
+    return (rem == 0) ? ceil : floor;
+  }
+  return Kokkos::round(x);
+}
+
+}  // namespace Impl
 }  // namespace Experimental
 
 template <class T, class Abi>

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -431,20 +431,52 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>> abs(
-    Experimental::simd<double,
-                       Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    abs(Experimental::simd<
+        double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
       vabsq_f64(static_cast<float64x2_t>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>> copysign(
-    Experimental::simd<double,
-                       Experimental::simd_abi::neon_fixed_size<2>> const& a,
-    Experimental::simd<double,
-                       Experimental::simd_abi::neon_fixed_size<2>> const& b) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    floor(Experimental::simd<
+          double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
+      vrndmq_f64(static_cast<float64x2_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    ceil(Experimental::simd<
+         double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
+      vrndpq_f64(static_cast<float64x2_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    round(Experimental::simd<
+          double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
+      vrndxq_f64(static_cast<float64x2_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    trunc(Experimental::simd<
+          double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
+      vrndq_f64(static_cast<float64x2_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    copysign(Experimental::simd<
+                 double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
+             Experimental::simd<
+                 double, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
   uint64x2_t const sign_mask = vreinterpretq_u64_f64(vmovq_n_f64(-0.0));
   return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
       vreinterpretq_f64_u64(vorrq_u64(
@@ -453,43 +485,43 @@ Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>> copysign(
                     vreinterpretq_u64_f64(static_cast<float64x2_t>(b))))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>> sqrt(
-    Experimental::simd<double,
-                       Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    sqrt(Experimental::simd<
+         double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
       vsqrtq_f64(static_cast<float64x2_t>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>> fma(
-    Experimental::simd<double,
-                       Experimental::simd_abi::neon_fixed_size<2>> const& a,
-    Experimental::simd<double,
-                       Experimental::simd_abi::neon_fixed_size<2>> const& b,
-    Experimental::simd<double,
-                       Experimental::simd_abi::neon_fixed_size<2>> const& c) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    fma(Experimental::simd<double,
+                           Experimental::simd_abi::neon_fixed_size<2>> const& a,
+        Experimental::simd<double,
+                           Experimental::simd_abi::neon_fixed_size<2>> const& b,
+        Experimental::simd<
+            double, Experimental::simd_abi::neon_fixed_size<2>> const& c) {
   return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
       vfmaq_f64(static_cast<float64x2_t>(c), static_cast<float64x2_t>(b),
                 static_cast<float64x2_t>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>> max(
-    Experimental::simd<double,
-                       Experimental::simd_abi::neon_fixed_size<2>> const& a,
-    Experimental::simd<double,
-                       Experimental::simd_abi::neon_fixed_size<2>> const& b) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    max(Experimental::simd<double,
+                           Experimental::simd_abi::neon_fixed_size<2>> const& a,
+        Experimental::simd<
+            double, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
   return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
       vmaxq_f64(static_cast<float64x2_t>(a), static_cast<float64x2_t>(b)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>> min(
-    Experimental::simd<double,
-                       Experimental::simd_abi::neon_fixed_size<2>> const& a,
-    Experimental::simd<double,
-                       Experimental::simd_abi::neon_fixed_size<2>> const& b) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    min(Experimental::simd<double,
+                           Experimental::simd_abi::neon_fixed_size<2>> const& a,
+        Experimental::simd<
+            double, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
   return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
       vminq_f64(static_cast<float64x2_t>(a), static_cast<float64x2_t>(b)));
 }
@@ -630,62 +662,111 @@ class simd<float, simd_abi::neon_fixed_size<2>> {
   }
 };
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::neon_fixed_size<2>> abs(
-    simd<float, simd_abi::neon_fixed_size<2>> const& a) {
-  return simd<float, simd_abi::neon_fixed_size<2>>(
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+    abs(Experimental::simd<
+        float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
       vabs_f32(static_cast<float32x2_t>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::neon_fixed_size<2>> copysign(
-    simd<float, simd_abi::neon_fixed_size<2>> const& a,
-    simd<float, simd_abi::neon_fixed_size<2>> const& b) {
-  uint32x2_t const sign_mask = vreinterpret_u32_f32(vmov_n_f32(-0.0));
-  return simd<float, simd_abi::neon_fixed_size<2>>(vreinterpret_f32_u32(
-      vorr_u32(vreinterpret_u32_f32(static_cast<float32x2_t>(abs(a))),
-               vand_u32(sign_mask,
-                        vreinterpret_u32_f32(static_cast<float32x2_t>(b))))));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+    floor(Experimental::simd<
+          float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
+      vrndm_f32(static_cast<float32x2_t>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::neon_fixed_size<2>> sqrt(
-    simd<float, simd_abi::neon_fixed_size<2>> const& a) {
-  return simd<float, simd_abi::neon_fixed_size<2>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+    ceil(Experimental::simd<
+         float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
+      vrndp_f32(static_cast<float32x2_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+    round(Experimental::simd<
+          float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
+      vrndx_f32(static_cast<float32x2_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+    trunc(Experimental::simd<
+          float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
+      vrnd_f32(static_cast<float32x2_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::neon_fixed_size<2>>
+copysign(
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
+        a,
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
+        b) {
+  uint32x2_t const sign_mask = vreinterpret_u32_f32(vmov_n_f32(-0.0));
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
+      vreinterpret_f32_u32(vorr_u32(
+          vreinterpret_u32_f32(static_cast<float32x2_t>(abs(a))),
+          vand_u32(sign_mask,
+                   vreinterpret_u32_f32(static_cast<float32x2_t>(b))))));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+    sqrt(Experimental::simd<
+         float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
       vsqrt_f32(static_cast<float32x2_t>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::neon_fixed_size<2>> fma(
-    simd<float, simd_abi::neon_fixed_size<2>> const& a,
-    simd<float, simd_abi::neon_fixed_size<2>> const& b,
-    simd<float, simd_abi::neon_fixed_size<2>> const& c) {
-  return simd<float, simd_abi::neon_fixed_size<2>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::neon_fixed_size<2>>
+fma(Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
+        a,
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
+        b,
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
+        c) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
       vfma_f32(static_cast<float32x2_t>(c), static_cast<float32x2_t>(b),
                static_cast<float32x2_t>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::neon_fixed_size<2>> max(
-    simd<float, simd_abi::neon_fixed_size<2>> const& a,
-    simd<float, simd_abi::neon_fixed_size<2>> const& b) {
-  return simd<float, simd_abi::neon_fixed_size<2>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::neon_fixed_size<2>>
+max(Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
+        a,
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
+        b) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
       vmax_f32(static_cast<float32x2_t>(a), static_cast<float32x2_t>(b)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::neon_fixed_size<2>> min(
-    simd<float, simd_abi::neon_fixed_size<2>> const& a,
-    simd<float, simd_abi::neon_fixed_size<2>> const& b) {
-  return simd<float, simd_abi::neon_fixed_size<2>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::neon_fixed_size<2>>
+min(Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
+        a,
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
+        b) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
       vmin_f32(static_cast<float32x2_t>(a), static_cast<float32x2_t>(b)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::neon_fixed_size<2>> condition(
-    simd_mask<float, simd_abi::neon_fixed_size<2>> const& a,
-    simd<float, simd_abi::neon_fixed_size<2>> const& b,
-    simd<float, simd_abi::neon_fixed_size<2>> const& c) {
+namespace Experimental {
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<float, simd_abi::neon_fixed_size<2>>
+    condition(simd_mask<float, simd_abi::neon_fixed_size<2>> const& a,
+              simd<float, simd_abi::neon_fixed_size<2>> const& b,
+              simd<float, simd_abi::neon_fixed_size<2>> const& c) {
   return simd<float, simd_abi::neon_fixed_size<2>>(
       vbsl_f32(static_cast<uint32x2_t>(a), static_cast<float32x2_t>(b),
                static_cast<float32x2_t>(c)));
@@ -840,12 +921,46 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
   }
 };
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::neon_fixed_size<2>> abs(
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& a) {
-  return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
+    abs(Experimental::simd<
+        std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::simd<std::int32_t,
+                            Experimental::simd_abi::neon_fixed_size<2>>(
       vabs_s32(static_cast<int32x2_t>(a)));
 }
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
+    floor(Experimental::simd<
+          std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return a;
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
+    ceil(Experimental::simd<
+         std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return a;
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
+    round(Experimental::simd<
+          std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return a;
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
+    trunc(Experimental::simd<
+          std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return a;
+}
+
+namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::int32_t, simd_abi::neon_fixed_size<2>>
@@ -1006,12 +1121,46 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
   }
 };
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::neon_fixed_size<2>> abs(
-    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& a) {
-  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
+    abs(Experimental::simd<
+        std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::simd<std::int64_t,
+                            Experimental::simd_abi::neon_fixed_size<2>>(
       vabsq_s64(static_cast<int64x2_t>(a)));
 }
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
+    floor(Experimental::simd<
+          std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return a;
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
+    ceil(Experimental::simd<
+         std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return a;
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
+    round(Experimental::simd<
+          std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return a;
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
+    trunc(Experimental::simd<
+          std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return a;
+}
+
+namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::int64_t, simd_abi::neon_fixed_size<2>>
@@ -1172,6 +1321,38 @@ simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
     abs(simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
+
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>>
+floor(Experimental::simd<std::uint64_t,
+                         Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return a;
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>>
+ceil(Experimental::simd<std::uint64_t,
+                        Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return a;
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>>
+round(Experimental::simd<std::uint64_t,
+                         Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return a;
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>>
+trunc(Experimental::simd<std::uint64_t,
+                         Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return a;
+}
+
+namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>>

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -239,8 +239,7 @@ template <typename T>
     Experimental::simd<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
   return Experimental::simd<data_type, Experimental::simd_abi::scalar>(
-      Experimental::round_half_to_nearest_even(
-          static_cast<data_type>(a[0])));
+      Experimental::round_half_to_nearest_even(static_cast<data_type>(a[0])));
 };
 
 template <typename T>

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -239,7 +239,7 @@ template <typename T>
     Experimental::simd<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
   return Experimental::simd<data_type, Experimental::simd_abi::scalar>(
-      Experimental::Impl::round_half_to_nearest_even(
+      Experimental::round_half_to_nearest_even(
           static_cast<data_type>(a[0])));
 };
 

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -239,7 +239,8 @@ template <typename T>
     Experimental::simd<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
   return Experimental::simd<data_type, Experimental::simd_abi::scalar>(
-      Experimental::Impl::round_half_to_nearest_even(static_cast<data_type>(a[0])));
+      Experimental::Impl::round_half_to_nearest_even(
+          static_cast<data_type>(a[0])));
 };
 
 template <typename T>

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -218,6 +218,38 @@ template <class T>
   return a;
 }
 
+template <typename T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto floor(
+    Experimental::simd<T, Experimental::simd_abi::scalar> const& a) {
+  using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
+  return Experimental::simd<data_type, Experimental::simd_abi::scalar>(
+      Kokkos::floor(static_cast<data_type>(a[0])));
+};
+
+template <typename T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto ceil(
+    Experimental::simd<T, Experimental::simd_abi::scalar> const& a) {
+  using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
+  return Experimental::simd<data_type, Experimental::simd_abi::scalar>(
+      Kokkos::ceil(static_cast<data_type>(a[0])));
+};
+
+template <typename T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto round(
+    Experimental::simd<T, Experimental::simd_abi::scalar> const& a) {
+  using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
+  return Experimental::simd<data_type, Experimental::simd_abi::scalar>(
+      Experimental::Impl::round_half_to_nearest_even(static_cast<data_type>(a[0])));
+};
+
+template <typename T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto trunc(
+    Experimental::simd<T, Experimental::simd_abi::scalar> const& a) {
+  using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
+  return Experimental::simd<data_type, Experimental::simd_abi::scalar>(
+      Kokkos::trunc(static_cast<data_type>(a[0])));
+};
+
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION
     Experimental::simd<T, Experimental::simd_abi::scalar>

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -105,6 +105,86 @@ class absolutes {
   }
 };
 
+class floors {
+ public:
+  template <typename T>
+  auto on_host(T const& a) const {
+    return Kokkos::floor(a);
+  }
+  template <typename T>
+  auto on_host_serial(T const& a) const {
+    return Kokkos::floor(a);
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a) const {
+    return Kokkos::floor(a);
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a) const {
+    return Kokkos::floor(a);
+  }
+};
+
+class ceils {
+ public:
+  template <typename T>
+  auto on_host(T const& a) const {
+    return Kokkos::ceil(a);
+  }
+  template <typename T>
+  auto on_host_serial(T const& a) const {
+    return Kokkos::ceil(a);
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a) const {
+    return Kokkos::ceil(a);
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a) const {
+    return Kokkos::ceil(a);
+  }
+};
+
+class rounds {
+ public:
+  template <typename T>
+  auto on_host(T const& a) const {
+    return Kokkos::round(a);
+  }
+  template <typename T>
+  auto on_host_serial(T const& a) const {
+    return std::rint(a);
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a) const {
+    return Kokkos::round(a);
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a) const {
+    return Kokkos::Experimental::Impl::round_half_to_nearest_even(a);
+  }
+};
+
+class truncates {
+ public:
+  template <typename T>
+  auto on_host(T const& a) const {
+    return Kokkos::trunc(a);
+  }
+  template <typename T>
+  auto on_host_serial(T const& a) const {
+    return Kokkos::trunc(a);
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a) const {
+    return Kokkos::trunc(a);
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a) const {
+    return Kokkos::trunc(a);
+  }
+};
+
 class shift_right {
  public:
   template <typename T, typename U>

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -161,7 +161,7 @@ class rounds {
   }
   template <typename T>
   KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a) const {
-    return Kokkos::Experimental::Impl::round_half_to_nearest_even(a);
+    return Kokkos::Experimental::round_half_to_nearest_even(a);
   }
 };
 

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -61,12 +61,13 @@ void host_check_math_op_one_loader(UnaryOp unary_op, std::size_t n,
     simd_type arg;
     bool const loaded_arg = loader.host_load(args + i, nlanes, arg);
     if (!loaded_arg) continue;
-    simd_type expected_result;
+    auto computed_result = unary_op.on_host(arg);
+
+    decltype(computed_result) expected_result;
     for (std::size_t lane = 0; lane < simd_type::size(); ++lane) {
       if (lane < nlanes)
         expected_result[lane] = unary_op.on_host_serial(T(arg[lane]));
     }
-    simd_type const computed_result = unary_op.on_host(arg);
     host_check_equality(expected_result, computed_result, nlanes);
   }
 }
@@ -85,12 +86,17 @@ inline void host_check_all_math_ops(const DataType (&first_args)[n],
   host_check_math_op_all_loaders<Abi>(plus(), n, first_args, second_args);
   host_check_math_op_all_loaders<Abi>(minus(), n, first_args, second_args);
   host_check_math_op_all_loaders<Abi>(multiplies(), n, first_args, second_args);
-
-  // TODO: Place fallback division implementations for all simd integer types
-  if constexpr (std::is_same_v<DataType, double>)
-    host_check_math_op_all_loaders<Abi>(divides(), n, first_args, second_args);
-
   host_check_math_op_all_loaders<Abi>(absolutes(), n, first_args);
+
+  host_check_math_op_all_loaders<Abi>(floors(), n, first_args);
+  host_check_math_op_all_loaders<Abi>(ceils(), n, first_args);
+  host_check_math_op_all_loaders<Abi>(rounds(), n, first_args);
+  host_check_math_op_all_loaders<Abi>(truncates(), n, first_args);
+
+  // TODO: Place fallback implementations for all simd integer types
+  if constexpr (std::is_floating_point_v<DataType>) {
+    host_check_math_op_all_loaders<Abi>(divides(), n, first_args, second_args);
+  }
 }
 
 template <typename Abi, typename DataType>
@@ -100,20 +106,28 @@ inline void host_check_abi_size() {
   static_assert(simd_type::size() == mask_type::size());
 }
 
-template <class Abi, typename DataType>
+template <typename Abi, typename DataType>
 inline void host_check_math_ops() {
   constexpr size_t n = 11;
 
   host_check_abi_size<Abi, DataType>();
 
-  if constexpr (std::is_signed_v<DataType>) {
-    DataType const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
-    DataType const second_args[n] = {1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2};
+  if constexpr (!std::is_integral_v<DataType>) {
+    DataType const first_args[n]  = {0.1,  0.4,  0.5, 0.7, 1.0, 1.5,
+                                    -2.0, 10.0, 0.0, 1.2, -2.8};
+    DataType const second_args[n] = {1.0,  0.2, 1.1,  1.8,  -0.1, -3.0,
+                                     -2.4, 1.0, 13.0, -3.2, -2.1};
     host_check_all_math_ops<Abi>(first_args, second_args);
   } else {
-    DataType const first_args[n]  = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
-    DataType const second_args[n] = {1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2};
-    host_check_all_math_ops<Abi>(first_args, second_args);
+    if constexpr (std::is_signed_v<DataType>) {
+      DataType const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
+      DataType const second_args[n] = {1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2};
+      host_check_all_math_ops<Abi>(first_args, second_args);
+    } else {
+      DataType const first_args[n]  = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
+      DataType const second_args[n] = {1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2};
+      host_check_all_math_ops<Abi>(first_args, second_args);
+    }
   }
 }
 
@@ -171,11 +185,12 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_one_loader(UnaryOp unary_op,
     simd_type arg;
     bool const loaded_arg = loader.device_load(args + i, nlanes, arg);
     if (!loaded_arg) continue;
-    simd_type expected_result;
+    auto computed_result = unary_op.on_device(arg);
+
+    decltype(computed_result) expected_result;
     for (std::size_t lane = 0; lane < nlanes; ++lane) {
       expected_result[lane] = unary_op.on_device_serial(arg[lane]);
     }
-    simd_type const computed_result = unary_op.on_device(arg);
     device_check_equality(expected_result, computed_result, nlanes);
   }
 }
@@ -196,12 +211,17 @@ KOKKOS_INLINE_FUNCTION void device_check_all_math_ops(
   device_check_math_op_all_loaders<Abi>(minus(), n, first_args, second_args);
   device_check_math_op_all_loaders<Abi>(multiplies(), n, first_args,
                                         second_args);
+  device_check_math_op_all_loaders<Abi>(absolutes(), n, first_args);
 
-  if constexpr (std::is_same_v<DataType, double>)
+  device_check_math_op_all_loaders<Abi>(floors(), n, first_args);
+  device_check_math_op_all_loaders<Abi>(ceils(), n, first_args);
+  device_check_math_op_all_loaders<Abi>(rounds(), n, first_args);
+  device_check_math_op_all_loaders<Abi>(truncates(), n, first_args);
+
+  if constexpr (std::is_floating_point_v<DataType>) {
     device_check_math_op_all_loaders<Abi>(divides(), n, first_args,
                                           second_args);
-
-  device_check_math_op_all_loaders<Abi>(absolutes(), n, first_args);
+  }
 }
 
 template <typename Abi, typename DataType>
@@ -217,14 +237,22 @@ KOKKOS_INLINE_FUNCTION void device_check_math_ops() {
 
   device_check_abi_size<Abi, DataType>();
 
-  if constexpr (std::is_signed_v<DataType>) {
-    DataType const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
-    DataType const second_args[n] = {1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2};
+  if constexpr (!std::is_integral_v<DataType>) {
+    DataType const first_args[n]  = {0.1,  0.4,  0.5, 0.7, 1.0, 1.5,
+                                    -2.0, 10.0, 0.0, 1.2, -2.8};
+    DataType const second_args[n] = {1.0,  0.2, 1.1,  1.8,  -0.1, -3.0,
+                                     -2.4, 1.0, 13.0, -3.2, -2.1};
     device_check_all_math_ops<Abi>(first_args, second_args);
   } else {
-    DataType const first_args[n]  = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
-    DataType const second_args[n] = {1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2};
-    device_check_all_math_ops<Abi>(first_args, second_args);
+    if constexpr (std::is_signed_v<DataType>) {
+      DataType const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
+      DataType const second_args[n] = {1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2};
+      device_check_all_math_ops<Abi>(first_args, second_args);
+    } else {
+      DataType const first_args[n]  = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
+      DataType const second_args[n] = {1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2};
+      device_check_all_math_ops<Abi>(first_args, second_args);
+    }
   }
 }
 


### PR DESCRIPTION
Requested features from #6330.

This PR adds `floor`, `ceil`, `round`, and `trunc` operations for ~~supported simd `double` and `float` types~~ for all supported simd types.

- `simd Kokkos::Experimental::floor(simd const& a)`
- `simd Kokkos::Experimental::ceil(simd const& a)`
- `simd Kokkos::Experimental::round(simd const& a)`
- `simd Kokkos::Experimental::trunc(simd const& a)`