### PR TITLE
Do not append " - blocks" to the bitset label

### DIFF
--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -28,24 +28,6 @@
 
 namespace Kokkos {
 
-namespace Impl {
-//! Either append to the label if the property already exists, or set it.
-template <typename... P>
-auto with_updated_label(const ViewCtorProp<P...>& view_ctor_prop,
-                        const std::string& label) {
-  using vcp_t = ViewCtorProp<P...>;
-  //! If the label property is already set, append. Otherwise, set label.
-  if constexpr (vcp_t::has_label) {
-    vcp_t new_ctor_props(view_ctor_prop);
-    static_cast<ViewCtorProp<void, std::string>&>(new_ctor_props)
-        .value.append(label);
-    return new_ctor_props;
-  } else {
-    return Impl::with_properties_if_unset(view_ctor_prop, label);
-  }
-}
-}  // namespace Impl
-
 template <typename Device = Kokkos::DefaultExecutionSpace>
 class Bitset;
 
@@ -108,9 +90,8 @@ class Bitset {
         "Allocation properties should not contain the 'pointer' property.");
 
     //! Update 'label' property and allocate.
-    const auto prop_copy = Kokkos::Impl::with_updated_label(
-        Impl::with_properties_if_unset(arg_prop, std::string("Bitset")),
-        " - blocks");
+    const auto prop_copy =
+        Impl::with_properties_if_unset(arg_prop, std::string("Bitset"));
     m_blocks =
         block_view_type(prop_copy, ((m_size + block_mask) >> block_shift));
 

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -337,27 +337,27 @@ class UnorderedMap {
         Impl::get_property<Impl::LabelTag>(prop_copy) + " - size"));
 
     m_available_indexes =
-        bitset_type(Kokkos::Impl::with_updated_label(prop_copy, " - bitset"),
+        bitset_type(Kokkos::Impl::append_to_label(prop_copy, " - bitset"),
                     calculate_capacity(capacity_hint));
 
     m_hash_lists = size_type_view(
-        Kokkos::Impl::with_updated_label(prop_copy_noinit, " - hash list"),
+        Kokkos::Impl::append_to_label(prop_copy_noinit, " - hash list"),
         Impl::find_hash_size(capacity()));
 
     m_next_index = size_type_view(
-        Kokkos::Impl::with_updated_label(prop_copy_noinit, " - next index"),
+        Kokkos::Impl::append_to_label(prop_copy_noinit, " - next index"),
         capacity() + 1);  // +1 so that the *_at functions can always return a
                           // valid reference
 
-    m_keys = key_type_view(
-        Kokkos::Impl::with_updated_label(prop_copy, " - keys"), capacity());
+    m_keys = key_type_view(Kokkos::Impl::append_to_label(prop_copy, " - keys"),
+                           capacity());
 
-    m_values = value_type_view(
-        Kokkos::Impl::with_updated_label(prop_copy, " - values"),
-        is_set ? 0 : capacity());
+    m_values =
+        value_type_view(Kokkos::Impl::append_to_label(prop_copy, " - values"),
+                        is_set ? 0 : capacity());
 
     m_scalars =
-        scalars_view(Kokkos::Impl::with_updated_label(prop_copy, " - scalars"));
+        scalars_view(Kokkos::Impl::append_to_label(prop_copy, " - scalars"));
 
     /**
      * Deep copies should also be done using the space instance if given.

--- a/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
+++ b/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
@@ -27,6 +27,22 @@
 namespace Kokkos {
 namespace Impl {
 
+//! Either append to the label if the property already exists, or set it.
+template <typename... P>
+auto with_updated_label(const ViewCtorProp<P...>& view_ctor_prop,
+                        const std::string& label) {
+  using vcp_t = ViewCtorProp<P...>;
+  //! If the label property is already set, append. Otherwise, set label.
+  if constexpr (vcp_t::has_label) {
+    vcp_t new_ctor_props(view_ctor_prop);
+    static_cast<ViewCtorProp<void, std::string>&>(new_ctor_props)
+        .value.append(label);
+    return new_ctor_props;
+  } else {
+    return Impl::with_properties_if_unset(view_ctor_prop, label);
+  }
+}
+
 uint32_t find_hash_size(uint32_t size);
 
 template <typename Map>

--- a/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
+++ b/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
@@ -27,20 +27,16 @@
 namespace Kokkos {
 namespace Impl {
 
-//! Either append to the label if the property already exists, or set it.
+//! Append to the label contained in view_ctor_prop.
 template <typename... P>
-auto with_updated_label(const ViewCtorProp<P...>& view_ctor_prop,
-                        const std::string& label) {
+auto append_to_label(const ViewCtorProp<P...>& view_ctor_prop,
+                     const std::string& label) {
   using vcp_t = ViewCtorProp<P...>;
-  //! If the label property is already set, append. Otherwise, set label.
-  if constexpr (vcp_t::has_label) {
-    vcp_t new_ctor_props(view_ctor_prop);
-    static_cast<ViewCtorProp<void, std::string>&>(new_ctor_props)
-        .value.append(label);
-    return new_ctor_props;
-  } else {
-    return Impl::with_properties_if_unset(view_ctor_prop, label);
-  }
+  static_assert(vcp_t::has_label);
+  vcp_t new_ctor_props(view_ctor_prop);
+  static_cast<ViewCtorProp<void, std::string>&>(new_ctor_props)
+      .value.append(label);
+  return new_ctor_props;
 }
 
 uint32_t find_hash_size(uint32_t size);


### PR DESCRIPTION
Fixup for #6198

Rational:  Unnecessary as there is only one view (in contrast to UnorderedMap that has multiple accessory views).  IMO this is something that should rather be dealt with at call site.

code/label | Before this PR | After this PR
--- | --- | ---
`Bitset<D> bs(N);` | "Bitset - blocks" | "Bitset"
`Bitset<D> bs(view_alloc("MyLbl"), N);` | "MyLbl - blocks" | "MyLbl"
`UnorderedMap<K,V,D> m;` | "UnorderedMap - bitset - blocks" | "UnorderedMap - bitset"
`UnorderedMap<K,V,D> m(view_alloc("MyLbl"));` | "MyLbl - bitset - blocks" | "MyLbl - bitset"

cc @uliegecsm @romintomasetti