### PR TITLE
Moving abort and assert into their own public headers

### DIFF
--- a/Makefile.targets
+++ b/Makefile.targets
@@ -36,6 +36,8 @@ Kokkos_HostSpace_deepcopy.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/impl/
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
 Kokkos_NumericTraits.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/impl/Kokkos_NumericTraits.cpp
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/impl/Kokkos_NumericTraits.cpp
+Kokkos_Abort.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/impl/Kokkos_Abort.cpp
+	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/impl/Kokkos_Abort.cpp
 
 ifeq ($(KOKKOS_INTERNAL_USE_SERIAL), 1)
 Kokkos_Serial.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/Serial/Kokkos_Serial.cpp

--- a/core/src/Kokkos_Abort.hpp
+++ b/core/src/Kokkos_Abort.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_ABORT_HPP
 
 #include <Kokkos_Macros.hpp>
+#include <impl/Kokkos_Printf.hpp>
 #ifdef KOKKOS_ENABLE_CUDA
 #include <Cuda/Kokkos_Cuda_abort.hpp>
 #endif

--- a/core/src/Kokkos_Abort.hpp
+++ b/core/src/Kokkos_Abort.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_ABORT_HPP
 #define KOKKOS_ABORT_HPP
 
+#include <ostream>
 #include <Kokkos_Macros.hpp>
 #include <impl/Kokkos_Printf.hpp>
 #ifdef KOKKOS_ENABLE_CUDA
@@ -32,6 +33,7 @@
 namespace Kokkos {
 namespace Impl {
 
+void traceback_callstack(std::ostream &);
 [[noreturn]] void host_abort(const char *const);
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)

--- a/core/src/Kokkos_Abort.hpp
+++ b/core/src/Kokkos_Abort.hpp
@@ -1,0 +1,104 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_ABORT_HPP
+#define KOKKOS_ABORT_HPP
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_CUDA
+#include <Cuda/Kokkos_Cuda_abort.hpp>
+#endif
+#ifdef KOKKOS_ENABLE_HIP
+#include <HIP/Kokkos_HIP_Abort.hpp>
+#endif
+#ifdef KOKKOS_ENABLE_SYCL
+#include <SYCL/Kokkos_SYCL_Abort.hpp>
+#endif
+
+namespace Kokkos {
+namespace Impl {
+
+[[noreturn]] void host_abort(const char *const);
+
+#if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
+
+#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+// required to workaround failures in random number generator unit tests with
+// pre-volta architectures
+#define KOKKOS_IMPL_ABORT_NORETURN
+#else
+// cuda_abort aborts when building for other platforms than macOS
+#define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]
+#endif
+
+#elif defined(KOKKOS_COMPILER_NVHPC)
+
+#define KOKKOS_IMPL_ABORT_NORETURN
+
+#elif defined(KOKKOS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)
+// HIP aborts
+#define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]
+#elif defined(KOKKOS_ENABLE_SYCL) && defined(__SYCL_DEVICE_ONLY__)
+// FIXME_SYCL SYCL doesn't abort
+#define KOKKOS_IMPL_ABORT_NORETURN
+#elif !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(KOKKOS_ENABLE_OPENACC)
+// Host aborts
+#define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]
+#else
+// Everything else does not abort
+#define KOKKOS_IMPL_ABORT_NORETURN
+#endif
+
+// FIXME_SYCL
+// Accomodate host pass for device functions that are not [[noreturn]]
+#if defined(KOKKOS_ENABLE_SYCL) || \
+    (defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK))
+#define KOKKOS_IMPL_ABORT_NORETURN_DEVICE
+#else
+#define KOKKOS_IMPL_ABORT_NORETURN_DEVICE KOKKOS_IMPL_ABORT_NORETURN
+#endif
+
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) ||          \
+    defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENMPTARGET) || \
+    defined(KOKKOS_ENABLE_OPENACC)
+KOKKOS_IMPL_ABORT_NORETURN_DEVICE inline KOKKOS_IMPL_DEVICE_FUNCTION void
+device_abort(const char *const msg) {
+#if defined(KOKKOS_ENABLE_CUDA)
+  ::Kokkos::Impl::cuda_abort(msg);
+#elif defined(KOKKOS_ENABLE_HIP)
+  ::Kokkos::Impl::hip_abort(msg);
+#elif defined(KOKKOS_ENABLE_SYCL)
+  ::Kokkos::Impl::sycl_abort(msg);
+#elif defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_OPENACC)
+  printf("%s", msg);  // FIXME_OPENMPTARGET FIXME_OPENACC
+#else
+#error faulty logic
+#endif
+}
+#endif
+}  // namespace Impl
+
+KOKKOS_IMPL_ABORT_NORETURN KOKKOS_INLINE_FUNCTION void abort(
+    const char *const message) {
+  KOKKOS_IF_ON_HOST(::Kokkos::Impl::host_abort(message);)
+  KOKKOS_IF_ON_DEVICE(::Kokkos::Impl::device_abort(message);)
+}
+
+#undef KOKKOS_IMPL_ABORT_NORETURN
+
+}  // namespace Kokkos
+
+#endif /* #ifndef KOKKOS_ABORT_HPP */

