### PR TITLE
team-level stdalgos: improve tests, check intra-team result matching (part 4/7)

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsTeamAllOf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamAllOf.cpp
@@ -33,18 +33,22 @@ struct GreaterThanValueFunctor {
   bool operator()(ValueType val) const { return (val > m_val); }
 };
 
-template <class DataViewType, class AlllOfResultsViewType, class UnaryPredType>
+template <class DataViewType, class AlllOfResultsViewType,
+          class IntraTeamSentinelView, class UnaryPredType>
 struct TestFunctorA {
   DataViewType m_dataView;
   AlllOfResultsViewType m_allOfResultsView;
+  IntraTeamSentinelView m_intraTeamSentinelView;
   int m_apiPick;
   UnaryPredType m_unaryPred;
 
   TestFunctorA(const DataViewType dataView,
-               const AlllOfResultsViewType allOfResultsView, int apiPick,
+               const AlllOfResultsViewType allOfResultsView,
+               const IntraTeamSentinelView intraTeamSentinelView, int apiPick,
                UnaryPredType unaryPred)
       : m_dataView(dataView),
         m_allOfResultsView(allOfResultsView),
+        m_intraTeamSentinelView(intraTeamSentinelView),
         m_apiPick(apiPick),
         m_unaryPred(unaryPred) {}
 
@@ -53,11 +57,12 @@ struct TestFunctorA {
     const auto myRowIndex = member.league_rank();
 
     auto myRowViewFrom = Kokkos::subview(m_dataView, myRowIndex, Kokkos::ALL());
+    bool result        = false;
 
     switch (m_apiPick) {
       case 0: {
-        const bool result = KE::all_of(member, KE::cbegin(myRowViewFrom),
-                                       KE::cend(myRowViewFrom), m_unaryPred);
+        result = KE::all_of(member, KE::cbegin(myRowViewFrom),
+                            KE::cend(myRowViewFrom), m_unaryPred);
         Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
           m_allOfResultsView(myRowIndex) = result;
         });
@@ -65,13 +70,22 @@ struct TestFunctorA {
       }
 
       case 1: {
-        const bool result = KE::all_of(member, myRowViewFrom, m_unaryPred);
+        result = KE::all_of(member, myRowViewFrom, m_unaryPred);
         Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
           m_allOfResultsView(myRowIndex) = result;
         });
         break;
       }
     }
+
+    // store result of checking if all members have their local
+    // values matching the one stored in m_distancesView
+    member.team_barrier();
+    const bool intraTeamCheck = team_members_have_matching_result(
+        member, result, m_allOfResultsView(myRowIndex));
+    Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
+      m_intraTeamSentinelView(myRowIndex) = intraTeamCheck;
+    });
   }
 };
 
@@ -104,23 +118,28 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
   // to verify that things work, each team stores the result of its all_of call,
   // and then we check that these match what we expect
   Kokkos::View<bool*> allOfResultsView("allOfResultsView", numTeams);
+  // sentinel to check if all members of the team compute the same result
+  Kokkos::View<bool*> intraTeamSentinelView("intraTeamSameResult", numTeams);
 
   GreaterThanValueFunctor unaryPred{lowerBound - 1};
 
   // use CTAD for functor
-  TestFunctorA fnc(dataView, allOfResultsView, apiId, unaryPred);
+  TestFunctorA fnc(dataView, allOfResultsView, intraTeamSentinelView, apiId,
+                   unaryPred);
   Kokkos::parallel_for(policy, fnc);
 
   // -----------------------------------------------
   // run cpp-std kernel and check
   // -----------------------------------------------
-  auto allOfResultsView_h = create_host_space_copy(allOfResultsView);
+  auto allOfResultsView_h      = create_host_space_copy(allOfResultsView);
+  auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
 
   for (std::size_t i = 0; i < dataView.extent(0); ++i) {
     auto rowFrom = Kokkos::subview(dataViewBeforeOp_h, i, Kokkos::ALL());
     const bool result =
         std::all_of(KE::cbegin(rowFrom), KE::cend(rowFrom), unaryPred);
     ASSERT_EQ(result, allOfResultsView_h(i));
+    ASSERT_TRUE(intraTeamSentinelView_h(i));
   }
 }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamFind.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamFind.cpp
