### PR TITLE
Rollback changes to view constructors to reduce the number of instantiations

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1489,20 +1489,26 @@ class View : public ViewTraits<DataType, Properties...> {
   }
 
   // Allocate with label and layout
-  explicit inline View(std::string const& arg_label,
-                       typename traits::array_layout const& arg_layout)
+  template <typename Label>
+  explicit inline View(
+      const Label& arg_label,
+      std::enable_if_t<Kokkos::Impl::is_view_label<Label>::value,
+                       typename traits::array_layout> const& arg_layout)
       : View(Impl::ViewCtorProp<std::string>(arg_label), arg_layout) {}
 
   // Allocate label and layout, must disambiguate from subview constructor.
-  explicit inline View(std::string const& arg_label,
-                       const size_t arg_N0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                       const size_t arg_N1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                       const size_t arg_N2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                       const size_t arg_N3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                       const size_t arg_N4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                       const size_t arg_N5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                       const size_t arg_N6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                       const size_t arg_N7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
+  template <typename Label>
+  explicit inline View(
+      const Label& arg_label,
+      std::enable_if_t<Kokkos::Impl::is_view_label<Label>::value, const size_t>
+          arg_N0          = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+      const size_t arg_N1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+      const size_t arg_N2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+      const size_t arg_N3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+      const size_t arg_N4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+      const size_t arg_N5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+      const size_t arg_N6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+      const size_t arg_N7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
       : View(Impl::ViewCtorProp<std::string>(arg_label),
              typename traits::array_layout(arg_N0, arg_N1, arg_N2, arg_N3,
                                            arg_N4, arg_N5, arg_N6, arg_N7)) {
@@ -1559,10 +1565,8 @@ class View : public ViewTraits<DataType, Properties...> {
         arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7));
   }
 
-  template <class PointerType, class = std::enable_if_t<std::is_convertible_v<
-                                   PointerType, pointer_type>>>
   explicit KOKKOS_INLINE_FUNCTION View(
-      PointerType arg_ptr, const size_t arg_N0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+      pointer_type arg_ptr, const size_t arg_N0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
       const size_t arg_N1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
       const size_t arg_N2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
       const size_t arg_N3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
@@ -1578,10 +1582,8 @@ class View : public ViewTraits<DataType, Properties...> {
                   "overload taking a layout object instead.");
   }
 
-  template <class PointerType, class = std::enable_if_t<std::is_convertible_v<
-                                   PointerType, pointer_type>>>
   explicit KOKKOS_INLINE_FUNCTION View(
-      PointerType arg_ptr, const typename traits::array_layout& arg_layout)
+      pointer_type arg_ptr, const typename traits::array_layout& arg_layout)
       : View(Impl::ViewCtorProp<pointer_type>(arg_ptr), arg_layout) {}
 
   //----------------------------------------

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -233,6 +233,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       ViewCopy_a
       ViewCopy_b
       ViewCtorDimMatch
+      ViewEmptyRuntimeUnmanaged
       ViewHooks
       ViewLayoutStrideAssignment
       ViewMapping_a

--- a/core/unit_test/TestViewEmptyRuntimeUnmanaged.hpp
+++ b/core/unit_test/TestViewEmptyRuntimeUnmanaged.hpp
@@ -28,20 +28,20 @@ void test_empty_view_runtime_unmanaged() {
   (void)Kokkos::View<T>(p);
   (void)Kokkos::View<T>(&d);
   (void)Kokkos::View<T>(nullptr);
-  (void)Kokkos::View<T>(NULL);
-  (void)Kokkos::View<T>(0);
+  (void)Kokkos::View<T>(NULL);  // NOLINT(modernize-use-nullptr)
+  (void)Kokkos::View<T>(0);     // NOLINT(modernize-use-nullptr)
 
   (void)Kokkos::View<T*>(p, 0);
   (void)Kokkos::View<T*>(&d, 0);
   (void)Kokkos::View<T*>(nullptr, 0);
-  (void)Kokkos::View<T*>(NULL, 0);
-  (void)Kokkos::View<T*>(0, 0);
+  (void)Kokkos::View<T*>(NULL, 0);  // NOLINT(modernize-use-nullptr)
+  (void)Kokkos::View<T*>(0, 0);     // NOLINT(modernize-use-nullptr)
 
   (void)Kokkos::View<T**>(p, 0, 0);
   (void)Kokkos::View<T**>(&d, 0, 0);
   (void)Kokkos::View<T**>(nullptr, 0, 0);
-  (void)Kokkos::View<T**>(NULL, 0, 0);
-  (void)Kokkos::View<T**>(0, 0, 0);
+  (void)Kokkos::View<T**>(NULL, 0, 0);  // NOLINT(modernize-use-nullptr)
+  (void)Kokkos::View<T**>(0, 0, 0);     // NOLINT(modernize-use-nullptr)
 }
 
 TEST(TEST_CATEGORY, view_empty_runtime_unmanaged) {

--- a/core/unit_test/TestViewEmptyRuntimeUnmanaged.hpp
+++ b/core/unit_test/TestViewEmptyRuntimeUnmanaged.hpp
@@ -46,8 +46,10 @@ void test_empty_view_runtime_unmanaged() {
 
 TEST(TEST_CATEGORY, view_empty_runtime_unmanaged) {
   test_empty_view_runtime_unmanaged<float>();
+  test_empty_view_runtime_unmanaged<const double>();
   test_empty_view_runtime_unmanaged<int>();
   test_empty_view_runtime_unmanaged<char>();
+  test_empty_view_runtime_unmanaged<const char>();
 }
 
 }  // namespace

--- a/core/unit_test/TestViewEmptyRuntimeUnmanaged.hpp
+++ b/core/unit_test/TestViewEmptyRuntimeUnmanaged.hpp
@@ -1,0 +1,53 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+
+namespace {
+
+template <class T>
+void test_empty_view_runtime_unmanaged() {
+  T d{};
+  auto* p = reinterpret_cast<T*>(0xABADBABE);
+
+  (void)Kokkos::View<T>(p);
+  (void)Kokkos::View<T>(&d);
+  (void)Kokkos::View<T>(nullptr);
+  (void)Kokkos::View<T>(NULL);
+  (void)Kokkos::View<T>(0);
+
+  (void)Kokkos::View<T*>(p, 0);
+  (void)Kokkos::View<T*>(&d, 0);
+  (void)Kokkos::View<T*>(nullptr, 0);
+  (void)Kokkos::View<T*>(NULL, 0);
+  (void)Kokkos::View<T*>(0, 0);
+
+  (void)Kokkos::View<T**>(p, 0, 0);
+  (void)Kokkos::View<T**>(&d, 0, 0);
+  (void)Kokkos::View<T**>(nullptr, 0, 0);
+  (void)Kokkos::View<T**>(NULL, 0, 0);
+  (void)Kokkos::View<T**>(0, 0, 0);
+}
+
+TEST(TEST_CATEGORY, view_empty_runtime_unmanaged) {
+  test_empty_view_runtime_unmanaged<float>();
+  test_empty_view_runtime_unmanaged<int>();
+  test_empty_view_runtime_unmanaged<char>();
+}
+
+}  // namespace


### PR DESCRIPTION
Temporary fix for #6563

Revert merge of #6536 and add a test capturing the use case that was broken by that change