### PR TITLE
core(spaces): consistency of verify_is_initialized

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -350,19 +350,21 @@ CudaInternal::~CudaInternal() {
   }
 }
 
-int CudaInternal::verify_is_initialized(const char *const label) const {
+bool CudaInternal::verify_is_initialized(const char *const label) const {
   if (m_cudaDev < 0) {
-    Kokkos::abort((std::string("Kokkos::Cuda::") + label +
-                   " : ERROR device not initialized\n")
+    Kokkos::abort((std::string("Kokkos::Cuda : ") + label +
+                   " : ERROR device not initialized")
                       .c_str());
   }
   return 0 <= m_cudaDev;
 }
+
 uint32_t CudaInternal::impl_get_instance_id() const { return m_instance_id; }
 CudaInternal &CudaInternal::singleton() {
   static CudaInternal self;
   return self;
 }
+
 void CudaInternal::fence(const std::string &name) const {
   Impl::cuda_stream_synchronize(get_stream(), this, name);
 }

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -125,7 +125,7 @@ class CudaInternal {
 
   static CudaInternal& singleton();
 
-  int verify_is_initialized(const char* const label) const;
+  bool verify_is_initialized(const char* const label) const;
 
   int is_initialized() const {
     return nullptr != m_scratchSpace && nullptr != m_scratchFlags;

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -128,10 +128,10 @@ HIPInternal::~HIPInternal() {
   m_stream            = nullptr;
 }
 
-int HIPInternal::verify_is_initialized(const char *const label) const {
+bool HIPInternal::verify_is_initialized(const char *const label) const {
   if (m_hipDev < 0) {
-    Kokkos::abort((std::string("Kokkos::HIP::") + label +
-                   " : ERROR device not initialized\n")
+    Kokkos::abort((std::string("Kokkos::HIP : ") + label +
+                   " : ERROR device not initialized")
                       .c_str());
   }
   return 0 <= m_hipDev;

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -117,7 +117,7 @@ class HIPInternal {
 
   static HIPInternal &singleton();
 
-  int verify_is_initialized(const char *const label) const;
+  bool verify_is_initialized(const char *const label) const;
 
   int is_initialized() const {
     return nullptr != m_scratchSpace && nullptr != m_scratchFlags;

--- a/core/src/OpenACC/Kokkos_OpenACC_Instance.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Instance.cpp
@@ -37,7 +37,7 @@ Kokkos::Experimental::Impl::OpenACCInternal::singleton() {
 bool Kokkos::Experimental::Impl::OpenACCInternal::verify_is_initialized(
     const char* const label) const {
   if (!m_is_initialized) {
-    Kokkos::abort((std::string("Kokkos::Experimental::OpenACC::") + label +
+    Kokkos::abort((std::string("Kokkos::Experimental::OpenACC : ") + label +
                    " : ERROR device not initialized\n")
                       .c_str());
   }

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -325,10 +325,12 @@ void OpenMPInternal::print_configuration(std::ostream &s) const {
 
 bool OpenMPInternal::verify_is_initialized(const char *const label) const {
   if (!m_initialized) {
-    std::cerr << "Kokkos::OpenMP " << label
-              << " : ERROR OpenMP is not initialized" << std::endl;
+    Kokkos::abort((std::string("Kokkos::OpenMP : ") + label +
+                   " : ERROR device not initialized")
+                      .c_str());
   }
   return m_initialized;
 }
+
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -62,14 +62,15 @@ SYCLInternal::~SYCLInternal() {
   }
 }
 
-int SYCLInternal::verify_is_initialized(const char* const label) const {
+bool SYCLInternal::verify_is_initialized(const char* const label) const {
   if (!is_initialized()) {
-    Kokkos::abort((std::string("Kokkos::Experimental::SYCL::") + label +
-                   " : ERROR device not initialized\n")
+    Kokkos::abort((std::string("Kokkos::Experimental::SYCL : ") + label +
+                   " : ERROR device not initialized")
                       .c_str());
   }
   return is_initialized();
 }
+
 SYCLInternal& SYCLInternal::singleton() {
   static SYCLInternal self;
   return self;

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -197,7 +197,7 @@ class SYCLInternal {
 
   static SYCLInternal& singleton();
 
-  int verify_is_initialized(const char* const label) const;
+  bool verify_is_initialized(const char* const label) const;
 
   void initialize(const sycl::device& d);
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -629,6 +629,13 @@ IF(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
     ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_Atomics.cpp)
 endif()
 
+KOKKOS_ADD_EXECUTABLE_AND_TEST(
+  CoreUnitTest_Instance
+  SOURCES
+    UnitTestMain.cpp
+    TestInstance.cpp
+)
+
 if(Kokkos_ENABLE_SERIAL)
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     CoreUnitTest_Serial1

--- a/core/unit_test/TestInstance.cpp
+++ b/core/unit_test/TestInstance.cpp
@@ -1,0 +1,44 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+
+namespace Test {
+
+/**
+ * @test Ensure that any execution space fails in a consistent manner when @c Kokkos is not initialized.
+ *
+ * The expected behavior is that the execution space instance constructor aborts
+ * with a message that look s like:
+ *  @code
+ *  Kokkos::<execution space name> : <label> : ERROR device not initialized
+ *  @endcode
+ */
+TEST(TEST_CATEGORY, instance_verify_is_initialized) {
+  using execution_space = Kokkos::DefaultExecutionSpace;
+
+  ASSERT_FALSE(Kokkos::is_initialized());
+
+  ASSERT_EXIT(
+    execution_space space{},
+    ::testing::KilledBySignal(SIGABRT),
+    ::testing::ContainsRegex("Kokkos::[A-Za-z:]+ : [A-Za-z ]+ : ERROR device not initialized")
+  );
+}
+
+} // namespace Test


### PR DESCRIPTION
This PR addresses the main issue discussed in:
- #6447

Basically, `Kokkos::Impl::OpenMPInternal` would not `Kokkos::abort` as others do.

Also, some `...::verify_is_initialized()` would return `bool`, others `int`. I made them all return `bool`.