### PR TITLE
team-level stdalgos: improve tests, check intra-team result matching (part 1/7)

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -212,6 +212,21 @@ auto create_deep_copyable_compatible_clone(ViewType view) {
 // others
 //
 
+template <class TeamHandleType, class ValueType1, class ValueType2>
+KOKKOS_FUNCTION bool team_members_have_matching_result(
+    const TeamHandleType& teamHandle, const ValueType1 memberValueIn,
+    const ValueType2 targetIn) {
+  using T             = std::common_type_t<ValueType1, ValueType2>;
+  const T memberValue = memberValueIn;
+  const T target      = targetIn;
+
+  // set accum to 1 if a mismach is found
+  const bool mismatch = memberValue != target;
+  int accum           = static_cast<int>(mismatch);
+  teamHandle.team_reduce(Kokkos::Sum<int>(accum));
+  return (accum == 0);
+}
+
 template <class ValueType1, class ValueType2>
 auto make_bounds(const ValueType1& lower, const ValueType2 upper) {
   return Kokkos::pair<ValueType1, ValueType2>{lower, upper};

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamMaxElement.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamMaxElement.cpp
@@ -23,33 +23,40 @@ namespace TeamMaxElement {
 
 namespace KE = Kokkos::Experimental;
 
-template <class ViewType, class DistancesViewType>
+template <class ViewType, class DistancesViewType, class IntraTeamSentinelView>
 struct TestFunctorA {
   ViewType m_view;
   DistancesViewType m_distancesView;
+  IntraTeamSentinelView m_intraTeamSentinelView;
   int m_apiPick;
 
   TestFunctorA(const ViewType view, const DistancesViewType distancesView,
-               int apiPick)
-      : m_view(view), m_distancesView(distancesView), m_apiPick(apiPick) {}
+               IntraTeamSentinelView intraTeamSentinelView, int apiPick)
+      : m_view(view),
+        m_distancesView(distancesView),
+        m_intraTeamSentinelView(intraTeamSentinelView),
+        m_apiPick(apiPick) {}
 
   template <class MemberType>
   KOKKOS_INLINE_FUNCTION void operator()(const MemberType& member) const {
     const auto myRowIndex = member.league_rank();
     auto myRowView        = Kokkos::subview(m_view, myRowIndex, Kokkos::ALL());
+    ptrdiff_t resultDist  = 0;
 
     if (m_apiPick == 0) {
       auto it =
           KE::max_element(member, KE::cbegin(myRowView), KE::cend(myRowView));
+      resultDist = KE::distance(KE::cbegin(myRowView), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) = KE::distance(KE::cbegin(myRowView), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     }
 
     else if (m_apiPick == 1) {
-      auto it = KE::max_element(member, myRowView);
+      auto it    = KE::max_element(member, myRowView);
+      resultDist = KE::distance(KE::begin(myRowView), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) = KE::distance(KE::begin(myRowView), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     }
 #if not defined KOKKOS_ENABLE_OPENMPTARGET
@@ -58,8 +65,9 @@ struct TestFunctorA {
       auto it =
           KE::max_element(member, KE::cbegin(myRowView), KE::cend(myRowView),
                           CustomLessThanComparator<value_type>{});
+      resultDist = KE::distance(KE::cbegin(myRowView), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) = KE::distance(KE::cbegin(myRowView), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     }
 
@@ -67,11 +75,21 @@ struct TestFunctorA {
       using value_type = typename ViewType::value_type;
       auto it          = KE::max_element(member, myRowView,
                                 CustomLessThanComparator<value_type>{});
+      resultDist       = KE::distance(KE::begin(myRowView), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) = KE::distance(KE::begin(myRowView), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     }
 #endif
+
+    // store result of checking if all members have their local
+    // values matching the one stored in m_distancesView
+    member.team_barrier();
+    const bool intraTeamCheck = team_members_have_matching_result(
+        member, resultDist, m_distancesView(myRowIndex));
+    Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
+      m_intraTeamSentinelView(myRowIndex) = intraTeamCheck;
+    });
   }
 };
 
@@ -102,9 +120,11 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
   // beginning of the interval that team operates on and then we check
   // that these distances match the expectation
   Kokkos::View<std::size_t*> distancesView("distancesView", numTeams);
+  // sentinel to check if all members of the team compute the same result
+  Kokkos::View<bool*> intraTeamSentinelView("intraTeamSameResult", numTeams);
 
   // use CTAD for functor
-  TestFunctorA fnc(dataView, distancesView, apiId);
+  TestFunctorA fnc(dataView, distancesView, intraTeamSentinelView, apiId);
   Kokkos::parallel_for(policy, fnc);
 
   // -----------------------------------------------
@@ -112,8 +132,9 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
   // -----------------------------------------------
   // here I can use cloneOfDataViewBeforeOp_h to run std algo on
   // since that contains a valid copy of the data
-  auto distancesView_h   = create_host_space_copy(distancesView);
-  auto dataViewAfterOp_h = create_host_space_copy(dataView);
+  auto distancesView_h         = create_host_space_copy(distancesView);
+  auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
+  auto dataViewAfterOp_h       = create_host_space_copy(dataView);
   for (std::size_t i = 0; i < cloneOfDataViewBeforeOp_h.extent(0); ++i) {
     auto myRow = Kokkos::subview(cloneOfDataViewBeforeOp_h, i, Kokkos::ALL());
 
@@ -128,6 +149,7 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
     }
 
     ASSERT_EQ(stdDistance, distancesView_h(i));
+    ASSERT_TRUE(intraTeamSentinelView_h(i));
   }
 
   // dataView should remain unchanged

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamMinElement.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamMinElement.cpp
@@ -23,33 +23,40 @@ namespace TeamMinElement {
 
 namespace KE = Kokkos::Experimental;
 
-template <class ViewType, class DistancesViewType>
+template <class ViewType, class DistancesViewType, class IntraTeamSentinelView>
 struct TestFunctorA {
   ViewType m_view;
   DistancesViewType m_distancesView;
+  IntraTeamSentinelView m_intraTeamSentinelView;
   int m_apiPick;
 
   TestFunctorA(const ViewType view, const DistancesViewType distancesView,
-               int apiPick)
-      : m_view(view), m_distancesView(distancesView), m_apiPick(apiPick) {}
+               IntraTeamSentinelView intraTeamSentinelView, int apiPick)
+      : m_view(view),
+        m_distancesView(distancesView),
+        m_intraTeamSentinelView(intraTeamSentinelView),
+        m_apiPick(apiPick) {}
 
   template <class MemberType>
   KOKKOS_INLINE_FUNCTION void operator()(const MemberType& member) const {
     const auto myRowIndex = member.league_rank();
     auto myRowView        = Kokkos::subview(m_view, myRowIndex, Kokkos::ALL());
+    ptrdiff_t resultDist  = 0;
 
     if (m_apiPick == 0) {
       auto it =
           KE::min_element(member, KE::cbegin(myRowView), KE::cend(myRowView));
+      resultDist = KE::distance(KE::cbegin(myRowView), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) = KE::distance(KE::cbegin(myRowView), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     }
 
     else if (m_apiPick == 1) {
-      auto it = KE::min_element(member, myRowView);
+      auto it    = KE::min_element(member, myRowView);
+      resultDist = KE::distance(KE::begin(myRowView), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) = KE::distance(KE::begin(myRowView), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     }
 #if not defined KOKKOS_ENABLE_OPENMPTARGET
@@ -58,8 +65,9 @@ struct TestFunctorA {
       auto it =
           KE::min_element(member, KE::cbegin(myRowView), KE::cend(myRowView),
                           CustomLessThanComparator<value_type>{});
+      resultDist = KE::distance(KE::cbegin(myRowView), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) = KE::distance(KE::cbegin(myRowView), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     }
 
@@ -67,11 +75,21 @@ struct TestFunctorA {
       using value_type = typename ViewType::value_type;
       auto it          = KE::min_element(member, myRowView,
                                 CustomLessThanComparator<value_type>{});
+      resultDist       = KE::distance(KE::begin(myRowView), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) = KE::distance(KE::begin(myRowView), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     }
 #endif
+
+    // store result of checking if all members have their local
+    // values matching the one stored in m_distancesView
+    member.team_barrier();
+    const bool intraTeamCheck = team_members_have_matching_result(
+        member, resultDist, m_distancesView(myRowIndex));
+    Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
+      m_intraTeamSentinelView(myRowIndex) = intraTeamCheck;
+    });
   }
 };
 
@@ -102,9 +120,11 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
   // beginning of the interval that team operates on and then we check
   // that these distances match the expectation
   Kokkos::View<std::size_t*> distancesView("distancesView", numTeams);
+  // sentinel to check if all members of the team compute the same result
+  Kokkos::View<bool*> intraTeamSentinelView("intraTeamSameResult", numTeams);
 
   // use CTAD for functor
-  TestFunctorA fnc(dataView, distancesView, apiId);
+  TestFunctorA fnc(dataView, distancesView, intraTeamSentinelView, apiId);
   Kokkos::parallel_for(policy, fnc);
 
   // -----------------------------------------------
@@ -112,8 +132,9 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
   // -----------------------------------------------
   // here I can use cloneOfDataViewBeforeOp_h to run std algo on
   // since that contains a valid copy of the data
-  auto distancesView_h   = create_host_space_copy(distancesView);
-  auto dataViewAfterOp_h = create_host_space_copy(dataView);
+  auto distancesView_h         = create_host_space_copy(distancesView);
+  auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
+  auto dataViewAfterOp_h       = create_host_space_copy(dataView);
   for (std::size_t i = 0; i < cloneOfDataViewBeforeOp_h.extent(0); ++i) {
     auto myRow = Kokkos::subview(cloneOfDataViewBeforeOp_h, i, Kokkos::ALL());
 
@@ -127,6 +148,7 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
       stdDistance = KE::distance(KE::cbegin(myRow), it);
     }
     ASSERT_EQ(stdDistance, distancesView_h(i));
+    ASSERT_TRUE(intraTeamSentinelView_h(i));
   }
 
   // dataView should remain unchanged

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamMinMaxElement.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamMinMaxElement.cpp
@@ -23,41 +23,47 @@ namespace TeamMinMaxElement {
 
 namespace KE = Kokkos::Experimental;
 
-template <class ViewType, class DistancesViewType>
+template <class ViewType, class DistancesViewType, class IntraTeamSentinelView>
 struct TestFunctorA {
   ViewType m_view;
   DistancesViewType m_distancesView;
+  IntraTeamSentinelView m_intraTeamSentinelView;
   int m_apiPick;
 
   TestFunctorA(const ViewType view, const DistancesViewType distancesView,
-               int apiPick)
-      : m_view(view), m_distancesView(distancesView), m_apiPick(apiPick) {}
+               IntraTeamSentinelView intraTeamSentinelView, int apiPick)
+      : m_view(view),
+        m_distancesView(distancesView),
+        m_intraTeamSentinelView(intraTeamSentinelView),
+        m_apiPick(apiPick) {}
 
   template <class MemberType>
   KOKKOS_INLINE_FUNCTION void operator()(const MemberType& member) const {
     const auto myRowIndex = member.league_rank();
     auto myRowView        = Kokkos::subview(m_view, myRowIndex, Kokkos::ALL());
+    ptrdiff_t resultDist1 = 0;
+    ptrdiff_t resultDist2 = 0;
 
     if (m_apiPick == 0) {
       auto itPair = KE::minmax_element(member, KE::cbegin(myRowView),
                                        KE::cend(myRowView));
+      resultDist1 = KE::distance(KE::cbegin(myRowView), itPair.first);
+      resultDist2 = KE::distance(KE::cbegin(myRowView), itPair.second);
 
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex, 0) =
-            KE::distance(KE::cbegin(myRowView), itPair.first);
-        m_distancesView(myRowIndex, 1) =
-            KE::distance(KE::cbegin(myRowView), itPair.second);
+        m_distancesView(myRowIndex, 0) = resultDist1;
+        m_distancesView(myRowIndex, 1) = resultDist2;
       });
     }
 
     else if (m_apiPick == 1) {
       auto itPair = KE::minmax_element(member, myRowView);
+      resultDist1 = KE::distance(KE::begin(myRowView), itPair.first);
+      resultDist2 = KE::distance(KE::begin(myRowView), itPair.second);
 
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex, 0) =
-            KE::distance(KE::begin(myRowView), itPair.first);
-        m_distancesView(myRowIndex, 1) =
-            KE::distance(KE::begin(myRowView), itPair.second);
+        m_distancesView(myRowIndex, 0) = resultDist1;
+        m_distancesView(myRowIndex, 1) = resultDist2;
       });
     }
 #if not defined KOKKOS_ENABLE_OPENMPTARGET
