### PR TITLE
SYCL: half_t/bhalf_t math functions

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
@@ -19,7 +19,8 @@
 
 #ifdef KOKKOS_IMPL_SYCL_HALF_TYPE_DEFINED
 
-#include <Kokkos_Half.hpp>
+#include <SYCL/Kokkos_SYCL_Half_Impl_Type.hpp>
+#include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
 #include <Kokkos_ReductionIdentity.hpp>
 
 namespace Kokkos {

--- a/core/src/SYCL/Kokkos_SYCL_Half_MathematicalFunctions.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_MathematicalFunctions.hpp
@@ -1,0 +1,194 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_SYCL_HALF_MATHEMATICAL_FUNCTIONS_HPP_
+#define KOKKOS_SYCL_HALF_MATHEMATICAL_FUNCTIONS_HPP_
+
+#include <SYCL/Kokkos_SYCL_Half_Impl_Type.hpp>
+#include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
+#include <Kokkos_MathematicalFunctions.hpp>
+
+namespace Kokkos {
+#ifdef KOKKOS_IMPL_SYCL_HALF_TYPE_DEFINED
+
+#define KOKKOS_SYCL_HALF_UNARY_FUNCTION(OP)              \
+  KOKKOS_INLINE_FUNCTION Experimental::half_t impl_##OP( \
+      Experimental::half_t x) {                          \
+    return sycl::OP(Experimental::half_t::impl_type(x)); \
+  }
+
+#define KOKKOS_SYCL_HALF_BINARY_FUNCTION(OP)             \
+  KOKKOS_INLINE_FUNCTION Experimental::half_t impl_##OP( \
+      Experimental::half_t x, Experimental::half_t y) {  \
+    return static_cast<Experimental::half_t>(            \
+        sycl::OP(Experimental::half_t::impl_type(x),     \
+                 Experimental::half_t::impl_type(y)));   \
+  }
+
+#define KOKKOS_SYCL_HALF_UNARY_PREDICATE(OP)                      \
+  KOKKOS_INLINE_FUNCTION bool impl_##OP(Experimental::half_t x) { \
+    return sycl::OP(Experimental::half_t::impl_type(x));          \
+  }
+
+// Basic operations
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(abs)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(fabs)
+KOKKOS_SYCL_HALF_BINARY_FUNCTION(fmod)
+KOKKOS_SYCL_HALF_BINARY_FUNCTION(remainder)
+KOKKOS_SYCL_HALF_BINARY_FUNCTION(fmax)
+KOKKOS_SYCL_HALF_BINARY_FUNCTION(fmin)
+KOKKOS_SYCL_HALF_BINARY_FUNCTION(fdim)
+// Exponential functions
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(exp)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(exp2)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(expm1)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(log)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(log10)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(log2)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(log1p)
+// Power functions
+KOKKOS_SYCL_HALF_BINARY_FUNCTION(pow)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(sqrt)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(cbrt)
+KOKKOS_SYCL_HALF_BINARY_FUNCTION(hypot)
+// Trigonometric functions
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(sin)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(cos)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(tan)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(asin)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(acos)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(atan)
+KOKKOS_SYCL_HALF_BINARY_FUNCTION(atan2)
+// Hyperbolic functions
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(sinh)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(cosh)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(tanh)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(asinh)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(acosh)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(atanh)
+// Error and gamma functions
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(erf)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(erfc)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(tgamma)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(lgamma)
+// Nearest integer floating point functions
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(ceil)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(floor)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(trunc)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(round)
+// KOKKOS_SYCL_HALF_UNARY_FUNCTION(nearbyint)
+KOKKOS_SYCL_HALF_UNARY_FUNCTION(logb)
+KOKKOS_SYCL_HALF_BINARY_FUNCTION(nextafter)
+KOKKOS_SYCL_HALF_BINARY_FUNCTION(copysign)
+KOKKOS_SYCL_HALF_UNARY_PREDICATE(isfinite)
+KOKKOS_SYCL_HALF_UNARY_PREDICATE(isinf)
+KOKKOS_SYCL_HALF_UNARY_PREDICATE(isnan)
+KOKKOS_SYCL_HALF_UNARY_PREDICATE(signbit)
+
+#undef KOKKOS_SYCL_HALF_UNARY_FUNCTION
+#undef KOKKOS_SYCL_HALF_BINARY_FUNCTION
+#undef KOKKOS_SYCL_HALF_UNARY_PREDICATE
+
+#endif
+
+#ifdef KOKKOS_IMPL_SYCL_BHALF_TYPE_DEFINED
+
+#define KOKKOS_SYCL_BHALF_UNARY_FUNCTION(OP)              \
+  KOKKOS_INLINE_FUNCTION Experimental::bhalf_t impl_##OP( \
+      Experimental::bhalf_t x) {                          \
+    return sycl::ext::oneapi::experimental::OP(           \
+        Experimental::bhalf_t::impl_type(x));             \
+  }
+
+#define KOKKOS_SYCL_BHALF_BINARY_FUNCTION(OP)             \
+  KOKKOS_INLINE_FUNCTION Experimental::bhalf_t impl_##OP( \
+      Experimental::bhalf_t x, Experimental::bhalf_t y) { \
+    return static_cast<Experimental::bhalf_t>(            \
+        sycl::ext::oneapi::experimental::OP(              \
+            Experimental::bhalf_t::impl_type(x),          \
+            Experimental::bhalf_t::impl_type(y)));        \
+  }
+
+#define KOKKOS_SYCL_BHALF_UNARY_PREDICATE(OP)                      \
+  KOKKOS_INLINE_FUNCTION bool impl_##OP(Experimental::bhalf_t x) { \
+    return sycl::ext::oneapi::experimental::OP(                    \
+        Experimental::bhalf_t::impl_type(x));                      \
+  }
+
+// Basic operations
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(abs)
+KOKKOS_SYCL_BHALF_UNARY_FUNCTION(fabs)
+// KOKKOS_SYCL_BHALF_BINARY_FUNCTION(fmod)
+// KOKKOS_SYCL_BHALF_BINARY_FUNCTION(remainder)
+KOKKOS_SYCL_BHALF_BINARY_FUNCTION(fmax)
+KOKKOS_SYCL_BHALF_BINARY_FUNCTION(fmin)
+// KOKKOS_SYCL_BHALF_BINARY_FUNCTION(fdim)
+// Exponential functions
+KOKKOS_SYCL_BHALF_UNARY_FUNCTION(exp)
+KOKKOS_SYCL_BHALF_UNARY_FUNCTION(exp2)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(expm1)
+KOKKOS_SYCL_BHALF_UNARY_FUNCTION(log)
+KOKKOS_SYCL_BHALF_UNARY_FUNCTION(log10)
+KOKKOS_SYCL_BHALF_UNARY_FUNCTION(log2)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(log1p)
+// Power functions
+// KOKKOS_SYCL_BHALF_BINARY_FUNCTION(pow)
+KOKKOS_SYCL_BHALF_UNARY_FUNCTION(sqrt)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(cbrt)
+// KOKKOS_SYCL_BHALF_BINARY_FUNCTION(hypot)
+// Trigonometric functions
+KOKKOS_SYCL_BHALF_UNARY_FUNCTION(sin)
+KOKKOS_SYCL_BHALF_UNARY_FUNCTION(cos)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(tan)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(asin)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(acos)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(atan)
+// KOKKOS_SYCL_BHALF_BINARY_FUNCTION(atan2)
+// Hyperbolic functions
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(sinh)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(cosh)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(tanh)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(asinh)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(acosh)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(atanh)
+// Error and gamma functions
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(erf)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(erfc)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(tgamma)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(lgamma)
+// Nearest integer floating point functions
+KOKKOS_SYCL_BHALF_UNARY_FUNCTION(ceil)
+KOKKOS_SYCL_BHALF_UNARY_FUNCTION(floor)
+KOKKOS_SYCL_BHALF_UNARY_FUNCTION(trunc)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(round)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(nearbyint)
+// KOKKOS_SYCL_BHALF_UNARY_FUNCTION(logb)
+// KOKKOS_SYCL_BHALF_BINARY_FUNCTION(nextafter)
+// KOKKOS_SYCL_BHALF_BINARY_FUNCTION(copysign)
+// KOKKOS_SYCL_BHALF_UNARY_PREDICATE(isfinite)
+// KOKKOS_SYCL_BHALF_UNARY_PREDICATE(isinf)
+KOKKOS_SYCL_BHALF_UNARY_PREDICATE(isnan)
+// KOKKOS_SYCL_BHALF_UNARY_PREDICATE(signbit)
+
+#undef KOKKOS_SYCL_BHALF_UNARY_FUNCTION
+#undef KOKKOS_SYCL_BHALF_BINARY_FUNCTION
+#undef KOKKOS_SYCL_BHALF_UNARY_PREDICATE
+
+#endif
+
+}  // namespace Kokkos
+
+#endif