@@ -23,19 +23,22 @@ namespace TeamFind {
 namespace KE = Kokkos::Experimental;
 
 template <class DataViewType, class SearchedValuesViewType,
-          class DistancesViewType>
+          class DistancesViewType, class IntraTeamSentinelView>
 struct TestFunctorA {
   DataViewType m_dataView;
   SearchedValuesViewType m_searchedValuesView;
   DistancesViewType m_distancesView;
+  IntraTeamSentinelView m_intraTeamSentinelView;
   int m_apiPick;
 
   TestFunctorA(const DataViewType dataView,
                const SearchedValuesViewType searchedValuesView,
-               const DistancesViewType distancesView, int apiPick)
+               const DistancesViewType distancesView,
+               const IntraTeamSentinelView intraTeamSentinelView, int apiPick)
       : m_dataView(dataView),
         m_searchedValuesView(searchedValuesView),
         m_distancesView(distancesView),
+        m_intraTeamSentinelView(intraTeamSentinelView),
         m_apiPick(apiPick) {}
 
   template <class MemberType>
@@ -43,31 +46,39 @@ struct TestFunctorA {
     const auto myRowIndex = member.league_rank();
     auto myRowViewFrom = Kokkos::subview(m_dataView, myRowIndex, Kokkos::ALL());
     const auto searchedValue = m_searchedValuesView(myRowIndex);
+    ptrdiff_t resultDist     = 0;
 
     switch (m_apiPick) {
       case 0: {
-        auto it = KE::find(member, KE::cbegin(myRowViewFrom),
+        auto it    = KE::find(member, KE::cbegin(myRowViewFrom),
                            KE::cend(myRowViewFrom), searchedValue);
-
+        resultDist = KE::distance(KE::cbegin(myRowViewFrom), it);
         Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-          m_distancesView(myRowIndex) =
-              KE::distance(KE::cbegin(myRowViewFrom), it);
+          m_distancesView(myRowIndex) = resultDist;
         });
 
         break;
       }
 
       case 1: {
-        auto it = KE::find(member, myRowViewFrom, searchedValue);
-
+        auto it    = KE::find(member, myRowViewFrom, searchedValue);
+        resultDist = KE::distance(KE::begin(myRowViewFrom), it);
         Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-          m_distancesView(myRowIndex) =
-              KE::distance(KE::begin(myRowViewFrom), it);
+          m_distancesView(myRowIndex) = resultDist;
         });
 
         break;
       }
     }
+
+    // store result of checking if all members have their local
+    // values matching the one stored in m_distancesView
+    member.team_barrier();
+    const bool intraTeamCheck = team_members_have_matching_result(
+        member, resultDist, m_distancesView(myRowIndex));
+    Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
+      m_intraTeamSentinelView(myRowIndex) = intraTeamCheck;
+    });
   }
 };
 
@@ -103,6 +114,8 @@ void test_A(const bool searchedValuesExist, std::size_t numTeams,
   // beginning of the interval that team operates on and then we check
   // that these distances match the std result
   Kokkos::View<std::size_t*> distancesView("distancesView", numTeams);
+  // sentinel to check if all members of the team compute the same result
+  Kokkos::View<bool*> intraTeamSentinelView("intraTeamSameResult", numTeams);
 
   // If searchedValuesExist == true we want to ensure that each value we're
   // looking for exists in dataView. To do that, for each numTeams, a random j
@@ -135,13 +148,15 @@ void test_A(const bool searchedValuesExist, std::size_t numTeams,
   Kokkos::deep_copy(searchedValuesView, searchedValuesView_h);
 
   // use CTAD for functor
-  TestFunctorA fnc(dataView, searchedValuesView, distancesView, apiId);
+  TestFunctorA fnc(dataView, searchedValuesView, distancesView,
+                   intraTeamSentinelView, apiId);
   Kokkos::parallel_for(policy, fnc);
 
   // -----------------------------------------------
   // run cpp-std kernel and check
   // -----------------------------------------------
-  auto distancesView_h = create_host_space_copy(distancesView);
+  auto distancesView_h         = create_host_space_copy(distancesView);
+  auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
 
   for (std::size_t i = 0; i < dataView.extent(0); ++i) {
     auto rowFrom = Kokkos::subview(dataViewBeforeOp_h, i, Kokkos::ALL());
@@ -160,6 +175,7 @@ void test_A(const bool searchedValuesExist, std::size_t numTeams,
     }
 
     ASSERT_EQ(stdDistance, distancesView_h(i));
+    ASSERT_TRUE(intraTeamSentinelView_h(i));
   }
 }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamFindIfNot.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamFindIfNot.cpp
@@ -34,19 +34,22 @@ struct GreaterEqualFunctor {
 };
 
 template <class DataViewType, class GreaterThanValuesViewType,
-          class DistancesViewType>
+          class DistancesViewType, class IntraTeamSentinelView>
 struct TestFunctorA {
   DataViewType m_dataView;
   GreaterThanValuesViewType m_greaterThanValuesView;
   DistancesViewType m_distancesView;
+  IntraTeamSentinelView m_intraTeamSentinelView;
   int m_apiPick;
 
   TestFunctorA(const DataViewType dataView,
                const GreaterThanValuesViewType greaterThanValuesView,
-               DistancesViewType distancesView, int apiPick)
+               DistancesViewType distancesView,
+               const IntraTeamSentinelView intraTeamSentinelView, int apiPick)
       : m_dataView(dataView),
         m_greaterThanValuesView(greaterThanValuesView),
         m_distancesView(distancesView),
+        m_intraTeamSentinelView(intraTeamSentinelView),
         m_apiPick(apiPick) {}
 
   template <class MemberType>
@@ -62,31 +65,39 @@ struct TestFunctorA {
 #else
     GreaterEqualFunctor unaryPred{val};
 #endif
+    ptrdiff_t resultDist = 0;
 
     switch (m_apiPick) {
       case 0: {
-        auto it = KE::find_if_not(member, KE::cbegin(myRowViewFrom),
+        auto it    = KE::find_if_not(member, KE::cbegin(myRowViewFrom),
                                   KE::cend(myRowViewFrom), unaryPred);
-
+        resultDist = KE::distance(KE::cbegin(myRowViewFrom), it);
         Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-          m_distancesView(myRowIndex) =
-              KE::distance(KE::cbegin(myRowViewFrom), it);
+          m_distancesView(myRowIndex) = resultDist;
         });
 
         break;
       }
 
       case 1: {
-        auto it = KE::find_if_not(member, myRowViewFrom, unaryPred);
-
+        auto it    = KE::find_if_not(member, myRowViewFrom, unaryPred);
+        resultDist = KE::distance(KE::begin(myRowViewFrom), it);
         Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-          m_distancesView(myRowIndex) =
-              KE::distance(KE::begin(myRowViewFrom), it);
+          m_distancesView(myRowIndex) = resultDist;
         });
 
         break;
       }
     }
