### PR TITLE
Remove unused `HIPInternal` static data members

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -108,7 +108,6 @@ class CudaInternal {
   inline static unsigned m_multiProcCount           = 0;
   inline static unsigned m_maxWarpCount             = 0;
   inline static std::array<size_type, 3> m_maxBlock = {0, 0, 0};
-  inline static unsigned m_maxSharedWords           = 0;
   inline static int m_shmemPerSM                    = 0;
   inline static int m_maxShmemPerBlock              = 0;
   inline static int m_maxBlocksPerSM                = 0;

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -60,8 +60,6 @@ void HIP::impl_initialize(InitializationSettings const& settings) {
   if (Impl::HIPTraits::WarpSize < Impl::HIPInternal::m_maxWarpCount) {
     Impl::HIPInternal::m_maxWarpCount = Impl::HIPTraits::WarpSize;
   }
-  constexpr int WordSize              = sizeof(size_type);
-  Impl::HIPInternal::m_maxSharedWords = hipProp.sharedMemPerBlock / WordSize;
 
   //----------------------------------
   // Maximum number of blocks

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -70,7 +70,6 @@ class HIPInternal {
   using size_type = ::Kokkos::HIP::size_type;
 
   inline static int m_hipDev                        = -1;
-  inline static int m_hipArch                       = -1;
   inline static unsigned m_multiProcCount           = 0;
   inline static unsigned m_maxWarpCount             = 0;
   inline static std::array<size_type, 3> m_maxBlock = {0, 0, 0};

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -75,7 +75,6 @@ class HIPInternal {
   inline static unsigned m_maxWarpCount             = 0;
   inline static std::array<size_type, 3> m_maxBlock = {0, 0, 0};
   inline static unsigned m_maxWavesPerCU            = 0;
-  inline static unsigned m_maxSharedWords           = 0;
   inline static int m_shmemPerSM                    = 0;
   inline static int m_maxShmemPerBlock              = 0;
   inline static int m_maxThreadsPerSM               = 0;


### PR DESCRIPTION
Drop `HIPInternal::{m_maxSharedWords,m_hipArch}` static data members.
`m_maxSharedWords`'s equivalent in the Cuda backend was removed in #6408 

