### PR TITLE
team-level stdalgos: improve tests, check intra-team result matching (part 7/7)

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsTeamMoveBackward.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamMoveBackward.cpp
@@ -22,18 +22,22 @@ namespace TeamMovebackward {
 
 namespace KE = Kokkos::Experimental;
 
-template <class SourceViewType, class DestViewType, class DistancesViewType>
+template <class SourceViewType, class DestViewType, class DistancesViewType,
+          class IntraTeamSentinelView>
 struct TestFunctorA {
   SourceViewType m_sourceView;
   DestViewType m_destView;
   DistancesViewType m_distancesView;
+  IntraTeamSentinelView m_intraTeamSentinelView;
   int m_apiPick;
 
   TestFunctorA(const SourceViewType sourceView, const DestViewType destView,
-               const DistancesViewType distancesView, int apiPick)
+               const DistancesViewType distancesView,
+               const IntraTeamSentinelView intraTeamSentinelView, int apiPick)
       : m_sourceView(sourceView),
         m_destView(destView),
         m_distancesView(distancesView),
+        m_intraTeamSentinelView(intraTeamSentinelView),
         m_apiPick(apiPick) {}
 
   template <class MemberType>
@@ -42,23 +46,32 @@ struct TestFunctorA {
     auto myRowViewFrom =
         Kokkos::subview(m_sourceView, myRowIndex, Kokkos::ALL());
     auto myRowViewDest = Kokkos::subview(m_destView, myRowIndex, Kokkos::ALL());
+    ptrdiff_t resultDist = 0;
 
     if (m_apiPick == 0) {
       auto it =
           KE::move_backward(member, KE::cbegin(myRowViewFrom),
                             KE::cend(myRowViewFrom), KE::end(myRowViewDest));
-
+      resultDist = KE::distance(KE::begin(myRowViewDest), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) =
-            KE::distance(KE::begin(myRowViewDest), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     } else if (m_apiPick == 1) {
-      auto it = KE::move_backward(member, myRowViewFrom, myRowViewDest);
+      auto it    = KE::move_backward(member, myRowViewFrom, myRowViewDest);
+      resultDist = KE::distance(KE::begin(myRowViewDest), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) =
-            KE::distance(KE::begin(myRowViewDest), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     }
+
+    // store result of checking if all members have their local
+    // values matching the one stored in m_distancesView
+    member.team_barrier();
+    const bool intraTeamCheck = team_members_have_matching_result(
+        member, resultDist, m_distancesView(myRowIndex));
+    Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
+      m_intraTeamSentinelView(myRowIndex) = intraTeamCheck;
+    });
   }
 };
 
@@ -98,9 +111,12 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
   // beginning of the interval that team operates on and then we check
   // that these distances match the expectation
   Kokkos::View<std::size_t*> distancesView("distancesView", numTeams);
+  // sentinel to check if all members of the team compute the same result
+  Kokkos::View<bool*> intraTeamSentinelView("intraTeamSameResult", numTeams);
 
   // use CTAD for functor
-  TestFunctorA fnc(sourceView, destView, distancesView, apiId);
+  TestFunctorA fnc(sourceView, destView, distancesView, intraTeamSentinelView,
+                   apiId);
   Kokkos::parallel_for(policy, fnc);
 
   // -----------------------------------------------
@@ -110,8 +126,9 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
   // NOT use sourceView henceforth, becuase all its elements
   // have been moved from.
 
-  auto distancesView_h   = create_host_space_copy(distancesView);
-  auto destViewAfterOp_h = create_host_space_copy(destView);
+  auto distancesView_h         = create_host_space_copy(distancesView);
+  auto destViewAfterOp_h       = create_host_space_copy(destView);
+  auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
   for (std::size_t i = 0; i < destViewAfterOp_h.extent(0); ++i) {
     // first extra num of columns should be unchanged
     for (std::size_t j = 0; j < extra; ++j) {
@@ -127,6 +144,7 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
     // each team should have returned an interator whose distance
     // from the beginning of the row should satisfy this
     EXPECT_TRUE(distancesView_h(i) == extra);
+    ASSERT_TRUE(intraTeamSentinelView_h(i));
   }
 }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamShiftRight.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamShiftRight.cpp
