### PR TITLE
Use execution space instance argument to get device properties in block size deduction

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
@@ -183,9 +183,7 @@ int cuda_get_max_block_size(const CudaInternal* cuda_instance,
                             const FunctorType& f, const size_t vector_length,
                             const size_t shmem_block,
                             const size_t shmem_thread) {
-  (void)cuda_instance;
-
-  auto const& prop = Kokkos::Cuda().cuda_device_prop();
+  auto const& prop = cuda_instance->m_deviceProp;
 
   auto const block_size_to_dynamic_shmem = [&f, vector_length, shmem_block,
                                             shmem_thread](int block_size) {
@@ -209,9 +207,7 @@ int cuda_get_opt_block_size(const CudaInternal* cuda_instance,
                             const FunctorType& f, const size_t vector_length,
                             const size_t shmem_block,
                             const size_t shmem_thread) {
-  (void)cuda_instance;
-
-  auto const& prop = Kokkos::Cuda().cuda_device_prop();
+  auto const& prop = cuda_instance->m_deviceProp;
 
   auto const block_size_to_dynamic_shmem = [&f, vector_length, shmem_block,
                                             shmem_thread](int block_size) {


### PR DESCRIPTION
Harmless bug as we only support a single device from the current process but nevertheless not the right way to get the device properties.