### PR TITLE
Fix minimum version for Google benchmark

### DIFF
--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -38,7 +38,7 @@ IF (KOKKOS_HAS_TRILINOS)
 ENDIF()
 
 # Find or download google/benchmark library
-find_package(benchmark QUIET)
+find_package(benchmark QUIET 1.5.6)
 IF(benchmark_FOUND)
   MESSAGE(STATUS "Using google benchmark found in ${benchmark_DIR}")
 ELSE()


### PR DESCRIPTION
It turns out that we are using `Shutdown` and `CreateRange` which are not present in version 1.5.4 that I was using.
`ShutDown` was introduced in 1.5.5 (https://github.com/google/benchmark/commit/d17ea665515f0c54d100c6fc973632431379f64b) and `CreateRange` in 1.5.6 (https://github.com/google/benchmark/commit/c932169e76f8bcdbc36f3b1e910642d529f66268). Thus, this pull request proposes to set the minimum version to 1.5.6 (and otherwise fallback to fetching it).