### PR TITLE
fix unreachable for intel in unit test for math funcs

### DIFF
--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -30,6 +30,12 @@
 #define MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
 #endif
 
+#if defined KOKKOS_COMPILER_INTEL
+#define MATHEMATICAL_FUNCTIONS_TEST_UNREACHABLE __builtin_unreachable();
+#else
+#define MATHEMATICAL_FUNCTIONS_TEST_UNREACHABLE
+#endif
+
 namespace KE = Kokkos::Experimental;
 
 // clang-format off
@@ -318,6 +324,7 @@ struct math_function_name;
                          math_unary_function_return_type_t<T>>::value); \
         return std::FUNC(x);                                            \
       }                                                                 \
+      MATHEMATICAL_FUNCTIONS_TEST_UNREACHABLE                           \
     }                                                                   \
     static KOKKOS_FUNCTION double ulp_factor() { return ULP_FACTOR; }   \
   };                                                                    \
@@ -444,6 +451,7 @@ DEFINE_UNARY_FUNCTION_EVAL(logb, 2);
                          math_binary_function_return_type_t<T, U>>::value);    \
         return std::FUNC(x, y);                                                \
       }                                                                        \
+      MATHEMATICAL_FUNCTIONS_TEST_UNREACHABLE                                  \
     }                                                                          \
     static KOKKOS_FUNCTION double ulp_factor() { return ULP_FACTOR; }          \
   };                                                                           \


### PR DESCRIPTION
fixes https://github.com/kokkos/kokkos/issues/6440
Builds and runs successfully using the reproducer command in the issue

This seems similar to the error solved in https://github.com/kokkos/kokkos/pull/6335