### PR TITLE
re-enable unit tests for sort and random via makefile

### DIFF
--- a/algorithms/unit_tests/Makefile
+++ b/algorithms/unit_tests/Makefile
@@ -28,41 +28,47 @@ TARGETS =
 tmp := $(foreach device, $(KOKKOS_DEVICELIST), \
   $(if $(filter Test$(device).cpp, $(shell ls Test$(device).cpp 2>/dev/null)),,\
      $(shell echo "\#include <Test"${device}"_Category.hpp>" > Test$(device).cpp); \
+     $(shell echo "\#include <TestRandom.hpp>" >> Test$(device).cpp); \
+     $(shell echo "\#include <TestSort.hpp>" >> Test$(device).cpp); \
+     $(shell echo "\#include <TestBinSortA.hpp>" >> Test$(device).cpp); \
+     $(shell echo "\#include <TestBinSortB.hpp>" >> Test$(device).cpp); \
+     $(shell echo "\#include <TestNestedSort.hpp>" >> Test$(device).cpp); \
+     $(shell echo "\#include <TestSortCustomComp.hpp>" >> Test$(device).cpp); \
    ) \
 )
 
 ifeq ($(KOKKOS_INTERNAL_USE_CUDA), 1)
-	OBJ_CUDA = TestCuda.o UnitTestMain.o gtest-all.o
+	OBJ_CUDA = TestCuda.o TestStdAlgorithmsCommon.o UnitTestMain.o gtest-all.o
 	TARGETS += KokkosAlgorithms_UnitTest_Cuda
 	TEST_TARGETS += test-cuda
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_HIP), 1)
-	OBJ_HIP = TestHIP.o UnitTestMain.o gtest-all.o
+	OBJ_HIP = TestHIP.o TestStdAlgorithmsCommon.o UnitTestMain.o gtest-all.o
 	TARGETS += KokkosAlgorithms_UnitTest_HIP
 	TEST_TARGETS += test-hip
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_THREADS), 1)
-	OBJ_THREADS = TestThreads.o UnitTestMain.o gtest-all.o
+	OBJ_THREADS = TestThreads.o TestStdAlgorithmsCommon.o UnitTestMain.o gtest-all.o
 	TARGETS += KokkosAlgorithms_UnitTest_Threads
 	TEST_TARGETS += test-threads
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_OPENMP), 1)
-	OBJ_OPENMP = TestOpenMP.o UnitTestMain.o gtest-all.o
+	OBJ_OPENMP = TestOpenMP.o TestStdAlgorithmsCommon.o UnitTestMain.o gtest-all.o
 	TARGETS += KokkosAlgorithms_UnitTest_OpenMP
 	TEST_TARGETS += test-openmp
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_HPX), 1)
-	OBJ_HPX = TestHPX.o UnitTestMain.o gtest-all.o
+	OBJ_HPX = TestHPX.o TestStdAlgorithmsCommon.o UnitTestMain.o gtest-all.o
 	TARGETS += KokkosAlgorithms_UnitTest_HPX
 	TEST_TARGETS += test-hpx
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_SERIAL), 1)
-	OBJ_SERIAL = TestSerial.o UnitTestMain.o gtest-all.o
+	OBJ_SERIAL = TestSerial.o TestStdAlgorithmsCommon.o UnitTestMain.o gtest-all.o
 	TARGETS += KokkosAlgorithms_UnitTest_Serial
 	TEST_TARGETS += test-serial
 endif

