### PR TITLE
Fix guard for isnan test for bhalf_t

### DIFF
--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1575,7 +1575,6 @@ struct TestIsNaN {
       ++e;
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed isnan(KE::half_t)\n");
     }
-#endif
     if (isnan(static_cast<KE::bhalf_t>(2.f))
 #if !defined(KOKKOS_ENABLE_CUDA)
         || !isnan(quiet_NaN<KE::bhalf_t>::value) ||
@@ -1585,6 +1584,7 @@ struct TestIsNaN {
       ++e;
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed isnan(KE::bhalf_t)\n");
     }
+#endif
     if (isnan(3.)
 #ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
         || !isnan(quiet_NaN<double>::value) ||


### PR DESCRIPTION
Fixes #6420. We don't define this overload for SYCL and HIP, see https://github.com/kokkos/kokkos/blob/9081d366c4a67a5900a512993cfd79a884b73674/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp#L160C1-L162, and already disable the test for `half_t`.
We should investigate the test failures caused when testing `[b]half_t` elsewhere (they already have FIXMEs).