### PR TITLE
Drop check whether device supports unified addressing

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -499,7 +499,7 @@ Cuda::size_type *CudaInternal::scratch_space(const std::size_t size) const {
 }
 
 Cuda::size_type *CudaInternal::scratch_unified(const std::size_t size) const {
-  if (verify_is_initialized("scratch_unified") && m_scratchUnifiedSupported &&
+  if (verify_is_initialized("scratch_unified") &&
       m_scratchUnifiedCount < scratch_count(size)) {
     m_scratchUnifiedCount = scratch_count(size);
 
@@ -791,15 +791,6 @@ void Cuda::impl_initialize(InitializationSettings const &settings) {
   Impl::CudaInternal::m_maxThreadsPerBlock = cudaProp.maxThreadsPerBlock;
 
   //----------------------------------
-
-  Impl::CudaInternal::m_scratchUnifiedSupported = cudaProp.unifiedAddressing;
-
-  if (Kokkos::show_warnings() &&
-      !Impl::CudaInternal::m_scratchUnifiedSupported) {
-    std::cerr << "Kokkos::Cuda device " << cudaProp.name << " capability "
-              << cudaProp.major << "." << cudaProp.minor
-              << " does not support unified virtual address space" << std::endl;
-  }
 
   cudaStream_t singleton_stream;
   KOKKOS_IMPL_CUDA_SAFE_CALL(

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -123,7 +123,6 @@ class CudaInternal {
   mutable std::size_t m_scratchUnifiedCount;
   mutable std::size_t m_scratchFunctorSize;
 
-  inline static size_type m_scratchUnifiedSupported = 0;
   mutable size_type* m_scratchSpace;
   mutable size_type* m_scratchFlags;
   mutable size_type* m_scratchUnified;


### PR DESCRIPTION
This check is obsolete and only prints a warning when it should probably cause program termination if it ever failed because everything would crash and burn (for example we use `cudaMemcpyDefault` in all our `cudaMemCpy*` calls)

I suggest to simply remove it.