### PR TITLE
Simplify fence functions in the Threads backend

### DIFF
--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -39,14 +39,6 @@ static_assert(false,
 /*--------------------------------------------------------------------------*/
 
 namespace Kokkos {
-namespace Impl {
-enum class fence_is_static { yes, no };
-}  // namespace Impl
-}  // namespace Kokkos
-
-/*--------------------------------------------------------------------------*/
-
-namespace Kokkos {
 
 /** \brief  Execution space for a pool of C++11 threads on a CPU. */
 class Threads {

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -254,7 +254,7 @@ int ThreadsInternal::in_parallel() {
          (s_threads_process.m_pool_base || !is_process());
 }
 void ThreadsInternal::fence() {
-  fence("Kokkos::ThreadsInternal::fence : Unnamed Instance Fence");
+  fence("Kokkos::ThreadsInternal::fence: Unnamed Instance Fence");
 }
 void ThreadsInternal::fence(const std::string &name) {
   Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Threads>(

--- a/core/src/Threads/Kokkos_Threads_Instance.hpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.hpp
@@ -405,11 +405,7 @@ class ThreadsInternal {
   static int in_parallel();
   static void fence();
   static void fence(const std::string &);
-  static void internal_fence(
-      Impl::fence_is_static is_static = Impl::fence_is_static::yes);
-  static void internal_fence(
-      const std::string &,
-      Impl::fence_is_static is_static = Impl::fence_is_static::yes);
+  static void internal_fence();
 
   /* Dynamic Scheduling related functionality */
   // Initialize the work range for this thread
@@ -572,7 +568,11 @@ inline void Threads::print_configuration(std::ostream &os, bool verbose) const {
 }
 
 inline void Threads::impl_static_fence(const std::string &name) {
-  Impl::ThreadsInternal::internal_fence(name, Impl::fence_is_static::yes);
+  Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Threads>(
+      name,
+      Kokkos::Tools::Experimental::SpecialSynchronizationCases::
+          GlobalDeviceSynchronization,
+      Impl::ThreadsInternal::internal_fence);
 }
 } /* namespace Kokkos */
 


### PR DESCRIPTION
Rework fencing in the Threads backend. Currently, we use an `enum` to call the right profiling event in `internal_fence`. The profiling event calls a lambda function defined inside `internal_fence`. This PR removes the enum and move the profiling events to the `fence` and `impl_static_fence` functions. The profiling events now call `internal_fence` which only contains the fencing logic.
This PR also changes the profiling message in `ThreadsInternal::fence()` from `Kokkos::ThreadsInternal::fence: Unnamed Static Fence` to `Kokkos::ThreadsInternal::fence: Unnamed Instance Fence`