### PR TITLE
Cleanup for static_asserts with empty error

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsModOps.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsModOps.cpp
@@ -48,7 +48,7 @@ struct MyMovableType {
 TEST(std_algorithms_mod_ops_test, move) {
   MyMovableType a;
   using move_t = decltype(std::move(a));
-  static_assert(std::is_rvalue_reference<move_t>::value, "");
+  static_assert(std::is_rvalue_reference<move_t>::value);
 
   // move constr
   MyMovableType b(std::move(a));
@@ -70,7 +70,7 @@ struct StdAlgoModSeqOpsTestMove {
   void operator()(const int index) const {
     typename ViewType::value_type a{11};
     using move_t = decltype(std::move(a));
-    static_assert(std::is_rvalue_reference<move_t>::value, "");
+    static_assert(std::is_rvalue_reference<move_t>::value);
     m_view(index) = std::move(a);
   }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsPartitionCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsPartitionCopy.cpp
@@ -110,11 +110,9 @@ void verify_data(const std::string& name, ResultType my_result,
                  ViewTypeDestFalse view_dest_false, PredType pred) {
   using value_type = typename ViewTypeFrom::value_type;
   static_assert(
-      std::is_same<value_type, typename ViewTypeDestTrue::value_type>::value,
-      "");
+      std::is_same<value_type, typename ViewTypeDestTrue::value_type>::value);
   static_assert(
-      std::is_same<value_type, typename ViewTypeDestFalse::value_type>::value,
-      "");
+      std::is_same<value_type, typename ViewTypeDestFalse::value_type>::value);
 
   const std::size_t ext = view_from.extent(0);
 

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1340,7 +1340,7 @@ class ViewMapping<
 
   template <class MemoryTraits>
   struct apply {
-    static_assert(Kokkos::is_memory_traits<MemoryTraits>::value, "");
+    static_assert(Kokkos::is_memory_traits<MemoryTraits>::value);
 
     using traits_type =
         Kokkos::ViewTraits<data_type, array_layout,

--- a/core/src/Cuda/Kokkos_CudaSpace.hpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.hpp
@@ -280,15 +280,12 @@ const std::unique_ptr<Kokkos::Cuda>& cuda_get_deep_copy_space(
     bool initialize = true);
 
 static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaSpace,
-                                              Kokkos::CudaSpace>::assignable,
-              "");
-static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaUVMSpace,
-                                              Kokkos::CudaUVMSpace>::assignable,
-              "");
+                                              Kokkos::CudaSpace>::assignable);
+static_assert(Kokkos::Impl::MemorySpaceAccess<
+              Kokkos::CudaUVMSpace, Kokkos::CudaUVMSpace>::assignable);
 static_assert(
     Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaHostPinnedSpace,
-                                    Kokkos::CudaHostPinnedSpace>::assignable,
-    "");
+                                    Kokkos::CudaHostPinnedSpace>::assignable);
 
 //----------------------------------------
 

