### PR TITLE
Fix compiling code using Kokkos::printf for OpenMPTarget on Intel GPUs

### DIFF
--- a/core/src/impl/Kokkos_Printf.hpp
+++ b/core/src/impl/Kokkos_Printf.hpp
@@ -39,10 +39,13 @@ KOKKOS_FUNCTION void printf(const char* format, Args... args) {
   else
     sycl::ext::oneapi::experimental::printf(format, args...);
 #else
-  if constexpr (sizeof...(Args) == 0)
-    ::printf("%s", format);
+  if constexpr (sizeof...(Args) == 0) ::printf("%s", format);
+    // FIXME_OPENMPTARGET non-string-literal argument used in printf is not
+    // supported for spir64
+#if !(defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU))
   else
     ::printf(format, args...);
+#endif
 #endif
 }
 

--- a/core/unit_test/TestPrintf.hpp
+++ b/core/unit_test/TestPrintf.hpp
@@ -30,4 +30,8 @@ void test_kokkos_printf() {
   ASSERT_EQ(captured, expected_string);
 }
 
+// FIXME_OPENMPTARGET non-string-literal argument used in printf is not
+// supported for spir64
+#if !(defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU))
 TEST(TEST_CATEGORY, kokkos_printf) { test_kokkos_printf<TEST_EXECSPACE>(); }
+#endif


### PR DESCRIPTION
Compiling the unit tests with `OpenMPTargets` on `Intel GPUs` gives warnings like
```
non-string-literal argument used in printf is not supported for spir64
```
and compilation fails. As a workaround make `Kokkos::printf` a no-op in these cases if there are arguments.