### PR TITLE
HIP: Fix concurrency

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -76,8 +76,8 @@ std::size_t scratch_count(const std::size_t size) {
 //----------------------------------------------------------------------------
 
 int HIPInternal::concurrency() {
-  static int const concurrency = m_deviceProp.maxThreadsPerMultiProcessor *
-                                 m_deviceProp.multiProcessorCount;
+  static int const concurrency = m_maxThreadsPerSM * m_multiProcCount;
+
   return concurrency;
 }
 


### PR DESCRIPTION
This PR fixes 
- #6473.

i.e., Kokkos hardodes in `Kokkos_HIP.cpp` the maximum number of waves per CU, and the goal of this PR is to make computations of the concurrency consistent with this hardcoded number.

Longer term, should we try to work towards removing this hardcoded value, and ping somebody from AMD to bring this issue to their attention and ask if there is a way for the hip function to ideally return directly the appropriate value for `maxThreadsPerMultiProcessor`?