@@ -66,11 +72,12 @@ struct TestFunctorA {
       auto itPair =
           KE::minmax_element(member, KE::cbegin(myRowView), KE::cend(myRowView),
                              CustomLessThanComparator<value_type>{});
+      resultDist1 = KE::distance(KE::cbegin(myRowView), itPair.first);
+      resultDist2 = KE::distance(KE::cbegin(myRowView), itPair.second);
+
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex, 0) =
-            KE::distance(KE::cbegin(myRowView), itPair.first);
-        m_distancesView(myRowIndex, 1) =
-            KE::distance(KE::cbegin(myRowView), itPair.second);
+        m_distancesView(myRowIndex, 0) = resultDist1;
+        m_distancesView(myRowIndex, 1) = resultDist2;
       });
     }
 
@@ -78,14 +85,26 @@ struct TestFunctorA {
       using value_type = typename ViewType::value_type;
       auto itPair      = KE::minmax_element(member, myRowView,
                                        CustomLessThanComparator<value_type>{});
+      resultDist1      = KE::distance(KE::begin(myRowView), itPair.first);
+      resultDist2      = KE::distance(KE::begin(myRowView), itPair.second);
+
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex, 0) =
-            KE::distance(KE::begin(myRowView), itPair.first);
-        m_distancesView(myRowIndex, 1) =
-            KE::distance(KE::begin(myRowView), itPair.second);
+        m_distancesView(myRowIndex, 0) = resultDist1;
+        m_distancesView(myRowIndex, 1) = resultDist2;
       });
     }
 #endif
