### PR TITLE
Prefer defaulted default constructor for Bitset

### DIFF
--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -92,9 +92,10 @@ class Bitset {
   using block_view_type = View<unsigned*, Device, MemoryTraits<RandomAccess>>;
 
  public:
-  /// constructor
+  Bitset() = default;
+
   /// arg_size := number of bit in set
-  Bitset(unsigned arg_size = 0u) : Bitset(Kokkos::view_alloc(), arg_size) {}
+  Bitset(unsigned arg_size) : Bitset(Kokkos::view_alloc(), arg_size) {}
 
   template <class... P>
   Bitset(const Impl::ViewCtorProp<P...>& arg_prop, unsigned arg_size)
@@ -310,8 +311,8 @@ class Bitset {
   }
 
  private:
-  unsigned m_size;
-  unsigned m_last_block_mask;
+  unsigned m_size            = 0;
+  unsigned m_last_block_mask = 0;
   block_view_type m_blocks;
 
  private:

--- a/containers/unit_tests/TestBitset.hpp
+++ b/containers/unit_tests/TestBitset.hpp
@@ -155,7 +155,7 @@ void test_bitset() {
 
   {
     unsigned ts = 100u;
-    bitset_type b1;
+    bitset_type b1(Kokkos::view_alloc("MyBitset"), 0);
     ASSERT_TRUE(b1.is_allocated());
 
     b1 = bitset_type(ts);
@@ -165,6 +165,9 @@ void test_bitset() {
     ASSERT_TRUE(b1.is_allocated());
     ASSERT_TRUE(b2.is_allocated());
     ASSERT_TRUE(b3.is_allocated());
+
+    bitset_type b4;
+    ASSERT_FALSE(b4.is_allocated());
   }
 
   std::array<unsigned, 7> test_sizes = {

--- a/containers/unit_tests/TestBitset.hpp
+++ b/containers/unit_tests/TestBitset.hpp
@@ -260,26 +260,6 @@ TEST(TEST_CATEGORY, bitset_default_constructor_no_alloc) {
   listen_tool_events(Config::DisableAll());
 }
 
-TEST(TEST_CATEGORY, bitset_zero_size_does_alloc) {
-  using namespace Kokkos::Test::Tools;
-  listen_tool_events(Config::DisableAll(), Config::EnableAllocs());
-
-  auto success = validate_existence(
-      [&]() {
-        Kokkos::Bitset bs1(0);
-        EXPECT_TRUE(bs1.is_allocated());
-
-        Kokkos::Bitset bs2(Kokkos::view_alloc("MyBitset"), 0);
-        EXPECT_TRUE(bs2.is_allocated());
-      },
-      [&](AllocateDataEvent) {
-        return MatchDiagnostic{true, {"Found alloc event"}};
-      });
-  ASSERT_TRUE(success);
-
-  listen_tool_events(Config::DisableAll());
-}
-
 }  // namespace Test
 
 #endif  // KOKKOS_TEST_BITSET_HPP

--- a/containers/unit_tests/TestBitset.hpp
+++ b/containers/unit_tests/TestBitset.hpp
@@ -23,6 +23,8 @@
 #include <Kokkos_Bitset.hpp>
 #include <array>
 
+#include <../../core/unit_test/tools/include/ToolTestingUtilities.hpp>
+
 namespace Test {
 
 namespace Impl {
@@ -240,6 +242,24 @@ void test_bitset() {
 }
 
 TEST(TEST_CATEGORY, bitset) { test_bitset<TEST_EXECSPACE>(); }
+
+TEST(TEST_CATEGORY, bitset_default_constructor_no_alloc) {
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableAllocs());
+
+  auto success = validate_absence(
+      [&]() {
+        Kokkos::Bitset bs;
+        EXPECT_FALSE(bs.is_allocated());
+      },
+      [&](AllocateDataEvent) {
+        return MatchDiagnostic{true, {"Found alloc event"}};
+      });
+  ASSERT_TRUE(success);
+
+  listen_tool_events(Config::DisableAll());
+}
+
 }  // namespace Test
 
 #endif  // KOKKOS_TEST_BITSET_HPP

--- a/containers/unit_tests/TestBitset.hpp
+++ b/containers/unit_tests/TestBitset.hpp
@@ -260,6 +260,26 @@ TEST(TEST_CATEGORY, bitset_default_constructor_no_alloc) {
   listen_tool_events(Config::DisableAll());
 }
 
+TEST(TEST_CATEGORY, bitset_zero_size_does_alloc) {
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableAllocs());
+
+  auto success = validate_existence(
+      [&]() {
+        Kokkos::Bitset bs1(0);
+        EXPECT_TRUE(bs1.is_allocated());
+
+        Kokkos::Bitset bs2(Kokkos::view_alloc("MyBitset"), 0);
+        EXPECT_TRUE(bs2.is_allocated());
+      },
+      [&](AllocateDataEvent) {
+        return MatchDiagnostic{true, {"Found alloc event"}};
+      });
+  ASSERT_TRUE(success);
+
+  listen_tool_events(Config::DisableAll());
+}
+
 }  // namespace Test
 
 #endif  // KOKKOS_TEST_BITSET_HPP


### PR DESCRIPTION
The default argument to the constructor that takes the size of the bitset was deferring to another constructor that creates an empty view with a label argument.  This alocates 128 bits for the view header. This showed when constructing an UnorderedMap with a pointless 128-bit "header-only" allocation which implies an unnecessary fence.

cc @uliegecsm @romintomasetti