### PR TITLE
SYCL: Restrict workaround for is_device_copyable to oneAPI versions before 2024.0.0

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -330,8 +330,8 @@ struct sycl::is_device_copyable<
     Kokkos::Experimental::Impl::SYCLFunctionWrapper<Functor, Storage, false>>
     : std::true_type {};
 
-// FIXME_SYCL Remove when this specialization when specializations for
-// sycl::device_copyable also apply to const-qualified types.
+#if defined(KOKKOS_ENABLE_SYCL) && defined(__INTEL_LLVM_COMPILER) && \
+    __INTEL_LLVM_COMPILER < 20240000
 template <typename>
 struct NonTriviallyCopyableAndDeviceCopyable {
   NonTriviallyCopyableAndDeviceCopyable(
@@ -354,5 +354,6 @@ struct sycl::is_device_copyable<
     std::enable_if_t<!sycl::is_device_copyable_v<
         const NonTriviallyCopyableAndDeviceCopyable<Functor>>>>
     : std::true_type {};
+#endif
 #endif
 #endif

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -330,8 +330,9 @@ struct sycl::is_device_copyable<
     Kokkos::Experimental::Impl::SYCLFunctionWrapper<Functor, Storage, false>>
     : std::true_type {};
 
-#if defined(KOKKOS_ENABLE_SYCL) && defined(__INTEL_LLVM_COMPILER) && \
-    __INTEL_LLVM_COMPILER < 20240000
+#if defined(KOKKOS_ENABLE_SYCL) &&                                           \
+    ((defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20240000) || \
+     (defined(__LIBSYCL_MAJOR_VERSION) && __LIBSYCL_MAJOR_VERSION >= 7))
 template <typename>
 struct NonTriviallyCopyableAndDeviceCopyable {
   NonTriviallyCopyableAndDeviceCopyable(

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -331,7 +331,7 @@ struct sycl::is_device_copyable<
     : std::true_type {};
 
 #if (defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20240000) || \
-    (defined(__LIBSYCL_MAJOR_VERSION) && __LIBSYCL_MAJOR_VERSION >= 7)
+    (defined(__LIBSYCL_MAJOR_VERSION) && __LIBSYCL_MAJOR_VERSION < 7)
 template <typename>
 struct NonTriviallyCopyableAndDeviceCopyable {
   NonTriviallyCopyableAndDeviceCopyable(

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -330,9 +330,8 @@ struct sycl::is_device_copyable<
     Kokkos::Experimental::Impl::SYCLFunctionWrapper<Functor, Storage, false>>
     : std::true_type {};
 
-#if defined(KOKKOS_ENABLE_SYCL) &&                                           \
-    ((defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20240000) || \
-     (defined(__LIBSYCL_MAJOR_VERSION) && __LIBSYCL_MAJOR_VERSION >= 7))
+#if (defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20240000) || \
+    (defined(__LIBSYCL_MAJOR_VERSION) && __LIBSYCL_MAJOR_VERSION >= 7)
 template <typename>
 struct NonTriviallyCopyableAndDeviceCopyable {
   NonTriviallyCopyableAndDeviceCopyable(


### PR DESCRIPTION
It turns out that the workaround in https://github.com/kokkos/kokkos/pull/6009 (triggered by https://github.com/intel/llvm/pull/8195) was not as robust as expected since `Intel` decided in https://github.com/intel/llvm/pull/11388 to drop the second template parameter for `sycl::is_device_copyable` (in accordance with the SYCL2020 specs). I expect that commit to land in `oneAPI 2024.0.0` (or later) so we restrict the workaround to versions before that.
