### PR TITLE
Don't use local headers or runtime in HPX backend

### DIFF
--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -25,11 +25,11 @@
 
 #include <impl/Kokkos_ExecSpaceManager.hpp>
 
-#include <hpx/local/condition_variable.hpp>
-#include <hpx/local/init.hpp>
-#include <hpx/local/runtime.hpp>
-#include <hpx/local/thread.hpp>
-#include <hpx/local/mutex.hpp>
+#include <hpx/condition_variable.hpp>
+#include <hpx/init.hpp>
+#include <hpx/mutex.hpp>
+#include <hpx/runtime.hpp>
+#include <hpx/thread.hpp>
 #include <hpx/version.hpp>
 
 #include <atomic>
@@ -207,7 +207,7 @@ int HPX::concurrency() const {
 void HPX::impl_initialize(InitializationSettings const &settings) {
   hpx::runtime *rt = hpx::get_runtime_ptr();
   if (rt == nullptr) {
-    hpx::local::init_params i;
+    hpx::init_params i;
     if (settings.has_num_threads()) {
       i.cfg.emplace_back("hpx.os_threads=" +
                          std::to_string(settings.get_num_threads()));
@@ -215,7 +215,7 @@ void HPX::impl_initialize(InitializationSettings const &settings) {
     int argc_hpx     = 1;
     char name[]      = "kokkos_hpx";
     char *argv_hpx[] = {name, nullptr};
-    hpx::local::start(nullptr, argc_hpx, argv_hpx, i);
+    hpx::start(nullptr, argc_hpx, argv_hpx, i);
 
     m_hpx_initialized = true;
   }
@@ -231,11 +231,11 @@ void HPX::impl_finalize() {
     hpx::runtime *rt = hpx::get_runtime_ptr();
     if (rt != nullptr) {
 #if HPX_VERSION_FULL >= 0x010900
-      hpx::post([]() { hpx::local::finalize(); });
+      hpx::post([]() { hpx::finalize(); });
 #else
-      hpx::apply([]() { hpx::local::finalize(); });
+      hpx::apply([]() { hpx::finalize(); });
 #endif
-      hpx::local::stop();
+      hpx::stop();
     } else {
       Kokkos::abort(
           "Kokkos::Experimental::HPX::impl_finalize: Kokkos started "
@@ -325,4 +325,4 @@ int g_hpx_space_factory_initialized =
 
 #else
 void KOKKOS_CORE_SRC_IMPL_HPX_PREVENT_LINK_ERROR() {}
-#endif  //#ifdef KOKKOS_ENABLE_HPX
+#endif  // #ifdef KOKKOS_ENABLE_HPX

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -50,12 +50,12 @@ static_assert(false,
 
 #include <KokkosExp_MDRangePolicy.hpp>
 
-#include <hpx/local/barrier.hpp>
-#include <hpx/local/condition_variable.hpp>
-#include <hpx/local/execution.hpp>
-#include <hpx/local/future.hpp>
-#include <hpx/local/mutex.hpp>
-#include <hpx/local/thread.hpp>
+#include <hpx/barrier.hpp>
+#include <hpx/condition_variable.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/future.hpp>
+#include <hpx/mutex.hpp>
+#include <hpx/thread.hpp>
 
 #include <Kokkos_UniqueToken.hpp>
 

--- a/core/src/HPX/Kokkos_HPX_Task.hpp
+++ b/core/src/HPX/Kokkos_HPX_Task.hpp
@@ -25,8 +25,8 @@
 
 #include <HPX/Kokkos_HPX.hpp>
 
-#include <hpx/local/execution.hpp>
-#include <hpx/local/future.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/future.hpp>
 
 #include <type_traits>
 

--- a/core/src/HPX/Kokkos_HPX_WorkGraphPolicy.hpp
+++ b/core/src/HPX/Kokkos_HPX_WorkGraphPolicy.hpp
@@ -19,8 +19,7 @@
 
 #include <HPX/Kokkos_HPX.hpp>
 
-#include <hpx/local/algorithm.hpp>
-#include <hpx/local/execution.hpp>
+#include <hpx/execution.hpp>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/unit_test/hpx/TestHPX_IndependentInstances.cpp
+++ b/core/unit_test/hpx/TestHPX_IndependentInstances.cpp
@@ -18,7 +18,7 @@
 #include <TestHPX_Category.hpp>
 
 #include <hpx/config.hpp>
-#include <hpx/local/future.hpp>
+#include <hpx/future.hpp>
 
 #ifndef HPX_COMPUTE_DEVICE_CODE
 

--- a/core/unit_test/hpx/TestHPX_IndependentInstancesDelayedExecution.cpp
+++ b/core/unit_test/hpx/TestHPX_IndependentInstancesDelayedExecution.cpp
@@ -17,7 +17,7 @@
 #include <Kokkos_Core.hpp>
 #include <TestHPX_Category.hpp>
 
-#include <hpx/local/execution.hpp>
+#include <hpx/execution.hpp>
 
 namespace {
 

--- a/core/unit_test/hpx/TestHPX_IndependentInstancesInstanceIds.cpp
+++ b/core/unit_test/hpx/TestHPX_IndependentInstancesInstanceIds.cpp
@@ -17,7 +17,7 @@
 #include <Kokkos_Core.hpp>
 #include <TestHPX_Category.hpp>
 
-#include <hpx/local/execution.hpp>
+#include <hpx/execution.hpp>
 
 namespace {
 


### PR DESCRIPTION
HPX used to have a "local" (non-distributed) runtime and corresponding headers. They've since been deprecated and will be removed. This changes the use of both to the "regular" (distributed) headers and runtime of HPX.

@hkaiser could you give this a go and see if this will work for your use case?