### PR TITLE
Fix compiling SIMD unit tests on NVIDIA

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -758,7 +758,7 @@ class simd<float, simd_abi::avx2_fixed_size<4>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(G&& gen)
       : m_value(_mm_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                             gen(std::integral_constant<std::size_t, 1>()),
                             gen(std::integral_constant<std::size_t, 2>()),

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -1064,7 +1064,7 @@ class simd<float, simd_abi::avx512_fixed_size<8>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(G&& gen)
       : m_value(_mm256_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                                gen(std::integral_constant<std::size_t, 1>()),
                                gen(std::integral_constant<std::size_t, 2>()),

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -381,7 +381,7 @@ template <class T, class Abi>
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 namespace Experimental {
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     Experimental::simd<T, Abi>
     min(Experimental::simd<T, Abi> const& a,
         Experimental::simd<T, Abi> const& b) {
@@ -403,7 +403,7 @@ template <class T, class Abi>
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 namespace Experimental {
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     Experimental::simd<T, Abi>
     max(Experimental::simd<T, Abi> const& a,
         Experimental::simd<T, Abi> const& b) {
@@ -431,8 +431,9 @@ template <class T, class Abi>
   }                                                                          \
   namespace Experimental {                                                   \
   template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>   \
-  FUNC(simd<T, Abi> const& a) {                                              \
+  [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION      \
+      simd<T, Abi>                                                           \
+      FUNC(simd<T, Abi> const& a) {                                          \
     return Kokkos::FUNC(a);                                                  \
   }                                                                          \
   }
@@ -488,8 +489,9 @@ KOKKOS_IMPL_SIMD_UNARY_FUNCTION(lgamma)
   }                                                                          \
   namespace Experimental {                                                   \
   template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>   \
-  FUNC(simd<T, Abi> const& a, simd<T, Abi> const& b) {                       \
+  [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION      \
+      simd<T, Abi>                                                           \
+      FUNC(simd<T, Abi> const& a, simd<T, Abi> const& b) {                   \
     Kokkos::FUNC(a, b);                                                      \
   }                                                                          \
   }
@@ -513,24 +515,26 @@ KOKKOS_IMPL_SIMD_BINARY_FUNCTION(atan2)
 KOKKOS_IMPL_SIMD_BINARY_FUNCTION(copysign)
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-#define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                               \
-  template <class T, class Abi>                                               \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> FUNC(  \
-      Experimental::simd<T, Abi> const& a,                                    \
-      Experimental::simd<T, Abi> const& b,                                    \
-      Experimental::simd<T, Abi> const& c) {                                  \
-    Experimental::simd<T, Abi> result;                                        \
-    for (std::size_t i = 0; i < Experimental::simd<T, Abi>::size(); ++i) {    \
-      result[i] = Kokkos::FUNC(a[i], b[i], c[i]);                             \
-    }                                                                         \
-    return result;                                                            \
-  }                                                                           \
-  namespace Experimental {                                                    \
-  template <class T, class Abi>                                               \
-  [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>    \
-  FUNC(simd<T, Abi> const& a, simd<T, Abi> const& b, simd<T, Abi> const& c) { \
-    return Kokkos::FUNC(a, b, c);                                             \
-  }                                                                           \
+#define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                              \
+  template <class T, class Abi>                                              \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> FUNC( \
+      Experimental::simd<T, Abi> const& a,                                   \
+      Experimental::simd<T, Abi> const& b,                                   \
+      Experimental::simd<T, Abi> const& c) {                                 \
+    Experimental::simd<T, Abi> result;                                       \
+    for (std::size_t i = 0; i < Experimental::simd<T, Abi>::size(); ++i) {   \
+      result[i] = Kokkos::FUNC(a[i], b[i], c[i]);                            \
+    }                                                                        \
+    return result;                                                           \
+  }                                                                          \
+  namespace Experimental {                                                   \
+  template <class T, class Abi>                                              \
+  [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION      \
+      simd<T, Abi>                                                           \
+      FUNC(simd<T, Abi> const& a, simd<T, Abi> const& b,                     \
+           simd<T, Abi> const& c) {                                          \
+    return Kokkos::FUNC(a, b, c);                                            \
+  }                                                                          \
   }
 #else
 #define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                              \

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -550,7 +550,7 @@ class simd<float, simd_abi::neon_fixed_size<2>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen) {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(G&& gen) {
     m_value = vset_lane_f32(gen(std::integral_constant<std::size_t, 0>()),
                             m_value, 0);
     m_value = vset_lane_f32(gen(std::integral_constant<std::size_t, 1>()),

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -80,7 +80,7 @@ class absolutes {
   template <typename T>
   auto on_host(T const& a) const {
     if constexpr (std::is_signed_v<typename T::value_type>) {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) && !defined(KOKKOS_COMPILER_NVCC)
       return Kokkos::Experimental::abs(a);
 #else
       return Kokkos::abs(a);
@@ -95,11 +95,7 @@ class absolutes {
   template <typename T>
   KOKKOS_INLINE_FUNCTION auto on_device(T const& a) const {
     if constexpr (std::is_signed_v<typename T::value_type>) {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-      return Kokkos::Experimental::abs(a);
-#else
       return Kokkos::abs(a);
-#endif
     }
     return a;
   }

--- a/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
+++ b/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
@@ -36,20 +36,33 @@ inline void host_check_gen_ctor() {
     expected[i] = (init_mask[i]) ? init[i] * 9 : init[i];
   }
 
-  simd_type basic(KOKKOS_LAMBDA(std::size_t i) { return init[i]; });
-  mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return init_mask[i]; });
-
   simd_type rhs;
   rhs.copy_from(init, Kokkos::Experimental::element_aligned_tag());
-  host_check_equality(basic, rhs, lanes);
-
-  simd_type lhs(KOKKOS_LAMBDA(std::size_t i) { return init[i] * 9; });
-  simd_type result(
-      KOKKOS_LAMBDA(std::size_t i) { return (mask[i]) ? lhs[i] : rhs[i]; });
 
   simd_type blend;
   blend.copy_from(expected, Kokkos::Experimental::element_aligned_tag());
-  host_check_equality(blend, result, lanes);
+
+  if constexpr (std::is_same_v<Abi, Kokkos::Experimental::simd_abi::scalar>) {
+    simd_type basic(KOKKOS_LAMBDA(std::size_t i) { return init[i]; });
+    host_check_equality(basic, rhs, lanes);
+
+    simd_type lhs(KOKKOS_LAMBDA(std::size_t i) { return init[i] * 9; });
+    mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return init_mask[i]; });
+    simd_type result(
+        KOKKOS_LAMBDA(std::size_t i) { return (mask[i]) ? lhs[i] : rhs[i]; });
+
+    host_check_equality(blend, result, lanes);
+  } else {
+    simd_type basic([=](std::size_t i) { return init[i]; });
+    host_check_equality(basic, rhs, lanes);
+
+    simd_type lhs([=](std::size_t i) { return init[i] * 9; });
+    mask_type mask([=](std::size_t i) { return init_mask[i]; });
+    simd_type result(
+        [=](std::size_t i) { return (mask[i]) ? lhs[i] : rhs[i]; });
+
+    host_check_equality(blend, result, lanes);
+  }
 }
 
 template <typename Abi, typename... DataTypes>


### PR DESCRIPTION
This pull request fixes the issue with using SIMD `Experimental` math functions with `nvcc` we are currently seeing on `develop`:
```
/var/jenkins/workspace/Kokkos/install/include/Kokkos_SIMD_Common.hpp(452): error: "Kokkos::Experimental::simd<int32_t, Kokkos::Experimental::simd_abi::avx512_fixed_size<8>>" contains a vector, which is not supported in device code
          detected during:
            instantiation of "Kokkos::Experimental::simd<T, Abi> Kokkos::abs(const Kokkos::Experimental::simd<T, Abi> &) [with T=int32_t, Abi=Kokkos::Experimental::simd_abi::avx512_fixed_size<8>]" 
(452): here
            instantiation of "Kokkos::Experimental::simd<T, Abi> Kokkos::Experimental::abs(const Kokkos::Experimental::simd<T, Abi> &) [with T=int32_t, Abi=Kokkos::Experimental::simd_abi::avx512_fixed_size<8>]" 
/var/jenkins/workspace/Kokkos/simd/unit_tests/include/TestSIMD_MathOps.hpp(69): here
            instantiation of "void host_check_math_op_one_loader<Abi,Loader,UnaryOp,T>(UnaryOp, std::size_t, const T *) [with Abi=Kokkos::Experimental::simd_abi::avx512_fixed_size<8>, Loader=load_element_aligned, UnaryOp=absolutes, T=int32_t]" 
/var/jenkins/workspace/Kokkos/simd/unit_tests/include/TestSIMD_MathOps.hpp(77): here
            instantiation of "void host_check_math_op_all_loaders<Abi,Op,T...>(Op, std::size_t, const T *...) [with Abi=Kokkos::Experimental::simd_abi::avx512_fixed_size<8>, Op=absolutes, T=<int32_t>]" 
/var/jenkins/workspace/Kokkos/simd/unit_tests/include/TestSIMD_MathOps.hpp(93): here
            instantiation of "void host_check_all_math_ops<Abi,DataType,n>(const DataType (&)[n], const DataType (&)[n]) [with Abi=Kokkos::Experimental::simd_abi::avx512_fixed_size<8>, DataType=int32_t, n=11UL]" 
/var/jenkins/workspace/Kokkos/simd/unit_tests/include/TestSIMD_MathOps.hpp(112): here
            instantiation of "void host_check_math_ops<Abi,DataType>() [with Abi=Kokkos::Experimental::simd_abi::avx512_fixed_size<8>, DataType=int32_t]" 
/var/jenkins/workspace/Kokkos/simd/unit_tests/include/TestSIMD_MathOps.hpp(123): here
            instantiation of "void host_check_math_ops_all_types<Abi,DataTypes...>(Kokkos::Experimental::Impl::data_types<DataTypes...>) [with Abi=Kokkos::Experimental::simd_abi::avx512_fixed_size<8>, DataTypes=<int32_t, uint32_t, int64_t, uint64_t, double, float>]" 
/var/jenkins/workspace/Kokkos/simd/unit_tests/include/TestSIMD_MathOps.hpp(130): here
            instantiation of "void host_check_math_ops_all_abis(Kokkos::Experimental::Impl::abi_set<Abis...>) [with Abis=<Kokkos::Experimental::simd_abi::scalar, Kokkos::Experimental::simd_abi::avx512_fixed_size<8>>]" 
/var/jenkins/workspace/Kokkos/simd/unit_tests/include/TestSIMD_MathOps.hpp(253): here
```
We don't overload the `Experimental` math function so it makes sense that the compiler complains in the `device` pass for host-only SIMD types. Since specializations are provided for `host`-only SIMD types, this pull request annotates the `Experimental` (deprecated) functions as `host`-only.
It seems, however, that the compiler doesn't see that the correct overload referred to in the `Kokkos::Experimental` math function is annotated as host-only function. Therefore, we never call the `Experimental` function for `nvcc`.

The pull request also fixes a bunch of other warnings where we were calling host functions from host-device functions.