### PR TITLE
tests: add missing assert for team level `copy_if`

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsTeamCopyIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamCopyIf.cpp
@@ -147,6 +147,7 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
                            KE::begin(rowDest), predicate);
     const std::size_t stdDistance = KE::distance(KE::begin(rowDest), it);
     ASSERT_EQ(stdDistance, distancesView_h(i));
+    ASSERT_TRUE(intraTeamSentinelView_h(i));
   }
 
   auto dataViewAfterOp_h = create_host_space_copy(destView);


### PR DESCRIPTION
somehow this slipped in https://github.com/kokkos/kokkos/pull/6212 