--- a/algorithms/unit_tests/TestBinSortB.hpp
+++ b/algorithms/unit_tests/TestBinSortB.hpp
@@ -142,8 +142,8 @@ void test_on_view_with_stride(std::size_t numRows, std::size_t indB,
 template <class ExecutionSpace, class KeyType, class ValueType>
 void run_for_rank1() {
   constexpr int rank = 1;
-  (void)rank;
-  // // trivial case
+
+  // trivial case
   test_on_view_with_stride<ExecutionSpace, KeyType, ValueType, rank>(1, 0, 1);
 
   // nontrivial cases

--- a/algorithms/unit_tests/TestBinSortB.hpp
+++ b/algorithms/unit_tests/TestBinSortB.hpp
@@ -22,76 +22,12 @@
 #include <Kokkos_Random.hpp>
 #include <Kokkos_Sort.hpp>
 #include <Kokkos_StdAlgorithms.hpp>
-#include <TestStdAlgorithmsHelperFunctors.hpp>
+#include <TestStdAlgorithmsCommon.hpp>
 #include <random>
 #include <numeric>  //needed for iota
 
 namespace Test {
 namespace BinSortSetB {
-
-template <class ViewTypeFrom, class ViewTypeTo>
-struct CopyFunctorRank2 {
-  ViewTypeFrom m_view_from;
-  ViewTypeTo m_view_to;
-
-  CopyFunctorRank2() = delete;
-
-  CopyFunctorRank2(const ViewTypeFrom view_from, const ViewTypeTo view_to)
-      : m_view_from(view_from), m_view_to(view_to) {}
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(int k) const {
-    const auto i    = k / m_view_from.extent(1);
-    const auto j    = k % m_view_from.extent(1);
-    m_view_to(i, j) = m_view_from(i, j);
-  }
-};
-
-template <class ValueType, class... Props>
-auto create_deep_copyable_compatible_view_with_same_extent(
-    Kokkos::View<ValueType*, Props...> view) {
-  using view_type            = Kokkos::View<ValueType*, Props...>;
-  using view_value_type      = typename view_type::value_type;
-  using view_exespace        = typename view_type::execution_space;
-  const std::size_t ext0     = view.extent(0);
-  using view_deep_copyable_t = Kokkos::View<view_value_type*, view_exespace>;
-  return view_deep_copyable_t{"view_dc", ext0};
-}
-
-template <class ValueType, class... Props>
-auto create_deep_copyable_compatible_view_with_same_extent(
-    Kokkos::View<ValueType**, Props...> view) {
-  using view_type            = Kokkos::View<ValueType**, Props...>;
-  using view_value_type      = typename view_type::value_type;
-  using view_exespace        = typename view_type::execution_space;
-  using view_deep_copyable_t = Kokkos::View<view_value_type**, view_exespace>;
-  const std::size_t ext0     = view.extent(0);
-  const std::size_t ext1     = view.extent(1);
-  return view_deep_copyable_t{"view_dc", ext0, ext1};
-}
-
-template <class ViewType>
-auto create_deep_copyable_compatible_clone(ViewType view) {
-  static_assert(ViewType::rank <= 2);
-
-  auto view_dc    = create_deep_copyable_compatible_view_with_same_extent(view);
-  using view_dc_t = decltype(view_dc);
-  if constexpr (ViewType::rank == 1) {
-    Test::stdalgos::CopyFunctor<ViewType, view_dc_t> F1(view, view_dc);
-    Kokkos::parallel_for("copy", view.extent(0), F1);
-  } else {
-    static_assert(ViewType::rank == 2, "Only rank 1 or 2 supported.");
-    CopyFunctorRank2<ViewType, view_dc_t> F1(view, view_dc);
-    Kokkos::parallel_for("copy", view.extent(0) * view.extent(1), F1);
-  }
-  return view_dc;
-}
-
-template <class ViewType>
-auto create_host_space_copy(ViewType view) {
-  auto view_dc = create_deep_copyable_compatible_clone(view);
-  return create_mirror_view_and_copy(Kokkos::HostSpace(), view_dc);
-}
 
 template <class KeyType, class ExecutionSpace>
 auto create_rank1_dev_and_host_views_of_keys(const ExecutionSpace& exec,
@@ -171,9 +107,9 @@ void test_on_view_with_stride(std::size_t numRows, std::size_t indB,
 
   Kokkos::Random_XorShift64_Pool<ExecutionSpace> pool(73931);
   Kokkos::fill_random(v, pool, ValueType(545));
-  auto v_before_sort_h = create_host_space_copy(v);
+  auto v_before_sort_h = stdalgos::create_host_space_copy(v);
   sorter.sort(exec, v, indB, indE);
-  auto v_after_sort_h = create_host_space_copy(v);
+  auto v_after_sort_h = stdalgos::create_host_space_copy(v);
 
   for (size_t i = 0; i < v.extent(0); ++i) {
     // if i within [indB,indE), the sorting was done
@@ -206,8 +142,8 @@ void test_on_view_with_stride(std::size_t numRows, std::size_t indB,
 template <class ExecutionSpace, class KeyType, class ValueType>
 void run_for_rank1() {
   constexpr int rank = 1;
-
-  // trivial case
+  (void)rank;
+  // // trivial case
   test_on_view_with_stride<ExecutionSpace, KeyType, ValueType, rank>(1, 0, 1);
 
   // nontrivial cases

--- a/algorithms/unit_tests/TestSortCustomComp.hpp
+++ b/algorithms/unit_tests/TestSortCustomComp.hpp
@@ -85,7 +85,7 @@ void run_all_scenarios(int api)
     namespace KE = Kokkos::Experimental;
 
     if (api == 0) {
-       Kokkos::sort(dataView, comp_t{});
+      Kokkos::sort(dataView, comp_t{});
       std::sort(KE::begin(dataViewBeforeOp_h), KE::end(dataViewBeforeOp_h),
                 comp_t{});
     }

--- a/algorithms/unit_tests/TestSortCustomComp.hpp
+++ b/algorithms/unit_tests/TestSortCustomComp.hpp
@@ -54,7 +54,8 @@ auto create_random_view_and_host_clone(
   Kokkos::deep_copy(dataView_dc, dataView_dc_h);
   // use CTAD
   CopyFunctor F1(dataView_dc, dataView);
-  Kokkos::parallel_for("copy", dataView.extent(0), F1);
+  Kokkos::RangePolicy<ExecutionSpace> policy(0, dataView.extent(0));
+  Kokkos::parallel_for("copy", policy, F1);
 
   return std::make_pair(dataView, dataView_dc_h);
 }
@@ -84,7 +85,7 @@ void run_all_scenarios(int api)
     namespace KE = Kokkos::Experimental;
 
     if (api == 0) {
-      Kokkos::sort(dataView, comp_t{});
+       Kokkos::sort(dataView, comp_t{});
       std::sort(KE::begin(dataViewBeforeOp_h), KE::end(dataViewBeforeOp_h),
                 comp_t{});
     }
@@ -115,7 +116,7 @@ void run_all_scenarios(int api)
 TEST(TEST_CATEGORY, SortWithCustomComparator) {
   using ExeSpace = TEST_EXECSPACE;
   using namespace ::Test::stdalgos;
-  for (int api = 0; api < 2; api++) {
+  for (int api = 0; api < 1; api++) {
     run_all_scenarios<ExeSpace, DynamicTag, int>(api);
     run_all_scenarios<ExeSpace, DynamicTag, double>(api);
     run_all_scenarios<ExeSpace, DynamicLayoutLeftTag, int>(api);

--- a/algorithms/unit_tests/TestSortCustomComp.hpp
+++ b/algorithms/unit_tests/TestSortCustomComp.hpp
@@ -26,20 +26,21 @@
 namespace {
 namespace SortWithComp {
 
-template <class LayoutTagType, class ValueType>
+template <class ExecutionSpace, class LayoutTagType, class ValueType>
 auto create_random_view_and_host_clone(
     LayoutTagType LayoutTag, std::size_t n,
     Kokkos::pair<ValueType, ValueType> bounds, const std::string& label,
     std::size_t seedIn = 12371) {
   using namespace ::Test::stdalgos;
 
-  // construct in memory space associated with default exespace
-  auto dataView = create_view<ValueType>(LayoutTag, n, label);
+  using mem_space = typename ExecutionSpace::memory_space;
+  auto dataView   = create_view<ValueType, mem_space>(LayoutTag, n, label);
 
   // dataView might not be deep copyable (e.g. strided layout) so to
   // randomize it, we make a new view that is for sure deep copyable,
   // modify it on the host, deep copy to device and then launch
   // a kernel to copy to dataView
+
   auto dataView_dc =
       create_deep_copyable_compatible_view_with_same_extent(dataView);
   auto dataView_dc_h = create_mirror_view(Kokkos::HostSpace(), dataView_dc);
@@ -76,7 +77,7 @@ void run_all_scenarios(int api)
   const std::vector<std::size_t> my_scenarios = {0, 1, 2, 9, 1003, 51513};
   for (std::size_t N : my_scenarios)
   {
-    auto [dataView, dataViewBeforeOp_h] = create_random_view_and_host_clone(
+    auto [dataView, dataViewBeforeOp_h] = create_random_view_and_host_clone<ExecutionSpace>(
         Tag{}, N, Kokkos::pair<ValueType, ValueType>{-1045, 565},
         "dataView");
 

--- a/algorithms/unit_tests/TestSortCustomComp.hpp
+++ b/algorithms/unit_tests/TestSortCustomComp.hpp
@@ -116,7 +116,7 @@ void run_all_scenarios(int api)
 TEST(TEST_CATEGORY, SortWithCustomComparator) {
   using ExeSpace = TEST_EXECSPACE;
   using namespace ::Test::stdalgos;
-  for (int api = 0; api < 1; api++) {
+  for (int api = 0; api < 2; api++) {
     run_all_scenarios<ExeSpace, DynamicTag, int>(api);
     run_all_scenarios<ExeSpace, DynamicTag, double>(api);
     run_all_scenarios<ExeSpace, DynamicLayoutLeftTag, int>(api);

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -75,44 +75,49 @@ std::string view_tag_to_string(StridedThreeRowsTag);
 //
 
 // dynamic
-template <class ValueType>
+template <class ValueType,
+          class MemSpace = typename Kokkos::DefaultExecutionSpace::memory_space>
 auto create_view(DynamicTag, std::size_t ext, const std::string label) {
-  using view_t = Kokkos::View<ValueType*>;
+  using view_t = Kokkos::View<ValueType*, MemSpace>;
   view_t view{label + "_" + view_tag_to_string(DynamicTag{}), ext};
   return view;
 }
 
 // dynamic layout left
-template <class ValueType>
+template <class ValueType,
+          class MemSpace = typename Kokkos::DefaultExecutionSpace::memory_space>
 auto create_view(DynamicLayoutLeftTag, std::size_t ext,
                  const std::string label) {
-  using view_t = Kokkos::View<ValueType*, Kokkos::LayoutLeft>;
+  using view_t = Kokkos::View<ValueType*, Kokkos::LayoutLeft, MemSpace>;
   view_t view{label + "_" + view_tag_to_string(DynamicLayoutLeftTag{}), ext};
   return view;
 }
 
 // dynamic layout right
-template <class ValueType>
+template <class ValueType,
+          class MemSpace = typename Kokkos::DefaultExecutionSpace::memory_space>
 auto create_view(DynamicLayoutRightTag, std::size_t ext,
                  const std::string label) {
-  using view_t = Kokkos::View<ValueType*, Kokkos::LayoutRight>;
+  using view_t = Kokkos::View<ValueType*, Kokkos::LayoutRight, MemSpace>;
   view_t view{label + "_" + view_tag_to_string(DynamicLayoutRightTag{}), ext};
   return view;
 }
 
 // stride2
-template <class ValueType>
+template <class ValueType,
+          class MemSpace = typename Kokkos::DefaultExecutionSpace::memory_space>
 auto create_view(StridedTwoTag, std::size_t ext, const std::string label) {
-  using view_t = Kokkos::View<ValueType*, Kokkos::LayoutStride>;
+  using view_t = Kokkos::View<ValueType*, Kokkos::LayoutStride, MemSpace>;
   Kokkos::LayoutStride layout{ext, 2};
   view_t view{label + "_" + view_tag_to_string(StridedTwoTag{}), layout};
   return view;
 }
 
 // stride3
-template <class ValueType>
+template <class ValueType,
+          class MemSpace = typename Kokkos::DefaultExecutionSpace::memory_space>
 auto create_view(StridedThreeTag, std::size_t ext, const std::string label) {
-  using view_t = Kokkos::View<ValueType*, Kokkos::LayoutStride>;
+  using view_t = Kokkos::View<ValueType*, Kokkos::LayoutStride, MemSpace>;
   Kokkos::LayoutStride layout{ext, 3};
   view_t view{label + "_" + view_tag_to_string(StridedThreeTag{}), layout};
   return view;
@@ -123,49 +128,54 @@ auto create_view(StridedThreeTag, std::size_t ext, const std::string label) {
 //
 
 // dynamic
-template <class ValueType>
+template <class ValueType,
+          class MemSpace = typename Kokkos::DefaultExecutionSpace::memory_space>
 auto create_view(DynamicTag, std::size_t ext0, std::size_t ext1,
                  const std::string label) {
-  using view_t = Kokkos::View<ValueType**>;
+  using view_t = Kokkos::View<ValueType**, MemSpace>;
   view_t view{label + "_" + view_tag_to_string(DynamicTag{}), ext0, ext1};
   return view;
 }
 
 // dynamic layout left
-template <class ValueType>
+template <class ValueType,
+          class MemSpace = typename Kokkos::DefaultExecutionSpace::memory_space>
 auto create_view(DynamicLayoutLeftTag, std::size_t ext0, std::size_t ext1,
                  const std::string label) {
-  using view_t = Kokkos::View<ValueType**, Kokkos::LayoutLeft>;
+  using view_t = Kokkos::View<ValueType**, Kokkos::LayoutLeft, MemSpace>;
   view_t view{label + "_" + view_tag_to_string(DynamicLayoutLeftTag{}), ext0,
               ext1};
   return view;
 }
 
 // dynamic layout right
-template <class ValueType>
+template <class ValueType,
+          class MemSpace = typename Kokkos::DefaultExecutionSpace::memory_space>
 auto create_view(DynamicLayoutRightTag, std::size_t ext0, std::size_t ext1,
                  const std::string label) {
-  using view_t = Kokkos::View<ValueType**, Kokkos::LayoutRight>;
+  using view_t = Kokkos::View<ValueType**, Kokkos::LayoutRight, MemSpace>;
   view_t view{label + "_" + view_tag_to_string(DynamicLayoutRightTag{}), ext0,
               ext1};
   return view;
 }
 
 // stride2rows
-template <class ValueType>
+template <class ValueType,
+          class MemSpace = typename Kokkos::DefaultExecutionSpace::memory_space>
 auto create_view(StridedTwoRowsTag, std::size_t ext0, std::size_t ext1,
                  const std::string label) {
-  using view_t = Kokkos::View<ValueType**, Kokkos::LayoutStride>;
+  using view_t = Kokkos::View<ValueType**, Kokkos::LayoutStride, MemSpace>;
   Kokkos::LayoutStride layout{ext0, 2, ext1, ext0 * 2};
   view_t view{label + "_" + view_tag_to_string(StridedTwoRowsTag{}), layout};
   return view;
 }
 
 // stride3rows
-template <class ValueType>
+template <class ValueType,
+          class MemSpace = typename Kokkos::DefaultExecutionSpace::memory_space>
 auto create_view(StridedThreeRowsTag, std::size_t ext0, std::size_t ext1,
                  const std::string label) {
-  using view_t = Kokkos::View<ValueType**, Kokkos::LayoutStride>;
+  using view_t = Kokkos::View<ValueType**, Kokkos::LayoutStride, MemSpace>;
   Kokkos::LayoutStride layout{ext0, 3, ext1, ext0 * 3};
   view_t view{label + "_" + view_tag_to_string(StridedThreeRowsTag{}), layout};
   return view;

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -207,13 +207,17 @@ template <class ViewType>
 auto create_deep_copyable_compatible_clone(ViewType view) {
   auto view_dc    = create_deep_copyable_compatible_view_with_same_extent(view);
   using view_dc_t = decltype(view_dc);
+  using exe_space = typename view_dc_t::execution_space;
   if constexpr (ViewType::rank == 1) {
     CopyFunctor<ViewType, view_dc_t> F1(view, view_dc);
-    Kokkos::parallel_for("copy", view.extent(0), F1);
+    Kokkos::RangePolicy<exe_space> policy(0, view.extent(0));
+    Kokkos::parallel_for("copy", policy, F1);
+
   } else {
     static_assert(ViewType::rank == 2, "Only rank 1 or 2 supported.");
     CopyFunctorRank2<ViewType, view_dc_t> F1(view, view_dc);
-    Kokkos::parallel_for("copy", view.extent(0) * view.extent(1), F1);
+    Kokkos::RangePolicy<exe_space> policy(0, view.extent(0) * view.extent(1));
+    Kokkos::parallel_for("copy", policy, F1);
   }
   return view_dc;
 }


### PR DESCRIPTION
In https://github.com/kokkos/kokkos/pull/6081, where all files for sorting and random were reorganized, I accidentally forgot to update the `Makefile` inside the unit tests accordingly. To fix that, this PR does this: 

1. it adds those files back so that all sort and random tests are rebuilt when using the makefile

2. simplifies `TestBinSortB.hpp`: this file was using duplicated helper functions because those were not accessible in develop at that time. Now, they are accessible in develop, so we get rid of those and simply use them from `TestStdAlgorithmsCommon.hpp` 

3. because of how the Makefile works (for example if seria/cuda are enabled, the test is enabled for both cuda and serial by passing to the test the actual exespace space to use via a define statement), some code needed to be fixed to allow this behavior to work properly (before it was just assumed to use the default execution space in all cases) 
