### PR TITLE
Remove sleep and wake functions

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -137,26 +137,6 @@ class Cuda {
 #endif
   }
 
-  /** \brief  Set the device in a "sleep" state.
-   *
-   * This function sets the device in a "sleep" state in which it is
-   * not ready for work.  This may consume less resources than if the
-   * device were in an "awake" state, but it may also take time to
-   * bring the device from a sleep state to be ready for work.
-   *
-   * \return True if the device is in the "sleep" state, else false if
-   *   the device is actively working and could not enter the "sleep"
-   *   state.
-   */
-  static bool sleep();
-
-  /// \brief Wake the device from the 'sleep' state so it is ready for work.
-  ///
-  /// \return True if the device is in the "ready" state, else "false"
-  ///  if the device is actively working (which also means that it's
-  ///  awake).
-  static bool wake();
-
   /// \brief Wait until all dispatched functors complete.
   ///
   /// The parallel_for or parallel_reduce dispatch of a functor may

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -86,12 +86,6 @@ class SYCL {
 #endif
   }
 
-  /** \brief  Set the device in a "sleep" state. */
-  static bool sleep();
-
-  /** \brief Wake the device from the 'sleep' state. A noop for OpenMP. */
-  static bool wake();
-
   /** \brief Wait until all dispatched functors complete. A noop for OpenMP. */
   static void impl_static_fence(const std::string& name);
 

--- a/core/src/Threads/Kokkos_Threads_Instance.hpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.hpp
@@ -81,7 +81,6 @@ class ThreadsInternal {
 
   static void first_touch_allocate_thread_private_scratch(ThreadsInternal &,
                                                           const void *);
-  static void execute_sleep(ThreadsInternal &, const void *);
 
   ThreadsInternal(const ThreadsInternal &);
   ThreadsInternal &operator=(const ThreadsInternal &);
@@ -424,8 +423,6 @@ class ThreadsInternal {
   static void internal_fence(
       const std::string &,
       Impl::fence_is_static is_static = Impl::fence_is_static::yes);
-  static bool sleep();
-  static bool wake();
 
   /* Dynamic Scheduling related functionality */
   // Initialize the work range for this thread


### PR DESCRIPTION
This PR removes `sleep`, `wake`, and `execute_sleep` from the `Threads` backend. These functions are not used. The CUDA and SYCL backends declare `sleep` and `wake` but they don't implement them.