### PR TITLE
(fix for issue #6254) Avoid `#186-D pointless comparison warning`.

### DIFF
--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3667,7 +3667,7 @@ class ViewMapping<
     size_t exp_stride = 1;
     if (std::is_same<typename DstTraits::array_layout,
                      Kokkos::LayoutLeft>::value) {
-      for (unsigned int i = 0; i < src.Rank; i++) {
+      for (int i = 0; i < (int)src.Rank; i++) {
         if (i > 0) exp_stride *= src.extent(i - 1);
         if (strides[i] != exp_stride) {
           assignable = false;
@@ -3676,7 +3676,7 @@ class ViewMapping<
       }
     } else if (std::is_same<typename DstTraits::array_layout,
                             Kokkos::LayoutRight>::value) {
-      for (unsigned int i = 0; i < src.Rank; i++) {
+      for (int i = 0; i < (int)src.Rank; i++) {
         if (i > 0) exp_stride *= src.extent(src.Rank - i);
         if (strides[src.Rank - 1 - i] != exp_stride) {
           assignable = false;


### PR DESCRIPTION
This is a follow up of issue #6254.

In this issue, @romintomasetti had raised that `nvcc` gives a `#186-D pointless comparison warning` for a comparison of an `unsigned int` with the rank of a zero-rank view.

In #6254, @ajpowelsnl had asked to open a PR with a fix proposed by @dalg24 (cast to `int`), which was an alternative to a fix proposed by @romintomasetti (new specialisation of `assignable_layout_check` for case of zero rank view).

And so this is the PR with @dalg24's proposed fix :)
