### PR TITLE
check-copyright improvements

### DIFF
--- a/scripts/check-copyright
+++ b/scripts/check-copyright
@@ -1,17 +1,16 @@
 files=`git ls-files | grep -e '.*\.\(cc\|cpp\|hpp\)' | grep -v 'tpls/'`
 echo "" &> scripts/diff_files
-tmp=`cat LICENSE_FILE_HEADER | wc -l`
+tmp=`wc -l < LICENSE_FILE_HEADER`
 NNEW=$(($tmp))
 for file in $files; do
   head -n +$NNEW $file &> header
-  diff header LICENSE_FILE_HEADER &> header_diff
-  count=`cat header_diff | wc -l`
-  #echo $file " " COUNT " " $count >> diff_headers
-  if [ "$count" -ne "0" ]; then
+  diff -q header LICENSE_FILE_HEADER > /dev/null
+  if [[ "${?}" == 1 ]]
+  then
     echo $file >> scripts/diff_files
   fi
 done
 tmpfile=$(mktemp -t kokkos_diff_files.XXXX)
-cat scripts/diff_files | sort &> $tmpfile
+sort < scripts/diff_files &> $tmpfile
 mv $tmpfile scripts/diff_files
-rm -f header header_diff
+rm -f header

--- a/scripts/check-copyright
+++ b/scripts/check-copyright
@@ -1,6 +1,6 @@
 files=$(git ls-files | grep -e '.*\.\(cc\|cpp\|hpp\)' | grep -v 'tpls/')
 echo "" &> scripts/diff_files
-tmp=`wc -l < LICENSE_FILE_HEADER`
+tmp=$(wc -l < LICENSE_FILE_HEADER)
 NNEW=$(($tmp))
 for file in $files
 do

--- a/scripts/check-copyright
+++ b/scripts/check-copyright
@@ -11,5 +11,5 @@ do
   fi
 done
 tmpfile=$(mktemp -t kokkos_diff_files.XXXX)
-sort < scripts/diff_files &> $tmpfile
-mv $tmpfile scripts/diff_files
+sort < scripts/diff_files &> "$tmpfile"
+mv "$tmpfile" scripts/diff_files

--- a/scripts/check-copyright
+++ b/scripts/check-copyright
@@ -1,4 +1,4 @@
-files=`git ls-files | grep -e '.*\.\(cc\|cpp\|hpp\)' | grep -v 'tpls/'`
+files=$(git ls-files | grep -e '.*\.\(cc\|cpp\|hpp\)' | grep -v 'tpls/')
 echo "" &> scripts/diff_files
 tmp=`wc -l < LICENSE_FILE_HEADER`
 NNEW=$(($tmp))

--- a/scripts/check-copyright
+++ b/scripts/check-copyright
@@ -4,12 +4,12 @@ tmp=$(wc -l < LICENSE_FILE_HEADER)
 NNEW=$(($tmp))
 for file in $files
 do
-  head -n +$NNEW "$file" | diff -q - LICENSE_FILE_HEADER > /dev/null
+  head -n +$NNEW "${file}" | diff -q - LICENSE_FILE_HEADER > /dev/null
   if [[ "${?}" == 1 ]]
   then
-    echo "$file" >> scripts/diff_files
+    echo "${file}" >> scripts/diff_files
   fi
 done
 tmpfile=$(mktemp -t kokkos_diff_files.XXXX)
-sort < scripts/diff_files &> "$tmpfile"
-mv "$tmpfile" scripts/diff_files
+sort < scripts/diff_files &> "${tmpfile}"
+mv "${tmpfile}" scripts/diff_files

--- a/scripts/check-copyright
+++ b/scripts/check-copyright
@@ -2,9 +2,9 @@ files=`git ls-files | grep -e '.*\.\(cc\|cpp\|hpp\)' | grep -v 'tpls/'`
 echo "" &> scripts/diff_files
 tmp=`wc -l < LICENSE_FILE_HEADER`
 NNEW=$(($tmp))
-for file in $files; do
-  head -n +$NNEW $file &> header
-  diff -q header LICENSE_FILE_HEADER > /dev/null
+for file in $files
+do
+  head -n +$NNEW $file | diff -q - LICENSE_FILE_HEADER > /dev/null
   if [[ "${?}" == 1 ]]
   then
     echo $file >> scripts/diff_files
@@ -13,4 +13,3 @@ done
 tmpfile=$(mktemp -t kokkos_diff_files.XXXX)
 sort < scripts/diff_files &> $tmpfile
 mv $tmpfile scripts/diff_files
-rm -f header

--- a/scripts/check-copyright
+++ b/scripts/check-copyright
@@ -4,7 +4,7 @@ tmp=$(wc -l < LICENSE_FILE_HEADER)
 NNEW=$(($tmp))
 for file in $files
 do
-  head -n +$NNEW $file | diff -q - LICENSE_FILE_HEADER > /dev/null
+  head -n +$NNEW "$file" | diff -q - LICENSE_FILE_HEADER > /dev/null
   if [[ "${?}" == 1 ]]
   then
     echo $file >> scripts/diff_files

--- a/scripts/check-copyright
+++ b/scripts/check-copyright
@@ -14,3 +14,4 @@ done
 tmpfile=$(mktemp -t kokkos_diff_files.XXXX)
 cat scripts/diff_files | sort &> $tmpfile
 mv $tmpfile scripts/diff_files
+rm -f header header_diff

--- a/scripts/check-copyright
+++ b/scripts/check-copyright
@@ -7,7 +7,7 @@ do
   head -n +$NNEW "$file" | diff -q - LICENSE_FILE_HEADER > /dev/null
   if [[ "${?}" == 1 ]]
   then
-    echo $file >> scripts/diff_files
+    echo "$file" >> scripts/diff_files
   fi
 done
 tmpfile=$(mktemp -t kokkos_diff_files.XXXX)


### PR DESCRIPTION
Looking to just remove the files `header` and `header_diff` that `check-copyright` left behind, I ended up making some performance improvements (mainly in the inner loop):

- Eliminated the use of temporary files `header` and `header_diff`.
- Replaced constructs of the form `cat file | do_something` with `do_something < file`.

On my M2 Max MacBook Pro, this consistently reduces the time it takes to run `check_format_cpp.sh` (which eventually calls `check-copyright`) from around 34s to around 24s.