### PR TITLE
Remove Kokkos::[b]half_t volatile overloads

### DIFF
--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -196,20 +196,12 @@ KOKKOS_INLINE_FUNCTION
 
 template <class T>
 static KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t cast_to_wrapper(
-    T x, const
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-    volatile
-#endif
-    Kokkos::Impl::half_impl_t::type&);
+    T x, const Kokkos::Impl::half_impl_t::type&);
 
 #ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
 template <class T>
 static KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t cast_to_wrapper(
-    T x, const
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-    volatile
-#endif
-    Kokkos::Impl::bhalf_impl_t::type&);
+    T x, const Kokkos::Impl::bhalf_impl_t::type&);
 #endif  // KOKKOS_IMPL_BHALF_TYPE_DEFINED
 
 template <class T>
@@ -291,15 +283,6 @@ class alignas(FloatType) floating_point_wrapper {
 
  private:
   impl_type val;
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  using fixed_width_integer_type = std::conditional_t<
-      sizeof(impl_type) == 2, uint16_t,
-      std::conditional_t<
-          sizeof(impl_type) == 4, uint32_t,
-          std::conditional_t<sizeof(impl_type) == 8, uint64_t, void>>>;
-  static_assert(!std::is_void<fixed_width_integer_type>::value,
-                "Invalid impl_type");
-#endif
 
  public:
   // In-class initialization and defaulted default constructors not used
@@ -326,20 +309,6 @@ class alignas(FloatType) floating_point_wrapper {
   KOKKOS_DEFAULTED_FUNCTION
   floating_point_wrapper& operator=(const floating_point_wrapper&) noexcept =
       default;
-#endif
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION
-  floating_point_wrapper(const volatile floating_point_wrapper& rhs) {
-#if defined(KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH) && !defined(KOKKOS_ENABLE_SYCL)
-    val = rhs.val;
-#else
-    const volatile fixed_width_integer_type* rv_ptr =
-        reinterpret_cast<const volatile fixed_width_integer_type*>(&rhs.val);
-    const fixed_width_integer_type rv_val = *rv_ptr;
-    val = reinterpret_cast<const impl_type&>(rv_val);
-#endif  // KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
-  }
 #endif
 
   KOKKOS_FUNCTION
@@ -504,17 +473,6 @@ class alignas(FloatType) floating_point_wrapper {
     return *this;
   }
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  template <class T>
-  KOKKOS_DEPRECATED KOKKOS_FUNCTION void operator=(T rhs) volatile {
-    impl_type new_val = cast_to_wrapper(rhs, val).val;
-    volatile fixed_width_integer_type* val_ptr =
-        reinterpret_cast<volatile fixed_width_integer_type*>(
-            const_cast<impl_type*>(&val));
-    *val_ptr = reinterpret_cast<fixed_width_integer_type&>(new_val);
-  }
-#endif
-
   // Compound operators
   KOKKOS_FUNCTION
   floating_point_wrapper& operator+=(floating_point_wrapper rhs) {
@@ -528,17 +486,6 @@ class alignas(FloatType) floating_point_wrapper {
 #endif
     return *this;
   }
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED KOKKOS_FUNCTION void operator+=(
-      const volatile floating_point_wrapper& rhs) volatile {
-    floating_point_wrapper tmp_rhs = rhs;
-    floating_point_wrapper tmp_lhs = *this;
-
-    tmp_lhs += tmp_rhs;
-    *this = tmp_lhs;
-  }
-#endif
 
   // Compound operators: upcast overloads for +=
   template <class T>
@@ -576,17 +523,6 @@ class alignas(FloatType) floating_point_wrapper {
     return *this;
   }
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED KOKKOS_FUNCTION void operator-=(
-      const volatile floating_point_wrapper& rhs) volatile {
-    floating_point_wrapper tmp_rhs = rhs;
-    floating_point_wrapper tmp_lhs = *this;
-
-    tmp_lhs -= tmp_rhs;
-    *this = tmp_lhs;
-  }
-#endif
-
   // Compund operators: upcast overloads for -=
   template <class T>
   KOKKOS_FUNCTION friend std::enable_if_t<
@@ -623,17 +559,6 @@ class alignas(FloatType) floating_point_wrapper {
     return *this;
   }
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED KOKKOS_FUNCTION void operator*=(
-      const volatile floating_point_wrapper& rhs) volatile {
-    floating_point_wrapper tmp_rhs = rhs;
-    floating_point_wrapper tmp_lhs = *this;
-
-    tmp_lhs *= tmp_rhs;
-    *this = tmp_lhs;
-  }
-#endif
-
   // Compund operators: upcast overloads for *=
   template <class T>
   KOKKOS_FUNCTION friend std::enable_if_t<
@@ -669,17 +594,6 @@ class alignas(FloatType) floating_point_wrapper {
 #endif
     return *this;
   }
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED KOKKOS_FUNCTION void operator/=(
-      const volatile floating_point_wrapper& rhs) volatile {
-    floating_point_wrapper tmp_rhs = rhs;
-    floating_point_wrapper tmp_lhs = *this;
-
-    tmp_lhs /= tmp_rhs;
-    *this = tmp_lhs;
-  }
-#endif
 
   // Compund operators: upcast overloads for /=
   template <class T>
@@ -906,29 +820,6 @@ class alignas(FloatType) floating_point_wrapper {
 #endif
   }
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED KOKKOS_FUNCTION friend bool operator==(
-      const volatile floating_point_wrapper& lhs,
-      const volatile floating_point_wrapper& rhs) {
-    floating_point_wrapper tmp_lhs = lhs, tmp_rhs = rhs;
-    return tmp_lhs == tmp_rhs;
-  }
-
-  KOKKOS_DEPRECATED KOKKOS_FUNCTION friend bool operator!=(
-      const volatile floating_point_wrapper& lhs,
-      const volatile floating_point_wrapper& rhs) {
-    floating_point_wrapper tmp_lhs = lhs, tmp_rhs = rhs;
-    return tmp_lhs != tmp_rhs;
-  }
-
-  KOKKOS_DEPRECATED KOKKOS_FUNCTION friend bool operator<(
-      const volatile floating_point_wrapper& lhs,
-      const volatile floating_point_wrapper& rhs) {
-    floating_point_wrapper tmp_lhs = lhs, tmp_rhs = rhs;
-    return tmp_lhs < tmp_rhs;
-  }
-#endif
-
   template <class T>
   KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
                                               (std::is_same_v<T, float> ||
@@ -946,15 +837,6 @@ class alignas(FloatType) floating_point_wrapper {
   operator<(T lhs, floating_point_wrapper rhs) {
     return lhs < static_cast<float>(rhs);
   }
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED KOKKOS_FUNCTION friend bool operator>(
-      const volatile floating_point_wrapper& lhs,
-      const volatile floating_point_wrapper& rhs) {
-    floating_point_wrapper tmp_lhs = lhs, tmp_rhs = rhs;
-    return tmp_lhs > tmp_rhs;
-  }
-#endif
 
   template <class T>
   KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
@@ -974,15 +856,6 @@ class alignas(FloatType) floating_point_wrapper {
     return lhs > static_cast<float>(rhs);
   }
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED KOKKOS_FUNCTION friend bool operator<=(
-      const volatile floating_point_wrapper& lhs,
-      const volatile floating_point_wrapper& rhs) {
-    floating_point_wrapper tmp_lhs = lhs, tmp_rhs = rhs;
-    return tmp_lhs <= tmp_rhs;
-  }
-#endif
-
   template <class T>
   KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
                                               (std::is_same_v<T, float> ||
@@ -1000,15 +873,6 @@ class alignas(FloatType) floating_point_wrapper {
   operator<=(T lhs, floating_point_wrapper rhs) {
     return lhs <= static_cast<float>(rhs);
   }
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED KOKKOS_FUNCTION friend bool operator>=(
-      const volatile floating_point_wrapper& lhs,
-      const volatile floating_point_wrapper& rhs) {
-    floating_point_wrapper tmp_lhs = lhs, tmp_rhs = rhs;
-    return tmp_lhs >= tmp_rhs;
-  }
-#endif
 
   template <class T>
   KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
@@ -1048,22 +912,14 @@ class alignas(FloatType) floating_point_wrapper {
 // Declare wrapper overloads now that floating_point_wrapper is declared
 template <class T>
 static KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t cast_to_wrapper(
-    T x, const
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-    volatile
-#endif
-    Kokkos::Impl::half_impl_t::type&) {
+    T x, const Kokkos::Impl::half_impl_t::type&) {
   return Kokkos::Experimental::cast_to_half(x);
 }
 
 #ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
 template <class T>
 static KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t cast_to_wrapper(
-    T x, const
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-    volatile
-#endif
-    Kokkos::Impl::bhalf_impl_t::type&) {
+    T x, const Kokkos::Impl::bhalf_impl_t::type&) {
   return Kokkos::Experimental::cast_to_bhalf(x);
 }
 #endif  // KOKKOS_IMPL_BHALF_TYPE_DEFINED

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -196,12 +196,20 @@ KOKKOS_INLINE_FUNCTION
 
 template <class T>
 static KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t cast_to_wrapper(
-    T x, const volatile Kokkos::Impl::half_impl_t::type&);
+    T x, const
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+    volatile
+#endif
+    Kokkos::Impl::half_impl_t::type&);
 
 #ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
 template <class T>
 static KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t cast_to_wrapper(
-    T x, const volatile Kokkos::Impl::bhalf_impl_t::type&);
+    T x, const
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+    volatile
+#endif
+    Kokkos::Impl::bhalf_impl_t::type&);
 #endif  // KOKKOS_IMPL_BHALF_TYPE_DEFINED
 
 template <class T>
@@ -283,6 +291,7 @@ class alignas(FloatType) floating_point_wrapper {
 
  private:
   impl_type val;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   using fixed_width_integer_type = std::conditional_t<
       sizeof(impl_type) == 2, uint16_t,
       std::conditional_t<
@@ -290,6 +299,7 @@ class alignas(FloatType) floating_point_wrapper {
           std::conditional_t<sizeof(impl_type) == 8, uint64_t, void>>>;
   static_assert(!std::is_void<fixed_width_integer_type>::value,
                 "Invalid impl_type");
+#endif
 
  public:
   // In-class initialization and defaulted default constructors not used
@@ -318,7 +328,8 @@ class alignas(FloatType) floating_point_wrapper {
       default;
 #endif
 
-  KOKKOS_INLINE_FUNCTION
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION
   floating_point_wrapper(const volatile floating_point_wrapper& rhs) {
 #if defined(KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH) && !defined(KOKKOS_ENABLE_SYCL)
     val = rhs.val;
@@ -326,9 +337,10 @@ class alignas(FloatType) floating_point_wrapper {
     const volatile fixed_width_integer_type* rv_ptr =
         reinterpret_cast<const volatile fixed_width_integer_type*>(&rhs.val);
     const fixed_width_integer_type rv_val = *rv_ptr;
-    val       = reinterpret_cast<const impl_type&>(rv_val);
+    val = reinterpret_cast<const impl_type&>(rv_val);
 #endif  // KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
   }
+#endif
 
   KOKKOS_FUNCTION
   floating_point_wrapper(bit_comparison_type rhs) {
@@ -492,14 +504,16 @@ class alignas(FloatType) floating_point_wrapper {
     return *this;
   }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   template <class T>
-  KOKKOS_FUNCTION void operator=(T rhs) volatile {
+  KOKKOS_DEPRECATED KOKKOS_FUNCTION void operator=(T rhs) volatile {
     impl_type new_val = cast_to_wrapper(rhs, val).val;
     volatile fixed_width_integer_type* val_ptr =
         reinterpret_cast<volatile fixed_width_integer_type*>(
             const_cast<impl_type*>(&val));
     *val_ptr = reinterpret_cast<fixed_width_integer_type&>(new_val);
   }
+#endif
 
   // Compound operators
   KOKKOS_FUNCTION
@@ -515,14 +529,16 @@ class alignas(FloatType) floating_point_wrapper {
     return *this;
   }
 
-  KOKKOS_FUNCTION
-  void operator+=(const volatile floating_point_wrapper& rhs) volatile {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED KOKKOS_FUNCTION void operator+=(
+      const volatile floating_point_wrapper& rhs) volatile {
     floating_point_wrapper tmp_rhs = rhs;
     floating_point_wrapper tmp_lhs = *this;
 
     tmp_lhs += tmp_rhs;
     *this = tmp_lhs;
   }
+#endif
 
   // Compound operators: upcast overloads for +=
   template <class T>
@@ -560,14 +576,16 @@ class alignas(FloatType) floating_point_wrapper {
     return *this;
   }
 
-  KOKKOS_FUNCTION
-  void operator-=(const volatile floating_point_wrapper& rhs) volatile {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED KOKKOS_FUNCTION void operator-=(
+      const volatile floating_point_wrapper& rhs) volatile {
     floating_point_wrapper tmp_rhs = rhs;
     floating_point_wrapper tmp_lhs = *this;
 
     tmp_lhs -= tmp_rhs;
     *this = tmp_lhs;
   }
+#endif
 
   // Compund operators: upcast overloads for -=
   template <class T>
@@ -605,14 +623,16 @@ class alignas(FloatType) floating_point_wrapper {
     return *this;
   }
 
-  KOKKOS_FUNCTION
-  void operator*=(const volatile floating_point_wrapper& rhs) volatile {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED KOKKOS_FUNCTION void operator*=(
+      const volatile floating_point_wrapper& rhs) volatile {
     floating_point_wrapper tmp_rhs = rhs;
     floating_point_wrapper tmp_lhs = *this;
 
     tmp_lhs *= tmp_rhs;
     *this = tmp_lhs;
   }
+#endif
 
   // Compund operators: upcast overloads for *=
   template <class T>
@@ -650,14 +670,16 @@ class alignas(FloatType) floating_point_wrapper {
     return *this;
   }
 
-  KOKKOS_FUNCTION
-  void operator/=(const volatile floating_point_wrapper& rhs) volatile {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED KOKKOS_FUNCTION void operator/=(
+      const volatile floating_point_wrapper& rhs) volatile {
     floating_point_wrapper tmp_rhs = rhs;
     floating_point_wrapper tmp_lhs = *this;
 
     tmp_lhs /= tmp_rhs;
     *this = tmp_lhs;
   }
+#endif
 
   // Compund operators: upcast overloads for /=
   template <class T>
@@ -884,26 +906,28 @@ class alignas(FloatType) floating_point_wrapper {
 #endif
   }
 
-  KOKKOS_FUNCTION
-  friend bool operator==(const volatile floating_point_wrapper& lhs,
-                         const volatile floating_point_wrapper& rhs) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED KOKKOS_FUNCTION friend bool operator==(
+      const volatile floating_point_wrapper& lhs,
+      const volatile floating_point_wrapper& rhs) {
     floating_point_wrapper tmp_lhs = lhs, tmp_rhs = rhs;
     return tmp_lhs == tmp_rhs;
   }
 
-  KOKKOS_FUNCTION
-  friend bool operator!=(const volatile floating_point_wrapper& lhs,
-                         const volatile floating_point_wrapper& rhs) {
+  KOKKOS_DEPRECATED KOKKOS_FUNCTION friend bool operator!=(
+      const volatile floating_point_wrapper& lhs,
+      const volatile floating_point_wrapper& rhs) {
     floating_point_wrapper tmp_lhs = lhs, tmp_rhs = rhs;
     return tmp_lhs != tmp_rhs;
   }
 
-  KOKKOS_FUNCTION
-  friend bool operator<(const volatile floating_point_wrapper& lhs,
-                        const volatile floating_point_wrapper& rhs) {
+  KOKKOS_DEPRECATED KOKKOS_FUNCTION friend bool operator<(
+      const volatile floating_point_wrapper& lhs,
+      const volatile floating_point_wrapper& rhs) {
     floating_point_wrapper tmp_lhs = lhs, tmp_rhs = rhs;
     return tmp_lhs < tmp_rhs;
   }
+#endif
 
   template <class T>
   KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
@@ -923,12 +947,14 @@ class alignas(FloatType) floating_point_wrapper {
     return lhs < static_cast<float>(rhs);
   }
 
-  KOKKOS_FUNCTION
-  friend bool operator>(const volatile floating_point_wrapper& lhs,
-                        const volatile floating_point_wrapper& rhs) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED KOKKOS_FUNCTION friend bool operator>(
+      const volatile floating_point_wrapper& lhs,
+      const volatile floating_point_wrapper& rhs) {
     floating_point_wrapper tmp_lhs = lhs, tmp_rhs = rhs;
     return tmp_lhs > tmp_rhs;
   }
+#endif
 
   template <class T>
   KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
@@ -948,12 +974,14 @@ class alignas(FloatType) floating_point_wrapper {
     return lhs > static_cast<float>(rhs);
   }
 
-  KOKKOS_FUNCTION
-  friend bool operator<=(const volatile floating_point_wrapper& lhs,
-                         const volatile floating_point_wrapper& rhs) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED KOKKOS_FUNCTION friend bool operator<=(
+      const volatile floating_point_wrapper& lhs,
+      const volatile floating_point_wrapper& rhs) {
     floating_point_wrapper tmp_lhs = lhs, tmp_rhs = rhs;
     return tmp_lhs <= tmp_rhs;
   }
+#endif
 
   template <class T>
   KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
@@ -973,12 +1001,14 @@ class alignas(FloatType) floating_point_wrapper {
     return lhs <= static_cast<float>(rhs);
   }
 
-  KOKKOS_FUNCTION
-  friend bool operator>=(const volatile floating_point_wrapper& lhs,
-                         const volatile floating_point_wrapper& rhs) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED KOKKOS_FUNCTION friend bool operator>=(
+      const volatile floating_point_wrapper& lhs,
+      const volatile floating_point_wrapper& rhs) {
     floating_point_wrapper tmp_lhs = lhs, tmp_rhs = rhs;
     return tmp_lhs >= tmp_rhs;
   }
+#endif
 
   template <class T>
   KOKKOS_FUNCTION friend std::enable_if_t<std::is_convertible_v<T, float> &&
@@ -1018,14 +1048,22 @@ class alignas(FloatType) floating_point_wrapper {
 // Declare wrapper overloads now that floating_point_wrapper is declared
 template <class T>
 static KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t cast_to_wrapper(
-    T x, const volatile Kokkos::Impl::half_impl_t::type&) {
+    T x, const
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+    volatile
+#endif
+    Kokkos::Impl::half_impl_t::type&) {
   return Kokkos::Experimental::cast_to_half(x);
 }
 
 #ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
 template <class T>
 static KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t cast_to_wrapper(
-    T x, const volatile Kokkos::Impl::bhalf_impl_t::type&) {
+    T x, const
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+    volatile
+#endif
+    Kokkos::Impl::bhalf_impl_t::type&) {
   return Kokkos::Experimental::cast_to_bhalf(x);
 }
 #endif  // KOKKOS_IMPL_BHALF_TYPE_DEFINED

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -269,7 +269,8 @@ enum OP_TESTS {
 };
 
 // volatile-qualified parameter type 'volatile half_type' is deprecated
-#if !defined(KOKKOS_ENABLE_CXX20) && !defined(KOKKOS_ENABLE_CXX23)
+#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) && \
+    !defined(KOKKOS_ENABLE_CXX20) && !defined(KOKKOS_ENABLE_CXX23)
 template <class view_type, class half_type>
 struct Functor_TestHalfVolatileOperators {
   volatile half_type h_lhs, h_rhs;
@@ -996,7 +997,8 @@ void __test_half_operators(half_type h_lhs, half_type h_rhs) {
   }
 
 // volatile-qualified parameter type 'volatile half_type' is deprecated
-#if !defined(KOKKOS_ENABLE_CXX20) && !defined(KOKKOS_ENABLE_CXX23)
+#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) && \
+    !defined(KOKKOS_ENABLE_CXX20) && !defined(KOKKOS_ENABLE_CXX23)
   // Test partial volatile support
   volatile half_type _h_lhs = h_lhs;
   volatile half_type _h_rhs = h_rhs;

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -268,97 +268,6 @@ enum OP_TESTS {
   N_OP_TESTS
 };
 
-// volatile-qualified parameter type 'volatile half_type' is deprecated
-#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) && \
-    !defined(KOKKOS_ENABLE_CXX20) && !defined(KOKKOS_ENABLE_CXX23)
-template <class view_type, class half_type>
-struct Functor_TestHalfVolatileOperators {
-  volatile half_type h_lhs, h_rhs;
-  view_type actual_lhs, expected_lhs;
-  double d_lhs, d_rhs;
-  Functor_TestHalfVolatileOperators(volatile half_type lhs = half_type(0),
-                                    volatile half_type rhs = half_type(0))
-      : h_lhs(lhs), h_rhs(rhs) {
-    actual_lhs   = view_type("actual_lhs", N_OP_TESTS);
-    expected_lhs = view_type("expected_lhs", N_OP_TESTS);
-    half_type nv_tmp;
-    nv_tmp = h_lhs;
-    d_lhs  = static_cast<double>(nv_tmp);
-    nv_tmp = h_rhs;
-    d_rhs  = static_cast<double>(nv_tmp);
-    if (std::is_same<view_type, ViewTypeHost>::value) {
-      auto run_on_host = *this;
-      run_on_host(0);
-    } else {
-      Kokkos::parallel_for("Test::Functor_TestHalfVolatileOperators",
-                           Kokkos::RangePolicy<ExecutionSpace>(0, 1), *this);
-    }
-  }
-
-  KOKKOS_FUNCTION
-  void operator()(int) const {
-    volatile half_type tmp_lhs;
-    half_type nv_tmp;
-
-    // Initialze output views to catch missing test invocations
-    for (int i = 0; i < N_OP_TESTS; ++i) {
-      actual_lhs(i)   = 1;
-      expected_lhs(i) = -1;
-    }
-
-    nv_tmp               = h_lhs;
-    actual_lhs(ASSIGN)   = static_cast<double>(nv_tmp);
-    expected_lhs(ASSIGN) = d_lhs;
-
-    actual_lhs(LT_H_H)   = h_lhs < h_rhs;
-    expected_lhs(LT_H_H) = d_lhs < d_rhs;
-
-    actual_lhs(LE_H_H)   = h_lhs <= h_rhs;
-    expected_lhs(LE_H_H) = d_lhs <= d_rhs;
-
-    actual_lhs(NEQ)   = h_lhs != h_rhs;
-    expected_lhs(NEQ) = d_lhs != d_rhs;
-
-    actual_lhs(GT_H_H)   = h_lhs > h_rhs;
-    expected_lhs(GT_H_H) = d_lhs > d_rhs;
-
-    actual_lhs(GE_H_H)   = h_lhs >= h_rhs;
-    expected_lhs(GE_H_H) = d_lhs >= d_rhs;
-
-    actual_lhs(EQ)   = h_lhs == h_rhs;
-    expected_lhs(EQ) = d_lhs == d_rhs;
-
-    tmp_lhs = h_lhs;
-    tmp_lhs += h_rhs;
-    nv_tmp                 = tmp_lhs;
-    actual_lhs(CADD_H_H)   = static_cast<double>(nv_tmp);
-    expected_lhs(CADD_H_H) = d_lhs;
-    expected_lhs(CADD_H_H) += d_rhs;
-
-    tmp_lhs = h_lhs;
-    tmp_lhs -= h_rhs;
-    nv_tmp                 = tmp_lhs;
-    actual_lhs(CSUB_H_H)   = static_cast<double>(nv_tmp);
-    expected_lhs(CSUB_H_H) = d_lhs;
-    expected_lhs(CSUB_H_H) -= d_rhs;
-
-    tmp_lhs = h_lhs;
-    tmp_lhs *= h_rhs;
-    nv_tmp                 = tmp_lhs;
-    actual_lhs(CMUL_H_H)   = static_cast<double>(nv_tmp);
-    expected_lhs(CMUL_H_H) = d_lhs;
-    expected_lhs(CMUL_H_H) *= d_rhs;
-
-    tmp_lhs = h_lhs;
-    tmp_lhs /= h_rhs;
-    nv_tmp                 = tmp_lhs;
-    actual_lhs(CDIV_H_H)   = static_cast<double>(nv_tmp);
-    expected_lhs(CDIV_H_H) = d_lhs;
-    expected_lhs(CDIV_H_H) /= d_rhs;
-  }
-};
-#endif
-
 template <class view_type, class half_type>
 struct Functor_TestHalfOperators {
   half_type h_lhs, h_rhs;
@@ -995,34 +904,6 @@ void __test_half_operators(half_type h_lhs, half_type h_rhs) {
     ASSERT_NEAR(f_host.actual_lhs(op_test), f_host.expected_lhs(op_test),
                 static_cast<double>(epsilon));
   }
-
-// volatile-qualified parameter type 'volatile half_type' is deprecated
-#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) && \
-    !defined(KOKKOS_ENABLE_CXX20) && !defined(KOKKOS_ENABLE_CXX23)
-  // Test partial volatile support
-  volatile half_type _h_lhs = h_lhs;
-  volatile half_type _h_rhs = h_rhs;
-  Functor_TestHalfVolatileOperators<ViewType, half_type> f_volatile_device(
-      _h_lhs, _h_rhs);
-  Functor_TestHalfVolatileOperators<ViewTypeHost, half_type> f_volatile_host(
-      _h_lhs, _h_rhs);
-
-  ExecutionSpace().fence();
-  Kokkos::deep_copy(f_device_actual_lhs, f_device.actual_lhs);
-  Kokkos::deep_copy(f_device_expected_lhs, f_device.expected_lhs);
-  for (int op_test = 0; op_test < N_OP_TESTS; op_test++) {
-    // printf("op_test = %d\n", op_test);
-    if (op_test == ASSIGN || op_test == LT_H_H || op_test == LE_H_H ||
-        op_test == NEQ || op_test == EQ || op_test == GT_H_H ||
-        op_test == GE_H_H || op_test == CADD_H_H || op_test == CSUB_H_H ||
-        op_test == CMUL_H_H || op_test == CDIV_H_H) {
-      ASSERT_NEAR(f_device_actual_lhs(op_test), f_device_expected_lhs(op_test),
-                  static_cast<double>(epsilon));
-      ASSERT_NEAR(f_host.actual_lhs(op_test), f_host.expected_lhs(op_test),
-                  static_cast<double>(epsilon));
-    }
-  }
-#endif
 
   // is_trivially_copyable is false with the addition of explicit
   // copy constructors that are required for supporting reductions


### PR DESCRIPTION
`Kokkos::[b]half_t` is the only `Kokkos`-defined type that still supports `volatile` semantics (without deprecations). In particular, we deprecated the overloads for the more widely used `Kokkos::complex` in https://github.com/kokkos/kokkos/pull/5412. `fixed_width_integer_type` is defined only for these overloads and we need to do some `reinterpret_cast` to work around missing support for the backend-specific types. #6543 introduces `bit_comparison_type` that serves a similar purpose but replacing the `reinterpret_casts` with `bit_cast` is difficult. Thus, to clean up the interface, this pull request suggests to ~~deprecate~~ remove the `volatile` overloads.