+
+    // store result of checking if all members have their local
+    // values matching the one stored in m_distancesView
+    member.team_barrier();
+    const bool intraTeamCheck = team_members_have_matching_result(
+        member, resultDist, m_distancesView(myRowIndex));
+    Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
+      m_intraTeamSentinelView(myRowIndex) = intraTeamCheck;
+    });
   }
 };
 
@@ -122,6 +133,8 @@ void test_A(const bool predicatesReturnTrue, std::size_t numTeams,
   // beginning of the interval that team operates on and then we check
   // that these distances match the std result
   Kokkos::View<std::size_t*> distancesView("distancesView", numTeams);
+  // sentinel to check if all members of the team compute the same result
+  Kokkos::View<bool*> intraTeamSentinelView("intraTeamSameResult", numTeams);
 
   // If predicatesReturnTrue == true, we want to ensure that for each dataView's
   // row find_if_not always returns end iterator. To do that,
@@ -152,13 +165,16 @@ void test_A(const bool predicatesReturnTrue, std::size_t numTeams,
   Kokkos::deep_copy(greaterEqualValuesView, greaterEqualValuesView_h);
 
   // use CTAD for functor
-  TestFunctorA fnc(dataView, greaterEqualValuesView, distancesView, apiId);
+  TestFunctorA fnc(dataView, greaterEqualValuesView, distancesView,
+                   intraTeamSentinelView, apiId);
   Kokkos::parallel_for(policy, fnc);
 
   // -----------------------------------------------
   // run cpp-std kernel and check
   // -----------------------------------------------
-  auto distancesView_h = create_host_space_copy(distancesView);
+  auto distancesView_h         = create_host_space_copy(distancesView);
+  auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
+
   for (std::size_t i = 0; i < dataView.extent(0); ++i) {
     auto rowFrom = Kokkos::subview(dataViewBeforeOp_h, i, Kokkos::ALL());
     const auto rowFromBegin = KE::cbegin(rowFrom);
@@ -183,6 +199,7 @@ void test_A(const bool predicatesReturnTrue, std::size_t numTeams,
     }
 
     ASSERT_EQ(stdDistance, distancesView_h(i));
+    ASSERT_TRUE(intraTeamSentinelView_h(i));
   }
 }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamNoneOf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamNoneOf.cpp
@@ -33,18 +33,22 @@ struct GreaterThanValueFunctor {
   bool operator()(ValueType val) const { return (val > m_val); }
 };
 
-template <class DataViewType, class NoneOfResultsViewType, class UnaryPredType>
+template <class DataViewType, class NoneOfResultsViewType,
+          class IntraTeamSentinelView, class UnaryPredType>
 struct TestFunctorA {
   DataViewType m_dataView;
   NoneOfResultsViewType m_noneOfResultsView;
+  IntraTeamSentinelView m_intraTeamSentinelView;
   int m_apiPick;
   UnaryPredType m_unaryPred;
 
   TestFunctorA(const DataViewType dataView,
-               const NoneOfResultsViewType noneOfResultsView, int apiPick,
+               const NoneOfResultsViewType noneOfResultsView,
+               const IntraTeamSentinelView intraTeamSentinelView, int apiPick,
                UnaryPredType unaryPred)
       : m_dataView(dataView),
         m_noneOfResultsView(noneOfResultsView),
+        m_intraTeamSentinelView(intraTeamSentinelView),
         m_apiPick(apiPick),
         m_unaryPred(unaryPred) {}
 
@@ -53,11 +57,12 @@ struct TestFunctorA {
     const auto myRowIndex = member.league_rank();
 
     auto myRowViewFrom = Kokkos::subview(m_dataView, myRowIndex, Kokkos::ALL());
+    bool result        = false;
 
     switch (m_apiPick) {
       case 0: {
-        const bool result = KE::none_of(member, KE::cbegin(myRowViewFrom),
-                                        KE::cend(myRowViewFrom), m_unaryPred);
+        result = KE::none_of(member, KE::cbegin(myRowViewFrom),
+                             KE::cend(myRowViewFrom), m_unaryPred);
         Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
           m_noneOfResultsView(myRowIndex) = result;
         });
@@ -65,13 +70,22 @@ struct TestFunctorA {
       }
 
       case 1: {
-        const bool result = KE::none_of(member, myRowViewFrom, m_unaryPred);
+        result = KE::none_of(member, myRowViewFrom, m_unaryPred);
         Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
           m_noneOfResultsView(myRowIndex) = result;
         });
         break;
       }
     }
