### PR TITLE
simd: temporarily skip device math ops unit test for OpenMPTarget build

### DIFF
--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -298,7 +298,7 @@ TEST(simd, device_math_ops) {
   GTEST_SKIP()
       << "skipping because of a non-deterministic failure reporting: "
          "Failure to synchronize stream (nil): Error in "
-         "cuStreamSynchronize: an illegal memory access was encountered"
+         "cuStreamSynchronize: an illegal memory access was encountered";
 #endif
       Kokkos::parallel_for(1, simd_device_math_ops_functor());
 }

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -300,7 +300,7 @@ TEST(simd, device_math_ops) {
          "Failure to synchronize stream (nil): Error in "
          "cuStreamSynchronize: an illegal memory access was encountered";
 #endif
-      Kokkos::parallel_for(1, simd_device_math_ops_functor());
+  Kokkos::parallel_for(1, simd_device_math_ops_functor());
 }
 
 #endif

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -294,6 +294,9 @@ TEST(simd, host_math_ops) {
 }
 
 TEST(simd, device_math_ops) {
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+  GTEST_SKIP();
+#endif
   Kokkos::parallel_for(1, simd_device_math_ops_functor());
 }
 

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -294,10 +294,13 @@ TEST(simd, host_math_ops) {
 }
 
 TEST(simd, device_math_ops) {
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
-  GTEST_SKIP();
+#ifdef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET
+  GTEST_SKIP()
+      << "skipping because of a non-deterministic failure reporting: "
+         "Failure to synchronize stream (nil): Error in "
+         "cuStreamSynchronize: an illegal memory access was encountered"
 #endif
-  Kokkos::parallel_for(1, simd_device_math_ops_functor());
+      Kokkos::parallel_for(1, simd_device_math_ops_functor());
 }
 
 #endif


### PR DESCRIPTION
Follow-up from https://github.com/kokkos/kokkos/pull/6570#issuecomment-1791677168.

The CI test has been reporting following simd test failures for OpenMPTarget build:
```
48: [ RUN      ] simd.device_math_ops
48: "PluginInterface" error: Failure to synchronize stream (nil): Error in cuStreamSynchronize: an illegal memory access was encountered
48: Libomptarget error: Consult https://openmp.llvm.org/design/Runtimes.html for debugging options.
48: Kokkos_OpenMPTarget_ParallelFor_Range.hpp:54:1: Libomptarget fatal error 1: failure of target construct while offloading is mandatory
48/48 Test #48: Kokkos_UnitTest_SIMD ........................Subprocess aborted***Exception:   3.21 sec
```
However, this failure seems non-deterministic, seeing that only a few PRs, including non-SIMD related PRs, are producing this particular error during the CI testing while some other SIMD PRs are not producing this error.
Placing a temporary skip in `simd.device_math_ops` for `OpenMPTarget` build to avoid noise in the CI test results.