### PR TITLE
Fix implementation for cyl_bessel_i0

### DIFF
--- a/core/unit_test/TestMathematicalSpecialFunctions.hpp
+++ b/core/unit_test/TestMathematicalSpecialFunctions.hpp
@@ -1058,7 +1058,7 @@ struct TestComplexBesselI0K0Function {
   void testit() {
     using Kokkos::Experimental::infinity;
 
-    int N      = 25;
+    int N      = 26;
     d_z        = ViewType("d_z", N);
     d_cbi0     = ViewType("d_cbi0", N);
     d_cbk0     = ViewType("d_cbk0", N);
@@ -1094,6 +1094,7 @@ struct TestComplexBesselI0K0Function {
     h_z(22) = Kokkos::complex<double>(-28.0, 0.0);
     h_z(23) = Kokkos::complex<double>(60.0, 0.0);
     h_z(24) = Kokkos::complex<double>(-60.0, 0.0);
+    h_z(25) = Kokkos::complex<double>(7.998015e-5, 0.0);
 
     Kokkos::deep_copy(d_z, h_z);
 
@@ -1152,6 +1153,7 @@ struct TestComplexBesselI0K0Function {
     h_ref_cbi0(22) = Kokkos::complex<double>(1.095346047317573e+11, 0);
     h_ref_cbi0(23) = Kokkos::complex<double>(5.894077055609803e+24, 0);
     h_ref_cbi0(24) = Kokkos::complex<double>(5.894077055609803e+24, 0);
+    h_ref_cbi0(25) = Kokkos::complex<double>(1.0000000015992061009, 0);
 
     h_ref_cbk0(0) = Kokkos::complex<double>(infinity<double>::value, 0);
     h_ref_cbk0(1) =
@@ -1198,6 +1200,7 @@ struct TestComplexBesselI0K0Function {
     h_ref_cbk0(23) = Kokkos::complex<double>(1.413897840559108e-27, 0);
     h_ref_cbk0(24) =
         Kokkos::complex<double>(1.413897840559108e-27, -1.851678917759592e+25);
+    h_ref_cbk0(25) = Kokkos::complex<double>(9.5496636116079915979, 0.);
 
     // FIXME_HIP Disable the test when using ROCm 5.5 and 5.6 due to a known
     // compiler bug


### PR DESCRIPTION
Fixes #6475. The updated implementation uses `CIK01` instead of `CIKNB` from https://people.math.sc.edu/Burkardt/f_src/special_functions/special_functions.f90 which seems more appropriate.
Also see https://en.wikipedia.org/wiki/Bessel_function#Modified_Bessel_functions for the power series used.