### PR TITLE
OpenMPTarget: Guard scratch memory usage in ParallelReduce

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.cpp
@@ -75,6 +75,7 @@ int* OpenMPTargetExec::m_lock_array           = nullptr;
 uint64_t OpenMPTargetExec::m_lock_size        = 0;
 uint32_t* OpenMPTargetExec::m_uniquetoken_ptr = nullptr;
 int OpenMPTargetExec::MAX_ACTIVE_THREADS      = 0;
+std::mutex OpenMPTargetExec::m_mutex_scratch_ptr;
 
 void OpenMPTargetExec::clear_scratch() {
   Kokkos::Experimental::OpenMPTargetSpace space;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -750,6 +750,7 @@ class OpenMPTargetExec {
                              int64_t thread_local_bytes, int64_t league_size);
 
   static void* m_scratch_ptr;
+  static std::mutex m_mutex_scratch_ptr;
   static int64_t m_scratch_size;
   static int* m_lock_array;
   static uint64_t m_lock_size;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Team.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Team.hpp
@@ -470,6 +470,10 @@ class ParallelReduce<CombinedFunctorReducerType,
   const pointer_type m_result_ptr;
   const size_t m_shmem_size;
 
+  // Only let one ParallelReduce instance at a time use the scratch memory.
+  // The constructor acquires the mutex which is released in the destructor.
+  std::scoped_lock<std::mutex> m_scratch_memory_lock;
+
  public:
   void execute() const {
     const FunctorType& functor = m_functor_reducer.get_functor();
@@ -517,7 +521,8 @@ class ParallelReduce<CombinedFunctorReducerType,
         m_shmem_size(
             arg_policy.scratch_size(0) + arg_policy.scratch_size(1) +
             FunctorTeamShmemSize<FunctorType>::value(
-                arg_functor_reducer.get_functor(), arg_policy.team_size())) {}
+                arg_functor_reducer.get_functor(), arg_policy.team_size())),
+        m_scratch_memory_lock(OpenMPTargetExec::m_mutex_scratch_ptr) {}
 };
 
 }  // namespace Impl


### PR DESCRIPTION
This should fix the occasional `openmptarget.partitioning_by_args` failures. AFAIK, we don't guard the usage of scratch memory in the OpenMPTarget backend so that we could run into race conditions when executing `parallel_reduce` from multiple simultaneously like `partitioning_by_args` does.
Names of the variables are up for bikeshedding, of course.