### PR TITLE
core/src: Add half single and double mixed compare (LT,GT,LE,GE)

### DIFF
--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -839,11 +839,39 @@ class alignas(FloatType) floating_point_wrapper {
     return tmp_lhs < tmp_rhs;
   }
 
+  template <class T>
+  KOKKOS_FUNCTION friend std::enable_if_t<
+      std::is_same_v<T, float> || std::is_same_v<T, double>, bool>
+  operator<(floating_point_wrapper lhs, T rhs) {
+    return T(lhs) < rhs;
+  }
+
+  template <class T>
+  KOKKOS_FUNCTION friend std::enable_if_t<
+      std::is_same_v<T, float> || std::is_same_v<T, double>, bool>
+  operator<(T lhs, floating_point_wrapper rhs) {
+    return lhs < T(rhs);
+  }
+
   KOKKOS_FUNCTION
   friend bool operator>(const volatile floating_point_wrapper& lhs,
                         const volatile floating_point_wrapper& rhs) {
     floating_point_wrapper tmp_lhs = lhs, tmp_rhs = rhs;
     return tmp_lhs > tmp_rhs;
+  }
+
+  template <class T>
+  KOKKOS_FUNCTION friend std::enable_if_t<
+      std::is_same_v<T, float> || std::is_same_v<T, double>, bool>
+  operator>(floating_point_wrapper lhs, T rhs) {
+    return T(lhs) > rhs;
+  }
+
+  template <class T>
+  KOKKOS_FUNCTION friend std::enable_if_t<
+      std::is_same_v<T, float> || std::is_same_v<T, double>, bool>
+  operator>(T lhs, floating_point_wrapper rhs) {
+    return lhs > T(rhs);
   }
 
   KOKKOS_FUNCTION
@@ -853,11 +881,39 @@ class alignas(FloatType) floating_point_wrapper {
     return tmp_lhs <= tmp_rhs;
   }
 
+  template <class T>
+  KOKKOS_FUNCTION friend std::enable_if_t<
+      std::is_same_v<T, float> || std::is_same_v<T, double>, bool>
+  operator<=(floating_point_wrapper lhs, T rhs) {
+    return T(lhs) <= rhs;
+  }
+
+  template <class T>
+  KOKKOS_FUNCTION friend std::enable_if_t<
+      std::is_same_v<T, float> || std::is_same_v<T, double>, bool>
+  operator<=(T lhs, floating_point_wrapper rhs) {
+    return lhs <= T(rhs);
+  }
+
   KOKKOS_FUNCTION
   friend bool operator>=(const volatile floating_point_wrapper& lhs,
                          const volatile floating_point_wrapper& rhs) {
     floating_point_wrapper tmp_lhs = lhs, tmp_rhs = rhs;
     return tmp_lhs >= tmp_rhs;
+  }
+
+  template <class T>
+  KOKKOS_FUNCTION friend std::enable_if_t<
+      std::is_same_v<T, float> || std::is_same_v<T, double>, bool>
+  operator>=(floating_point_wrapper lhs, T rhs) {
+    return T(lhs) >= rhs;
+  }
+
+  template <class T>
+  KOKKOS_FUNCTION friend std::enable_if_t<
+      std::is_same_v<T, float> || std::is_same_v<T, double>, bool>
+  operator>=(T lhs, floating_point_wrapper rhs) {
+    return lhs >= T(rhs);
   }
 
   // Insertion and extraction operators

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -850,6 +850,7 @@ class alignas(FloatType) floating_point_wrapper {
     return lhs.val < rhs;
 #else
     return static_cast<float>(lhs) < rhs;
+#endif
   }
 
   template <class T>
@@ -861,8 +862,9 @@ class alignas(FloatType) floating_point_wrapper {
 #ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
     // CAUTION: this may result in different implicit casting across backends
     return lhs < rhs.val;
-#else 
+#else
     return lhs < static_cast<float>(rhs);
+#endif
   }
 
   KOKKOS_FUNCTION