@@ -22,17 +22,20 @@ namespace TeamShiftRight {
 
 namespace KE = Kokkos::Experimental;
 
-template <class ViewType, class DistancesViewType>
+template <class ViewType, class DistancesViewType, class IntraTeamSentinelView>
 struct TestFunctorA {
   ViewType m_view;
   DistancesViewType m_distancesView;
+  IntraTeamSentinelView m_intraTeamSentinelView;
   std::size_t m_shift;
   int m_apiPick;
 
   TestFunctorA(const ViewType view, const DistancesViewType distancesView,
+               const IntraTeamSentinelView intraTeamSentinelView,
                std::size_t shift, int apiPick)
       : m_view(view),
         m_distancesView(distancesView),
+        m_intraTeamSentinelView(intraTeamSentinelView),
         m_shift(shift),
         m_apiPick(apiPick) {}
 
@@ -40,21 +43,31 @@ struct TestFunctorA {
   KOKKOS_INLINE_FUNCTION void operator()(const MemberType& member) const {
     const auto myRowIndex = member.league_rank();
     auto myRowView        = Kokkos::subview(m_view, myRowIndex, Kokkos::ALL());
+    ptrdiff_t resultDist  = 0;
 
     if (m_apiPick == 0) {
-      auto it = KE::shift_right(member, KE::begin(myRowView),
+      auto it    = KE::shift_right(member, KE::begin(myRowView),
                                 KE::end(myRowView), m_shift);
-
+      resultDist = KE::distance(KE::begin(myRowView), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) = KE::distance(KE::begin(myRowView), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     } else if (m_apiPick == 1) {
-      auto it = KE::shift_right(member, myRowView, m_shift);
-
+      auto it    = KE::shift_right(member, myRowView, m_shift);
+      resultDist = KE::distance(KE::begin(myRowView), it);
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
-        m_distancesView(myRowIndex) = KE::distance(KE::begin(myRowView), it);
+        m_distancesView(myRowIndex) = resultDist;
       });
     }
+
+    // store result of checking if all members have their local
+    // values matching the one stored in m_distancesView
+    member.team_barrier();
+    const bool intraTeamCheck = team_members_have_matching_result(
+        member, resultDist, m_distancesView(myRowIndex));
+    Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
+      m_intraTeamSentinelView(myRowIndex) = intraTeamCheck;
+    });
   }
 };
 
@@ -106,9 +119,12 @@ void test_A(std::size_t numTeams, std::size_t numCols, std::size_t shift,
   // beginning of the interval that team operates on and then we check
   // that these distances match the expectation
   Kokkos::View<std::size_t*> distancesView("distancesView", numTeams);
+  // sentinel to check if all members of the team compute the same result
+  Kokkos::View<bool*> intraTeamSentinelView("intraTeamSameResult", numTeams);
 
   // use CTAD for functor
-  TestFunctorA fnc(dataView, distancesView, shift, apiId);
+  TestFunctorA fnc(dataView, distancesView, intraTeamSentinelView, shift,
+                   apiId);
   Kokkos::parallel_for(policy, fnc);
 
   // -----------------------------------------------
@@ -116,12 +132,14 @@ void test_A(std::size_t numTeams, std::size_t numCols, std::size_t shift,
   // -----------------------------------------------
   // here I can use cloneOfDataViewBeforeOp_h to run std algo on
   // since that contains a valid copy of the data
-  auto distancesView_h = create_host_space_copy(distancesView);
+  auto distancesView_h         = create_host_space_copy(distancesView);
+  auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
   for (std::size_t i = 0; i < cloneOfDataViewBeforeOp_h.extent(0); ++i) {
     auto myRow = Kokkos::subview(cloneOfDataViewBeforeOp_h, i, Kokkos::ALL());
     auto it    = my_std_shift_right(KE::begin(myRow), KE::end(myRow), shift);
     const std::size_t stdDistance = KE::distance(KE::begin(myRow), it);
     ASSERT_EQ(stdDistance, distancesView_h(i));
+    ASSERT_TRUE(intraTeamSentinelView_h(i));
   }
 
   auto dataViewAfterOp_h = create_host_space_copy(dataView);


### PR DESCRIPTION
This PR improves the tests for team-level algorithms merged in #6211

- `Kokkos_Move.hpp`
- `Kokkos_MoveBackward.hpp`
- `Kokkos_ShiftLeft.hpp`
- `Kokkos_ShiftRight.hpp`

to verify that when doing:
```cpp
auto returnValue = Kokkos::Experimental::std_algo_function_name(...)
```
the return value is the *same* for every member of the team. 
Scope: this/these PRs are meant to address the concern raised here https://github.com/kokkos/kokkos/pull/6212

### CONFLICT

Potentially conflicting with any of those in the same batch of PRs due to the `team_members_have_matching_result` function.
