### PR TITLE
Disable one Bessel function test when using Intel 23.1

### DIFF
--- a/core/unit_test/TestMathematicalSpecialFunctions.hpp
+++ b/core/unit_test/TestMathematicalSpecialFunctions.hpp
@@ -911,11 +911,16 @@ struct TestComplexBesselJ1Y1Function {
                 Kokkos::abs(h_ref_cbj1(i)) * 1e-13);
     }
 
+    // FIXME_SYCL Disable the test when using intel/2023.1.0 due to a suspected
+    // compiler bug.
+#if !defined(KOKKOS_ENABLE_SYCL) || \
+    (defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER != 20230100)
     EXPECT_EQ(h_ref_cby1(0), h_cby1(0));
     for (int i = 1; i < N; i++) {
       EXPECT_LE(Kokkos::abs(h_cby1(i) - h_ref_cby1(i)),
                 Kokkos::abs(h_ref_cby1(i)) * 1e-13);
     }
+#endif
 
     ////Test large arguments
     d_z_large        = ViewType("d_z_large", 6);


### PR DESCRIPTION
@ndellingwood Can you try this patch and check that it fixes the issue found in https://github.com/kokkos/kokkos/issues/6396 I don't have access to Intel GPU.