--- a/core/src/decl/Kokkos_Declare_SYCL.hpp
+++ b/core/src/decl/Kokkos_Declare_SYCL.hpp
@@ -21,6 +21,7 @@
 #include <SYCL/Kokkos_SYCL.hpp>
 #include <SYCL/Kokkos_SYCL_Half_Impl_Type.hpp>
 #include <SYCL/Kokkos_SYCL_Half_Conversion.hpp>
+#include <SYCL/Kokkos_SYCL_Half_MathematicalFunctions.hpp>
 #include <SYCL/Kokkos_SYCL_DeepCopy.hpp>
 #include <SYCL/Kokkos_SYCL_MDRangePolicy.hpp>
 #include <SYCL/Kokkos_SYCL_ParallelFor_Range.hpp>

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -42,47 +42,71 @@ namespace Kokkos {
 
 
 #define KOKKOS_IMPL_MATH_UNARY_FUNCTION_HALF_TYPE(FUNC, HALF_TYPE)      \
-  KOKKOS_INLINE_FUNCTION HALF_TYPE FUNC(HALF_TYPE x) {                  \
+  template <bool specialized = true>                                    \
+  KOKKOS_INLINE_FUNCTION HALF_TYPE impl_##FUNC(HALF_TYPE x) {           \
     return static_cast<HALF_TYPE>(Kokkos::FUNC(static_cast<float>(x))); \
+  }                                                                     \
+  KOKKOS_INLINE_FUNCTION HALF_TYPE FUNC(HALF_TYPE x) {                  \
+    return Kokkos::impl_##FUNC(x);                                      \
   }
 
 #define KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, MIXED_TYPE) \
-  KOKKOS_INLINE_FUNCTION double FUNC(HALF_TYPE x, MIXED_TYPE y) {  \
+  template <bool specialized = true>                                     \
+  KOKKOS_INLINE_FUNCTION double impl_##FUNC(HALF_TYPE x, MIXED_TYPE y) { \
     return Kokkos::FUNC(static_cast<double>(x), static_cast<double>(y)); \
-  } \
-  KOKKOS_INLINE_FUNCTION double FUNC(MIXED_TYPE x, HALF_TYPE y) {  \
+  }                                                                      \
+  KOKKOS_INLINE_FUNCTION double FUNC(HALF_TYPE x, MIXED_TYPE y) {        \
+    return Kokkos::impl_##FUNC(x, y);                                    \
+  }                                                                      \
+  template <bool specialized = true>                                     \
+  KOKKOS_INLINE_FUNCTION double impl_##FUNC(MIXED_TYPE x, HALF_TYPE y) { \
     return Kokkos::FUNC(static_cast<double>(x), static_cast<double>(y)); \
+  }                                                                      \
+  KOKKOS_INLINE_FUNCTION double FUNC(MIXED_TYPE x, HALF_TYPE y) {        \
+    return Kokkos::impl_##FUNC(x, y);                                    \
   }
 
