### PR TITLE
Fixup checked integer operations death test not properly setup

### DIFF
--- a/core/unit_test/TestCheckedIntegerOps.hpp
+++ b/core/unit_test/TestCheckedIntegerOps.hpp
@@ -35,7 +35,8 @@ TEST(TEST_CATEGORY, checked_integer_operations_multiply_overflow) {
   }
 }
 
-TEST(TEST_CATEGORY, checked_integer_operations_multiply_overflow_abort) {
+TEST(TEST_CATEGORY_DEATH, checked_integer_operations_multiply_overflow_abort) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   {
     auto result = Kokkos::Impl::multiply_overflow_abort(1u, 2u);
     EXPECT_EQ(result, 2u);


### PR DESCRIPTION
Fixup for #6159
`checked_integer_operations_multiply_overflow_abort` is not properly tagged as death test and not constrained to run in a threadsafe environment.
```
[ RUN      ] hip.checked_integer_operations_multiply_overflow_abort

[WARNING] /path/to/kokkos/tpls/gtest/gtest/gtest-all.cc:9326:: Death tests use fork(), which is unsafe particularly in a threaded context. For this test, Google Test detected 3 threads. See https://github.com/google/googletest/blob/master/docs/advanced.md#death-tests-and-threads for more explanation and suggested solutions, especially if this is the last message you see before your test times out.