### PR TITLE
Relax accessibility mandate in `View` constructor

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1096,7 +1096,7 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
         prop_copy,
         Impl::DynRankDimTraits<typename traits::specialize>::
             template createLayout<traits, P...>(arg_prop, arg_layout),
-        Impl::ViewCtorProp<P...>::has_execution_space);
+        std::bool_constant<Impl::ViewCtorProp<P...>::has_execution_space>());
 
     // Setup and initialization complete, start tracking
     m_track.assign_allocated_record_to_uninitialized(record);

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1196,7 +1196,8 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
 
     Kokkos::Impl::SharedAllocationRecord<>* record = m_map.allocate_shared(
         prop_copy, arg_layout,
-        Kokkos::Impl::ViewCtorProp<P...>::has_execution_space);
+        std::bool_constant<
+            Kokkos::Impl::ViewCtorProp<P...>::has_execution_space>());
 
     // Setup and initialization complete, start tracking
     m_track.assign_allocated_record_to_uninitialized(record);

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1419,7 +1419,8 @@ class View : public ViewTraits<DataType, Properties...> {
         i4, i5, i6, i7, alloc_name);
 
     Kokkos::Impl::SharedAllocationRecord<>* record = m_map.allocate_shared(
-        prop_copy, arg_layout, Impl::ViewCtorProp<P...>::has_execution_space);
+        prop_copy, arg_layout,
+        std::bool_constant<Impl::ViewCtorProp<P...>::has_execution_space>());
 
     // Setup and initialization complete, start tracking
     m_track.m_tracker.assign_allocated_record_to_uninitialized(record);

--- a/core/src/impl/Kokkos_ViewArray.hpp
+++ b/core/src/impl/Kokkos_ViewArray.hpp
@@ -319,18 +319,19 @@ class ViewMapping<Traits, Kokkos::Array<>> {
 
   //----------------------------------------
 
-  template <class... P>
+  template <class... P, bool B>
   Kokkos::Impl::SharedAllocationRecord<> *allocate_shared(
       Kokkos::Impl::ViewCtorProp<P...> const &arg_prop,
       typename Traits::array_layout const &arg_layout,
-      bool execution_space_specified) {
+      std::bool_constant<B> execution_space_specified) {
     using alloc_prop = Kokkos::Impl::ViewCtorProp<P...>;
 
     using execution_space = typename alloc_prop::execution_space;
     using memory_space    = typename Traits::memory_space;
-    static_assert(
-        SpaceAccessibility<execution_space, memory_space>::accessible ||
-        !alloc_prop::initialize);
+    if constexpr (execution_space_specified || alloc_prop::initialize) {
+      static_assert(
+          SpaceAccessibility<execution_space, memory_space>::accessible);
+    }
     using functor_type =
         ViewValueFunctor<typename Traits::device_type, scalar_type>;
     using record_type =

--- a/core/src/impl/Kokkos_ViewArray.hpp
+++ b/core/src/impl/Kokkos_ViewArray.hpp
@@ -329,7 +329,8 @@ class ViewMapping<Traits, Kokkos::Array<>> {
     using execution_space = typename alloc_prop::execution_space;
     using memory_space    = typename Traits::memory_space;
     static_assert(
-        SpaceAccessibility<execution_space, memory_space>::accessible);
+        SpaceAccessibility<execution_space, memory_space>::accessible ||
+        !alloc_prop::initialize);
     using functor_type =
         ViewValueFunctor<typename Traits::device_type, scalar_type>;
     using record_type =

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3400,7 +3400,8 @@ class ViewMapping<
     using execution_space = typename alloc_prop::execution_space;
     using memory_space    = typename Traits::memory_space;
     static_assert(
-        SpaceAccessibility<execution_space, memory_space>::accessible);
+        SpaceAccessibility<execution_space, memory_space>::accessible ||
+        !alloc_prop::initialize);
     using value_type = typename Traits::value_type;
     using functor_type =
         ViewValueFunctor<Kokkos::Device<execution_space, memory_space>,

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3390,18 +3390,19 @@ class ViewMapping<
    *  Allocate via shared allocation record and
    *  return that record for allocation tracking.
    */
-  template <class... P>
+  template <class... P, bool B>
   Kokkos::Impl::SharedAllocationRecord<>* allocate_shared(
       Kokkos::Impl::ViewCtorProp<P...> const& arg_prop,
       typename Traits::array_layout const& arg_layout,
-      bool execution_space_specified) {
+      std::bool_constant<B> execution_space_specified) {
     using alloc_prop = Kokkos::Impl::ViewCtorProp<P...>;
 
     using execution_space = typename alloc_prop::execution_space;
     using memory_space    = typename Traits::memory_space;
-    static_assert(
-        SpaceAccessibility<execution_space, memory_space>::accessible ||
-        !alloc_prop::initialize);
+    if constexpr (execution_space_specified || alloc_prop::initialize) {
+      static_assert(
+          SpaceAccessibility<execution_space, memory_space>::accessible);
+    }
     using value_type = typename Traits::value_type;
     using functor_type =
         ViewValueFunctor<Kokkos::Device<execution_space, memory_space>,

--- a/core/unit_test/tools/TestLogicalSpaces.hpp
+++ b/core/unit_test/tools/TestLogicalSpaces.hpp
@@ -174,4 +174,13 @@ TEST(defaultdevicetype_DeathTest, access_forbidden) {
 }
 #endif
 
+TEST(defaultdevicetype,
+     logical_space_construct_view_without_initializing_then_deep_copy) {
+  Kokkos::View<int*, semantically_independent_logical_space> v(
+      Kokkos::view_alloc("v", Kokkos::WithoutInitializing), 1);
+  Kokkos::deep_copy(v, 3);
+  // not asserting anything, just checking view allocation w/o init followed by
+  // fill using deep_copy does not error out.
+}
+
 }  // namespace Test


### PR DESCRIPTION
Addressing https://github.com/kokkos/kokkos/issues/5609#issuecomment-1490777893

As Phil pointed out, it makes little sense to enforce accessibility when the user explicitly requests allocation with no initialization.

Consider the code below that Phil had suggested in his original comment
```C++
struct TestSpaceNamer {
  static constexpr const char* get_name() { return "TestSpace"; }
};

using fake_memory_space = Kokkos::Experimental::LogicalMemorySpace<
    Kokkos::HostSpace, Kokkos::DefaultHostExecutionSpace, TestSpaceNamer,
    Kokkos::Experimental::LogicalSpaceSharesAccess::no_shared_access>;

TEST(defaultdevicetypeKokkosViewContentsTest, test_logical_device_view_contents) {
  // Create an inaccessible View
  using LogicalViewType = Kokkos::View<int*, fake_memory_space>;
  auto lv = LogicalViewType(Kokkos::view_alloc("lv", Kokkos::WithoutInitializing), 1); // static_assert fails

  // Initialize a value
  Kokkos::deep_copy(lv, 3);
}
```
With this the change proposed here the code will now compile.

You may ask why I did not add the code snippet as a unit test.  The answer is that I actually plan to propose removing `LogicalSpace` as soon as I am done opening this PR.  I think that nevertheless Phil was right, that the static assertion was too strict, and it is worth fixing.