### PR TITLE
SIMD: Math functions should be in namespace Kokkos

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -629,81 +629,99 @@ class simd<double, simd_abi::avx2_fixed_size<4>> {
   }
 };
 
+}  // namespace Experimental
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> copysign(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<double, simd_abi::avx2_fixed_size<4>> const& b) {
+Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> copysign(
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
   __m256d const sign_mask = _mm256_set1_pd(-0.0);
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_xor_pd(_mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)),
                     _mm256_and_pd(sign_mask, static_cast<__m256d>(b))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> abs(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
+Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> abs(
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   __m256d const sign_mask = _mm256_set1_pd(-0.0);
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> sqrt(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
+Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> sqrt(
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_sqrt_pd(static_cast<__m256d>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> cbrt(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
+Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> cbrt(
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cbrt_pd(static_cast<__m256d>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> exp(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
+Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> exp(
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_exp_pd(static_cast<__m256d>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> log(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
+Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> log(
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_log_pd(static_cast<__m256d>(a)));
 }
 
 #endif
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> fma(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<double, simd_abi::avx2_fixed_size<4>> const& b,
-    simd<double, simd_abi::avx2_fixed_size<4>> const& c) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
+Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> fma(
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& b,
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& c) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_fmadd_pd(static_cast<__m256d>(a), static_cast<__m256d>(b),
                       static_cast<__m256d>(c)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> max(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<double, simd_abi::avx2_fixed_size<4>> const& b) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
+Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> max(
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_max_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> min(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<double, simd_abi::avx2_fixed_size<4>> const& b) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
+Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>> min(
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
+  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_min_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
 }
+
+namespace Experimental {
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<double, simd_abi::avx2_fixed_size<4>> condition(
@@ -814,80 +832,99 @@ class simd<float, simd_abi::avx2_fixed_size<4>> {
   }
 };
 
+}  // namespace Experimental
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx2_fixed_size<4>> copysign(
-    simd<float, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<float, simd_abi::avx2_fixed_size<4>> const& b) {
+Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> copysign(
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+        a,
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+        b) {
   __m128 const sign_mask = _mm_set1_ps(-0.0);
-  return simd<float, simd_abi::avx2_fixed_size<4>>(
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_xor_ps(_mm_andnot_ps(sign_mask, static_cast<__m128>(a)),
                  _mm_and_ps(sign_mask, static_cast<__m128>(b))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx2_fixed_size<4>> abs(
-    simd<float, simd_abi::avx2_fixed_size<4>> const& a) {
+Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> abs(
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+        a) {
   __m128 const sign_mask = _mm_set1_ps(-0.0);
-  return simd<float, simd_abi::avx2_fixed_size<4>>(
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_andnot_ps(sign_mask, static_cast<__m128>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx2_fixed_size<4>> sqrt(
-    simd<float, simd_abi::avx2_fixed_size<4>> const& a) {
-  return simd<float, simd_abi::avx2_fixed_size<4>>(
+Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> sqrt(
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+        a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_sqrt_ps(static_cast<__m128>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx2_fixed_size<4>> cbrt(
-    simd<float, simd_abi::avx2_fixed_size<4>> const& a) {
-  return simd<float, simd_abi::avx2_fixed_size<4>>(
+Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> cbrt(
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+        a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_cbrt_ps(static_cast<__m128>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx2_fixed_size<4>> exp(
-    simd<float, simd_abi::avx2_fixed_size<4>> const& a) {
-  return simd<float, simd_abi::avx2_fixed_size<4>>(
+Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> exp(
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+        a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_exp_ps(static_cast<__m128>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx2_fixed_size<4>> log(
-    simd<float, simd_abi::avx2_fixed_size<4>> const& a) {
-  return simd<float, simd_abi::avx2_fixed_size<4>>(
+Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> log(
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+        a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_log_ps(static_cast<__m128>(a)));
 }
 
 #endif
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx2_fixed_size<4>> fma(
-    simd<float, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<float, simd_abi::avx2_fixed_size<4>> const& b,
-    simd<float, simd_abi::avx2_fixed_size<4>> const& c) {
-  return simd<float, simd_abi::avx2_fixed_size<4>>(_mm_fmadd_ps(
-      static_cast<__m128>(a), static_cast<__m128>(b), static_cast<__m128>(c)));
+Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> fma(
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+        a,
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+        b,
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+        c) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm_fmadd_ps(static_cast<__m128>(a), static_cast<__m128>(b),
+                   static_cast<__m128>(c)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx2_fixed_size<4>> max(
-    simd<float, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<float, simd_abi::avx2_fixed_size<4>> const& b) {
-  return simd<float, simd_abi::avx2_fixed_size<4>>(
+Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> max(
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+        a,
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+        b) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_max_ps(static_cast<__m128>(a), static_cast<__m128>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx2_fixed_size<4>> min(
-    simd<float, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<float, simd_abi::avx2_fixed_size<4>> const& b) {
-  return simd<float, simd_abi::avx2_fixed_size<4>>(
+Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> min(
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+        a,
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
+        b) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_min_ps(static_cast<__m128>(a), static_cast<__m128>(b)));
 }
+
+namespace Experimental {
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<float, simd_abi::avx2_fixed_size<4>> condition(
@@ -1021,12 +1058,19 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   }
 };
 
+}  // namespace Experimental
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx2_fixed_size<4>> abs(
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a) {
+Experimental::simd<std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>>
+abs(Experimental::simd<std::int32_t,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   __m128i const rhs = static_cast<__m128i>(a);
-  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(_mm_abs_epi32(rhs));
+  return Experimental::simd<std::int32_t,
+                            Experimental::simd_abi::avx2_fixed_size<4>>(
+      _mm_abs_epi32(rhs));
 }
+
+namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
@@ -1177,14 +1221,20 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   }
 };
 
+}  // namespace Experimental
+
 // Manually computing absolute values, because _mm256_abs_epi64
 // is not in AVX2; it's available in AVX512.
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
-    abs(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a) {
-  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+    Experimental::simd<std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>>
+    abs(Experimental::simd<
+        std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::simd<std::int64_t,
+                            Experimental::simd_abi::avx2_fixed_size<4>>(
       [&](std::size_t i) { return (a[i] < 0) ? -a[i] : a[i]; });
 }
+
+namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
@@ -1313,12 +1363,6 @@ simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::simd(
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other)
     : m_value(static_cast<__m256i>(other)) {}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> abs(
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a) {
-  return a;
-}
-
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
     condition(simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a,
@@ -1337,6 +1381,17 @@ simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::simd(
     (*this)[i] = std::int32_t(other[i]);
   }
 }
+
+}  // namespace Experimental
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::simd<std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>>
+abs(Experimental::simd<std::uint64_t,
+                       Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return a;
+}
+
+namespace Experimental {
 
 template <>
 class const_where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -272,13 +272,19 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
   }
 };
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
-    abs(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a) {
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>>
+abs(Experimental::simd<std::int32_t,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256i const rhs = static_cast<__m256i>(a);
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+  return Experimental::simd<std::int32_t,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_abs_epi32(rhs));
 }
+
+namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
@@ -425,11 +431,16 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
   }
 };
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
-    abs(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a) {
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>>
+abs(Experimental::simd<std::uint32_t,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   return a;
 }
+
+namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
@@ -580,13 +591,19 @@ class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
   }
 };
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
-    abs(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a) {
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>>
+abs(Experimental::simd<std::int64_t,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m512i const rhs = static_cast<__m512i>(a);
-  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+  return Experimental::simd<std::int64_t,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_abs_epi64(rhs));
 }
+
+namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
@@ -742,11 +759,16 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   }
 };
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
-    abs(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a) {
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>>
+abs(Experimental::simd<std::uint64_t,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   return a;
 }
+
+namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
@@ -886,13 +908,21 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
   }
 };
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    copysign(simd<double, simd_abi::avx512_fixed_size<8>> const& a,
-             simd<double, simd_abi::avx512_fixed_size<8>> const& b) {
-  static const __m512i sign_mask = reinterpret_cast<__m512i>(
-      static_cast<__m512d>(simd<double, simd_abi::avx512_fixed_size<8>>(-0.0)));
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+copysign(
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a,
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
+  static const __m512i sign_mask =
+      reinterpret_cast<__m512i>(static_cast<__m512d>(
+          Experimental::simd<
+              double, Experimental::simd_abi::avx512_fixed_size<8>>(-0.0)));
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       reinterpret_cast<__m512d>(_mm512_xor_epi64(
           _mm512_andnot_epi64(
               sign_mask, reinterpret_cast<__m512i>(static_cast<__m512d>(a))),
@@ -901,74 +931,99 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    abs(simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
+    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
+    abs(Experimental::simd<
+        double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m512d const rhs = static_cast<__m512d>(a);
 #if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 830)
-  return simd<double, simd_abi::avx512_fixed_size<8>>((__m512d)_mm512_and_epi64(
-      (__m512i)rhs, _mm512_set1_epi64(0x7fffffffffffffffLL)));
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      (__m512d)_mm512_and_epi64((__m512i)rhs,
+                                _mm512_set1_epi64(0x7fffffffffffffffLL)));
 #else
-  return simd<double, simd_abi::avx512_fixed_size<8>>(_mm512_abs_pd(rhs));
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm512_abs_pd(rhs));
 #endif
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    sqrt(simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
+    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
+    sqrt(Experimental::simd<
+         double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_sqrt_pd(static_cast<__m512d>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    cbrt(simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
+    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
+    cbrt(Experimental::simd<
+         double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cbrt_pd(static_cast<__m512d>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    exp(simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
+    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
+    exp(Experimental::simd<
+        double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_exp_pd(static_cast<__m512d>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    log(simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
+    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
+    log(Experimental::simd<
+        double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_log_pd(static_cast<__m512d>(a)));
 }
 
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    fma(simd<double, simd_abi::avx512_fixed_size<8>> const& a,
-        simd<double, simd_abi::avx512_fixed_size<8>> const& b,
-        simd<double, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+fma(Experimental::simd<double,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a,
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& b,
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& c) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_fmadd_pd(static_cast<__m512d>(a), static_cast<__m512d>(b),
                       static_cast<__m512d>(c)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    max(simd<double, simd_abi::avx512_fixed_size<8>> const& a,
-        simd<double, simd_abi::avx512_fixed_size<8>> const& b) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+max(Experimental::simd<double,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a,
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_max_pd(static_cast<__m512d>(a), static_cast<__m512d>(b)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    min(simd<double, simd_abi::avx512_fixed_size<8>> const& a,
-        simd<double, simd_abi::avx512_fixed_size<8>> const& b) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+min(Experimental::simd<double,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a,
+    Experimental::simd<double,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
+  return Experimental::simd<double,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_min_pd(static_cast<__m512d>(a), static_cast<__m512d>(b)));
 }
+
+namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<double, simd_abi::avx512_fixed_size<8>>
@@ -1085,80 +1140,109 @@ class simd<float, simd_abi::avx512_fixed_size<8>> {
   }
 };
 
+}  // namespace Experimental
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx512_fixed_size<8>> copysign(
-    simd<float, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<float, simd_abi::avx512_fixed_size<8>> const& b) {
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
+copysign(
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a,
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
   __m256 const sign_mask = _mm256_set1_ps(-0.0);
-  return simd<float, simd_abi::avx512_fixed_size<8>>(
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_xor_ps(_mm256_andnot_ps(sign_mask, static_cast<__m256>(a)),
                     _mm256_and_ps(sign_mask, static_cast<__m256>(b))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx512_fixed_size<8>> abs(
-    simd<float, simd_abi::avx512_fixed_size<8>> const& a) {
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> abs(
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256 const sign_mask = _mm256_set1_ps(-0.0);
-  return simd<float, simd_abi::avx512_fixed_size<8>>(
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_andnot_ps(sign_mask, static_cast<__m256>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx512_fixed_size<8>> sqrt(
-    simd<float, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<float, simd_abi::avx512_fixed_size<8>>(
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> sqrt(
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_sqrt_ps(static_cast<__m256>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx512_fixed_size<8>> cbrt(
-    simd<float, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<float, simd_abi::avx512_fixed_size<8>>(
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> cbrt(
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_cbrt_ps(static_cast<__m256>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx512_fixed_size<8>> exp(
-    simd<float, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<float, simd_abi::avx512_fixed_size<8>>(
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> exp(
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_exp_ps(static_cast<__m256>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx512_fixed_size<8>> log(
-    simd<float, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<float, simd_abi::avx512_fixed_size<8>>(
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> log(
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_log_ps(static_cast<__m256>(a)));
 }
 
 #endif
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx512_fixed_size<8>> fma(
-    simd<float, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<float, simd_abi::avx512_fixed_size<8>> const& b,
-    simd<float, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<float, simd_abi::avx512_fixed_size<8>>(_mm256_fmadd_ps(
-      static_cast<__m256>(a), static_cast<__m256>(b), static_cast<__m256>(c)));
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> fma(
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a,
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& b,
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& c) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
+      _mm256_fmadd_ps(static_cast<__m256>(a), static_cast<__m256>(b),
+                      static_cast<__m256>(c)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx512_fixed_size<8>> max(
-    simd<float, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<float, simd_abi::avx512_fixed_size<8>> const& b) {
-  return simd<float, simd_abi::avx512_fixed_size<8>>(
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> max(
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a,
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_max_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx512_fixed_size<8>> min(
-    simd<float, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<float, simd_abi::avx512_fixed_size<8>> const& b) {
-  return simd<float, simd_abi::avx512_fixed_size<8>>(
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> min(
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& a,
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_min_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
 }
+
+namespace Experimental {
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<float, simd_abi::avx512_fixed_size<8>> condition(

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -378,6 +378,18 @@ template <class T, class Abi>
   return result;
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+namespace Experimental {
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION
+    Experimental::simd<T, Abi>
+    min(Experimental::simd<T, Abi> const& a,
+        Experimental::simd<T, Abi> const& b) {
+  return Kokkos::min(a, b);
+}
+}  // namespace Experimental
+#endif
+
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> max(
     Experimental::simd<T, Abi> const& a, Experimental::simd<T, Abi> const& b) {
@@ -388,23 +400,54 @@ template <class T, class Abi>
   return result;
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+namespace Experimental {
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION
+    Experimental::simd<T, Abi>
+    max(Experimental::simd<T, Abi> const& a,
+        Experimental::simd<T, Abi> const& b) {
+  return Kokkos::max(a, b);
+}
+}  // namespace Experimental
+#endif
+
 // fallback implementations of <cmath> functions.
 // individual Abi types may provide overloads with more efficient
 // implementations.
 // These are not in the Experimental namespace because their double
 // overloads are not either
 
-#define KOKKOS_IMPL_SIMD_UNARY_FUNCTION(FUNC)                               \
-  template <class Abi>                                                      \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<double, Abi> \
-  FUNC(Experimental::simd<double, Abi> const& a) {                          \
-    Experimental::simd<double, Abi> result;                                 \
-    for (std::size_t i = 0; i < Experimental::simd<double, Abi>::size();    \
-         ++i) {                                                             \
-      result[i] = Kokkos::FUNC(a[i]);                                       \
-    }                                                                       \
-    return result;                                                          \
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#define KOKKOS_IMPL_SIMD_UNARY_FUNCTION(FUNC)                                \
+  template <class T, class Abi>                                              \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> FUNC( \
+      Experimental::simd<T, Abi> const& a) {                                 \
+    Experimental::simd<T, Abi> result;                                       \
+    for (std::size_t i = 0; i < Experimental::simd<T, Abi>::size(); ++i) {   \
+      result[i] = Kokkos::FUNC(a[i]);                                        \
+    }                                                                        \
+    return result;                                                           \
+  }                                                                          \
+  namespace Experimental {                                                   \
+  template <class T, class Abi>                                              \
+  [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>   \
+  FUNC(simd<T, Abi> const& a) {                                              \
+    return Kokkos::FUNC(a);                                                  \
+  }                                                                          \
   }
+#else
+#define KOKKOS_IMPL_SIMD_UNARY_FUNCTION(FUNC)                                \
+  template <class T, class Abi>                                              \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> FUNC( \
+      Experimental::simd<T, Abi> const& a) {                                 \
+    Experimental::simd<T, Abi> result;                                       \
+    for (std::size_t i = 0; i < Experimental::simd<T, Abi>::size(); ++i) {   \
+      result[i] = Kokkos::FUNC(a[i]);                                        \
+    }                                                                        \
+    return result;                                                           \
+  }
+#endif
 
 KOKKOS_IMPL_SIMD_UNARY_FUNCTION(abs)
 KOKKOS_IMPL_SIMD_UNARY_FUNCTION(exp)
@@ -431,37 +474,78 @@ KOKKOS_IMPL_SIMD_UNARY_FUNCTION(erfc)
 KOKKOS_IMPL_SIMD_UNARY_FUNCTION(tgamma)
 KOKKOS_IMPL_SIMD_UNARY_FUNCTION(lgamma)
 
-#define KOKKOS_IMPL_SIMD_BINARY_FUNCTION(FUNC)                              \
-  template <class Abi>                                                      \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<double, Abi> \
-  FUNC(Experimental::simd<double, Abi> const& a,                            \
-       Experimental::simd<double, Abi> const& b) {                          \
-    Experimental::simd<double, Abi> result;                                 \
-    for (std::size_t i = 0; i < Experimental::simd<double, Abi>::size();    \
-         ++i) {                                                             \
-      result[i] = Kokkos::FUNC(a[i], b[i]);                                 \
-    }                                                                       \
-    return result;                                                          \
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#define KOKKOS_IMPL_SIMD_BINARY_FUNCTION(FUNC)                               \
+  template <class T, class Abi>                                              \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> FUNC( \
+      Experimental::simd<T, Abi> const& a,                                   \
+      Experimental::simd<T, Abi> const& b) {                                 \
+    Experimental::simd<T, Abi> result;                                       \
+    for (std::size_t i = 0; i < Experimental::simd<T, Abi>::size(); ++i) {   \
+      result[i] = Kokkos::FUNC(a[i], b[i]);                                  \
+    }                                                                        \
+    return result;                                                           \
+  }                                                                          \
+  namespace Experimental {                                                   \
+  template <class T, class Abi>                                              \
+  [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>   \
+  FUNC(simd<T, Abi> const& a, simd<T, Abi> const& b) {                       \
+    Kokkos::FUNC(a, b);                                                      \
+  }                                                                          \
   }
+#else
+#define KOKKOS_IMPL_SIMD_BINARY_FUNCTION(FUNC)                               \
+  template <class T, class Abi>                                              \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> FUNC( \
+      Experimental::simd<T, Abi> const& a,                                   \
+      Experimental::simd<T, Abi> const& b) {                                 \
+    Experimental::simd<T, Abi> result;                                       \
+    for (std::size_t i = 0; i < Experimental::simd<T, Abi>::size(); ++i) {   \
+      result[i] = Kokkos::FUNC(a[i], b[i]);                                  \
+    }                                                                        \
+    return result;                                                           \
+  }
+#endif
 
 KOKKOS_IMPL_SIMD_BINARY_FUNCTION(pow)
 KOKKOS_IMPL_SIMD_BINARY_FUNCTION(hypot)
 KOKKOS_IMPL_SIMD_BINARY_FUNCTION(atan2)
 KOKKOS_IMPL_SIMD_BINARY_FUNCTION(copysign)
 
-#define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                             \
-  template <class Abi>                                                      \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<double, Abi> \
-  FUNC(Experimental::simd<double, Abi> const& a,                            \
-       Experimental::simd<double, Abi> const& b,                            \
-       Experimental::simd<double, Abi> const& c) {                          \
-    Experimental::simd<double, Abi> result;                                 \
-    for (std::size_t i = 0; i < Experimental::simd<double, Abi>::size();    \
-         ++i) {                                                             \
-      result[i] = Kokkos::FUNC(a[i], b[i], c[i]);                           \
-    }                                                                       \
-    return result;                                                          \
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                               \
+  template <class T, class Abi>                                               \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> FUNC(  \
+      Experimental::simd<T, Abi> const& a,                                    \
+      Experimental::simd<T, Abi> const& b,                                    \
+      Experimental::simd<T, Abi> const& c) {                                  \
+    Experimental::simd<T, Abi> result;                                        \
+    for (std::size_t i = 0; i < Experimental::simd<T, Abi>::size(); ++i) {    \
+      result[i] = Kokkos::FUNC(a[i], b[i], c[i]);                             \
+    }                                                                         \
+    return result;                                                            \
+  }                                                                           \
+  namespace Experimental {                                                    \
+  template <class T, class Abi>                                               \
+  [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>    \
+  FUNC(simd<T, Abi> const& a, simd<T, Abi> const& b, simd<T, Abi> const& c) { \
+    return Kokkos::FUNC(a, b, c);                                             \
+  }                                                                           \
   }
+#else
+#define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                              \
+  template <class T, class Abi>                                              \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> FUNC( \
+      Experimental::simd<T, Abi> const& a,                                   \
+      Experimental::simd<T, Abi> const& b,                                   \
+      Experimental::simd<T, Abi> const& c) {                                 \
+    Experimental::simd<T, Abi> result;                                       \
+    for (std::size_t i = 0; i < Experimental::simd<T, Abi>::size(); ++i) {   \
+      result[i] = Kokkos::FUNC(a[i], b[i], c[i]);                            \
+    }                                                                        \
+    return result;                                                           \
+  }
+#endif
 
 KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(fma)
 KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(hypot)

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -424,56 +424,72 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
   }
 };
 
+}  // namespace Experimental
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::neon_fixed_size<2>> abs(
-    simd<double, simd_abi::neon_fixed_size<2>> const& a) {
-  return simd<double, simd_abi::neon_fixed_size<2>>(
+Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>> abs(
+    Experimental::simd<double,
+                       Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
       vabsq_f64(static_cast<float64x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::neon_fixed_size<2>> copysign(
-    simd<double, simd_abi::neon_fixed_size<2>> const& a,
-    simd<double, simd_abi::neon_fixed_size<2>> const& b) {
+Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>> copysign(
+    Experimental::simd<double,
+                       Experimental::simd_abi::neon_fixed_size<2>> const& a,
+    Experimental::simd<double,
+                       Experimental::simd_abi::neon_fixed_size<2>> const& b) {
   uint64x2_t const sign_mask = vreinterpretq_u64_f64(vmovq_n_f64(-0.0));
-  return simd<double, simd_abi::neon_fixed_size<2>>(vreinterpretq_f64_u64(
-      vorrq_u64(vreinterpretq_u64_f64(static_cast<float64x2_t>(abs(a))),
-                vandq_u64(sign_mask, vreinterpretq_u64_f64(
-                                         static_cast<float64x2_t>(b))))));
+  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
+      vreinterpretq_f64_u64(vorrq_u64(
+          vreinterpretq_u64_f64(static_cast<float64x2_t>(abs(a))),
+          vandq_u64(sign_mask,
+                    vreinterpretq_u64_f64(static_cast<float64x2_t>(b))))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::neon_fixed_size<2>> sqrt(
-    simd<double, simd_abi::neon_fixed_size<2>> const& a) {
-  return simd<double, simd_abi::neon_fixed_size<2>>(
+Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>> sqrt(
+    Experimental::simd<double,
+                       Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
       vsqrtq_f64(static_cast<float64x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::neon_fixed_size<2>> fma(
-    simd<double, simd_abi::neon_fixed_size<2>> const& a,
-    simd<double, simd_abi::neon_fixed_size<2>> const& b,
-    simd<double, simd_abi::neon_fixed_size<2>> const& c) {
-  return simd<double, simd_abi::neon_fixed_size<2>>(
+Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>> fma(
+    Experimental::simd<double,
+                       Experimental::simd_abi::neon_fixed_size<2>> const& a,
+    Experimental::simd<double,
+                       Experimental::simd_abi::neon_fixed_size<2>> const& b,
+    Experimental::simd<double,
+                       Experimental::simd_abi::neon_fixed_size<2>> const& c) {
+  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
       vfmaq_f64(static_cast<float64x2_t>(c), static_cast<float64x2_t>(b),
                 static_cast<float64x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::neon_fixed_size<2>> max(
-    simd<double, simd_abi::neon_fixed_size<2>> const& a,
-    simd<double, simd_abi::neon_fixed_size<2>> const& b) {
-  return simd<double, simd_abi::neon_fixed_size<2>>(
+Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>> max(
+    Experimental::simd<double,
+                       Experimental::simd_abi::neon_fixed_size<2>> const& a,
+    Experimental::simd<double,
+                       Experimental::simd_abi::neon_fixed_size<2>> const& b) {
+  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
       vmaxq_f64(static_cast<float64x2_t>(a), static_cast<float64x2_t>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::neon_fixed_size<2>> min(
-    simd<double, simd_abi::neon_fixed_size<2>> const& a,
-    simd<double, simd_abi::neon_fixed_size<2>> const& b) {
-  return simd<double, simd_abi::neon_fixed_size<2>>(
+Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>> min(
+    Experimental::simd<double,
+                       Experimental::simd_abi::neon_fixed_size<2>> const& a,
+    Experimental::simd<double,
+                       Experimental::simd_abi::neon_fixed_size<2>> const& b) {
+  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
       vminq_f64(static_cast<float64x2_t>(a), static_cast<float64x2_t>(b)));
 }
+
+namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<double, simd_abi::neon_fixed_size<2>>

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -201,9 +201,12 @@ class simd<T, simd_abi::scalar> {
   }
 };
 
+}  // namespace Experimental
+
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> abs(
-    simd<T, simd_abi::scalar> const& a) {
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION
+    Experimental::simd<T, Experimental::simd_abi::scalar>
+    abs(Experimental::simd<T, Experimental::simd_abi::scalar> const& a) {
   if constexpr (std::is_signed_v<T>) {
     return (a < 0 ? -a : a);
   }
@@ -211,18 +214,32 @@ template <class T>
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> sqrt(
-    simd<T, simd_abi::scalar> const& a) {
-  return simd<T, simd_abi::scalar>(std::sqrt(static_cast<T>(a)));
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION
+    Experimental::simd<T, Experimental::simd_abi::scalar>
+    sqrt(Experimental::simd<T, Experimental::simd_abi::scalar> const& a) {
+  return Experimental::simd<T, Experimental::simd_abi::scalar>(
+      std::sqrt(static_cast<T>(a)));
 }
 
 template <class T>
-KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> fma(
-    simd<T, simd_abi::scalar> const& x, simd<T, simd_abi::scalar> const& y,
-    simd<T, simd_abi::scalar> const& z) {
-  return simd<T, simd_abi::scalar>((static_cast<T>(x) * static_cast<T>(y)) +
-                                   static_cast<T>(z));
+KOKKOS_FORCEINLINE_FUNCTION
+    Experimental::simd<T, Experimental::simd_abi::scalar>
+    fma(Experimental::simd<T, Experimental::simd_abi::scalar> const& x,
+        Experimental::simd<T, Experimental::simd_abi::scalar> const& y,
+        Experimental::simd<T, Experimental::simd_abi::scalar> const& z) {
+  return Experimental::simd<T, Experimental::simd_abi::scalar>(
+      (static_cast<T>(x) * static_cast<T>(y)) + static_cast<T>(z));
 }
+
+template <class T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION
+    Experimental::simd<T, Experimental::simd_abi::scalar>
+    copysign(Experimental::simd<T, Experimental::simd_abi::scalar> const& a,
+             Experimental::simd<T, Experimental::simd_abi::scalar> const& b) {
+  return std::copysign(static_cast<T>(a), static_cast<T>(b));
+}
+
+namespace Experimental {
 
 template <class T>
 KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> condition(
@@ -231,12 +248,6 @@ KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> condition(
     simd<T, simd_abi::scalar> const& b, simd<T, simd_abi::scalar> const& c) {
   return simd<T, simd_abi::scalar>(static_cast<bool>(a) ? static_cast<T>(b)
                                                         : static_cast<T>(c));
-}
-
-template <class T, class Abi>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi> copysign(
-    simd<T, Abi> const& a, simd<T, Abi> const& b) {
-  return std::copysign(static_cast<T>(a), static_cast<T>(b));
 }
 
 template <class T>

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -79,7 +79,14 @@ class absolutes {
  public:
   template <typename T>
   auto on_host(T const& a) const {
-    return Kokkos::Experimental::abs(a);
+    if constexpr (std::is_signed_v<typename T::value_type>) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+      return Kokkos::Experimental::abs(a);
+#else
+      return Kokkos::abs(a);
+#endif
+    }
+    return a;
   }
   template <typename T>
   auto on_host_serial(T const& a) const {
@@ -87,7 +94,14 @@ class absolutes {
   }
   template <typename T>
   KOKKOS_INLINE_FUNCTION auto on_device(T const& a) const {
-    return Kokkos::Experimental::abs(a);
+    if constexpr (std::is_signed_v<typename T::value_type>) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+      return Kokkos::Experimental::abs(a);
+#else
+      return Kokkos::abs(a);
+#endif
+    }
+    return a;
   }
   template <typename T>
   KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a) const {


### PR DESCRIPTION
This fixes the confusion in https://github.com/kokkos/kokkos/pull/6276#discussion_r1316444804.
At the moment, we have fallback SIMD math functions (those that are also defined in `cmath`) defined in namespace `Kokkos` but the specialized ones in namespace `Kokkos::Experimental`.
This pull request makes sure to have all these functions in namespace `Kokkos` so that users don't have to use different namespaces based on the SIMD type having specializations or not. If `DEPRECATED_CODE_4` is enabled, all of these functions are also defined  in namespace `Kokkos::Experimental` similar to what we are doing for the non-SIMD `Kokkos` math functions.