### PR TITLE
SYCL: Improve team_reduce implementation

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -146,6 +146,7 @@ class SYCLTeamMember {
     shuffle_combine(8);
     shuffle_combine(16);
     shuffle_combine(32);
+    KOKKOS_ASSERT(sub_group_range <= 32);
 #else
     for (unsigned int shift = 1; vector_range * shift < sub_group_range;
          shift <<= 1) {

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -194,7 +194,7 @@ class SYCLTeamMember {
       reducer.join(value, reduction_array[i]);
 
     reducer.reference() = value;
-    // Make sure that the reduction array hasn't been modified in the meantime.
+    // Make sure that every thread is done using the reduction array.
     sycl::group_barrier(m_item.get_group());
   }
 

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -161,6 +161,11 @@ class SYCLTeamMember {
       return;
     }
 
+    // It was found experimentally that 16 is a good value for Intel PVC.
+    // Since there is a maximum number of 1024 threads with subgroup size 16,
+    // we have a maximum of 64 subgroups per workgroup which means 64/16=4
+    // rounds for loading values into the reduction_array, and 16 redundant
+    // reduction steps executed by every thread.
     constexpr int step_width = 16;
     auto tmp_alloc = sycl::ext::oneapi::group_local_memory_for_overwrite<
         value_type[step_width]>(m_item.get_group());

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -133,11 +133,27 @@ class SYCLTeamMember {
     const unsigned int team_rank_ = team_rank();
 
     // First combine the values in the same subgroup
+#if defined(KOKKOS_ARCH_INTEL_GPU) || defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
+    auto shuffle_combine = [&](int shift) {
+      if (vector_range * shift < sub_group_range) {
+        const value_type tmp = sg.shuffle_down(value, vector_range * shift); 
+        if (team_rank_ + shift < team_size_) reducer.join(value, tmp); 
+      }
+    };
+    shuffle_combine(1);
+    shuffle_combine(2);
+    shuffle_combine(4);
+    shuffle_combine(8);
+    shuffle_combine(16);
+    shuffle_combine(32);
+#else
     for (unsigned int shift = 1; vector_range * shift < sub_group_range;
          shift <<= 1) {
       const value_type tmp = sg.shuffle_down(value, vector_range * shift);
       if (team_rank_ + shift < team_size_) reducer.join(value, tmp);
+    
     }
+#endif
     value = sg.shuffle(value, 0);
 
     const int n_subgroups = sg.get_group_range()[0];

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -194,6 +194,8 @@ class SYCLTeamMember {
       reducer.join(value, reduction_array[i]);
 
     reducer.reference() = value;
+    // Make sure that the reduction array hasn't been modified in the meantime.
+    sycl::group_barrier(m_item.get_group());
   }
 
   //--------------------------------------------------------------------------

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -145,7 +145,6 @@ class SYCLTeamMember {
     shuffle_combine(4);
     shuffle_combine(8);
     shuffle_combine(16);
-    shuffle_combine(32);
     KOKKOS_ASSERT(sub_group_range <= 32);
 #else
     for (unsigned int shift = 1; vector_range * shift < sub_group_range;

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -136,8 +136,8 @@ class SYCLTeamMember {
 #if defined(KOKKOS_ARCH_INTEL_GPU) || defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
     auto shuffle_combine = [&](int shift) {
       if (vector_range * shift < sub_group_range) {
-        const value_type tmp = sg.shuffle_down(value, vector_range * shift); 
-        if (team_rank_ + shift < team_size_) reducer.join(value, tmp); 
+        const value_type tmp = sg.shuffle_down(value, vector_range * shift);
+        if (team_rank_ + shift < team_size_) reducer.join(value, tmp);
       }
     };
     shuffle_combine(1);
@@ -151,7 +151,6 @@ class SYCLTeamMember {
          shift <<= 1) {
       const value_type tmp = sg.shuffle_down(value, vector_range * shift);
       if (team_rank_ + shift < team_size_) reducer.join(value, tmp);
-    
     }
 #endif
     value = sg.shuffle(value, 0);
@@ -162,7 +161,7 @@ class SYCLTeamMember {
       return;
     }
 
-    constexpr int step_width = 8;
+    constexpr int step_width = 16;
     auto tmp_alloc = sycl::ext::oneapi::group_local_memory_for_overwrite<
         value_type[step_width]>(m_item.get_group());
     auto& reduction_array = *tmp_alloc;

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -171,22 +171,21 @@ class SYCLTeamMember {
     // Load values into the first step_width values of the reduction
     // array in chunks. This means that only sub groups with an id in the
     // corresponding chunk load values.
-    const auto group_id = sg.get_group_id()[0];
+    const int group_id = sg.get_group_id()[0];
     if (id_in_sg == 0 && group_id < step_width)
       reduction_array[group_id] = value;
     sycl::group_barrier(m_item.get_group());
 
-    for (unsigned int start = step_width; start < n_subgroups;
-         start += step_width) {
+    for (int start = step_width; start < n_subgroups; start += step_width) {
       if (id_in_sg == 0 && group_id >= start &&
-          group_id < std::min<unsigned int>(start + step_width, n_subgroups))
+          group_id < std::min(start + step_width, n_subgroups))
         reducer.join(reduction_array[group_id - start], value);
       sycl::group_barrier(m_item.get_group());
     }
 
     // Do the final reduction for all threads redundantly
     value = reduction_array[0];
-    for (unsigned int i = 1; i < std::min(step_width, n_subgroups); ++i)
+    for (int i = 1; i < std::min(step_width, n_subgroups); ++i)
       reducer.join(value, reduction_array[i]);
 
     reducer.reference() = value;


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/pull/5334#issuecomment-1787497628.
#5334 exposed that `team_reduce` in `SYCL` doesn't use arbitrarily large types in general.
The current implementation relies on using some fixed-size local memory (that is also used for `team_scan`) since the SYCL2020 standard doesn't support requesting local memory at function scope. That means that the best we could do was to allocate some fixed-size local memory when launching the kernel but that allocation might not be big enough.
`intel/llvm` proposes an extension that allows this, see https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc.
With this extension, we can implement `team_reduce` in a similar way as we do for `Cuda` and `HIP`. The relevant `Cuda` backend function is `cuda_inter_warp_reduction`: https://github.com/kokkos/kokkos/blob/54f2e7f23dff4dcd4675e6dcf35106a46a063381/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp#L61-L92

The strategy is to first do a shuffle reduction within warps, then load warp results in chunks of 4 in shared memory and do the final reduction for all threads redundantly. This also what we now do with this pull request. Note that it's not clear to me whether using a chunk size of 8 is optimal. We have a maximum of 1024 threads per workgroup which means 32 subgroups for subgroup size 32 and 64 for subgroup size 16. That means that loading all subgroup results into local memory might take up to 32/8=4, or 64/8=8 rounds.
Also, note that we are using a chunk size of 8 for HIP (max 1024 threads, 64 threads per wavefront, max 16 wavefronts, maximum of 16/8=2 rounds) and 4 for CUDA (max 1024 threads, 32 threads per warp, max 32 warps, maximum of 32/4=8 rounds).