### PR TITLE
team-level stdalgos: improve tests, check intra-team result matching (part 3/7)

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -223,8 +223,16 @@ KOKKOS_FUNCTION bool team_members_have_matching_result(
   // set accum to 1 if a mismach is found
   const bool mismatch = memberValue != target;
   int accum           = static_cast<int>(mismatch);
+  // FIXME_OPENMPTARGET: team API does not meet the TeamHandle concept and
+  // ignores the reducer passed
+#if defined KOKKOS_ENABLE_OPENMPTARGET
+  Kokkos::Sum<int> dummyReducer(accum);
+  const auto result = teamHandle.team_reduce(accum, dummyReducer);
+  return (result == 0);
+#else
   teamHandle.team_reduce(Kokkos::Sum<int>(accum));
   return (accum == 0);
+#endif
 }
 
 template <class ValueType1, class ValueType2>

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -212,6 +212,21 @@ auto create_deep_copyable_compatible_clone(ViewType view) {
 // others
 //
 
+template <class TeamHandleType, class ValueType1, class ValueType2>
+KOKKOS_FUNCTION bool team_members_have_matching_result(
+    const TeamHandleType& teamHandle, const ValueType1 memberValueIn,
+    const ValueType2 targetIn) {
+  using T             = std::common_type_t<ValueType1, ValueType2>;
+  const T memberValue = memberValueIn;
+  const T target      = targetIn;
+
+  // set accum to 1 if a mismach is found
+  const bool mismatch = memberValue != target;
+  int accum           = static_cast<int>(mismatch);
+  teamHandle.team_reduce(Kokkos::Sum<int>(accum));
+  return (accum == 0);
+}
+
 template <class ValueType1, class ValueType2>
 auto make_bounds(const ValueType1& lower, const ValueType2 upper) {
   return Kokkos::pair<ValueType1, ValueType2>{lower, upper};

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamFindFirstOf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamFindFirstOf.cpp
@@ -31,21 +31,25 @@ struct EqualFunctor {
 };
 
 template <class DataViewType, class SearchedSequencesViewType,
-          class DistancesViewType, class BinaryPredType>
+          class DistancesViewType, class IntraTeamSentinelView,
+          class BinaryPredType>
 struct TestFunctorA {
   DataViewType m_dataView;
   SearchedSequencesViewType m_searchedSequencesView;
   DistancesViewType m_distancesView;
+  IntraTeamSentinelView m_intraTeamSentinelView;
   BinaryPredType m_binaryPred;
   int m_apiPick;
 
   TestFunctorA(const DataViewType dataView,
                const SearchedSequencesViewType searchedSequencesView,
-               const DistancesViewType distancesView, BinaryPredType binaryPred,
-               int apiPick)
+               const DistancesViewType distancesView,
+               const IntraTeamSentinelView intraTeamSentinelView,
+               BinaryPredType binaryPred, int apiPick)
       : m_dataView(dataView),
         m_searchedSequencesView(searchedSequencesView),
         m_distancesView(distancesView),
+        m_intraTeamSentinelView(intraTeamSentinelView),
         m_binaryPred(binaryPred),
         m_apiPick(apiPick) {}
 
@@ -55,15 +59,16 @@ struct TestFunctorA {
     auto myRowViewFrom = Kokkos::subview(m_dataView, myRowIndex, Kokkos::ALL());
     auto myRowSearchedSeqView =
         Kokkos::subview(m_searchedSequencesView, myRowIndex, Kokkos::ALL());
+    ptrdiff_t resultDist = 0;
 
     switch (m_apiPick) {
       case 0: {
         auto it = KE::find_first_of(
             member, KE::cbegin(myRowViewFrom), KE::cend(myRowViewFrom),
             KE::cbegin(myRowSearchedSeqView), KE::cend(myRowSearchedSeqView));
+        resultDist = KE::distance(KE::cbegin(myRowViewFrom), it);
         Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-          m_distancesView(myRowIndex) =
-              KE::distance(KE::cbegin(myRowViewFrom), it);
+          m_distancesView(myRowIndex) = resultDist;
         });
 
         break;
@@ -72,9 +77,9 @@ struct TestFunctorA {
       case 1: {
         auto it =
             KE::find_first_of(member, myRowViewFrom, myRowSearchedSeqView);
+        resultDist = KE::distance(KE::begin(myRowViewFrom), it);
         Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-          m_distancesView(myRowIndex) =
-              KE::distance(KE::begin(myRowViewFrom), it);
+          m_distancesView(myRowIndex) = resultDist;
         });
 
         break;
@@ -85,9 +90,9 @@ struct TestFunctorA {
             member, KE::cbegin(myRowViewFrom), KE::cend(myRowViewFrom),
             KE::cbegin(myRowSearchedSeqView), KE::cend(myRowSearchedSeqView),
             m_binaryPred);
+        resultDist = KE::distance(KE::cbegin(myRowViewFrom), it);
         Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-          m_distancesView(myRowIndex) =
-              KE::distance(KE::cbegin(myRowViewFrom), it);
+          m_distancesView(myRowIndex) = resultDist;
         });
 
         break;
@@ -96,14 +101,23 @@ struct TestFunctorA {
       case 3: {
         auto it = KE::find_first_of(member, myRowViewFrom, myRowSearchedSeqView,
                                     m_binaryPred);
+        resultDist = KE::distance(KE::begin(myRowViewFrom), it);
         Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-          m_distancesView(myRowIndex) =
-              KE::distance(KE::begin(myRowViewFrom), it);
+          m_distancesView(myRowIndex) = resultDist;
         });
 
         break;
       }
     }