+
+    // store result of checking if all members have their local
+    // values matching the one stored in m_distancesView
+    member.team_barrier();
+    const bool intraTeamCheck = team_members_have_matching_result(
+        member, result, m_noneOfResultsView(myRowIndex));
+    Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
+      m_intraTeamSentinelView(myRowIndex) = intraTeamCheck;
+    });
   }
 };
 
@@ -104,23 +118,28 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
   // to verify that things work, each team stores the result of its none_of
   // call, and then we check that these match what we expect
   Kokkos::View<bool*> noneOfResultsView("noneOfResultsView", numTeams);
+  // sentinel to check if all members of the team compute the same result
+  Kokkos::View<bool*> intraTeamSentinelView("intraTeamSameResult", numTeams);
 
   GreaterThanValueFunctor unaryPred{upperBound};
 
   // use CTAD for functor
-  TestFunctorA fnc(dataView, noneOfResultsView, apiId, unaryPred);
+  TestFunctorA fnc(dataView, noneOfResultsView, intraTeamSentinelView, apiId,
+                   unaryPred);
   Kokkos::parallel_for(policy, fnc);
 
   // -----------------------------------------------
   // run cpp-std kernel and check
   // -----------------------------------------------
-  auto noneOfResultsView_h = create_host_space_copy(noneOfResultsView);
+  auto noneOfResultsView_h     = create_host_space_copy(noneOfResultsView);
+  auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
 
   for (std::size_t i = 0; i < dataView.extent(0); ++i) {
     auto rowFrom = Kokkos::subview(dataViewBeforeOp_h, i, Kokkos::ALL());
     const bool result =
         std::none_of(KE::cbegin(rowFrom), KE::cend(rowFrom), unaryPred);
     ASSERT_EQ(result, noneOfResultsView_h(i));
+    ASSERT_TRUE(intraTeamSentinelView_h(i));
   }
 }
 


### PR DESCRIPTION
This PR improves the tests for team-level algorithms merged in #6207 

- `Kokkos_Find.hpp`
- `Kokkos_FindIf.hpp` 
- `Kokkos_FindIfNot.hpp` 
- `Kokkos_AllOf.hpp`
- `Kokkos_AnyOf.hpp`
- `Kokkos_NoneOf.hpp`
- `Kokkos_SearchN.hpp`

to verify that when doing:
```cpp
auto returnValue = Kokkos::Experimental::std_algo_function_name(...)
```
the return value is the *same* for every member of the team. 
Scope: this/these PRs are meant to address the concern raised here https://github.com/kokkos/kokkos/pull/6212

### CONFLICT

Potentially conflicting with any of those in the same batch of PRs due to the `team_members_have_matching_result` function.