-#define KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF(FUNC, HALF_TYPE)       \
-  KOKKOS_INLINE_FUNCTION HALF_TYPE FUNC(HALF_TYPE x, HALF_TYPE y) {  \
-    return static_cast<HALF_TYPE>(                                   \
-        Kokkos::FUNC(static_cast<float>(x), static_cast<float>(y))); \
-  } \
-  KOKKOS_INLINE_FUNCTION float FUNC(float x, HALF_TYPE y) {  \
-    return Kokkos::FUNC(static_cast<float>(x), static_cast<float>(y)); \
-  } \
-  KOKKOS_INLINE_FUNCTION float FUNC(HALF_TYPE x, float y) {  \
-    return Kokkos::FUNC(static_cast<float>(x), static_cast<float>(y)); \
-  } \
-  KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, double) \
-  KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, short) \
+#define KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF(FUNC, HALF_TYPE)                 \
+  template <bool specialized = true>                                           \
+  KOKKOS_INLINE_FUNCTION HALF_TYPE impl_##FUNC(HALF_TYPE x, HALF_TYPE y) {     \
+    return static_cast<HALF_TYPE>(                                             \
+        Kokkos::FUNC(static_cast<float>(x), static_cast<float>(y)));           \
+  }                                                                            \
+  KOKKOS_INLINE_FUNCTION HALF_TYPE FUNC(HALF_TYPE x, HALF_TYPE y) {            \
+    return Kokkos::impl_##FUNC(x, y);                                          \
+  }                                                                            \
+  template <bool specialized = true>                                           \
+  KOKKOS_INLINE_FUNCTION float impl_##FUNC(float x, HALF_TYPE y) {             \
+    return Kokkos::FUNC(static_cast<float>(x), static_cast<float>(y));         \
+  }                                                                            \
+  KOKKOS_INLINE_FUNCTION float FUNC(float x, HALF_TYPE y) {                    \
+    return Kokkos::impl_##FUNC(x, y);                                          \
+  }                                                                            \
+  template <bool specialized = true>                                           \
+  KOKKOS_INLINE_FUNCTION float impl_##FUNC(HALF_TYPE x, float y) {             \
+    return Kokkos::FUNC(static_cast<float>(x), static_cast<float>(y));         \
+  }                                                                            \
+  KOKKOS_INLINE_FUNCTION float FUNC(HALF_TYPE x, float y) {                    \
+    return Kokkos::impl_##FUNC(x, y);                                          \
+  }                                                                            \
+  KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, double)         \
+  KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, short)          \
   KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, unsigned short) \
