### PR TITLE
team-level stdalgos: improve tests, check intra-team result matching (part 6/7)

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsTeamReverseCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamReverseCopy.cpp
@@ -22,18 +22,22 @@ namespace TeamReverseCopy {
 
 namespace KE = Kokkos::Experimental;
 
-template <class SourceViewType, class DestViewType, class DistancesViewType>
+template <class SourceViewType, class DestViewType, class DistancesViewType,
+          class IntraTeamSentinelView>
 struct TestFunctorA {
   SourceViewType m_sourceView;
   DestViewType m_destView;
   DistancesViewType m_distancesView;
+  IntraTeamSentinelView m_intraTeamSentinelView;
   int m_apiPick;
 
   TestFunctorA(const SourceViewType sourceView, const DestViewType destView,
-               const DistancesViewType distancesView, int apiPick)
+               const DistancesViewType distancesView,
+               const IntraTeamSentinelView intraTeamSentinelView, int apiPick)
       : m_sourceView(sourceView),
         m_destView(destView),
         m_distancesView(distancesView),
+        m_intraTeamSentinelView(intraTeamSentinelView),
         m_apiPick(apiPick) {}
 
   template <class MemberType>
@@ -42,23 +46,32 @@ struct TestFunctorA {
     auto myRowViewFrom =
         Kokkos::subview(m_sourceView, myRowIndex, Kokkos::ALL());
     auto myRowViewDest = Kokkos::subview(m_destView, myRowIndex, Kokkos::ALL());
+    ptrdiff_t resultDist = 0;
 
     if (m_apiPick == 0) {
       auto it =
           KE::reverse_copy(member, KE::begin(myRowViewFrom),
                            KE::end(myRowViewFrom), KE::begin(myRowViewDest));
-
+      resultDist = KE::distance(KE::begin(myRowViewDest), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) =
-            KE::distance(KE::begin(myRowViewDest), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     } else if (m_apiPick == 1) {
-      auto it = KE::reverse_copy(member, myRowViewFrom, myRowViewDest);
+      auto it    = KE::reverse_copy(member, myRowViewFrom, myRowViewDest);
+      resultDist = KE::distance(KE::begin(myRowViewDest), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) =
-            KE::distance(KE::begin(myRowViewDest), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     }
+
+    // store result of checking if all members have their local
+    // values matching the one stored in m_distancesView
+    member.team_barrier();
+    const bool intraTeamCheck = team_members_have_matching_result(
+        member, resultDist, m_distancesView(myRowIndex));
+    Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
+      m_intraTeamSentinelView(myRowIndex) = intraTeamCheck;
+    });
   }
 };
 
@@ -93,9 +106,12 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
   // beginning of the interval that team operates on and then we check
   // that these distances match the expectation
   Kokkos::View<std::size_t*> distancesView("distancesView", numTeams);
+  // sentinel to check if all members of the team compute the same result
+  Kokkos::View<bool*> intraTeamSentinelView("intraTeamSameResult", numTeams);
 
   // use CTAD for functor
-  TestFunctorA fnc(sourceView, destView, distancesView, apiId);
+  TestFunctorA fnc(sourceView, destView, distancesView, intraTeamSentinelView,
+                   apiId);
   Kokkos::parallel_for(policy, fnc);
 
   // -----------------------------------------------
@@ -110,6 +126,7 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
     }
     // each team should return an iterator past the last column
     EXPECT_TRUE(distancesView_h(i) == numCols);
+    ASSERT_TRUE(intraTeamSentinelView_h(i));
   }
 }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamReverseCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamReverseCopy.cpp
@@ -117,8 +117,9 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
   // -----------------------------------------------
   // check
   // -----------------------------------------------
