### PR TITLE
Use `cudaMallocAsync` by default

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -30,7 +30,7 @@ KOKKOS_TRIBITS ?= "no"
 KOKKOS_STANDALONE_CMAKE ?= "no"
 
 # Default settings specific options.
-# Options: force_uvm,use_ldg,rdc,enable_lambda,enable_constexpr
+# Options: force_uvm,use_ldg,rdc,enable_lambda,enable_constexpr,disable_malloc_async
 KOKKOS_CUDA_OPTIONS ?= ""
 
 # Options: rdc
@@ -82,6 +82,7 @@ KOKKOS_INTERNAL_CUDA_USE_UVM := $(call kokkos_has_string,$(KOKKOS_CUDA_OPTIONS),
 KOKKOS_INTERNAL_CUDA_USE_RELOC := $(call kokkos_has_string,$(KOKKOS_CUDA_OPTIONS),rdc)
 KOKKOS_INTERNAL_CUDA_USE_LAMBDA := $(call kokkos_has_string,$(KOKKOS_CUDA_OPTIONS),enable_lambda)
 KOKKOS_INTERNAL_CUDA_USE_CONSTEXPR := $(call kokkos_has_string,$(KOKKOS_CUDA_OPTIONS),enable_constexpr)
+KOKKOS_INTERNAL_CUDA_DISABLE_MALLOC_ASYNC := $(call kokkos_has_string,$(KOKKOS_CUDA_OPTIONS),disable_malloc_async)
 KOKKOS_INTERNAL_HPX_ENABLE_ASYNC_DISPATCH := $(call kokkos_has_string,$(KOKKOS_HPX_OPTIONS),enable_async_dispatch)
 # deprecated
 KOKKOS_INTERNAL_ENABLE_DESUL_ATOMICS := $(call kokkos_has_string,$(KOKKOS_OPTIONS),enable_desul_atomics)
@@ -688,6 +689,12 @@ ifeq ($(KOKKOS_INTERNAL_USE_CUDA), 1)
 
   ifeq ($(KOKKOS_INTERNAL_COMPILER_CLANG), 1)
     tmp := $(call kokkos_append_header,"$H""define KOKKOS_IMPL_CUDA_CLANG_WORKAROUND")
+  endif
+
+  ifeq ($(KOKKOS_INTERNAL_CUDA_DISABLE_MALLOC_ASYNC), 0)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC")
+  else
+    tmp := $(call kokkos_append_header,"/* $H""undef KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC */")
   endif
 endif
 

--- a/cmake/kokkos_enable_options.cmake
+++ b/cmake/kokkos_enable_options.cmake
@@ -43,8 +43,10 @@ ELSE()
 ENDIF()
 KOKKOS_ENABLE_OPTION(CUDA_LAMBDA ${CUDA_LAMBDA_DEFAULT} "Whether to allow lambda expressions on the device with NVCC **DEPRECATED**")
 
-# As of 08/12/2021 CudaMallocAsync causes issues if UCX is used as MPI communication layer.
-KOKKOS_ENABLE_OPTION(IMPL_CUDA_MALLOC_ASYNC      OFF  "Whether to enable CudaMallocAsync (requires CUDA Toolkit 11.2)")
+# May be used to disable our use of CudaMallocAsync.  It had caused issues in
+# the past when UCX was used as MPI communication layer.  We expect it is
+# resolved but we keep the option around a bit longer to be safe.
+KOKKOS_ENABLE_OPTION(IMPL_CUDA_MALLOC_ASYNC ON  "Whether to enable CudaMallocAsync (requires CUDA Toolkit 11.2)")
 KOKKOS_ENABLE_OPTION(DEPRECATED_CODE_3    OFF "Whether code deprecated in major release 3 is available" )
 KOKKOS_ENABLE_OPTION(DEPRECATED_CODE_4    ON "Whether code deprecated in major release 4 is available" )
 KOKKOS_ENABLE_OPTION(DEPRECATION_WARNINGS ON "Whether to emit deprecation warnings" )

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -929,6 +929,12 @@ void Cuda::print_configuration(std::ostream &os, bool /*verbose*/) const {
 #else
   os << "no\n";
 #endif
+  os << "  KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC: ";
+#ifdef KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC
+  os << "yes\n";
+#else
+  os << "no\n";
+#endif
 
   os << "\nCuda Runtime Configuration:\n";
 


### PR DESCRIPTION
We decided we would change the default value of the `Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC` option from `OFF` to `ON` a couple weeks ago at the developer meeting but somehow we didn't get around to implement it.  So here it is.

This option was introduced in #4233 because of issues downstream with UCX.  It has been 2 years now and we expect this has been resolved on the UCX side.  We preserve the option a bit longer so it is possible to revert to the old behavior.
I also introduce a `disable_malloc_async` option so it can be disabled with the generated makefiles.

Drive-by change:  Say whether `KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC` is defined or not from `Kokkos::print_configuration()`.
