### PR TITLE
Skip bessel function tests known to fail on Intel GPUs

### DIFF
--- a/core/unit_test/TestMathematicalSpecialFunctions.hpp
+++ b/core/unit_test/TestMathematicalSpecialFunctions.hpp
@@ -1208,7 +1208,7 @@ struct TestComplexBesselI0K0Function {
 
     EXPECT_EQ(h_ref_cbk0(0), h_cbk0(0));
     int upper_limit = N;
-    // FIXME_SYCL Failing for Intel GPUs
+    // FIXME_SYCL Failing for Intel GPUs, 19 is the first failing test case
 #if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_ARCH_INTEL_GPU)
     if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
       upper_limit = 19;
@@ -1457,7 +1457,7 @@ struct TestComplexBesselI1K1Function {
 
     EXPECT_EQ(h_ref_cbk1(0), h_cbk1(0));
     int upper_limit = N;
-    // FIXME_SYCL Failing for Intel GPUs
+    // FIXME_SYCL Failing for Intel GPUs, 8 is the first failing test case
 #if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_ARCH_INTEL_GPU)
     if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
       upper_limit = 8;
@@ -1720,7 +1720,7 @@ struct TestComplexBesselH1Function {
 
     EXPECT_EQ(h_ref_ch11(0), h_ch11(0));
     int upper_limit = N;
-    // FIXME_SYCL Failing for Intel GPUs
+    // FIXME_SYCL Failing for Intel GPUs, 16 is the first failing test case
 #if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_ARCH_INTEL_GPU)
     if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
       upper_limit = 16;
@@ -1913,7 +1913,7 @@ struct TestComplexBesselH2Function {
 
     EXPECT_EQ(h_ref_ch21(0), h_ch21(0));
     int upper_limit = N;
-    // FIXME_SYCL Failing for Intel GPUs
+    // FIXME_SYCL Failing for Intel GPUs, 17 is the first failing test case
 #if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_ARCH_INTEL_GPU)
     if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
       upper_limit = 17;

--- a/core/unit_test/TestMathematicalSpecialFunctions.hpp
+++ b/core/unit_test/TestMathematicalSpecialFunctions.hpp
@@ -1207,9 +1207,16 @@ struct TestComplexBesselI0K0Function {
     }
 
     EXPECT_EQ(h_ref_cbk0(0), h_cbk0(0));
-    for (int i = 1; i < N; i++) {
+    int upper_limit = N;
+    // FIXME_SYCL Failing for Intel GPUs
+#if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_ARCH_INTEL_GPU)
+    if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
+      upper_limit = 19;
+#endif
+    for (int i = 1; i < upper_limit; i++) {
       EXPECT_LE(Kokkos::abs(h_cbk0(i) - h_ref_cbk0(i)),
-                Kokkos::abs(h_ref_cbk0(i)) * 1e-13);
+                Kokkos::abs(h_ref_cbk0(i)) * 1e-13)
+          << "at index " << i;
     }
 #endif
 
@@ -1449,9 +1456,16 @@ struct TestComplexBesselI1K1Function {
     }
 
     EXPECT_EQ(h_ref_cbk1(0), h_cbk1(0));
-    for (int i = 1; i < N; i++) {
+    int upper_limit = N;
+    // FIXME_SYCL Failing for Intel GPUs
+#if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_ARCH_INTEL_GPU)
+    if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
+      upper_limit = 8;
+#endif
+    for (int i = 1; i < upper_limit; i++) {
       EXPECT_LE(Kokkos::abs(h_cbk1(i) - h_ref_cbk1(i)),
-                Kokkos::abs(h_ref_cbk1(i)) * 1e-13);
+                Kokkos::abs(h_ref_cbk1(i)) * 1e-13)
+          << "at index " << i;
     }
 
     ////Test large arguments
@@ -1705,7 +1719,13 @@ struct TestComplexBesselH1Function {
     }
 
     EXPECT_EQ(h_ref_ch11(0), h_ch11(0));
-    for (int i = 1; i < N; i++) {
+    int upper_limit = N;
+    // FIXME_SYCL Failing for Intel GPUs
+#if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_ARCH_INTEL_GPU)
+    if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
+      upper_limit = 16;
+#endif
+    for (int i = 1; i < upper_limit; i++) {
       EXPECT_LE(Kokkos::abs(h_ch11(i) - h_ref_ch11(i)),
                 Kokkos::abs(h_ref_ch11(i)) * 1e-13)
           << "at index " << i;
@@ -1892,9 +1912,16 @@ struct TestComplexBesselH2Function {
     }
 
     EXPECT_EQ(h_ref_ch21(0), h_ch21(0));
-    for (int i = 1; i < N; i++) {
+    int upper_limit = N;
+    // FIXME_SYCL Failing for Intel GPUs
+#if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_ARCH_INTEL_GPU)
+    if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
+      upper_limit = 17;
+#endif
+    for (int i = 1; i < upper_limit; i++) {
       EXPECT_LE(Kokkos::abs(h_ch21(i) - h_ref_ch21(i)),
-                Kokkos::abs(h_ref_ch21(i)) * 1e-13);
+                Kokkos::abs(h_ref_ch21(i)) * 1e-13)
+          << "at index " << i;
     }
 #endif
   }


### PR DESCRIPTION
Fixes #6396, supersedes #6416.
We have reported these test failures to Intel.