### PR TITLE
Fix example/build_cmake_installed_different_compiler

### DIFF
--- a/example/build_cmake_installed_different_compiler/foo.cpp
+++ b/example/build_cmake_installed_different_compiler/foo.cpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #include <Kokkos_Core.hpp>
-#include <cstdio>
+#include <iostream>
 
 struct CountFunctor {
   KOKKOS_FUNCTION void operator()(const long i, long& lcount) const {


### PR DESCRIPTION
After https://github.com/kokkos/kokkos/pull/6482, we need to explicitly include `<iostream>` in `example/build_cmake_installed_different_compiler` for `std::cout`.