### PR TITLE
[4.2.00] `Kokkos_BitSet.hpp`: spell out type explicitly inside `Impl::with_updated_label`

### DIFF
--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -33,9 +33,10 @@ namespace Impl {
 template <typename... P>
 auto with_updated_label(const ViewCtorProp<P...>& view_ctor_prop,
                         const std::string& label) {
+  using vcp_t = ViewCtorProp<P...>;
   //! If the label property is already set, append. Otherwise, set label.
-  if constexpr (ViewCtorProp<P...>::has_label) {
-    auto new_ctor_props(view_ctor_prop);
+  if constexpr (vcp_t::has_label) {
+    vcp_t new_ctor_props(view_ctor_prop);
     static_cast<ViewCtorProp<void, std::string>&>(new_ctor_props)
         .value.append(label);
     return new_ctor_props;


### PR DESCRIPTION
Merge pull request #6518 from fnrizzi/fix_6515

(cherry picked from commit 505c396dc75bff8ef4b0cbbae9d180a022c91da9)