### PR TITLE
team-level stdalgos: improve tests, check intra-team result matching (part 5/7)

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsTeamReplaceCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamReplaceCopy.cpp
@@ -38,21 +38,24 @@ struct UnifDist<int> {
 };
 
 template <class SourceViewType, class DestViewType, class DistancesViewType,
-          class ValueType>
+          class IntraTeamSentinelView, class ValueType>
 struct TestFunctorA {
   SourceViewType m_sourceView;
   DestViewType m_destView;
   DistancesViewType m_distancesView;
+  IntraTeamSentinelView m_intraTeamSentinelView;
   ValueType m_targetValue;
   ValueType m_newValue;
   int m_apiPick;
 
   TestFunctorA(const SourceViewType sourceView, const DestViewType destView,
-               const DistancesViewType distancesView, ValueType targetVal,
-               ValueType newVal, int apiPick)
+               const DistancesViewType distancesView,
+               const IntraTeamSentinelView intraTeamSentinelView,
+               ValueType targetVal, ValueType newVal, int apiPick)
       : m_sourceView(sourceView),
         m_destView(destView),
         m_distancesView(distancesView),
+        m_intraTeamSentinelView(intraTeamSentinelView),
         m_targetValue(targetVal),
         m_newValue(newVal),
         m_apiPick(apiPick) {}
@@ -63,24 +66,33 @@ struct TestFunctorA {
     auto myRowViewFrom =
         Kokkos::subview(m_sourceView, myRowIndex, Kokkos::ALL());
     auto myRowViewDest = Kokkos::subview(m_destView, myRowIndex, Kokkos::ALL());
+    ptrdiff_t resultDist = 0;
 
     if (m_apiPick == 0) {
       auto it = KE::replace_copy(
           member, KE::begin(myRowViewFrom), KE::end(myRowViewFrom),
           KE::begin(myRowViewDest), m_targetValue, m_newValue);
-
+      resultDist = KE::distance(KE::begin(myRowViewDest), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) =
-            KE::distance(KE::begin(myRowViewDest), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     } else if (m_apiPick == 1) {
-      auto it = KE::replace_copy(member, myRowViewFrom, myRowViewDest,
+      auto it    = KE::replace_copy(member, myRowViewFrom, myRowViewDest,
                                  m_targetValue, m_newValue);
+      resultDist = KE::distance(KE::begin(myRowViewDest), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) =
-            KE::distance(KE::begin(myRowViewDest), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     }
+
+    // store result of checking if all members have their local
+    // values matching the one stored in m_distancesView
+    member.team_barrier();
+    const bool intraTeamCheck = team_members_have_matching_result(
+        member, resultDist, m_distancesView(myRowIndex));
+    Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
+      m_intraTeamSentinelView(myRowIndex) = intraTeamCheck;
+    });
   }
 };
 
@@ -141,16 +153,19 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
   // beginning of the interval that team operates on and then we check
   // that these distances match the std result
   Kokkos::View<std::size_t*> distancesView("distancesView", numTeams);
+  // sentinel to check if all members of the team compute the same result
+  Kokkos::View<bool*> intraTeamSentinelView("intraTeamSameResult", numTeams);
 
   // use CTAD for functor
-  TestFunctorA fnc(sourceView, destView, distancesView, targetVal, newVal,
-                   apiId);
+  TestFunctorA fnc(sourceView, destView, distancesView, intraTeamSentinelView,
+                   targetVal, newVal, apiId);
   Kokkos::parallel_for(policy, fnc);
 
   // -----------------------------------------------
   // run cpp-std kernel and check
   // -----------------------------------------------
-  auto distancesView_h = create_host_space_copy(distancesView);
+  auto distancesView_h         = create_host_space_copy(distancesView);
+  auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
   Kokkos::View<ValueType**, Kokkos::HostSpace> stdDestView("stdDestView",
                                                            numTeams, numCols);
   for (std::size_t i = 0; i < sourceView_dc_h.extent(0); ++i) {
@@ -160,6 +175,7 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
                                 KE::begin(rowDest), targetVal, newVal);
     const std::size_t stdDistance = KE::distance(KE::begin(rowDest), it);
     ASSERT_EQ(stdDistance, distancesView_h(i));
+    ASSERT_TRUE(intraTeamSentinelView_h(i));
   }
 
   auto dataViewAfterOp_h = create_host_space_copy(destView);


### PR DESCRIPTION
This PR improves the tests for team-level algorithms merged in #6209

- `Kokkos_FillN.hpp` 
- `Kokkos_ReplaceCopy.hpp`
- `Kokkos_ReplaceCopyIf.hpp`

to verify that when doing:
```cpp
auto returnValue = Kokkos::Experimental::std_algo_function_name(...)
```
the return value is the *same* for every member of the team. 
Scope: this/these PRs are meant to address the concern raised here https://github.com/kokkos/kokkos/pull/6212

### CONFLICT

Potentially conflicting with any of those in the same batch of PRs due to the `team_members_have_matching_result` function.
