### PR TITLE
fix intel compile error for CTAD

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsTeamFindIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamFindIf.cpp
@@ -54,7 +54,14 @@ struct TestFunctorA {
     const auto myRowIndex = member.league_rank();
     auto myRowViewFrom = Kokkos::subview(m_dataView, myRowIndex, Kokkos::ALL());
     const auto val     = m_greaterThanValuesView(myRowIndex);
+    // FIXME_INTEL
+#if defined(KOKKOS_COMPILER_INTEL) && (1900 == KOKKOS_COMPILER_INTEL)
+    GreaterEqualFunctor<
+        typename GreaterThanValuesViewType::non_const_value_type>
+        unaryPred{val};
+#else
     GreaterEqualFunctor unaryPred{val};
+#endif
 
     switch (m_apiPick) {
       case 0: {
@@ -162,7 +169,12 @@ void test_A(const bool predicatesReturnTrue, std::size_t numTeams,
     const auto rowFromBegin = KE::cbegin(rowFrom);
     const auto rowFromEnd   = KE::cend(rowFrom);
     const auto val          = greaterEqualValuesView_h(i);
+    // FIXME_INTEL
+#if defined(KOKKOS_COMPILER_INTEL) && (1900 == KOKKOS_COMPILER_INTEL)
+    const GreaterEqualFunctor<ValueType> unaryPred{val};
+#else
     const GreaterEqualFunctor unaryPred{val};
+#endif
 
     auto it = std::find_if(rowFromBegin, rowFromEnd, unaryPred);
 

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamFindIfNot.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamFindIfNot.cpp
@@ -54,7 +54,14 @@ struct TestFunctorA {
     const auto myRowIndex = member.league_rank();
     auto myRowViewFrom = Kokkos::subview(m_dataView, myRowIndex, Kokkos::ALL());
     const auto val     = m_greaterThanValuesView(myRowIndex);
+    // FIXME_INTEL
+#if defined(KOKKOS_COMPILER_INTEL) && (1900 == KOKKOS_COMPILER_INTEL)
+    GreaterEqualFunctor<
+        typename GreaterThanValuesViewType::non_const_value_type>
+        unaryPred{val};
+#else
     GreaterEqualFunctor unaryPred{val};
+#endif
 
     switch (m_apiPick) {
       case 0: {
@@ -157,7 +164,12 @@ void test_A(const bool predicatesReturnTrue, std::size_t numTeams,
     const auto rowFromBegin = KE::cbegin(rowFrom);
     const auto rowFromEnd   = KE::cend(rowFrom);
     const auto val          = greaterEqualValuesView_h(i);
+    // FIXME_INTEL
+#if defined(KOKKOS_COMPILER_INTEL) && (1900 == KOKKOS_COMPILER_INTEL)
+    const GreaterEqualFunctor<ValueType> unaryPred{val};
+#else
     const GreaterEqualFunctor unaryPred{val};
+#endif
 
     auto it = std::find_if_not(rowFromBegin, rowFromEnd, unaryPred);
 


### PR DESCRIPTION
fixes https://github.com/kokkos/kokkos/issues/6442

Was also able to reproduce on godbolt: https://godbolt.org/z/MaaaeWxYT
Looks like this version of the intel compiler did not like the const qualifier. 
Also verified it works for higher versions of intel https://godbolt.org/z/GEWocj71q