### PR TITLE
view: restore constexprness

### DIFF
--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -414,10 +414,11 @@ union SharedAllocationTracker {
     m_record_bits = DO_NOT_DEREF_FLAG;
   }
 
-  // Copy:
+  //! Destructor. Current problem: a constexpr destructor is only allowed from C++20 onwards.
   KOKKOS_FORCEINLINE_FUNCTION
-  ~SharedAllocationTracker(){KOKKOS_IMPL_SHARED_ALLOCATION_TRACKER_DECREMENT}
+  constexpr ~SharedAllocationTracker(){KOKKOS_IMPL_SHARED_ALLOCATION_TRACKER_DECREMENT}
 
+  //! Constructor.
   KOKKOS_FORCEINLINE_FUNCTION constexpr SharedAllocationTracker()
       : m_record_bits(DO_NOT_DEREF_FLAG) {}
 

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3133,16 +3133,12 @@ class ViewMapping<
 
   using handle_type = typename ViewDataHandle<Traits>::handle_type;
 
-  handle_type m_impl_handle;
+  handle_type m_impl_handle = nullptr;
   offset_type m_impl_offset;
 
  private:
   template <class, class...>
   friend class ViewMapping;
-
-  KOKKOS_INLINE_FUNCTION
-  ViewMapping(const handle_type& arg_handle, const offset_type& arg_offset)
-      : m_impl_handle(arg_handle), m_impl_offset(arg_offset) {}
 
  public:
   using printable_label_typedef = void;
@@ -3350,7 +3346,7 @@ class ViewMapping<
   //----------------------------------------
 
   KOKKOS_DEFAULTED_FUNCTION ~ViewMapping() = default;
-  KOKKOS_INLINE_FUNCTION ViewMapping() : m_impl_handle(), m_impl_offset() {}
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping()  = default;
 
   KOKKOS_DEFAULTED_FUNCTION ViewMapping(const ViewMapping&) = default;
   KOKKOS_DEFAULTED_FUNCTION ViewMapping& operator=(const ViewMapping&) =

--- a/core/src/impl/Kokkos_ViewTracker.hpp
+++ b/core/src/impl/Kokkos_ViewTracker.hpp
@@ -42,8 +42,8 @@ struct ViewTracker {
 
   track_type m_tracker;
 
-  KOKKOS_INLINE_FUNCTION
-  ViewTracker() : m_tracker() {}
+  KOKKOS_DEFAULTED_FUNCTION
+  ViewTracker() = default;
 
   KOKKOS_INLINE_FUNCTION
   ViewTracker(const ViewTracker& vt) noexcept

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -1235,6 +1235,10 @@ KOKKOS_ADD_EXECUTABLE_AND_TEST(
   ARGS "one 2 THREE"
 )
 
+KOKKOS_ADD_EXECUTABLE_AND_TEST( TestConstexpr
+  SOURCES TestConstexpr.cpp UnitTestMainInit.cpp
+)
+
 # This test is not properly set up to run within Trilinos
 if (NOT KOKKOS_HAS_TRILINOS)
   SET_SOURCE_FILES_PROPERTIES(UnitTest_DeviceAndThreads.cpp PROPERTIES LANGUAGE ${KOKKOS_COMPILE_LANGUAGE})

--- a/core/unit_test/TestConstexpr.cpp
+++ b/core/unit_test/TestConstexpr.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+
+constexpr size_t size = 5;
+
+using device_type     = Kokkos::View<int*>::device_type;
+using execution_space = typename device_type::execution_space;
+using view_t          = Kokkos::View<double[size], execution_space>;
+
+static const view_t my_view; // needed otherwise I get incomplete type for ViewTracker... wtf
+
+using view_tracker_t  = Kokkos::Impl::ViewTracker<view_t>;
+using track_t         = typename view_tracker_t::track_type;
+using map_t           = Kokkos::Impl::ViewMapping<typename view_t::traits, typename view_t::traits::specialize>;
+
+/// Can be replaced by lambda defined inside of a @c static_assert once @c c++20 is available.
+/// @todo Do something meaningful with the @c track object.
+constexpr auto test_SharedAllocationTracker()
+{
+    track_t track;
+    return true;
+}
+
+TEST(Constexprness, SharedAllocationTracker)
+{
+    static_assert(test_SharedAllocationTracker());
+}
+
+/// Can be replaced by lambda defined inside of a @c static_assert once @c c++20 is available.
+/// @todo Do something meaningful with the @c view_tracker object.
+constexpr auto test_ViewTracker()
+{
+    view_tracker_t view_tracker;
+    return true;
+}
+
+TEST(Constexpr, ViewTracker)
+{
+    static_assert(test_ViewTracker());
+}
+
+/// Can be replaced by lambda defined inside of a @c static_assert once @c c++20 is available.
+/// @todo Do something meaningful with the @c map object.
+constexpr auto test_ViewMapping()
+{
+    map_t map;
+    return map.m_impl_handle == nullptr;
+}
+
+TEST(Constexpr, ViewMapping)
+{
+    static_assert(test_ViewMapping());
+}
+
+/// Can be replaced by lambda defined inside of a @c static_assert once @c c++20 is available.
+/// @todo Do something meaningful with the @c view object.
+constexpr auto test_View()
+{
+    view_t my_view;
+    return my_view.size() == my_view.extent(0) && my_view.size() == size;
+}
+
+TEST(Constexpr, View)
+{
+    static_assert(test_View());
+}


### PR DESCRIPTION
This PR brings back some `Kokkos::View` *constexprness*.

Indeed, it seems a lot of `Kokkos` functionalities have been marked `constexpr`, but that's not tested thoroughly. For instance, it was broken for the `Kokkos::View`.

I think the changes are legitimate because they are mostly writing `constructor() = default;`.

This is a draft, because it only works in C++20 for the moment. The culprit seems the `SharedAllocationTracker` destructor that can be made *constexpr* in `c++20`, but not in `c++17`.