### PR TITLE
simd: Add conversions between simd types

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -164,6 +164,25 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m512d const& value_in)
       : m_value(value_in) {}
+
+  template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                         bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<U, abi_type> const& other) noexcept
+      : m_value(simd([&](std::size_t i) {
+          return static_cast<value_type>(other[i]);
+        })) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(
+      simd<float, abi_type> const& other) noexcept;
+
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -449,6 +468,25 @@ class simd<float, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m256 const& value_in)
       : m_value(value_in) {}
+
+  template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                         bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<U, abi_type> const& other) noexcept
+      : m_value(simd([&](std::size_t i) {
+          return static_cast<value_type>(other[i]);
+        })) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<double, abi_type> const& other) noexcept;
+
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -708,8 +746,21 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m256i const& value_in)
       : m_value(value_in) {}
+
+  template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                         bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::uint64_t, abi_type> const& other);
+      simd<U, abi_type> const& other) noexcept
+      : m_value(simd([&](std::size_t i) {
+          return static_cast<value_type>(other[i]);
+        })) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint64_t, abi_type> const& other) noexcept;
+
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -906,9 +957,21 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m256i const& value_in)
       : m_value(value_in) {}
+
+  template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                         bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other)
-      : m_value(static_cast<__m256i>(other)) {}
+      simd<U, abi_type> const& other) noexcept
+      : m_value(simd([&](std::size_t i) {
+          return static_cast<value_type>(other[i]);
+        })) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint64_t, abi_type> const& other) noexcept;
+
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -1094,11 +1157,21 @@ class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
       : m_value(_mm512_set1_epi64(value_type(value))) {}
+
+  template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                         bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other)
-      : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
+      simd<U, abi_type> const& other) noexcept
+      : m_value(simd([&](std::size_t i) {
+          return static_cast<value_type>(other[i]);
+        })) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(
+      simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(
+      simd<std::uint32_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other);
+      simd<std::uint64_t, abi_type> const& other) noexcept;
+
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -1296,9 +1369,21 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
             Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m512i const& value_in)
       : m_value(value_in) {}
+
+  template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                         bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int32_t, abi_type> const& other)
-      : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
+      simd<U, abi_type> const& other) noexcept
+      : m_value(simd([&](std::size_t i) {
+          return static_cast<value_type>(other[i]);
+        })) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(
+      simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(
+      simd<std::uint32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int64_t, abi_type> const& other) noexcept;
+
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -1317,9 +1402,7 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int64_t, abi_type> const& other)
-      : m_value(static_cast<__m512i>(other)) {}
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -1475,13 +1558,103 @@ namespace Experimental {
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::simd(
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other)
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(static_cast<__m256i>(other)) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(static_cast<__m256i>(other)) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
     : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::simd(
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other)
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
     : m_value(static_cast<__m512i>(other)) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(static_cast<__m512i>(other)) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtepi32_pd(static_cast<__m256i>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtepu32_pd(static_cast<__m256i>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtepi64_pd(static_cast<__m512i>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtepu64_pd(static_cast<__m512i>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtps_pd(static_cast<__m256>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm256_maskz_cvtepi32_ps(
+          static_cast<__mmask8>(
+              simd<float, simd_abi::avx512_fixed_size<8>>::mask_type(true)),
+          (static_cast<__m256i>(other)))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm256_maskz_cvtepi32_ps(
+          static_cast<__mmask8>(
+              simd<float, simd_abi::avx512_fixed_size<8>>::mask_type(true)),
+          (static_cast<__m256i>(other)))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtepi64_ps(static_cast<__m512i>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtepu64_ps(static_cast<__m512i>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtpd_ps(static_cast<__m512d>(other))) {}
 
 template <>
 class const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -331,6 +331,22 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
+
+  template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                         bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<U, abi_type> const& other) noexcept
+      : simd([&](std::size_t i) { return static_cast<value_type>(other[i]); }) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(
+      simd<float, abi_type> const& other) noexcept;
+
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
@@ -349,6 +365,7 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
     m_value = vsetq_lane_f64(gen(std::integral_constant<std::size_t, 1>()),
                              m_value, 1);
   }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       float64x2_t const& value_in)
       : m_value(value_in) {}
@@ -578,6 +595,21 @@ class simd<float, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
+  template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                         bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<U, abi_type> const& other) noexcept
+      : simd([&](std::size_t i) { return static_cast<value_type>(other[i]); }) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<double, abi_type> const& other) noexcept;
+
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
@@ -593,6 +625,7 @@ class simd<float, simd_abi::neon_fixed_size<2>> {
     m_value = vset_lane_f32(gen(std::integral_constant<std::size_t, 1>()),
                             m_value, 1);
   }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       float32x2_t const& value_in)
       : m_value(value_in) {}
@@ -812,6 +845,21 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
+  template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                         bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<U, abi_type> const& other) noexcept
+      : simd([&](std::size_t i) { return static_cast<value_type>(other[i]); }) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<float, abi_type> const& other) noexcept;
+
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
@@ -828,11 +876,10 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
     m_value = vset_lane_s32(gen(std::integral_constant<std::size_t, 1>()),
                             m_value, 1);
   }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       int32x2_t const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::uint64_t, abi_type> const& other);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reference(m_value, int(i));
   }
