### PR TITLE
Enable `Experimental::LogicalMemorySpace` with OpenACC and OpenMPTarget backends

### DIFF
--- a/core/src/Kokkos_LogicalSpaces.hpp
+++ b/core/src/Kokkos_LogicalSpaces.hpp
@@ -52,15 +52,6 @@ template <class BaseSpace, class DefaultBaseExecutionSpace = void,
           class Namer                = DefaultMemorySpaceNamer,
           class SharesAccessWithBase = LogicalSpaceSharesAccess::shared_access>
 class LogicalMemorySpace {
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
-  // [DZP] For some reason I don't yet know, using LogicalMemorySpaces
-  // inside an OpenMPTarget build causes errors in the
-  // SharedAllocationRecords of other types. This is my way of erroring
-  // a build if we instantiate a LogicalMemSpace in an OMPTarget build
-  static_assert(!std::is_same<BaseSpace, BaseSpace>::value,
-                "Can't use LogicalMemorySpaces in an OpenMPTarget build, we're "
-                "debugging memory issues");
-#endif
  public:
   //! Tag this class as a kokkos memory space
   using memory_space = LogicalMemorySpace<BaseSpace, DefaultBaseExecutionSpace,

--- a/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
@@ -62,6 +62,8 @@ class OpenACCSpace {
   static constexpr char const* name() { return "OpenACCSpace"; }
 
  private:
+  template <class, class, class, class>
+  friend class Kokkos::Experimental::LogicalMemorySpace;
   void* impl_allocate(const Kokkos::Experimental::OpenACC& exec_space,
                       const char* arg_label, const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.hpp
@@ -112,6 +112,8 @@ class OpenMPTargetSpace {
   static constexpr const char* name() { return "OpenMPTargetSpace"; }
 
  private:
+  template <class, class, class, class>
+  friend class Kokkos::Experimental::LogicalMemorySpace;
   void* impl_allocate(const char* arg_label, const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,
                       const Kokkos::Tools::SpaceHandle =

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -1038,13 +1038,11 @@ KOKKOS_ADD_ADVANCED_TEST( CoreUnitTest_PushFinalizeHook_terminate
       tools/TestCategoricalTuner.cpp
     )
   endif()
-  if((NOT Kokkos_ENABLE_OPENMPTARGET) AND (NOT Kokkos_ENABLE_OPENACC))
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     CoreUnitTest_LogicalSpaces
     SOURCES
       tools/TestLogicalSpaces.cpp
   )
-  endif()
   SET(KOKKOSP_SOURCES
     UnitTestMainInit.cpp
     tools/TestEventCorrectness.cpp


### PR DESCRIPTION
Since there is at least an objection to removing `Experimental::LogicalMemorySpace` and it is not clear at this time if we will remove or not, I figured I would attempt to enable.  I noticed these friend declarations were missing and assumed it would just work if I add them.