### PR TITLE
Cleanup ThreadsInternal

### DIFF
--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -40,7 +40,6 @@ static_assert(false,
 
 namespace Kokkos {
 namespace Impl {
-class ThreadsInternal;
 enum class fence_is_static { yes, no };
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -92,16 +92,6 @@ inline unsigned fan_size(const unsigned rank, const unsigned size) {
 namespace Kokkos {
 namespace Impl {
 
-//----------------------------------------------------------------------------
-// Spawn a thread
-
-void ThreadsInternal::spawn() {
-  std::thread t(internal_cppthread_driver);
-  t.detach();
-}
-
-//----------------------------------------------------------------------------
-
 bool ThreadsInternal::is_process() {
   static const std::thread::id master_pid = std::this_thread::get_id();
 
@@ -592,7 +582,8 @@ void ThreadsInternal::initialize(int thread_count_arg) {
       // Wait until spawned thread has attempted to initialize.
       // If spawning and initialization is successful then
       // an entry in 's_threads_exec' will be assigned.
-      ThreadsInternal::spawn();
+      std::thread t(internal_cppthread_driver);
+      t.detach();
       wait_yield(s_threads_process.m_pool_state, ThreadState::Inactive);
       if (s_threads_process.m_pool_state == ThreadState::Terminating) break;
     }

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -136,8 +136,8 @@ ThreadsInternal::ThreadsInternal()
       m_pool_fan_size(0),
       m_pool_state(ThreadState::Terminating) {
   if (&s_threads_process != this) {
-    // A spawned thread
-
+    // The code in the if is executed by a spawned thread not by the root
+    // thread
     ThreadsInternal *const nil = nullptr;
 
     // Which entry in 's_threads_exec', possibly determined from hwloc binding
@@ -326,7 +326,9 @@ void ThreadsInternal::start(void (*func)(ThreadsInternal &, const void *),
   // Make sure function and arguments are written before activating threads.
   memory_fence();
 
-  // Activate threads:
+  // Activate threads. The spawned threads will start working on
+  // s_current_function. The root thread is only set to active, we still need to
+  // call s_current_function.
   for (int i = s_thread_pool_size[0]; 0 < i--;) {
     s_threads_exec[i]->m_pool_state = ThreadState::Active;
   }

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -595,7 +595,7 @@ void ThreadsInternal::initialize(int thread_count_arg) {
     for (unsigned ith = 1; ith < thread_count; ++ith) {
       // Try to protect against cache coherency failure by casting to volatile.
       ThreadsInternal *const th =
-          ((ThreadsInternal *volatile *)s_threads_exec)[ith];
+          ((ThreadsInternal * volatile *)s_threads_exec)[ith];
       if (th) {
         wait_yield(th->m_pool_state, ThreadState::Active);
       } else {

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -73,18 +73,6 @@ int s_thread_pool_size[3] = {0, 0, 0};
 void (*volatile s_current_function)(ThreadsInternal &, const void *);
 const void *volatile s_current_function_arg = nullptr;
 
-struct Sentinel {
-  ~Sentinel() {
-    if (s_thread_pool_size[0] || s_thread_pool_size[1] ||
-        s_thread_pool_size[2] || s_current_function || s_current_function_arg ||
-        s_threads_exec[0]) {
-      std::cerr << "ERROR : Process exiting while Kokkos::Threads is still "
-                   "initialized"
-                << std::endl;
-    }
-  }
-};
-
 inline unsigned fan_size(const unsigned rank, const unsigned size) {
   const unsigned rank_rev = size - (rank + 1);
   unsigned count          = 0;
@@ -549,8 +537,6 @@ void ThreadsInternal::initialize(int thread_count_arg) {
   unsigned use_numa_count     = 0;
   unsigned use_cores_per_numa = 0;
   bool allow_asynchronous_threadpool = false;
-  // need to provide an initializer for Intel compilers
-  static const Sentinel sentinel = {};
 
   const bool is_initialized = 0 != s_thread_pool_size[0];
 

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -70,17 +70,13 @@ std::pair<unsigned, unsigned>
 
 int s_thread_pool_size[3] = {0, 0, 0};
 
-unsigned s_current_reduce_size = 0;
-unsigned s_current_shared_size = 0;
-
 void (*volatile s_current_function)(ThreadsInternal &, const void *);
 const void *volatile s_current_function_arg = nullptr;
 
 struct Sentinel {
   ~Sentinel() {
     if (s_thread_pool_size[0] || s_thread_pool_size[1] ||
-        s_thread_pool_size[2] || s_current_reduce_size ||
-        s_current_shared_size || s_current_function || s_current_function_arg ||
+        s_thread_pool_size[2] || s_current_function || s_current_function_arg ||
         s_threads_exec[0]) {
       std::cerr << "ERROR : Process exiting while Kokkos::Threads is still "
                    "initialized"
@@ -511,8 +507,6 @@ void ThreadsInternal::print_configuration(std::ostream &s, const bool detail) {
     if (nullptr == s_threads_process.m_pool_base) {
       s << " Asynchronous";
     }
-    s << " ReduceScratch[" << s_current_reduce_size << "]"
-      << " SharedScratch[" << s_current_shared_size << "]";
     s << std::endl;
 
     if (detail) {

--- a/core/src/Threads/Kokkos_Threads_Instance.hpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.hpp
@@ -77,7 +77,6 @@ class ThreadsInternal {
 
   static void global_lock();
   static void global_unlock();
-  static void spawn();
 
   static void first_touch_allocate_thread_private_scratch(ThreadsInternal &,
                                                           const void *);


### PR DESCRIPTION
This PR does a few unrelated thing but it is pretty small that's why I didn't split it. The two most interesting changes in this PR are:

1. Cleanup of `ThreadsInternal::initialize`. This mainly consists in removing variables that have been unnecessary since https://github.com/kokkos/kokkos/pull/5127
2. Remove the `Sentinel` structure. This structure throws an error if we don't call `Kokkos::finalize` or call it in the wrong scope. It's pretty neat but it's the only backend that does this and I am not convinced that it's something that should be done at the backend level.

It's easier to review the PR if you hide the whitespace changes