### PR TITLE
simd: added a missing generator ctor for avx2 float simd_mask

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -163,6 +163,18 @@ class simd_mask<float, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
       : m_value(_mm_castsi128_ps(_mm_set1_epi32(-std::int32_t(value)))) {}
+  template <class G,
+            std::enable_if_t<
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+      G&& gen) noexcept
+      : m_value(_mm_castsi128_ps(_mm_setr_epi32(
+            -std::int32_t(gen(std::integral_constant<std::size_t, 0>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 1>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 2>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 3>()))))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }


### PR DESCRIPTION
After #6177 was merged, the following error was being produced for build with AVX2.
```
error: no matching function for call to 'Kokkos::Experimental::simd_mask<float, Kokkos::Experimental::simd_abi::avx2_fixed_size<4> >::simd_mask(host_check_mask_ops<Kokkos::Experimental::simd_abi::avx2_fixed_size<4>, float>::<lambda(std::size_t)>)'
```
This is coming from a missing generator constructor for float `simd_mask` for AVX2.

Added in a generator contructor for float `simd_mask` for AVX2.