### PR TITLE
cuda: reduction with `RangePolicy`: fix grid dimensions to work for large values and avoid overflow

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -115,7 +115,6 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
         std::min(typename Policy::index_type((nwork + block.y - 1) / block.y),
                  typename Policy::index_type(maxGridSizeX)),
         1, 1);
-
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
     if (Kokkos::Impl::CudaInternal::cuda_use_serial_execution()) {
       block = dim3(1, 1, 1);

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -32,7 +32,6 @@
 
 #include <impl/Kokkos_Tools.hpp>
 #include <typeinfo>
-#include <iostream>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -37,8 +37,8 @@ namespace Kokkos {
 namespace Impl {
 
 template <typename IndexType>
-void admissible_iteration_count_else_throw(IndexType /*nwork*/, int blockSize,
-                                           const std::string& /*patternName*/,
+void admissible_iteration_count_else_throw(IndexType nwork, int blockSize,
+                                           const std::string& patternName,
                                            Impl::CudaInternal* instance) {
   const int max_grid_size        = instance->m_deviceProp.maxGridSize[0];
   const std::size_t max_num_iter = (std::size_t)max_grid_size * blockSize;

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -42,7 +42,8 @@ void admissible_iteration_count_else_throw(IndexType nwork, int blockSize,
                                            Impl::CudaInternal* instance) {
   const int max_grid_size        = instance->m_deviceProp.maxGridSize[0];
   const std::size_t max_num_iter = (std::size_t)max_grid_size * blockSize;
-  if ((std::size_t)nwork / blockSize > (std::size_t)max_grid_size) {
+
+  if ((std::size_t)nwork > max_num_iter) {
     const std::string msg =
         patternName + ": the target number of iterations " +
         std::to_string(nwork) + " > the maximum number of iterations " +

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -971,8 +971,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
     if (nwork) {
       enum { GridMaxComputeCapability_2x = 0x0ffff };
 
-      const int block_size =
-          256;  // local_block_size(m_functor_reducer.get_functor());
+      const int block_size = local_block_size(m_functor_reducer.get_functor());
       KOKKOS_ASSERT(block_size > 0);
 
       const int grid_max =

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -40,9 +40,9 @@ template <typename IndexType>
 void admissible_iteration_count_else_throw(IndexType nwork, int blockSize,
                                            const std::string& patternName,
                                            Impl::CudaInternal* instance) {
-  const int max_grid_size    = instance->m_deviceProp.maxGridSize[0];
-  const int64_t max_num_iter = (int64_t)max_grid_size * blockSize;
-  if (nwork / blockSize > max_grid_size) {
+  const int max_grid_size        = instance->m_deviceProp.maxGridSize[0];
+  const std::size_t max_num_iter = (std::size_t)max_grid_size * blockSize;
+  if ((std::size_t)nwork / blockSize > (std::size_t)max_grid_size) {
     const std::string msg =
         patternName + ": the target number of iterations " +
         std::to_string(nwork) + " > the maximum number of iterations " +

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -99,8 +99,6 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
         std::min(typename Policy::index_type((nwork + block.y - 1) / block.y),
                  typename Policy::index_type(maxGridSizeX)),
         1, 1);
-    std::cout << block.x << " " << block.y << " " << block.z << '\n';
-    std::cout << grid.x << " " << grid.y << " " << grid.z << '\n';
 
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
     if (Kokkos::Impl::CudaInternal::cuda_use_serial_execution()) {

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -36,22 +36,6 @@
 namespace Kokkos {
 namespace Impl {
 
-template <typename IndexType>
-void admissible_iteration_count_else_throw(IndexType nwork, int blockSize,
-                                           const std::string& patternName,
-                                           Impl::CudaInternal* instance) {
-  const int max_grid_size        = instance->m_deviceProp.maxGridSize[0];
-  const std::size_t max_num_iter = (std::size_t)max_grid_size * blockSize;
-
-  if ((std::size_t)nwork > max_num_iter) {
-    const std::string msg =
-        patternName + ": the target number of iterations " +
-        std::to_string(nwork) + " > the maximum number of iterations " +
-        std::to_string(max_num_iter) + " currently allowed on CUDA.";
-    Impl::throw_runtime_exception(msg);
-  }
-}
-
 template <class FunctorType, class... Traits>
 class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
  public:
@@ -115,6 +99,9 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
         std::min(typename Policy::index_type((nwork + block.y - 1) / block.y),
                  typename Policy::index_type(maxGridSizeX)),
         1, 1);
+    std::cout << block.x << " " << block.y << " " << block.z << '\n';
+    std::cout << grid.x << " " << grid.y << " " << grid.z << '\n';
+
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
     if (Kokkos::Impl::CudaInternal::cuda_use_serial_execution()) {
       block = dim3(1, 1, 1);
@@ -324,12 +311,9 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
       // REQUIRED ( 1 , N , 1 )
       dim3 block(1, block_size, 1);
       // Required grid.x <= block.y
-      dim3 grid(std::min(int(block.y), int((nwork + block.y - 1) / block.y)), 1,
-                1);
-
-      auto cuda_instance = m_policy.space().impl_internal_space_instance();
-      admissible_iteration_count_else_throw(nwork, block_size,
-                                            "parallel_reduce", cuda_instance);
+      dim3 grid(std::min(index_type(block.y),
+                         index_type((nwork + block.y - 1) / block.y)),
+                1, 1);
 
       // TODO @graph We need to effectively insert this in to the graph
       const int shmem =
@@ -350,7 +334,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
 
       CudaParallelLaunch<ParallelReduce, LaunchBounds>(
           *this, grid, block, shmem,
-          cuda_instance);  // copy to device and execute
+          m_policy.space()
+              .impl_internal_space_instance());  // copy to device and execute
 
       if (!m_result_ptr_device_accessible) {
         if (m_result_ptr) {
@@ -675,10 +660,6 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
       const int shmem = Analysis::value_size(m_functor_reducer.get_functor()) *
                         (block_size + 2);
 
-      auto cuda_instance = m_policy.space().impl_internal_space_instance();
-      admissible_iteration_count_else_throw(nwork, block_size, "parallel_scan",
-                                            cuda_instance);
-
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
       if (m_run_serial) {
         block = dim3(1, 1, 1);
@@ -688,14 +669,16 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
         m_final = false;
         CudaParallelLaunch<ParallelScan, LaunchBounds>(
             *this, grid, block, shmem,
-            cuda_instance);  // copy to device and execute
+            m_policy.space()
+                .impl_internal_space_instance());  // copy to device and execute
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
       }
 #endif
       m_final = true;
       CudaParallelLaunch<ParallelScan, LaunchBounds>(
           *this, grid, block, shmem,
-          cuda_instance);  // copy to device and execute
+          m_policy.space()
+              .impl_internal_space_instance());  // copy to device and execute
     }
   }
 
@@ -1001,10 +984,6 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
       dim3 block(1, block_size, 1);  // REQUIRED DIMENSIONS ( 1 , N , 1 )
       const int shmem = final_reducer.value_size() * (block_size + 2);
 
-      auto cuda_instance = m_policy.space().impl_internal_space_instance();
-      admissible_iteration_count_else_throw(nwork, block_size, "parallel_scan",
-                                            cuda_instance);
-
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
       if (m_run_serial) {
         block = dim3(1, 1, 1);
@@ -1015,12 +994,14 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
         m_final = false;
         CudaParallelLaunch<ParallelScanWithTotal, LaunchBounds>(
             *this, grid, block, shmem,
-            cuda_instance);  // copy to device and execute
+            m_policy.space()
+                .impl_internal_space_instance());  // copy to device and execute
       }
       m_final = true;
       CudaParallelLaunch<ParallelScanWithTotal, LaunchBounds>(
           *this, grid, block, shmem,
-          cuda_instance);  // copy to device and execute
+          m_policy.space()
+              .impl_internal_space_instance());  // copy to device and execute
 
       const int size = final_reducer.value_size();
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -644,7 +644,6 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
     const auto nwork = m_policy.end() - m_policy.begin();
     if (nwork) {
       constexpr int GridMaxComputeCapability_2x = 0x0ffff;
-      std::cout << GridMaxComputeCapability_2x << '\n';
 
       const int block_size = local_block_size(m_functor_reducer.get_functor());
       KOKKOS_ASSERT(block_size > 0);

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -99,7 +99,6 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
         std::min(typename Policy::index_type((nwork + block.y - 1) / block.y),
                  typename Policy::index_type(maxGridSizeX)),
         1, 1);
-
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
     if (Kokkos::Impl::CudaInternal::cuda_use_serial_execution()) {
       block = dim3(1, 1, 1);

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -121,6 +121,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
       grid  = dim3(1, 1, 1);
     }
 #endif
+
     CudaParallelLaunch<ParallelFor, LaunchBounds>(
         *this, grid, block, 0, m_policy.space().impl_internal_space_instance());
   }

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -627,7 +627,7 @@ TEST(TEST_CATEGORY, int_combined_reduce_mixed) {
 #endif
 
 #if defined(NDEBUG)
-// the following test is for the following issue:
+// the following test was made for:
 // https://github.com/kokkos/kokkos/issues/6517
 
 template <class T>

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -638,21 +638,25 @@ template <>
 struct EnableTestForReductionWithLargeIterationCount<Kokkos::Cuda>
     : std::true_type {};
 #endif
+
 #ifdef KOKKOS_ENABLE_HIP
 template <>
 struct EnableTestForReductionWithLargeIterationCount<Kokkos::HIP>
     : std::true_type {};
 #endif
+
 #ifdef KOKKOS_ENABLE_SYCL
 template <>
 struct EnableTestForReductionWithLargeIterationCount<Kokkos::Experimental::SYCL>
     : std::true_type {};
 #endif
+
 #ifdef KOKKOS_ENABLE_OPENACC
 template <>
 struct EnableTestForReductionWithLargeIterationCount<
     Kokkos::Experimental::OpenACC> : std::true_type {};
 #endif
+
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
 template <>
 struct EnableTestForReductionWithLargeIterationCount<

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -637,7 +637,7 @@ struct FunctorReductionWithLargeIterationCount {
 };
 
 TEST(TEST_CATEGORY, reduction_with_large_iteration_count) {
-  if constexpr (std::is_same_v<TEST_EXECSPACE::memory_space,
+  if constexpr (std::is_same_v<typename TEST_EXECSPACE::memory_space,
                                Kokkos::HostSpace>::value) {
     GTEST_SKIP() << "Disabling for host backends";
   }

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -626,7 +626,6 @@ TEST(TEST_CATEGORY, int_combined_reduce_mixed) {
 #endif
 #endif
 
-#if defined(KOKKOS_ENABLE_CUDA)
 struct FunctorIssue6517 {
   KOKKOS_FUNCTION void operator()(const int64_t /*i*/, double& update) const {
     update += 1.0;
@@ -635,12 +634,11 @@ struct FunctorIssue6517 {
 
 TEST(TEST_CATEGORY, issue6517) {
   const int64_t N = pow(2LL, 39LL) - pow(2LL, 8LL) + 1;
-  Kokkos::RangePolicy<Kokkos::Cuda, Kokkos::IndexType<int64_t>> p(0, N);
+  Kokkos::RangePolicy<TEST_EXECSPACE, Kokkos::IndexType<int64_t>> p(0, N);
   double nu = 0;
   EXPECT_NO_THROW(
       Kokkos::parallel_reduce("sample reduction", p, FunctorIssue6517(), nu));
   ASSERT_DOUBLE_EQ(nu, double(N));
 }
-#endif
 
 }  // namespace Test

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -627,38 +627,45 @@ TEST(TEST_CATEGORY, int_combined_reduce_mixed) {
 #endif
 
 #if defined(NDEBUG)
+// the following test is for the following issue:
+// https://github.com/kokkos/kokkos/issues/6517
+
 template <class T>
-struct EnableTestForIssue6517 : std::false_type {};
+struct EnableTestForReductionWithLargeIterationCount : std::false_type {};
 
 #ifdef KOKKOS_ENABLE_CUDA
 template <>
-struct EnableTestForIssue6517<Kokkos::Cuda> : std::true_type {};
+struct EnableTestForReductionWithLargeIterationCount<Kokkos::Cuda>
+    : std::true_type {};
 #endif
 #ifdef KOKKOS_ENABLE_HIP
 template <>
-struct EnableTestForIssue6517<Kokkos::HIP> : std::true_type {};
+struct EnableTestForReductionWithLargeIterationCount<Kokkos::HIP>
+    : std::true_type {};
 #endif
 #ifdef KOKKOS_ENABLE_SYCL
 template <>
-struct EnableTestForIssue6517<Kokkos::Experimental::SYCL> : std::true_type {};
+struct EnableTestForReductionWithLargeIterationCount<Kokkos::Experimental::SYCL>
+    : std::true_type {};
 #endif
 
-struct FunctorIssue6517 {
+struct FunctorReductionWithLargeIterationCount {
   KOKKOS_FUNCTION void operator()(const int64_t /*i*/, double& update) const {
     update += 1.0;
   }
 };
 
-TEST(TEST_CATEGORY, issue6517) {
-  if constexpr (!EnableTestForIssue6517<TEST_EXECSPACE>::value) {
+TEST(TEST_CATEGORY, reduction_with_large_iteration_count) {
+  if constexpr (!EnableTestForReductionWithLargeIterationCount<
+                    TEST_EXECSPACE>::value) {
     GTEST_SKIP() << "Disabling for host backends";
   }
 
   const int64_t N = pow(2LL, 39LL) - pow(2LL, 8LL) + 1;
   Kokkos::RangePolicy<TEST_EXECSPACE, Kokkos::IndexType<int64_t>> p(0, N);
   double nu = 0;
-  EXPECT_NO_THROW(
-      Kokkos::parallel_reduce("sample reduction", p, FunctorIssue6517(), nu));
+  EXPECT_NO_THROW(Kokkos::parallel_reduce(
+      "sample reduction", p, FunctorReductionWithLargeIterationCount(), nu));
   ASSERT_DOUBLE_EQ(nu, double(N));
 }
 #endif

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -638,7 +638,7 @@ struct FunctorReductionWithLargeIterationCount {
 
 TEST(TEST_CATEGORY, reduction_with_large_iteration_count) {
   if constexpr (std::is_same_v<typename TEST_EXECSPACE::memory_space,
-                               Kokkos::HostSpace>::value) {
+                               Kokkos::HostSpace>) {
     GTEST_SKIP() << "Disabling for host backends";
   }
 

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -630,39 +630,6 @@ TEST(TEST_CATEGORY, int_combined_reduce_mixed) {
 // the following test was made for:
 // https://github.com/kokkos/kokkos/issues/6517
 
-template <class T>
-struct EnableTestForReductionWithLargeIterationCount : std::false_type {};
-
-#ifdef KOKKOS_ENABLE_CUDA
-template <>
-struct EnableTestForReductionWithLargeIterationCount<Kokkos::Cuda>
-    : std::true_type {};
-#endif
-
-#ifdef KOKKOS_ENABLE_HIP
-template <>
-struct EnableTestForReductionWithLargeIterationCount<Kokkos::HIP>
-    : std::true_type {};
-#endif
-
-#ifdef KOKKOS_ENABLE_SYCL
-template <>
-struct EnableTestForReductionWithLargeIterationCount<Kokkos::Experimental::SYCL>
-    : std::true_type {};
-#endif
-
-#ifdef KOKKOS_ENABLE_OPENACC
-template <>
-struct EnableTestForReductionWithLargeIterationCount<
-    Kokkos::Experimental::OpenACC> : std::true_type {};
-#endif
-
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
-template <>
-struct EnableTestForReductionWithLargeIterationCount<
-    Kokkos::Experimental::OpenMPTarget> : std::true_type {};
-#endif
-
 struct FunctorReductionWithLargeIterationCount {
   KOKKOS_FUNCTION void operator()(const int64_t /*i*/, double& update) const {
     update += 1.0;
@@ -670,8 +637,8 @@ struct FunctorReductionWithLargeIterationCount {
 };
 
 TEST(TEST_CATEGORY, reduction_with_large_iteration_count) {
-  if constexpr (!EnableTestForReductionWithLargeIterationCount<
-                    TEST_EXECSPACE>::value) {
+  if constexpr (std::is_same_v<TEST_EXECSPACE::memory_space,
+                               Kokkos::HostSpace>::value) {
     GTEST_SKIP() << "Disabling for host backends";
   }
 

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -625,4 +625,22 @@ TEST(TEST_CATEGORY, int_combined_reduce_mixed) {
 }
 #endif
 #endif
+
+#if defined(KOKKOS_ENABLE_CUDA)
+struct FunctorIssue6517 {
+  KOKKOS_FUNCTION void operator()(const int64_t /*i*/, double& update) const {
+    update += 1.0;
+  }
+};
+
+TEST(TEST_CATEGORY, issue6517) {
+  const int64_t N = pow(2LL, 39LL) - pow(2LL, 8LL) + 1;
+  Kokkos::RangePolicy<Kokkos::Cuda, Kokkos::IndexType<int64_t>> p(0, N);
+  double nu = 0;
+  EXPECT_NO_THROW(
+      Kokkos::parallel_reduce("sample reduction", p, FunctorIssue6517(), nu));
+  ASSERT_DOUBLE_EQ(nu, double(N));
+}
+#endif
+
 }  // namespace Test

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -648,6 +648,16 @@ template <>
 struct EnableTestForReductionWithLargeIterationCount<Kokkos::Experimental::SYCL>
     : std::true_type {};
 #endif
+#ifdef KOKKOS_ENABLE_OPENACC
+template <>
+struct EnableTestForReductionWithLargeIterationCount<
+    Kokkos::Experimental::OpenACC> : std::true_type {};
+#endif
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+template <>
+struct EnableTestForReductionWithLargeIterationCount<
+    Kokkos::Experimental::OpenMPTarget> : std::true_type {};
+#endif
 
 struct FunctorReductionWithLargeIterationCount {
   KOKKOS_FUNCTION void operator()(const int64_t /*i*/, double& update) const {


### PR DESCRIPTION
This PR addresses https://github.com/kokkos/kokkos/issues/6517 

## what is the issue
The reduction did not work in that test case because, currently, the code setting the grid in the cuda reduction via Range policy is using the following logic (note the use of `int`):
```cpp
// REQUIRED ( 1 , N , 1 )
dim3 block(1, block_size, 1);
// Required grid.x <= block.y
dim3 grid(std::min(int(block.y), int((nwork + block.y - 1) / block.y)), 1, 1);
```
so when `block_size` is 256 (which happens to be the case for the use case reported in 6517), this evaluates to: 
```
block = 1,256,1
grid = -2147483648 1 1
```
so the min is taking 2147483648 and the grid is set incorrectly. 
So the issue was not a too large value of N for the reduction, but the actual logic in setting the grid dim internally. 

## solution 
This PR replaces the code above with: 
```cpp
// REQUIRED ( 1 , N , 1 )
dim3 block(1, block_size, 1);
// Required grid.x <= block.y
dim3 grid(std::min(index_type(block.y), index_type((nwork + block.y - 1) / block.y)), 1, 1);
```
so that `min` operates on meaningful values, and `grid` is set correctly even for large values of `nwork`.

## test 

The test added reproduces the original issue and should pass now