### PR TITLE
Drop (unused) `Impl::cuda_internal_maximum_shared_words`

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -690,10 +690,6 @@ std::array<Cuda::size_type, 3> cuda_internal_maximum_grid_count() {
   return CudaInternal::singleton().m_maxBlock;
 }
 
-Cuda::size_type cuda_internal_maximum_shared_words() {
-  return CudaInternal::singleton().m_maxSharedWords;
-}
-
 Cuda::size_type *cuda_internal_scratch_space(const Cuda &instance,
                                              const std::size_t size) {
   return instance.impl_internal_space_instance()->scratch_space(size);
@@ -796,10 +792,6 @@ void Cuda::impl_initialize(InitializationSettings const &settings) {
     if (Impl::CudaTraits::WarpSize < Impl::CudaInternal::m_maxWarpCount) {
       Impl::CudaInternal::m_maxWarpCount = Impl::CudaTraits::WarpSize;
     }
-
-    constexpr auto WordSize = sizeof(size_type);
-    Impl::CudaInternal::m_maxSharedWords =
-        cudaProp.sharedMemPerBlock / WordSize;
 
     //----------------------------------
     // Maximum number of blocks:

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -73,7 +73,6 @@ struct CudaTraits {
 CudaSpace::size_type cuda_internal_multiprocessor_count();
 CudaSpace::size_type cuda_internal_maximum_warp_count();
 std::array<CudaSpace::size_type, 3> cuda_internal_maximum_grid_count();
-CudaSpace::size_type cuda_internal_maximum_shared_words();
 
 CudaSpace::size_type cuda_internal_maximum_concurrent_block_count();
 


### PR DESCRIPTION
As far as I can tell, it has never been used since the source code has been under version control with Git.
It is not clear to me what useful thing one can do with it.  ~I found no use case in Trilinos.
The name say "internal" which I interpret as not legal to use so I propose simple removal.  Let me know if you disagree and think we need to go through deprecation.~  It is a free function defined in `Kokkos::Impl::` so it is safe to remove.