### PR TITLE
Potential data race in HIP parallel reduce

### DIFF
--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -154,7 +154,8 @@ struct HIPReductionsFunctor<FunctorType, false> {
     int const lane_id =
         (threadIdx.y * blockDim.x + threadIdx.x) % HIPTraits::WarpSize;
     for (int delta = skip_vector ? blockDim.x : 1; delta < width; delta *= 2) {
-      if (lane_id + delta < HIPTraits::WarpSize) {
+      if (lane_id + delta < HIPTraits::WarpSize &&
+          (lane_id % (delta * 2) == 0)) {
         functor.join(value, value + delta);
       }
     }


### PR DESCRIPTION
Unnecessary computation creates a potential race condition in HIP. Same as the CUDA version in https://github.com/kokkos/kokkos/pull/6236.