### PR TITLE
cleaning: remove iostream from headers where possible (IWYU)

### DIFF
--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -35,8 +35,6 @@
 #include <impl/Kokkos_Traits.hpp>
 #include <impl/Kokkos_UnorderedMap_impl.hpp>
 
-#include <iostream>
-
 #include <cstdint>
 
 namespace Kokkos {

--- a/containers/src/impl/Kokkos_Bitset_impl.hpp
+++ b/containers/src/impl/Kokkos_Bitset_impl.hpp
@@ -23,7 +23,6 @@
 
 #include <cstdio>
 #include <climits>
-#include <iostream>
 #include <iomanip>
 
 namespace Kokkos {

--- a/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
+++ b/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
@@ -22,7 +22,6 @@
 
 #include <cstdio>
 #include <climits>
-#include <iostream>
 #include <iomanip>
 
 namespace Kokkos {

--- a/core/perf_test/test_mempool.cpp
+++ b/core/perf_test/test_mempool.cpp
@@ -17,6 +17,7 @@
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
+#include <iostream>
 #include <limits>
 
 #include <benchmark/benchmark.h>

--- a/core/perf_test/test_taskdag.cpp
+++ b/core/perf_test/test_taskdag.cpp
@@ -14,6 +14,8 @@
 //
 //@HEADER
 
+#include <iostream>
+
 #include <Kokkos_Core.hpp>
 
 #if !defined(KOKKOS_ENABLE_TASKDAG) || \

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -29,8 +29,6 @@ static_assert(false,
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>
 
-#include <iostream>
-
 namespace Kokkos {
 namespace Impl {
 /* Report violation of size constraints:

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -27,7 +27,6 @@ static_assert(false,
 #include <impl/Kokkos_FunctorAnalysis.hpp>
 #include <impl/Kokkos_Tools_Generic.hpp>
 #include <type_traits>
-#include <iostream>
 
 namespace Kokkos {
 

--- a/core/src/OpenMP/Kokkos_OpenMP.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.cpp
@@ -18,6 +18,8 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE
 #endif
 
+#include <iostream>
+
 #include <OpenMP/Kokkos_OpenMP.hpp>
 #include <OpenMP/Kokkos_OpenMP_Instance.hpp>
 

--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -20,8 +20,9 @@
 #include <Kokkos_Macros.hpp>
 
 #include <cstdio>
-
+#include <ostream>
 #include <utility>
+
 #include <impl/Kokkos_Spinwait.hpp>
 
 #include <Kokkos_Atomic.hpp>

--- a/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
+++ b/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
@@ -21,8 +21,6 @@
 #include <Kokkos_HostSpace.hpp>
 #include <impl/Kokkos_ZeroMemset_fwd.hpp>
 
-#include <iostream>
-
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
@@ -24,9 +24,9 @@
 
 #include <Kokkos_HostSpace.hpp>  // used with HostInaccessible specializations
 
-#include <string>    // std::string
-#include <cstring>   // strncpy
-#include <iostream>  // ostream
+#include <cstring>
+#include <ostream>
+#include <string>
 
 namespace Kokkos {
 namespace Impl {

--- a/example/build_cmake_in_tree/cmake_example.cpp
+++ b/example/build_cmake_in_tree/cmake_example.cpp
@@ -15,7 +15,9 @@
 //@HEADER
 
 #include <Kokkos_Core.hpp>
+
 #include <cstdio>
+#include <iostream>
 
 int main(int argc, char* argv[]) {
   Kokkos::initialize(argc, argv);

--- a/example/build_cmake_installed/cmake_example.cpp
+++ b/example/build_cmake_installed/cmake_example.cpp
@@ -15,7 +15,9 @@
 //@HEADER
 
 #include <Kokkos_Core.hpp>
+
 #include <cstdio>
+#include <iostream>
 
 extern "C" void print_fortran_();
 

--- a/example/build_cmake_installed_kk_as_language/cmake_example.cpp
+++ b/example/build_cmake_installed_kk_as_language/cmake_example.cpp
@@ -15,7 +15,9 @@
 //@HEADER
 
 #include <Kokkos_Core.hpp>
+
 #include <cstdio>
+#include <iostream>
 
 extern "C" void print_fortran_();
 void print_cxx();


### PR DESCRIPTION
This PR removes `#include <iostream>` where possible from header files.

Related to "Include What You Use" policy (IWYU).

Extracted from #6198 (see kokkos/kokkos/pull/6198#discussion_r1345760198).