### PR TITLE
Fix infinity, quiet_NaN, signaling_Nan, isfinite, isnan, isinf for half_t and bhalf_t

### DIFF
--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -46,6 +46,11 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
      LIST(REMOVE_ITEM UnitTestSources ${dir}/TestCuda_DynViewAPI_generic.cpp)
     endif()
 
+    # FIXME_NVHPC: NVC++-S-0000-Internal compiler error. extractor: bad opc       0
+    if(KOKKOS_ENABLE_CUDA AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
+     LIST(REMOVE_ITEM UnitTestSources ${dir}/TestCuda_WithoutInitializing.cpp)
+    endif()
+
     KOKKOS_ADD_EXECUTABLE_AND_TEST(ContainersUnitTest_${Tag} SOURCES ${UnitTestSources})
   endif()
 endforeach()

--- a/core/src/Kokkos_BitManipulation.hpp
+++ b/core/src/Kokkos_BitManipulation.hpp
@@ -115,7 +115,7 @@ bit_cast(From const& from) noexcept {
   return sycl::bit_cast<To>(from);
 #else
   To to;
-  memcpy(&to, &from, sizeof(To));
+  memcpy(static_cast<void*>(&to), static_cast<const void*>(&from), sizeof(To));
   return to;
 #endif
 }

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -220,6 +220,36 @@ namespace Impl {
 template <typename FloatType>
 struct BitComparisonWrapper {
   std::uint16_t value;
+
+  template <typename Number>
+  KOKKOS_FUNCTION friend bool operator==(BitComparisonWrapper a, Number b) {
+    return static_cast<FloatType>(a) == b;
+  }
+
+  template <typename Number>
+  KOKKOS_FUNCTION friend bool operator!=(BitComparisonWrapper a, Number b) {
+    return static_cast<FloatType>(a) != b;
+  }
+
+  template <typename Number>
+  KOKKOS_FUNCTION friend bool operator<(BitComparisonWrapper a, Number b) {
+    return static_cast<FloatType>(a) < b;
+  }
+
+  template <typename Number>
+  KOKKOS_FUNCTION friend bool operator<=(BitComparisonWrapper a, Number b) {
+    return static_cast<FloatType>(a) <= b;
+  }
+
+  template <typename Number>
+  KOKKOS_FUNCTION friend bool operator>(BitComparisonWrapper a, Number b) {
+    return static_cast<FloatType>(a) > b;
+  }
+
+  template <typename Number>
+  KOKKOS_FUNCTION friend bool operator>=(BitComparisonWrapper a, Number b) {
+    return static_cast<FloatType>(a) >= b;
+  }
 };
 
 template <typename FloatType>

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -223,32 +223,25 @@ struct BitComparisonWrapper {
 };
 
 template <typename FloatType>
-static constexpr BitComparisonWrapper<FloatType> exponent_mask;
-
-#ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
-template <>
-constexpr BitComparisonWrapper<Kokkos::Experimental::half_t>
-    exponent_mask<Kokkos::Experimental::half_t>{0b0'11111'0000000000};
-#endif
-
-#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
-template <>
-constexpr BitComparisonWrapper<Kokkos::Experimental::bhalf_t>
-    exponent_mask<Kokkos::Experimental::bhalf_t>{0b0'11111111'0000000};
-#endif
-
+inline constexpr BitComparisonWrapper<FloatType> exponent_mask;
 template <typename FloatType>
-constexpr BitComparisonWrapper<FloatType> fraction_mask;
+inline constexpr BitComparisonWrapper<FloatType> fraction_mask;
 
 #ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
 template <>
-constexpr BitComparisonWrapper<Kokkos::Experimental::half_t>
+inline constexpr BitComparisonWrapper<Kokkos::Experimental::half_t>
+    exponent_mask<Kokkos::Experimental::half_t>{0b0'11111'0000000000};
+template <>
+inline constexpr BitComparisonWrapper<Kokkos::Experimental::half_t>
     fraction_mask<Kokkos::Experimental::half_t>{0b0'00000'1111111111};
 #endif
 
 #ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
 template <>
-constexpr BitComparisonWrapper<Kokkos::Experimental::bhalf_t>
+inline constexpr BitComparisonWrapper<Kokkos::Experimental::bhalf_t>
+    exponent_mask<Kokkos::Experimental::bhalf_t>{0b0'11111111'0000000};
+template <>
+inline constexpr BitComparisonWrapper<Kokkos::Experimental::bhalf_t>
     fraction_mask<Kokkos::Experimental::bhalf_t>{0b0'00000000'1111111};
 #endif
 

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -222,11 +222,41 @@ struct BitComparisonWrapper {
   std::uint16_t value;
 };
 
+template <typename FloatType>
+static constexpr BitComparisonWrapper<FloatType> exponent_mask;
+
+#ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
+template <>
+static constexpr BitComparisonWrapper<Kokkos::Experimental::half_t>
+    exponent_mask<Kokkos::Experimental::half_t>{0b0'11111'0000000000};
+#endif
+
+#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+template <>
+static constexpr BitComparisonWrapper<Kokkos::Experimental::bhalf_t>
+    exponent_mask<Kokkos::Experimental::bhalf_t>{0b0'11111111'0000000};
+#endif
+
+template <typename FloatType>
+static constexpr BitComparisonWrapper<FloatType> fraction_mask;
+
+#ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
+template <>
+static constexpr BitComparisonWrapper<Kokkos::Experimental::half_t>
+    fraction_mask<Kokkos::Experimental::half_t>{0b0'00000'1111111111};
+#endif
+
+#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+template <>
+static constexpr BitComparisonWrapper<Kokkos::Experimwental::bhalf_t>
+    fraction_mask<Kokkos::Experimental::bhalf_t>{0b0'00000000'1111111};
+#endif
+
 template <class FloatType>
 class alignas(FloatType) floating_point_wrapper {
  public:
   using impl_type           = FloatType;
-  using bit_comparison_type = BitComparisonWrapper<FloatType>;
+  using bit_comparison_type = BitComparisonWrapper<floating_point_wrapper>;
 
  private:
   impl_type val;

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_HALF_FLOATING_POINT_WRAPPER_HPP_
 
 #include <Kokkos_Macros.hpp>
+#include <Kokkos_BitManipulation.hpp>  // bit_cast
 
 #include <type_traits>
 #include <iosfwd>  // istream & ostream for extraction and insertion ops
@@ -215,10 +216,17 @@ cast_from_wrapper(const Kokkos::Experimental::bhalf_t& x);
 /************************** END forward declarations **************************/
 
 namespace Impl {
+
+template <typename FloatType>
+struct BitComparisonWrapper {
+  std::uint16_t value;
+};
+
 template <class FloatType>
 class alignas(FloatType) floating_point_wrapper {
  public:
-  using impl_type = FloatType;
+  using impl_type           = FloatType;
+  using bit_comparison_type = BitComparisonWrapper<FloatType>;
 
  private:
   impl_type val;
@@ -267,6 +275,11 @@ class alignas(FloatType) floating_point_wrapper {
     const fixed_width_integer_type rv_val = *rv_ptr;
     val       = reinterpret_cast<const impl_type&>(rv_val);
 #endif  // KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+  }
+
+  KOKKOS_FUNCTION
+  floating_point_wrapper(bit_comparison_type rhs) {
+    val = Kokkos::bit_cast<impl_type>(rhs);
   }
 
   // Don't support implicit conversion back to impl_type.

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -227,28 +227,28 @@ static constexpr BitComparisonWrapper<FloatType> exponent_mask;
 
 #ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
 template <>
-static constexpr BitComparisonWrapper<Kokkos::Experimental::half_t>
+constexpr BitComparisonWrapper<Kokkos::Experimental::half_t>
     exponent_mask<Kokkos::Experimental::half_t>{0b0'11111'0000000000};
 #endif
 
 #ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
 template <>
-static constexpr BitComparisonWrapper<Kokkos::Experimental::bhalf_t>
+constexpr BitComparisonWrapper<Kokkos::Experimental::bhalf_t>
     exponent_mask<Kokkos::Experimental::bhalf_t>{0b0'11111111'0000000};
 #endif
 
 template <typename FloatType>
-static constexpr BitComparisonWrapper<FloatType> fraction_mask;
+constexpr BitComparisonWrapper<FloatType> fraction_mask;
 
 #ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
 template <>
-static constexpr BitComparisonWrapper<Kokkos::Experimental::half_t>
+constexpr BitComparisonWrapper<Kokkos::Experimental::half_t>
     fraction_mask<Kokkos::Experimental::half_t>{0b0'00000'1111111111};
 #endif
 
 #ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
 template <>
-static constexpr BitComparisonWrapper<Kokkos::Experimwental::bhalf_t>
+constexpr BitComparisonWrapper<Kokkos::Experimental::bhalf_t>
     fraction_mask<Kokkos::Experimental::bhalf_t>{0b0'00000000'1111111};
 #endif
 

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -160,7 +160,7 @@ KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF, copysi
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION bool isfinite(Kokkos::Experimental::half_t x) {
   using bit_type = Kokkos::Experimental::half_t::bit_comparison_type;
-  const bit_type exponent_mask{0b0'11111'0000000000};
+  constexpr bit_type exponent_mask = Kokkos::Experimental::Impl::exponent_mask<Kokkos::Experimental::half_t>;
   const bit_type bit_pattern_x = bit_cast<bit_type>(
       static_cast<Kokkos::Experimental::half_t::impl_type>(x));
   return (bit_pattern_x.value & exponent_mask.value) != exponent_mask.value;
@@ -170,7 +170,7 @@ KOKKOS_INLINE_FUNCTION bool isfinite(Kokkos::Experimental::half_t x) {
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION bool isfinite(Kokkos::Experimental::bhalf_t x) {
   using bit_type = Kokkos::Experimental::bhalf_t::bit_comparison_type;
-  const bit_type exponent_mask{0b0'11111111'0000000};
+  constexpr bit_type exponent_mask = Kokkos::Experimental::Impl::exponent_mask<Kokkos::Experimental::bhalf_t>;
   const bit_type bit_pattern_x = bit_cast<bit_type>(
       static_cast<Kokkos::Experimental::bhalf_t::impl_type>(x));
   return (bit_pattern_x.value & exponent_mask.value) != exponent_mask.value;
@@ -180,8 +180,8 @@ KOKKOS_INLINE_FUNCTION bool isfinite(Kokkos::Experimental::bhalf_t x) {
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION bool isinf(Kokkos::Experimental::half_t x) {
   using bit_type = Kokkos::Experimental::half_t::bit_comparison_type;
-  const bit_type exponent_mask{0b0'11111'0000000000};
-  const bit_type fraction_mask{0b0'00000'1111111111};
+  constexpr bit_type exponent_mask = Kokkos::Experimental::Impl::exponent_mask<Kokkos::Experimental::half_t>;
+  constexpr bit_type fraction_mask = Kokkos::Experimental::Impl::fraction_mask<Kokkos::Experimental::half_t>;
   const bit_type bit_pattern_x = bit_cast<bit_type>(
       static_cast<Kokkos::Experimental::half_t::impl_type>(x));
   return (
@@ -193,8 +193,8 @@ KOKKOS_INLINE_FUNCTION bool isinf(Kokkos::Experimental::half_t x) {
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION bool isinf(Kokkos::Experimental::bhalf_t x) {
   using bit_type = Kokkos::Experimental::bhalf_t::bit_comparison_type;
-  const bit_type exponent_mask{0b0'11111111'0000000};
-  const bit_type fraction_mask{0b0'00000000'1111111};
+  constexpr bit_type exponent_mask = Kokkos::Experimental::Impl::exponent_mask<Kokkos::Experimental::bhalf_t>;
+  constexpr bit_type fraction_mask = Kokkos::Experimental::Impl::fraction_mask<Kokkos::Experimental::bhalf_t>;
   const bit_type bit_pattern_x = bit_cast<bit_type>(
       static_cast<Kokkos::Experimental::bhalf_t::impl_type>(x));
   return (
@@ -206,8 +206,8 @@ KOKKOS_INLINE_FUNCTION bool isinf(Kokkos::Experimental::bhalf_t x) {
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION bool isnan(Kokkos::Experimental::half_t x) {
   using bit_type = Kokkos::Experimental::half_t::bit_comparison_type;
-  const bit_type exponent_mask{0b0'11111'0000000000};
-  const bit_type fraction_mask{0b0'00000'1111111111};
+  constexpr bit_type exponent_mask = Kokkos::Experimental::Impl::exponent_mask<Kokkos::Experimental::half_t>;
+  constexpr bit_type fraction_mask = Kokkos::Experimental::Impl::fraction_mask<Kokkos::Experimental::half_t>;
   const bit_type bit_pattern_x = bit_cast<bit_type>(
       static_cast<Kokkos::Experimental::half_t::impl_type>(x));
   return (
@@ -219,8 +219,8 @@ KOKKOS_INLINE_FUNCTION bool isnan(Kokkos::Experimental::half_t x) {
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION bool isnan(Kokkos::Experimental::bhalf_t x) {
   using bit_type = Kokkos::Experimental::bhalf_t::bit_comparison_type;
-  const bit_type exponent_mask{0b0'11111111'0000000};
-  const bit_type fraction_mask{0b0'00000000'1111111};
+  constexpr bit_type exponent_mask = Kokkos::Experimental::Impl::exponent_mask<Kokkos::Experimental::bhalf_t>;
+  constexpr bit_type fraction_mask = Kokkos::Experimental::Impl::fraction_mask<Kokkos::Experimental::bhalf_t>;
   const bit_type bit_pattern_x = bit_cast<bit_type>(
       static_cast<Kokkos::Experimental::bhalf_t::impl_type>(x));
   return (

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_HALF_MATHEMATICAL_FUNCTIONS_HPP_
 
 #include <Kokkos_MathematicalFunctions.hpp>  // For the float overloads
+#include <Kokkos_BitManipulation.hpp>        // bit_cast
 
 // clang-format off
 namespace Kokkos {
@@ -74,7 +75,7 @@ namespace Kokkos {
   KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, unsigned long) \
   KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, long long) \
   KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF_MIXED(FUNC, HALF_TYPE, unsigned long long)
-  
+
 
 #define KOKKOS_IMPL_MATH_UNARY_PREDICATE_HALF(FUNC, HALF_TYPE) \
   KOKKOS_INLINE_FUNCTION bool FUNC(HALF_TYPE x) {              \
@@ -155,10 +156,77 @@ KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF, nextaf
 KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF, copysign)
 // Classification and comparison functions
 // fpclassify
-KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_UNARY_PREDICATE_HALF, isfinite)
-KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_UNARY_PREDICATE_HALF, isinf)
-#if !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_HIP) // FIXME_SYCL, FIXME_HIP
-KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_UNARY_PREDICATE_HALF, isnan)
+
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+KOKKOS_INLINE_FUNCTION bool isfinite(Kokkos::Experimental::half_t x) {
+  using bit_type = Kokkos::Experimental::half_t::bit_comparison_type;
+  const bit_type exponent_mask{0b0'11111'0000000000};
+  const bit_type bit_pattern_x = bit_cast<bit_type>(
+      static_cast<Kokkos::Experimental::half_t::impl_type>(x));
+  return (bit_pattern_x.value & exponent_mask.value) != exponent_mask.value;
+}
+#endif
+
+#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+KOKKOS_INLINE_FUNCTION bool isfinite(Kokkos::Experimental::bhalf_t x) {
+  using bit_type = Kokkos::Experimental::bhalf_t::bit_comparison_type;
+  const bit_type exponent_mask{0b0'11111111'0000000};
+  const bit_type bit_pattern_x = bit_cast<bit_type>(
+      static_cast<Kokkos::Experimental::bhalf_t::impl_type>(x));
+  return (bit_pattern_x.value & exponent_mask.value) != exponent_mask.value;
+}
+#endif
+
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+KOKKOS_INLINE_FUNCTION bool isinf(Kokkos::Experimental::half_t x) {
+  using bit_type = Kokkos::Experimental::half_t::bit_comparison_type;
+  const bit_type exponent_mask{0b0'11111'0000000000};
+  const bit_type fraction_mask{0b0'00000'1111111111};
+  const bit_type bit_pattern_x = bit_cast<bit_type>(
+      static_cast<Kokkos::Experimental::half_t::impl_type>(x));
+  return (
+      ((bit_pattern_x.value & exponent_mask.value) == exponent_mask.value) &&
+      ((bit_pattern_x.value & fraction_mask.value) == 0));
+}
+#endif
+
+#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+KOKKOS_INLINE_FUNCTION bool isinf(Kokkos::Experimental::bhalf_t x) {
+  using bit_type = Kokkos::Experimental::bhalf_t::bit_comparison_type;
+  const bit_type exponent_mask{0b0'11111111'0000000};
+  const bit_type fraction_mask{0b0'00000000'1111111};
+  const bit_type bit_pattern_x = bit_cast<bit_type>(
+      static_cast<Kokkos::Experimental::bhalf_t::impl_type>(x));
+  return (
+      ((bit_pattern_x.value & exponent_mask.value) == exponent_mask.value) &&
+      ((bit_pattern_x.value & fraction_mask.value) == 0));
+}
+#endif
+
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+KOKKOS_INLINE_FUNCTION bool isnan(Kokkos::Experimental::half_t x) {
+  using bit_type = Kokkos::Experimental::half_t::bit_comparison_type;
+  const bit_type exponent_mask{0b0'11111'0000000000};
+  const bit_type fraction_mask{0b0'00000'1111111111};
+  const bit_type bit_pattern_x = bit_cast<bit_type>(
+      static_cast<Kokkos::Experimental::half_t::impl_type>(x));
+  return (
+      ((bit_pattern_x.value & exponent_mask.value) == exponent_mask.value) &&
+      ((bit_pattern_x.value & fraction_mask.value) != 0));
+}
+#endif
+
+#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+KOKKOS_INLINE_FUNCTION bool isnan(Kokkos::Experimental::bhalf_t x) {
+  using bit_type = Kokkos::Experimental::bhalf_t::bit_comparison_type;
+  const bit_type exponent_mask{0b0'11111111'0000000};
+  const bit_type fraction_mask{0b0'00000000'1111111};
+  const bit_type bit_pattern_x = bit_cast<bit_type>(
+      static_cast<Kokkos::Experimental::bhalf_t::impl_type>(x));
+  return (
+      ((bit_pattern_x.value & exponent_mask.value) == exponent_mask.value) &&
+      ((bit_pattern_x.value & fraction_mask.value) != 0));
+}
 #endif
 // isnormal
 KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_UNARY_PREDICATE_HALF, signbit)

--- a/core/src/impl/Kokkos_Half_NumericTraits.hpp
+++ b/core/src/impl/Kokkos_Half_NumericTraits.hpp
@@ -70,7 +70,7 @@
 ///
 template <>
 struct Kokkos::Experimental::Impl::infinity_helper<Kokkos::Experimental::half_t> {
-  static constexpr int value = 0x7C00;
+  static constexpr Kokkos::Experimental::half_t::bit_comparison_type value{0b0'11111'0000000000};
 };
 
 /// \brief: Minimum normalized number
@@ -157,30 +157,30 @@ struct Kokkos::Experimental::Impl::norm_min_helper<
 
 /// \brief: Quiet not a half precision number
 ///
-/// IEEE 754 defines this as all exponent bits high.
-///
-/// Quiet NaN in binary16:
-///             [s  e  e  e  e  e  f f f f f f f f f f]
-///             [1  1  1  1  1  1  0 0 0 0 0 0 0 0 0 0]
-/// bit index:   15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
-template <>
-struct Kokkos::Experimental::Impl::quiet_NaN_helper<
-    Kokkos::Experimental::half_t> {
-  static constexpr float value = 0xfc000;
-};
-
-/// \brief: Signaling not a half precision number
-///
 /// IEEE 754 defines this as all exponent bits and the first fraction bit high.
 ///
 /// Quiet NaN in binary16:
 ///             [s  e  e  e  e  e  f f f f f f f f f f]
-///             [1  1  1  1  1  1  1 0 0 0 0 0 0 0 0 0]
+///             [0  1  1  1  1  1  1 0 0 0 0 0 0 0 0 0]
+/// bit index:   15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
+template <>
+struct Kokkos::Experimental::Impl::quiet_NaN_helper<
+    Kokkos::Experimental::half_t> {
+  static constexpr Kokkos::Experimental::half_t::bit_comparison_type value{0b0'11111'1000000000};
+};
+
+/// \brief: Signaling not a half precision number
+///
+/// IEEE 754 defines this as all exponent bits and the second fraction bit high.
+///
+/// Quiet NaN in binary16:
+///             [s  e  e  e  e  e  f f f f f f f f f f]
+///             [0  1  1  1  1  1  0 1 0 0 0 0 0 0 0 0]
 /// bit index:   15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
 template <>
 struct Kokkos::Experimental::Impl::signaling_NaN_helper<
     Kokkos::Experimental::half_t> {
-  static constexpr float value = 0xfe000;
+  static constexpr Kokkos::Experimental::half_t::bit_comparison_type value{0b0'11111'0100000000};
 };
 
 /// \brief: Number of digits in the matissa that can be represented
@@ -267,7 +267,7 @@ struct Kokkos::Experimental::Impl::max_exponent_helper<
 ///
 template <>
 struct Kokkos::Experimental::Impl::infinity_helper<Kokkos::Experimental::bhalf_t> {
-  static constexpr int value = 0x7F80;
+  static constexpr Kokkos::Experimental::bhalf_t::bit_comparison_type value{0b0'11111111'0000000};
 };
 
 // Minimum normalized number
@@ -303,13 +303,13 @@ struct Kokkos::Experimental::Impl::norm_min_helper<
 template <>
 struct Kokkos::Experimental::Impl::quiet_NaN_helper<
     Kokkos::Experimental::bhalf_t> {
-  static constexpr float value = 0x7fc000;
+  static constexpr Kokkos::Experimental::bhalf_t::bit_comparison_type value{0b0'11111111'1000000};
 };
 // Signaling not a bhalf number
 template <>
 struct Kokkos::Experimental::Impl::signaling_NaN_helper<
     Kokkos::Experimental::bhalf_t> {
-  static constexpr float value = 0x7fe000;
+  static constexpr Kokkos::Experimental::bhalf_t::bit_comparison_type value{0b0'11111111'0100000};
 };
 // Number of digits in the matissa that can be represented
 // without losing precision.

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1290,12 +1290,12 @@ struct TestAbsoluteValueFunction {
     if (abs(static_cast<KE::half_t>(4.f)) != static_cast<KE::half_t>(4.f) ||
         abs(static_cast<KE::half_t>(-4.f)) != static_cast<KE::half_t>(4.f)) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed abs(KE::half_t)\n");
+      Kokkos::printf("failed abs(KE::half_t)\n");
     }
     if (abs(static_cast<KE::bhalf_t>(4.f)) != static_cast<KE::bhalf_t>(4.f) ||
         abs(static_cast<KE::bhalf_t>(-4.f)) != static_cast<KE::bhalf_t>(4.f)) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed abs(KE::bhalf_t)\n");
+      Kokkos::printf("failed abs(KE::bhalf_t)\n");
     }
     if (abs(5.) != 5. || abs(-5.) != 5.) {
       ++e;
@@ -1315,19 +1315,19 @@ struct TestAbsoluteValueFunction {
       Kokkos::printf("failed abs(floating_point) special values\n");
     }
 
-    static_assert(std::is_same<decltype(abs(1)), int>::value, "");
-    static_assert(std::is_same<decltype(abs(2l)), long>::value, "");
-    static_assert(std::is_same<decltype(abs(3ll)), long long>::value, "");
+    static_assert(std::is_same<decltype(abs(1)), int>::value);
+    static_assert(std::is_same<decltype(abs(2l)), long>::value);
+    static_assert(std::is_same<decltype(abs(3ll)), long long>::value);
     static_assert(std::is_same<decltype(abs(static_cast<KE::half_t>(4.f))),
                                KE::half_t>::value,
                   "");
     static_assert(std::is_same<decltype(abs(static_cast<KE::bhalf_t>(4.f))),
                                KE::bhalf_t>::value,
                   "");
-    static_assert(std::is_same<decltype(abs(4.f)), float>::value, "");
-    static_assert(std::is_same<decltype(abs(5.)), double>::value, "");
+    static_assert(std::is_same<decltype(abs(4.f)), float>::value);
+    static_assert(std::is_same<decltype(abs(5.)), double>::value);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same<decltype(abs(6.l)), long double>::value, "");
+    static_assert(std::is_same<decltype(abs(6.l)), long double>::value);
 #endif
   }
 };
@@ -1348,26 +1348,26 @@ struct TestFloatingPointAbsoluteValueFunction {
     using Kokkos::fabs;
     if (fabs(4.f) != 4.f || fabs(-4.f) != 4.f) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fabs(float)\n");
+      Kokkos::printf("failed fabs(float)\n");
     }
     if (fabs(static_cast<KE::half_t>(4.f)) != static_cast<KE::half_t>(4.f) ||
         fabs(static_cast<KE::half_t>(-4.f)) != static_cast<KE::half_t>(4.f)) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fabs(KE::half_t)\n");
+      Kokkos::printf("failed fabs(KE::half_t)\n");
     }
     if (fabs(static_cast<KE::bhalf_t>(4.f)) != static_cast<KE::bhalf_t>(4.f) ||
         fabs(static_cast<KE::bhalf_t>(-4.f)) != static_cast<KE::bhalf_t>(4.f)) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fabs(KE::bhalf_t)\n");
+      Kokkos::printf("failed fabs(KE::bhalf_t)\n");
     }
     if (fabs(5.) != 5. || fabs(-5.) != 5.) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fabs(double)\n");
+      Kokkos::printf("failed fabs(double)\n");
     }
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     if (fabs(6.l) != 6.l || fabs(-6.l) != 6.l) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fabs(long double)\n");
+      Kokkos::printf("failed fabs(long double)\n");
     }
 #endif
     // special values
@@ -1375,8 +1375,7 @@ struct TestFloatingPointAbsoluteValueFunction {
     using Kokkos::isnan;
     if (fabs(-0.) != 0. || !isinf(fabs(-INFINITY)) || !isnan(fabs(-NAN))) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-          "failed fabs(floating_point) special values\n");
+      Kokkos::printf("failed fabs(floating_point) special values\n");
     }
 
     static_assert(std::is_same<decltype(fabs(static_cast<KE::half_t>(4.f))),
@@ -1408,7 +1407,7 @@ struct TestFloatingPointRemainderFunction : FloatingPointComparison {
     if (!compare(fmod(6.2f, 4.f), 2.2f, 1) &&
         !compare(fmod(-6.2f, 4.f), -2.2f, 1)) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fmod(float)\n");
+      Kokkos::printf("failed fmod(float)\n");
     }
     if (!compare(
             fmod(static_cast<KE::half_t>(6.2f), static_cast<KE::half_t>(4.f)),
@@ -1417,7 +1416,7 @@ struct TestFloatingPointRemainderFunction : FloatingPointComparison {
             fmod(static_cast<KE::half_t>(-6.2f), static_cast<KE::half_t>(4.f)),
             -static_cast<KE::half_t>(2.2f), 1)) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fmod(KE::half_t)\n");
+      Kokkos::printf("failed fmod(KE::half_t)\n");
     }
     if (!compare(
             fmod(static_cast<KE::bhalf_t>(6.2f), static_cast<KE::bhalf_t>(4.f)),
@@ -1426,17 +1425,17 @@ struct TestFloatingPointRemainderFunction : FloatingPointComparison {
                       static_cast<KE::bhalf_t>(4.f)),
                  -static_cast<KE::bhalf_t>(2.2f), 1)) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fmod(KE::bhalf_t)\n");
+      Kokkos::printf("failed fmod(KE::bhalf_t)\n");
     }
     if (!compare(fmod(6.2, 4.), 2.2, 1) && !compare(fmod(-6.2, 4.), -2.2, 1)) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fmod(double)\n");
+      Kokkos::printf("failed fmod(double)\n");
     }
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     if (!compare(fmod(6.2l, 4.l), 2.2l, 1) &&
         !compare(fmod(-6.2l, 4.l), -2.2l, 1)) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fmod(long double)\n");
+      Kokkos::printf("failed fmod(long double)\n");
     }
 #endif
     // special values
@@ -1445,8 +1444,7 @@ struct TestFloatingPointRemainderFunction : FloatingPointComparison {
     if (!isinf(fmod(-KE::infinity<float>::value, 1.f)) &&
         !isnan(fmod(-KE::quiet_NaN<float>::value, 1.f))) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-          "failed fmod(floating_point) special values\n");
+      Kokkos::printf("failed fmod(floating_point) special values\n");
     }
 
     static_assert(std::is_same<decltype(fmod(static_cast<KE::half_t>(4.f),
@@ -1457,8 +1455,8 @@ struct TestFloatingPointRemainderFunction : FloatingPointComparison {
                                              static_cast<KE::bhalf_t>(4.f))),
                                KE::bhalf_t>::value,
                   "");
-    static_assert(std::is_same<decltype(fmod(4.f, 4.f)), float>::value, "");
-    static_assert(std::is_same<decltype(fmod(5., 5.)), double>::value, "");
+    static_assert(std::is_same<decltype(fmod(4.f, 4.f)), float>::value);
+    static_assert(std::is_same<decltype(fmod(5., 5.)), double>::value);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     static_assert(std::is_same<decltype(fmod(6.l, 6.l)), long double>::value,
                   "");
@@ -1485,7 +1483,7 @@ struct TestIEEEFloatingPointRemainderFunction : FloatingPointComparison {
     if (!compare(remainder(6.2f, 4.f), 2.2f, 2) &&
         !compare(remainder(-6.2f, 4.f), 2.2f, 1)) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed remainder(float)\n");
+      Kokkos::printf("failed remainder(float)\n");
     }
     if (!compare(remainder(static_cast<KE::half_t>(6.2f),
                            static_cast<KE::half_t>(4.f)),
@@ -1494,7 +1492,7 @@ struct TestIEEEFloatingPointRemainderFunction : FloatingPointComparison {
                            static_cast<KE::half_t>(4.f)),
                  -static_cast<KE::half_t>(2.2f), 1)) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed remainder(KE::half_t)\n");
+      Kokkos::printf("failed remainder(KE::half_t)\n");
     }
     if (!compare(remainder(static_cast<KE::bhalf_t>(6.2f),
                            static_cast<KE::bhalf_t>(4.f)),
@@ -1503,18 +1501,18 @@ struct TestIEEEFloatingPointRemainderFunction : FloatingPointComparison {
                            static_cast<KE::bhalf_t>(4.f)),
                  -static_cast<KE::bhalf_t>(2.2f), 1)) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed remainder(KE::bhalf_t)\n");
+      Kokkos::printf("failed remainder(KE::bhalf_t)\n");
     }
     if (!compare(remainder(6.2, 4.), 2.2, 2) &&
         !compare(remainder(-6.2, 4.), 2.2, 1)) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed remainder(double)\n");
+      Kokkos::printf("failed remainder(double)\n");
     }
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     if (!compare(remainder(6.2l, 4.l), 2.2l, 1) &&
         !compare(remainder(-6.2l, 4.l), -2.2l, 1)) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed remainder(long double)\n");
+      Kokkos::printf("failed remainder(long double)\n");
     }
 #endif
     // special values
