### PR TITLE
Bump HPX version used in CI to 1.9.0

### DIFF
--- a/.github/workflows/continuous-integration-workflow-hpx.yml
+++ b/.github/workflows/continuous-integration-workflow-hpx.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: STELLAR-GROUP/hpx
-          ref: 1.8.0
+          ref: v1.9.0
           path: hpx
       - uses: actions/cache@v3
         id:   cache-hpx


### PR DESCRIPTION
Avoids ("fixes") https://github.com/kokkos/kokkos/issues/6546.

HPX is unlikely to get a patch release for < 1.9.0 and users can easily enough work around the problem if they would like to keep using HPX < 1.9.0. I don't think it's worth a workaround in Kokkos for this.