### PR TITLE
Threads: replace enum with constexpr int and enum class

### DIFF
--- a/Makefile.targets
+++ b/Makefile.targets
@@ -20,8 +20,6 @@ Kokkos_TaskQueue.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/impl/Kokkos_Ta
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/impl/Kokkos_TaskQueue.cpp
 Kokkos_HostThreadTeam.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/impl/Kokkos_HostThreadTeam.cpp
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/impl/Kokkos_HostThreadTeam.cpp
-Kokkos_Spinwait.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/impl/Kokkos_Spinwait.cpp
-	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/impl/Kokkos_Spinwait.cpp
 Kokkos_HostBarrier.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/impl/Kokkos_HostBarrier.cpp
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/impl/Kokkos_HostBarrier.cpp
 Kokkos_Profiling.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/impl/Kokkos_Profiling.cpp
@@ -84,6 +82,8 @@ endif
 ifeq ($(KOKKOS_INTERNAL_USE_THREADS), 1)
 Kokkos_Threads_Instance.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/Threads/Kokkos_Threads_Instance.cpp
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/Threads/Kokkos_Threads_Instance.cpp
+Kokkos_Threads_Spinwait.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/Threads/Kokkos_Threads_Spinwait.cpp
+	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/Threads/Kokkos_Spinwait.cpp
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_OPENMP), 1)

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -255,8 +255,8 @@ class OpenMPTargetExecTeamMember {
     const int l0_offset = reduce_offset + TEAM_REDUCE_SIZE;
     const int l1_offset = l0_offset + shmem_size_L0;
     m_team_shared       = scratch_memory_space(
-              (static_cast<char*>(glb_scratch) + l0_offset), shmem_size_L0,
-              static_cast<char*>(glb_scratch) + l1_offset, shmem_size_L1);
+        (static_cast<char*>(glb_scratch) + l0_offset), shmem_size_L0,
+        static_cast<char*>(glb_scratch) + l1_offset, shmem_size_L1);
     m_reduce_scratch = static_cast<char*>(glb_scratch) + reduce_offset;
     m_league_rank    = league_rank;
     m_team_rank      = omp_tid;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -21,7 +21,6 @@
 #include <sstream>
 #include <Kokkos_Parallel.hpp>
 #include <impl/Kokkos_Traits.hpp>
-#include <impl/Kokkos_Spinwait.hpp>
 
 #include <Kokkos_Atomic.hpp>
 #include "Kokkos_OpenMPTarget_Abort.hpp"
@@ -256,8 +255,8 @@ class OpenMPTargetExecTeamMember {
     const int l0_offset = reduce_offset + TEAM_REDUCE_SIZE;
     const int l1_offset = l0_offset + shmem_size_L0;
     m_team_shared       = scratch_memory_space(
-        (static_cast<char*>(glb_scratch) + l0_offset), shmem_size_L0,
-        static_cast<char*>(glb_scratch) + l1_offset, shmem_size_L1);
+              (static_cast<char*>(glb_scratch) + l0_offset), shmem_size_L0,
+              static_cast<char*>(glb_scratch) + l1_offset, shmem_size_L1);
     m_reduce_scratch = static_cast<char*>(glb_scratch) + reduce_offset;
     m_league_rank    = league_rank;
     m_team_rank      = omp_tid;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Reducer.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Reducer.hpp
@@ -18,7 +18,6 @@
 #define KOKKOS_OPENMPTARGETREDUCER_HPP
 
 #include <impl/Kokkos_Traits.hpp>