+
+    // store result of checking if all members have their local
+    // values matching the one stored in m_distancesView
+    member.team_barrier();
+    const bool intraTeamCheck = team_members_have_matching_result(
+        member, resultDist, m_distancesView(myRowIndex));
+    Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
+      m_intraTeamSentinelView(myRowIndex) = intraTeamCheck;
+    });
   }
 };
 
@@ -167,18 +181,21 @@ void test_A(const bool sequencesExist, std::size_t numTeams,
   // beginning of the interval that team operates on and then we check
   // that these distances match the std result
   Kokkos::View<std::size_t*> distancesView("distancesView", numTeams);
+  // sentinel to check if all members of the team compute the same result
+  Kokkos::View<bool*> intraTeamSentinelView("intraTeamSameResult", numTeams);
 
   EqualFunctor<ValueType> binaryPred;
 
   // use CTAD for functor
-  TestFunctorA fnc(dataView, searchedSequencesView, distancesView, binaryPred,
-                   apiId);
+  TestFunctorA fnc(dataView, searchedSequencesView, distancesView,
+                   intraTeamSentinelView, binaryPred, apiId);
   Kokkos::parallel_for(policy, fnc);
 
   // -----------------------------------------------
   // run cpp-std kernel and check
   // -----------------------------------------------
-  auto distancesView_h = create_host_space_copy(distancesView);
+  auto distancesView_h         = create_host_space_copy(distancesView);
+  auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
 
   for (std::size_t i = 0; i < dataView.extent(0); ++i) {
     auto rowFrom = Kokkos::subview(dataViewBeforeOp_h, i, Kokkos::ALL());
@@ -192,6 +209,7 @@ void test_A(const bool sequencesExist, std::size_t numTeams,
 
     const std::size_t beginEndDistance = KE::distance(rowFromBegin, rowFromEnd);
 
+    ASSERT_TRUE(intraTeamSentinelView_h(i));
     switch (apiId) {
       case 0:
       case 1: {

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamSearch.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamSearch.cpp
@@ -31,21 +31,25 @@ struct EqualFunctor {
 };
 
 template <class DataViewType, class SearchedSequencesViewType,
-          class DistancesViewType, class BinaryPredType>
+          class DistancesViewType, class IntraTeamSentinelView,
+          class BinaryPredType>
 struct TestFunctorA {
   DataViewType m_dataView;
   SearchedSequencesViewType m_searchedSequencesView;
   DistancesViewType m_distancesView;
+  IntraTeamSentinelView m_intraTeamSentinelView;
   BinaryPredType m_binaryPred;
   int m_apiPick;
 
   TestFunctorA(const DataViewType dataView,
                const SearchedSequencesViewType searchedSequencesView,
-               const DistancesViewType distancesView, BinaryPredType binaryPred,
-               int apiPick)
+               const DistancesViewType distancesView,
+               const IntraTeamSentinelView intraTeamSentinelView,
+               BinaryPredType binaryPred, int apiPick)
       : m_dataView(dataView),
         m_searchedSequencesView(searchedSequencesView),
         m_distancesView(distancesView),
+        m_intraTeamSentinelView(intraTeamSentinelView),
         m_binaryPred(binaryPred),
         m_apiPick(apiPick) {}
 
@@ -55,15 +59,16 @@ struct TestFunctorA {
     auto myRowViewFrom = Kokkos::subview(m_dataView, myRowIndex, Kokkos::ALL());
     auto myRowSearchedSeqView =
         Kokkos::subview(m_searchedSequencesView, myRowIndex, Kokkos::ALL());
+    ptrdiff_t resultDist = 0;
 
     switch (m_apiPick) {
       case 0: {
         const auto it = KE::search(
             member, KE::cbegin(myRowViewFrom), KE::cend(myRowViewFrom),
             KE::cbegin(myRowSearchedSeqView), KE::cend(myRowSearchedSeqView));
+        resultDist = KE::distance(KE::cbegin(myRowViewFrom), it);
         Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-          m_distancesView(myRowIndex) =
-              KE::distance(KE::cbegin(myRowViewFrom), it);
+          m_distancesView(myRowIndex) = resultDist;
         });
 
         break;
@@ -71,9 +76,9 @@ struct TestFunctorA {
 
       case 1: {
         const auto it = KE::search(member, myRowViewFrom, myRowSearchedSeqView);
+        resultDist    = KE::distance(KE::begin(myRowViewFrom), it);
         Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-          m_distancesView(myRowIndex) =
-              KE::distance(KE::begin(myRowViewFrom), it);
+          m_distancesView(myRowIndex) = resultDist;
         });
 
         break;
@@ -84,9 +89,9 @@ struct TestFunctorA {
             member, KE::cbegin(myRowViewFrom), KE::cend(myRowViewFrom),
             KE::cbegin(myRowSearchedSeqView), KE::cend(myRowSearchedSeqView),
             m_binaryPred);
+        resultDist = KE::distance(KE::cbegin(myRowViewFrom), it);
         Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-          m_distancesView(myRowIndex) =
-              KE::distance(KE::cbegin(myRowViewFrom), it);
+          m_distancesView(myRowIndex) = resultDist;
         });
 
         break;
@@ -95,14 +100,23 @@ struct TestFunctorA {
       case 3: {
         const auto it = KE::search(member, myRowViewFrom, myRowSearchedSeqView,
                                    m_binaryPred);
+        resultDist    = KE::distance(KE::begin(myRowViewFrom), it);
         Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-          m_distancesView(myRowIndex) =
-              KE::distance(KE::begin(myRowViewFrom), it);
+          m_distancesView(myRowIndex) = resultDist;
         });
 
         break;
       }
     }
+
+    // store result of checking if all members have their local
+    // values matching the one stored in m_distancesView
+    member.team_barrier();
+    const bool intraTeamCheck = team_members_have_matching_result(
+        member, resultDist, m_distancesView(myRowIndex));
+    Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
+      m_intraTeamSentinelView(myRowIndex) = intraTeamCheck;
+    });
   }
 };
 