@@ -1523,7 +1521,7 @@ struct TestIEEEFloatingPointRemainderFunction : FloatingPointComparison {
     if (!isinf(remainder(-KE::infinity<float>::value, 1.f)) &&
         !isnan(remainder(-KE::quiet_NaN<float>::value, 1.f))) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "failed remainder(floating_point) special values\n");
     }
 
@@ -1539,10 +1537,10 @@ struct TestIEEEFloatingPointRemainderFunction : FloatingPointComparison {
         "");
     static_assert(std::is_same<decltype(remainder(4.f, 4.f)), float>::value,
                   "");
-    static_assert(std::is_same<decltype(remainder(5., 5.)), double>::value, "");
+    static_assert(std::is_same<decltype(remainder(5., 5.)), double>::value);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     static_assert(
-        std::is_same<decltype(remainder(6.l, 6.l)), long double>::value, "");
+        std::is_same<decltype(remainder(6.l, 6.l)), long double>::value);
 #endif
   }
 };
@@ -1554,9 +1552,163 @@ TEST(TEST_CATEGORY, mathematical_functions_ieee_remainder_function) {
 
 // TODO: TestFpClassify, see https://github.com/kokkos/kokkos/issues/6279
 
-// TODO: TestIsFinite, see https://github.com/kokkos/kokkos/issues/6279
+template <class Space>
+struct TestIsFinite {
+  TestIsFinite() { run(); }
+  void run() const {
+    int errors = 0;
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
+    ASSERT_EQ(errors, 0);
+  }
+  KOKKOS_FUNCTION void operator()(int, int& e) const {
+    using KE::infinity;
+    using KE::quiet_NaN;
+    using KE::signaling_NaN;
+    using Kokkos::isfinite;
+    if (!isfinite(1) || !isfinite(INT_MAX)) {
+      ++e;
+      Kokkos::printf("failed isfinite(integral)\n");
+    }
+    if (!isfinite(2.f) || isfinite(quiet_NaN<float>::value) ||
+        isfinite(signaling_NaN<float>::value) ||
+        isfinite(infinity<float>::value)) {
+      ++e;
+      Kokkos::printf("failed isfinite(float)\n");
+    }
+    if (!isfinite(static_cast<KE::half_t>(2.f))
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
+        || isfinite(quiet_NaN<KE::half_t>::value) ||
+        isfinite(signaling_NaN<KE::half_t>::value) ||
+        isfinite(infinity<KE::half_t>::value)
+#endif
+    ) {
+      ++e;
+      Kokkos::printf("failed isfinite(KE::half_t)\n");
+    }
+    if (!isfinite(static_cast<KE::bhalf_t>(2.f))
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
+        || isfinite(quiet_NaN<KE::bhalf_t>::value) ||
+        isfinite(signaling_NaN<KE::bhalf_t>::value) ||
+        isfinite(infinity<KE::bhalf_t>::value)
+#endif
+    ) {
+      ++e;
+      Kokkos::printf("failed isfinite(KE::bhalf_t)\n");
+    }
+    if (!isfinite(3.)
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
+        || isfinite(quiet_NaN<double>::value) ||
+        isfinite(signaling_NaN<double>::value) ||
+        isfinite(infinity<double>::value)
+#endif
+    ) {
+      ++e;
+      Kokkos::printf("failed isfinite(double)\n");
+    }
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+    if (!isfinite(4.l) || isfinite(quiet_NaN<long double>::value) ||
+        isfinite(signaling_NaN<long double>::value) ||
+        isfinite(infinity<long double>::value)) {
+      ++e;
+      Kokkos::printf("failed isfinite(long double)\n");
+    }
+#endif
+    // special values
+    if (isfinite(INFINITY) || isfinite(NAN)) {
+      ++e;
+      Kokkos::printf("failed isfinite(floating_point) special values\n");
+    }
 
-// TODO: TestIsInf, see https://github.com/kokkos/kokkos/issues/6279
+    static_assert(std::is_same<decltype(isfinite(1)), bool>::value);
+    static_assert(std::is_same<decltype(isfinite(2.f)), bool>::value);
+    static_assert(std::is_same<decltype(isfinite(3.)), bool>::value);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+    static_assert(std::is_same<decltype(isfinite(4.l)), bool>::value);
+#endif
+  }
+};
+
+TEST(TEST_CATEGORY, mathematical_functions_isfinite) {
+  TestIsFinite<TEST_EXECSPACE>();
+}
+
+template <class Space>
+struct TestIsInf {
+  TestIsInf() { run(); }
+  void run() const {
+    int errors = 0;
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
+    ASSERT_EQ(errors, 0);
+  }
+  KOKKOS_FUNCTION void operator()(int, int& e) const {
+    using KE::infinity;
+    using KE::quiet_NaN;
+    using KE::signaling_NaN;
+    using Kokkos::isinf;
+    if (isinf(1) || isinf(INT_MAX)) {
+      ++e;
+      Kokkos::printf("failed isinf(integral)\n");
+    }
+    if (isinf(2.f) || isinf(quiet_NaN<float>::value) ||
+        isinf(signaling_NaN<float>::value) || !isinf(infinity<float>::value)) {
+      ++e;
+      Kokkos::printf("failed isinf(float)\n");
+    }
+    if (isinf(static_cast<KE::half_t>(2.f))
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
+        || isinf(quiet_NaN<KE::half_t>::value) ||
+        isinf(signaling_NaN<KE::half_t>::value) ||
+        !isinf(infinity<KE::half_t>::value)
+#endif
+    ) {
+      ++e;
+      Kokkos::printf("failed isinf(KE::half_t)\n");
+    }
+    if (isinf(static_cast<KE::bhalf_t>(2.f))
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
+        || isinf(quiet_NaN<KE::bhalf_t>::value) ||
+        isinf(signaling_NaN<KE::bhalf_t>::value) ||
+        !isinf(infinity<KE::bhalf_t>::value)
+#endif
+    ) {
+      ++e;
+      Kokkos::printf("failed isinf(KE::bhalf_t)\n");
+    }
+    if (isinf(3.)
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
+        || isinf(quiet_NaN<double>::value) ||
+        isinf(signaling_NaN<double>::value) || !isinf(infinity<double>::value)
+#endif
+    ) {
+      ++e;
+      Kokkos::printf("failed isinf(double)\n");
+    }
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+    if (isinf(4.l) || isinf(quiet_NaN<long double>::value) ||
+        isinf(signaling_NaN<long double>::value) ||
+        !isinf(infinity<long double>::value)) {
+      ++e;
+      Kokkos::printf("failed isinf(long double)\n");
+    }
+#endif
+    // special values
+    if (!isinf(INFINITY) || isinf(NAN)) {
+      ++e;
+      Kokkos::printf("failed isinf(floating_point) special values\n");
+    }
+
+    static_assert(std::is_same<decltype(isinf(1)), bool>::value);
+    static_assert(std::is_same<decltype(isinf(2.f)), bool>::value);
+    static_assert(std::is_same<decltype(isinf(3.)), bool>::value);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+    static_assert(std::is_same<decltype(isinf(4.l)), bool>::value);
+#endif
+  }
+};
+
+TEST(TEST_CATEGORY, mathematical_functions_isinf) {
+  TestIsInf<TEST_EXECSPACE>();
+}
 
 template <class Space>
 struct TestIsNaN {
@@ -1567,6 +1719,7 @@ struct TestIsNaN {
     ASSERT_EQ(errors, 0);
   }
   KOKKOS_FUNCTION void operator()(int, int& e) const {
+    using KE::infinity;
     using KE::quiet_NaN;
     using KE::signaling_NaN;
     using Kokkos::isnan;
@@ -1575,35 +1728,34 @@ struct TestIsNaN {
       Kokkos::printf("failed isnan(integral)\n");
     }
     if (isnan(2.f) || !isnan(quiet_NaN<float>::value) ||
-        !isnan(signaling_NaN<float>::value)) {
+        !isnan(signaling_NaN<float>::value) || isnan(infinity<float>::value)) {
       ++e;
       Kokkos::printf("failed isnan(float)\n");
     }
-#if !defined(KOKKOS_ENABLE_SYCL) && \
-    !defined(KOKKOS_ENABLE_HIP)  // FIXME_SYCL, FIXME_HIP
     if (isnan(static_cast<KE::half_t>(2.f))
-#if !defined(KOKKOS_ENABLE_CUDA)
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
         || !isnan(quiet_NaN<KE::half_t>::value) ||
-        !isnan(signaling_NaN<KE::half_t>::value)
+        !isnan(signaling_NaN<KE::half_t>::value) ||
+        isnan(infinity<KE::half_t>::value)
 #endif
     ) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed isnan(KE::half_t)\n");
+      Kokkos::printf("failed isnan(KE::half_t)\n");
     }
     if (isnan(static_cast<KE::bhalf_t>(2.f))
-#if !defined(KOKKOS_ENABLE_CUDA)
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
         || !isnan(quiet_NaN<KE::bhalf_t>::value) ||
-        !isnan(signaling_NaN<KE::bhalf_t>::value)
+        !isnan(signaling_NaN<KE::bhalf_t>::value) ||
+        isnan(infinity<KE::bhalf_t>::value)
 #endif
     ) {
       ++e;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed isnan(KE::bhalf_t)\n");
+      Kokkos::printf("failed isnan(KE::bhalf_t)\n");
     }
-#endif
     if (isnan(3.)
 #ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
         || !isnan(quiet_NaN<double>::value) ||
-        !isnan(signaling_NaN<double>::value)
+        !isnan(signaling_NaN<double>::value) || isnan(infinity<double>::value)
 #endif
     ) {
       ++e;
@@ -1611,7 +1763,8 @@ struct TestIsNaN {
     }
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     if (isnan(4.l) || !isnan(quiet_NaN<long double>::value) ||
-        !isnan(signaling_NaN<long double>::value)) {
+        !isnan(signaling_NaN<long double>::value) ||
+        isnan(infinity<long double>::value)) {
       ++e;
       Kokkos::printf("failed isnan(long double)\n");
     }
@@ -1622,11 +1775,11 @@ struct TestIsNaN {
       Kokkos::printf("failed isnan(floating_point) special values\n");
     }
 
-    static_assert(std::is_same<decltype(isnan(1)), bool>::value, "");
-    static_assert(std::is_same<decltype(isnan(2.f)), bool>::value, "");
-    static_assert(std::is_same<decltype(isnan(3.)), bool>::value, "");
+    static_assert(std::is_same<decltype(isnan(1)), bool>::value);
+    static_assert(std::is_same<decltype(isnan(2.f)), bool>::value);
+    static_assert(std::is_same<decltype(isnan(3.)), bool>::value);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same<decltype(isnan(4.l)), bool>::value, "");
+    static_assert(std::is_same<decltype(isnan(4.l)), bool>::value);
 #endif
   }
 };

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1290,12 +1290,12 @@ struct TestAbsoluteValueFunction {
     if (abs(static_cast<KE::half_t>(4.f)) != static_cast<KE::half_t>(4.f) ||
         abs(static_cast<KE::half_t>(-4.f)) != static_cast<KE::half_t>(4.f)) {
       ++e;
-      Kokkos::printf("failed abs(KE::half_t)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed abs(KE::half_t)\n");
     }
     if (abs(static_cast<KE::bhalf_t>(4.f)) != static_cast<KE::bhalf_t>(4.f) ||
         abs(static_cast<KE::bhalf_t>(-4.f)) != static_cast<KE::bhalf_t>(4.f)) {
       ++e;
-      Kokkos::printf("failed abs(KE::bhalf_t)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed abs(KE::bhalf_t)\n");
     }
     if (abs(5.) != 5. || abs(-5.) != 5.) {
       ++e;
@@ -1315,19 +1315,19 @@ struct TestAbsoluteValueFunction {
       Kokkos::printf("failed abs(floating_point) special values\n");
     }
 
-    static_assert(std::is_same<decltype(abs(1)), int>::value);
-    static_assert(std::is_same<decltype(abs(2l)), long>::value);
-    static_assert(std::is_same<decltype(abs(3ll)), long long>::value);
+    static_assert(std::is_same<decltype(abs(1)), int>::value, "");
+    static_assert(std::is_same<decltype(abs(2l)), long>::value, "");
+    static_assert(std::is_same<decltype(abs(3ll)), long long>::value, "");
     static_assert(std::is_same<decltype(abs(static_cast<KE::half_t>(4.f))),
                                KE::half_t>::value,
                   "");
     static_assert(std::is_same<decltype(abs(static_cast<KE::bhalf_t>(4.f))),
                                KE::bhalf_t>::value,
                   "");
-    static_assert(std::is_same<decltype(abs(4.f)), float>::value);
-    static_assert(std::is_same<decltype(abs(5.)), double>::value);
+    static_assert(std::is_same<decltype(abs(4.f)), float>::value, "");
+    static_assert(std::is_same<decltype(abs(5.)), double>::value, "");
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same<decltype(abs(6.l)), long double>::value);
+    static_assert(std::is_same<decltype(abs(6.l)), long double>::value, "");
 #endif
   }
 };
