### PR TITLE
SYCL: Allow setting subgroup size

### DIFF
--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -121,6 +121,13 @@ struct LaunchBounds {
   static constexpr unsigned int minBperSM{minB};
 };
 
+template <int size>
+struct SubGroupSize {
+  using subgroup_size        = SubGroupSize;
+  using type                 = SubGroupSize<size>;
+  static constexpr int value = size;
+};
+
 }  // namespace Kokkos
 
 //----------------------------------------------------------------------------

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Range.hpp
@@ -27,7 +27,16 @@ struct FunctorWrapperRangePolicyParallelFor {
   using WorkTag = typename Policy::work_tag;
 
     template <int sg_size = Policy::subgroup_size>
-    std::enable_if_t<(sg_size<0)> operator()(sycl::item<1> item) const {
+    std::enable_if_t<(sg_size<=0)> operator()(sycl::item<1> item) const {
+    const typename Policy::index_type id = item.get_linear_id() + m_begin;
+    if constexpr (std::is_void_v<WorkTag>)
+      m_functor_wrapper.get_functor()(id);
+    else
+      m_functor_wrapper.get_functor()(WorkTag(), id);
+  }
+
+    template <int sg_size = Policy::subgroup_size>
+    [[sycl::reqd_work_group_size(sg_size)]] std::enable_if_t<(sg_size>0)> operator()(sycl::item<1> item) const {
     const typename Policy::index_type id = item.get_linear_id() + m_begin;
     if constexpr (std::is_void_v<WorkTag>)
       m_functor_wrapper.get_functor()(id);

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Range.hpp
@@ -87,6 +87,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
 #else
       (void)memcpy_event;
 #endif
+      static_assert(Policy::subgroup_size<0);
       if (policy.chunk_size() <= 1) {
         FunctorWrapperRangePolicyParallelFor<Functor, Policy> f{policy.begin(),
                                                                 functor};

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Range.hpp
@@ -26,7 +26,8 @@ template <typename FunctorWrapper, typename Policy>
 struct FunctorWrapperRangePolicyParallelFor {
   using WorkTag = typename Policy::work_tag;
 
-  void operator()(sycl::item<1> item) const {
+    template <int sg_size = Policy::subgroup_size>
+    std::enable_if_t<(sg_size<0)> operator()(sycl::item<1> item) const {
     const typename Policy::index_type id = item.get_linear_id() + m_begin;
     if constexpr (std::is_void_v<WorkTag>)
       m_functor_wrapper.get_functor()(id);
@@ -87,7 +88,6 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
 #else
       (void)memcpy_event;
 #endif
-      static_assert(Policy::subgroup_size<0);
       if (policy.chunk_size() <= 1) {
         FunctorWrapperRangePolicyParallelFor<Functor, Policy> f{policy.begin(),
                                                                 functor};

--- a/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
+++ b/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
@@ -62,6 +62,43 @@ struct PolicyTraitMatcher<LaunchBoundsTrait, LaunchBounds<maxT, minB>>
 // </editor-fold> end PolicyTraitMatcher specialization }}}1
 //==============================================================================
 
+//==============================================================================
+// <editor-fold desc="trait specification"> {{{1
+
+struct SubGroupSizeTrait : TraitSpecificationBase<SubGroupSizeTrait> {
+  struct base_traits {
+    static constexpr bool launch_bounds_is_defaulted = true;
+    static constexpr int subgroup_size               = -1;
+
+    KOKKOS_IMPL_MSVC_NVCC_EBO_WORKAROUND
+  };
+  template <class SubGroupSizeParam, class AnalyzeNextTrait>
+  struct mixin_matching_trait : AnalyzeNextTrait {
+    using base_t = AnalyzeNextTrait;
+    using base_t::base_t;
+
+    static constexpr bool launch_bounds_is_defaulted = false;
+
+    static_assert(base_t::launch_bounds_is_defaulted,
+                  "Kokkos Error: More than one launch_bounds given");
+
+    static constexpr int subgroup_size = SubGroupSizeParam::size;
+  };
+};
+
+// </editor-fold> end trait specification }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="PolicyTraitMatcher specialization"> {{{1
+
+template <int size>
+struct PolicyTraitMatcher<SubGroupsSizeTrait, SubGroupSize<size>>
+    : std::true_type {};
+
+// </editor-fold> end PolicyTraitMatcher specialization }}}1
+//==============================================================================
+
 }  // end namespace Impl
 }  // end namespace Kokkos
 

--- a/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
+++ b/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
@@ -67,7 +67,7 @@ struct PolicyTraitMatcher<LaunchBoundsTrait, LaunchBounds<maxT, minB>>
 
 struct SubGroupSizeTrait : TraitSpecificationBase<SubGroupSizeTrait> {
   struct base_traits {
-    static constexpr bool launch_bounds_is_defaulted = true;
+    static constexpr bool subgroup_size_is_defaulted = true;
     static constexpr int subgroup_size               = -1;
 
     KOKKOS_IMPL_MSVC_NVCC_EBO_WORKAROUND
@@ -77,12 +77,12 @@ struct SubGroupSizeTrait : TraitSpecificationBase<SubGroupSizeTrait> {
     using base_t = AnalyzeNextTrait;
     using base_t::base_t;
 
-    static constexpr bool launch_bounds_is_defaulted = false;
+    static constexpr bool subgroup_size_is_defaulted = false;
 
-    static_assert(base_t::launch_bounds_is_defaulted,
-                  "Kokkos Error: More than one launch_bounds given");
+    static_assert(base_t::subgroup_size_is_defaulted,
+                  "Kokkos Error: More than one subgroup size given");
 
-    static constexpr int subgroup_size = SubGroupSizeParam::size;
+    static constexpr int subgroup_size = SubGroupSizeParam::value;
   };
 };
 
@@ -93,7 +93,7 @@ struct SubGroupSizeTrait : TraitSpecificationBase<SubGroupSizeTrait> {
 // <editor-fold desc="PolicyTraitMatcher specialization"> {{{1
 
 template <int size>
-struct PolicyTraitMatcher<SubGroupsSizeTrait, SubGroupSize<size>>
+struct PolicyTraitMatcher<SubGroupSizeTrait, SubGroupSize<size>>
     : std::true_type {};
 
 // </editor-fold> end PolicyTraitMatcher specialization }}}1

--- a/core/src/traits/Kokkos_Traits_fwd.hpp
+++ b/core/src/traits/Kokkos_Traits_fwd.hpp
@@ -63,6 +63,7 @@ struct ScheduleTrait;
 struct IterationPatternTrait;
 struct WorkItemPropertyTrait;
 struct LaunchBoundsTrait;
+struct SubGroupSizeTrait;
 struct OccupancyControlTrait;
 struct GraphKernelTrait;
 struct WorkTagTrait;
@@ -78,6 +79,7 @@ using execution_policy_trait_specifications =
     IterationPatternTrait,
     WorkItemPropertyTrait,
     LaunchBoundsTrait,
+    SubGroupSizeTrait,
     OccupancyControlTrait,
     GraphKernelTrait,
     // This one has to be last, unfortunately:

--- a/core/unit_test/incremental/Test04_ParallelFor_RangePolicy.hpp
+++ b/core/unit_test/incremental/Test04_ParallelFor_RangePolicy.hpp
@@ -100,7 +100,7 @@ struct TestParallel_For {
 
     // parallel-for functor called for num_elements number of iterations.
     Kokkos::parallel_for("parallel_for",
-                         Kokkos::RangePolicy<ExecSpace>(0, num_elements),
+                         Kokkos::RangePolicy<ExecSpace, Kokkos::SubGroupSize<32>>(0, num_elements),
                          ParallelForFunctor(deviceData, value));
 
     Kokkos::fence();


### PR DESCRIPTION
There is demand for being able to set the subgroup size per kernel. This is mostly for discussion and for people to try it out. At the moment, only `RangePolicy` with `parallel_for` is supported.