### PR TITLE
Fix CMake warning when fetching `benchmark` library

### DIFF
--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -49,6 +49,7 @@ ELSE()
   list(APPEND CMAKE_MESSAGE_INDENT "[benchmark] ")
   FetchContent_Declare(
     googlebenchmark
+    DOWNLOAD_EXTRACT_TIMESTAMP FALSE
     URL https://github.com/google/benchmark/archive/refs/tags/v1.6.2.tar.gz
     URL_HASH MD5=14d14849e075af116143a161bc3b927b
   )


### PR DESCRIPTION
Silence following CMake warning (when building with benchmarks enabled):

```
CMake Warning (dev) at /usr/share/cmake/Modules/FetchContent.cmake:1316 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  core/perf_test/CMakeLists.txt:50 (FetchContent_Declare)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Setting `DOWNLOAD_EXTRACT_TIMESTAMP` to `FALSE` means that the archive extraction time will be used for timestamps.
CMake docs: https://cmake.org/cmake/help/latest/module/ExternalProject.html.