-  auto distancesView_h   = create_host_space_copy(distancesView);
-  auto destViewAfterOp_h = create_host_space_copy(destView);
+  auto distancesView_h         = create_host_space_copy(distancesView);
+  auto destViewAfterOp_h       = create_host_space_copy(destView);
+  auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
   for (std::size_t i = 0; i < destViewAfterOp_h.extent(0); ++i) {
     for (std::size_t j = 0; j < destViewAfterOp_h.extent(1); ++j) {
       EXPECT_TRUE(destViewAfterOp_h(i, j) ==

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamRotate.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamRotate.cpp
@@ -115,7 +115,8 @@ void test_A(std::size_t numTeams, std::size_t numCols, std::size_t pivotShift,
   // -----------------------------------------------
   // here I can use cloneOfDataViewBeforeOp_h to run std algo on
   // since that contains a valid copy of the data
-  auto distancesView_h = create_host_space_copy(distancesView);
+  auto distancesView_h         = create_host_space_copy(distancesView);
+  auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
   for (std::size_t i = 0; i < cloneOfDataViewBeforeOp_h.extent(0); ++i) {
     auto myRow = Kokkos::subview(cloneOfDataViewBeforeOp_h, i, Kokkos::ALL());
     auto pivot = KE::begin(myRow) + pivotShift;

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamRotate.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamRotate.cpp
@@ -23,17 +23,20 @@ namespace TeamRotate {
 
 namespace KE = Kokkos::Experimental;
 
-template <class ViewType, class DistancesViewType>
+template <class ViewType, class DistancesViewType, class IntraTeamSentinelView>
 struct TestFunctorA {
   ViewType m_view;
   DistancesViewType m_distancesView;
+  IntraTeamSentinelView m_intraTeamSentinelView;
   std::size_t m_pivotShift;
   int m_apiPick;
 
   TestFunctorA(const ViewType view, const DistancesViewType distancesView,
+               const IntraTeamSentinelView intraTeamSentinelView,
                std::size_t pivotShift, int apiPick)
       : m_view(view),
         m_distancesView(distancesView),
+        m_intraTeamSentinelView(intraTeamSentinelView),
         m_pivotShift(pivotShift),
         m_apiPick(apiPick) {}
 
@@ -41,22 +44,32 @@ struct TestFunctorA {
   KOKKOS_INLINE_FUNCTION void operator()(const MemberType& member) const {
     const auto myRowIndex = member.league_rank();
     auto myRowView        = Kokkos::subview(m_view, myRowIndex, Kokkos::ALL());
+    ptrdiff_t resultDist  = 0;
 
     if (m_apiPick == 0) {
       auto pivot = KE::begin(myRowView) + m_pivotShift;
       auto it =
           KE::rotate(member, KE::begin(myRowView), pivot, KE::end(myRowView));
-
+      resultDist = KE::distance(KE::begin(myRowView), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) = KE::distance(KE::begin(myRowView), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     } else if (m_apiPick == 1) {
-      auto it = KE::rotate(member, myRowView, m_pivotShift);
-
+      auto it    = KE::rotate(member, myRowView, m_pivotShift);
+      resultDist = KE::distance(KE::begin(myRowView), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) = KE::distance(KE::begin(myRowView), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     }
+
+    // store result of checking if all members have their local
+    // values matching the one stored in m_distancesView
+    member.team_barrier();
+    const bool intraTeamCheck = team_members_have_matching_result(
+        member, resultDist, m_distancesView(myRowIndex));
+    Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
+      m_intraTeamSentinelView(myRowIndex) = intraTeamCheck;
+    });
   }
 };
 
@@ -89,9 +102,12 @@ void test_A(std::size_t numTeams, std::size_t numCols, std::size_t pivotShift,
   // beginning of the interval that team operates on and then we check
   // that these distances match the expectation
   Kokkos::View<std::size_t*> distancesView("distancesView", numTeams);
+  // sentinel to check if all members of the team compute the same result
+  Kokkos::View<bool*> intraTeamSentinelView("intraTeamSameResult", numTeams);
 
   // use CTAD for functor
-  TestFunctorA fnc(dataView, distancesView, pivotShift, apiId);
+  TestFunctorA fnc(dataView, distancesView, intraTeamSentinelView, pivotShift,
+                   apiId);
   Kokkos::parallel_for(policy, fnc);
 
   // -----------------------------------------------
@@ -107,6 +123,7 @@ void test_A(std::size_t numTeams, std::size_t numCols, std::size_t pivotShift,
     auto it = std::rotate(KE::begin(myRow), pivot, KE::end(myRow));
     const std::size_t stdDistance = KE::distance(KE::begin(myRow), it);
     ASSERT_EQ(stdDistance, distancesView_h(i));
+    ASSERT_TRUE(intraTeamSentinelView_h(i));
   }
 
   auto dataViewAfterOp_h = create_host_space_copy(dataView);

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamRotateCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamRotateCopy.cpp
@@ -126,7 +126,8 @@ void test_A(std::size_t numTeams, std::size_t numCols, std::size_t pivotShift,
   // -----------------------------------------------
   Kokkos::View<ValueType**, Kokkos::HostSpace> stdDestView("stdDestView",
                                                            numTeams, numCols);
-  auto distancesView_h = create_host_space_copy(distancesView);
+  auto distancesView_h         = create_host_space_copy(distancesView);
+  auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
   for (std::size_t i = 0; i < cloneOfSourceViewBeforeOp_h.extent(0); ++i) {
     auto myRowFrom =
         Kokkos::subview(cloneOfSourceViewBeforeOp_h, i, Kokkos::ALL());

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamRotateCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamRotateCopy.cpp
@@ -128,6 +128,7 @@ void test_A(std::size_t numTeams, std::size_t numCols, std::size_t pivotShift,
                                                            numTeams, numCols);
   auto distancesView_h         = create_host_space_copy(distancesView);
   auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
+
   for (std::size_t i = 0; i < cloneOfSourceViewBeforeOp_h.extent(0); ++i) {
     auto myRowFrom =
         Kokkos::subview(cloneOfSourceViewBeforeOp_h, i, Kokkos::ALL());

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamRotateCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamRotateCopy.cpp
@@ -23,20 +23,24 @@ namespace TeamRotateCopy {
 
 namespace KE = Kokkos::Experimental;
 
-template <class SourceViewType, class DestViewType, class DistancesViewType>
+template <class SourceViewType, class DestViewType, class DistancesViewType,
+          class IntraTeamSentinelView>
 struct TestFunctorA {
   SourceViewType m_sourceView;
   DestViewType m_destView;
   DistancesViewType m_distancesView;
+  IntraTeamSentinelView m_intraTeamSentinelView;
   std::size_t m_pivotShift;
   int m_apiPick;
 
   TestFunctorA(const SourceViewType sourceView, const DestViewType destView,
-               const DistancesViewType distancesView, std::size_t pivotShift,
-               int apiPick)
+               const DistancesViewType distancesView,
+               const IntraTeamSentinelView intraTeamSentinelView,
+               std::size_t pivotShift, int apiPick)
       : m_sourceView(sourceView),
         m_destView(destView),
         m_distancesView(distancesView),
+        m_intraTeamSentinelView(intraTeamSentinelView),
         m_pivotShift(pivotShift),
         m_apiPick(apiPick) {}
 
@@ -46,26 +50,34 @@ struct TestFunctorA {
     auto myRowViewFrom =
         Kokkos::subview(m_sourceView, myRowIndex, Kokkos::ALL());
     auto myRowViewDest = Kokkos::subview(m_destView, myRowIndex, Kokkos::ALL());
+    ptrdiff_t resultDist = 0;
 
     if (m_apiPick == 0) {
       auto pivot = KE::cbegin(myRowViewFrom) + m_pivotShift;
       auto it =
           KE::rotate_copy(member, KE::cbegin(myRowViewFrom), pivot,
                           KE::cend(myRowViewFrom), KE::begin(myRowViewDest));
-
+      resultDist = KE::distance(KE::begin(myRowViewDest), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) =
-            KE::distance(KE::begin(myRowViewDest), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     } else if (m_apiPick == 1) {
       auto it =
           KE::rotate_copy(member, myRowViewFrom, m_pivotShift, myRowViewDest);
-
+      resultDist = KE::distance(KE::begin(myRowViewDest), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) =
-            KE::distance(KE::begin(myRowViewDest), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     }
+
+    // store result of checking if all members have their local
+    // values matching the one stored in m_distancesView
+    member.team_barrier();
+    const bool intraTeamCheck = team_members_have_matching_result(
+        member, resultDist, m_distancesView(myRowIndex));
+    Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
+      m_intraTeamSentinelView(myRowIndex) = intraTeamCheck;
+    });
   }
 };
 
@@ -101,9 +113,12 @@ void test_A(std::size_t numTeams, std::size_t numCols, std::size_t pivotShift,
   // beginning of the interval that team operates on and then we check
   // that these distances match the expectation
   Kokkos::View<std::size_t*> distancesView("distancesView", numTeams);
+  // sentinel to check if all members of the team compute the same result
+  Kokkos::View<bool*> intraTeamSentinelView("intraTeamSameResult", numTeams);
 
   // use CTAD for functor
-  TestFunctorA fnc(sourceView, destView, distancesView, pivotShift, apiId);
+  TestFunctorA fnc(sourceView, destView, distancesView, intraTeamSentinelView,
+                   pivotShift, apiId);
   Kokkos::parallel_for(policy, fnc);
 
   // -----------------------------------------------
@@ -122,6 +137,7 @@ void test_A(std::size_t numTeams, std::size_t numCols, std::size_t pivotShift,
                                KE::cend(myRowFrom), KE::begin(myRowDest));
     const std::size_t stdDistance = KE::distance(KE::begin(myRowDest), it);
     ASSERT_EQ(stdDistance, distancesView_h(i));
+    ASSERT_TRUE(intraTeamSentinelView_h(i));
   }
 
   auto destViewAfterOp_h = create_host_space_copy(destView);


### PR DESCRIPTION
This PR improves the tests for team-level algorithms merged in #6210

- `Kokkos_ReverseCopy.hpp` 
- `Kokkos_Rotate.hpp`
- `Kokkos_RotateCopy.hpp`

to verify that when doing:
```cpp
auto returnValue = Kokkos::Experimental::std_algo_function_name(...)
```
the return value is the *same* for every member of the team. 
Scope: this/these PRs are meant to address the concern raised here https://github.com/kokkos/kokkos/pull/6212

### CONFLICT

Potentially conflicting with any of those in the same batch of PRs due to the `team_members_have_matching_result` function.
