### PR TITLE
[SYCL][Reduce/Scan] Group counter should use at least memory_order::acq_rel

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
@@ -215,7 +215,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                     value_count, reducer, false, wgroup_size);
 
                 if (local_id == 0) {
-                  sycl::atomic_ref<unsigned, sycl::memory_order::relaxed,
+                  sycl::atomic_ref<unsigned, sycl::memory_order::acq_rel,
                                    sycl::memory_scope::device,
                                    sycl::access::address_space::global_space>
                       scratch_flags_ref(*scratch_flags);
@@ -260,7 +260,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                     device_accessible_result_ptr, reducer, false, wgroup_size);
 
                 if (local_id == 0) {
-                  sycl::atomic_ref<unsigned, sycl::memory_order::relaxed,
+                  sycl::atomic_ref<unsigned, sycl::memory_order::acq_rel,
                                    sycl::memory_scope::device,
                                    sycl::access::address_space::global_space>
                       scratch_flags_ref(*scratch_flags);

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
@@ -160,7 +160,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                     value_count, reducer, false, std::min(size, wgroup_size));
 
                 if (local_id == 0) {
-                  sycl::atomic_ref<unsigned, sycl::memory_order::relaxed,
+                  sycl::atomic_ref<unsigned, sycl::memory_order::acq_rel,
                                    sycl::memory_scope::device,
                                    sycl::access::address_space::global_space>
                       scratch_flags_ref(*scratch_flags);
@@ -202,7 +202,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                     std::min(size, wgroup_size));
 
                 if (local_id == 0) {
-                  sycl::atomic_ref<unsigned, sycl::memory_order::relaxed,
+                  sycl::atomic_ref<unsigned, sycl::memory_order::acq_rel,
                                    sycl::memory_scope::device,
                                    sycl::access::address_space::global_space>
                       scratch_flags_ref(*scratch_flags);

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -208,7 +208,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                                                 item.get_local_range()[1]));
 
                   if (local_id == 0) {
-                    sycl::atomic_ref<unsigned, sycl::memory_order::relaxed,
+                    sycl::atomic_ref<unsigned, sycl::memory_order::acq_rel,
                                      sycl::memory_scope::device,
                                      sycl::access::address_space::global_space>
                         scratch_flags_ref(*scratch_flags);
@@ -260,7 +260,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                                                 item.get_local_range()[1]));
 
                   if (local_id == 0) {
-                    sycl::atomic_ref<unsigned, sycl::memory_order::relaxed,
+                    sycl::atomic_ref<unsigned, sycl::memory_order::acq_rel,
                                      sycl::memory_scope::device,
                                      sycl::access::address_space::global_space>
                         scratch_flags_ref(*scratch_flags);

--- a/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
@@ -179,7 +179,7 @@ class ParallelScanSYCLBase {
               group_results[item.get_group_linear_id()] =
                   local_mem[item.get_sub_group().get_group_range()[0] - 1];
 
-              sycl::atomic_ref<unsigned, sycl::memory_order::relaxed,
+              sycl::atomic_ref<unsigned, sycl::memory_order::acq_rel,
                                sycl::memory_scope::device,
                                sycl::access::address_space::global_space>
                   scratch_flags_ref(*scratch_flags);


### PR DESCRIPTION
From https://en.cppreference.com/w/cpp/atomic/memory_order:

> Atomic operations tagged memory_order_relaxed are not synchronization
> operations; they do not impose an order among concurrent memory
> accesses. They only guarantee atomicity and modification order
> consistency.

Yet we want to use that counter exactly for the synchronization purposes - to decide which WG finished last and should perform the final step.

The same issue had been fixed in DPC++ at https://github.com/intel/llvm/pull/8058.