### PR TITLE
Avoid gcc-13 warning about out-of-range access for subviews

### DIFF
--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -450,8 +450,8 @@ struct SubviewExtents {
   }
 
   template <int DRank, int RRank, class T, size_t... DimArgs, class... Args>
-  KOKKOS_FORCEINLINE_FUNCTION bool set(const ViewDimension<DimArgs...>& dim,
-                                       const T& val, Args... args) {
+  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<std::is_integral_v<T>, bool> set(
+      const ViewDimension<DimArgs...>& dim, const T& val, Args... args) {
     const size_t v = static_cast<size_t>(val);
 
     m_begin[DRank] = v;

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -444,104 +444,90 @@ struct SubviewExtents {
   size_t m_length[InternalRangeRank];
   unsigned m_index[InternalRangeRank];
 
-  template <size_t... DimArgs>
-  KOKKOS_FORCEINLINE_FUNCTION bool set(unsigned, unsigned,
-                                       const ViewDimension<DimArgs...>&) {
+  template <int DRank, int RRank, size_t... DimArgs>
+  KOKKOS_FORCEINLINE_FUNCTION bool set(const ViewDimension<DimArgs...>&) {
     return true;
   }
 
-  template <class T, size_t... DimArgs, class... Args>
-  KOKKOS_FORCEINLINE_FUNCTION bool set(unsigned domain_rank,
-                                       unsigned range_rank,
-                                       const ViewDimension<DimArgs...>& dim,
+  template <int DRank, int RRank, class T, size_t... DimArgs, class... Args>
+  KOKKOS_FORCEINLINE_FUNCTION bool set(const ViewDimension<DimArgs...>& dim,
                                        const T& val, Args... args) {
     const size_t v = static_cast<size_t>(val);
 
-    m_begin[domain_rank] = v;
+    m_begin[DRank] = v;
 
-    return set(domain_rank + 1, range_rank, dim, args...)
+    return set<DRank + 1, RRank>(dim, args...)
 #if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-           && (v < dim.extent(domain_rank))
+           && (v < dim.extent(DRank))
 #endif
         ;
   }
 
   // ALL_t
-  template <size_t... DimArgs, class... Args>
-  KOKKOS_FORCEINLINE_FUNCTION bool set(unsigned domain_rank,
-                                       unsigned range_rank,
-                                       const ViewDimension<DimArgs...>& dim,
+  template <int DRank, int RRank, size_t... DimArgs, class... Args>
+  KOKKOS_FORCEINLINE_FUNCTION bool set(const ViewDimension<DimArgs...>& dim,
                                        Kokkos::ALL_t, Args... args) {
     // should never fail but silences a gcc-13 warning
-    if (domain_rank < DomainRank && range_rank < RangeRank) {
-      m_begin[domain_rank] = 0;
-      m_length[range_rank] = dim.extent(domain_rank);
-      m_index[range_rank]  = domain_rank;
+    m_begin[DRank]  = 0;
+    m_length[RRank] = dim.extent(DRank);
+    m_index[RRank]  = DRank;
 
-      return set(domain_rank + 1, range_rank + 1, dim, args...);
-    } else
-      return false;
+    return set<DRank + 1, RRank + 1>(dim, args...);
   }
 
   // std::pair range
-  template <class T, size_t... DimArgs, class... Args>
-  KOKKOS_FORCEINLINE_FUNCTION bool set(unsigned domain_rank,
-                                       unsigned range_rank,
-                                       const ViewDimension<DimArgs...>& dim,
+  template <int DRank, int RRank, class T, size_t... DimArgs, class... Args>
+  KOKKOS_FORCEINLINE_FUNCTION bool set(const ViewDimension<DimArgs...>& dim,
                                        const std::pair<T, T>& val,
                                        Args... args) {
     const size_t b = static_cast<size_t>(val.first);
     const size_t e = static_cast<size_t>(val.second);
 
-    m_begin[domain_rank] = b;
-    m_length[range_rank] = e - b;
-    m_index[range_rank]  = domain_rank;
+    m_begin[DRank]  = b;
+    m_length[RRank] = e - b;
+    m_index[RRank]  = DRank;
 
-    return set(domain_rank + 1, range_rank + 1, dim, args...)
+    return set<DRank + 1, RRank + 1>(dim, args...)
 #if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-           && (e <= b + dim.extent(domain_rank))
+           && (e <= b + dim.extent(DRank))
 #endif
         ;
   }
 
   // Kokkos::pair range
-  template <class T, size_t... DimArgs, class... Args>
-  KOKKOS_FORCEINLINE_FUNCTION bool set(unsigned domain_rank,
-                                       unsigned range_rank,
-                                       const ViewDimension<DimArgs...>& dim,
+  template <int DRank, int RRank, class T, size_t... DimArgs, class... Args>
+  KOKKOS_FORCEINLINE_FUNCTION bool set(const ViewDimension<DimArgs...>& dim,
                                        const Kokkos::pair<T, T>& val,
                                        Args... args) {
     const size_t b = static_cast<size_t>(val.first);
     const size_t e = static_cast<size_t>(val.second);
 
-    m_begin[domain_rank] = b;
-    m_length[range_rank] = e - b;
-    m_index[range_rank]  = domain_rank;
+    m_begin[DRank]  = b;
+    m_length[RRank] = e - b;
+    m_index[RRank]  = DRank;
 
-    return set(domain_rank + 1, range_rank + 1, dim, args...)
+    return set<DRank + 1, RRank + 1>(dim, args...)
 #if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-           && (e <= b + dim.extent(domain_rank))
+           && (e <= b + dim.extent(DRank))
 #endif
         ;
   }
 
   // { begin , end } range
-  template <class T, size_t... DimArgs, class... Args>
-  KOKKOS_FORCEINLINE_FUNCTION bool set(unsigned domain_rank,
-                                       unsigned range_rank,
-                                       const ViewDimension<DimArgs...>& dim,
+  template <int DRank, int RRank, class T, size_t... DimArgs, class... Args>
+  KOKKOS_FORCEINLINE_FUNCTION bool set(const ViewDimension<DimArgs...>& dim,
                                        const std::initializer_list<T>& val,
                                        Args... args) {
     const size_t b = static_cast<size_t>(val.begin()[0]);
     const size_t e = static_cast<size_t>(val.begin()[1]);
 
-    m_begin[domain_rank] = b;
-    m_length[range_rank] = e - b;
-    m_index[range_rank]  = domain_rank;
+    m_begin[DRank]  = b;
+    m_length[RRank] = e - b;
+    m_index[RRank]  = DRank;
 
-    return set(domain_rank + 1, range_rank + 1, dim, args...)
+    return set<DRank + 1, RRank + 1>(dim, args...)
 #if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-           && (val.size() == 2) && (e <= b + dim.extent(domain_rank))
+           && (val.size() == 2) && (e <= b + dim.extent(DRank))
 #endif
         ;
   }
@@ -682,7 +668,7 @@ struct SubviewExtents {
       m_index[0]  = ~0u;
     }
 
-    if (!set(0, 0, dim, args...)) error(dim, args...);
+    if (!set<0, 0>(dim, args...)) error(dim, args...);
   }
 
   template <typename iType>

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -472,11 +472,15 @@ struct SubviewExtents {
                                        unsigned range_rank,
                                        const ViewDimension<DimArgs...>& dim,
                                        Kokkos::ALL_t, Args... args) {
-    m_begin[domain_rank] = 0;
-    m_length[range_rank] = dim.extent(domain_rank);
-    m_index[range_rank]  = domain_rank;
+    // should never fail but silences a gcc-13 warning
+    if (domain_rank < DomainRank && range_rank < RangeRank) {
+      m_begin[domain_rank] = 0;
+      m_length[range_rank] = dim.extent(domain_rank);
+      m_index[range_rank]  = domain_rank;
 
-    return set(domain_rank + 1, range_rank + 1, dim, args...);
+      return set(domain_rank + 1, range_rank + 1, dim, args...);
+    } else
+      return false;
   }
 
   // std::pair range


### PR DESCRIPTION
Using gcc-13 I am seeing warnings such as
```
[...]
[ 27%] Building CXX object core/unit_test/CMakeFiles/Kokkos_CoreUnitTest_Serial2.dir/serial/TestSerial_SubView_c07.cpp.o
In file included from /tmp/kokkos/core/src/Kokkos_View.hpp:490,
                 from /tmp/kokkos/core/src/Kokkos_Parallel.hpp:31,
                 from /tmp/kokkos/core/src/Kokkos_MemoryPool.hpp:26,
                 from /tmp/kokkos/core/src/Kokkos_TaskScheduler.hpp:34,
                 from /tmp/kokkos/core/src/Serial/Kokkos_Serial.hpp:36,
                 from /tmp/kokkos/core/src/decl/Kokkos_Declare_SERIAL.hpp:21,
                 from /tmp/kokkos/build/KokkosCore_Config_DeclareBackend.hpp:22,
                 from /tmp/kokkos/core/src/Kokkos_Core.hpp:45,
                 from /tmp/kokkos/core/unit_test/TestViewSubview.hpp:20,
                 from /tmp/kokkos/core/unit_test/TestSubView_c07.hpp:19,
                 from /tmp/kokkos/build/core/unit_test/serial/TestSerial_SubView_c07.cpp:2:
In member function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 0, 0}; Args = {Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]',
    inlined from 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 0, 0}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]' at /tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:479:15:
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:475:12: error: array subscript 6 is above array bounds of 'size_t [5]' {aka 'long unsigned int [5]'} [-Werror=array-bounds=]
  475 |     m_begin[domain_rank] = 0;
      |     ~~~~~~~^
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp: In function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 0, 0}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]':
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:443:10: note: while referencing 'Kokkos::Impl::SubviewExtents<5, 3>::m_begin'
  443 |   size_t m_begin[DomainRank];
      |          ^~~~~~~
In member function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 0, 0}; Args = {Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]',
    inlined from 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 0, 0}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]' at /tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:479:15:
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:475:12: error: array subscript 5 is above array bounds of 'size_t [5]' {aka 'long unsigned int [5]'} [-Werror=array-bounds=]
  475 |     m_begin[domain_rank] = 0;
      |     ~~~~~~~^
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp: In function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 0, 0}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]':
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:443:10: note: while referencing 'Kokkos::Impl::SubviewExtents<5, 3>::m_begin'
  443 |   size_t m_begin[DomainRank];
      |          ^~~~~~~
In member function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 17, 5, 7}; Args = {Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]',
    inlined from 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 17, 5, 7}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]' at /tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:479:15:
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:475:12: error: array subscript 5 is above array bounds of 'size_t [5]' {aka 'long unsigned int [5]'} [-Werror=array-bounds=]
  475 |     m_begin[domain_rank] = 0;
      |     ~~~~~~~^
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp: In function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 17, 5, 7}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]':
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:443:10: note: while referencing 'Kokkos::Impl::SubviewExtents<5, 3>::m_begin'
  443 |   size_t m_begin[DomainRank];
      |          ^~~~~~~
In member function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 17, 5, 7}; Args = {Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]',
    inlined from 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 17, 5, 7}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]' at /tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:479:15:
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:475:12: error: array subscript 6 is above array bounds of 'size_t [5]' {aka 'long unsigned int [5]'} [-Werror=array-bounds=]
  475 |     m_begin[domain_rank] = 0;
      |     ~~~~~~~^
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp: In function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 17, 5, 7}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]':
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:443:10: note: while referencing 'Kokkos::Impl::SubviewExtents<5, 3>::m_begin'
  443 |   size_t m_begin[DomainRank];
      |          ^~~~~~~
In member function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 11, 17, 5, 7}; Args = {Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]',
    inlined from 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 11, 17, 5, 7}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]' at /tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:479:15:
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:475:12: error: array subscript 5 is above array bounds of 'size_t [5]' {aka 'long unsigned int [5]'} [-Werror=array-bounds=]
  475 |     m_begin[domain_rank] = 0;
      |     ~~~~~~~^
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp: In function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 11, 17, 5, 7}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]':
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:443:10: note: while referencing 'Kokkos::Impl::SubviewExtents<5, 3>::m_begin'
  443 |   size_t m_begin[DomainRank];
      |          ^~~~~~~
In member function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 11, 17, 5, 7}; Args = {}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]',
    inlined from 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 11, 17, 5, 7}; Args = {Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]' at /tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:479:15,
    inlined from 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 11, 17, 5, 7}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]' at /tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:479:15:
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:475:12: error: array subscript 5 is above array bounds of 'size_t [5]' {aka 'long unsigned int [5]'} [-Werror=array-bounds=]
  475 |     m_begin[domain_rank] = 0;
      |     ~~~~~~~^
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp: In function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 11, 17, 5, 7}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]':
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:443:10: note: while referencing 'Kokkos::Impl::SubviewExtents<5, 3>::m_begin'
  443 |   size_t m_begin[DomainRank];
      |          ^~~~~~~
In member function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 0, 7}; Args = {Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]',
    inlined from 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 0, 7}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]' at /tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:479:15:
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:475:12: error: array subscript 5 is above array bounds of 'size_t [5]' {aka 'long unsigned int [5]'} [-Werror=array-bounds=]
  475 |     m_begin[domain_rank] = 0;
      |     ~~~~~~~^
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp: In function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 0, 7}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]':
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:443:10: note: while referencing 'Kokkos::Impl::SubviewExtents<5, 3>::m_begin'
  443 |   size_t m_begin[DomainRank];
      |          ^~~~~~~
In member function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 0, 7}; Args = {Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]',
    inlined from 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 0, 7}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]' at /tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:479:15:
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:475:12: error: array subscript 6 is above array bounds of 'size_t [5]' {aka 'long unsigned int [5]'} [-Werror=array-bounds=]
  475 |     m_begin[domain_rank] = 0;
      |     ~~~~~~~^
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp: In function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 0, 7}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]':
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:443:10: note: while referencing 'Kokkos::Impl::SubviewExtents<5, 3>::m_begin'
  443 |   size_t m_begin[DomainRank];
      |          ^~~~~~~
In member function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 5, 7}; Args = {Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]',
    inlined from 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 5, 7}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]' at /tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:479:15:
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:475:12: error: array subscript 5 is above array bounds of 'size_t [5]' {aka 'long unsigned int [5]'} [-Werror=array-bounds=]
  475 |     m_begin[domain_rank] = 0;
      |     ~~~~~~~^
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp: In function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 5, 7}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]':
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:443:10: note: while referencing 'Kokkos::Impl::SubviewExtents<5, 3>::m_begin'
  443 |   size_t m_begin[DomainRank];
      |          ^~~~~~~
In member function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 5, 7}; Args = {Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]',
    inlined from 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 5, 7}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]' at /tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:479:15:
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:475:12: error: array subscript 6 is above array bounds of 'size_t [5]' {aka 'long unsigned int [5]'} [-Werror=array-bounds=]
  475 |     m_begin[domain_rank] = 0;
      |     ~~~~~~~^
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp: In function 'bool Kokkos::Impl::SubviewExtents<DomainRank, RangeRank>::set(unsigned int, unsigned int, const Kokkos::Impl::ViewDimension<DimArgs ...>&, Kokkos::ALL_t, Args ...) [with long unsigned int ...DimArgs = {0, 0, 0, 5, 7}; Args = {Kokkos::ALL_t, Kokkos::ALL_t}; unsigned int DomainRank = 5; unsigned int RangeRank = 3]':
/tmp/kokkos/core/src/impl/Kokkos_ViewMapping.hpp:443:10: note: while referencing 'Kokkos::Impl::SubviewExtents<5, 3>::m_begin'
  443 |   size_t m_begin[DomainRank];
      |          ^~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [core/unit_test/CMakeFiles/Kokkos_CoreUnitTest_Serial2.dir/serial/TestSerial_SubView_c07.cpp.o] Error 1
make[1]: *** [core/unit_test/CMakeFiles/Kokkos_CoreUnitTest_Serial2.dir/all] Error 2
make: *** [all] Error 2
```
As far as I can tell these warnings are spurious.
This pull request proposes two different solutions to suppress this warning:
1. Guard the offending code with a check for our-of-bounds access and return `false` otherwise (which reports an error).
2. Use template arguments for the running dimensions.