+
+    // store result of checking if all members have their local
+    // values matching the one stored in m_distancesView
+    member.team_barrier();
+    const bool intraTeamCheck1 = team_members_have_matching_result(
+        member, resultDist1, m_distancesView(myRowIndex, 0));
+    const bool intraTeamCheck2 = team_members_have_matching_result(
+        member, resultDist2, m_distancesView(myRowIndex, 1));
+    Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
+      m_intraTeamSentinelView(myRowIndex) = intraTeamCheck1 && intraTeamCheck2;
+    });
   }
 };
 
@@ -116,9 +135,11 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
   // beginning of the interval that team operates on and then we check
   // that these distances match the expectation
   Kokkos::View<std::size_t**> distancesView("distancesView", numTeams, 2);
+  // sentinel to check if all members of the team compute the same result
+  Kokkos::View<bool*> intraTeamSentinelView("intraTeamSameResult", numTeams);
 
   // use CTAD for functor
-  TestFunctorA fnc(dataView, distancesView, apiId);
+  TestFunctorA fnc(dataView, distancesView, intraTeamSentinelView, apiId);
   Kokkos::parallel_for(policy, fnc);
 
   // -----------------------------------------------
@@ -126,8 +147,9 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
   // -----------------------------------------------
   // here I can use cloneOfDataViewBeforeOp_h to run std algo on
   // since that contains a valid copy of the data
