### PR TITLE
Reduce number of `View` constructor instantiations

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1489,26 +1489,20 @@ class View : public ViewTraits<DataType, Properties...> {
   }
 
   // Allocate with label and layout
-  template <typename Label>
-  explicit inline View(
-      const Label& arg_label,
-      std::enable_if_t<Kokkos::Impl::is_view_label<Label>::value,
-                       typename traits::array_layout> const& arg_layout)
+  explicit inline View(std::string const& arg_label,
+                       typename traits::array_layout const& arg_layout)
       : View(Impl::ViewCtorProp<std::string>(arg_label), arg_layout) {}
 
   // Allocate label and layout, must disambiguate from subview constructor.
-  template <typename Label>
-  explicit inline View(
-      const Label& arg_label,
-      std::enable_if_t<Kokkos::Impl::is_view_label<Label>::value, const size_t>
-          arg_N0          = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-      const size_t arg_N1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-      const size_t arg_N2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-      const size_t arg_N3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-      const size_t arg_N4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-      const size_t arg_N5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-      const size_t arg_N6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-      const size_t arg_N7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
+  explicit inline View(std::string const& arg_label,
+                       const size_t arg_N0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                       const size_t arg_N1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                       const size_t arg_N2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                       const size_t arg_N3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                       const size_t arg_N4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                       const size_t arg_N5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                       const size_t arg_N6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                       const size_t arg_N7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
       : View(Impl::ViewCtorProp<std::string>(arg_label),
              typename traits::array_layout(arg_N0, arg_N1, arg_N2, arg_N3,
                                            arg_N4, arg_N5, arg_N6, arg_N7)) {
@@ -1565,8 +1559,10 @@ class View : public ViewTraits<DataType, Properties...> {
         arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7));
   }
 
+  template <class PointerType, class = std::enable_if_t<std::is_convertible_v<
+                                   PointerType, pointer_type>>>
   explicit KOKKOS_INLINE_FUNCTION View(
-      pointer_type arg_ptr, const size_t arg_N0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+      PointerType arg_ptr, const size_t arg_N0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
       const size_t arg_N1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
       const size_t arg_N2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
       const size_t arg_N3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
@@ -1582,8 +1578,10 @@ class View : public ViewTraits<DataType, Properties...> {
                   "overload taking a layout object instead.");
   }
 
+  template <class PointerType, class = std::enable_if_t<std::is_convertible_v<
+                                   PointerType, pointer_type>>>
   explicit KOKKOS_INLINE_FUNCTION View(
-      pointer_type arg_ptr, const typename traits::array_layout& arg_layout)
+      PointerType arg_ptr, const typename traits::array_layout& arg_layout)
       : View(Impl::ViewCtorProp<pointer_type>(arg_ptr), arg_layout) {}
 
   //----------------------------------------


### PR DESCRIPTION
Templating the `View` constructors on the label type is a bad idea.  It yields a bunch of pointless instantiations.
```C++
Kokkos::View<int> v("v"); // -> instantiate for char[2]
Kokkos::View<int> w("MyLabel"); // -> instantiate for char[8]
Kokkos::View<int> x(std::string("MyLabel")); //  -> instantiate for std::string
```
even though the label is just converted to `std::string` when deferring to the `View` constructor that takes `Impl::ViewCtorProp`.

I suggest to take a const reference to `std::string` instead.
We could also take it by value and move.  Let me know if you want to this instead.

For reference, our current documentation says we have
```C++
View(const std::string &name, const IntType&... indices);
View(const std::string &name, const array_layout &layout);
```
https://kokkos.github.io/kokkos-core-wiki/API/core/view/view.html#_CPPv44ViewRKNSt6stringEDpRK7IntType
and
https://kokkos.github.io/kokkos-core-wiki/API/core/view/view.html#_CPPv44ViewRKNSt6stringERK12array_layout


This was prompted in https://github.com/kokkos/kokkos/pull/6477#discussion_r1352791393