### PR TITLE
Enable death tests for fedora rawhide

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -80,9 +80,6 @@ jobs:
           path: ~/.cache/ccache
           key: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.cmake_build_type }}-${{ matrix.openmp }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.cmake_build_type }}-${{ matrix.openmp }}-${{ github.ref }}
-      - name: maybe_disable_death_tests
-        if: ${{ matrix.distro == 'fedora:rawhide' }}
-        run: echo "GTEST_FILTER=-*DeathTest*" >> $GITHUB_ENV
       - name: maybe_use_flang_new
         if: ${{ matrix.cxx == 'clang++' && startsWith(matrix.distro,'fedora:') }}
         run: echo "FC=flang-new" >> $GITHUB_ENV


### PR DESCRIPTION
Re-enable death tests for builds using fedora:rawhide image. They seem to be passing consistently now.