### PR TITLE
OpenMPTarget init-join fix

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.cpp
@@ -67,8 +67,6 @@ void OpenMPTargetExec::verify_initialized(const char* const label) {
     msg.append(" ERROR: not initialized");
     Kokkos::Impl::throw_runtime_exception(msg);
   }
-  OpenMPTargetExec::MAX_ACTIVE_THREADS =
-      Kokkos::Experimental::OpenMPTarget().concurrency();
 }
 
 void* OpenMPTargetExec::m_scratch_ptr         = nullptr;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
@@ -115,6 +115,9 @@ void OpenMPTargetInternal::impl_finalize() {
 void OpenMPTargetInternal::impl_initialize() {
   m_is_initialized = true;
 
+  Kokkos::Impl::OpenMPTargetExec::MAX_ACTIVE_THREADS =
+      Kokkos::Experimental::OpenMPTarget().concurrency();
+
   // FIXME_OPENMPTARGET:  Only fix the number of teams for NVIDIA architectures
   // from Pascal and upwards.
   // FIXME_OPENMPTARGTE: Cray compiler did not yet implement omp_set_num_teams.

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
@@ -112,11 +112,11 @@ void OpenMPTargetInternal::impl_finalize() {
     Kokkos::kokkos_free<Kokkos::Experimental::OpenMPTargetSpace>(
         space.m_uniquetoken_ptr);
 }
+
 void OpenMPTargetInternal::impl_initialize() {
   m_is_initialized = true;
 
-  Kokkos::Impl::OpenMPTargetExec::MAX_ACTIVE_THREADS =
-      Kokkos::Experimental::OpenMPTarget().concurrency();
+  Kokkos::Impl::OpenMPTargetExec::MAX_ACTIVE_THREADS = concurrency();
 
   // FIXME_OPENMPTARGET:  Only fix the number of teams for NVIDIA architectures
   // from Pascal and upwards.

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp
@@ -197,6 +197,10 @@ struct ParallelReduceSpecialize<FunctorType, Kokkos::RangePolicy<PolicyArgs...>,
 
   static void execute_init_join(const FunctorType& f, const PolicyType& p,
                                 PointerType ptr, const bool ptr_on_device) {
+    OpenMPTargetExec::verify_is_process(
+        "Kokkos::Experimental::OpenMPTarget parallel_for");
+    OpenMPTargetExec::verify_initialized(
+        "Kokkos::Experimental::OpenMPTarget parallel_for");
     const auto begin = p.begin();
     const auto end   = p.end();
 
@@ -560,6 +564,10 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
   // RangePolicy. Need a new implementation.
   static void execute_init_join(const FunctorType& f, const PolicyType& p,
                                 PointerType ptr, const bool ptr_on_device) {
+    OpenMPTargetExec::verify_is_process(
+        "Kokkos::Experimental::OpenMPTarget parallel_for");
+    OpenMPTargetExec::verify_initialized(
+        "Kokkos::Experimental::OpenMPTarget parallel_for");
     using FunctorAnalysis =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
                               FunctorType, ValueType>;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp
@@ -84,9 +84,11 @@ struct ParallelReduceSpecialize<FunctorType, Kokkos::RangePolicy<PolicyArgs...>,
   static void execute_reducer(const FunctorType& f, const PolicyType& p,
                               PointerType result_ptr, bool ptr_on_device) {
     OpenMPTargetExec::verify_is_process(
-        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
+        "Kokkos::Experimental::OpenMPTarget RangePolicy "
+        "parallel_reduce:reducer");
     OpenMPTargetExec::verify_initialized(
-        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
+        "Kokkos::Experimental::OpenMPTarget RangePolicy "
+        "parallel_reduce:reducer");
     const auto begin = p.begin();
     const auto end   = p.end();
 
@@ -125,9 +127,11 @@ struct ParallelReduceSpecialize<FunctorType, Kokkos::RangePolicy<PolicyArgs...>,
   static void execute_array(const FunctorType& f, const PolicyType& p,
                             PointerType result_ptr, bool ptr_on_device) {
     OpenMPTargetExec::verify_is_process(
-        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
+        "Kokkos::Experimental::OpenMPTarget RangePolicy "
+        "parallel_reduce:array_reduction");
     OpenMPTargetExec::verify_initialized(
-        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
+        "Kokkos::Experimental::OpenMPTarget RangePolicy "
+        "parallel_reduce:array_reduction");
     const auto begin = p.begin();
     const auto end   = p.end();
 
@@ -198,9 +202,11 @@ struct ParallelReduceSpecialize<FunctorType, Kokkos::RangePolicy<PolicyArgs...>,
   static void execute_init_join(const FunctorType& f, const PolicyType& p,
                                 PointerType ptr, const bool ptr_on_device) {
     OpenMPTargetExec::verify_is_process(
-        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
+        "Kokkos::Experimental::OpenMPTarget RangePolicy "
+        "parallel_reduce:init_join");
     OpenMPTargetExec::verify_initialized(
-        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
+        "Kokkos::Experimental::OpenMPTarget RangePolicy "
+        "parallel_reduce:init_join");
     const auto begin = p.begin();
     const auto end   = p.end();
 
@@ -351,9 +357,11 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
   static void execute_reducer(const FunctorType& f, const PolicyType& p,
                               PointerType result_ptr, bool ptr_on_device) {
     OpenMPTargetExec::verify_is_process(
-        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
+        "Kokkos::Experimental::OpenMPTarget TeamPolicy "
+        "parallel_reduce:reducer");
     OpenMPTargetExec::verify_initialized(
-        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
+        "Kokkos::Experimental::OpenMPTarget TeamPolicy "
+        "parallel_reduce:reducer");
 
     const int league_size   = p.league_size();
     const int team_size     = p.team_size();
@@ -439,9 +447,11 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
   static void execute_array(const FunctorType& f, const PolicyType& p,
                             PointerType result_ptr, bool ptr_on_device) {
     OpenMPTargetExec::verify_is_process(
-        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
+        "Kokkos::Experimental::OpenMPTarget TeamPolicy "
+        "parallel_reduce:array_reduction");
     OpenMPTargetExec::verify_initialized(
-        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
+        "Kokkos::Experimental::OpenMPTarget TeamPolicy "
+        "parallel_reduce:array_reduction");
 
     const int league_size   = p.league_size();
     const int team_size     = p.team_size();
@@ -565,9 +575,11 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
   static void execute_init_join(const FunctorType& f, const PolicyType& p,
                                 PointerType ptr, const bool ptr_on_device) {
     OpenMPTargetExec::verify_is_process(
-        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
+        "Kokkos::Experimental::OpenMPTarget TeamPolicy "
+        "parallel_reduce:init_join ");
     OpenMPTargetExec::verify_initialized(
-        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
+        "Kokkos::Experimental::OpenMPTarget TeamPolicy "
+        "parallel_reduce:init_join");
     using FunctorAnalysis =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
                               FunctorType, ValueType>;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp
@@ -84,9 +84,9 @@ struct ParallelReduceSpecialize<FunctorType, Kokkos::RangePolicy<PolicyArgs...>,
   static void execute_reducer(const FunctorType& f, const PolicyType& p,
                               PointerType result_ptr, bool ptr_on_device) {
     OpenMPTargetExec::verify_is_process(
-        "Kokkos::Experimental::OpenMPTarget parallel_for");
+        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
     OpenMPTargetExec::verify_initialized(
-        "Kokkos::Experimental::OpenMPTarget parallel_for");
+        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
     const auto begin = p.begin();
     const auto end   = p.end();
 
@@ -125,9 +125,9 @@ struct ParallelReduceSpecialize<FunctorType, Kokkos::RangePolicy<PolicyArgs...>,
   static void execute_array(const FunctorType& f, const PolicyType& p,
                             PointerType result_ptr, bool ptr_on_device) {
     OpenMPTargetExec::verify_is_process(
-        "Kokkos::Experimental::OpenMPTarget parallel_for");
+        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
     OpenMPTargetExec::verify_initialized(
-        "Kokkos::Experimental::OpenMPTarget parallel_for");
+        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
     const auto begin = p.begin();
     const auto end   = p.end();
 
@@ -198,9 +198,9 @@ struct ParallelReduceSpecialize<FunctorType, Kokkos::RangePolicy<PolicyArgs...>,
   static void execute_init_join(const FunctorType& f, const PolicyType& p,
                                 PointerType ptr, const bool ptr_on_device) {
     OpenMPTargetExec::verify_is_process(
-        "Kokkos::Experimental::OpenMPTarget parallel_for");
+        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
     OpenMPTargetExec::verify_initialized(
-        "Kokkos::Experimental::OpenMPTarget parallel_for");
+        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
     const auto begin = p.begin();
     const auto end   = p.end();
 
@@ -351,9 +351,9 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
   static void execute_reducer(const FunctorType& f, const PolicyType& p,
                               PointerType result_ptr, bool ptr_on_device) {
     OpenMPTargetExec::verify_is_process(
-        "Kokkos::Experimental::OpenMPTarget parallel_for");
+        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
     OpenMPTargetExec::verify_initialized(
-        "Kokkos::Experimental::OpenMPTarget parallel_for");
+        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
 
     const int league_size   = p.league_size();
     const int team_size     = p.team_size();
@@ -439,9 +439,9 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
   static void execute_array(const FunctorType& f, const PolicyType& p,
                             PointerType result_ptr, bool ptr_on_device) {
     OpenMPTargetExec::verify_is_process(
-        "Kokkos::Experimental::OpenMPTarget parallel_for");
+        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
     OpenMPTargetExec::verify_initialized(
-        "Kokkos::Experimental::OpenMPTarget parallel_for");
+        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
 
     const int league_size   = p.league_size();
     const int team_size     = p.team_size();
@@ -565,9 +565,9 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
   static void execute_init_join(const FunctorType& f, const PolicyType& p,
                                 PointerType ptr, const bool ptr_on_device) {
     OpenMPTargetExec::verify_is_process(
-        "Kokkos::Experimental::OpenMPTarget parallel_for");
+        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
     OpenMPTargetExec::verify_initialized(
-        "Kokkos::Experimental::OpenMPTarget parallel_for");
+        "Kokkos::Experimental::OpenMPTarget parallel_reduce");
     using FunctorAnalysis =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
                               FunctorType, ValueType>;


### PR DESCRIPTION
The PR adds verification for OpenMP process and initialization in init-join reducers.
This also fixes the backward_compatibility test failure with the backend.