-  KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, int) \
-  KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, unsigned int) \
-  KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, long) \
-  KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, unsigned long) \
-  KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, long long) \
+  KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, int)            \
+  KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, unsigned int)   \
+  KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, long)           \
+  KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, unsigned long)  \
+  KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, long long)      \
   KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, unsigned long long)
-  
 
 #define KOKKOS_IMPL_MATH_UNARY_PREDICATE_HALF(FUNC, HALF_TYPE) \
-  KOKKOS_INLINE_FUNCTION bool FUNC(HALF_TYPE x) {              \
+  template <bool specialized = true>                           \
+  KOKKOS_INLINE_FUNCTION bool impl_##FUNC(HALF_TYPE x) {       \
     return Kokkos::FUNC(static_cast<float>(x));                \
-  }
+  }                                                            \
+  KOKKOS_INLINE_FUNCTION bool FUNC(HALF_TYPE x) { return impl_##FUNC(x); }
 
 // END macros definitions
-
 
 // Basic operations
 KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_UNARY_FUNCTION_HALF_TYPE, abs)
@@ -136,7 +160,7 @@ KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_UNARY_FUNCTION_HALF_TYPE, ro
 // lround
 // llround
 // FIXME_SYCL not available as of current SYCL 2020 specification (revision 4)
-#ifndef KOKKOS_ENABLE_SYCL // FIXME_SYCL
+#ifndef KOKKOS_ENABLE_SYCL  // FIXME_SYCL
 KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_UNARY_FUNCTION_HALF_TYPE, nearbyint)
 #endif
 // rint
@@ -157,7 +181,7 @@ KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF, copysi
 // fpclassify
 KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_UNARY_PREDICATE_HALF, isfinite)
 KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_UNARY_PREDICATE_HALF, isinf)
-#if !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_HIP) // FIXME_SYCL, FIXME_HIP
+#if !defined(KOKKOS_ENABLE_HIP)  // FIXME_HIP
 KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_UNARY_PREDICATE_HALF, isnan)
 #endif
 // isnormal


### PR DESCRIPTION
This pull request provides overloads for math functions that `SYCL`/`oneAPI` provides for the `half_t`/`b_halft` implementation types.