### PR TITLE
Rename Kokkos_ThreadsExec to align with the other backends

### DIFF
--- a/Makefile.targets
+++ b/Makefile.targets
@@ -82,8 +82,8 @@ Lock_Array_HIP.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/tpls/desul/src/Lock_Array
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_THREADS), 1)
-Kokkos_ThreadsExec.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/Threads/Kokkos_ThreadsExec.cpp
-	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/Threads/Kokkos_ThreadsExec.cpp
+Kokkos_Threads_Instance.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/Threads/Kokkos_Threads_Instance.cpp
+	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/Threads/Kokkos_Threads_Instance.cpp
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_OPENMP), 1)

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -40,7 +40,7 @@ static_assert(false,
 
 namespace Kokkos {
 namespace Impl {
-class ThreadsExec;
+class ThreadsInternal;
 enum class fence_is_static { yes, no };
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -50,8 +50,8 @@ class ThreadsExecTeamMember {
 
  private:
   using space = execution_space::scratch_memory_space;
-  ThreadsExec* const m_exec;
-  ThreadsExec* const* m_team_base;  ///< Base for team fan-in
+  ThreadsInternal* const m_instance;
+  ThreadsInternal* const* m_team_base;  ///< Base for team fan-in
   space m_team_shared;
   size_t m_team_shared_size;
   int m_team_size;
@@ -85,13 +85,14 @@ class ThreadsExecTeamMember {
          (!(m_team_rank_rev & n)) && ((j = m_team_rank_rev + n) < m_team_size);
          n <<= 1) {
       Impl::spinwait_while_equal<int>(m_team_base[j]->state(),
-                                      ThreadsExec::Active);
+                                      ThreadsInternal::Active);
     }
 
     // If not root then wait for release
     if (m_team_rank_rev) {
-      m_exec->state() = ThreadsExec::Rendezvous;
-      Impl::spinwait_while_equal<int>(m_exec->state(), ThreadsExec::Rendezvous);
+      m_instance->state() = ThreadsInternal::Rendezvous;
+      Impl::spinwait_while_equal<int>(m_instance->state(),
+                                      ThreadsInternal::Rendezvous);
     }
 
     return !m_team_rank_rev;
@@ -102,7 +103,7 @@ class ThreadsExecTeamMember {
     for (n = 1;
          (!(m_team_rank_rev & n)) && ((j = m_team_rank_rev + n) < m_team_size);
          n <<= 1) {
-      m_team_base[j]->state() = ThreadsExec::Active;
+      m_team_base[j]->state() = ThreadsInternal::Active;
     }
   }
 
@@ -188,10 +189,10 @@ class ThreadsExecTeamMember {
         using type =
             typename if_c<sizeof(Type) < TEAM_REDUCE_SIZE, Type, void>::type;
 
-        if (nullptr == m_exec) return value;
+        if (m_instance == nullptr) return value;
 
         if (team_rank() != team_size() - 1) *
-            ((volatile type*)m_exec->scratch_memory()) = value;
+            ((volatile type*)m_instance->scratch_memory()) = value;
 
         memory_fence();
 
@@ -229,9 +230,9 @@ class ThreadsExecTeamMember {
         using type = typename if_c<sizeof(value_type) < TEAM_REDUCE_SIZE,
                                    value_type, void>::type;
 
-        if (nullptr == m_exec) return;
+        if (m_instance == nullptr) return;
 
-        type* const local_value = ((type*)m_exec->scratch_memory());
+        type* const local_value = ((type*)m_instance->scratch_memory());
 
         // Set this thread's contribution
         if (team_rank() != team_size() - 1) { *local_value = contribution; }
@@ -285,9 +286,9 @@ class ThreadsExecTeamMember {
         using type = typename if_c<sizeof(ArgType) < TEAM_REDUCE_SIZE, ArgType,
                                    void>::type;
 
-        if (nullptr == m_exec) return type(0);
+        if (m_instance == nullptr) return type(0);
 
-        volatile type* const work_value = ((type*)m_exec->scratch_memory());
+        volatile type* const work_value = ((type*)m_instance->scratch_memory());
 
         *work_value = value;
 
@@ -342,10 +343,10 @@ class ThreadsExecTeamMember {
 
   template <class... Properties>
   ThreadsExecTeamMember(
-      Impl::ThreadsExec* exec,
+      Impl::ThreadsInternal* instance,
       const TeamPolicyInternal<Kokkos::Threads, Properties...>& team,
       const size_t shared_size)
-      : m_exec(exec),
+      : m_instance(instance),
         m_team_base(nullptr),
         m_team_shared(nullptr, 0),
         m_team_shared_size(shared_size),
@@ -361,9 +362,11 @@ class ThreadsExecTeamMember {
     if (team.league_size()) {
       // Execution is using device-team interface:
 
-      const int pool_rank_rev = m_exec->pool_size() - (m_exec->pool_rank() + 1);
+      const int pool_rank_rev =
+          m_instance->pool_size() - (m_instance->pool_rank() + 1);
       const int team_rank_rev = pool_rank_rev % team.team_alloc();
-      const size_t pool_league_size = m_exec->pool_size() / team.team_alloc();
+      const size_t pool_league_size =
+          m_instance->pool_size() / team.team_alloc();
       const size_t pool_league_rank_rev = pool_rank_rev / team.team_alloc();
       if (pool_league_rank_rev >= pool_league_size) {
         m_invalid_thread = 1;
@@ -372,7 +375,7 @@ class ThreadsExecTeamMember {
       const size_t pool_league_rank =
           pool_league_size - (pool_league_rank_rev + 1);
 
-      const int pool_num_teams = m_exec->pool_size() / team.team_alloc();
+      const int pool_num_teams = m_instance->pool_size() / team.team_alloc();
       const int chunk_size =
           team.chunk_size() > 0 ? team.chunk_size() : team.team_iter();
       const int chunks_per_team =
@@ -387,8 +390,8 @@ class ThreadsExecTeamMember {
 
       if ((team.team_alloc() > size_t(m_team_size))
               ? (team_rank_rev >= m_team_size)
-              : (m_exec->pool_size() - pool_num_teams * m_team_size >
-                 m_exec->pool_rank()))
+              : (m_instance->pool_size() - pool_num_teams * m_team_size >
+                 m_instance->pool_rank()))
         m_invalid_thread = 1;
       else
         m_invalid_thread = 0;
@@ -398,7 +401,7 @@ class ThreadsExecTeamMember {
 
       if (team_rank_rev < team.team_size() && !m_invalid_thread) {
         m_team_base =
-            m_exec->pool_base() + team.team_alloc() * pool_league_rank_rev;
+            m_instance->pool_base() + team.team_alloc() * pool_league_rank_rev;
         m_team_size     = team.team_size();
         m_team_rank     = team.team_size() - (team_rank_rev + 1);
         m_team_rank_rev = team_rank_rev;
@@ -413,13 +416,13 @@ class ThreadsExecTeamMember {
       }
 
       if ((m_team_rank_rev == 0) && (m_invalid_thread == 0)) {
-        m_exec->set_work_range(m_league_rank, m_league_end, m_chunk_size);
-        m_exec->reset_steal_target(m_team_size);
+        m_instance->set_work_range(m_league_rank, m_league_end, m_chunk_size);
+        m_instance->reset_steal_target(m_team_size);
       }
       if (std::is_same<typename TeamPolicyInternal<
                            Kokkos::Threads, Properties...>::schedule_type::type,
                        Kokkos::Dynamic>::value) {
-        m_exec->barrier();
+        m_instance->barrier();
       }
     } else {
       m_invalid_thread = 1;
@@ -427,7 +430,7 @@ class ThreadsExecTeamMember {
   }
 
   ThreadsExecTeamMember()
-      : m_exec(nullptr),
+      : m_instance(nullptr),
         m_team_base(nullptr),
         m_team_shared(nullptr, 0),
         m_team_shared_size(0),
@@ -442,8 +445,8 @@ class ThreadsExecTeamMember {
         m_invalid_thread(0),
         m_team_alloc(0) {}
 
-  inline ThreadsExec& threads_exec_team_base() const {
-    return m_team_base ? **m_team_base : *m_exec;
+  inline ThreadsInternal& threads_exec_team_base() const {
+    return m_team_base ? **m_team_base : *m_instance;
   }
 
   bool valid_static() const { return m_league_rank < m_league_end; }

--- a/core/src/Threads/Kokkos_Threads_Instance.hpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.hpp
@@ -14,8 +14,8 @@
 //
 //@HEADER
 
-#ifndef KOKKOS_THREADSEXEC_HPP
-#define KOKKOS_THREADSEXEC_HPP
+#ifndef KOKKOS_THREADS_INSTANCE_HPP
+#define KOKKOS_THREADS_INSTANCE_HPP
 
 #include <Kokkos_Macros.hpp>
 
@@ -35,7 +35,7 @@
 
 namespace Kokkos {
 namespace Impl {
-class ThreadsExec {
+class ThreadsInternal {
  public:
   // Fan array has log_2(NT) reduction threads plus 2 scan threads
   // Currently limited to 16k threads.
@@ -67,7 +67,7 @@ class ThreadsExec {
   // the threads that need them.
   // For a simple reduction the thread location is arbitrary.
 
-  ThreadsExec *const *m_pool_base;  ///< Base for pool fan-in
+  ThreadsInternal *const *m_pool_base;  ///< Base for pool fan-in
 
   void *m_scratch;
   int m_scratch_reduce_end;
@@ -95,12 +95,12 @@ class ThreadsExec {
   static void global_unlock();
   static void spawn();
 
-  static void first_touch_allocate_thread_private_scratch(ThreadsExec &,
+  static void first_touch_allocate_thread_private_scratch(ThreadsInternal &,
                                                           const void *);
-  static void execute_sleep(ThreadsExec &, const void *);
+  static void execute_sleep(ThreadsInternal &, const void *);
 
-  ThreadsExec(const ThreadsExec &);
-  ThreadsExec &operator=(const ThreadsExec &);
+  ThreadsInternal(const ThreadsInternal &);
+  ThreadsInternal &operator=(const ThreadsInternal &);
 
   static void execute_resize_scratch_in_serial();
 
@@ -112,7 +112,7 @@ class ThreadsExec {
   inline long team_work_index() const { return m_team_work_index; }
 
   static int get_thread_count();
-  static ThreadsExec *get_thread(const int init_thread_rank);
+  static ThreadsInternal *get_thread(const int init_thread_rank);
 
   inline void *reduce_memory() const { return m_scratch; }
   KOKKOS_INLINE_FUNCTION void *scratch_memory() const {
@@ -120,14 +120,14 @@ class ThreadsExec {
   }
 
   KOKKOS_INLINE_FUNCTION int volatile &state() { return m_pool_state; }
-  KOKKOS_INLINE_FUNCTION ThreadsExec *const *pool_base() const {
+  KOKKOS_INLINE_FUNCTION ThreadsInternal *const *pool_base() const {
     return m_pool_base;
   }
 
   static void driver(void);
 
-  ~ThreadsExec();
-  ThreadsExec();
+  ~ThreadsInternal();
+  ThreadsInternal();
 
   static void *resize_scratch(size_t reduce_size, size_t thread_size);
 
@@ -167,13 +167,15 @@ class ThreadsExec {
     for (int i = 0; i < m_pool_fan_size; ++i) {
       // Wait: Active -> Rendezvous
       Impl::spinwait_while_equal<int>(
-          m_pool_base[rev_rank + (1 << i)]->m_pool_state, ThreadsExec::Active);
+          m_pool_base[rev_rank + (1 << i)]->m_pool_state,
+          ThreadsInternal::Active);
     }
 
     if (rev_rank) {
-      m_pool_state = ThreadsExec::Rendezvous;
+      m_pool_state = ThreadsInternal::Rendezvous;
       // Wait: Rendezvous -> Active
-      Impl::spinwait_while_equal<int>(m_pool_state, ThreadsExec::Rendezvous);
+      Impl::spinwait_while_equal<int>(m_pool_state,
+                                      ThreadsInternal::Rendezvous);
     } else {
       // Root thread does the reduction and broadcast
 
@@ -191,7 +193,7 @@ class ThreadsExec {
       memory_fence();
 
       for (int rank = 0; rank < m_pool_size; ++rank) {
-        get_thread(rank)->m_pool_state = ThreadsExec::Active;
+        get_thread(rank)->m_pool_state = ThreadsInternal::Active;
       }
     }
 
@@ -208,20 +210,22 @@ class ThreadsExec {
     for (int i = 0; i < m_pool_fan_size; ++i) {
       // Wait: Active -> Rendezvous
       Impl::spinwait_while_equal<int>(
-          m_pool_base[rev_rank + (1 << i)]->m_pool_state, ThreadsExec::Active);
+          m_pool_base[rev_rank + (1 << i)]->m_pool_state,
+          ThreadsInternal::Active);
     }
 
     if (rev_rank) {
-      m_pool_state = ThreadsExec::Rendezvous;
+      m_pool_state = ThreadsInternal::Rendezvous;
       // Wait: Rendezvous -> Active
-      Impl::spinwait_while_equal<int>(m_pool_state, ThreadsExec::Rendezvous);
+      Impl::spinwait_while_equal<int>(m_pool_state,
+                                      ThreadsInternal::Rendezvous);
     } else {
       // Root thread does the reduction and broadcast
 
       memory_fence();
 
       for (int rank = 0; rank < m_pool_size; ++rank) {
-        get_thread(rank)->m_pool_state = ThreadsExec::Active;
+        get_thread(rank)->m_pool_state = ThreadsInternal::Active;
       }
     }
   }
@@ -234,9 +238,10 @@ class ThreadsExec {
     const int rev_rank = m_pool_size - (m_pool_rank + 1);
 
     for (int i = 0; i < m_pool_fan_size; ++i) {
-      ThreadsExec &fan = *m_pool_base[rev_rank + (1 << i)];
+      ThreadsInternal &fan = *m_pool_base[rev_rank + (1 << i)];
 
-      Impl::spinwait_while_equal<int>(fan.m_pool_state, ThreadsExec::Active);
+      Impl::spinwait_while_equal<int>(fan.m_pool_state,
+                                      ThreadsInternal::Active);
 
       f.join(
           reinterpret_cast<typename FunctorType::value_type *>(reduce_memory()),
@@ -266,7 +271,8 @@ class ThreadsExec {
 
     for (int i = 0; i < m_pool_fan_size; ++i) {
       Impl::spinwait_while_equal<int>(
-          m_pool_base[rev_rank + (1 << i)]->m_pool_state, ThreadsExec::Active);
+          m_pool_base[rev_rank + (1 << i)]->m_pool_state,
+          ThreadsInternal::Active);
     }
   }
 
@@ -289,10 +295,11 @@ class ThreadsExec {
     //--------------------------------
     // Fan-in reduction with highest ranking thread as the root
     for (int i = 0; i < m_pool_fan_size; ++i) {
-      ThreadsExec &fan = *m_pool_base[rev_rank + (1 << i)];
+      ThreadsInternal &fan = *m_pool_base[rev_rank + (1 << i)];
 
       // Wait: Active -> ReductionAvailable (or ScanAvailable)
-      Impl::spinwait_while_equal<int>(fan.m_pool_state, ThreadsExec::Active);
+      Impl::spinwait_while_equal<int>(fan.m_pool_state,
+                                      ThreadsInternal::Active);
       f.join(work_value, fan.reduce_memory());
     }
 
@@ -303,39 +310,41 @@ class ThreadsExec {
 
     if (rev_rank) {
       // Set: Active -> ReductionAvailable
-      m_pool_state = ThreadsExec::ReductionAvailable;
+      m_pool_state = ThreadsInternal::ReductionAvailable;
 
       // Wait for contributing threads' scan value to be available.
       if ((1 << m_pool_fan_size) < (m_pool_rank + 1)) {
-        ThreadsExec &th = *m_pool_base[rev_rank + (1 << m_pool_fan_size)];
+        ThreadsInternal &th = *m_pool_base[rev_rank + (1 << m_pool_fan_size)];
 
         // Wait: Active             -> ReductionAvailable
         // Wait: ReductionAvailable -> ScanAvailable
-        Impl::spinwait_while_equal<int>(th.m_pool_state, ThreadsExec::Active);
         Impl::spinwait_while_equal<int>(th.m_pool_state,
-                                        ThreadsExec::ReductionAvailable);
+                                        ThreadsInternal::Active);
+        Impl::spinwait_while_equal<int>(th.m_pool_state,
+                                        ThreadsInternal::ReductionAvailable);
 
         f.join(work_value + count, ((scalar_type *)th.reduce_memory()) + count);
       }
 
       // This thread has completed inclusive scan
       // Set: ReductionAvailable -> ScanAvailable
-      m_pool_state = ThreadsExec::ScanAvailable;
+      m_pool_state = ThreadsInternal::ScanAvailable;
 
       // Wait for all threads to complete inclusive scan
       // Wait: ScanAvailable -> Rendezvous
-      Impl::spinwait_while_equal<int>(m_pool_state, ThreadsExec::ScanAvailable);
+      Impl::spinwait_while_equal<int>(m_pool_state,
+                                      ThreadsInternal::ScanAvailable);
     }
 
     //--------------------------------
 
     for (int i = 0; i < m_pool_fan_size; ++i) {
-      ThreadsExec &fan = *m_pool_base[rev_rank + (1 << i)];
+      ThreadsInternal &fan = *m_pool_base[rev_rank + (1 << i)];
       // Wait: ReductionAvailable -> ScanAvailable
       Impl::spinwait_while_equal<int>(fan.m_pool_state,
-                                      ThreadsExec::ReductionAvailable);
+                                      ThreadsInternal::ReductionAvailable);
       // Set: ScanAvailable -> Rendezvous
-      fan.m_pool_state = ThreadsExec::Rendezvous;
+      fan.m_pool_state = ThreadsInternal::Rendezvous;
     }
 
     // All threads have completed the inclusive scan.
@@ -346,7 +355,7 @@ class ThreadsExec {
     if ((rev_rank + 1) < m_pool_size) {
       // Exclusive scan: copy the previous thread's inclusive scan value
 
-      ThreadsExec &th = *m_pool_base[rev_rank + 1];  // Not the root thread
+      ThreadsInternal &th = *m_pool_base[rev_rank + 1];  // Not the root thread
 
       const scalar_type *const src_value =
           ((scalar_type *)th.reduce_memory()) + count;
@@ -364,17 +373,18 @@ class ThreadsExec {
     for (int i = 0; i < m_pool_fan_size; ++i) {
       Impl::spinwait_while_equal<int>(
           m_pool_base[rev_rank + (1 << i)]->m_pool_state,
-          ThreadsExec::Rendezvous);
+          ThreadsInternal::Rendezvous);
     }
     if (rev_rank) {
       // Set: ScanAvailable -> ScanCompleted
-      m_pool_state = ThreadsExec::ScanCompleted;
+      m_pool_state = ThreadsInternal::ScanCompleted;
       // Wait: ScanCompleted -> Active
-      Impl::spinwait_while_equal<int>(m_pool_state, ThreadsExec::ScanCompleted);
+      Impl::spinwait_while_equal<int>(m_pool_state,
+                                      ThreadsInternal::ScanCompleted);
     }
     // Set: ScanCompleted -> Active
     for (int i = 0; i < m_pool_fan_size; ++i) {
-      m_pool_base[rev_rank + (1 << i)]->m_pool_state = ThreadsExec::Active;
+      m_pool_base[rev_rank + (1 << i)]->m_pool_state = ThreadsInternal::Active;
     }
   }
 
@@ -392,7 +402,8 @@ class ThreadsExec {
     for (int i = 0; i < m_pool_fan_size; ++i) {
       // Wait: Active -> Rendezvous
       Impl::spinwait_while_equal<int>(
-          m_pool_base[rev_rank + (1 << i)]->m_pool_state, ThreadsExec::Active);
+          m_pool_base[rev_rank + (1 << i)]->m_pool_state,
+          ThreadsInternal::Active);
     }
 
     for (unsigned i = 0; i < count; ++i) {
@@ -400,9 +411,10 @@ class ThreadsExec {
     }
 
     if (rev_rank) {
-      m_pool_state = ThreadsExec::Rendezvous;
+      m_pool_state = ThreadsInternal::Rendezvous;
       // Wait: Rendezvous -> Active
-      Impl::spinwait_while_equal<int>(m_pool_state, ThreadsExec::Rendezvous);
+      Impl::spinwait_while_equal<int>(m_pool_state,
+                                      ThreadsInternal::Rendezvous);
     } else {
       // Root thread does the thread-scan before releasing threads
 
@@ -424,7 +436,7 @@ class ThreadsExec {
     }
 
     for (int i = 0; i < m_pool_fan_size; ++i) {
-      m_pool_base[rev_rank + (1 << i)]->m_pool_state = ThreadsExec::Active;
+      m_pool_base[rev_rank + (1 << i)]->m_pool_state = ThreadsInternal::Active;
     }
   }
 
@@ -433,7 +445,7 @@ class ThreadsExec {
    *          complete and release the Threads device.
    *          Acquire the Threads device and start this functor.
    */
-  static void start(void (*)(ThreadsExec &, const void *), const void *);
+  static void start(void (*)(ThreadsInternal &, const void *), const void *);
 
   static int in_parallel();
   static void fence();
@@ -583,30 +595,32 @@ class ThreadsExec {
 
 namespace Kokkos {
 
-inline int Threads::in_parallel() { return Impl::ThreadsExec::in_parallel(); }
+inline int Threads::in_parallel() {
+  return Impl::ThreadsInternal::in_parallel();
+}
 
 inline int Threads::impl_is_initialized() {
-  return Impl::ThreadsExec::is_initialized();
+  return Impl::ThreadsInternal::is_initialized();
 }
 
 inline void Threads::impl_initialize(InitializationSettings const &settings) {
-  Impl::ThreadsExec::initialize(
+  Impl::ThreadsInternal::initialize(
       settings.has_num_threads() ? settings.get_num_threads() : -1);
 }
 
-inline void Threads::impl_finalize() { Impl::ThreadsExec::finalize(); }
+inline void Threads::impl_finalize() { Impl::ThreadsInternal::finalize(); }
 
 inline void Threads::print_configuration(std::ostream &os, bool verbose) const {
   os << "Host Parallel Execution Space:\n";
   os << "  KOKKOS_ENABLE_THREADS: yes\n";
 
   os << "\nThreads Runtime Configuration:\n";
-  Impl::ThreadsExec::print_configuration(os, verbose);
+  Impl::ThreadsInternal::print_configuration(os, verbose);
 }
 
 inline void Threads::impl_static_fence(const std::string &name) {
-  Impl::ThreadsExec::internal_fence(name, Impl::fence_is_static::yes);
+  Impl::ThreadsInternal::internal_fence(name, Impl::fence_is_static::yes);
 }
 } /* namespace Kokkos */
 
-#endif /* #define KOKKOS_THREADSEXEC_HPP */
+#endif

--- a/core/src/Threads/Kokkos_Threads_ParallelFor_Range.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelFor_Range.hpp
@@ -59,37 +59,37 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
     }
   }
 
-  static void exec(ThreadsExec &exec, const void *arg) {
-    exec_schedule<typename Policy::schedule_type::type>(exec, arg);
+  static void exec(ThreadsInternal &instance, const void *arg) {
+    exec_schedule<typename Policy::schedule_type::type>(instance, arg);
   }
 
   template <class Schedule>
   static std::enable_if_t<std::is_same<Schedule, Kokkos::Static>::value>
-  exec_schedule(ThreadsExec &exec, const void *arg) {
+  exec_schedule(ThreadsInternal &instance, const void *arg) {
     const ParallelFor &self = *((const ParallelFor *)arg);
 
-    WorkRange range(self.m_policy, exec.pool_rank(), exec.pool_size());
+    WorkRange range(self.m_policy, instance.pool_rank(), instance.pool_size());
 
     ParallelFor::template exec_range<WorkTag>(self.m_functor, range.begin(),
                                               range.end());
 
-    exec.fan_in();
+    instance.fan_in();
   }
 
   template <class Schedule>
   static std::enable_if_t<std::is_same<Schedule, Kokkos::Dynamic>::value>
-  exec_schedule(ThreadsExec &exec, const void *arg) {
+  exec_schedule(ThreadsInternal &instance, const void *arg) {
     const ParallelFor &self = *((const ParallelFor *)arg);
 
-    WorkRange range(self.m_policy, exec.pool_rank(), exec.pool_size());
+    WorkRange range(self.m_policy, instance.pool_rank(), instance.pool_size());
 
-    exec.set_work_range(range.begin() - self.m_policy.begin(),
-                        range.end() - self.m_policy.begin(),
-                        self.m_policy.chunk_size());
-    exec.reset_steal_target();
-    exec.barrier();
+    instance.set_work_range(range.begin() - self.m_policy.begin(),
+                            range.end() - self.m_policy.begin(),
+                            self.m_policy.chunk_size());
+    instance.reset_steal_target();
+    instance.barrier();
 
-    long work_index = exec.get_work_index();
+    long work_index = instance.get_work_index();
 
     while (work_index != -1) {
       const Member begin =
@@ -100,16 +100,16 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
               ? begin + self.m_policy.chunk_size()
               : self.m_policy.end();
       ParallelFor::template exec_range<WorkTag>(self.m_functor, begin, end);
-      work_index = exec.get_work_index();
+      work_index = instance.get_work_index();
     }
 
-    exec.fan_in();
+    instance.fan_in();
   }
 
  public:
   inline void execute() const {
-    ThreadsExec::start(&ParallelFor::exec, this);
-    ThreadsExec::fence();
+    ThreadsInternal::start(&ParallelFor::exec, this);
+    ThreadsInternal::fence();
   }
 
   ParallelFor(const FunctorType &arg_functor, const Policy &arg_policy)

--- a/core/src/Threads/Kokkos_Threads_ParallelFor_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelFor_Team.hpp
@@ -73,14 +73,14 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     }
   }
 
-  static void exec(ThreadsExec &exec, const void *arg) {
+  static void exec(ThreadsInternal &instance, const void *arg) {
     const ParallelFor &self = *((const ParallelFor *)arg);
 
     ParallelFor::exec_team<WorkTag, typename Policy::schedule_type::type>(
-        self.m_functor, Member(&exec, self.m_policy, self.m_shared));
+        self.m_functor, Member(&instance, self.m_policy, self.m_shared));
 
-    exec.barrier();
-    exec.fan_in();
+    instance.barrier();
+    instance.fan_in();
   }
   template <typename Policy>
   Policy fix_policy(Policy policy) {
@@ -96,12 +96,12 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
  public:
   inline void execute() const {
-    ThreadsExec::resize_scratch(
+    ThreadsInternal::resize_scratch(
         0, Policy::member_type::team_reduce_size() + m_shared);
 
-    ThreadsExec::start(&ParallelFor::exec, this);
+    ThreadsInternal::start(&ParallelFor::exec, this);
 
-    ThreadsExec::fence();
+    ThreadsInternal::fence();
   }
 
   ParallelFor(const FunctorType &arg_functor, const Policy &arg_policy)

--- a/core/src/Threads/Kokkos_Threads_ParallelScan_Range.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelScan_Range.hpp
@@ -65,33 +65,33 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
     }
   }
 
-  static void exec(ThreadsExec &exec, const void *arg) {
+  static void exec(ThreadsInternal &instance, const void *arg) {
     const ParallelScan &self = *((const ParallelScan *)arg);
 
-    const WorkRange range(self.m_policy, exec.pool_rank(), exec.pool_size());
+    const WorkRange range(self.m_policy, instance.pool_rank(),
+                          instance.pool_size());
 
     typename Analysis::Reducer final_reducer(self.m_functor);
 
     reference_type update =
-        final_reducer.init(static_cast<pointer_type>(exec.reduce_memory()));
+        final_reducer.init(static_cast<pointer_type>(instance.reduce_memory()));
 
     ParallelScan::template exec_range<WorkTag>(self.m_functor, range.begin(),
                                                range.end(), update, false);
 
-    //  exec.template scan_large( final_reducer );
-    exec.scan_small(final_reducer);
+    instance.scan_small(final_reducer);
 
     ParallelScan::template exec_range<WorkTag>(self.m_functor, range.begin(),
                                                range.end(), update, true);
 
-    exec.fan_in();
+    instance.fan_in();
   }
 
  public:
   inline void execute() const {
-    ThreadsExec::resize_scratch(2 * Analysis::value_size(m_functor), 0);
-    ThreadsExec::start(&ParallelScan::exec, this);
-    ThreadsExec::fence();
+    ThreadsInternal::resize_scratch(2 * Analysis::value_size(m_functor), 0);
+    ThreadsInternal::start(&ParallelScan::exec, this);
+    ThreadsInternal::fence();
   }
 
   ParallelScan(const FunctorType &arg_functor, const Policy &arg_policy)
@@ -145,37 +145,37 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
     }
   }
 
-  static void exec(ThreadsExec &exec, const void *arg) {
+  static void exec(ThreadsInternal &instance, const void *arg) {
     const ParallelScanWithTotal &self = *((const ParallelScanWithTotal *)arg);
 
-    const WorkRange range(self.m_policy, exec.pool_rank(), exec.pool_size());
+    const WorkRange range(self.m_policy, instance.pool_rank(),
+                          instance.pool_size());
 
     typename Analysis::Reducer final_reducer(self.m_functor);
 
     reference_type update =
-        final_reducer.init(static_cast<pointer_type>(exec.reduce_memory()));
+        final_reducer.init(static_cast<pointer_type>(instance.reduce_memory()));
 
     ParallelScanWithTotal::template exec_range<WorkTag>(
         self.m_functor, range.begin(), range.end(), update, false);
 
-    //  exec.template scan_large(final_reducer);
-    exec.scan_small(final_reducer);
+    instance.scan_small(final_reducer);
 
     ParallelScanWithTotal::template exec_range<WorkTag>(
         self.m_functor, range.begin(), range.end(), update, true);
 
-    exec.fan_in();
+    instance.fan_in();
 
-    if (exec.pool_rank() == exec.pool_size() - 1) {
+    if (instance.pool_rank() == instance.pool_size() - 1) {
       *self.m_result_ptr = update;
     }
   }
 
  public:
   inline void execute() const {
-    ThreadsExec::resize_scratch(2 * Analysis::value_size(m_functor), 0);
-    ThreadsExec::start(&ParallelScanWithTotal::exec, this);
-    ThreadsExec::fence();
+    ThreadsInternal::resize_scratch(2 * Analysis::value_size(m_functor), 0);
+    ThreadsInternal::start(&ParallelScanWithTotal::exec, this);
+    ThreadsInternal::fence();
   }
 
   template <class ViewType>

--- a/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
+++ b/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
@@ -18,7 +18,7 @@
 #define KOKKOS_THREADS_WORKGRAPHPOLICY_HPP
 
 #include <Kokkos_Core_fwd.hpp>
-#include <Threads/Kokkos_ThreadsExec.hpp>
+#include <Threads/Kokkos_Threads_Instance.hpp>
 
 namespace Kokkos {
 namespace Impl {
@@ -61,16 +61,17 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
     }
   }
 
-  static inline void thread_main(ThreadsExec& exec, const void* arg) noexcept {
+  static inline void thread_main(ThreadsInternal& instance,
+                                 const void* arg) noexcept {
     const Self& self = *(static_cast<const Self*>(arg));
     self.exec_one_thread();
-    exec.fan_in();
+    instance.fan_in();
   }
 
  public:
   inline void execute() {
-    ThreadsExec::start(&Self::thread_main, this);
-    ThreadsExec::fence();
+    ThreadsInternal::start(&Self::thread_main, this);
+    ThreadsInternal::fence();
   }
 
   inline ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)

--- a/core/src/decl/Kokkos_Declare_THREADS.hpp
+++ b/core/src/decl/Kokkos_Declare_THREADS.hpp
@@ -19,7 +19,7 @@
 
 #if defined(KOKKOS_ENABLE_THREADS)
 #include <Threads/Kokkos_Threads.hpp>
-#include <Threads/Kokkos_ThreadsExec.hpp>
+#include <Threads/Kokkos_Threads_Instance.hpp>
 #include <Threads/Kokkos_Threads_MDRangePolicy.hpp>
 #include <Threads/Kokkos_Threads_ParallelFor_Range.hpp>
 #include <Threads/Kokkos_Threads_ParallelFor_MDRange.hpp>


### PR DESCRIPTION
This PR renames:
-  `Kokkos_ThreadsExec` -> `Kokkos_Threads_Instance`
-  `ThreadsExec` -> `ThreadsInternal`
- `exec` -> `instance`

There are no changes in the code itself  except for renaming.