### PR TITLE
Drop check that the host backend is initialized before the device one

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -376,15 +376,6 @@ void CudaInternal::initialize(cudaStream_t stream, bool manage_stream) {
   was_initialized = true;
   if (is_initialized()) return;
 
-#ifndef KOKKOS_IMPL_TURN_OFF_CUDA_HOST_INIT_CHECK
-  if (!HostSpace::execution_space::impl_is_initialized()) {
-    const std::string msg(
-        "Cuda::initialize ERROR : HostSpace::execution_space is not "
-        "initialized");
-    throw_runtime_exception(msg);
-  }
-#endif
-
   const bool ok_init = nullptr == m_scratchSpace || nullptr == m_scratchFlags;
 
   if (ok_init) {

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -165,13 +165,6 @@ void HIPInternal::initialize(hipStream_t stream, bool manage_stream) {
 
   if (is_initialized()) return;
 
-  if (!HostSpace::execution_space::impl_is_initialized()) {
-    const std::string msg(
-        "HIP::initialize ERROR : HostSpace::execution_space "
-        "is not initialized");
-    Kokkos::Impl::throw_runtime_exception(msg);
-  }
-
   const bool ok_init = nullptr == m_scratchSpace || nullptr == m_scratchFlags;
 
   if (ok_init) {

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -104,13 +104,6 @@ void SYCLInternal::initialize(const sycl::queue& q) {
 
   if (is_initialized()) return;
 
-  if (!HostSpace::execution_space::impl_is_initialized()) {
-    const std::string msg(
-        "SYCL::initialize ERROR : HostSpace::execution_space is not "
-        "initialized");
-    Kokkos::Impl::throw_runtime_exception(msg);
-  }
-
   const bool ok_init = nullptr == m_scratchSpace || nullptr == m_scratchFlags;
   const bool ok_dev  = true;
   if (ok_init && ok_dev) {


### PR DESCRIPTION
These assertions were only present in the Cuda, HIP, and SYCL backend, presumably just copied over without questioning whether it was necessary.
In #2825, we had guarded the Cuda check with `#ifndef KOKKOS_IMPL_TURN_OFF_CUDA_HOST_INIT_CHECK` so that Legion is able to disable it.  On the issue this PR was addressing it is already suggested that this might very well be unnecessary.  I looked at the `{Cuda,HIP}::impl_initialize` and I could find anything that would actually require the host execution space to be initialized before.  I also tried
```diff
diff --git a/core/src/Serial/Kokkos_Serial.cpp b/core/src/Serial/Kokkos_Serial.cpp
index 6d55dffb7..271b92e39 100644
--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -171,7 +171,7 @@ const char* Serial::name() { return "Serial"; }
 namespace Impl {

 int g_serial_space_factory_initialized =
-    initialize_space_factory<Serial>("100_Serial");
+    initialize_space_factory<Serial>("999_Serial");

 }  // namespace Impl
```
to force the Serial backend to be initialized after HIP and all tests were passing.

**TLDR:** These check are unnecessary and are dictate the order in which to initialize backends.  I suggest to remove them.