--- a/core/src/Kokkos_Abort.hpp
+++ b/core/src/Kokkos_Abort.hpp
@@ -17,7 +17,6 @@
 #ifndef KOKKOS_ABORT_HPP
 #define KOKKOS_ABORT_HPP
 
-#include <ostream>
 #include <Kokkos_Macros.hpp>
 #include <impl/Kokkos_Printf.hpp>
 #ifdef KOKKOS_ENABLE_CUDA
@@ -33,7 +32,6 @@
 namespace Kokkos {
 namespace Impl {
 
-void traceback_callstack(std::ostream &);
 [[noreturn]] void host_abort(const char *const);
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)

--- a/core/src/Kokkos_Assert.hpp
+++ b/core/src/Kokkos_Assert.hpp
@@ -1,0 +1,70 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_ASSERT_HPP
+#define KOKKOS_ASSERT_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <Kokkos_Abort.hpp>
+
+#if !defined(NDEBUG) || defined(KOKKOS_ENFORCE_CONTRACTS) || \
+    defined(KOKKOS_ENABLE_DEBUG)
+#define KOKKOS_EXPECTS(...)                                                    \
+  {                                                                            \
+    if (!bool(__VA_ARGS__)) {                                                  \
+      ::Kokkos::abort(                                                         \
+          "Kokkos contract violation:\n  "                                     \
+          "  Expected precondition `" #__VA_ARGS__                             \
+          "` evaluated false.\n"                                               \
+          "Error at " KOKKOS_IMPL_TOSTRING(__FILE__) ":" KOKKOS_IMPL_TOSTRING( \
+              __LINE__) " \n");                                                \
+    }                                                                          \
+  }
+#define KOKKOS_ENSURES(...)                                                    \
+  {                                                                            \
+    if (!bool(__VA_ARGS__)) {                                                  \
+      ::Kokkos::abort(                                                         \
+          "Kokkos contract violation:\n  "                                     \
+          "  Ensured postcondition `" #__VA_ARGS__                             \
+          "` evaluated false.\n"                                               \
+          "Error at " KOKKOS_IMPL_TOSTRING(__FILE__) ":" KOKKOS_IMPL_TOSTRING( \
+              __LINE__) " \n");                                                \
+    }                                                                          \
+  }
+// some projects already define this for themselves, so don't mess
+// them up
+#ifndef KOKKOS_ASSERT
+#define KOKKOS_ASSERT(...)                                                     \
+  {                                                                            \
+    if (!bool(__VA_ARGS__)) {                                                  \
+      ::Kokkos::abort(                                                         \
+          "Kokkos contract violation:\n  "                                     \
+          "  Asserted condition `" #__VA_ARGS__                                \
+          "` evaluated false.\n"                                               \
+          "Error at " KOKKOS_IMPL_TOSTRING(__FILE__) ":" KOKKOS_IMPL_TOSTRING( \
+              __LINE__) " \n");                                                \
+    }                                                                          \
+  }
+#endif  // ifndef KOKKOS_ASSERT
+#else   // not debug mode
+#define KOKKOS_EXPECTS(...)
+#define KOKKOS_ENSURES(...)
+#ifndef KOKKOS_ASSERT
+#define KOKKOS_ASSERT(...)
+#endif  // ifndef KOKKOS_ASSERT
+#endif  // end debug mode ifdefs
+
+#endif /* #ifndef KOKKOS_ASSERT_HPP */

--- a/core/src/impl/Kokkos_Abort.cpp
+++ b/core/src/impl/Kokkos_Abort.cpp
@@ -23,26 +23,20 @@
 #include <Kokkos_Abort.hpp>
 #include <impl/Kokkos_Stacktrace.hpp>
 
-namespace {
-
-void traceback_callstack(std::ostream &msg) {
-#ifdef KOKKOS_IMPL_ENABLE_STACKTRACE
-  msg << "\nBacktrace:\n";
-  save_stacktrace();
-  print_demangled_saved_stacktrace(msg);
-#else
-  msg << "\nTraceback functionality not available\n";
-#endif
-}
-
-}  // namespace
-
 namespace Kokkos {
 namespace Impl {
 
 void host_abort(const char *const message) {
   std::cerr << message;
-  traceback_callstack(std::cerr);
+
+#ifdef KOKKOS_IMPL_ENABLE_STACKTRACE
+  std::cerr << "\nBacktrace:\n";
+  save_stacktrace();
+  print_demangled_saved_stacktrace(std::cerr);
+#else
+  std::cerr << "\nTraceback functionality not available\n";
+#endif
+
   ::abort();
 }
 

--- a/core/src/impl/Kokkos_Abort.cpp
+++ b/core/src/impl/Kokkos_Abort.cpp
@@ -27,7 +27,6 @@
 namespace Kokkos {
 namespace Impl {
 
-void traceback_callstack(std::ostream &);
 void traceback_callstack(std::ostream &msg) {
 #ifdef KOKKOS_IMPL_ENABLE_STACKTRACE
   msg << "\nBacktrace:\n";

--- a/core/src/impl/Kokkos_Abort.cpp
+++ b/core/src/impl/Kokkos_Abort.cpp
@@ -27,7 +27,7 @@
 namespace Kokkos {
 namespace Impl {
 
-void traceback_callstack(std::ostream &msg) {
+inline void traceback_callstack(std::ostream &msg) {
 #ifdef KOKKOS_IMPL_ENABLE_STACKTRACE
   msg << "\nBacktrace:\n";
   save_stacktrace();

--- a/core/src/impl/Kokkos_Abort.cpp
+++ b/core/src/impl/Kokkos_Abort.cpp
@@ -22,12 +22,21 @@
 #include <iostream>
 #include <Kokkos_Abort.hpp>
 #include <impl/Kokkos_Error.hpp>
-
-//----------------------------------------------------------------------------
-//----------------------------------------------------------------------------
+#include <impl/Kokkos_Stacktrace.hpp>
 
 namespace Kokkos {
 namespace Impl {
+
+void traceback_callstack(std::ostream &);
+void traceback_callstack(std::ostream &msg) {
+#ifdef KOKKOS_IMPL_ENABLE_STACKTRACE
+  msg << "\nBacktrace:\n";
+  save_stacktrace();
+  print_demangled_saved_stacktrace(msg);
+#else
+  msg << "\nTraceback functionality not available\n";
+#endif
+}
 
 void host_abort(const char *const message) {
   std::cerr << message;

--- a/core/src/impl/Kokkos_Abort.cpp
+++ b/core/src/impl/Kokkos_Abort.cpp
@@ -21,13 +21,11 @@
 #include <cstdlib>
 #include <iostream>
 #include <Kokkos_Abort.hpp>
-#include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Stacktrace.hpp>
 
-namespace Kokkos {
-namespace Impl {
+namespace {
 
-inline void traceback_callstack(std::ostream &msg) {
+void traceback_callstack(std::ostream &msg) {
 #ifdef KOKKOS_IMPL_ENABLE_STACKTRACE
   msg << "\nBacktrace:\n";
   save_stacktrace();
@@ -36,6 +34,11 @@ inline void traceback_callstack(std::ostream &msg) {
   msg << "\nTraceback functionality not available\n";
 #endif
 }
+
+}  // namespace
+
+namespace Kokkos {
+namespace Impl {
 
 void host_abort(const char *const message) {
   std::cerr << message;

--- a/core/src/impl/Kokkos_Abort.cpp
+++ b/core/src/impl/Kokkos_Abort.cpp
@@ -1,0 +1,39 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+#define KOKKOS_IMPL_PUBLIC_INCLUDE
+#endif
+
+#include <cstdlib>
+#include <iostream>
+#include <Kokkos_Abort.hpp>
+#include <impl/Kokkos_Error.hpp>
+
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+
+namespace Kokkos {
+namespace Impl {
+
+void host_abort(const char *const message) {
+  std::cerr << message;
+  traceback_callstack(std::cerr);
+  ::abort();
+}
+
+}  // namespace Impl
+}  // namespace Kokkos

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -21,7 +21,7 @@
 #include <cstring>
 #include <cstdlib>
 
-#include <iostream>
+#include <ostream>
 #include <sstream>
 #include <iomanip>
 #include <stdexcept>
@@ -46,12 +46,6 @@ void traceback_callstack(std::ostream &msg) {
 
 void throw_runtime_exception(const std::string &msg) {
   throw std::runtime_error(msg);
-}
-
-void host_abort(const char *const message) {
-  std::cerr << message;
-  traceback_callstack(std::cerr);
-  ::abort();
 }
 
 std::string human_memory_size(size_t arg_bytes) {

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -26,7 +26,6 @@
 #include <iomanip>
 #include <stdexcept>
 #include <impl/Kokkos_Error.hpp>
-#include <impl/Kokkos_Stacktrace.hpp>
 #include <Cuda/Kokkos_Cuda_Error.hpp>
 
 //----------------------------------------------------------------------------
@@ -34,15 +33,6 @@
 
 namespace Kokkos {
 namespace Impl {
-void traceback_callstack(std::ostream &msg) {
-#ifdef KOKKOS_IMPL_ENABLE_STACKTRACE
-  msg << "\nBacktrace:\n";
-  save_stacktrace();
-  print_demangled_saved_stacktrace(msg);
-#else
-  msg << "\nTraceback functionality not available\n";
-#endif
-}
 
 void throw_runtime_exception(const std::string &msg) {
   throw std::runtime_error(msg);

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -20,77 +20,10 @@
 #include <string>
 #include <iosfwd>
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_CUDA
-#include <Cuda/Kokkos_Cuda_abort.hpp>
-#endif
-#ifdef KOKKOS_ENABLE_HIP
-#include <HIP/Kokkos_HIP_Abort.hpp>
-#endif
-#ifdef KOKKOS_ENABLE_SYCL
-#include <SYCL/Kokkos_SYCL_Abort.hpp>
-#endif
+#include <Kokkos_Abort.hpp>
 
 namespace Kokkos {
 namespace Impl {
-
-[[noreturn]] void host_abort(const char *const);
-
-#if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
-
-#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-// required to workaround failures in random number generator unit tests with
-// pre-volta architectures
-#define KOKKOS_IMPL_ABORT_NORETURN
-#else
-// cuda_abort aborts when building for other platforms than macOS
-#define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]
-#endif
-
-#elif defined(KOKKOS_COMPILER_NVHPC)
-
-#define KOKKOS_IMPL_ABORT_NORETURN
-
-#elif defined(KOKKOS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)
-// HIP aborts
-#define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]
-#elif defined(KOKKOS_ENABLE_SYCL) && defined(__SYCL_DEVICE_ONLY__)
-// FIXME_SYCL SYCL doesn't abort
-#define KOKKOS_IMPL_ABORT_NORETURN
-#elif !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(KOKKOS_ENABLE_OPENACC)
-// Host aborts
-#define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]
-#else
-// Everything else does not abort
-#define KOKKOS_IMPL_ABORT_NORETURN
-#endif
-
-// FIXME_SYCL
-// Accomodate host pass for device functions that are not [[noreturn]]
-#if defined(KOKKOS_ENABLE_SYCL) || \
-    (defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK))
-#define KOKKOS_IMPL_ABORT_NORETURN_DEVICE
-#else
-#define KOKKOS_IMPL_ABORT_NORETURN_DEVICE KOKKOS_IMPL_ABORT_NORETURN
-#endif
-
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) ||          \
-    defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENMPTARGET) || \
-    defined(KOKKOS_ENABLE_OPENACC)
-KOKKOS_IMPL_ABORT_NORETURN_DEVICE inline KOKKOS_IMPL_DEVICE_FUNCTION void
-device_abort(const char *const msg) {
-#if defined(KOKKOS_ENABLE_CUDA)
-  ::Kokkos::Impl::cuda_abort(msg);
-#elif defined(KOKKOS_ENABLE_HIP)
-  ::Kokkos::Impl::hip_abort(msg);
-#elif defined(KOKKOS_ENABLE_SYCL)
-  ::Kokkos::Impl::sycl_abort(msg);
-#elif defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_OPENACC)
-  printf("%s", msg);  // FIXME_OPENMPTARGET FIXME_OPENACC
-#else
-#error faulty logic
-#endif
-}
-#endif
 
 [[noreturn]] void throw_runtime_exception(const std::string &msg);
 
@@ -192,21 +125,6 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
 };
 
 }  // end namespace Experimental
-
-}  // namespace Kokkos
-
-//----------------------------------------------------------------------------
-//----------------------------------------------------------------------------
-
-namespace Kokkos {
-
-KOKKOS_IMPL_ABORT_NORETURN KOKKOS_INLINE_FUNCTION void abort(
-    const char *const message) {
-  KOKKOS_IF_ON_HOST(::Kokkos::Impl::host_abort(message);)
-  KOKKOS_IF_ON_DEVICE(::Kokkos::Impl::device_abort(message);)
-}
-
-#undef KOKKOS_IMPL_ABORT_NORETURN
 
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -28,8 +28,6 @@ namespace Impl {
 
 [[noreturn]] void throw_runtime_exception(const std::string &msg);
 
-void traceback_callstack(std::ostream &);
-
 std::string human_memory_size(size_t arg_bytes);
 
 }  // namespace Impl

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -21,6 +21,7 @@
 #include <iosfwd>
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Abort.hpp>
+#include <Kokkos_Assert.hpp>
 
 namespace Kokkos {
 namespace Impl {
@@ -127,58 +128,5 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
 }  // end namespace Experimental
 
 }  // namespace Kokkos
-
-//----------------------------------------------------------------------------
-//----------------------------------------------------------------------------
-
-#if !defined(NDEBUG) || defined(KOKKOS_ENFORCE_CONTRACTS) || \
-    defined(KOKKOS_ENABLE_DEBUG)
-#define KOKKOS_EXPECTS(...)                                                    \
-  {                                                                            \
-    if (!bool(__VA_ARGS__)) {                                                  \
-      ::Kokkos::abort(                                                         \
-          "Kokkos contract violation:\n  "                                     \
-          "  Expected precondition `" #__VA_ARGS__                             \
-          "` evaluated false.\n"                                               \
-          "Error at " KOKKOS_IMPL_TOSTRING(__FILE__) ":" KOKKOS_IMPL_TOSTRING( \
-              __LINE__) " \n");                                                \
-    }                                                                          \
-  }
-#define KOKKOS_ENSURES(...)                                                    \
-  {                                                                            \
-    if (!bool(__VA_ARGS__)) {                                                  \
-      ::Kokkos::abort(                                                         \
-          "Kokkos contract violation:\n  "                                     \
-          "  Ensured postcondition `" #__VA_ARGS__                             \
-          "` evaluated false.\n"                                               \
-          "Error at " KOKKOS_IMPL_TOSTRING(__FILE__) ":" KOKKOS_IMPL_TOSTRING( \
-              __LINE__) " \n");                                                \
-    }                                                                          \
-  }
-// some projects already define this for themselves, so don't mess
-// them up
-#ifndef KOKKOS_ASSERT
-#define KOKKOS_ASSERT(...)                                                     \
-  {                                                                            \
-    if (!bool(__VA_ARGS__)) {                                                  \
-      ::Kokkos::abort(                                                         \
-          "Kokkos contract violation:\n  "                                     \
-          "  Asserted condition `" #__VA_ARGS__                                \
-          "` evaluated false.\n"                                               \
-          "Error at " KOKKOS_IMPL_TOSTRING(__FILE__) ":" KOKKOS_IMPL_TOSTRING( \
-              __LINE__) " \n");                                                \
-    }                                                                          \
-  }
-#endif  // ifndef KOKKOS_ASSERT
-#else   // not debug mode
-#define KOKKOS_EXPECTS(...)
-#define KOKKOS_ENSURES(...)
-#ifndef KOKKOS_ASSERT
-#define KOKKOS_ASSERT(...)
-#endif  // ifndef KOKKOS_ASSERT
-#endif  // end debug mode ifdefs
-
-//----------------------------------------------------------------------------
-//----------------------------------------------------------------------------
 
 #endif /* #ifndef KOKKOS_IMPL_ERROR_HPP */


### PR DESCRIPTION
Fixes #5403 

`Kokkos::abort` is now in core/src/Kokkos_Abort.hpp.
`KOKKOS_ASSERT`, `KOKKOS_EXPECTS` & `KOKKOS_ENSURES` is now in core/src/Kokkos_Assert.hpp.

The implementation of `Kokkos::Impl::host_abort` is now in core/src/impl/Kokkos_Abort.cpp.