### PR TITLE
SYCL: Address deprecations after oneAPI 2023.2.0

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
@@ -76,14 +76,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
       auto lambda = [=](sycl::nd_item<2> item) {
         const member_type team_member(
-#if defined(KOKKOS_COMPILER_INTEL_LLVM) && \
-    KOKKOS_COMPILER_INTEL_LLVM >= 20230200
-            team_scratch_memory_L0
-                .get_multi_ptr<sycl::access::decorated::yes>(),
-#else
-            team_scratch_memory_L0.get_pointer(),
-#endif
-            shmem_begin, scratch_size[0],
+            KOKKOS_IMPL_SYCL_GET_MULTI_PTR(team_scratch_memory_L0), shmem_begin,
+            scratch_size[0],
             global_scratch_ptr + item.get_group(1) * scratch_size[1],
             scratch_size[1], item, item.get_group_linear_id(),
             item.get_group_range(1));

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
@@ -76,7 +76,14 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
       auto lambda = [=](sycl::nd_item<2> item) {
         const member_type team_member(
-            team_scratch_memory_L0.get_pointer(), shmem_begin, scratch_size[0],
+#if defined(KOKKOS_COMPILER_INTEL_LLVM) && \
+    KOKKOS_COMPILER_INTEL_LLVM >= 20230200
+            team_scratch_memory_L0
+                .get_multi_ptr<sycl::access::decorated::yes>(),
+#else
+            team_scratch_memory_L0.get_pointer(),
+#endif
+            shmem_begin, scratch_size[0],
             global_scratch_ptr + item.get_group(1) * scratch_size[1],
             scratch_size[1], item, item.get_group_linear_id(),
             item.get_group_range(1));

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -131,9 +131,16 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
               reference_type update = reducer.init(results_ptr);
               if (size == 1) {
                 const member_type team_member(
-                    team_scratch_memory_L0.get_pointer(), shmem_begin,
-                    scratch_size[0], global_scratch_ptr, scratch_size[1], item,
-                    item.get_group_linear_id(), item.get_group_range(1));
+#if defined(KOKKOS_COMPILER_INTEL_LLVM) && \
+    KOKKOS_COMPILER_INTEL_LLVM >= 20230200
+                    team_scratch_memory_L0
+                        .get_multi_ptr<sycl::access::decorated::yes>(),
+#else
+                    team_scratch_memory_L0.get_pointer(),
+#endif
+                    shmem_begin, scratch_size[0], global_scratch_ptr,
+                    scratch_size[1], item, item.get_group_linear_id(),
+                    item.get_group_range(1));
                 if constexpr (std::is_void_v<WorkTag>)
                   functor(team_member, update);
                 else
@@ -201,8 +208,14 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                   for (int league_rank = group_id; league_rank < league_size;
                        league_rank += n_wgroups) {
                     const member_type team_member(
-                        team_scratch_memory_L0.get_pointer(), shmem_begin,
-                        scratch_size[0],
+#if defined(KOKKOS_COMPILER_INTEL_LLVM) && \
+    KOKKOS_COMPILER_INTEL_LLVM >= 20230200
+                        team_scratch_memory_L0
+                            .get_multi_ptr<sycl::access::decorated::yes>(),
+#else
+                        team_scratch_memory_L0.get_pointer(),
+#endif
+                        shmem_begin, scratch_size[0],
                         global_scratch_ptr +
                             item.get_group(1) * scratch_size[1],
                         scratch_size[1], item, league_rank, league_size);
@@ -254,8 +267,14 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                   for (int league_rank = group_id; league_rank < league_size;
                        league_rank += n_wgroups) {
                     const member_type team_member(
-                        team_scratch_memory_L0.get_pointer(), shmem_begin,
-                        scratch_size[0],
+#if defined(KOKKOS_COMPILER_INTEL_LLVM) && \
+    KOKKOS_COMPILER_INTEL_LLVM >= 20230200
+                        team_scratch_memory_L0
+                            .get_multi_ptr<sycl::access::decorated::yes>(),
+#else
+                        team_scratch_memory_L0.get_pointer(),
+#endif
+                        shmem_begin, scratch_size[0],
                         global_scratch_ptr +
                             item.get_group(1) * scratch_size[1],
                         scratch_size[1], item, league_rank, league_size);

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -131,13 +131,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
               reference_type update = reducer.init(results_ptr);
               if (size == 1) {
                 const member_type team_member(
-#if defined(KOKKOS_COMPILER_INTEL_LLVM) && \
-    KOKKOS_COMPILER_INTEL_LLVM >= 20230200
-                    team_scratch_memory_L0
-                        .get_multi_ptr<sycl::access::decorated::yes>(),
-#else
-                    team_scratch_memory_L0.get_pointer(),
-#endif
+                    KOKKOS_IMPL_SYCL_GET_MULTI_PTR(team_scratch_memory_L0),
                     shmem_begin, scratch_size[0], global_scratch_ptr,
                     scratch_size[1], item, item.get_group_linear_id(),
                     item.get_group_range(1));
@@ -208,13 +202,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                   for (int league_rank = group_id; league_rank < league_size;
                        league_rank += n_wgroups) {
                     const member_type team_member(
-#if defined(KOKKOS_COMPILER_INTEL_LLVM) && \
-    KOKKOS_COMPILER_INTEL_LLVM >= 20230200
-                        team_scratch_memory_L0
-                            .get_multi_ptr<sycl::access::decorated::yes>(),
-#else
-                        team_scratch_memory_L0.get_pointer(),
-#endif
+                        KOKKOS_IMPL_SYCL_GET_MULTI_PTR(team_scratch_memory_L0),
                         shmem_begin, scratch_size[0],
                         global_scratch_ptr +
                             item.get_group(1) * scratch_size[1],
@@ -267,13 +255,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                   for (int league_rank = group_id; league_rank < league_size;
                        league_rank += n_wgroups) {
                     const member_type team_member(
-#if defined(KOKKOS_COMPILER_INTEL_LLVM) && \
-    KOKKOS_COMPILER_INTEL_LLVM >= 20230200
-                        team_scratch_memory_L0
-                            .get_multi_ptr<sycl::access::decorated::yes>(),
-#else
-                        team_scratch_memory_L0.get_pointer(),
-#endif
+                        KOKKOS_IMPL_SYCL_GET_MULTI_PTR(team_scratch_memory_L0),
                         shmem_begin, scratch_size[0],
                         global_scratch_ptr +
                             item.get_group(1) * scratch_size[1],

--- a/core/src/setup/Kokkos_Setup_SYCL.hpp
+++ b/core/src/setup/Kokkos_Setup_SYCL.hpp
@@ -38,4 +38,11 @@
 #include <CL/sycl.hpp>
 #endif
 
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20230200
+#define KOKKOS_IMPL_SYCL_GET_MULTI_PTR(accessor) \
+  accessor.get_multi_ptr<sycl::access::decorated::yes>()
+#else
+#define KOKKOS_IMPL_SYCL_GET_MULTI_PTR(accessor) accessor.get_pointer()
+#endif
+
 #endif


### PR DESCRIPTION
The only new API function introduced in `oneAPI 2023.2.0` that addresses later deprecations (for `sycl::accessor::get_pointer`) is `sycl::accessor<>::get_multi_ptr`, see the changelog at https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-dpc-c-compiler-release-notes.html. `get_multi_ptr` is conforming to the SYCL2020 specifications, see https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_interface_for_buffer_command_accessors.
We can use decorated pointers here, so we can make it easier for the compiler to figure out the correct address space (although that wasn't a problem before).