### PR TITLE
Replace Marsaglia polar method with Box-muller to generate a normally distributed random number

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -849,18 +849,17 @@ class Random_XorShift64 {
     return drand(end - start) + start;
   }
 
-  // Marsaglia polar method for drawing a standard normal distributed random
+  // Box-muller method for drawing a standard normal distributed random
   // number
   KOKKOS_INLINE_FUNCTION
   double normal() {
-    double S = 2.0;
-    double U;
-    while (S >= 1.0) {
-      U              = 2.0 * drand() - 1.0;
-      const double V = 2.0 * drand() - 1.0;
-      S              = U * U + V * V;
-    }
-    return U * std::sqrt(-2.0 * std::log(S) / S);
+    constexpr double M_PI2 = 2.0 * Kokkos::numbers::pi_v<double>;
+
+    double u = drand();
+    double v = drand();
+    double r = Kokkos::sqrt(-2.0 * Kokkos::log(u));
+    double theta = v * M_PI2;
+    return r * Kokkos::cos(theta);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -1094,18 +1093,17 @@ class Random_XorShift1024 {
     return drand(end - start) + start;
   }
 
-  // Marsaglia polar method for drawing a standard normal distributed random
+  // Box-muller method for drawing a standard normal distributed random
   // number
   KOKKOS_INLINE_FUNCTION
   double normal() {
-    double S = 2.0;
-    double U;
-    while (S >= 1.0) {
-      U              = 2.0 * drand() - 1.0;
-      const double V = 2.0 * drand() - 1.0;
-      S              = U * U + V * V;
-    }
-    return U * std::sqrt(-2.0 * std::log(S) / S);
+    constexpr double M_PI2 = 2.0 * Kokkos::numbers::pi_v<double>;
+
+    double u = drand();
+    double v = drand();
+    double r = Kokkos::sqrt(-2.0 * Kokkos::log(u));
+    double theta = v * M_PI2;
+    return r * Kokkos::cos(theta);
   }
 
   KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
On GPU, Box-Muller is expected to significantly outperform current Marsaglia polar. The reasoning can be found [here](https://developer.nvidia.com/gpugems/gpugems3/part-vi-gpu-computing/chapter-37-efficient-random-number-generation-and-application):

_The polar method (Press et. al. 1992) is simple and relatively efficient, but the probability of looping per thread is 14 percent. This leads to an expected 1.6 iterations per generated sample turning into an expected 3.1 iterations when warp effects are taken into account._

On the CPU side, there doesn't seem to be any difference.

## Before 

|   N    |     CPU      |     CPU      |    CUDA     |    CUDA     |
|--------|--------------|--------------|-------------|-------------|
|        |     64       |    1024      |     64      |    1024     |
| 1e4 | 0.061071 | 0.0757334 |   0.0150474   |  0.016794  |
| 1e5 | 0.600972 | 0.761684 |  0.120827 | 0.28777 |
| 2e5 | 1.19428 | 1.50356 | 0.236278 | 0.586949 |

## After
|   N    |     CPU      |     CPU      |    CUDA     |    CUDA     |
|--------|--------------|--------------|-------------|-------------|
|        |     64       |    1024      |     64      |    1024     |
| 1e4 | 0.0610803 | 0.0734002 |   0.0119627   |  0.0119717  |
| 1e5 | 0.60062 | 0.73712 |  0.0957707 | 0.0968437 |
| 2e5 | 1.17503 | 1.47986 | 0.195854 | 0.19791 |

(The timings are taken using one of the kokkos examples [here](https://github.com/kokkos/kokkos/tree/master/example/tutorial/Algorithms/01_random_numbers). All values in seconds. CPU is AMD 3070x, GPU is Nvidia 1650 super, 16GB RAM)

I'm not quite sure why there is such a performance gap in Polar method on GPU between the 64 and 1024 bit versions. Maybe this can be tuned out by trying different kernel launch configurations (i.e. #blocks, #threads/block). I wanted to present the results before diving deeper.  