### PR TITLE
OpenMP: No memset in viewfill

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1350,8 +1350,7 @@ contiguous_fill_or_memset(
     typename ViewTraits<DT, DP...>::const_value_type& value) {
 // On A64FX memset seems to do the wrong thing with regards to first touch
 // leading to the significant performance issues
-#if !defined(KOKKOS_ARCH_A64FX) && !defined(KOKKOS_ENABLE_OPENMP) && \
-    !defined(KOKKOS_ENABLE_SERIAL)
+#if !defined(KOKKOS_ARCH_A64FX) && !defined(KOKKOS_ENABLE_OPENMP)
   if (Impl::is_zero_byte(value))
     ZeroMemset<ExecutionSpace, View<DT, DP...>>(exec_space, dst, value);
   else

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1348,16 +1348,14 @@ inline std::enable_if_t<
 contiguous_fill_or_memset(
     const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {
-// On A64FX memset seems to do the wrong thing with regards to first touch
-// leading to the significant performance issues
+  // With OpenMP, using memset has significant performance issues.
   if (Impl::is_zero_byte(value)
 #ifdef KOKKOS_ENABLE_OPENMP
-      && std::is_same_v<ExecutionSpace, Kokkos::OpenMP>
+      && !std::is_same_v<ExecutionSpace, Kokkos::OpenMP>
 #endif
   )
     ZeroMemset<ExecutionSpace, View<DT, DP...>>(exec_space, dst, value);
   else
-#endif
     contiguous_fill(exec_space, dst, value);
 }
 

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1350,8 +1350,11 @@ contiguous_fill_or_memset(
     typename ViewTraits<DT, DP...>::const_value_type& value) {
 // On A64FX memset seems to do the wrong thing with regards to first touch
 // leading to the significant performance issues
-#if !defined(KOKKOS_ARCH_A64FX) && !defined(KOKKOS_ENABLE_OPENMP)
-  if (Impl::is_zero_byte(value))
+  if (Impl::is_zero_byte(value)
+#ifdef KOKKOS_ENABLE_OPENMP
+      && std::is_same_v<ExecutionSpace, Kokkos::OpenMP>
+#endif
+  )
     ZeroMemset<ExecutionSpace, View<DT, DP...>>(exec_space, dst, value);
   else
 #endif

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1350,7 +1350,8 @@ contiguous_fill_or_memset(
     typename ViewTraits<DT, DP...>::const_value_type& value) {
 // On A64FX memset seems to do the wrong thing with regards to first touch
 // leading to the significant performance issues
-#ifndef KOKKOS_ARCH_A64FX
+#if !defined(KOKKOS_ARCH_A64FX) && !defined(KOKKOS_ENABLE_OPENMP) && \
+    !defined(KOKKOS_ENABLE_SERIAL)
   if (Impl::is_zero_byte(value))
     ZeroMemset<ExecutionSpace, View<DT, DP...>>(exec_space, dst, value);
   else


### PR DESCRIPTION
The PR attempts to fix issue #6480 where filling a view with 0's is very slow compared to filling the same with 1's.
 The slowdown observed is repeatable with clang and g++ compilers and with OpenMP and Serial backend

Example to test the solution with OpenMP
```cpp
#include <Kokkos_Core.hpp>

using Device = Kokkos::DefaultExecutionSpace;
using exec_space = typename Device::execution_space;
using type = int64_t;
using policy = Kokkos::RangePolicy<exec_space>;
using view = Kokkos::View<type*, Device>;

void fill_test(size_t n, type x) {
    view a(Kokkos::view_alloc(Kokkos::WithoutInitializing, "test"), n);
    uint32_t t_iter = 5;
    for (uint32_t i = 0; i < t_iter; i++) {
        Kokkos::fence();
        Kokkos::Timer t;
        Kokkos::deep_copy(exec_space(), a, x);
        Kokkos::fence();
        double d = t.seconds();
        double bandwidth = static_cast<double>(sizeof(type) * n) / d;
        printf("Write time: %.2fs; Write Bandwidth: %.2fGB/s\n", d,
               bandwidth / 1000000000);
    }
}

int main() {
    Kokkos::initialize();
    {
        for (size_t n = 100000; n < 100000000; n *= 10) {
            printf("n = %zu, Fill test -1\n",n);
            fill_test(n, -1);

            printf("n = %zu, Fill test 0\n",n);
            fill_test(n, 0);
        }
    }
    Kokkos::finalize();
    return 0;
}
```

Results with `OMP_NUM_THREADS=8` with gcc/11.2 on AMD EPYC.
Similar behavior observed with more number of threads too. 

### current develop
```shell
n = 100000, Fill test -1
Write time: 0.00s; Write Bandwidth: 4.61GB/s
Write time: 0.00s; Write Bandwidth: 45.42GB/s
Write time: 0.00s; Write Bandwidth: 51.78GB/s
Write time: 0.00s; Write Bandwidth: 54.10GB/s
Write time: 0.00s; Write Bandwidth: 55.33GB/s
n = 100000, Fill test 0
Write time: 0.00s; Write Bandwidth: 2.21GB/s
Write time: 0.00s; Write Bandwidth: 38.52GB/s
Write time: 0.00s; Write Bandwidth: 44.66GB/s
Write time: 0.00s; Write Bandwidth: 38.48GB/s
Write time: 0.00s; Write Bandwidth: 43.51GB/s
n = 1000000, Fill test -1
Write time: 0.00s; Write Bandwidth: 18.05GB/s
Write time: 0.00s; Write Bandwidth: 468.30GB/s
Write time: 0.00s; Write Bandwidth: 426.53GB/s
Write time: 0.00s; Write Bandwidth: 488.37GB/s
Write time: 0.00s; Write Bandwidth: 490.14GB/s
n = 1000000, Fill test 0
Write time: 0.00s; Write Bandwidth: 6.71GB/s
Write time: 0.00s; Write Bandwidth: 50.00GB/s
Write time: 0.00s; Write Bandwidth: 52.21GB/s
Write time: 0.00s; Write Bandwidth: 52.14GB/s
Write time: 0.00s; Write Bandwidth: 52.29GB/s
n = 10000000, Fill test -1
Write time: 0.00s; Write Bandwidth: 83.36GB/s
Write time: 0.00s; Write Bandwidth: 749.45GB/s
Write time: 0.00s; Write Bandwidth: 650.32GB/s
Write time: 0.00s; Write Bandwidth: 709.24GB/s
Write time: 0.00s; Write Bandwidth: 749.23GB/s
n = 10000000, Fill test 0
Write time: 0.01s; Write Bandwidth: 10.28GB/s
Write time: 0.00s; Write Bandwidth: 44.09GB/s
Write time: 0.00s; Write Bandwidth: 49.85GB/s
Write time: 0.00s; Write Bandwidth: 49.66GB/s
Write time: 0.00s; Write Bandwidth: 49.94GB/s
```

### This PR
```shell
n = 100000, Fill test -1
Write time: 0.00s; Write Bandwidth: 4.58GB/s
Write time: 0.00s; Write Bandwidth: 54.69GB/s
Write time: 0.00s; Write Bandwidth: 56.95GB/s
Write time: 0.00s; Write Bandwidth: 67.04GB/s
Write time: 0.00s; Write Bandwidth: 68.07GB/s
n = 100000, Fill test 0
Write time: 0.00s; Write Bandwidth: 5.39GB/s
Write time: 0.00s; Write Bandwidth: 55.49GB/s
Write time: 0.00s; Write Bandwidth: 66.43GB/s
Write time: 0.00s; Write Bandwidth: 67.72GB/s
Write time: 0.00s; Write Bandwidth: 76.26GB/s
n = 1000000, Fill test -1
Write time: 0.00s; Write Bandwidth: 20.49GB/s
Write time: 0.00s; Write Bandwidth: 432.99GB/s
Write time: 0.00s; Write Bandwidth: 457.82GB/s
Write time: 0.00s; Write Bandwidth: 462.61GB/s
Write time: 0.00s; Write Bandwidth: 472.76GB/s
n = 1000000, Fill test 0
Write time: 0.00s; Write Bandwidth: 21.60GB/s
Write time: 0.00s; Write Bandwidth: 430.20GB/s
Write time: 0.00s; Write Bandwidth: 462.05GB/s
Write time: 0.00s; Write Bandwidth: 467.48GB/s
Write time: 0.00s; Write Bandwidth: 483.03GB/s
n = 10000000, Fill test -1
Write time: 0.00s; Write Bandwidth: 133.27GB/s
Write time: 0.00s; Write Bandwidth: 761.82GB/s
Write time: 0.00s; Write Bandwidth: 766.50GB/s
Write time: 0.00s; Write Bandwidth: 771.60GB/s
Write time: 0.00s; Write Bandwidth: 764.00GB/s
n = 10000000, Fill test 0
Write time: 0.00s; Write Bandwidth: 126.01GB/s
Write time: 0.00s; Write Bandwidth: 761.09GB/s
Write time: 0.00s; Write Bandwidth: 770.19GB/s
Write time: 0.00s; Write Bandwidth: 770.12GB/s
Write time: 0.00s; Write Bandwidth: 769.30GB/s
``` 

In a follow up PR, I will add it as a benchmark. 