### PR TITLE
`Kokkos_BitSet.hpp`: spell out type explicitly inside `Impl::with_updated_label`

### DIFF
--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -33,9 +33,10 @@ namespace Impl {
 template <typename... P>
 auto with_updated_label(const ViewCtorProp<P...>& view_ctor_prop,
                         const std::string& label) {
+  using vcp_t = ViewCtorProp<P...>;
   //! If the label property is already set, append. Otherwise, set label.
-  if constexpr (ViewCtorProp<P...>::has_label) {
-    auto new_ctor_props(view_ctor_prop);
+  if constexpr (vcp_t::has_label) {
+    vcp_t new_ctor_props(view_ctor_prop);
     static_cast<ViewCtorProp<void, std::string>&>(new_ctor_props)
         .value.append(label);
     return new_ctor_props;


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/6515.
Still exploring why auto fails. But since here the issue is just a copy constructor and we know the type, i don't see why not making things explicit. 

This works on kokkos-dev-2. 