@@ -1016,6 +1063,21 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
+  template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                         bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<U, abi_type> const& other)
+      : simd([&](std::size_t i) { return static_cast<value_type>(other[i]); }) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(
+      simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<float, abi_type> const& other) noexcept;
+
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
@@ -1032,11 +1094,10 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
     m_value = vsetq_lane_s64(gen(std::integral_constant<std::size_t, 1>()),
                              m_value, 1);
   }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       int64x2_t const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::uint64_t, abi_type> const&);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reference(m_value, int(i));
   }
@@ -1219,6 +1280,21 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
+  template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                         bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<U, abi_type> const& other) noexcept
+      : simd([&](std::size_t i) { return static_cast<value_type>(other[i]); }) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<float, abi_type> const& other) noexcept;
+
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
@@ -1235,13 +1311,10 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
     m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 1>()),
                              m_value, 1);
   }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       uint64x2_t const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int32_t, abi_type> const& other)
-      : m_value(
-            vreinterpretq_u64_s64(vmovl_s32(static_cast<int32x2_t>(other)))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reference(m_value, int(i));
   }
@@ -1315,17 +1388,6 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   }
 };
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::neon_fixed_size<2>>::simd(
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other)
-    : m_value(
-          vmovn_s64(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other)))) {}
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other)
-    : m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other))) {}
-
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>>
     abs(simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a) {
@@ -1373,6 +1435,92 @@ namespace Experimental {
       vbslq_u64(static_cast<uint64x2_t>(a), static_cast<uint64x2_t>(b),
                 static_cast<uint64x2_t>(c)));
 }
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::neon_fixed_size<2>>::simd(
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vcvt_f64_f32(vcvt_f32_s32(static_cast<int32x2_t>(other)))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::neon_fixed_size<2>>::simd(
+    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vcvtq_f64_s64(static_cast<int64x2_t>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::neon_fixed_size<2>>::simd(
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vcvtq_f64_u64(static_cast<uint64x2_t>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::neon_fixed_size<2>>::simd(
+    simd<float, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vcvt_f64_f32(static_cast<float32x2_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::neon_fixed_size<2>>::simd(
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vcvt_f32_s32(static_cast<int32x2_t>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::neon_fixed_size<2>>::simd(
+    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vcvt_f32_f64(vcvtq_f64_s64(static_cast<int64x2_t>(other)))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::neon_fixed_size<2>>::simd(
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vcvt_f32_f64(vcvtq_f64_u64(static_cast<uint64x2_t>(other)))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::neon_fixed_size<2>>::simd(
+    simd<double, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vcvt_f32_f64(static_cast<float64x2_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::neon_fixed_size<2>>::simd(
+    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vmovn_s64(static_cast<int64x2_t>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::neon_fixed_size<2>>::simd(
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(
+          vmovn_s64(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other)))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::neon_fixed_size<2>>::simd(
+    simd<double, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vcvt_s32_f32(vcvt_f32_f64(static_cast<float64x2_t>(other)))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::neon_fixed_size<2>>::simd(
+    simd<float, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vcvt_s32_f32(static_cast<float32x2_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vmovl_s32(static_cast<int32x2_t>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
+    simd<double, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vcvtq_s64_f64(static_cast<float64x2_t>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
+    simd<float, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vcvtq_s64_f64(vcvt_f64_f32(static_cast<float32x2_t>(other)))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::neon_fixed_size<2>>::simd(
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vmovl_s32(static_cast<int32x2_t>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::neon_fixed_size<2>>::simd(
+    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value((vreinterpretq_u64_s64(static_cast<int64x2_t>(other)))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::neon_fixed_size<2>>::simd(
+    simd<double, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vcvtq_u64_f64(static_cast<float64x2_t>(other))) {}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::neon_fixed_size<2>>::simd(
+    simd<float, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vcvtq_u64_f64(vcvt_f64_f32(static_cast<float32x2_t>(other)))) {}
 
 template <>
 class const_where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -58,8 +58,8 @@ class simd_mask<T, simd_abi::scalar> {
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit simd_mask(G&& gen) noexcept
       : m_value(gen(0)) {}
   template <class U>
-  KOKKOS_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<U, simd_abi::scalar> const& other)
+  KOKKOS_FORCEINLINE_FUNCTION explicit simd_mask(
+      simd_mask<U, simd_abi::scalar> const& other) noexcept
       : m_value(static_cast<bool>(other)) {}
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator bool() const {
     return m_value;
@@ -109,7 +109,7 @@ class simd<T, simd_abi::scalar> {
   KOKKOS_FORCEINLINE_FUNCTION simd(U&& value) : m_value(value) {}
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION explicit simd(simd<U, abi_type> const& other)
+  KOKKOS_FORCEINLINE_FUNCTION simd(simd<U, abi_type> const& other) noexcept
       : m_value(static_cast<U>(other)) {}
   template <class G,
             std::enable_if_t<

--- a/simd/unit_tests/include/TestSIMD_Conversions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Conversions.hpp
@@ -29,8 +29,7 @@ inline void host_check_conversions() {
     auto from = Kokkos::Experimental::simd<DataTypeA, Abi>(test_val);
     auto to   = Kokkos::Experimental::simd<DataTypeB, Abi>(from);
     EXPECT_EQ(from.size(), to.size());
-    host_check_equality(to, decltype(to)(static_cast<std::int64_t>(test_val)),
-                        to.size());
+    host_check_equality(to, decltype(to)(test_val), to.size());
   }
   {
     auto from = Kokkos::Experimental::simd_mask<DataTypeA, Abi>(test_mask_val);


### PR DESCRIPTION
Related: #5674 

This PR adds conversion constructors between all supported simd data types:
- `explicit simd(simd<data_type, abi_type> const& other);`

As described in [p1928r7](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p1928r7.pdf),
- `simd<T0, A0> is convertible to simd<T1, A1> if simd_size_v<T0, A0> == simd_size_v<T1, A1>`

Additionally, simd types are implictly convertible if:
- `the conversion T0 to T1 is value-preserving, and`
- `if both T0 and T1 are integral types, the integer conversion rank of T1 is greater than or equal to the integer conversion rank of T0, and`
- `if both T0 and T1 are floating-point types, the floating-point conversion rank of T1 is greater than or equal to the floating-point conversion rank of T0.`