### PR TITLE
HIP: Restrict AVX2 workaround to ROCm 5.6 and 5.7

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -25,10 +25,9 @@
 
 #include <immintrin.h>
 
-// FIXME_HIP ROCm 5.6 can't compile with the intrinsic used here.
-#if defined(__HIPCC__) &&       \
-    ((HIP_VERSION_MAJOR > 5) || \
-     ((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR >= 6)))
+// FIXME_HIP ROCm 5.6 and 5.7 can't compile with the intrinsic used here.
+#if defined(__HIPCC__) && (HIP_VERSION_MAJOR == 5) && \
+    ((HIP_VERSION_MINOR == 6) || (HIP_VERSION_MINOR == 7))
 #define KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
 #endif
 


### PR DESCRIPTION
Follow-up to https://github.com/kokkos/kokkos/pull/6449#discussion_r1333162868:
> Let's change the condition to only check for ROCm 5.6 and 5.7. I've talked with AMD and it's easier for the compiler team to fix the issue if they can just pull Kokkos without having to mess with our code to reproduce the error.