### PR TITLE
team-level std algorithms: remove guards for HPX and OpenMPTarget 

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_MustUseKokkosSingleInTeam.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_MustUseKokkosSingleInTeam.hpp
@@ -36,20 +36,6 @@ struct stdalgo_must_use_kokkos_single_for_team_scan<
     Kokkos::Experimental::OpenACC> : std::true_type {};
 #endif
 
-// FIXME_OPENMPTARGET
-#if defined(KOKKOS_ENABLE_OPENMPTARGET)
-template <>
-struct stdalgo_must_use_kokkos_single_for_team_scan<
-    Kokkos::Experimental::OpenMPTarget> : std::true_type {};
-#endif
-
-// FIXME_HPX
-#if defined(KOKKOS_ENABLE_HPX)
-template <>
-struct stdalgo_must_use_kokkos_single_for_team_scan<Kokkos::Experimental::HPX>
-    : std::true_type {};
-#endif
-
 template <typename T>
 inline constexpr bool stdalgo_must_use_kokkos_single_for_team_scan_v =
     stdalgo_must_use_kokkos_single_for_team_scan<T>::value;


### PR DESCRIPTION
Remove guards for HPX and OpenMPTarget that were needed due to missing par_scan overload with return value. 

THIS MUST BE MERGED AFTER https://github.com/kokkos/kokkos/pull/6497 and https://github.com/kokkos/kokkos/pull/6495