--- a/core/src/HIP/Kokkos_HIP_Space.hpp
+++ b/core/src/HIP/Kokkos_HIP_Space.hpp
@@ -239,8 +239,7 @@ struct Impl::is_hip_type_space<HIPManagedSpace> : public std::true_type {};
 namespace Kokkos {
 namespace Impl {
 
-static_assert(Kokkos::Impl::MemorySpaceAccess<HIPSpace, HIPSpace>::assignable,
-              "");
+static_assert(Kokkos::Impl::MemorySpaceAccess<HIPSpace, HIPSpace>::assignable);
 
 //----------------------------------------
 

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -96,7 +96,7 @@ constexpr Array to_array_potentially_narrowing(const U (&init)[M]) {
   using T = typename Array::value_type;
   Array a{};
   constexpr std::size_t N = a.size();
-  static_assert(M <= N, "");
+  static_assert(M <= N);
   auto* ptr = a.data();
   // NOTE equivalent to
   // std::transform(std::begin(init), std::end(init), a.data(),
@@ -120,7 +120,7 @@ constexpr NVCC_WONT_LET_ME_CALL_YOU_Array to_array_potentially_narrowing(
   using T = typename NVCC_WONT_LET_ME_CALL_YOU_Array::value_type;
   NVCC_WONT_LET_ME_CALL_YOU_Array a{};
   constexpr std::size_t N = a.size();
-  static_assert(M <= N, "");
+  static_assert(M <= N);
   for (std::size_t i = 0; i < M; ++i) {
     a[i] = checked_narrow_cast<T>(other[i]);
     (void)checked_narrow_cast<IndexType>(other[i]);  // see note above

--- a/core/src/Kokkos_HBWSpace.hpp
+++ b/core/src/Kokkos_HBWSpace.hpp
@@ -188,10 +188,9 @@ namespace Kokkos {
 
 namespace Impl {
 
-static_assert(
-    Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::HBWSpace,
-                                    Kokkos::Experimental::HBWSpace>::assignable,
-    "");
+static_assert(Kokkos::Impl::MemorySpaceAccess<
+              Kokkos::Experimental::HBWSpace,
+              Kokkos::Experimental::HBWSpace>::assignable);
 
 template <>
 struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::Experimental::HBWSpace> {

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -129,8 +129,7 @@ namespace Kokkos {
 namespace Impl {
 
 static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
-                                              Kokkos::HostSpace>::assignable,
-              "");
+                                              Kokkos::HostSpace>::assignable);
 
 template <typename S>
 struct HostMirror {

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -198,7 +198,7 @@ using promote_3_t = typename promote_3<T, U, V>::type;
                           long double>                                         \
   FUNC(T1 x, T2 y) {                                                           \
     using Promoted = Kokkos::Impl::promote_2_t<T1, T2>;                        \
-    static_assert(std::is_same_v<Promoted, long double>, "");                  \
+    static_assert(std::is_same_v<Promoted, long double>);                      \
     using std::FUNC;                                                           \
     return FUNC(static_cast<Promoted>(x), static_cast<Promoted>(y));           \
   }

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -814,15 +814,15 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename... Is>
   static KOKKOS_FUNCTION void check_access_member_function_valid_args(Is...) {
-    static_assert(rank <= sizeof...(Is), "");
-    static_assert(sizeof...(Is) <= 8, "");
-    static_assert(Kokkos::Impl::are_integral<Is...>::value, "");
+    static_assert(rank <= sizeof...(Is));
+    static_assert(sizeof...(Is) <= 8);
+    static_assert(Kokkos::Impl::are_integral<Is...>::value);
   }
 
   template <typename... Is>
   static KOKKOS_FUNCTION void check_operator_parens_valid_args(Is...) {
-    static_assert(rank == sizeof...(Is), "");
-    static_assert(Kokkos::Impl::are_integral<Is...>::value, "");
+    static_assert(rank == sizeof...(Is));
+    static_assert(Kokkos::Impl::are_integral<Is...>::value);
   }
 
  public:

--- a/core/src/SYCL/Kokkos_SYCL_Space.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.hpp
@@ -166,19 +166,16 @@ struct is_sycl_type_space<Kokkos::Experimental::SYCLHostUSMSpace>
     : public std::true_type {};
 
 static_assert(Kokkos::Impl::MemorySpaceAccess<
-                  Kokkos::Experimental::SYCLDeviceUSMSpace,
-                  Kokkos::Experimental::SYCLDeviceUSMSpace>::assignable,
-              "");
+              Kokkos::Experimental::SYCLDeviceUSMSpace,
+              Kokkos::Experimental::SYCLDeviceUSMSpace>::assignable);
 
 static_assert(Kokkos::Impl::MemorySpaceAccess<
-                  Kokkos::Experimental::SYCLSharedUSMSpace,
-                  Kokkos::Experimental::SYCLSharedUSMSpace>::assignable,
-              "");
+              Kokkos::Experimental::SYCLSharedUSMSpace,
+              Kokkos::Experimental::SYCLSharedUSMSpace>::assignable);
 
 static_assert(Kokkos::Impl::MemorySpaceAccess<
-                  Kokkos::Experimental::SYCLDeviceUSMSpace,
-                  Kokkos::Experimental::SYCLDeviceUSMSpace>::assignable,
-              "");
+              Kokkos::Experimental::SYCLDeviceUSMSpace,
+              Kokkos::Experimental::SYCLDeviceUSMSpace>::assignable);
 
 template <>
 struct MemorySpaceAccess<Kokkos::HostSpace,

--- a/core/src/impl/Kokkos_ViewArray.hpp
+++ b/core/src/impl/Kokkos_ViewArray.hpp
@@ -27,10 +27,9 @@ struct ViewDataAnalysis<DataType, ArrayLayout, Kokkos::Array<V, N, P>> {
  private:
   using array_analysis = ViewArrayAnalysis<DataType>;
 
-  static_assert(std::is_void<P>::value, "");
+  static_assert(std::is_void<P>::value);
   static_assert(std::is_same<typename array_analysis::non_const_value_type,
-                             Kokkos::Array<V, N, P>>::value,
-                "");
+                             Kokkos::Array<V, N, P>>::value);
   static_assert(std::is_scalar<V>::value,
                 "View of Array type must be of a scalar type");
 
@@ -507,7 +506,7 @@ class ViewMapping<
                       Kokkos::LayoutStride>::value))>,
     SrcTraits, Args...> {
  private:
-  static_assert(SrcTraits::rank == sizeof...(Args), "");
+  static_assert(SrcTraits::rank == sizeof...(Args));
 
   enum : bool {
     R0 = is_integral_extent<0, Args...>::value,

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -657,21 +657,20 @@ struct SubviewExtents {
   template <size_t... DimArgs, class... Args>
   KOKKOS_INLINE_FUNCTION SubviewExtents(const ViewDimension<DimArgs...>& dim,
                                         Args... args) {
-    static_assert(DomainRank == sizeof...(DimArgs), "");
-    static_assert(DomainRank == sizeof...(Args), "");
+    static_assert(DomainRank == sizeof...(DimArgs));
+    static_assert(DomainRank == sizeof...(Args));
 
     // Verifies that all arguments, up to 8, are integral types,
     // integral extents, or don't exist.
-    static_assert(
-        RangeRank == unsigned(is_integral_extent<0, Args...>::value) +
-                         unsigned(is_integral_extent<1, Args...>::value) +
-                         unsigned(is_integral_extent<2, Args...>::value) +
-                         unsigned(is_integral_extent<3, Args...>::value) +
-                         unsigned(is_integral_extent<4, Args...>::value) +
-                         unsigned(is_integral_extent<5, Args...>::value) +
-                         unsigned(is_integral_extent<6, Args...>::value) +
-                         unsigned(is_integral_extent<7, Args...>::value),
-        "");
+    static_assert(RangeRank ==
+                  unsigned(is_integral_extent<0, Args...>::value) +
+                      unsigned(is_integral_extent<1, Args...>::value) +
+                      unsigned(is_integral_extent<2, Args...>::value) +
+                      unsigned(is_integral_extent<3, Args...>::value) +
+                      unsigned(is_integral_extent<4, Args...>::value) +
+                      unsigned(is_integral_extent<5, Args...>::value) +
+                      unsigned(is_integral_extent<6, Args...>::value) +
+                      unsigned(is_integral_extent<7, Args...>::value));
 
     if (RangeRank == 0) {
       m_length[0] = 0;
@@ -814,8 +813,7 @@ struct ViewDataAnalysis {
   // Must match array analysis when this default template is used.
   static_assert(
       std::is_same<ValueType,
-                   typename array_analysis::non_const_value_type>::value,
-      "");
+                   typename array_analysis::non_const_value_type>::value);
 
  public:
   using specialize = void;  // No specialization
@@ -3896,7 +3894,7 @@ class ViewMapping<
 
   template <class MemoryTraits>
   struct apply {
-    static_assert(Kokkos::is_memory_traits<MemoryTraits>::value, "");
+    static_assert(Kokkos::is_memory_traits<MemoryTraits>::value);
 
     using traits_type =
         Kokkos::ViewTraits<data_type, array_layout,

--- a/core/src/traits/Kokkos_IndexTypeTrait.hpp
+++ b/core/src/traits/Kokkos_IndexTypeTrait.hpp
@@ -83,7 +83,7 @@ struct IndexTypePolicyMixin : AnalyzeNextTrait {
                 "Kokkos Error: More than one index type given. Search "
                 "compiler output for 'show_extra_index_type' to see the "
                 "type of the errant tag.");
-  static_assert(std::is_integral<IntegralIndexType>::value, "");
+  static_assert(std::is_integral<IntegralIndexType>::value);
   static constexpr bool index_type_is_defaulted = false;
   using index_type = Kokkos::IndexType<IntegralIndexType>;
 };

--- a/core/src/traits/Kokkos_OccupancyControlTrait.hpp
+++ b/core/src/traits/Kokkos_OccupancyControlTrait.hpp
@@ -163,7 +163,7 @@ auto prefer(Policy const& p, DesiredOccupancy occ) {
 
 template <typename Policy>
 constexpr auto prefer(Policy const& p, MaximizeOccupancy) {
-  static_assert(Kokkos::is_execution_policy<Policy>::value, "");
+  static_assert(Kokkos::is_execution_policy<Policy>::value);
   using new_policy_t =
       Kokkos::Impl::OccupancyControlTrait::policy_with_trait<Policy,
                                                              MaximizeOccupancy>;

--- a/core/src/traits/Kokkos_PolicyTraitAdaptor.hpp
+++ b/core/src/traits/Kokkos_PolicyTraitAdaptor.hpp
@@ -68,7 +68,7 @@ struct PolicyTraitAdaptorImpl<
     TraitSpec, PolicyTemplate, type_list<ProcessedTraits...>,
     type_list<MatchingTrait, ToProcessTraits...>, NewTrait,
     std::enable_if_t<PolicyTraitMatcher<TraitSpec, MatchingTrait>::value>> {
-  static_assert(PolicyTraitMatcher<TraitSpec, NewTrait>::value, "");
+  static_assert(PolicyTraitMatcher<TraitSpec, NewTrait>::value);
   using type = PolicyTemplate<ProcessedTraits..., NewTrait, ToProcessTraits...>;
 };
 
@@ -92,7 +92,7 @@ template <class TraitSpec, template <class...> class PolicyTemplate,
 struct PolicyTraitAdaptorImpl<TraitSpec, PolicyTemplate,
                               type_list<ProcessedTraits...>, type_list<>,
                               NewTrait> {
-  static_assert(PolicyTraitMatcher<TraitSpec, NewTrait>::value, "");
+  static_assert(PolicyTraitMatcher<TraitSpec, NewTrait>::value);
   using type = PolicyTemplate<ProcessedTraits..., NewTrait>;
 };
 

--- a/core/src/traits/Kokkos_ScheduleTrait.hpp
+++ b/core/src/traits/Kokkos_ScheduleTrait.hpp
@@ -78,7 +78,7 @@ namespace Experimental {
 
 template <class Policy, class ScheduleType>
 constexpr auto require(Policy const& p, Kokkos::Schedule<ScheduleType>) {
-  static_assert(Kokkos::is_execution_policy<Policy>::value, "");
+  static_assert(Kokkos::is_execution_policy<Policy>::value);
   using new_policy_t = Kokkos::Impl::ScheduleTrait::policy_with_trait<
       Policy, Kokkos::Schedule<ScheduleType>>;
   return new_policy_t{p};

--- a/core/src/traits/Kokkos_WorkItemPropertyTrait.hpp
+++ b/core/src/traits/Kokkos_WorkItemPropertyTrait.hpp
@@ -57,7 +57,7 @@ namespace Experimental {
 template <class Policy, unsigned long Property>
 constexpr auto require(const Policy p,
                        WorkItemProperty::ImplWorkItemProperty<Property>) {
-  static_assert(Kokkos::is_execution_policy<Policy>::value, "");
+  static_assert(Kokkos::is_execution_policy<Policy>::value);
   using new_policy_t = Kokkos::Impl::WorkItemPropertyTrait::policy_with_trait<
       Policy, WorkItemProperty::ImplWorkItemProperty<Property>>;
   return new_policy_t{p};

--- a/core/unit_test/TestAggregate.hpp
+++ b/core/unit_test/TestAggregate.hpp
@@ -29,35 +29,31 @@ void TestViewAggregate() {
                                      value_type>;
 
   static_assert(
-      std::is_same<typename analysis_1d::specialize, Kokkos::Array<> >::value,
-      "");
+      std::is_same<typename analysis_1d::specialize, Kokkos::Array<> >::value);
 
   using a32_traits = Kokkos::ViewTraits<value_type **, DeviceType>;
   using flat_traits =
       Kokkos::ViewTraits<typename a32_traits::scalar_array_type, DeviceType>;
 
   static_assert(
-      std::is_same<typename a32_traits::specialize, Kokkos::Array<> >::value,
-      "");
+      std::is_same<typename a32_traits::specialize, Kokkos::Array<> >::value);
   static_assert(
-      std::is_same<typename a32_traits::value_type, value_type>::value, "");
-  static_assert(a32_traits::rank == 2, "");
-  static_assert(a32_traits::rank_dynamic == 2, "");
+      std::is_same<typename a32_traits::value_type, value_type>::value);
+  static_assert(a32_traits::rank == 2);
+  static_assert(a32_traits::rank_dynamic == 2);
 
-  static_assert(std::is_void<typename flat_traits::specialize>::value, "");
-  static_assert(flat_traits::rank == 3, "");
-  static_assert(flat_traits::rank_dynamic == 2, "");
-  static_assert(flat_traits::dimension::N2 == 32, "");
+  static_assert(std::is_void<typename flat_traits::specialize>::value);
+  static_assert(flat_traits::rank == 3);
+  static_assert(flat_traits::rank_dynamic == 2);
+  static_assert(flat_traits::dimension::N2 == 32);
 
   using a32_type      = Kokkos::View<Kokkos::Array<double, 32> **, DeviceType>;
   using a32_flat_type = typename a32_type::array_type;
 
-  static_assert(std::is_same<typename a32_type::value_type, value_type>::value,
-                "");
-  static_assert(std::is_same<typename a32_type::pointer_type, double *>::value,
-                "");
-  static_assert(a32_type::rank == 2, "");
-  static_assert(a32_flat_type::rank == 3, "");
+  static_assert(std::is_same<typename a32_type::value_type, value_type>::value);
+  static_assert(std::is_same<typename a32_type::pointer_type, double *>::value);
+  static_assert(a32_type::rank == 2);
+  static_assert(a32_flat_type::rank == 3);
 
   a32_type x("test", 4, 5);
   a32_flat_type y(x);

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -451,17 +451,15 @@ TEST(TEST_CATEGORY, complex_issue_3867) {
   ASSERT_FLOAT_EQ(x.real(), y.real());
   ASSERT_FLOAT_EQ(x.imag(), y.imag());
 
-#define CHECK_POW_COMPLEX_PROMOTION(ARGTYPE1, ARGTYPE2, RETURNTYPE)         \
-  static_assert(                                                            \
-      std::is_same<RETURNTYPE,                                              \
-                   decltype(Kokkos::pow(std::declval<ARGTYPE1>(),           \
-                                        std::declval<ARGTYPE2>()))>::value, \
-      "");                                                                  \
-  static_assert(                                                            \
-      std::is_same<RETURNTYPE,                                              \
-                   decltype(Kokkos::pow(std::declval<ARGTYPE2>(),           \
-                                        std::declval<ARGTYPE1>()))>::value, \
-      "");
+#define CHECK_POW_COMPLEX_PROMOTION(ARGTYPE1, ARGTYPE2, RETURNTYPE)          \
+  static_assert(                                                             \
+      std::is_same<RETURNTYPE,                                               \
+                   decltype(Kokkos::pow(std::declval<ARGTYPE1>(),            \
+                                        std::declval<ARGTYPE2>()))>::value); \
+  static_assert(                                                             \
+      std::is_same<RETURNTYPE,                                               \
+                   decltype(Kokkos::pow(std::declval<ARGTYPE2>(),            \
+                                        std::declval<ARGTYPE1>()))>::value);
 
   CHECK_POW_COMPLEX_PROMOTION(Kokkos::complex<long double>, long double,
                               Kokkos::complex<long double>);

--- a/core/unit_test/TestConcepts.hpp
+++ b/core/unit_test/TestConcepts.hpp
@@ -22,42 +22,42 @@ using ExecutionSpace = TEST_EXECSPACE;
 using MemorySpace    = typename ExecutionSpace::memory_space;
 using DeviceType     = typename ExecutionSpace::device_type;
 
-static_assert(Kokkos::is_execution_space<ExecutionSpace>{}, "");
-static_assert(Kokkos::is_execution_space<ExecutionSpace const>{}, "");
-static_assert(!Kokkos::is_execution_space<ExecutionSpace &>{}, "");
-static_assert(!Kokkos::is_execution_space<ExecutionSpace const &>{}, "");
+static_assert(Kokkos::is_execution_space<ExecutionSpace>{});
+static_assert(Kokkos::is_execution_space<ExecutionSpace const>{});
+static_assert(!Kokkos::is_execution_space<ExecutionSpace &>{});
+static_assert(!Kokkos::is_execution_space<ExecutionSpace const &>{});
 
-static_assert(Kokkos::is_memory_space<MemorySpace>{}, "");
-static_assert(Kokkos::is_memory_space<MemorySpace const>{}, "");
-static_assert(!Kokkos::is_memory_space<MemorySpace &>{}, "");
-static_assert(!Kokkos::is_memory_space<MemorySpace const &>{}, "");
+static_assert(Kokkos::is_memory_space<MemorySpace>{});
+static_assert(Kokkos::is_memory_space<MemorySpace const>{});
+static_assert(!Kokkos::is_memory_space<MemorySpace &>{});
+static_assert(!Kokkos::is_memory_space<MemorySpace const &>{});
 
-static_assert(Kokkos::is_device<DeviceType>{}, "");
-static_assert(Kokkos::is_device<DeviceType const>{}, "");
-static_assert(!Kokkos::is_device<DeviceType &>{}, "");
-static_assert(!Kokkos::is_device<DeviceType const &>{}, "");
+static_assert(Kokkos::is_device<DeviceType>{});
+static_assert(Kokkos::is_device<DeviceType const>{});
+static_assert(!Kokkos::is_device<DeviceType &>{});
+static_assert(!Kokkos::is_device<DeviceType const &>{});
 
-static_assert(!Kokkos::is_device<ExecutionSpace>{}, "");
-static_assert(!Kokkos::is_device<MemorySpace>{}, "");
+static_assert(!Kokkos::is_device<ExecutionSpace>{});
+static_assert(!Kokkos::is_device<MemorySpace>{});
 
-static_assert(Kokkos::is_space<ExecutionSpace>{}, "");
-static_assert(Kokkos::is_space<MemorySpace>{}, "");
-static_assert(Kokkos::is_space<DeviceType>{}, "");
-static_assert(Kokkos::is_space<ExecutionSpace const>{}, "");
-static_assert(Kokkos::is_space<MemorySpace const>{}, "");
-static_assert(Kokkos::is_space<DeviceType const>{}, "");
-static_assert(!Kokkos::is_space<ExecutionSpace &>{}, "");
-static_assert(!Kokkos::is_space<MemorySpace &>{}, "");
-static_assert(!Kokkos::is_space<DeviceType &>{}, "");
+static_assert(Kokkos::is_space<ExecutionSpace>{});
+static_assert(Kokkos::is_space<MemorySpace>{});
+static_assert(Kokkos::is_space<DeviceType>{});
+static_assert(Kokkos::is_space<ExecutionSpace const>{});
+static_assert(Kokkos::is_space<MemorySpace const>{});
+static_assert(Kokkos::is_space<DeviceType const>{});
+static_assert(!Kokkos::is_space<ExecutionSpace &>{});
+static_assert(!Kokkos::is_space<MemorySpace &>{});
+static_assert(!Kokkos::is_space<DeviceType &>{});
 
-static_assert(Kokkos::is_execution_space_v<ExecutionSpace>, "");
-static_assert(!Kokkos::is_execution_space_v<ExecutionSpace &>, "");
+static_assert(Kokkos::is_execution_space_v<ExecutionSpace>);
+static_assert(!Kokkos::is_execution_space_v<ExecutionSpace &>);
 
 static_assert(
-    std::is_same<float, Kokkos::Impl::remove_cvref_t<float const &>>{}, "");
-static_assert(std::is_same<int, Kokkos::Impl::remove_cvref_t<int &>>{}, "");
-static_assert(std::is_same<int, Kokkos::Impl::remove_cvref_t<int const>>{}, "");
-static_assert(std::is_same<float, Kokkos::Impl::remove_cvref_t<float>>{}, "");
+    std::is_same<float, Kokkos::Impl::remove_cvref_t<float const &>>{});
+static_assert(std::is_same<int, Kokkos::Impl::remove_cvref_t<int &>>{});
+static_assert(std::is_same<int, Kokkos::Impl::remove_cvref_t<int const>>{});
+static_assert(std::is_same<float, Kokkos::Impl::remove_cvref_t<float>>{});
 
 /*-------------------------------------------------
   begin test for team_handle concept

--- a/core/unit_test/TestFunctorAnalysis.hpp
+++ b/core/unit_test/TestFunctorAnalysis.hpp
@@ -59,16 +59,15 @@ void test_functor_analysis() {
 
   using R01 = typename A01::Reducer;
 
-  static_assert(std::is_void<typename A01::value_type>::value, "");
-  static_assert(std::is_void<typename A01::pointer_type>::value, "");
-  static_assert(std::is_void<typename A01::reference_type>::value, "");
-  static_assert(std::is_same<typename R01::functor_type, decltype(c01)>::value,
-                "");
+  static_assert(std::is_void<typename A01::value_type>::value);
+  static_assert(std::is_void<typename A01::pointer_type>::value);
+  static_assert(std::is_void<typename A01::reference_type>::value);
+  static_assert(std::is_same<typename R01::functor_type, decltype(c01)>::value);
 
-  static_assert(!A01::has_join_member_function, "");
-  static_assert(!A01::has_init_member_function, "");
-  static_assert(!A01::has_final_member_function, "");
-  static_assert(A01::StaticValueSize == 0, "");
+  static_assert(!A01::has_join_member_function);
+  static_assert(!A01::has_init_member_function);
+  static_assert(!A01::has_final_member_function);
+  static_assert(A01::StaticValueSize == 0);
   ASSERT_EQ(R01(c01).length(), 0);
 
   //------------------------------
@@ -78,16 +77,15 @@ void test_functor_analysis() {
       Kokkos::RangePolicy<ExecSpace>, decltype(c02), void>;
   using R02 = typename A02::Reducer;
 
-  static_assert(std::is_same<typename A02::value_type, double>::value, "");
-  static_assert(std::is_same<typename A02::pointer_type, double*>::value, "");
-  static_assert(std::is_same<typename A02::reference_type, double&>::value, "");
-  static_assert(std::is_same<typename R02::functor_type, decltype(c02)>::value,
-                "");
+  static_assert(std::is_same<typename A02::value_type, double>::value);
+  static_assert(std::is_same<typename A02::pointer_type, double*>::value);
+  static_assert(std::is_same<typename A02::reference_type, double&>::value);
+  static_assert(std::is_same<typename R02::functor_type, decltype(c02)>::value);
 
-  static_assert(!A02::has_join_member_function, "");
-  static_assert(!A02::has_init_member_function, "");
-  static_assert(!A02::has_final_member_function, "");
-  static_assert(A02::StaticValueSize == sizeof(double), "");
+  static_assert(!A02::has_join_member_function);
+  static_assert(!A02::has_init_member_function);
+  static_assert(!A02::has_final_member_function);
+  static_assert(A02::StaticValueSize == sizeof(double));
   ASSERT_EQ(R02(c02).length(), 1);
 
   //------------------------------
@@ -99,23 +97,19 @@ void test_functor_analysis() {
   using R03 = typename A03::Reducer;
 
   static_assert(std::is_same<typename A03::value_type,
-                             TestFunctorAnalysis_03::value_type>::value,
-                "");
+                             TestFunctorAnalysis_03::value_type>::value);
   static_assert(std::is_same<typename A03::pointer_type,
-                             TestFunctorAnalysis_03::value_type*>::value,
-                "");
+                             TestFunctorAnalysis_03::value_type*>::value);
   static_assert(std::is_same<typename A03::reference_type,
-                             TestFunctorAnalysis_03::value_type&>::value,
-                "");
+                             TestFunctorAnalysis_03::value_type&>::value);
   static_assert(
-      std::is_same<typename R03::functor_type, TestFunctorAnalysis_03>::value,
-      "");
+      std::is_same<typename R03::functor_type, TestFunctorAnalysis_03>::value);
 
-  static_assert(A03::has_join_member_function, "");
-  static_assert(A03::has_init_member_function, "");
-  static_assert(!A03::has_final_member_function, "");
-  static_assert(
-      A03::StaticValueSize == sizeof(TestFunctorAnalysis_03::value_type), "");
+  static_assert(A03::has_join_member_function);
+  static_assert(A03::has_init_member_function);
+  static_assert(!A03::has_final_member_function);
+  static_assert(A03::StaticValueSize ==
+                sizeof(TestFunctorAnalysis_03::value_type));
   ASSERT_EQ(R03(c03).length(), 1);
 
   //------------------------------

--- a/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
+++ b/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
@@ -37,7 +37,7 @@ template <class SmartPtr>
 struct CheckAccessStoredPointerAndDereferenceOnDevice {
   SmartPtr m_device_ptr;
   using ElementType = typename SmartPtr::element_type;
-  static_assert(std::is_same<ElementType, Data>::value, "");
+  static_assert(std::is_same<ElementType, Data>::value);
 
   CheckAccessStoredPointerAndDereferenceOnDevice(SmartPtr device_ptr)
       : m_device_ptr(device_ptr) {

--- a/core/unit_test/TestJoinBackwardCompatibility.hpp
+++ b/core/unit_test/TestJoinBackwardCompatibility.hpp
@@ -36,9 +36,8 @@ KOKKOS_FUNCTION constexpr MyErrorCode operator|(MyErrorCode lhs,
 }
 
 static_assert((no_error | error_operator_plus_equal_volatile) ==
-                  error_operator_plus_equal_volatile,
-              "");
-static_assert((error_join_volatile | error_operator_plus_equal) == 0b101, "");
+              error_operator_plus_equal_volatile);
+static_assert((error_join_volatile | error_operator_plus_equal) == 0b101);
 
 struct MyJoinBackCompatValueType {
   MyErrorCode err = no_error;

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1315,19 +1315,17 @@ struct TestAbsoluteValueFunction {
       Kokkos::printf("failed abs(floating_point) special values\n");
     }
 
-    static_assert(std::is_same<decltype(abs(1)), int>::value, "");
-    static_assert(std::is_same<decltype(abs(2l)), long>::value, "");
-    static_assert(std::is_same<decltype(abs(3ll)), long long>::value, "");
+    static_assert(std::is_same<decltype(abs(1)), int>::value);
+    static_assert(std::is_same<decltype(abs(2l)), long>::value);
+    static_assert(std::is_same<decltype(abs(3ll)), long long>::value);
     static_assert(std::is_same<decltype(abs(static_cast<KE::half_t>(4.f))),
-                               KE::half_t>::value,
-                  "");
+                               KE::half_t>::value);
     static_assert(std::is_same<decltype(abs(static_cast<KE::bhalf_t>(4.f))),
-                               KE::bhalf_t>::value,
-                  "");
-    static_assert(std::is_same<decltype(abs(4.f)), float>::value, "");
-    static_assert(std::is_same<decltype(abs(5.)), double>::value, "");
+                               KE::bhalf_t>::value);
+    static_assert(std::is_same<decltype(abs(4.f)), float>::value);
+    static_assert(std::is_same<decltype(abs(5.)), double>::value);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same<decltype(abs(6.l)), long double>::value, "");
+    static_assert(std::is_same<decltype(abs(6.l)), long double>::value);
 #endif
   }
 };
@@ -1451,17 +1449,14 @@ struct TestFloatingPointRemainderFunction : FloatingPointComparison {
 
     static_assert(std::is_same<decltype(fmod(static_cast<KE::half_t>(4.f),
                                              static_cast<KE::half_t>(4.f))),
-                               KE::half_t>::value,
-                  "");
+                               KE::half_t>::value);
     static_assert(std::is_same<decltype(fmod(static_cast<KE::bhalf_t>(4.f),
                                              static_cast<KE::bhalf_t>(4.f))),
-                               KE::bhalf_t>::value,
-                  "");
-    static_assert(std::is_same<decltype(fmod(4.f, 4.f)), float>::value, "");
-    static_assert(std::is_same<decltype(fmod(5., 5.)), double>::value, "");
+                               KE::bhalf_t>::value);
+    static_assert(std::is_same<decltype(fmod(4.f, 4.f)), float>::value);
+    static_assert(std::is_same<decltype(fmod(5., 5.)), double>::value);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same<decltype(fmod(6.l, 6.l)), long double>::value,
-                  "");
+    static_assert(std::is_same<decltype(fmod(6.l, 6.l)), long double>::value);
 #endif
   }
 };
@@ -1530,19 +1525,16 @@ struct TestIEEEFloatingPointRemainderFunction : FloatingPointComparison {
     static_assert(
         std::is_same<decltype(remainder(static_cast<KE::half_t>(4.f),
                                         static_cast<KE::half_t>(4.f))),
-                     KE::half_t>::value,
-        "");
+                     KE::half_t>::value);
     static_assert(
         std::is_same<decltype(remainder(static_cast<KE::bhalf_t>(4.f),
                                         static_cast<KE::bhalf_t>(4.f))),
-                     KE::bhalf_t>::value,
-        "");
-    static_assert(std::is_same<decltype(remainder(4.f, 4.f)), float>::value,
-                  "");
-    static_assert(std::is_same<decltype(remainder(5., 5.)), double>::value, "");
+                     KE::bhalf_t>::value);
+    static_assert(std::is_same<decltype(remainder(4.f, 4.f)), float>::value);
+    static_assert(std::is_same<decltype(remainder(5., 5.)), double>::value);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     static_assert(
-        std::is_same<decltype(remainder(6.l, 6.l)), long double>::value, "");
+        std::is_same<decltype(remainder(6.l, 6.l)), long double>::value);
 #endif
   }
 };
@@ -1622,11 +1614,11 @@ struct TestIsNaN {
       Kokkos::printf("failed isnan(floating_point) special values\n");
     }
 
-    static_assert(std::is_same<decltype(isnan(1)), bool>::value, "");
-    static_assert(std::is_same<decltype(isnan(2.f)), bool>::value, "");
-    static_assert(std::is_same<decltype(isnan(3.)), bool>::value, "");
+    static_assert(std::is_same<decltype(isnan(1)), bool>::value);
+    static_assert(std::is_same<decltype(isnan(2.f)), bool>::value);
+    static_assert(std::is_same<decltype(isnan(3.)), bool>::value);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same<decltype(isnan(4.l)), bool>::value, "");
+    static_assert(std::is_same<decltype(isnan(4.l)), bool>::value);
 #endif
   }
 };

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -407,7 +407,7 @@ struct HasNoSpecialization {};
   using TRAIT##_value_t = decltype(Kokkos::Experimental::TRAIT<T>::value); \
   template <class T>                                                       \
   using has_##TRAIT = Kokkos::is_detected<TRAIT##_value_t, T>;             \
-  static_assert(!has_##TRAIT<HasNoSpecialization>::value, "");
+  static_assert(!has_##TRAIT<HasNoSpecialization>::value);
 
 CHECK_TRAIT_IS_SFINAE_FRIENDLY(infinity)
 CHECK_TRAIT_IS_SFINAE_FRIENDLY(finite_min)
@@ -489,39 +489,39 @@ CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(long double, denorm_min);
 #endif
 
 // clang-format off
-static_assert(Kokkos::Experimental::norm_min<float      >::value == std::numeric_limits<      float>::min(), "");
-static_assert(Kokkos::Experimental::norm_min<double     >::value == std::numeric_limits<     double>::min(), "");
-static_assert(Kokkos::Experimental::norm_min<long double>::value == std::numeric_limits<long double>::min(), "");
+static_assert(Kokkos::Experimental::norm_min<float      >::value == std::numeric_limits<      float>::min());
+static_assert(Kokkos::Experimental::norm_min<double     >::value == std::numeric_limits<     double>::min());
+static_assert(Kokkos::Experimental::norm_min<long double>::value == std::numeric_limits<long double>::min());
 // integer types
-static_assert(Kokkos::Experimental::finite_min<char                  >::value == std::numeric_limits<                  char>::min(), "");
-static_assert(Kokkos::Experimental::finite_min<signed char           >::value == std::numeric_limits<           signed char>::min(), "");
-static_assert(Kokkos::Experimental::finite_min<unsigned char         >::value == std::numeric_limits<         unsigned char>::min(), "");
-static_assert(Kokkos::Experimental::finite_min<short                 >::value == std::numeric_limits<                 short>::min(), "");
-static_assert(Kokkos::Experimental::finite_min<unsigned short        >::value == std::numeric_limits<        unsigned short>::min(), "");
-static_assert(Kokkos::Experimental::finite_min<int                   >::value == std::numeric_limits<                   int>::min(), "");
-static_assert(Kokkos::Experimental::finite_min<unsigned int          >::value == std::numeric_limits<          unsigned int>::min(), "");
-static_assert(Kokkos::Experimental::finite_min<long int              >::value == std::numeric_limits<              long int>::min(), "");
-static_assert(Kokkos::Experimental::finite_min<unsigned long int     >::value == std::numeric_limits<     unsigned long int>::min(), "");
-static_assert(Kokkos::Experimental::finite_min<long long int         >::value == std::numeric_limits<         long long int>::min(), "");
-static_assert(Kokkos::Experimental::finite_min<unsigned long long int>::value == std::numeric_limits<unsigned long long int>::min(), "");
-static_assert(Kokkos::Experimental::finite_max<char                  >::value == std::numeric_limits<                  char>::max(), "");
-static_assert(Kokkos::Experimental::finite_max<signed char           >::value == std::numeric_limits<           signed char>::max(), "");
-static_assert(Kokkos::Experimental::finite_max<unsigned char         >::value == std::numeric_limits<         unsigned char>::max(), "");
-static_assert(Kokkos::Experimental::finite_max<short                 >::value == std::numeric_limits<                 short>::max(), "");
-static_assert(Kokkos::Experimental::finite_max<unsigned short        >::value == std::numeric_limits<        unsigned short>::max(), "");
-static_assert(Kokkos::Experimental::finite_max<int                   >::value == std::numeric_limits<                   int>::max(), "");
-static_assert(Kokkos::Experimental::finite_max<unsigned int          >::value == std::numeric_limits<          unsigned int>::max(), "");
-static_assert(Kokkos::Experimental::finite_max<long int              >::value == std::numeric_limits<              long int>::max(), "");
-static_assert(Kokkos::Experimental::finite_max<unsigned long int     >::value == std::numeric_limits<     unsigned long int>::max(), "");
-static_assert(Kokkos::Experimental::finite_max<long long int         >::value == std::numeric_limits<         long long int>::max(), "");
-static_assert(Kokkos::Experimental::finite_max<unsigned long long int>::value == std::numeric_limits<unsigned long long int>::max(), "");
+static_assert(Kokkos::Experimental::finite_min<char                  >::value == std::numeric_limits<                  char>::min());
+static_assert(Kokkos::Experimental::finite_min<signed char           >::value == std::numeric_limits<           signed char>::min());
+static_assert(Kokkos::Experimental::finite_min<unsigned char         >::value == std::numeric_limits<         unsigned char>::min());
+static_assert(Kokkos::Experimental::finite_min<short                 >::value == std::numeric_limits<                 short>::min());
+static_assert(Kokkos::Experimental::finite_min<unsigned short        >::value == std::numeric_limits<        unsigned short>::min());
+static_assert(Kokkos::Experimental::finite_min<int                   >::value == std::numeric_limits<                   int>::min());
+static_assert(Kokkos::Experimental::finite_min<unsigned int          >::value == std::numeric_limits<          unsigned int>::min());
+static_assert(Kokkos::Experimental::finite_min<long int              >::value == std::numeric_limits<              long int>::min());
+static_assert(Kokkos::Experimental::finite_min<unsigned long int     >::value == std::numeric_limits<     unsigned long int>::min());
+static_assert(Kokkos::Experimental::finite_min<long long int         >::value == std::numeric_limits<         long long int>::min());
+static_assert(Kokkos::Experimental::finite_min<unsigned long long int>::value == std::numeric_limits<unsigned long long int>::min());
+static_assert(Kokkos::Experimental::finite_max<char                  >::value == std::numeric_limits<                  char>::max());
+static_assert(Kokkos::Experimental::finite_max<signed char           >::value == std::numeric_limits<           signed char>::max());
+static_assert(Kokkos::Experimental::finite_max<unsigned char         >::value == std::numeric_limits<         unsigned char>::max());
+static_assert(Kokkos::Experimental::finite_max<short                 >::value == std::numeric_limits<                 short>::max());
+static_assert(Kokkos::Experimental::finite_max<unsigned short        >::value == std::numeric_limits<        unsigned short>::max());
+static_assert(Kokkos::Experimental::finite_max<int                   >::value == std::numeric_limits<                   int>::max());
+static_assert(Kokkos::Experimental::finite_max<unsigned int          >::value == std::numeric_limits<          unsigned int>::max());
+static_assert(Kokkos::Experimental::finite_max<long int              >::value == std::numeric_limits<              long int>::max());
+static_assert(Kokkos::Experimental::finite_max<unsigned long int     >::value == std::numeric_limits<     unsigned long int>::max());
+static_assert(Kokkos::Experimental::finite_max<long long int         >::value == std::numeric_limits<         long long int>::max());
+static_assert(Kokkos::Experimental::finite_max<unsigned long long int>::value == std::numeric_limits<unsigned long long int>::max());
 // floating point types
-static_assert(Kokkos::Experimental::finite_min<float      >::value == -std::numeric_limits<      float>::max(), "");
-static_assert(Kokkos::Experimental::finite_min<double     >::value == -std::numeric_limits<     double>::max(), "");
-static_assert(Kokkos::Experimental::finite_min<long double>::value == -std::numeric_limits<long double>::max(), "");
-static_assert(Kokkos::Experimental::finite_max<float      >::value ==  std::numeric_limits<      float>::max(), "");
-static_assert(Kokkos::Experimental::finite_max<double     >::value ==  std::numeric_limits<     double>::max(), "");
-static_assert(Kokkos::Experimental::finite_max<long double>::value ==  std::numeric_limits<long double>::max(), "");
+static_assert(Kokkos::Experimental::finite_min<float      >::value == -std::numeric_limits<      float>::max());
+static_assert(Kokkos::Experimental::finite_min<double     >::value == -std::numeric_limits<     double>::max());
+static_assert(Kokkos::Experimental::finite_min<long double>::value == -std::numeric_limits<long double>::max());
+static_assert(Kokkos::Experimental::finite_max<float      >::value ==  std::numeric_limits<      float>::max());
+static_assert(Kokkos::Experimental::finite_max<double     >::value ==  std::numeric_limits<     double>::max());
+static_assert(Kokkos::Experimental::finite_max<long double>::value ==  std::numeric_limits<long double>::max());
 // clang-format on
 
 CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_CONSTANT(bool, digits);
@@ -588,15 +588,13 @@ CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_CONSTANT(long double, max_exponent10);
 #undef CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION
 #undef CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_CONSTANT
 
-#define CHECK_NAN_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(T, TRAIT)             \
-  static_assert(Kokkos::Experimental::TRAIT<T>::value !=                       \
-                    Kokkos::Experimental::TRAIT<T>::value,                     \
-                "");                                                           \
-  static_assert(                                                               \
-      std::numeric_limits<T>::TRAIT() != std::numeric_limits<T>::TRAIT(), ""); \
-  static_assert(Kokkos::Experimental::TRAIT<T>::value !=                       \
-                    std::numeric_limits<T>::TRAIT(),                           \
-                "")
+#define CHECK_NAN_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(T, TRAIT) \
+  static_assert(Kokkos::Experimental::TRAIT<T>::value !=           \
+                Kokkos::Experimental::TRAIT<T>::value);            \
+  static_assert(std::numeric_limits<T>::TRAIT() !=                 \
+                std::numeric_limits<T>::TRAIT());                  \
+  static_assert(Kokkos::Experimental::TRAIT<T>::value !=           \
+                std::numeric_limits<T>::TRAIT())
 
 // Workaround compiler issue error: expression must have a constant value
 // See kokkos/kokkos#4574
@@ -616,14 +614,11 @@ CHECK_NAN_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(long double, signaling_NaN);
 
 #define CHECK_INSTANTIATED_ON_CV_QUALIFIED_TYPES(T, TRAIT)              \
   static_assert(Kokkos::Experimental::TRAIT<T const>::value ==          \
-                    Kokkos::Experimental::TRAIT<T>::value,              \
-                "");                                                    \
+                Kokkos::Experimental::TRAIT<T>::value);                 \
   static_assert(Kokkos::Experimental::TRAIT<T volatile>::value ==       \
-                    Kokkos::Experimental::TRAIT<T>::value,              \
-                "");                                                    \
+                Kokkos::Experimental::TRAIT<T>::value);                 \
   static_assert(Kokkos::Experimental::TRAIT<T const volatile>::value == \
-                    Kokkos::Experimental::TRAIT<T>::value,              \
-                "")
+                Kokkos::Experimental::TRAIT<T>::value)
 
 #define CHECK_INSTANTIATED_ON_CV_QUALIFIED_TYPES_FLOATING_POINT(TRAIT) \
   CHECK_INSTANTIATED_ON_CV_QUALIFIED_TYPES(float, TRAIT);              \
@@ -671,17 +666,13 @@ CHECK_INSTANTIATED_ON_CV_QUALIFIED_TYPES_FLOATING_POINT(max_exponent10);
 
 #define CHECK_NAN_INSTANTIATED_ON_CV_QUALIFIED_TYPES(T, TRAIT)          \
   static_assert(Kokkos::Experimental::TRAIT<T>::value !=                \
-                    Kokkos::Experimental::TRAIT<T>::value,              \
-                "");                                                    \
+                Kokkos::Experimental::TRAIT<T>::value);                 \
   static_assert(Kokkos::Experimental::TRAIT<T const>::value !=          \
-                    Kokkos::Experimental::TRAIT<T>::value,              \
-                "");                                                    \
+                Kokkos::Experimental::TRAIT<T>::value);                 \
   static_assert(Kokkos::Experimental::TRAIT<T volatile>::value !=       \
-                    Kokkos::Experimental::TRAIT<T>::value,              \
-                "");                                                    \
+                Kokkos::Experimental::TRAIT<T>::value);                 \
   static_assert(Kokkos::Experimental::TRAIT<T const volatile>::value != \
-                    Kokkos::Experimental::TRAIT<T>::value,              \
-                "")
+                Kokkos::Experimental::TRAIT<T>::value)
 
 #define CHECK_NAN_INSTANTIATED_ON_CV_QUALIFIED_TYPES_FLOATING_POINT(TRAIT) \
   CHECK_NAN_INSTANTIATED_ON_CV_QUALIFIED_TYPES(float, TRAIT);              \

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -280,7 +280,7 @@ namespace Test {
 
 // Test for non-arithmetic type
 TEST(TEST_CATEGORY, team_broadcast_long_wrapper) {
-  static_assert(!std::is_arithmetic<long_wrapper>::value, "");
+  static_assert(!std::is_arithmetic<long_wrapper>::value);
 
   TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
                     long_wrapper>::test_teambroadcast(0, 1);

--- a/core/unit_test/TestUtilities.hpp
+++ b/core/unit_test/TestUtilities.hpp
@@ -25,20 +25,18 @@ namespace Test {
 
 void test_is_specialization_of() {
   using Kokkos::Impl::is_specialization_of;
-  static_assert(is_specialization_of<Kokkos::pair<float, int>, Kokkos::pair>{},
-                "");
-  static_assert(!is_specialization_of<Kokkos::View<int*>, Kokkos::pair>{}, "");
-  static_assert(is_specialization_of<Kokkos::View<int*>, Kokkos::View>{}, "");
+  static_assert(is_specialization_of<Kokkos::pair<float, int>, Kokkos::pair>{});
+  static_assert(!is_specialization_of<Kokkos::View<int*>, Kokkos::pair>{});
+  static_assert(is_specialization_of<Kokkos::View<int*>, Kokkos::View>{});
   // NOTE Not removing cv-qualifiers
-  static_assert(!is_specialization_of<Kokkos::View<int*> const, Kokkos::View>{},
-                "");
+  static_assert(
+      !is_specialization_of<Kokkos::View<int*> const, Kokkos::View>{});
   // NOTE Would not compile because Kokkos::Array takes a non-type template
   // parameter
-  // static_assert(is_specialization_of<Kokkos::Array<int, 4>, Kokkos::Array>{},
-  // "");
+  // static_assert(is_specialization_of<Kokkos::Array<int, 4>,
+  //               Kokkos::Array>{});
   // But this is fine of course
-  static_assert(!is_specialization_of<Kokkos::Array<float, 2>, Kokkos::pair>{},
-                "");
+  static_assert(!is_specialization_of<Kokkos::Array<float, 2>, Kokkos::pair>{});
 }
 
 namespace {

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -958,8 +958,7 @@ class TestViewAPI {
     using mirror_type = typename view_type::HostMirror;
 
     static_assert(std::is_same<typename view_type::memory_space,
-                               typename mirror_type::memory_space>::value,
-                  "");
+                               typename mirror_type::memory_space>::value);
 
     view_type a("a");
     mirror_type am = Kokkos::create_mirror_view(a);

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -73,67 +73,67 @@ void test_view_mapping() {
   ASSERT_LE(sizeof(dim_s0_s0_s0_s0_s0_s0_s0), 8 * sizeof(unsigned));
   ASSERT_EQ(sizeof(dim_s0_s0_s0_s0_s0_s0_s0_s0), 8 * sizeof(unsigned));
 #endif
-  static_assert(int(dim_0::rank) == int(0), "");
-  static_assert(int(dim_0::rank_dynamic) == int(0), "");
-  static_assert(int(dim_0::ArgN0) == 1, "");
-  static_assert(int(dim_0::ArgN1) == 1, "");
-  static_assert(int(dim_0::ArgN2) == 1, "");
+  static_assert(int(dim_0::rank) == int(0));
+  static_assert(int(dim_0::rank_dynamic) == int(0));
+  static_assert(int(dim_0::ArgN0) == 1);
+  static_assert(int(dim_0::ArgN1) == 1);
+  static_assert(int(dim_0::ArgN2) == 1);
 
-  static_assert(int(dim_s2::rank) == int(1), "");
-  static_assert(int(dim_s2::rank_dynamic) == int(0), "");
-  static_assert(int(dim_s2::ArgN0) == 2, "");
-  static_assert(int(dim_s2::ArgN1) == 1, "");
+  static_assert(int(dim_s2::rank) == int(1));
+  static_assert(int(dim_s2::rank_dynamic) == int(0));
+  static_assert(int(dim_s2::ArgN0) == 2);
+  static_assert(int(dim_s2::ArgN1) == 1);
 
-  static_assert(int(dim_s2_s3::rank) == int(2), "");
-  static_assert(int(dim_s2_s3::rank_dynamic) == int(0), "");
-  static_assert(int(dim_s2_s3::ArgN0) == 2, "");
-  static_assert(int(dim_s2_s3::ArgN1) == 3, "");
-  static_assert(int(dim_s2_s3::ArgN2) == 1, "");
+  static_assert(int(dim_s2_s3::rank) == int(2));
+  static_assert(int(dim_s2_s3::rank_dynamic) == int(0));
+  static_assert(int(dim_s2_s3::ArgN0) == 2);
+  static_assert(int(dim_s2_s3::ArgN1) == 3);
+  static_assert(int(dim_s2_s3::ArgN2) == 1);
 
-  static_assert(int(dim_s2_s3_s4::rank) == int(3), "");
-  static_assert(int(dim_s2_s3_s4::rank_dynamic) == int(0), "");
-  static_assert(int(dim_s2_s3_s4::ArgN0) == 2, "");
-  static_assert(int(dim_s2_s3_s4::ArgN1) == 3, "");
-  static_assert(int(dim_s2_s3_s4::ArgN2) == 4, "");
-  static_assert(int(dim_s2_s3_s4::ArgN3) == 1, "");
+  static_assert(int(dim_s2_s3_s4::rank) == int(3));
+  static_assert(int(dim_s2_s3_s4::rank_dynamic) == int(0));
+  static_assert(int(dim_s2_s3_s4::ArgN0) == 2);
+  static_assert(int(dim_s2_s3_s4::ArgN1) == 3);
+  static_assert(int(dim_s2_s3_s4::ArgN2) == 4);
+  static_assert(int(dim_s2_s3_s4::ArgN3) == 1);
 
-  static_assert(int(dim_s0::rank) == int(1), "");
-  static_assert(int(dim_s0::rank_dynamic) == int(1), "");
+  static_assert(int(dim_s0::rank) == int(1));
+  static_assert(int(dim_s0::rank_dynamic) == int(1));
 
-  static_assert(int(dim_s0_s3::rank) == int(2), "");
-  static_assert(int(dim_s0_s3::rank_dynamic) == int(1), "");
-  static_assert(int(dim_s0_s3::ArgN0) == 0, "");
-  static_assert(int(dim_s0_s3::ArgN1) == 3, "");
+  static_assert(int(dim_s0_s3::rank) == int(2));
+  static_assert(int(dim_s0_s3::rank_dynamic) == int(1));
+  static_assert(int(dim_s0_s3::ArgN0) == 0);
+  static_assert(int(dim_s0_s3::ArgN1) == 3);
 
-  static_assert(int(dim_s0_s3_s4::rank) == int(3), "");
-  static_assert(int(dim_s0_s3_s4::rank_dynamic) == int(1), "");
-  static_assert(int(dim_s0_s3_s4::ArgN0) == 0, "");
-  static_assert(int(dim_s0_s3_s4::ArgN1) == 3, "");
-  static_assert(int(dim_s0_s3_s4::ArgN2) == 4, "");
+  static_assert(int(dim_s0_s3_s4::rank) == int(3));
+  static_assert(int(dim_s0_s3_s4::rank_dynamic) == int(1));
+  static_assert(int(dim_s0_s3_s4::ArgN0) == 0);
+  static_assert(int(dim_s0_s3_s4::ArgN1) == 3);
+  static_assert(int(dim_s0_s3_s4::ArgN2) == 4);
 
-  static_assert(int(dim_s0_s0_s4::rank) == int(3), "");
-  static_assert(int(dim_s0_s0_s4::rank_dynamic) == int(2), "");
-  static_assert(int(dim_s0_s0_s4::ArgN0) == 0, "");
-  static_assert(int(dim_s0_s0_s4::ArgN1) == 0, "");
-  static_assert(int(dim_s0_s0_s4::ArgN2) == 4, "");
+  static_assert(int(dim_s0_s0_s4::rank) == int(3));
+  static_assert(int(dim_s0_s0_s4::rank_dynamic) == int(2));
+  static_assert(int(dim_s0_s0_s4::ArgN0) == 0);
+  static_assert(int(dim_s0_s0_s4::ArgN1) == 0);
+  static_assert(int(dim_s0_s0_s4::ArgN2) == 4);
 
-  static_assert(int(dim_s0_s0_s0::rank) == int(3), "");
-  static_assert(int(dim_s0_s0_s0::rank_dynamic) == int(3), "");
+  static_assert(int(dim_s0_s0_s0::rank) == int(3));
+  static_assert(int(dim_s0_s0_s0::rank_dynamic) == int(3));
 
-  static_assert(int(dim_s0_s0_s0_s0::rank) == int(4), "");
-  static_assert(int(dim_s0_s0_s0_s0::rank_dynamic) == int(4), "");
+  static_assert(int(dim_s0_s0_s0_s0::rank) == int(4));
+  static_assert(int(dim_s0_s0_s0_s0::rank_dynamic) == int(4));
 
-  static_assert(int(dim_s0_s0_s0_s0_s0::rank) == int(5), "");
-  static_assert(int(dim_s0_s0_s0_s0_s0::rank_dynamic) == int(5), "");
+  static_assert(int(dim_s0_s0_s0_s0_s0::rank) == int(5));
+  static_assert(int(dim_s0_s0_s0_s0_s0::rank_dynamic) == int(5));
 
-  static_assert(int(dim_s0_s0_s0_s0_s0_s0::rank) == int(6), "");
-  static_assert(int(dim_s0_s0_s0_s0_s0_s0::rank_dynamic) == int(6), "");
+  static_assert(int(dim_s0_s0_s0_s0_s0_s0::rank) == int(6));
+  static_assert(int(dim_s0_s0_s0_s0_s0_s0::rank_dynamic) == int(6));
 
-  static_assert(int(dim_s0_s0_s0_s0_s0_s0_s0::rank) == int(7), "");
-  static_assert(int(dim_s0_s0_s0_s0_s0_s0_s0::rank_dynamic) == int(7), "");
+  static_assert(int(dim_s0_s0_s0_s0_s0_s0_s0::rank) == int(7));
+  static_assert(int(dim_s0_s0_s0_s0_s0_s0_s0::rank_dynamic) == int(7));
 
-  static_assert(int(dim_s0_s0_s0_s0_s0_s0_s0_s0::rank) == int(8), "");
-  static_assert(int(dim_s0_s0_s0_s0_s0_s0_s0_s0::rank_dynamic) == int(8), "");
+  static_assert(int(dim_s0_s0_s0_s0_s0_s0_s0_s0::rank) == int(8));
+  static_assert(int(dim_s0_s0_s0_s0_s0_s0_s0_s0::rank_dynamic) == int(8));
 
   dim_s0 d1(2, 3, 4, 5, 6, 7, 8, 9);
   dim_s0_s0 d2(2, 3, 4, 5, 6, 7, 8, 9);
@@ -514,11 +514,11 @@ void test_view_mapping() {
   {
     using namespace Kokkos::Impl;
 
-    static_assert(rank_dynamic<>::value == 0, "");
-    static_assert(rank_dynamic<1>::value == 0, "");
-    static_assert(rank_dynamic<0>::value == 1, "");
-    static_assert(rank_dynamic<0, 1>::value == 1, "");
-    static_assert(rank_dynamic<0, 0, 1>::value == 2, "");
+    static_assert(rank_dynamic<>::value == 0);
+    static_assert(rank_dynamic<1>::value == 0);
+    static_assert(rank_dynamic<0>::value == 1);
+    static_assert(rank_dynamic<0, 1>::value == 1);
+    static_assert(rank_dynamic<0, 0, 1>::value == 2);
   }
 
   {
@@ -529,54 +529,48 @@ void test_view_mapping() {
     using a_const_int_r1 = ViewArrayAnalysis<const int[]>;
     using a_const_int_r5 = ViewArrayAnalysis<const int* * [4][5][6]>;
 
-    static_assert(a_int_r1::dimension::rank == 1, "");
-    static_assert(a_int_r1::dimension::rank_dynamic == 1, "");
-    static_assert(a_int_r5::dimension::ArgN0 == 0, "");
-    static_assert(a_int_r5::dimension::ArgN1 == 0, "");
-    static_assert(a_int_r5::dimension::ArgN2 == 4, "");
-    static_assert(a_int_r5::dimension::ArgN3 == 5, "");
-    static_assert(a_int_r5::dimension::ArgN4 == 6, "");
-    static_assert(a_int_r5::dimension::ArgN5 == 1, "");
+    static_assert(a_int_r1::dimension::rank == 1);
+    static_assert(a_int_r1::dimension::rank_dynamic == 1);
+    static_assert(a_int_r5::dimension::ArgN0 == 0);
+    static_assert(a_int_r5::dimension::ArgN1 == 0);
+    static_assert(a_int_r5::dimension::ArgN2 == 4);
+    static_assert(a_int_r5::dimension::ArgN3 == 5);
+    static_assert(a_int_r5::dimension::ArgN4 == 6);
+    static_assert(a_int_r5::dimension::ArgN5 == 1);
 
     static_assert(
-        std::is_same<typename a_int_r1::dimension, ViewDimension<0> >::value,
-        "");
+        std::is_same<typename a_int_r1::dimension, ViewDimension<0> >::value);
     static_assert(
-        std::is_same<typename a_int_r1::non_const_value_type, int>::value, "");
+        std::is_same<typename a_int_r1::non_const_value_type, int>::value);
 
-    static_assert(a_const_int_r1::dimension::rank == 1, "");
-    static_assert(a_const_int_r1::dimension::rank_dynamic == 1, "");
+    static_assert(a_const_int_r1::dimension::rank == 1);
+    static_assert(a_const_int_r1::dimension::rank_dynamic == 1);
     static_assert(std::is_same<typename a_const_int_r1::dimension,
-                               ViewDimension<0> >::value,
-                  "");
-    static_assert(
-        std::is_same<typename a_const_int_r1::non_const_value_type, int>::value,
-        "");
+                               ViewDimension<0> >::value);
+    static_assert(std::is_same<typename a_const_int_r1::non_const_value_type,
+                               int>::value);
 
-    static_assert(a_const_int_r5::dimension::rank == 5, "");
-    static_assert(a_const_int_r5::dimension::rank_dynamic == 2, "");
+    static_assert(a_const_int_r5::dimension::rank == 5);
+    static_assert(a_const_int_r5::dimension::rank_dynamic == 2);
 
-    static_assert(a_const_int_r5::dimension::ArgN0 == 0, "");
-    static_assert(a_const_int_r5::dimension::ArgN1 == 0, "");
-    static_assert(a_const_int_r5::dimension::ArgN2 == 4, "");
-    static_assert(a_const_int_r5::dimension::ArgN3 == 5, "");
-    static_assert(a_const_int_r5::dimension::ArgN4 == 6, "");
-    static_assert(a_const_int_r5::dimension::ArgN5 == 1, "");
+    static_assert(a_const_int_r5::dimension::ArgN0 == 0);
+    static_assert(a_const_int_r5::dimension::ArgN1 == 0);
+    static_assert(a_const_int_r5::dimension::ArgN2 == 4);
+    static_assert(a_const_int_r5::dimension::ArgN3 == 5);
+    static_assert(a_const_int_r5::dimension::ArgN4 == 6);
+    static_assert(a_const_int_r5::dimension::ArgN5 == 1);
 
     static_assert(std::is_same<typename a_const_int_r5::dimension,
-                               ViewDimension<0, 0, 4, 5, 6> >::value,
-                  "");
-    static_assert(
-        std::is_same<typename a_const_int_r5::non_const_value_type, int>::value,
-        "");
+                               ViewDimension<0, 0, 4, 5, 6> >::value);
+    static_assert(std::is_same<typename a_const_int_r5::non_const_value_type,
+                               int>::value);
 
-    static_assert(a_int_r5::dimension::rank == 5, "");
-    static_assert(a_int_r5::dimension::rank_dynamic == 2, "");
+    static_assert(a_int_r5::dimension::rank == 5);
+    static_assert(a_int_r5::dimension::rank_dynamic == 2);
     static_assert(std::is_same<typename a_int_r5::dimension,
-                               ViewDimension<0, 0, 4, 5, 6> >::value,
-                  "");
+                               ViewDimension<0, 0, 4, 5, 6> >::value);
     static_assert(
-        std::is_same<typename a_int_r5::non_const_value_type, int>::value, "");
+        std::is_same<typename a_int_r5::non_const_value_type, int>::value);
   }
 
   {
@@ -587,15 +581,15 @@ void test_view_mapping() {
     // Dimensions of t_i4 are appended to the multdimensional array.
     using a_int_r5 = ViewArrayAnalysis<t_i4** * [3]>;
 
-    static_assert(a_int_r5::dimension::rank == 5, "");
-    static_assert(a_int_r5::dimension::rank_dynamic == 3, "");
-    static_assert(a_int_r5::dimension::ArgN0 == 0, "");
-    static_assert(a_int_r5::dimension::ArgN1 == 0, "");
-    static_assert(a_int_r5::dimension::ArgN2 == 0, "");
-    static_assert(a_int_r5::dimension::ArgN3 == 3, "");
-    static_assert(a_int_r5::dimension::ArgN4 == 4, "");
+    static_assert(a_int_r5::dimension::rank == 5);
+    static_assert(a_int_r5::dimension::rank_dynamic == 3);
+    static_assert(a_int_r5::dimension::ArgN0 == 0);
+    static_assert(a_int_r5::dimension::ArgN1 == 0);
+    static_assert(a_int_r5::dimension::ArgN2 == 0);
+    static_assert(a_int_r5::dimension::ArgN3 == 3);
+    static_assert(a_int_r5::dimension::ArgN4 == 4);
     static_assert(
-        std::is_same<typename a_int_r5::non_const_value_type, int>::value, "");
+        std::is_same<typename a_int_r5::non_const_value_type, int>::value);
   }
 
   {
@@ -603,71 +597,54 @@ void test_view_mapping() {
 
     using a_const_int_r1 = ViewDataAnalysis<const int[], void>;
 
-    static_assert(std::is_void<typename a_const_int_r1::specialize>::value, "");
+    static_assert(std::is_void<typename a_const_int_r1::specialize>::value);
     static_assert(std::is_same<typename a_const_int_r1::dimension,
-                               Kokkos::Impl::ViewDimension<0> >::value,
-                  "");
+                               Kokkos::Impl::ViewDimension<0> >::value);
 
     static_assert(
-        std::is_same<typename a_const_int_r1::type, const int*>::value, "");
+        std::is_same<typename a_const_int_r1::type, const int*>::value);
     static_assert(
-        std::is_same<typename a_const_int_r1::value_type, const int>::value,
-        "");
+        std::is_same<typename a_const_int_r1::value_type, const int>::value);
 
     static_assert(std::is_same<typename a_const_int_r1::scalar_array_type,
-                               const int*>::value,
-                  "");
+                               const int*>::value);
     static_assert(
-        std::is_same<typename a_const_int_r1::const_type, const int*>::value,
-        "");
+        std::is_same<typename a_const_int_r1::const_type, const int*>::value);
     static_assert(std::is_same<typename a_const_int_r1::const_value_type,
-                               const int>::value,
-                  "");
+                               const int>::value);
     static_assert(std::is_same<typename a_const_int_r1::const_scalar_array_type,
-                               const int*>::value,
-                  "");
+                               const int*>::value);
     static_assert(
-        std::is_same<typename a_const_int_r1::non_const_type, int*>::value, "");
-    static_assert(
-        std::is_same<typename a_const_int_r1::non_const_value_type, int>::value,
-        "");
+        std::is_same<typename a_const_int_r1::non_const_type, int*>::value);
+    static_assert(std::is_same<typename a_const_int_r1::non_const_value_type,
+                               int>::value);
 
     using a_const_int_r3 = ViewDataAnalysis<const int* * [4], void>;
 
-    static_assert(std::is_void<typename a_const_int_r3::specialize>::value, "");
+    static_assert(std::is_void<typename a_const_int_r3::specialize>::value);
 
     static_assert(std::is_same<typename a_const_int_r3::dimension,
-                               Kokkos::Impl::ViewDimension<0, 0, 4> >::value,
-                  "");
+                               Kokkos::Impl::ViewDimension<0, 0, 4> >::value);
 
     static_assert(
-        std::is_same<typename a_const_int_r3::type, const int* * [4]>::value,
-        "");
+        std::is_same<typename a_const_int_r3::type, const int* * [4]>::value);
     static_assert(
-        std::is_same<typename a_const_int_r3::value_type, const int>::value,
-        "");
+        std::is_same<typename a_const_int_r3::value_type, const int>::value);
     static_assert(std::is_same<typename a_const_int_r3::scalar_array_type,
-                               const int* * [4]>::value,
-                  "");
+                               const int* * [4]>::value);
     static_assert(std::is_same<typename a_const_int_r3::const_type,
-                               const int* * [4]>::value,
-                  "");
+                               const int* * [4]>::value);
     static_assert(std::is_same<typename a_const_int_r3::const_value_type,
-                               const int>::value,
-                  "");
+                               const int>::value);
     static_assert(std::is_same<typename a_const_int_r3::const_scalar_array_type,
-                               const int* * [4]>::value,
-                  "");
+                               const int* * [4]>::value);
     static_assert(std::is_same<typename a_const_int_r3::non_const_type,
-                               int* * [4]>::value,
-                  "");
-    static_assert(
-        std::is_same<typename a_const_int_r3::non_const_value_type, int>::value,
-        "");
+                               int* * [4]>::value);
+    static_assert(std::is_same<typename a_const_int_r3::non_const_value_type,
+                               int>::value);
     static_assert(
         std::is_same<typename a_const_int_r3::non_const_scalar_array_type,
-                     int* * [4]>::value,
-        "");
+                     int* * [4]>::value);
 
     // std::cout << "typeid( const int**[4] ).name() = " << typeid( const
     // int**[4] ).name() << std::endl;

--- a/core/unit_test/TestViewMapping_b.hpp
+++ b/core/unit_test/TestViewMapping_b.hpp
@@ -156,7 +156,7 @@ TEST(TEST_CATEGORY, view_mapping_assignable) {
     using dst_traits = Kokkos::ViewTraits<int, Kokkos::LayoutLeft, exec_space>;
     using src_traits = Kokkos::ViewTraits<int, Kokkos::LayoutRight, exec_space>;
     using mapping    = Kokkos::Impl::ViewMapping<dst_traits, src_traits, void>;
-    static_assert(mapping::is_assignable, "");
+    static_assert(mapping::is_assignable);
 
     Kokkos::View<int, Kokkos::LayoutRight, exec_space> src;
     Kokkos::View<int, Kokkos::LayoutLeft, exec_space> dst(src);
@@ -167,7 +167,7 @@ TEST(TEST_CATEGORY, view_mapping_assignable) {
     using dst_traits = Kokkos::ViewTraits<int, Kokkos::LayoutRight, exec_space>;
     using src_traits = Kokkos::ViewTraits<int, Kokkos::LayoutLeft, exec_space>;
     using mapping    = Kokkos::Impl::ViewMapping<dst_traits, src_traits, void>;
-    static_assert(mapping::is_assignable, "");
+    static_assert(mapping::is_assignable);
 
     Kokkos::View<int, Kokkos::LayoutLeft, exec_space> src;
     Kokkos::View<int, Kokkos::LayoutRight, exec_space> dst(src);
@@ -180,7 +180,7 @@ TEST(TEST_CATEGORY, view_mapping_assignable) {
     using src_traits =
         Kokkos::ViewTraits<int *, Kokkos::LayoutRight, exec_space>;
     using mapping = Kokkos::Impl::ViewMapping<dst_traits, src_traits, void>;
-    static_assert(mapping::is_assignable, "");
+    static_assert(mapping::is_assignable);
 
     Kokkos::View<int *, Kokkos::LayoutRight, exec_space> src;
     Kokkos::View<int *, Kokkos::LayoutLeft, exec_space> dst(src);
@@ -193,7 +193,7 @@ TEST(TEST_CATEGORY, view_mapping_assignable) {
     using src_traits =
         Kokkos::ViewTraits<int *, Kokkos::LayoutLeft, exec_space>;
     using mapping = Kokkos::Impl::ViewMapping<dst_traits, src_traits, void>;
-    static_assert(mapping::is_assignable, "");
+    static_assert(mapping::is_assignable);
 
     Kokkos::View<int *, Kokkos::LayoutLeft, exec_space> src;
     Kokkos::View<int *, Kokkos::LayoutRight, exec_space> dst(src);
@@ -206,7 +206,7 @@ TEST(TEST_CATEGORY, view_mapping_assignable) {
     using src_traits =
         Kokkos::ViewTraits<int **, Kokkos::LayoutRight, exec_space>;
     using mapping = Kokkos::Impl::ViewMapping<dst_traits, src_traits, void>;
-    static_assert(!mapping::is_assignable, "");
+    static_assert(!mapping::is_assignable);
   }
 
   {  // Assignment of rank-2 Right = Left
@@ -215,7 +215,7 @@ TEST(TEST_CATEGORY, view_mapping_assignable) {
     using src_traits =
         Kokkos::ViewTraits<int **, Kokkos::LayoutLeft, exec_space>;
     using mapping = Kokkos::Impl::ViewMapping<dst_traits, src_traits, void>;
-    static_assert(!mapping::is_assignable, "");
+    static_assert(!mapping::is_assignable);
   }
 }
 
@@ -226,7 +226,7 @@ TEST(TEST_CATEGORY, view_mapping_trivially_copyable) {
   using src_traits = dst_traits;
   using mapping    = Kokkos::Impl::ViewMapping<dst_traits, src_traits, void>;
 
-  static_assert(std::is_trivially_copyable<mapping>{}, "");
+  static_assert(std::is_trivially_copyable<mapping>{});
 }
 
 }  // namespace Test

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -29,200 +29,166 @@ __global__ void test_cuda_spaces_int_value(int *ptr) {
 
 TEST(cuda, space_access) {
   static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
-                                                Kokkos::HostSpace>::assignable,
-                "");
+                                                Kokkos::HostSpace>::assignable);
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
-                                      Kokkos::CudaHostPinnedSpace>::assignable,
-      "");
-
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
-                                                 Kokkos::CudaSpace>::assignable,
-                "");
-
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
-                                                 Kokkos::CudaSpace>::accessible,
-                "");
+                                      Kokkos::CudaHostPinnedSpace>::assignable);
 
   static_assert(
       !Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
-                                       Kokkos::CudaUVMSpace>::assignable,
-      "");
+                                       Kokkos::CudaSpace>::assignable);
+
+  static_assert(
+      !Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
+                                       Kokkos::CudaSpace>::accessible);
+
+  static_assert(
+      !Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
+                                       Kokkos::CudaUVMSpace>::assignable);
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
-                                      Kokkos::CudaUVMSpace>::accessible,
-      "");
+                                      Kokkos::CudaUVMSpace>::accessible);
 
   //--------------------------------------
 
   static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaSpace,
-                                                Kokkos::CudaSpace>::assignable,
-                "");
+                                                Kokkos::CudaSpace>::assignable);
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaSpace,
-                                      Kokkos::CudaUVMSpace>::assignable,
-      "");
+                                      Kokkos::CudaUVMSpace>::assignable);
+
+  static_assert(!Kokkos::Impl::MemorySpaceAccess<
+                Kokkos::CudaSpace, Kokkos::CudaHostPinnedSpace>::assignable);
+
+  static_assert(
+      Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaSpace,
+                                      Kokkos::CudaHostPinnedSpace>::accessible);
 
   static_assert(
       !Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaSpace,
-                                       Kokkos::CudaHostPinnedSpace>::assignable,
-      "");
+                                       Kokkos::HostSpace>::assignable);
 
   static_assert(
-      Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaSpace,
-                                      Kokkos::CudaHostPinnedSpace>::accessible,
-      "");
-
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaSpace,
-                                                 Kokkos::HostSpace>::assignable,
-                "");
-
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaSpace,
-                                                 Kokkos::HostSpace>::accessible,
-                "");
+      !Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaSpace,
+                                       Kokkos::HostSpace>::accessible);
 
   //--------------------------------------
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaUVMSpace,
-                                      Kokkos::CudaUVMSpace>::assignable,
-      "");
-
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaUVMSpace,
-                                                 Kokkos::CudaSpace>::assignable,
-                "");
-
-  static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaUVMSpace,
-                                                Kokkos::CudaSpace>::accessible,
-                "");
-
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaUVMSpace,
-                                                 Kokkos::HostSpace>::assignable,
-                "");
-
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaUVMSpace,
-                                                 Kokkos::HostSpace>::accessible,
-                "");
+                                      Kokkos::CudaUVMSpace>::assignable);
 
   static_assert(
       !Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaUVMSpace,
-                                       Kokkos::CudaHostPinnedSpace>::assignable,
-      "");
+                                       Kokkos::CudaSpace>::assignable);
+
+  static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaUVMSpace,
+                                                Kokkos::CudaSpace>::accessible);
+
+  static_assert(
+      !Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaUVMSpace,
+                                       Kokkos::HostSpace>::assignable);
+
+  static_assert(
+      !Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaUVMSpace,
+                                       Kokkos::HostSpace>::accessible);
+
+  static_assert(!Kokkos::Impl::MemorySpaceAccess<
+                Kokkos::CudaUVMSpace, Kokkos::CudaHostPinnedSpace>::assignable);
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaUVMSpace,
-                                      Kokkos::CudaHostPinnedSpace>::accessible,
-      "");
+                                      Kokkos::CudaHostPinnedSpace>::accessible);
 
   //--------------------------------------
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaHostPinnedSpace,
-                                      Kokkos::CudaHostPinnedSpace>::assignable,
-      "");
-
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaHostPinnedSpace,
-                                                 Kokkos::HostSpace>::assignable,
-                "");
-
-  static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaHostPinnedSpace,
-                                                Kokkos::HostSpace>::accessible,
-                "");
-
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaHostPinnedSpace,
-                                                 Kokkos::CudaSpace>::assignable,
-                "");
-
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaHostPinnedSpace,
-                                                 Kokkos::CudaSpace>::accessible,
-                "");
+                                      Kokkos::CudaHostPinnedSpace>::assignable);
 
   static_assert(
       !Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaHostPinnedSpace,
-                                       Kokkos::CudaUVMSpace>::assignable,
-      "");
+                                       Kokkos::HostSpace>::assignable);
+
+  static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaHostPinnedSpace,
+                                                Kokkos::HostSpace>::accessible);
+
+  static_assert(
+      !Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaHostPinnedSpace,
+                                       Kokkos::CudaSpace>::assignable);
+
+  static_assert(
+      !Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaHostPinnedSpace,
+                                       Kokkos::CudaSpace>::accessible);
+
+  static_assert(
+      !Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaHostPinnedSpace,
+                                       Kokkos::CudaUVMSpace>::assignable);
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaHostPinnedSpace,
-                                      Kokkos::CudaUVMSpace>::accessible,
-      "");
+                                      Kokkos::CudaUVMSpace>::accessible);
 
   //--------------------------------------
 
   static_assert(
-      !Kokkos::SpaceAccessibility<Kokkos::Cuda, Kokkos::HostSpace>::accessible,
-      "");
+      !Kokkos::SpaceAccessibility<Kokkos::Cuda, Kokkos::HostSpace>::accessible);
 
   static_assert(
-      Kokkos::SpaceAccessibility<Kokkos::Cuda, Kokkos::CudaSpace>::accessible,
-      "");
+      Kokkos::SpaceAccessibility<Kokkos::Cuda, Kokkos::CudaSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<Kokkos::Cuda,
-                                           Kokkos::CudaUVMSpace>::accessible,
-                "");
+                                           Kokkos::CudaUVMSpace>::accessible);
 
   static_assert(
       Kokkos::SpaceAccessibility<Kokkos::Cuda,
-                                 Kokkos::CudaHostPinnedSpace>::accessible,
-      "");
+                                 Kokkos::CudaHostPinnedSpace>::accessible);
 
   static_assert(!Kokkos::SpaceAccessibility<Kokkos::HostSpace,
-                                            Kokkos::CudaSpace>::accessible,
-                "");
+                                            Kokkos::CudaSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<Kokkos::HostSpace,
-                                           Kokkos::CudaUVMSpace>::accessible,
-                "");
+                                           Kokkos::CudaUVMSpace>::accessible);
 
   static_assert(
       Kokkos::SpaceAccessibility<Kokkos::HostSpace,
-                                 Kokkos::CudaHostPinnedSpace>::accessible,
-      "");
+                                 Kokkos::CudaHostPinnedSpace>::accessible);
 
   static_assert(std::is_same<Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::Space,
-                             Kokkos::HostSpace>::value,
-                "");
+                             Kokkos::HostSpace>::value);
 
   static_assert(
       std::is_same<Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::Space,
                    Kokkos::Device<Kokkos::HostSpace::execution_space,
-                                  Kokkos::CudaUVMSpace>>::value,
-      "");
+                                  Kokkos::CudaUVMSpace>>::value);
 
   static_assert(
       std::is_same<Kokkos::Impl::HostMirror<Kokkos::CudaHostPinnedSpace>::Space,
-                   Kokkos::CudaHostPinnedSpace>::value,
-      "");
+                   Kokkos::CudaHostPinnedSpace>::value);
 
   static_assert(std::is_same<Kokkos::Device<Kokkos::HostSpace::execution_space,
                                             Kokkos::CudaUVMSpace>,
                              Kokkos::Device<Kokkos::HostSpace::execution_space,
-                                            Kokkos::CudaUVMSpace>>::value,
-                "");
+                                            Kokkos::CudaUVMSpace>>::value);
 
   static_assert(
       Kokkos::SpaceAccessibility<Kokkos::Impl::HostMirror<Kokkos::Cuda>::Space,
-                                 Kokkos::HostSpace>::accessible,
-      "");
+                                 Kokkos::HostSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<
-                    Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::Space,
-                    Kokkos::HostSpace>::accessible,
-                "");
+                Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::Space,
+                Kokkos::HostSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<
-                    Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::Space,
-                    Kokkos::HostSpace>::accessible,
-                "");
+                Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::Space,
+                Kokkos::HostSpace>::accessible);
 
-  static_assert(
-      Kokkos::SpaceAccessibility<
-          Kokkos::Impl::HostMirror<Kokkos::CudaHostPinnedSpace>::Space,
-          Kokkos::HostSpace>::accessible,
-      "");
+  static_assert(Kokkos::SpaceAccessibility<
+                Kokkos::Impl::HostMirror<Kokkos::CudaHostPinnedSpace>::Space,
+                Kokkos::HostSpace>::accessible);
 #ifdef KOKKOS_ENABLE_CUDA_UVM
   using uvm_view = Kokkos::View<double *, Kokkos::CudaUVMSpace>;
   static_assert(std::is_same<uvm_view::HostMirror::execution_space,

--- a/core/unit_test/default/TestDefaultDeviceType.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType.cpp
@@ -32,16 +32,13 @@ TEST(TEST_CATEGORY, host_space_access) {
       Kokkos::Impl::HostMirror<Kokkos::DefaultExecutionSpace>::Space;
 
   static_assert(Kokkos::SpaceAccessibility<host_exec_space,
-                                           Kokkos::HostSpace>::accessible,
-                "");
+                                           Kokkos::HostSpace>::accessible);
 
   static_assert(
-      Kokkos::SpaceAccessibility<device_space, Kokkos::HostSpace>::accessible,
-      "");
+      Kokkos::SpaceAccessibility<device_space, Kokkos::HostSpace>::accessible);
 
   static_assert(
-      Kokkos::SpaceAccessibility<mirror_space, Kokkos::HostSpace>::accessible,
-      "");
+      Kokkos::SpaceAccessibility<mirror_space, Kokkos::HostSpace>::accessible);
 }
 
 }  // namespace Test

--- a/core/unit_test/hip/TestHIP_Spaces.cpp
+++ b/core/unit_test/hip/TestHIP_Spaces.cpp
@@ -29,198 +29,164 @@ __global__ void test_hip_spaces_int_value(int *ptr) {
 
 TEST(hip, space_access) {
   static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
-                                                Kokkos::HostSpace>::assignable,
-                "");
+                                                Kokkos::HostSpace>::assignable);
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
-                                      Kokkos::HIPHostPinnedSpace>::assignable,
-      "");
+                                      Kokkos::HIPHostPinnedSpace>::assignable);
 
   static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
-                                                 Kokkos::HIPSpace>::assignable,
-                "");
+                                                 Kokkos::HIPSpace>::assignable);
 
   static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
-                                                 Kokkos::HIPSpace>::accessible,
-                "");
+                                                 Kokkos::HIPSpace>::accessible);
 
   static_assert(
       !Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
-                                       Kokkos::HIPManagedSpace>::assignable,
-      "");
+                                       Kokkos::HIPManagedSpace>::assignable);
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
-                                      Kokkos::HIPManagedSpace>::accessible,
-      "");
+                                      Kokkos::HIPManagedSpace>::accessible);
 
   //--------------------------------------
 
   static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPSpace,
-                                                Kokkos::HIPSpace>::assignable,
-                "");
+                                                Kokkos::HIPSpace>::assignable);
 
   static_assert(
       !Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPSpace,
-                                       Kokkos::HIPHostPinnedSpace>::assignable,
-      "");
+                                       Kokkos::HIPHostPinnedSpace>::assignable);
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPSpace,
-                                      Kokkos::HIPHostPinnedSpace>::accessible,
-      "");
+                                      Kokkos::HIPHostPinnedSpace>::accessible);
 
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPSpace,
-                                                 Kokkos::HostSpace>::assignable,
-                "");
+  static_assert(
+      !Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPSpace,
+                                       Kokkos::HostSpace>::assignable);
 
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPSpace,
-                                                 Kokkos::HostSpace>::accessible,
-                "");
+  static_assert(
+      !Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPSpace,
+                                       Kokkos::HostSpace>::accessible);
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPSpace,
-                                      Kokkos::HIPManagedSpace>::assignable,
-      "");
+                                      Kokkos::HIPManagedSpace>::assignable);
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPSpace,
-                                      Kokkos::HIPManagedSpace>::accessible,
-      "");
+                                      Kokkos::HIPManagedSpace>::accessible);
 
   //--------------------------------------
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPHostPinnedSpace,
-                                      Kokkos::HIPHostPinnedSpace>::assignable,
-      "");
-
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPHostPinnedSpace,
-                                                 Kokkos::HostSpace>::assignable,
-                "");
-
-  static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPHostPinnedSpace,
-                                                Kokkos::HostSpace>::accessible,
-                "");
-
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPHostPinnedSpace,
-                                                 Kokkos::HIPSpace>::assignable,
-                "");
-
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPHostPinnedSpace,
-                                                 Kokkos::HIPSpace>::accessible,
-                "");
+                                      Kokkos::HIPHostPinnedSpace>::assignable);
 
   static_assert(
       !Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPHostPinnedSpace,
-                                       Kokkos::HIPManagedSpace>::assignable,
-      "");
+                                       Kokkos::HostSpace>::assignable);
+
+  static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPHostPinnedSpace,
+                                                Kokkos::HostSpace>::accessible);
+
+  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPHostPinnedSpace,
+                                                 Kokkos::HIPSpace>::assignable);
+
+  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPHostPinnedSpace,
+                                                 Kokkos::HIPSpace>::accessible);
+
+  static_assert(
+      !Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPHostPinnedSpace,
+                                       Kokkos::HIPManagedSpace>::assignable);
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPHostPinnedSpace,
-                                      Kokkos::HIPManagedSpace>::accessible,
-      "");
+                                      Kokkos::HIPManagedSpace>::accessible);
 
   //--------------------------------------
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPManagedSpace,
-                                      Kokkos::HIPManagedSpace>::assignable,
-      "");
-
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPManagedSpace,
-                                                 Kokkos::HostSpace>::assignable,
-                "");
-
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPManagedSpace,
-                                                 Kokkos::HostSpace>::accessible,
-                "");
-
-  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPManagedSpace,
-                                                 Kokkos::HIPSpace>::assignable,
-                "");
-
-  static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPManagedSpace,
-                                                Kokkos::HIPSpace>::accessible,
-                "");
+                                      Kokkos::HIPManagedSpace>::assignable);
 
   static_assert(
       !Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPManagedSpace,
-                                       Kokkos::HIPHostPinnedSpace>::assignable,
-      "");
+                                       Kokkos::HostSpace>::assignable);
+
+  static_assert(
+      !Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPManagedSpace,
+                                       Kokkos::HostSpace>::accessible);
+
+  static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPManagedSpace,
+                                                 Kokkos::HIPSpace>::assignable);
+
+  static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPManagedSpace,
+                                                Kokkos::HIPSpace>::accessible);
+
+  static_assert(
+      !Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPManagedSpace,
+                                       Kokkos::HIPHostPinnedSpace>::assignable);
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::HIPManagedSpace,
-                                      Kokkos::HIPHostPinnedSpace>::accessible,
-      "");
+                                      Kokkos::HIPHostPinnedSpace>::accessible);
 
   //--------------------------------------
 
   static_assert(
-      !Kokkos::SpaceAccessibility<Kokkos::HIP, Kokkos::HostSpace>::accessible,
-      "");
+      !Kokkos::SpaceAccessibility<Kokkos::HIP, Kokkos::HostSpace>::accessible);
 
   static_assert(
-      Kokkos::SpaceAccessibility<Kokkos::HIP, Kokkos::HIPSpace>::accessible,
-      "");
+      Kokkos::SpaceAccessibility<Kokkos::HIP, Kokkos::HIPSpace>::accessible);
 
   static_assert(
       Kokkos::SpaceAccessibility<Kokkos::HIP,
-                                 Kokkos::HIPHostPinnedSpace>::accessible,
-      "");
+                                 Kokkos::HIPHostPinnedSpace>::accessible);
 
-  static_assert(Kokkos::SpaceAccessibility<Kokkos::HIP,
-                                           Kokkos::HIPManagedSpace>::accessible,
-                "");
+  static_assert(
+      Kokkos::SpaceAccessibility<Kokkos::HIP,
+                                 Kokkos::HIPManagedSpace>::accessible);
 
   static_assert(!Kokkos::SpaceAccessibility<Kokkos::HostSpace,
-                                            Kokkos::HIPSpace>::accessible,
-                "");
+                                            Kokkos::HIPSpace>::accessible);
 
   static_assert(
       Kokkos::SpaceAccessibility<Kokkos::HostSpace,
-                                 Kokkos::HIPHostPinnedSpace>::accessible,
-      "");
+                                 Kokkos::HIPHostPinnedSpace>::accessible);
 
-  static_assert(Kokkos::SpaceAccessibility<Kokkos::HostSpace,
-                                           Kokkos::HIPManagedSpace>::accessible,
-                "");
+  static_assert(
+      Kokkos::SpaceAccessibility<Kokkos::HostSpace,
+                                 Kokkos::HIPManagedSpace>::accessible);
 
   static_assert(std::is_same<Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Space,
-                             Kokkos::HostSpace>::value,
-                "");
+                             Kokkos::HostSpace>::value);
 
   static_assert(
       std::is_same<Kokkos::Impl::HostMirror<Kokkos::HIPHostPinnedSpace>::Space,
-                   Kokkos::HIPHostPinnedSpace>::value,
-      "");
+                   Kokkos::HIPHostPinnedSpace>::value);
 
   static_assert(
       std::is_same<Kokkos::Impl::HostMirror<Kokkos::HIPManagedSpace>::Space,
                    Kokkos::Device<Kokkos::HostSpace::execution_space,
-                                  Kokkos::HIPManagedSpace>>::value,
-      "");
+                                  Kokkos::HIPManagedSpace>>::value);
 
   static_assert(
       Kokkos::SpaceAccessibility<Kokkos::Impl::HostMirror<Kokkos::HIP>::Space,
-                                 Kokkos::HostSpace>::accessible,
-      "");
+                                 Kokkos::HostSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<
-                    Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Space,
-                    Kokkos::HostSpace>::accessible,
-                "");
+                Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Space,
+                Kokkos::HostSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<
-                    Kokkos::Impl::HostMirror<Kokkos::HIPHostPinnedSpace>::Space,
-                    Kokkos::HostSpace>::accessible,
-                "");
+                Kokkos::Impl::HostMirror<Kokkos::HIPHostPinnedSpace>::Space,
+                Kokkos::HostSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<
-                    Kokkos::Impl::HostMirror<Kokkos::HIPManagedSpace>::Space,
-                    Kokkos::HostSpace>::accessible,
-                "");
+                Kokkos::Impl::HostMirror<Kokkos::HIPManagedSpace>::Space,
+                Kokkos::HostSpace>::accessible);
 }
 
 template <class MemSpace, class ExecSpace>

--- a/core/unit_test/sycl/TestSYCL_Spaces.cpp
+++ b/core/unit_test/sycl/TestSYCL_Spaces.cpp
@@ -21,235 +21,192 @@ namespace Test {
 
 TEST(sycl, space_access) {
   static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
-                                                Kokkos::HostSpace>::assignable,
-                "");
+                                                Kokkos::HostSpace>::assignable);
 
   static_assert(Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::HostSpace,
-                    Kokkos::Experimental::SYCLHostUSMSpace>::assignable,
-                "");
+                Kokkos::HostSpace,
+                Kokkos::Experimental::SYCLHostUSMSpace>::assignable);
 
   static_assert(!Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::HostSpace,
-                    Kokkos::Experimental::SYCLDeviceUSMSpace>::assignable,
-                "");
+                Kokkos::HostSpace,
+                Kokkos::Experimental::SYCLDeviceUSMSpace>::assignable);
 
   static_assert(!Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::HostSpace,
-                    Kokkos::Experimental::SYCLDeviceUSMSpace>::accessible,
-                "");
+                Kokkos::HostSpace,
+                Kokkos::Experimental::SYCLDeviceUSMSpace>::accessible);
 
   static_assert(!Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::HostSpace,
-                    Kokkos::Experimental::SYCLSharedUSMSpace>::assignable,
-                "");
+                Kokkos::HostSpace,
+                Kokkos::Experimental::SYCLSharedUSMSpace>::assignable);
 
   static_assert(Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::HostSpace,
-                    Kokkos::Experimental::SYCLSharedUSMSpace>::accessible,
-                "");
+                Kokkos::HostSpace,
+                Kokkos::Experimental::SYCLSharedUSMSpace>::accessible);
 
   //--------------------------------------
 
   static_assert(Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::Experimental::SYCLDeviceUSMSpace,
-                    Kokkos::Experimental::SYCLDeviceUSMSpace>::assignable,
-                "");
+                Kokkos::Experimental::SYCLDeviceUSMSpace,
+                Kokkos::Experimental::SYCLDeviceUSMSpace>::assignable);
 
   static_assert(Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::Experimental::SYCLDeviceUSMSpace,
-                    Kokkos::Experimental::SYCLSharedUSMSpace>::assignable,
-                "");
+                Kokkos::Experimental::SYCLDeviceUSMSpace,
+                Kokkos::Experimental::SYCLSharedUSMSpace>::assignable);
 
   static_assert(!Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::Experimental::SYCLDeviceUSMSpace,
-                    Kokkos::Experimental::SYCLHostUSMSpace>::assignable,
-                "");
+                Kokkos::Experimental::SYCLDeviceUSMSpace,
+                Kokkos::Experimental::SYCLHostUSMSpace>::assignable);
 
   static_assert(Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::Experimental::SYCLDeviceUSMSpace,
-                    Kokkos::Experimental::SYCLHostUSMSpace>::accessible,
-                "");
+                Kokkos::Experimental::SYCLDeviceUSMSpace,
+                Kokkos::Experimental::SYCLHostUSMSpace>::accessible);
 
   static_assert(
       !Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::SYCLDeviceUSMSpace,
-                                       Kokkos::HostSpace>::assignable,
-      "");
+                                       Kokkos::HostSpace>::assignable);
 
   static_assert(
       !Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::SYCLDeviceUSMSpace,
-                                       Kokkos::HostSpace>::accessible,
-      "");
+                                       Kokkos::HostSpace>::accessible);
 
   //--------------------------------------
 
   static_assert(Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::Experimental::SYCLSharedUSMSpace,
-                    Kokkos::Experimental::SYCLSharedUSMSpace>::assignable,
-                "");
+                Kokkos::Experimental::SYCLSharedUSMSpace,
+                Kokkos::Experimental::SYCLSharedUSMSpace>::assignable);
 
   static_assert(!Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::Experimental::SYCLSharedUSMSpace,
-                    Kokkos::Experimental::SYCLDeviceUSMSpace>::assignable,
-                "");
+                Kokkos::Experimental::SYCLSharedUSMSpace,
+                Kokkos::Experimental::SYCLDeviceUSMSpace>::assignable);
 
   static_assert(Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::Experimental::SYCLSharedUSMSpace,
-                    Kokkos::Experimental::SYCLDeviceUSMSpace>::accessible,
-                "");
+                Kokkos::Experimental::SYCLSharedUSMSpace,
+                Kokkos::Experimental::SYCLDeviceUSMSpace>::accessible);
 
   static_assert(
       !Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::SYCLSharedUSMSpace,
-                                       Kokkos::HostSpace>::assignable,
-      "");
+                                       Kokkos::HostSpace>::assignable);
 
   static_assert(
       !Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::SYCLSharedUSMSpace,
-                                       Kokkos::HostSpace>::accessible,
-      "");
+                                       Kokkos::HostSpace>::accessible);
 
   static_assert(!Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::Experimental::SYCLSharedUSMSpace,
-                    Kokkos::Experimental::SYCLHostUSMSpace>::assignable,
-                "");
+                Kokkos::Experimental::SYCLSharedUSMSpace,
+                Kokkos::Experimental::SYCLHostUSMSpace>::assignable);
 
   static_assert(Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::Experimental::SYCLSharedUSMSpace,
-                    Kokkos::Experimental::SYCLHostUSMSpace>::accessible,
-                "");
+                Kokkos::Experimental::SYCLSharedUSMSpace,
+                Kokkos::Experimental::SYCLHostUSMSpace>::accessible);
 
   //--------------------------------------
 
   static_assert(Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::Experimental::SYCLHostUSMSpace,
-                    Kokkos::Experimental::SYCLHostUSMSpace>::assignable,
-                "");
+                Kokkos::Experimental::SYCLHostUSMSpace,
+                Kokkos::Experimental::SYCLHostUSMSpace>::assignable);
 
   static_assert(
       !Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::SYCLHostUSMSpace,
-                                       Kokkos::HostSpace>::assignable,
-      "");
+                                       Kokkos::HostSpace>::assignable);
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::SYCLHostUSMSpace,
-                                      Kokkos::HostSpace>::accessible,
-      "");
+                                      Kokkos::HostSpace>::accessible);
 
   static_assert(!Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::Experimental::SYCLHostUSMSpace,
-                    Kokkos::Experimental::SYCLDeviceUSMSpace>::assignable,
-                "");
+                Kokkos::Experimental::SYCLHostUSMSpace,
+                Kokkos::Experimental::SYCLDeviceUSMSpace>::assignable);
 
   static_assert(!Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::Experimental::SYCLHostUSMSpace,
-                    Kokkos::Experimental::SYCLDeviceUSMSpace>::accessible,
-                "");
+                Kokkos::Experimental::SYCLHostUSMSpace,
+                Kokkos::Experimental::SYCLDeviceUSMSpace>::accessible);
 
   static_assert(!Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::Experimental::SYCLHostUSMSpace,
-                    Kokkos::Experimental::SYCLSharedUSMSpace>::assignable,
-                "");
+                Kokkos::Experimental::SYCLHostUSMSpace,
+                Kokkos::Experimental::SYCLSharedUSMSpace>::assignable);
 
   static_assert(Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::Experimental::SYCLHostUSMSpace,
-                    Kokkos::Experimental::SYCLSharedUSMSpace>::accessible,
-                "");
+                Kokkos::Experimental::SYCLHostUSMSpace,
+                Kokkos::Experimental::SYCLSharedUSMSpace>::accessible);
 
   //--------------------------------------
 
   static_assert(!Kokkos::SpaceAccessibility<Kokkos::Experimental::SYCL,
-                                            Kokkos::HostSpace>::accessible,
-                "");
+                                            Kokkos::HostSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<
-                    Kokkos::Experimental::SYCL,
-                    Kokkos::Experimental::SYCLDeviceUSMSpace>::accessible,
-                "");
+                Kokkos::Experimental::SYCL,
+                Kokkos::Experimental::SYCLDeviceUSMSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<
-                    Kokkos::Experimental::SYCL,
-                    Kokkos::Experimental::SYCLSharedUSMSpace>::accessible,
-                "");
+                Kokkos::Experimental::SYCL,
+                Kokkos::Experimental::SYCLSharedUSMSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<
-                    Kokkos::Experimental::SYCL,
-                    Kokkos::Experimental::SYCLHostUSMSpace>::accessible,
-                "");
+                Kokkos::Experimental::SYCL,
+                Kokkos::Experimental::SYCLHostUSMSpace>::accessible);
 
   static_assert(!Kokkos::SpaceAccessibility<
-                    Kokkos::HostSpace,
-                    Kokkos::Experimental::SYCLDeviceUSMSpace>::accessible,
-                "");
+                Kokkos::HostSpace,
+                Kokkos::Experimental::SYCLDeviceUSMSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<
-                    Kokkos::HostSpace,
-                    Kokkos::Experimental::SYCLSharedUSMSpace>::accessible,
-                "");
+                Kokkos::HostSpace,
+                Kokkos::Experimental::SYCLSharedUSMSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<
-                    Kokkos::HostSpace,
-                    Kokkos::Experimental::SYCLHostUSMSpace>::accessible,
-                "");
+                Kokkos::HostSpace,
+                Kokkos::Experimental::SYCLHostUSMSpace>::accessible);
 
   static_assert(
       std::is_same<Kokkos::Impl::HostMirror<
                        Kokkos::Experimental::SYCLDeviceUSMSpace>::Space,
-                   Kokkos::HostSpace>::value,
-      "");
+                   Kokkos::HostSpace>::value);
 
   static_assert(
       std::is_same<
           Kokkos::Impl::HostMirror<
               Kokkos::Experimental::SYCLSharedUSMSpace>::Space,
           Kokkos::Device<Kokkos::HostSpace::execution_space,
-                         Kokkos::Experimental::SYCLSharedUSMSpace>>::value,
-      "");
+                         Kokkos::Experimental::SYCLSharedUSMSpace>>::value);
 
   static_assert(
       Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::SYCLHostUSMSpace,
-                                      Kokkos::HostSpace>::accessible,
-      "");
+                                      Kokkos::HostSpace>::accessible);
 
   static_assert(Kokkos::Impl::MemorySpaceAccess<
-                    Kokkos::HostSpace,
-                    Kokkos::Experimental::SYCLHostUSMSpace>::accessible,
-                "");
+                Kokkos::HostSpace,
+                Kokkos::Experimental::SYCLHostUSMSpace>::accessible);
 
   static_assert(std::is_same<Kokkos::Impl::HostMirror<
                                  Kokkos::Experimental::SYCLHostUSMSpace>::Space,
-                             Kokkos::Experimental::SYCLHostUSMSpace>::value,
-                "");
+                             Kokkos::Experimental::SYCLHostUSMSpace>::value);
 
   static_assert(
       std::is_same<
           Kokkos::Device<Kokkos::HostSpace::execution_space,
                          Kokkos::Experimental::SYCLSharedUSMSpace>,
           Kokkos::Device<Kokkos::HostSpace::execution_space,
-                         Kokkos::Experimental::SYCLSharedUSMSpace>>::value,
-      "");
+                         Kokkos::Experimental::SYCLSharedUSMSpace>>::value);
 
   static_assert(Kokkos::SpaceAccessibility<
-                    Kokkos::Impl::HostMirror<Kokkos::Experimental::SYCL>::Space,
-                    Kokkos::HostSpace>::accessible,
-                "");
+                Kokkos::Impl::HostMirror<Kokkos::Experimental::SYCL>::Space,
+                Kokkos::HostSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<
-                    Kokkos::Impl::HostMirror<
-                        Kokkos::Experimental::SYCLDeviceUSMSpace>::Space,
-                    Kokkos::HostSpace>::accessible,
-                "");
+                Kokkos::Impl::HostMirror<
+                    Kokkos::Experimental::SYCLDeviceUSMSpace>::Space,
+                Kokkos::HostSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<
-                    Kokkos::Impl::HostMirror<
-                        Kokkos::Experimental::SYCLSharedUSMSpace>::Space,
-                    Kokkos::HostSpace>::accessible,
-                "");
+                Kokkos::Impl::HostMirror<
+                    Kokkos::Experimental::SYCLSharedUSMSpace>::Space,
+                Kokkos::HostSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<
-                    Kokkos::Impl::HostMirror<
-                        Kokkos::Experimental::SYCLHostUSMSpace>::Space,
-                    Kokkos::HostSpace>::accessible,
-                "");
+                Kokkos::Impl::HostMirror<
+                    Kokkos::Experimental::SYCLHostUSMSpace>::Space,
+                Kokkos::HostSpace>::accessible);
 }
 
 TEST(sycl, uvm) {

--- a/core/unit_test/tools/TestProfilingSection.cpp
+++ b/core/unit_test/tools/TestProfilingSection.cpp
@@ -108,8 +108,8 @@ TEST(defaultdevicetype, profiling_section) {
 }
 
 using Kokkos::Profiling::ProfilingSection;
-static_assert(!std::is_default_constructible<ProfilingSection>::value, "");
-static_assert(!std::is_copy_constructible<ProfilingSection>::value, "");
-static_assert(!std::is_move_constructible<ProfilingSection>::value, "");
-static_assert(!std::is_copy_assignable<ProfilingSection>::value, "");
-static_assert(!std::is_move_assignable<ProfilingSection>::value, "");
+static_assert(!std::is_default_constructible<ProfilingSection>::value);
+static_assert(!std::is_copy_constructible<ProfilingSection>::value);
+static_assert(!std::is_move_constructible<ProfilingSection>::value);
+static_assert(!std::is_copy_assignable<ProfilingSection>::value);
+static_assert(!std::is_move_assignable<ProfilingSection>::value);


### PR DESCRIPTION
Follow-up to https://github.com/kokkos/kokkos/pull/6543#discussion_r1378738193.
This pull request removes all `static_assert`s with an empty error message ~~and replaces `KOKKOS_IMPL_DO_NOT_USE_PRINTF` with `Kokkos::printf` for the few places we introduced it after the initial cleanup~~.