### PR TITLE
fixes build error for TeamReduce and TeamTranformReduced tests for specific GCC

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -254,7 +254,7 @@ auto make_bounds(const ValueType1& lower, const ValueType2 upper) {
   return Kokkos::pair<ValueType1, ValueType2>{lower, upper};
 }
 
-#if defined(__GNUC__) && (KOKKOS_COMPILER_GNU <= 920)
+#if defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE <= 9)
 
 // GCC 8 does not have reduce, transform_reduce, exclusive_scan, inclusive_scan,
 //       transform_exclusive_scan, transform_inclusive_scan

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -254,12 +254,12 @@ auto make_bounds(const ValueType1& lower, const ValueType2 upper) {
   return Kokkos::pair<ValueType1, ValueType2>{lower, upper};
 }
 
+// libstdc++ as provided by GCC 8 does not have reduce, transform_reduce,
+// exclusive_scan, inclusive_scan, transform_exclusive_scan,
+// transform_inclusive_scan and for GCC 9.1, 9.2 fails to compile them for
+// missing overload not accepting policy so use here simplified versions of
+// them, only for testing purpose
 #if defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE <= 9)
-
-// GCC 8 does not have reduce, transform_reduce, exclusive_scan, inclusive_scan,
-//       transform_exclusive_scan, transform_inclusive_scan
-// GCC 9.1, 9.2 fails to compile them for missing overload not accepting policy
-// so use here simplified versions of them, only for testing purpose
 
 template <class InputIterator, class ValueType, class BinaryOp>
 ValueType testing_reduce(InputIterator first, InputIterator last,

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -254,11 +254,12 @@ auto make_bounds(const ValueType1& lower, const ValueType2 upper) {
   return Kokkos::pair<ValueType1, ValueType2>{lower, upper};
 }
 
-#if defined(__GNUC__) && __GNUC__ == 8
+#if defined(__GNUC__) && (KOKKOS_COMPILER_GNU <= 920)
 
-// GCC 8 doesn't come with reduce, transform_reduce, exclusive_scan,
-// inclusive_scan, transform_exclusive_scan and transform_inclusive_scan so here
-// are simplified versions of them, only for testing purpose
+// GCC 8 does not have reduce, transform_reduce, exclusive_scan, inclusive_scan,
+//       transform_exclusive_scan, transform_inclusive_scan
+// GCC 9.1, 9.2 fails to compile them for missing overload not accepting policy
+// so use here simplified versions of them, only for testing purpose
 
 template <class InputIterator, class ValueType, class BinaryOp>
 ValueType testing_reduce(InputIterator first, InputIterator last,

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamReduce.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamReduce.cpp
@@ -196,7 +196,7 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
 
 // GCC 8 does not have reduce
 // GCC 9.1, 9.2 fails to compile for missing overload not accepting policy
-#if defined(__GNUC__) && (KOKKOS_COMPILER_GNU <= 920)
+#if defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE <= 9)
 #define reduce testing_reduce
 #else
 #define reduce std::reduce

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamReduce.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamReduce.cpp
@@ -197,8 +197,7 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
     // libstdc++ as provided by GCC 8 does not have reduce, transform_reduce,
     // exclusive_scan, inclusive_scan, transform_exclusive_scan,
     // transform_inclusive_scan and for GCC 9.1, 9.2 fails to compile them for
-    // missing overload not accepting policy so use here simplified versions of
-    // them, only for testing purpose
+    // missing overload not accepting policy
 
 #if defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE <= 9)
 #define reduce testing_reduce

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamReduce.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamReduce.cpp
@@ -194,8 +194,12 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
 
     ASSERT_TRUE(intraTeamSentinelView_h(i));
 
-// GCC 8 does not have reduce
-// GCC 9.1, 9.2 fails to compile for missing overload not accepting policy
+    // libstdc++ as provided by GCC 8 does not have reduce, transform_reduce,
+    // exclusive_scan, inclusive_scan, transform_exclusive_scan,
+    // transform_inclusive_scan and for GCC 9.1, 9.2 fails to compile them for
+    // missing overload not accepting policy so use here simplified versions of
+    // them, only for testing purpose
+
 #if defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE <= 9)
 #define reduce testing_reduce
 #else

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamReduce.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamReduce.cpp
@@ -194,8 +194,9 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
 
     ASSERT_TRUE(intraTeamSentinelView_h(i));
 
-// GCC 8 does not have reduce so guard against this
-#if defined(__GNUC__) && __GNUC__ == 8
+// GCC 8 does not have reduce
+// GCC 9.1, 9.2 fails to compile for missing overload not accepting policy
+#if defined(__GNUC__) && (KOKKOS_COMPILER_GNU <= 920)
 #define reduce testing_reduce
 #else
 #define reduce std::reduce

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamTransformReduce.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamTransformReduce.cpp
@@ -242,8 +242,7 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
 // libstdc++ as provided by GCC 8 does not have reduce, transform_reduce,
 // exclusive_scan, inclusive_scan, transform_exclusive_scan,
 // transform_inclusive_scan and for GCC 9.1, 9.2 fails to compile them for
-// missing overload not accepting policy so use here simplified versions of
-// them, only for testing purpose
+// missing overload not accepting policy
 #if defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE <= 9)
 #define transform_reduce testing_transform_reduce
 #else

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamTransformReduce.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamTransformReduce.cpp
@@ -241,7 +241,7 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
 
 // GCC 8 does not have transform_reduce
 // GCC 9.1, 9.2 fails to compile for missing overload not accepting policy
-#if defined(__GNUC__) && (KOKKOS_COMPILER_GNU <= 920)
+#if defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE <= 9)
 #define transform_reduce testing_transform_reduce
 #else
 #define transform_reduce std::transform_reduce

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamTransformReduce.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamTransformReduce.cpp
@@ -239,8 +239,11 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
 
     ASSERT_TRUE(intraTeamSentinelView_h(i));
 
-// GCC 8 does not have transform_reduce
-// GCC 9.1, 9.2 fails to compile for missing overload not accepting policy
+// libstdc++ as provided by GCC 8 does not have reduce, transform_reduce,
+// exclusive_scan, inclusive_scan, transform_exclusive_scan,
+// transform_inclusive_scan and for GCC 9.1, 9.2 fails to compile them for
+// missing overload not accepting policy so use here simplified versions of
+// them, only for testing purpose
 #if defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE <= 9)
 #define transform_reduce testing_transform_reduce
 #else

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamTransformReduce.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamTransformReduce.cpp
@@ -239,8 +239,9 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
 
     ASSERT_TRUE(intraTeamSentinelView_h(i));
 
-// GCC 8 does not have transform_reduce so guard against this
-#if defined(__GNUC__) && __GNUC__ == 8
+// GCC 8 does not have transform_reduce
+// GCC 9.1, 9.2 fails to compile for missing overload not accepting policy
+#if defined(__GNUC__) && (KOKKOS_COMPILER_GNU <= 920)
 #define transform_reduce testing_transform_reduce
 #else
 #define transform_reduce std::transform_reduce


### PR DESCRIPTION
Fixes #6458 
Some versions of GCC (8) do not have some algorithms, and some newer ones (9.1, 9.2) fail to compile when calling the overload without the policy. This PR tightens the guard in the tests accordingly.

See https://godbolt.org/z/qWv9v8Kbz for `std::reduce`, `std::transform_reduce`

<br>


NOTE: while the issue #6458 was about `reduce` and `transform_reduced`, this PR fixes the guard preemptively also the other algorithms that have a similar problem

See https://godbolt.org/z/GvEYj634c for `{ex,in}clusive_scan`, `transform_{ex,in}clusive_scan`, 