-  auto distancesView_h   = create_host_space_copy(distancesView);
-  auto dataViewAfterOp_h = create_host_space_copy(dataView);
+  auto distancesView_h         = create_host_space_copy(distancesView);
+  auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
+  auto dataViewAfterOp_h       = create_host_space_copy(dataView);
   for (std::size_t i = 0; i < cloneOfDataViewBeforeOp_h.extent(0); ++i) {
     auto myRow = Kokkos::subview(cloneOfDataViewBeforeOp_h, i, Kokkos::ALL());
 
@@ -145,6 +167,7 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
 
     ASSERT_EQ(stdDistance[0], distancesView_h(i, 0));
     ASSERT_EQ(stdDistance[1], distancesView_h(i, 1));
+    ASSERT_TRUE(intraTeamSentinelView_h(i));
   }
 
   // dataView should remain unchanged


### PR DESCRIPTION
This PR improves the tests for team-level algorithms `Kokkos_{MinElement, MaxElement, MinMaxElement}.hpp` that were merged in #6208 to verify that when doing:
```cpp
auto returnValue = Kokkos::Experimental::std_algo_function_name(...)
```
the return value is the *same* for every member of the team. 

This is the first in a series of PRs to cover all team level algos currently in develop. 
Note that this PR introduces `team_members_have_matching_result` which is scoped inside the test to help avoiding duplicating code. This will be used in all the subsequent PRs so this should be merged first. 

Scope: this/these PRs are meant to address the concern raised here https://github.com/kokkos/kokkos/pull/6212
