### PR TITLE
[4.2.00] Fix Intel compiler warnings in Kokkos_CopyIf.hpp and Kokkos_UniqueCopy.hpp

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_CopyIf.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_CopyIf.hpp
@@ -149,6 +149,11 @@ KOKKOS_FUNCTION OutputIterator copy_if_team_impl(
     // no barrier needed because of the scan accumulating into count
     return d_first + count;
   }
+
+#if defined KOKKOS_COMPILER_INTEL || \
+    (defined(KOKKOS_COMPILER_NVCC) && KOKKOS_COMPILER_NVCC >= 1130)
+  __builtin_unreachable();
+#endif
 }
 
 }  // namespace Impl

--- a/algorithms/src/std_algorithms/impl/Kokkos_UniqueCopy.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_UniqueCopy.hpp
@@ -174,6 +174,11 @@ KOKKOS_FUNCTION OutputIterator unique_copy_team_impl(
       return Impl::copy_team_impl(teamHandle, first + scan_size, last,
                                   d_first + count);
     }
+
+#if defined KOKKOS_COMPILER_INTEL || \
+    (defined(KOKKOS_COMPILER_NVCC) && KOKKOS_COMPILER_NVCC >= 1130)
+    __builtin_unreachable();
+#endif
   }
 }
 


### PR DESCRIPTION
Merge pull request #6516 from fnrizzi/fix_6502

(cherry picked from commit 0120c431b4441c3b39fcf5574e2a32c3d798538c)