@@ -166,18 +180,21 @@ void test_A(const bool sequencesExist, std::size_t numTeams,
   // that team operates on and then we check that these distances match the std
   // result
   Kokkos::View<std::size_t*> distancesView("distancesView", numTeams);
+  // sentinel to check if all members of the team compute the same result
+  Kokkos::View<bool*> intraTeamSentinelView("intraTeamSameResult", numTeams);
 
   EqualFunctor<ValueType> binaryPred;
 
   // use CTAD for functor
-  TestFunctorA fnc(dataView, searchedSequencesView, distancesView, binaryPred,
-                   apiId);
+  TestFunctorA fnc(dataView, searchedSequencesView, distancesView,
+                   intraTeamSentinelView, binaryPred, apiId);
   Kokkos::parallel_for(policy, fnc);
 
   // -----------------------------------------------
   // run cpp-std kernel and check
   // -----------------------------------------------
-  auto distancesView_h = create_host_space_copy(distancesView);
+  auto distancesView_h         = create_host_space_copy(distancesView);
+  auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
 
   for (std::size_t i = 0; i < dataView.extent(0); ++i) {
     auto rowFrom = Kokkos::subview(dataViewBeforeOp_h, i, Kokkos::ALL());
@@ -191,6 +208,7 @@ void test_A(const bool sequencesExist, std::size_t numTeams,
 
     const std::size_t beginEndDistance = KE::distance(rowFromBegin, rowFromEnd);
 
+    ASSERT_TRUE(intraTeamSentinelView_h(i));
     switch (apiId) {
       case 0:
       case 1: {


### PR DESCRIPTION
This PR improves the tests for team-level algorithms merged in #6205

- `Kokkos_Equal.hpp`
- `Kokkos_Search.hpp`
- `Kokkos_FindEnd.hpp`
- `Kokkos_FindFirstOf.hpp`

to verify that when doing:
```cpp
auto returnValue = Kokkos::Experimental::std_algo_function_name(...)
```
the return value is the *same* for every member of the team. 
Scope: this/these PRs are meant to address the concern raised here https://github.com/kokkos/kokkos/pull/6212

### CONFLICT

Potentially conflicting with any of those in the same batch of PRs due to the `team_members_have_matching_result` function.