@@ -874,24 +876,30 @@ class alignas(FloatType) floating_point_wrapper {
 
   template <class T>
   KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
-      (std::is_same_v<T, float> || std::is_same_v<T, double>), bool>
+                                              (std::is_same_v<T, float> ||
+                                               std::is_same_v<T, double>),
+                                          bool>
   operator>(floating_point_wrapper lhs, T rhs) {
 #ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
     // CAUTION: this may result in different implicit casting across backends
     return lhs.val > rhs;
 #else
     return static_cast<float>(lhs) > rhs;
+#endif
   }
 
   template <class T>
   KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
-      (std::is_same_v<T, float> || std::is_same_v<T, double>), bool>
+                                              (std::is_same_v<T, float> ||
+                                               std::is_same_v<T, double>),
+                                          bool>
   operator>(T lhs, floating_point_wrapper rhs) {
 #ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
     // CAUTION: this may result in different implicit casting across backends
     return lhs.val > rhs;
 #else
     return lhs > static_cast<float>(rhs);
+#endif
   }
 
   KOKKOS_FUNCTION
@@ -903,24 +911,30 @@ class alignas(FloatType) floating_point_wrapper {
 
   template <class T>
   KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
-      (std::is_same_v<T, float> || std::is_same_v<T, double>), bool>
+                                              (std::is_same_v<T, float> ||
+                                               std::is_same_v<T, double>),
+                                          bool>
   operator<=(floating_point_wrapper lhs, T rhs) {
 #ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
     // CAUTION: this may result in different implicit casting across backends
     return lhs.val <= rhs;
 #else
     return static_cast<float>(lhs) <= rhs;
+#endif
   }
 
   template <class T>
   KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
-      (std::is_same_v<T, float> || std::is_same_v<T, double>), bool>
+                                              (std::is_same_v<T, float> ||
+                                               std::is_same_v<T, double>),
+                                          bool>
   operator<=(T lhs, floating_point_wrapper rhs) {
 #ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
     // CAUTION: this may result in different implicit casting across backends
     return lhs <= rhs.val;
 #else
     return lhs <= static_cast<float>(rhs);
+#endif
   }
 
   KOKKOS_FUNCTION
@@ -932,14 +946,18 @@ class alignas(FloatType) floating_point_wrapper {
 
   template <class T>
   KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
-      (std::is_same_v<T, float> || std::is_same_v<T, double>), bool>
+                                              (std::is_same_v<T, float> ||
+                                               std::is_same_v<T, double>),
+                                          bool>
   operator>=(floating_point_wrapper lhs, T rhs) {
     return T(lhs) >= rhs;
   }
 
   template <class T>
   KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
-      (std::is_same_v<T, float> || std::is_same_v<T, double>), bool>
+                                              (std::is_same_v<T, float> ||
+                                               std::is_same_v<T, double>),
+                                          bool>
   operator>=(T lhs, floating_point_wrapper rhs) {
     return lhs >= T(rhs);
   }

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -950,7 +950,12 @@ class alignas(FloatType) floating_point_wrapper {
                                                std::is_same_v<T, double>),
                                           bool>
   operator>=(floating_point_wrapper lhs, T rhs) {
-    return T(lhs) >= rhs;
+#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+    // CAUTION: this may result in different implicit casting across backends
+    return lhs.val >= rhs;
+#else
+    return static_cast<float>(lhs) >= rhs;
+#endif
   }
 
   template <class T>
@@ -959,7 +964,12 @@ class alignas(FloatType) floating_point_wrapper {
                                                std::is_same_v<T, double>),
                                           bool>
   operator>=(T lhs, floating_point_wrapper rhs) {
-    return lhs >= T(rhs);
+#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+    // CAUTION: this may result in different implicit casting across backends
+    return lhs >= rhs.val;
+#else
+    return lhs >= static_cast<float>(rhs);
+#endif
   }
 
   // Insertion and extraction operators

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -845,12 +845,7 @@ class alignas(FloatType) floating_point_wrapper {
                                                std::is_same_v<T, double>),
                                           bool>
   operator<(floating_point_wrapper lhs, T rhs) {
-#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
-    // CAUTION: this may result in different implicit casting across backends
-    return lhs.val < rhs;
-#else
     return static_cast<float>(lhs) < rhs;
-#endif
   }
 
   template <class T>
@@ -859,12 +854,7 @@ class alignas(FloatType) floating_point_wrapper {
                                                std::is_same_v<T, double>),
                                           bool>
   operator<(T lhs, floating_point_wrapper rhs) {
-#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
-    // CAUTION: this may result in different implicit casting across backends
-    return lhs < rhs.val;
-#else
     return lhs < static_cast<float>(rhs);
-#endif
   }
 
   KOKKOS_FUNCTION
@@ -880,12 +870,7 @@ class alignas(FloatType) floating_point_wrapper {
                                                std::is_same_v<T, double>),
                                           bool>
   operator>(floating_point_wrapper lhs, T rhs) {
-#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
-    // CAUTION: this may result in different implicit casting across backends
-    return lhs.val > rhs;
-#else
     return static_cast<float>(lhs) > rhs;
-#endif
   }
 
   template <class T>
@@ -894,12 +879,7 @@ class alignas(FloatType) floating_point_wrapper {
                                                std::is_same_v<T, double>),
                                           bool>
   operator>(T lhs, floating_point_wrapper rhs) {
-#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
-    // CAUTION: this may result in different implicit casting across backends
-    return lhs > rhs.val;
-#else
     return lhs > static_cast<float>(rhs);
-#endif
   }
 
   KOKKOS_FUNCTION
@@ -915,12 +895,7 @@ class alignas(FloatType) floating_point_wrapper {
                                                std::is_same_v<T, double>),
                                           bool>
   operator<=(floating_point_wrapper lhs, T rhs) {
-#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
-    // CAUTION: this may result in different implicit casting across backends
-    return lhs.val <= rhs;
-#else
     return static_cast<float>(lhs) <= rhs;
-#endif
   }
 
   template <class T>
@@ -929,12 +904,7 @@ class alignas(FloatType) floating_point_wrapper {
                                                std::is_same_v<T, double>),
                                           bool>
   operator<=(T lhs, floating_point_wrapper rhs) {
-#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
-    // CAUTION: this may result in different implicit casting across backends
-    return lhs <= rhs.val;
-#else
     return lhs <= static_cast<float>(rhs);
-#endif
   }
 
   KOKKOS_FUNCTION
@@ -950,12 +920,7 @@ class alignas(FloatType) floating_point_wrapper {
                                                std::is_same_v<T, double>),
                                           bool>
   operator>=(floating_point_wrapper lhs, T rhs) {
-#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
-    // CAUTION: this may result in different implicit casting across backends
-    return lhs.val >= rhs;
-#else
     return static_cast<float>(lhs) >= rhs;
-#endif
   }
 
   template <class T>
@@ -964,12 +929,7 @@ class alignas(FloatType) floating_point_wrapper {
                                                std::is_same_v<T, double>),
                                           bool>
   operator>=(T lhs, floating_point_wrapper rhs) {
-#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
-    // CAUTION: this may result in different implicit casting across backends
-    return lhs >= rhs.val;
-#else
     return lhs >= static_cast<float>(rhs);
-#endif
   }
 
   // Insertion and extraction operators

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -896,7 +896,7 @@ class alignas(FloatType) floating_point_wrapper {
   operator>(T lhs, floating_point_wrapper rhs) {
 #ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
     // CAUTION: this may result in different implicit casting across backends
-    return lhs.val > rhs;
+    return lhs > rhs.val;
 #else
     return lhs > static_cast<float>(rhs);
 #endif

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -840,17 +840,29 @@ class alignas(FloatType) floating_point_wrapper {
   }
 
   template <class T>
-  KOKKOS_FUNCTION friend std::enable_if_t<
-      std::is_same_v<T, float> || std::is_same_v<T, double>, bool>
+  KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
+                                              (std::is_same_v<T, float> ||
+                                               std::is_same_v<T, double>),
+                                          bool>
   operator<(floating_point_wrapper lhs, T rhs) {
-    return T(lhs) < rhs;
+#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+    // CAUTION: this may result in different implicit casting across backends
+    return lhs.val < rhs;
+#else
+    return static_cast<float>(lhs) < rhs;
   }
 
   template <class T>
-  KOKKOS_FUNCTION friend std::enable_if_t<
-      std::is_same_v<T, float> || std::is_same_v<T, double>, bool>
+  KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
+                                              (std::is_same_v<T, float> ||
+                                               std::is_same_v<T, double>),
+                                          bool>
   operator<(T lhs, floating_point_wrapper rhs) {
-    return lhs < T(rhs);
+#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+    // CAUTION: this may result in different implicit casting across backends
+    return lhs < rhs.val;
+#else 
+    return lhs < static_cast<float>(rhs);
   }
 
   KOKKOS_FUNCTION
@@ -861,17 +873,25 @@ class alignas(FloatType) floating_point_wrapper {
   }
 
   template <class T>
-  KOKKOS_FUNCTION friend std::enable_if_t<
-      std::is_same_v<T, float> || std::is_same_v<T, double>, bool>
+  KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
+      (std::is_same_v<T, float> || std::is_same_v<T, double>), bool>
   operator>(floating_point_wrapper lhs, T rhs) {
-    return T(lhs) > rhs;
+#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+    // CAUTION: this may result in different implicit casting across backends
+    return lhs.val > rhs;
+#else
+    return static_cast<float>(lhs) > rhs;
   }
 
   template <class T>
-  KOKKOS_FUNCTION friend std::enable_if_t<
-      std::is_same_v<T, float> || std::is_same_v<T, double>, bool>
+  KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
+      (std::is_same_v<T, float> || std::is_same_v<T, double>), bool>
   operator>(T lhs, floating_point_wrapper rhs) {
-    return lhs > T(rhs);
+#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+    // CAUTION: this may result in different implicit casting across backends
+    return lhs.val > rhs;
+#else
+    return lhs > static_cast<float>(rhs);
   }
 
   KOKKOS_FUNCTION
@@ -882,17 +902,25 @@ class alignas(FloatType) floating_point_wrapper {
   }
 
   template <class T>
-  KOKKOS_FUNCTION friend std::enable_if_t<
-      std::is_same_v<T, float> || std::is_same_v<T, double>, bool>
+  KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
+      (std::is_same_v<T, float> || std::is_same_v<T, double>), bool>
   operator<=(floating_point_wrapper lhs, T rhs) {
-    return T(lhs) <= rhs;
+#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+    // CAUTION: this may result in different implicit casting across backends
+    return lhs.val <= rhs;
+#else
+    return static_cast<float>(lhs) <= rhs;
   }
 
   template <class T>
-  KOKKOS_FUNCTION friend std::enable_if_t<
-      std::is_same_v<T, float> || std::is_same_v<T, double>, bool>
+  KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
+      (std::is_same_v<T, float> || std::is_same_v<T, double>), bool>
   operator<=(T lhs, floating_point_wrapper rhs) {
-    return lhs <= T(rhs);
+#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+    // CAUTION: this may result in different implicit casting across backends
+    return lhs <= rhs.val;
+#else
+    return lhs <= static_cast<float>(rhs);
   }
 
   KOKKOS_FUNCTION
@@ -903,15 +931,15 @@ class alignas(FloatType) floating_point_wrapper {
   }
 
   template <class T>
-  KOKKOS_FUNCTION friend std::enable_if_t<
-      std::is_same_v<T, float> || std::is_same_v<T, double>, bool>
+  KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
+      (std::is_same_v<T, float> || std::is_same_v<T, double>), bool>
   operator>=(floating_point_wrapper lhs, T rhs) {
     return T(lhs) >= rhs;
   }
 
   template <class T>
-  KOKKOS_FUNCTION friend std::enable_if_t<
-      std::is_same_v<T, float> || std::is_same_v<T, double>, bool>
+  KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
+      (std::is_same_v<T, float> || std::is_same_v<T, double>), bool>
   operator>=(T lhs, floating_point_wrapper rhs) {
     return lhs >= T(rhs);
   }

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -241,10 +241,27 @@ enum OP_TESTS {
   OR,
   EQ,
   NEQ,
-  LT,
-  GT,
-  LE,
-  GE,  // TODO: TW,
+  LT_H_H,
+  LT_H_S,
+  LT_S_H,
+  LT_H_D,
+  LT_D_H,
+  GT_H_H,
+  GT_H_S,
+  GT_S_H,
+  GT_H_D,
+  GT_D_H,
+  LE_H_H,
+  LE_H_S,
+  LE_S_H,
+  LE_H_D,
+  LE_D_H,
+  GE_H_H,
+  GE_H_S,
+  GE_S_H,
+  GE_H_D,
+  GE_D_H,
+  // TODO: TW,
   PASS_BY_REF,
   AO_IMPL_HALF,
   AO_HALF_T,
@@ -292,20 +309,20 @@ struct Functor_TestHalfVolatileOperators {
     actual_lhs(ASSIGN)   = static_cast<double>(nv_tmp);
     expected_lhs(ASSIGN) = d_lhs;
 
-    actual_lhs(LT)   = h_lhs < h_rhs;
-    expected_lhs(LT) = d_lhs < d_rhs;
+    actual_lhs(LT_H_H)   = h_lhs < h_rhs;
+    expected_lhs(LT_H_H) = d_lhs < d_rhs;
 
-    actual_lhs(LE)   = h_lhs <= h_rhs;
-    expected_lhs(LE) = d_lhs <= d_rhs;
+    actual_lhs(LE_H_H)   = h_lhs <= h_rhs;
+    expected_lhs(LE_H_H) = d_lhs <= d_rhs;
 
     actual_lhs(NEQ)   = h_lhs != h_rhs;
     expected_lhs(NEQ) = d_lhs != d_rhs;
 
-    actual_lhs(GT)   = h_lhs > h_rhs;
-    expected_lhs(GT) = d_lhs > d_rhs;
+    actual_lhs(GT_H_H)   = h_lhs > h_rhs;
+    expected_lhs(GT_H_H) = d_lhs > d_rhs;
 
-    actual_lhs(GE)   = h_lhs >= h_rhs;
-    expected_lhs(GE) = d_lhs >= d_rhs;
+    actual_lhs(GE_H_H)   = h_lhs >= h_rhs;
+    expected_lhs(GE_H_H) = d_lhs >= d_rhs;
 
     actual_lhs(EQ)   = h_lhs == h_rhs;
     expected_lhs(EQ) = d_lhs == d_rhs;
@@ -879,17 +896,49 @@ struct Functor_TestHalfOperators {
     actual_lhs(NEQ)   = h_lhs != h_rhs;
     expected_lhs(NEQ) = d_lhs != d_rhs;
 
-    actual_lhs(LT)   = h_lhs < h_rhs;
-    expected_lhs(LT) = d_lhs < d_rhs;
+    actual_lhs(LT_H_H)   = h_lhs < h_rhs;
+    expected_lhs(LT_H_H) = d_lhs < d_rhs;
+    actual_lhs(LT_H_S)   = h_lhs < static_cast<float>(h_rhs);
+    expected_lhs(LT_H_S) = d_lhs < d_rhs;
+    actual_lhs(LT_S_H)   = static_cast<float>(h_lhs) < h_rhs;
+    expected_lhs(LT_S_H) = d_lhs < d_rhs;
+    actual_lhs(LT_H_D)   = h_lhs < static_cast<double>(h_rhs);
+    expected_lhs(LT_H_D) = d_lhs < d_rhs;
+    actual_lhs(LT_D_H)   = static_cast<double>(h_lhs) < h_rhs;
+    expected_lhs(LT_D_H) = d_lhs < d_rhs;
 
-    actual_lhs(GT)   = h_lhs > h_rhs;
-    expected_lhs(GT) = d_lhs > d_rhs;
+    actual_lhs(GT_H_H)   = h_lhs > h_rhs;
+    expected_lhs(GT_H_H) = d_lhs > d_rhs;
+    actual_lhs(GT_H_S)   = h_lhs > static_cast<float>(h_rhs);
+    expected_lhs(GT_H_S) = d_lhs > d_rhs;
+    actual_lhs(GT_S_H)   = static_cast<float>(h_lhs) > h_rhs;
+    expected_lhs(GT_S_H) = d_lhs > d_rhs;
+    actual_lhs(GT_H_D)   = h_lhs > static_cast<double>(h_rhs);
+    expected_lhs(GT_H_D) = d_lhs > d_rhs;
+    actual_lhs(GT_D_H)   = static_cast<double>(h_lhs) > h_rhs;
+    expected_lhs(GT_D_H) = d_lhs > d_rhs;
 
-    actual_lhs(LE)   = h_lhs <= h_rhs;
-    expected_lhs(LE) = d_lhs <= d_rhs;
+    actual_lhs(LE_H_H)   = h_lhs <= h_rhs;
+    expected_lhs(LE_H_H) = d_lhs <= d_rhs;
+    actual_lhs(LE_H_S)   = h_lhs <= static_cast<float>(h_rhs);
+    expected_lhs(LE_H_S) = d_lhs <= d_rhs;
+    actual_lhs(LE_S_H)   = static_cast<float>(h_lhs) <= h_rhs;
+    expected_lhs(LE_S_H) = d_lhs <= d_rhs;
+    actual_lhs(LE_H_D)   = h_lhs <= static_cast<double>(h_rhs);
+    expected_lhs(LE_H_D) = d_lhs <= d_rhs;
+    actual_lhs(LE_D_H)   = static_cast<double>(h_lhs) <= h_rhs;
+    expected_lhs(LE_D_H) = d_lhs <= d_rhs;
 
-    actual_lhs(GE)   = h_lhs >= h_rhs;
-    expected_lhs(GE) = d_lhs >= d_rhs;
+    actual_lhs(GE_H_H)   = h_lhs >= h_rhs;
+    expected_lhs(GE_H_H) = d_lhs >= d_rhs;
+    actual_lhs(GE_H_S)   = h_lhs >= static_cast<float>(h_rhs);
+    expected_lhs(GE_H_S) = d_lhs >= d_rhs;
+    actual_lhs(GE_S_H)   = static_cast<float>(h_lhs) >= h_rhs;
+    expected_lhs(GE_S_H) = d_lhs >= d_rhs;
+    actual_lhs(GE_H_D)   = h_lhs >= static_cast<double>(h_rhs);
+    expected_lhs(GE_H_D) = d_lhs >= d_rhs;
+    actual_lhs(GE_D_H)   = static_cast<double>(h_lhs) >= h_rhs;
+    expected_lhs(GE_D_H) = d_lhs >= d_rhs;
 
     // actual_lhs(TW)   = h_lhs <=> h_rhs;  // Need C++20?
     // expected_lhs(TW) = d_lhs <=> d_rhs;  // Need C++20?
@@ -961,10 +1010,10 @@ void __test_half_operators(half_type h_lhs, half_type h_rhs) {
   Kokkos::deep_copy(f_device_expected_lhs, f_device.expected_lhs);
   for (int op_test = 0; op_test < N_OP_TESTS; op_test++) {
     // printf("op_test = %d\n", op_test);
-    if (op_test == ASSIGN || op_test == LT || op_test == LE || op_test == NEQ ||
-        op_test == EQ || op_test == GT || op_test == GE ||
-        op_test == CADD_H_H || op_test == CSUB_H_H || op_test == CMUL_H_H ||
-        op_test == CDIV_H_H) {
+    if (op_test == ASSIGN || op_test == LT_H_H || op_test == LE_H_H ||
+        op_test == NEQ || op_test == EQ || op_test == GT_H_H ||
+        op_test == GE_H_H || op_test == CADD_H_H || op_test == CSUB_H_H ||
+        op_test == CMUL_H_H || op_test == CDIV_H_H) {
       ASSERT_NEAR(f_device_actual_lhs(op_test), f_device_expected_lhs(op_test),
                   epsilon);
       ASSERT_NEAR(f_host.actual_lhs(op_test), f_host.expected_lhs(op_test),


### PR DESCRIPTION
Related to #6404:
- Support mixed precision in operator>, operator>=, operator<=
- Do not downcast `T` for operator<