@@ -1348,26 +1348,26 @@ struct TestFloatingPointAbsoluteValueFunction {
     using Kokkos::fabs;
     if (fabs(4.f) != 4.f || fabs(-4.f) != 4.f) {
       ++e;
-      Kokkos::printf("failed fabs(float)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fabs(float)\n");
     }
     if (fabs(static_cast<KE::half_t>(4.f)) != static_cast<KE::half_t>(4.f) ||
         fabs(static_cast<KE::half_t>(-4.f)) != static_cast<KE::half_t>(4.f)) {
       ++e;
-      Kokkos::printf("failed fabs(KE::half_t)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fabs(KE::half_t)\n");
     }
     if (fabs(static_cast<KE::bhalf_t>(4.f)) != static_cast<KE::bhalf_t>(4.f) ||
         fabs(static_cast<KE::bhalf_t>(-4.f)) != static_cast<KE::bhalf_t>(4.f)) {
       ++e;
-      Kokkos::printf("failed fabs(KE::bhalf_t)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fabs(KE::bhalf_t)\n");
     }
     if (fabs(5.) != 5. || fabs(-5.) != 5.) {
       ++e;
-      Kokkos::printf("failed fabs(double)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fabs(double)\n");
     }
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     if (fabs(6.l) != 6.l || fabs(-6.l) != 6.l) {
       ++e;
-      Kokkos::printf("failed fabs(long double)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fabs(long double)\n");
     }
 #endif
     // special values
@@ -1375,7 +1375,8 @@ struct TestFloatingPointAbsoluteValueFunction {
     using Kokkos::isnan;
     if (fabs(-0.) != 0. || !isinf(fabs(-INFINITY)) || !isnan(fabs(-NAN))) {
       ++e;
-      Kokkos::printf("failed fabs(floating_point) special values\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "failed fabs(floating_point) special values\n");
     }
 
     static_assert(std::is_same<decltype(fabs(static_cast<KE::half_t>(4.f))),
@@ -1407,7 +1408,7 @@ struct TestFloatingPointRemainderFunction : FloatingPointComparison {
     if (!compare(fmod(6.2f, 4.f), 2.2f, 1) &&
         !compare(fmod(-6.2f, 4.f), -2.2f, 1)) {
       ++e;
-      Kokkos::printf("failed fmod(float)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fmod(float)\n");
     }
     if (!compare(
             fmod(static_cast<KE::half_t>(6.2f), static_cast<KE::half_t>(4.f)),
@@ -1416,7 +1417,7 @@ struct TestFloatingPointRemainderFunction : FloatingPointComparison {
             fmod(static_cast<KE::half_t>(-6.2f), static_cast<KE::half_t>(4.f)),
             -static_cast<KE::half_t>(2.2f), 1)) {
       ++e;
-      Kokkos::printf("failed fmod(KE::half_t)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fmod(KE::half_t)\n");
     }
     if (!compare(
             fmod(static_cast<KE::bhalf_t>(6.2f), static_cast<KE::bhalf_t>(4.f)),
@@ -1425,17 +1426,17 @@ struct TestFloatingPointRemainderFunction : FloatingPointComparison {
                       static_cast<KE::bhalf_t>(4.f)),
                  -static_cast<KE::bhalf_t>(2.2f), 1)) {
       ++e;
-      Kokkos::printf("failed fmod(KE::bhalf_t)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fmod(KE::bhalf_t)\n");
     }
     if (!compare(fmod(6.2, 4.), 2.2, 1) && !compare(fmod(-6.2, 4.), -2.2, 1)) {
       ++e;
-      Kokkos::printf("failed fmod(double)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fmod(double)\n");
     }
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     if (!compare(fmod(6.2l, 4.l), 2.2l, 1) &&
         !compare(fmod(-6.2l, 4.l), -2.2l, 1)) {
       ++e;
-      Kokkos::printf("failed fmod(long double)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed fmod(long double)\n");
     }
 #endif
     // special values
@@ -1444,7 +1445,8 @@ struct TestFloatingPointRemainderFunction : FloatingPointComparison {
     if (!isinf(fmod(-KE::infinity<float>::value, 1.f)) &&
         !isnan(fmod(-KE::quiet_NaN<float>::value, 1.f))) {
       ++e;
-      Kokkos::printf("failed fmod(floating_point) special values\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "failed fmod(floating_point) special values\n");
     }
 
     static_assert(std::is_same<decltype(fmod(static_cast<KE::half_t>(4.f),
@@ -1455,8 +1457,8 @@ struct TestFloatingPointRemainderFunction : FloatingPointComparison {
                                              static_cast<KE::bhalf_t>(4.f))),
                                KE::bhalf_t>::value,
                   "");
-    static_assert(std::is_same<decltype(fmod(4.f, 4.f)), float>::value);
-    static_assert(std::is_same<decltype(fmod(5., 5.)), double>::value);
+    static_assert(std::is_same<decltype(fmod(4.f, 4.f)), float>::value, "");
+    static_assert(std::is_same<decltype(fmod(5., 5.)), double>::value, "");
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     static_assert(std::is_same<decltype(fmod(6.l, 6.l)), long double>::value,
                   "");
@@ -1483,7 +1485,7 @@ struct TestIEEEFloatingPointRemainderFunction : FloatingPointComparison {
     if (!compare(remainder(6.2f, 4.f), 2.2f, 2) &&
         !compare(remainder(-6.2f, 4.f), 2.2f, 1)) {
       ++e;
-      Kokkos::printf("failed remainder(float)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed remainder(float)\n");
     }
     if (!compare(remainder(static_cast<KE::half_t>(6.2f),
                            static_cast<KE::half_t>(4.f)),
@@ -1492,7 +1494,7 @@ struct TestIEEEFloatingPointRemainderFunction : FloatingPointComparison {
                            static_cast<KE::half_t>(4.f)),
                  -static_cast<KE::half_t>(2.2f), 1)) {
       ++e;
-      Kokkos::printf("failed remainder(KE::half_t)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed remainder(KE::half_t)\n");
     }
     if (!compare(remainder(static_cast<KE::bhalf_t>(6.2f),
                            static_cast<KE::bhalf_t>(4.f)),
@@ -1501,18 +1503,18 @@ struct TestIEEEFloatingPointRemainderFunction : FloatingPointComparison {
                            static_cast<KE::bhalf_t>(4.f)),
                  -static_cast<KE::bhalf_t>(2.2f), 1)) {
       ++e;
-      Kokkos::printf("failed remainder(KE::bhalf_t)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed remainder(KE::bhalf_t)\n");
     }
     if (!compare(remainder(6.2, 4.), 2.2, 2) &&
         !compare(remainder(-6.2, 4.), 2.2, 1)) {
       ++e;
-      Kokkos::printf("failed remainder(double)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed remainder(double)\n");
     }
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     if (!compare(remainder(6.2l, 4.l), 2.2l, 1) &&
         !compare(remainder(-6.2l, 4.l), -2.2l, 1)) {
       ++e;
-      Kokkos::printf("failed remainder(long double)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed remainder(long double)\n");
     }
 #endif
     // special values
@@ -1521,7 +1523,7 @@ struct TestIEEEFloatingPointRemainderFunction : FloatingPointComparison {
     if (!isinf(remainder(-KE::infinity<float>::value, 1.f)) &&
         !isnan(remainder(-KE::quiet_NaN<float>::value, 1.f))) {
       ++e;
-      Kokkos::printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "failed remainder(floating_point) special values\n");
     }
 
@@ -1537,10 +1539,10 @@ struct TestIEEEFloatingPointRemainderFunction : FloatingPointComparison {
         "");
     static_assert(std::is_same<decltype(remainder(4.f, 4.f)), float>::value,
                   "");
-    static_assert(std::is_same<decltype(remainder(5., 5.)), double>::value);
+    static_assert(std::is_same<decltype(remainder(5., 5.)), double>::value, "");
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     static_assert(
-        std::is_same<decltype(remainder(6.l, 6.l)), long double>::value);
+        std::is_same<decltype(remainder(6.l, 6.l)), long double>::value, "");
 #endif
   }
 };
@@ -1740,7 +1742,7 @@ struct TestIsNaN {
 #endif
     ) {
       ++e;
-      Kokkos::printf("failed isnan(KE::half_t)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed isnan(KE::half_t)\n");
     }
     if (isnan(static_cast<KE::bhalf_t>(2.f))
 #ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
@@ -1750,7 +1752,7 @@ struct TestIsNaN {
 #endif
     ) {
       ++e;
-      Kokkos::printf("failed isnan(KE::bhalf_t)\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed isnan(KE::bhalf_t)\n");
     }
     if (isnan(3.)
 #ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
@@ -1775,11 +1777,11 @@ struct TestIsNaN {
       Kokkos::printf("failed isnan(floating_point) special values\n");
     }
 
-    static_assert(std::is_same<decltype(isnan(1)), bool>::value);
-    static_assert(std::is_same<decltype(isnan(2.f)), bool>::value);
-    static_assert(std::is_same<decltype(isnan(3.)), bool>::value);
+    static_assert(std::is_same<decltype(isnan(1)), bool>::value, "");
+    static_assert(std::is_same<decltype(isnan(2.f)), bool>::value, "");
+    static_assert(std::is_same<decltype(isnan(3.)), bool>::value, "");
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same<decltype(isnan(4.l)), bool>::value);
+    static_assert(std::is_same<decltype(isnan(4.l)), bool>::value, "");
 #endif
   }
 };

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -101,8 +101,8 @@ struct TestNumericTraits {
 
   KOKKOS_FUNCTION void operator()(Infinity, int, int& e) const {
     using Kokkos::Experimental::infinity;
-    auto const inf  = infinity<T>::value;
-    auto const zero = T(0);
+    T const inf  = infinity<T>::value;
+    T const zero = T(0);
     e += (int)!(inf + inf == inf);
     e += (int)!(inf != zero);
     use_on_device();
@@ -147,8 +147,8 @@ struct TestNumericTraits {
   KOKKOS_FUNCTION void operator()(QuietNaN, int, int& e) const {
 #ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7 nan
     using Kokkos::Experimental::quiet_NaN;
-    constexpr auto nan  = quiet_NaN<T>::value;
-    constexpr auto zero = T(0);
+    T const nan  = quiet_NaN<T>::value;
+    T const zero = T(0);
     e += (int)!(nan != nan);
     e += (int)!(nan != zero);
 #else
@@ -159,8 +159,8 @@ struct TestNumericTraits {
   KOKKOS_FUNCTION void operator()(SignalingNaN, int, int& e) const {
 #ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7 nan
     using Kokkos::Experimental::signaling_NaN;
-    constexpr auto nan  = signaling_NaN<T>::value;
-    constexpr auto zero = T(0);
+    T const nan  = signaling_NaN<T>::value;
+    T const zero = T(0);
     e += (int)!(nan != nan);
     e += (int)!(nan != zero);
 #else
@@ -204,6 +204,8 @@ struct TestNumericTraits<
 #endif
 
 TEST(TEST_CATEGORY, numeric_traits_infinity) {
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t, Infinity>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Infinity>();
   TestNumericTraits<TEST_EXECSPACE, float, Infinity>();
   TestNumericTraits<TEST_EXECSPACE, double, Infinity>();
   // FIXME_NVHPC long double not supported
@@ -387,6 +389,12 @@ TEST(TEST_CATEGORY, numeric_traits_min_max_exponent10) {
 #endif
 }
 TEST(TEST_CATEGORY, numeric_traits_quiet_and_signaling_nan) {
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t, QuietNaN>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t,
+                    SignalingNaN>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, QuietNaN>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t,
+                    SignalingNaN>();
   TestNumericTraits<TEST_EXECSPACE, float, QuietNaN>();
   TestNumericTraits<TEST_EXECSPACE, float, SignalingNaN>();
   TestNumericTraits<TEST_EXECSPACE, double, QuietNaN>();

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -101,8 +101,8 @@ struct TestNumericTraits {
 
   KOKKOS_FUNCTION void operator()(Infinity, int, int& e) const {
     using Kokkos::Experimental::infinity;
-    auto const inf  = infinity<T>::value;
-    auto const zero = T(0);
+    constexpr auto inf = infinity<T>::value;
+    auto const zero    = T(0);
     e += (int)!(inf + inf == inf);
     e += (int)!(inf != zero);
     use_on_device();
@@ -147,8 +147,8 @@ struct TestNumericTraits {
   KOKKOS_FUNCTION void operator()(QuietNaN, int, int& e) const {
 #ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7 nan
     using Kokkos::Experimental::quiet_NaN;
-    constexpr auto nan  = quiet_NaN<T>::value;
-    constexpr auto zero = T(0);
+    constexpr auto nan = quiet_NaN<T>::value;
+    auto const zero    = T(0);
     e += (int)!(nan != nan);
     e += (int)!(nan != zero);
 #else
@@ -159,8 +159,8 @@ struct TestNumericTraits {
   KOKKOS_FUNCTION void operator()(SignalingNaN, int, int& e) const {
 #ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7 nan
     using Kokkos::Experimental::signaling_NaN;
-    constexpr auto nan  = signaling_NaN<T>::value;
-    constexpr auto zero = T(0);
+    constexpr auto nan = signaling_NaN<T>::value;
+    auto const zero    = T(0);
     e += (int)!(nan != nan);
     e += (int)!(nan != zero);
 #else

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -101,8 +101,8 @@ struct TestNumericTraits {
 
   KOKKOS_FUNCTION void operator()(Infinity, int, int& e) const {
     using Kokkos::Experimental::infinity;
-    T const inf  = infinity<T>::value;
-    T const zero = T(0);
+    auto const inf  = infinity<T>::value;
+    auto const zero = T(0);
     e += (int)!(inf + inf == inf);
     e += (int)!(inf != zero);
     use_on_device();
@@ -147,8 +147,8 @@ struct TestNumericTraits {
   KOKKOS_FUNCTION void operator()(QuietNaN, int, int& e) const {
 #ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7 nan
     using Kokkos::Experimental::quiet_NaN;
-    T const nan  = quiet_NaN<T>::value;
-    T const zero = T(0);
+    constexpr auto nan  = quiet_NaN<T>::value;
+    constexpr auto zero = T(0);
     e += (int)!(nan != nan);
     e += (int)!(nan != zero);
 #else
@@ -159,8 +159,8 @@ struct TestNumericTraits {
   KOKKOS_FUNCTION void operator()(SignalingNaN, int, int& e) const {
 #ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7 nan
     using Kokkos::Experimental::signaling_NaN;
-    T const nan  = signaling_NaN<T>::value;
-    T const zero = T(0);
+    constexpr auto nan  = signaling_NaN<T>::value;
+    constexpr auto zero = T(0);
     e += (int)!(nan != nan);
     e += (int)!(nan != zero);
 #else

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -204,8 +204,10 @@ struct TestNumericTraits<
 #endif
 
 TEST(TEST_CATEGORY, numeric_traits_infinity) {
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t, Infinity>();
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Infinity>();
+#endif
   TestNumericTraits<TEST_EXECSPACE, float, Infinity>();
   TestNumericTraits<TEST_EXECSPACE, double, Infinity>();
   // FIXME_NVHPC long double not supported
@@ -389,12 +391,14 @@ TEST(TEST_CATEGORY, numeric_traits_min_max_exponent10) {
 #endif
 }
 TEST(TEST_CATEGORY, numeric_traits_quiet_and_signaling_nan) {
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t, QuietNaN>();
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t,
                     SignalingNaN>();
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, QuietNaN>();
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t,
                     SignalingNaN>();
+#endif
   TestNumericTraits<TEST_EXECSPACE, float, QuietNaN>();
   TestNumericTraits<TEST_EXECSPACE, float, SignalingNaN>();
   TestNumericTraits<TEST_EXECSPACE, double, QuietNaN>();


### PR DESCRIPTION
Fixes #6476.

This is a proposal for fixing the broken support for special values in half_t and bhalf_t. We basically introduce a bit comparison type that we use for `infinity`, `quite_NaN` and `signaling_NaN` and `bit_cast` the `impl_type` for comparison. This type is implicitly convertible to `Kokkos::Experimental::[b]half_t` but doesn't define any comparison operators or arithmetic operations on its own. 
Thus, `auto tmp = Kokkos::Experimental::infinity<half_t>::value` can be directly used to use the correct overload in `Kokkos::isinf(tmp)`. But comparisons such as `tmp==tmp` or operations like `tmp+=2` won't compile and the `tmp` must first be converted to `Kokkos::Experimental::[b]half_t`.
Note, that this limitation is a result of favoring `Kokkos::Experimental::infinity<half_t>::value` (and similar) to be `constexpr` over returning the correct type. 