### PR TITLE
fix cast warning in `TestRandom.cpp` test for Windows

### DIFF
--- a/algorithms/unit_tests/TestRandom.hpp
+++ b/algorithms/unit_tests/TestRandom.hpp
@@ -521,7 +521,7 @@ void test_duplicate_stream() {
   std::vector<size_t> indices(n_streams);
   std::iota(indices.begin(), indices.end(), 0);
 
-  auto comparator = [&](int i, int j) {
+  auto comparator = [&](size_t i, size_t j) {
     for (int k = 0; k < samples; k++) {
       if (vals_h(i, k) != vals_h(j, k)) return vals_h(i, k) < vals_h(j, k);
     }


### PR DESCRIPTION
I noticed that the current Windows CI emits this warning (has been there for a while) related to the `TestRandom.cpp`:
```
Generating Code...
  Kokkos_StackTraceTestExec.vcxproj -> C:\projects\source\build\core\unit_test\Debug\Kokkos_StackTraceTestExec.exe
  Building Custom Rule C:/projects/source/algorithms/unit_tests/CMakeLists.txt
  UnitTestMain.cpp
  TestRandom.cpp
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\xutility(240,43): warning C4244: 'argument': conversion from 'unsigned __int64' to 'int', possible loss of data [C:\projects\source\build\algorithms\unit_tests\Kokkos_UnitTest_Random.vcxproj]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\xutility(1455): message : see reference to function template instantiation 'decltype(auto) std::_Ref_fn<_Pr>::operator ()<unsigned __int64&,unsigned __int64&>(unsigned __int64 &,unsigned __int64 &)' being compiled [C:\projects\source\build\algorithms\unit_tests\Kokkos_UnitTest_Random.vcxproj]
          with
          [
              _Pr=Test::AlgoRandomImpl::test_duplicate_stream::<lambda_f225653e1552d8ea9cec822e66667b6f>
          ]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\xutility(1454): message : see reference to function template instantiation 'bool std::_Debug_lt_pred<_Pr&,unsigned __int64&,unsigned __int64&,0>(std::_Ref_fn<Test::AlgoRandomImpl::test_duplicate_stream::<lambda_f225653e1552d8ea9cec822e66667b6f>>&,_Ty1,_Ty2) noexcept(<expr>)' being compiled [C:\projects\source\build\algorithms\unit_tests\Kokkos_UnitTest_Random.vcxproj]
          with
          [
              _Pr=std::_Ref_fn<Test::AlgoRandomImpl::test_duplicate_stream::<lambda_f225653e1552d8ea9cec822e66667b6f>>,
              _Ty1=unsigned __int64 &,
              _Ty2=unsigned __int64 &
          ]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\algorithm(7050): message : see reference to function template instantiation '_BidIt std::_Insertion_sort_unchecked<_RanIt,_Pr>(const _BidIt,const _BidIt,_Pr)' being compiled [C:\projects\source\build\algorithms\unit_tests\Kokkos_UnitTest_Random.vcxproj]
          with
          [
              _BidIt=unsigned __int64 *,
              _RanIt=unsigned __int64 *,
              _Pr=std::_Ref_fn<Test::AlgoRandomImpl::test_duplicate_stream::<lambda_f225653e1552d8ea9cec822e66667b6f>>
          ]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\algorithm(7080): message : see reference to function template instantiation 'void std::_Sort_unchecked<unsigned __int64*,std::_Ref_fn<_Pr>>(_RanIt,_RanIt,__int64,std::_Ref_fn<_Pr>)' being compiled [C:\projects\source\build\algorithms\unit_tests\Kokkos_UnitTest_Random.vcxproj]
          with
          [
              _Pr=Test::AlgoRandomImpl::test_duplicate_stream::<lambda_f225653e1552d8ea9cec822e66667b6f>,
              _RanIt=unsigned __int64 *
          ]
C:\projects\source\algorithms\unit_tests\TestRandom.hpp([530](https://ci.appveyor.com/project/dalg24/kokkos/builds/48079547#L530)): message : see reference to function template instantiation 'void std::sort<std::_Vector_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>,Test::AlgoRandomImpl::test_duplicate_stream::<lambda_f225653e1552d8ea9cec822e66667b6f>>(const _RanIt,const _RanIt,_Pr)' being compiled [C:\projects\source\build\algorithms\unit_tests\Kokkos_UnitTest_Random.vcxproj]
          with
          [
              _Ty=size_t,
              _RanIt=std::_Vector_iterator<std::_Vector_val<std::_Simple_types<size_t>>>,
              _Pr=Test::AlgoRandomImpl::test_duplicate_stream::<lambda_f225653e1552d8ea9cec822e66667b6f>
          ]
C:\projects\source\algorithms\unit_tests\TestRandom.hpp(600): message : see reference to function template instantiation 'void Test::AlgoRandomImpl::test_duplicate_stream<ExecutionSpace,Pool64>(void)' being compiled [C:\projects\source\build\algorithms\unit_tests\Kokkos_UnitTest_Random.vcxproj]

```

<br>

This PR fixes it (see below the relevant output and the CI https://ci.appveyor.com/project/dalg24/kokkos/builds/48082667):

<img width="1121" alt="image" src="https://github.com/kokkos/kokkos/assets/18708772/c8e6d215-d40f-4141-b3c5-2140a50ee5ae">

<br>
<br>

NOTE: a separate PR https://github.com/kokkos/kokkos/pull/6339 is WIP to fix the warning for BinSort