-#include <impl/Kokkos_Spinwait.hpp>
 
 #include <Kokkos_Atomic.hpp>
 #include "Kokkos_OpenMPTarget_Abort.hpp"

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -690,7 +690,7 @@ void ThreadsInternal::initialize(int thread_count_arg) {
     for (unsigned ith = thread_spawn_begin; ith < thread_count; ++ith) {
       // Try to protect against cache coherency failure by casting to volatile.
       ThreadsInternal *const th =
-          ((ThreadsInternal *volatile *)s_threads_exec)[ith];
+          ((ThreadsInternal * volatile *)s_threads_exec)[ith];
       if (th) {
         wait_yield(th->m_pool_state, ThreadState::Active);
       } else {

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -133,7 +133,7 @@ void ThreadsInternal::global_unlock() {
 
 //----------------------------------------------------------------------------
 
-void ThreadsInternal::wait_yield(volatile int &flag, const int value) {
+void ThreadsInternal::wait_yield(volatile State &flag, const State value) {
   while (value == flag) {
     std::this_thread::yield();
   }
@@ -146,13 +146,13 @@ void ThreadsInternal::driver() {
 
   ThreadsInternal this_thread;
 
-  while (this_thread.m_pool_state == ThreadsInternal::Active) {
+  while (this_thread.m_pool_state == State::Active) {
     (*s_current_function)(this_thread, s_current_function_arg);
 
     // Deactivate thread and wait for reactivation
-    this_thread.m_pool_state = ThreadsInternal::Inactive;
+    this_thread.m_pool_state = State::Inactive;
 
-    wait_yield(this_thread.m_pool_state, ThreadsInternal::Inactive);
+    wait_yield(this_thread.m_pool_state, State::Inactive);
   }
 }
 
@@ -166,7 +166,7 @@ ThreadsInternal::ThreadsInternal()
       m_pool_rank(0),
       m_pool_size(0),
       m_pool_fan_size(0),
-      m_pool_state(ThreadsInternal::Terminating) {
+      m_pool_state(State::Terminating) {
   if (&s_threads_process != this) {
     // A spawned thread
 
@@ -192,21 +192,21 @@ ThreadsInternal::ThreadsInternal()
       m_pool_rank_rev  = s_thread_pool_size[0] - (pool_rank() + 1);
       m_pool_size      = s_thread_pool_size[0];
       m_pool_fan_size  = fan_size(m_pool_rank, m_pool_size);
-      m_pool_state     = ThreadsInternal::Active;
+      m_pool_state     = State::Active;
 
       s_threads_pid[m_pool_rank] = std::this_thread::get_id();
 
       // Inform spawning process that the threads_exec entry has been set.
-      s_threads_process.m_pool_state = ThreadsInternal::Active;
+      s_threads_process.m_pool_state = State::Active;
     } else {
       // Inform spawning process that the threads_exec entry could not be set.
-      s_threads_process.m_pool_state = ThreadsInternal::Terminating;
+      s_threads_process.m_pool_state = State::Terminating;
     }
   } else {
     // Enables 'parallel_for' to execute on unitialized Threads device
     m_pool_rank  = 0;
     m_pool_size  = 1;
-    m_pool_state = ThreadsInternal::Inactive;
+    m_pool_state = State::Inactive;
 
     s_threads_pid[m_pool_rank] = std::this_thread::get_id();
   }
@@ -234,14 +234,14 @@ ThreadsInternal::~ThreadsInternal() {
   m_pool_size          = 0;
   m_pool_fan_size      = 0;
 
-  m_pool_state = ThreadsInternal::Terminating;
+  m_pool_state = State::Terminating;
 
   if (&s_threads_process != this && entry < MAX_THREAD_COUNT) {
     ThreadsInternal *const nil = nullptr;
 
     atomic_compare_exchange(s_threads_exec + entry, this, nil);
 
-    s_threads_process.m_pool_state = ThreadsInternal::Terminating;
+    s_threads_process.m_pool_state = State::Terminating;
   }
 }
 
@@ -278,12 +278,11 @@ void ThreadsInternal::execute_sleep(ThreadsInternal &exec, const void *) {
   const int rank_rev = exec.m_pool_size - (exec.m_pool_rank + 1);
 
   for (int i = 0; i < n; ++i) {
-    Impl::spinwait_while_equal<int>(
-        exec.m_pool_base[rank_rev + (1 << i)]->m_pool_state,
-        ThreadsInternal::Active);
+    Impl::spinwait_while_equal<State>(
+        exec.m_pool_base[rank_rev + (1 << i)]->m_pool_state, State::Active);
   }
 
-  exec.m_pool_state = ThreadsInternal::Inactive;
+  exec.m_pool_state = State::Inactive;
 }
 
 }  // namespace Impl
@@ -336,8 +335,8 @@ void ThreadsInternal::internal_fence(const std::string &name,
   const auto &fence_lam = [&]() {
     if (s_thread_pool_size[0]) {
       // Wait for the root thread to complete:
-      Impl::spinwait_while_equal<int>(s_threads_exec[0]->m_pool_state,
-                                      ThreadsInternal::Active);
+      Impl::spinwait_while_equal<State>(s_threads_exec[0]->m_pool_state,
+                                        State::Active);
     }
 
     s_current_function     = nullptr;
@@ -378,13 +377,13 @@ void ThreadsInternal::start(void (*func)(ThreadsInternal &, const void *),
 
   // Activate threads:
   for (int i = s_thread_pool_size[0]; 0 < i--;) {
-    s_threads_exec[i]->m_pool_state = ThreadsInternal::Active;
+    s_threads_exec[i]->m_pool_state = State::Active;
   }
 
   if (s_threads_process.m_pool_size) {
     // Master process is the root thread, run it:
     (*func)(s_threads_process, arg);
-    s_threads_process.m_pool_state = ThreadsInternal::Inactive;
+    s_threads_process.m_pool_state = State::Inactive;
   }
 }
 
@@ -403,7 +402,7 @@ bool ThreadsInternal::sleep() {
 
   // Activate threads:
   for (unsigned i = s_thread_pool_size[0]; 0 < i;) {
-    s_threads_exec[--i]->m_pool_state = ThreadsInternal::Active;
+    s_threads_exec[--i]->m_pool_state = State::Active;
   }
 
   return true;
@@ -418,7 +417,7 @@ bool ThreadsInternal::wake() {
 
   if (s_threads_process.m_pool_base) {
     execute_sleep(s_threads_process, nullptr);
-    s_threads_process.m_pool_state = ThreadsInternal::Inactive;
+    s_threads_process.m_pool_state = State::Inactive;
   }
 
   fence();
@@ -455,16 +454,16 @@ void ThreadsInternal::execute_resize_scratch_in_serial() {
   for (unsigned i = s_thread_pool_size[0]; begin < i;) {
     ThreadsInternal &th = *s_threads_exec[--i];
 
-    th.m_pool_state = ThreadsInternal::Active;
+    th.m_pool_state = State::Active;
 
-    wait_yield(th.m_pool_state, ThreadsInternal::Active);
+    wait_yield(th.m_pool_state, State::Active);
   }
 
   if (s_threads_process.m_pool_base) {
     deallocate_scratch_memory(s_threads_process);
-    s_threads_process.m_pool_state = ThreadsInternal::Active;
+    s_threads_process.m_pool_state = State::Active;
     first_touch_allocate_thread_private_scratch(s_threads_process, nullptr);
-    s_threads_process.m_pool_state = ThreadsInternal::Inactive;
+    s_threads_process.m_pool_state = State::Inactive;
   }
 
   s_current_function_arg = nullptr;
@@ -663,7 +662,7 @@ void ThreadsInternal::initialize(int thread_count_arg) {
         &execute_function_noop;  // Initialization work function
 
     for (unsigned ith = thread_spawn_begin; ith < thread_count; ++ith) {
-      s_threads_process.m_pool_state = ThreadsInternal::Inactive;
+      s_threads_process.m_pool_state = State::Inactive;
 
       // If hwloc available then spawned thread will
       // choose its own entry in 's_threads_coord'
@@ -680,8 +679,8 @@ void ThreadsInternal::initialize(int thread_count_arg) {
       // If spawning and initialization is successful then
       // an entry in 's_threads_exec' will be assigned.
       ThreadsInternal::spawn();
-      wait_yield(s_threads_process.m_pool_state, ThreadsInternal::Inactive);
-      if (s_threads_process.m_pool_state == ThreadsInternal::Terminating) break;
+      wait_yield(s_threads_process.m_pool_state, State::Inactive);
+      if (s_threads_process.m_pool_state == State::Terminating) break;
     }
 
     // Wait for all spawned threads to deactivate before zeroing the function.
@@ -691,7 +690,7 @@ void ThreadsInternal::initialize(int thread_count_arg) {
       ThreadsInternal *const th =
           ((ThreadsInternal * volatile *)s_threads_exec)[ith];
       if (th) {
-        wait_yield(th->m_pool_state, ThreadsInternal::Active);
+        wait_yield(th->m_pool_state, State::Active);
       } else {
         ++thread_spawn_failed;
       }
@@ -699,7 +698,7 @@ void ThreadsInternal::initialize(int thread_count_arg) {
 
     s_current_function             = nullptr;
     s_current_function_arg         = nullptr;
-    s_threads_process.m_pool_state = ThreadsInternal::Inactive;
+    s_threads_process.m_pool_state = State::Inactive;
 
     memory_fence();
 
@@ -789,11 +788,11 @@ void ThreadsInternal::finalize() {
 
   for (unsigned i = s_thread_pool_size[0]; begin < i--;) {
     if (s_threads_exec[i]) {
-      s_threads_exec[i]->m_pool_state = ThreadsInternal::Terminating;
+      s_threads_exec[i]->m_pool_state = State::Terminating;
 
-      wait_yield(s_threads_process.m_pool_state, ThreadsInternal::Inactive);
+      wait_yield(s_threads_process.m_pool_state, State::Inactive);
 
-      s_threads_process.m_pool_state = ThreadsInternal::Inactive;
+      s_threads_process.m_pool_state = State::Inactive;
     }
 
     s_threads_pid[i] = std::thread::id();
@@ -819,7 +818,7 @@ void ThreadsInternal::finalize() {
   s_threads_process.m_pool_rank      = 0;
   s_threads_process.m_pool_size      = 1;
   s_threads_process.m_pool_fan_size  = 0;
-  s_threads_process.m_pool_state     = ThreadsInternal::Inactive;
+  s_threads_process.m_pool_state     = State::Inactive;
 
   Kokkos::Profiling::finalize();
 }

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -278,7 +278,7 @@ void ThreadsInternal::execute_sleep(ThreadsInternal &exec, const void *) {
   const int rank_rev = exec.m_pool_size - (exec.m_pool_rank + 1);
 
   for (int i = 0; i < n; ++i) {
-    Impl::spinwait_while_equal<State>(
+    Impl::spinwait_while_equal(
         exec.m_pool_base[rank_rev + (1 << i)]->m_pool_state, State::Active);
   }
 
@@ -335,8 +335,8 @@ void ThreadsInternal::internal_fence(const std::string &name,
   const auto &fence_lam = [&]() {
     if (s_thread_pool_size[0]) {
       // Wait for the root thread to complete:
-      Impl::spinwait_while_equal<State>(s_threads_exec[0]->m_pool_state,
-                                        State::Active);
+      Impl::spinwait_while_equal(s_threads_exec[0]->m_pool_state,
+                                 State::Active);
     }
 
     s_current_function     = nullptr;

--- a/core/src/Threads/Kokkos_Threads_Instance.hpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.hpp
@@ -165,14 +165,14 @@ class ThreadsInternal {
     // Fan-in reduction with highest ranking thread as the root
     for (int i = 0; i < m_pool_fan_size; ++i) {
       // Wait: Active -> Rendezvous
-      Impl::spinwait_while_equal<State>(
-          m_pool_base[rev_rank + (1 << i)]->m_pool_state, State::Active);
+      Impl::spinwait_while_equal(m_pool_base[rev_rank + (1 << i)]->m_pool_state,
+                                 State::Active);
     }
 
     if (rev_rank) {
       m_pool_state = State::Rendezvous;
       // Wait: Rendezvous -> Active
-      Impl::spinwait_while_equal<State>(m_pool_state, State::Rendezvous);
+      Impl::spinwait_while_equal(m_pool_state, State::Rendezvous);
     } else {
       // Root thread does the reduction and broadcast
 
@@ -206,14 +206,14 @@ class ThreadsInternal {
     // Fan-in reduction with highest ranking thread as the root
     for (int i = 0; i < m_pool_fan_size; ++i) {
       // Wait: Active -> Rendezvous
-      Impl::spinwait_while_equal<State>(
-          m_pool_base[rev_rank + (1 << i)]->m_pool_state, State::Active);
+      Impl::spinwait_while_equal(m_pool_base[rev_rank + (1 << i)]->m_pool_state,
+                                 State::Active);
     }
 
     if (rev_rank) {
       m_pool_state = State::Rendezvous;
       // Wait: Rendezvous -> Active
-      Impl::spinwait_while_equal<State>(m_pool_state, State::Rendezvous);
+      Impl::spinwait_while_equal(m_pool_state, State::Rendezvous);
     } else {
       // Root thread does the reduction and broadcast
 
@@ -235,7 +235,7 @@ class ThreadsInternal {
     for (int i = 0; i < m_pool_fan_size; ++i) {
       ThreadsInternal &fan = *m_pool_base[rev_rank + (1 << i)];
 
-      Impl::spinwait_while_equal<State>(fan.m_pool_state, State::Active);
+      Impl::spinwait_while_equal(fan.m_pool_state, State::Active);
 
       f.join(
           reinterpret_cast<typename FunctorType::value_type *>(reduce_memory()),
@@ -264,8 +264,8 @@ class ThreadsInternal {
     const int rev_rank = m_pool_size - (m_pool_rank + 1);
 
     for (int i = 0; i < m_pool_fan_size; ++i) {
-      Impl::spinwait_while_equal<State>(
-          m_pool_base[rev_rank + (1 << i)]->m_pool_state, State::Active);
+      Impl::spinwait_while_equal(m_pool_base[rev_rank + (1 << i)]->m_pool_state,
+                                 State::Active);
     }
   }
 
@@ -291,7 +291,7 @@ class ThreadsInternal {
       ThreadsInternal &fan = *m_pool_base[rev_rank + (1 << i)];
 
       // Wait: Active -> ReductionAvailable (or ScanAvailable)
-      Impl::spinwait_while_equal<State>(fan.m_pool_state, State::Active);
+      Impl::spinwait_while_equal(fan.m_pool_state, State::Active);
       f.join(work_value, fan.reduce_memory());
     }
 
@@ -310,9 +310,8 @@ class ThreadsInternal {
 
         // Wait: Active             -> ReductionAvailable
         // Wait: ReductionAvailable -> ScanAvailable
-        Impl::spinwait_while_equal<State>(th.m_pool_state, State::Active);
-        Impl::spinwait_while_equal<State>(th.m_pool_state,
-                                          State::ReductionAvailable);
+        Impl::spinwait_while_equal(th.m_pool_state, State::Active);
+        Impl::spinwait_while_equal(th.m_pool_state, State::ReductionAvailable);
 
         f.join(work_value + count, ((scalar_type *)th.reduce_memory()) + count);
       }
@@ -323,7 +322,7 @@ class ThreadsInternal {
 
       // Wait for all threads to complete inclusive scan
       // Wait: ScanAvailable -> Rendezvous
-      Impl::spinwait_while_equal<State>(m_pool_state, State::ScanAvailable);
+      Impl::spinwait_while_equal(m_pool_state, State::ScanAvailable);
     }
 
     //--------------------------------
@@ -331,8 +330,7 @@ class ThreadsInternal {
     for (int i = 0; i < m_pool_fan_size; ++i) {
       ThreadsInternal &fan = *m_pool_base[rev_rank + (1 << i)];
       // Wait: ReductionAvailable -> ScanAvailable
-      Impl::spinwait_while_equal<State>(fan.m_pool_state,
-                                        State::ReductionAvailable);
+      Impl::spinwait_while_equal(fan.m_pool_state, State::ReductionAvailable);
       // Set: ScanAvailable -> Rendezvous
       fan.m_pool_state = State::Rendezvous;
     }
@@ -361,14 +359,14 @@ class ThreadsInternal {
     // Wait for all threads to copy previous thread's inclusive scan value
     // Wait for all threads: Rendezvous -> ScanCompleted
     for (int i = 0; i < m_pool_fan_size; ++i) {
-      Impl::spinwait_while_equal<State>(
-          m_pool_base[rev_rank + (1 << i)]->m_pool_state, State::Rendezvous);
+      Impl::spinwait_while_equal(m_pool_base[rev_rank + (1 << i)]->m_pool_state,
+                                 State::Rendezvous);
     }
     if (rev_rank) {
       // Set: ScanAvailable -> ScanCompleted
       m_pool_state = State::ScanCompleted;
       // Wait: ScanCompleted -> Active
-      Impl::spinwait_while_equal<State>(m_pool_state, State::ScanCompleted);
+      Impl::spinwait_while_equal(m_pool_state, State::ScanCompleted);
     }
     // Set: ScanCompleted -> Active
     for (int i = 0; i < m_pool_fan_size; ++i) {
@@ -389,8 +387,8 @@ class ThreadsInternal {
     // Fan-in reduction with highest ranking thread as the root
     for (int i = 0; i < m_pool_fan_size; ++i) {
       // Wait: Active -> Rendezvous
-      Impl::spinwait_while_equal<State>(
-          m_pool_base[rev_rank + (1 << i)]->m_pool_state, State::Active);
+      Impl::spinwait_while_equal(m_pool_base[rev_rank + (1 << i)]->m_pool_state,
+                                 State::Active);
     }
 
     for (unsigned i = 0; i < count; ++i) {
@@ -400,7 +398,7 @@ class ThreadsInternal {
     if (rev_rank) {
       m_pool_state = State::Rendezvous;
       // Wait: Rendezvous -> Active
-      Impl::spinwait_while_equal<State>(m_pool_state, State::Rendezvous);
+      Impl::spinwait_while_equal(m_pool_state, State::Rendezvous);
     } else {
       // Root thread does the thread-scan before releasing threads
 

--- a/core/src/Threads/Kokkos_Threads_Spinwait.cpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.cpp
@@ -21,7 +21,7 @@
 #include <Kokkos_Macros.hpp>
 
 #include <Kokkos_Atomic.hpp>
-#include <impl/Kokkos_Spinwait.hpp>
+#include <Threads/Kokkos_Threads_Spinwait.hpp>
 #include <impl/Kokkos_BitOps.hpp>
 
 #include <thread>

--- a/core/src/Threads/Kokkos_Threads_Spinwait.cpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.cpp
@@ -108,5 +108,64 @@ void host_thread_yield(const uint32_t i, const WaitMode mode) {
 #endif /* defined( KOKKOS_ENABLE_ASM ) */
 }
 
+void root_spinwait_while_equal(ThreadState const volatile& flag,
+                               ThreadState const value) {
+  Kokkos::store_fence();
+  uint32_t i = 0;
+  while (value == flag) {
+    host_thread_yield(++i, WaitMode::ROOT);
+  }
+  Kokkos::load_fence();
+}
+
+void root_spinwait_until_equal(ThreadState const volatile& flag,
+                               ThreadState const value) {
+  Kokkos::store_fence();
+  uint32_t i = 0;
+  while (value != flag) {
+    host_thread_yield(++i, WaitMode::ROOT);
+  }
+  Kokkos::load_fence();
+}
+
+void spinwait_while_equal(ThreadState const volatile& flag,
+                          ThreadState const value) {
+  Kokkos::store_fence();
+  uint32_t i = 0;
+  while (value == flag) {
+    host_thread_yield(++i, WaitMode::ACTIVE);
+  }
+  Kokkos::load_fence();
+}
+
+void yield_while_equal(ThreadState const volatile& flag,
+                       ThreadState const value) {
+  Kokkos::store_fence();
+  uint32_t i = 0;
+  while (value == flag) {
+    host_thread_yield(++i, WaitMode::PASSIVE);
+  }
+  Kokkos::load_fence();
+}
+
+void spinwait_until_equal(ThreadState const volatile& flag,
+                          ThreadState const value) {
+  Kokkos::store_fence();
+  uint32_t i = 0;
+  while (value != flag) {
+    host_thread_yield(++i, WaitMode::ACTIVE);
+  }
+  Kokkos::load_fence();
+}
+
+void yield_until_equal(ThreadState const volatile& flag,
+                       ThreadState const value) {
+  Kokkos::store_fence();
+  uint32_t i = 0;
+  while (value != flag) {
+    host_thread_yield(++i, WaitMode::PASSIVE);
+  }
+  Kokkos::load_fence();
+}
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/Threads/Kokkos_Threads_Spinwait.cpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.cpp
@@ -108,26 +108,6 @@ void host_thread_yield(const uint32_t i, const WaitMode mode) {
 #endif /* defined( KOKKOS_ENABLE_ASM ) */
 }
 
-void root_spinwait_while_equal(ThreadState const volatile& flag,
-                               ThreadState const value) {
-  Kokkos::store_fence();
-  uint32_t i = 0;
-  while (value == flag) {
-    host_thread_yield(++i, WaitMode::ROOT);
-  }
-  Kokkos::load_fence();
-}
-
-void root_spinwait_until_equal(ThreadState const volatile& flag,
-                               ThreadState const value) {
-  Kokkos::store_fence();
-  uint32_t i = 0;
-  while (value != flag) {
-    host_thread_yield(++i, WaitMode::ROOT);
-  }
-  Kokkos::load_fence();
-}
-
 void spinwait_while_equal(ThreadState const volatile& flag,
                           ThreadState const value) {
   Kokkos::store_fence();
@@ -138,34 +118,5 @@ void spinwait_while_equal(ThreadState const volatile& flag,
   Kokkos::load_fence();
 }
 
-void yield_while_equal(ThreadState const volatile& flag,
-                       ThreadState const value) {
-  Kokkos::store_fence();
-  uint32_t i = 0;
-  while (value == flag) {
-    host_thread_yield(++i, WaitMode::PASSIVE);
-  }
-  Kokkos::load_fence();
-}
-
-void spinwait_until_equal(ThreadState const volatile& flag,
-                          ThreadState const value) {
-  Kokkos::store_fence();
-  uint32_t i = 0;
-  while (value != flag) {
-    host_thread_yield(++i, WaitMode::ACTIVE);
-  }
-  Kokkos::load_fence();
-}
-
-void yield_until_equal(ThreadState const volatile& flag,
-                       ThreadState const value) {
-  Kokkos::store_fence();
-  uint32_t i = 0;
-  while (value != flag) {
-    host_thread_yield(++i, WaitMode::PASSIVE);
-  }
-  Kokkos::load_fence();
-}
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/Threads/Kokkos_Threads_Spinwait.hpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.hpp
@@ -39,23 +39,8 @@ enum class WaitMode : int {
 
 void host_thread_yield(const uint32_t i, const WaitMode mode);
 
-void root_spinwait_while_equal(ThreadState const volatile& flag,
-                               ThreadState const value);
-
-void root_spinwait_until_equal(ThreadState const volatile& flag,
-                               ThreadState const value);
-
 void spinwait_while_equal(ThreadState const volatile& flag,
                           ThreadState const value);
-
-void yield_while_equal(ThreadState const volatile& flag,
-                       ThreadState const value);
-
-void spinwait_until_equal(ThreadState const volatile& flag,
-                          ThreadState const value);
-
-void yield_until_equal(ThreadState const volatile& flag,
-                       ThreadState const value);
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/Threads/Kokkos_Threads_Spinwait.hpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.hpp
@@ -14,8 +14,8 @@
 //
 //@HEADER
 
-#ifndef KOKKOS_SPINWAIT_HPP
-#define KOKKOS_SPINWAIT_HPP
+#ifndef KOKKOS_THREADS_SPINWAIT_HPP
+#define KOKKOS_THREADS_SPINWAIT_HPP
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Atomic.hpp>

--- a/core/src/Threads/Kokkos_Threads_Spinwait.hpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.hpp
@@ -17,14 +17,9 @@
 #ifndef KOKKOS_THREADS_SPINWAIT_HPP
 #define KOKKOS_THREADS_SPINWAIT_HPP
 
-#include <Kokkos_Macros.hpp>
-#include <Kokkos_Atomic.hpp>
-
 #include <Threads/Kokkos_Threads_State.hpp>
 
 #include <cstdint>
-
-#include <type_traits>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/Threads/Kokkos_Threads_Spinwait.hpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.hpp
@@ -20,6 +20,8 @@
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Atomic.hpp>
 
+#include <Threads/Kokkos_Threads_State.hpp>
+
 #include <cstdint>
 
 #include <type_traits>
@@ -37,73 +39,25 @@ enum class WaitMode : int {
 
 void host_thread_yield(const uint32_t i, const WaitMode mode);
 
-template <typename T>
-std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>, void>
-root_spinwait_while_equal(T const volatile& flag, const T value) {
-  Kokkos::store_fence();
-  uint32_t i = 0;
-  while (value == flag) {
-    host_thread_yield(++i, WaitMode::ROOT);
-  }
-  Kokkos::load_fence();
-}
+void root_spinwait_while_equal(ThreadState const volatile& flag,
+                               ThreadState const value);
 
-template <typename T>
-std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>, void>
-root_spinwait_until_equal(T const volatile& flag, const T value) {
-  Kokkos::store_fence();
-  uint32_t i = 0;
-  while (value != flag) {
-    host_thread_yield(++i, WaitMode::ROOT);
-  }
-  Kokkos::load_fence();
-}
+void root_spinwait_until_equal(ThreadState const volatile& flag,
+                               ThreadState const value);
 
-template <typename T>
-std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>, void>
-spinwait_while_equal(T const volatile& flag, const T value) {
-  Kokkos::store_fence();
-  uint32_t i = 0;
-  while (value == flag) {
-    host_thread_yield(++i, WaitMode::ACTIVE);
-  }
-  Kokkos::load_fence();
-}
+void spinwait_while_equal(ThreadState const volatile& flag,
+                          ThreadState const value);
 
-template <typename T>
-std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>, void>
-yield_while_equal(T const volatile& flag, const T value) {
-  Kokkos::store_fence();
-  uint32_t i = 0;
-  while (value == flag) {
-    host_thread_yield(++i, WaitMode::PASSIVE);
-  }
-  Kokkos::load_fence();
-}
+void yield_while_equal(ThreadState const volatile& flag,
+                       ThreadState const value);
 
-template <typename T>
-std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>, void>
-spinwait_until_equal(T const volatile& flag, const T value) {
-  Kokkos::store_fence();
-  uint32_t i = 0;
-  while (value != flag) {
-    host_thread_yield(++i, WaitMode::ACTIVE);
-  }
-  Kokkos::load_fence();
-}
+void spinwait_until_equal(ThreadState const volatile& flag,
+                          ThreadState const value);
 
-template <typename T>
-std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>, void>
-yield_until_equal(T const volatile& flag, const T value) {
-  Kokkos::store_fence();
-  uint32_t i = 0;
-  while (value != flag) {
-    host_thread_yield(++i, WaitMode::PASSIVE);
-  }
-  Kokkos::load_fence();
-}
+void yield_until_equal(ThreadState const volatile& flag,
+                       ThreadState const value);
 
-} /* namespace Impl */
-} /* namespace Kokkos */
+}  // namespace Impl
+}  // namespace Kokkos
 
-#endif /* #ifndef KOKKOS_SPINWAIT_HPP */
+#endif

--- a/core/src/Threads/Kokkos_Threads_State.hpp
+++ b/core/src/Threads/Kokkos_Threads_State.hpp
@@ -1,0 +1,39 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_THREADS_STATE_HPP
+#define KOKKOS_THREADS_STATE_HPP
+
+namespace Kokkos {
+namespace Impl {
+/** \brief States of a worker thread */
+enum class ThreadState {
+  Terminating  ///<  Termination in progress
+  ,
+  Inactive  ///<  Exists, waiting for work
+  ,
+  Active  ///<  Exists, performing work
+  ,
+  Rendezvous  ///<  Exists, waiting in a barrier or reduce
+  ,
+  ScanCompleted,
+  ScanAvailable,
+  ReductionAvailable
+};
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -22,10 +22,10 @@
 #include <cstdio>
 
 #include <utility>
-#include <impl/Kokkos_Spinwait.hpp>
 #include <impl/Kokkos_HostThreadTeam.hpp>
 
 #include <Kokkos_Atomic.hpp>
+#include <Threads/Kokkos_Threads_Spinwait.hpp>
 #include <Threads/Kokkos_Threads_State.hpp>
 
 //----------------------------------------------------------------------------
@@ -85,13 +85,13 @@ class ThreadsExecTeamMember {
     for (n = 1;
          (!(m_team_rank_rev & n)) && ((j = m_team_rank_rev + n) < m_team_size);
          n <<= 1) {
-      Impl::spinwait_while_equal(m_team_base[j]->state(), ThreadState::Active);
+      spinwait_while_equal(m_team_base[j]->state(), ThreadState::Active);
     }
 
     // If not root then wait for release
     if (m_team_rank_rev) {
       m_instance->state() = ThreadState::Rendezvous;
-      Impl::spinwait_while_equal(m_instance->state(), ThreadState::Rendezvous);
+      spinwait_while_equal(m_instance->state(), ThreadState::Rendezvous);
     }
 
     return !m_team_rank_rev;

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -84,15 +84,15 @@ class ThreadsExecTeamMember {
     for (n = 1;
          (!(m_team_rank_rev & n)) && ((j = m_team_rank_rev + n) < m_team_size);
          n <<= 1) {
-      Impl::spinwait_while_equal<ThreadsInternal::State>(
-          m_team_base[j]->state(), ThreadsInternal::State::Active);
+      Impl::spinwait_while_equal(m_team_base[j]->state(),
+                                 ThreadsInternal::State::Active);
     }
 
     // If not root then wait for release
     if (m_team_rank_rev) {
       m_instance->state() = ThreadsInternal::State::Rendezvous;
-      Impl::spinwait_while_equal<ThreadsInternal::State>(
-          m_instance->state(), ThreadsInternal::State::Rendezvous);
+      Impl::spinwait_while_equal(m_instance->state(),
+                                 ThreadsInternal::State::Rendezvous);
     }
 
     return !m_team_rank_rev;

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -84,15 +84,15 @@ class ThreadsExecTeamMember {
     for (n = 1;
          (!(m_team_rank_rev & n)) && ((j = m_team_rank_rev + n) < m_team_size);
          n <<= 1) {
-      Impl::spinwait_while_equal<int>(m_team_base[j]->state(),
-                                      ThreadsInternal::Active);
+      Impl::spinwait_while_equal<ThreadsInternal::State>(
+          m_team_base[j]->state(), ThreadsInternal::State::Active);
     }
 
     // If not root then wait for release
     if (m_team_rank_rev) {
-      m_instance->state() = ThreadsInternal::Rendezvous;
-      Impl::spinwait_while_equal<int>(m_instance->state(),
-                                      ThreadsInternal::Rendezvous);
+      m_instance->state() = ThreadsInternal::State::Rendezvous;
+      Impl::spinwait_while_equal<ThreadsInternal::State>(
+          m_instance->state(), ThreadsInternal::State::Rendezvous);
     }
 
     return !m_team_rank_rev;
@@ -103,7 +103,7 @@ class ThreadsExecTeamMember {
     for (n = 1;
          (!(m_team_rank_rev & n)) && ((j = m_team_rank_rev + n) < m_team_size);
          n <<= 1) {
-      m_team_base[j]->state() = ThreadsInternal::Active;
+      m_team_base[j]->state() = ThreadsInternal::State::Active;
     }
   }
 

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -26,6 +26,7 @@
 #include <impl/Kokkos_HostThreadTeam.hpp>
 
 #include <Kokkos_Atomic.hpp>
+#include <Threads/Kokkos_Threads_State.hpp>
 
 //----------------------------------------------------------------------------
 
@@ -84,15 +85,13 @@ class ThreadsExecTeamMember {
     for (n = 1;
          (!(m_team_rank_rev & n)) && ((j = m_team_rank_rev + n) < m_team_size);
          n <<= 1) {
-      Impl::spinwait_while_equal(m_team_base[j]->state(),
-                                 ThreadsInternal::State::Active);
+      Impl::spinwait_while_equal(m_team_base[j]->state(), ThreadState::Active);
     }
 
     // If not root then wait for release
     if (m_team_rank_rev) {
-      m_instance->state() = ThreadsInternal::State::Rendezvous;
-      Impl::spinwait_while_equal(m_instance->state(),
-                                 ThreadsInternal::State::Rendezvous);
+      m_instance->state() = ThreadState::Rendezvous;
+      Impl::spinwait_while_equal(m_instance->state(), ThreadState::Rendezvous);
     }
 
     return !m_team_rank_rev;
@@ -103,7 +102,7 @@ class ThreadsExecTeamMember {
     for (n = 1;
          (!(m_team_rank_rev & n)) && ((j = m_team_rank_rev + n) < m_team_size);
          n <<= 1) {
-      m_team_base[j]->state() = ThreadsInternal::State::Active;
+      m_team_base[j]->state() = ThreadState::Active;
     }
   }
 

--- a/core/src/impl/Kokkos_HostThreadTeam.cpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.cpp
@@ -22,7 +22,6 @@
 #include <Kokkos_Macros.hpp>
 #include <impl/Kokkos_HostThreadTeam.hpp>
 #include <impl/Kokkos_Error.hpp>
-#include <impl/Kokkos_Spinwait.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -131,10 +130,10 @@ int HostThreadTeamData::organize_team(const int team_size) {
     //     zombi team around (for example m_pool_size = 5 and team_size = 2
     // (ii) if team_alloc > team_size then the last team might have less
     //      threads than the others
-    m_team_rank = (team_base_rank + team_size <= m_pool_size) &&
+    m_team_rank            = (team_base_rank + team_size <= m_pool_size) &&
                           (team_alloc_rank < team_size)
-                      ? team_alloc_rank
-                      : -1;
+                                 ? team_alloc_rank
+                                 : -1;
     m_team_size            = team_size;
     m_team_alloc           = team_alloc_size;
     m_league_rank          = league_rank;

--- a/core/src/impl/Kokkos_HostThreadTeam.cpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.cpp
@@ -130,10 +130,10 @@ int HostThreadTeamData::organize_team(const int team_size) {
     //     zombi team around (for example m_pool_size = 5 and team_size = 2
     // (ii) if team_alloc > team_size then the last team might have less
     //      threads than the others
-    m_team_rank            = (team_base_rank + team_size <= m_pool_size) &&
+    m_team_rank = (team_base_rank + team_size <= m_pool_size) &&
                           (team_alloc_rank < team_size)
-                                 ? team_alloc_rank
-                                 : -1;
+                      ? team_alloc_rank
+                      : -1;
     m_team_size            = team_size;
     m_team_alloc           = team_alloc_size;
     m_league_rank          = league_rank;

--- a/core/src/impl/Kokkos_Spinwait.hpp
+++ b/core/src/impl/Kokkos_Spinwait.hpp
@@ -38,8 +38,8 @@ enum class WaitMode : int {
 void host_thread_yield(const uint32_t i, const WaitMode mode);
 
 template <typename T>
-std::enable_if_t<std::is_integral<T>::value, void> root_spinwait_while_equal(
-    T const volatile& flag, const T value) {
+std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>, void>
+root_spinwait_while_equal(T const volatile& flag, const T value) {
   Kokkos::store_fence();
   uint32_t i = 0;
   while (value == flag) {
@@ -49,8 +49,8 @@ std::enable_if_t<std::is_integral<T>::value, void> root_spinwait_while_equal(
 }
 
 template <typename T>
-std::enable_if_t<std::is_integral<T>::value, void> root_spinwait_until_equal(
-    T const volatile& flag, const T value) {
+std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>, void>
+root_spinwait_until_equal(T const volatile& flag, const T value) {
   Kokkos::store_fence();
   uint32_t i = 0;
   while (value != flag) {
@@ -60,8 +60,8 @@ std::enable_if_t<std::is_integral<T>::value, void> root_spinwait_until_equal(
 }
 
 template <typename T>
-std::enable_if_t<std::is_integral<T>::value, void> spinwait_while_equal(
-    T const volatile& flag, const T value) {
+std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>, void>
+spinwait_while_equal(T const volatile& flag, const T value) {
   Kokkos::store_fence();
   uint32_t i = 0;
   while (value == flag) {
@@ -71,8 +71,8 @@ std::enable_if_t<std::is_integral<T>::value, void> spinwait_while_equal(
 }
 
 template <typename T>
-std::enable_if_t<std::is_integral<T>::value, void> yield_while_equal(
-    T const volatile& flag, const T value) {
+std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>, void>
+yield_while_equal(T const volatile& flag, const T value) {
   Kokkos::store_fence();
   uint32_t i = 0;
   while (value == flag) {
@@ -82,8 +82,8 @@ std::enable_if_t<std::is_integral<T>::value, void> yield_while_equal(
 }
 
 template <typename T>
-std::enable_if_t<std::is_integral<T>::value, void> spinwait_until_equal(
-    T const volatile& flag, const T value) {
+std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>, void>
+spinwait_until_equal(T const volatile& flag, const T value) {
   Kokkos::store_fence();
   uint32_t i = 0;
   while (value != flag) {
@@ -93,8 +93,8 @@ std::enable_if_t<std::is_integral<T>::value, void> spinwait_until_equal(
 }
 
 template <typename T>
-std::enable_if_t<std::is_integral<T>::value, void> yield_until_equal(
-    T const volatile& flag, const T value) {
+std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>, void>
+yield_until_equal(T const volatile& flag, const T value) {
   Kokkos::store_fence();
   uint32_t i = 0;
   while (value != flag) {


### PR DESCRIPTION
This PR replaces the `enum` in `Kokkos_Threads_Instance` with `constexpr int` and `enum class` and move the `enum class` to its own file. The PR also moves `Kokkos_Spinwait.hpp` from `Impl` to `Threads`. `spinwait_while_equal` now takes a `ThreadState` as an argument. The template parameter has been removed. The following functions, which where not used, have been removed:
 - `root_spinwait_while_equal`
 - `root_spinwait_until_equal`
 - `spinwait_until_equal`
 - `yield_until_equal`