### PR TITLE
SYCL: Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL to detect support for device global variables

### DIFF
--- a/tpls/desul/include/desul/atomics/Adapt_SYCL.hpp
+++ b/tpls/desul/include/desul/atomics/Adapt_SYCL.hpp
@@ -88,14 +88,17 @@ using sycl_atomic_ref = sycl::atomic_ref<T,
                                          sycl::access::address_space::generic_space>;
 #endif
 
-// FIXME_SYCL Use SYCL_EXT_ONEAPI_DEVICE_GLOBAL when available instead
 #ifdef DESUL_SYCL_DEVICE_GLOBAL_SUPPORTED
-// FIXME_SYCL The compiler forces us to use device_image_scope. Drop this when possible.
+#ifdef SYCL_EXT_ONEAPI_DEVICE_GLOBAL
+template <class T>
+using sycl_device_global = sycl::ext::oneapi::experimental::device_global<T>;
+#else
 template <class T>
 using sycl_device_global = sycl::ext::oneapi::experimental::device_global<
     T,
     decltype(sycl::ext::oneapi::experimental::properties(
         sycl::ext::oneapi::experimental::device_image_scope))>;
+#endif
 #endif
 
 }  // namespace Impl


### PR DESCRIPTION
When `SYCL_EXT_ONEAPI_DEVICE_GLOBAL` is defined, we can at least get rid of
```
sycl::ext::oneapi::experimental::properties(sycl::ext::oneapi::experimental::device_image_scope)
``` 
which forces us to use `-fsycl-device-code-split=off` instead of, say, `-fsycl-device-code-split=per_kernel`. Being able to use the latter flag vastly improves compile time in combination with `-fsycl-max-parallel-link-jobs=N`. Unfortunately, `sycl::device_global` variables still don't work when compiling with shared libraries.

Corresponds to https://github.com/desul/desul/pull/113.