### PR TITLE
Add compatible copy assignment operator to DualView

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -292,6 +292,15 @@ class DualView : public ViewTraits<DataType, Properties...> {
         d_view(src.d_view),
         h_view(src.h_view) {}
 
+  //! Copy assignment operator (shallow copy assignment)
+  template <typename DT, typename... DP>
+  DualView& operator=(const DualView<DT, DP...>& src) {
+    modified_flags = src.modified_flags;
+    d_view         = src.d_view;
+    h_view         = src.h_view;
+    return *this;
+  }
+
   //! Subview constructor
   template <class DT, class... DP, class Arg0, class... Args>
   DualView(const DualView<DT, DP...>& src, const Arg0& arg0, Args... args)

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -65,14 +65,14 @@ struct test_dualview_copy_construction_and_assignment {
   using scalar_type     = Scalar;
   using execution_space = Device;
 
-  void run_me() {
+  void operator()() {
     constexpr unsigned int n = 10;
     constexpr unsigned int m = 5;
 
     using SrcViewType = Kokkos::DualView<Scalar**, Kokkos::LayoutLeft, Device>;
     using DstViewType =
         Kokkos::DualView<const Scalar * [m], Kokkos::LayoutLeft, Device>;
-    
+
     SrcViewType a("A", n, m);
 
     // Copy construction
@@ -99,8 +99,6 @@ struct test_dualview_copy_construction_and_assignment {
       a.clear_sync_state();
     }
   }
-
-  test_dualview_copy_construction_and_assignment() { run_me(); }
 };
 
 template <typename Scalar, class Device>
@@ -424,7 +422,7 @@ void test_dualview_alloc(unsigned int size) {
 
 template <typename Scalar, typename Device>
 void test_dualview_copy_construction_and_assignment() {
-  Impl::test_dualview_copy_construction_and_assignment<Scalar, Device>();
+  Impl::test_dualview_copy_construction_and_assignment<Scalar, Device>()();
 }
 
 template <typename Scalar, typename Device>

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -65,18 +65,21 @@ struct test_dualview_copy_construction_and_assignment {
   using scalar_type     = Scalar;
   using execution_space = Device;
 
-  template <typename ViewType>
   void run_me() {
-    const unsigned int n = 10;
-    const unsigned int m = 5;
+    constexpr unsigned int n = 10;
+    constexpr unsigned int m = 5;
 
-    ViewType a("A", n, m);
+    using SrcViewType = Kokkos::DualView<Scalar**, Kokkos::LayoutLeft, Device>;
+    using DstViewType =
+        Kokkos::DualView<const Scalar * [m], Kokkos::LayoutLeft, Device>;
+    
+    SrcViewType a("A", n, m);
 
     // Copy construction
-    ViewType b(a);
+    DstViewType b(a);
 
     // Copy assignment
-    ViewType c = a;
+    DstViewType c = a;
 
     // Check equality (shallow) of the host and device views
     ASSERT_EQ(a.view_host(), b.view_host());
@@ -87,7 +90,7 @@ struct test_dualview_copy_construction_and_assignment {
 
     // We can't test shallow equality of modified_flags because it's protected.
     // So we test it indirectly through sync state behavior.
-    if (!std::decay_t<ViewType>::impl_dualview_is_single_device::value) {
+    if (!std::decay_t<SrcViewType>::impl_dualview_is_single_device::value) {
       a.clear_sync_state();
       a.modify_host();
       ASSERT_TRUE(a.need_sync_device());
@@ -97,9 +100,7 @@ struct test_dualview_copy_construction_and_assignment {
     }
   }
 
-  test_dualview_copy_construction_and_assignment() {
-    run_me<Kokkos::DualView<Scalar**, Kokkos::LayoutLeft, Device> >();
-  }
+  test_dualview_copy_construction_and_assignment() { run_me(); }
 };
 
 template <typename Scalar, class Device>


### PR DESCRIPTION
This Kokkos PR is a companion to the merged Trilinos PR 
- https://github.com/trilinos/Trilinos/pull/12324

In that Trilinos PR, we had added a compatible copy constructor and assignment operator to `Tpetra` `WrappedDualView`. The motivation was to support reshaping copy construction and assignment of `MultiVector` filled with `Stokhos` UQ types.

As it stands, the `Kokkos` `DualView` has a compatible copy constructor, but it doesn't seem to have a compatible copy assignment operator yet. Hence, this PR adds it. 

Note that this PR doesn't add a test. Note also that the existing copy constructor doesn't seem to be tested. I tried to add a test for both. But then I found that the `DualView` seems to be missing an `operator==`, so it's not straightforward to test equality. I'd be happy to add a test, but I'm not sure how to best do it. If you should have a suggestion, I'll be happy to follow it.

Thanks!

@romintomasetti @etphipp @brian-kelley    


