### PR TITLE
Use binary wrapper for consistency in definition of half types numeric traits

### DIFF
--- a/core/src/impl/Kokkos_Half_NumericTraits.hpp
+++ b/core/src/impl/Kokkos_Half_NumericTraits.hpp
@@ -297,7 +297,7 @@ struct Kokkos::Experimental::Impl::round_error_helper<
 template <>
 struct Kokkos::Experimental::Impl::norm_min_helper<
     Kokkos::Experimental::bhalf_t> {
-  static constexpr Kokkos::Experimental::bhalf_t::bit_comparison_type value{0b0'00000001'0000000}; // 1.1754494351e-38
+  static constexpr Kokkos::Experimental::bhalf_t::bit_comparison_type value{0b0'00000001'0000000}; // 1.175494351e-38
 };
 // Quiet not a bhalf number
 template <>

--- a/core/src/impl/Kokkos_Half_NumericTraits.hpp
+++ b/core/src/impl/Kokkos_Half_NumericTraits.hpp
@@ -152,7 +152,7 @@ struct Kokkos::Experimental::Impl::round_error_helper<
 template <>
 struct Kokkos::Experimental::Impl::norm_min_helper<
     Kokkos::Experimental::half_t> {
-  static constexpr Kokkos::Experimental::half_t::bit_comparison_type value{0b0'00001'0000000001}; // 0.00006103515625
+  static constexpr Kokkos::Experimental::half_t::bit_comparison_type value{0b0'00001'0000000000}; // 0.00006103515625
 };
 
 /// \brief: Quiet not a half precision number
@@ -297,7 +297,7 @@ struct Kokkos::Experimental::Impl::round_error_helper<
 template <>
 struct Kokkos::Experimental::Impl::norm_min_helper<
     Kokkos::Experimental::bhalf_t> {
-  static constexpr Kokkos::Experimental::bhalf_t::bit_comparison_type value{0b0'00000001'0000001}; // 1.1754494351e-38
+  static constexpr Kokkos::Experimental::bhalf_t::bit_comparison_type value{0b0'00000001'0000000}; // 1.1754494351e-38
 };
 // Quiet not a bhalf number
 template <>

--- a/core/src/impl/Kokkos_Half_NumericTraits.hpp
+++ b/core/src/impl/Kokkos_Half_NumericTraits.hpp
@@ -87,7 +87,7 @@ struct Kokkos::Experimental::Impl::infinity_helper<Kokkos::Experimental::half_t>
 template <>
 struct Kokkos::Experimental::Impl::finite_min_helper<
     Kokkos::Experimental::half_t> {
-  static constexpr float value = -65504.0F;
+  static constexpr Kokkos::Experimental::half_t::bit_comparison_type value{0b1'11110'1111111111}; // -65504
 };
 
 /// \brief: Maximum normalized number
@@ -104,7 +104,7 @@ struct Kokkos::Experimental::Impl::finite_min_helper<
 template <>
 struct Kokkos::Experimental::Impl::finite_max_helper<
     Kokkos::Experimental::half_t> {
-  static constexpr float value = 65504.0F;
+  static constexpr Kokkos::Experimental::half_t::bit_comparison_type value{0b0'11110'1111111111}; // +65504
 };
 
 /// \brief: This is the difference between 1 and the smallest floating point
@@ -123,7 +123,7 @@ struct Kokkos::Experimental::Impl::finite_max_helper<
 template <>
 struct Kokkos::Experimental::Impl::epsilon_helper<
     Kokkos::Experimental::half_t> {
-  static constexpr float value = 0.0009765625F;
+  static constexpr Kokkos::Experimental::half_t::bit_comparison_type value{0b0'00101'0000000000}; // 0.0009765625
 };
 
 /// @brief: The largest possible rounding error in ULPs
@@ -134,7 +134,7 @@ struct Kokkos::Experimental::Impl::epsilon_helper<
 template <>
 struct Kokkos::Experimental::Impl::round_error_helper<
     Kokkos::Experimental::half_t> {
-  static constexpr float value = 0.5F;
+  static constexpr Kokkos::Experimental::half_t::bit_comparison_type value{0b0'01110'0000000000}; // 0.5
 };
 
 /// \brief: Minimum normalized positive half precision number
@@ -152,7 +152,7 @@ struct Kokkos::Experimental::Impl::round_error_helper<
 template <>
 struct Kokkos::Experimental::Impl::norm_min_helper<
     Kokkos::Experimental::half_t> {
-  static constexpr float value = 0.00006103515625F;
+  static constexpr Kokkos::Experimental::half_t::bit_comparison_type value{0b0'00001'0000000001}; // 0.00006103515625
 };
 
 /// \brief: Quiet not a half precision number
@@ -274,30 +274,30 @@ struct Kokkos::Experimental::Impl::infinity_helper<Kokkos::Experimental::bhalf_t
 template <>
 struct Kokkos::Experimental::Impl::finite_min_helper<
     Kokkos::Experimental::bhalf_t> {
-  static constexpr float value = -3.38953139e38;
+  static constexpr Kokkos::Experimental::bhalf_t::bit_comparison_type value{0b1'11111110'1111111}; // -3.38953139e38
 };
 // Maximum normalized number
 template <>
 struct Kokkos::Experimental::Impl::finite_max_helper<
     Kokkos::Experimental::bhalf_t> {
-  static constexpr float value = 3.38953139e38;
+  static constexpr Kokkos::Experimental::bhalf_t::bit_comparison_type value{0b0'11111110'1111111}; // +3.38953139e3
 };
 // 1/2^7
 template <>
 struct Kokkos::Experimental::Impl::epsilon_helper<
     Kokkos::Experimental::bhalf_t> {
-  static constexpr float value = 0.0078125F;
+  static constexpr Kokkos::Experimental::bhalf_t::bit_comparison_type value{0b0'01111000'0000000}; // 0.0078125
 };
 template <>
 struct Kokkos::Experimental::Impl::round_error_helper<
     Kokkos::Experimental::bhalf_t> {
-  static constexpr float value = 0.5F;
+  static constexpr Kokkos::Experimental::bhalf_t::bit_comparison_type value{0b0'01111110'0000000}; // 0.5
 };
 // Minimum normalized positive bhalf number
 template <>
 struct Kokkos::Experimental::Impl::norm_min_helper<
     Kokkos::Experimental::bhalf_t> {
-  static constexpr float value = 1.1754494351e-38;
+  static constexpr Kokkos::Experimental::bhalf_t::bit_comparison_type value{0b0'00000001'0000001}; // 1.1754494351e-38
 };
 // Quiet not a bhalf number
 template <>

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -975,7 +975,7 @@ struct Functor_TestHalfOperators {
 
 template <class half_type>
 void __test_half_operators(half_type h_lhs, half_type h_rhs) {
-  double epsilon = Kokkos::Experimental::epsilon<half_type>::value;
+  half_type epsilon = Kokkos::Experimental::epsilon<half_type>::value;
 
   Functor_TestHalfOperators<ViewType, half_type> f_device(h_lhs, h_rhs);
   Functor_TestHalfOperators<ViewTypeHost, half_type> f_host(h_lhs, h_rhs);
@@ -990,9 +990,9 @@ void __test_half_operators(half_type h_lhs, half_type h_rhs) {
   for (int op_test = 0; op_test < N_OP_TESTS; op_test++) {
     // printf("op_test = %d\n", op_test);
     ASSERT_NEAR(f_device_actual_lhs(op_test), f_device_expected_lhs(op_test),
-                epsilon);
+                static_cast<double>(epsilon));
     ASSERT_NEAR(f_host.actual_lhs(op_test), f_host.expected_lhs(op_test),
-                epsilon);
+                static_cast<double>(epsilon));
   }
 
 // volatile-qualified parameter type 'volatile half_type' is deprecated
@@ -1015,9 +1015,9 @@ void __test_half_operators(half_type h_lhs, half_type h_rhs) {
         op_test == GE_H_H || op_test == CADD_H_H || op_test == CSUB_H_H ||
         op_test == CMUL_H_H || op_test == CDIV_H_H) {
       ASSERT_NEAR(f_device_actual_lhs(op_test), f_device_expected_lhs(op_test),
-                  epsilon);
+                  static_cast<double>(epsilon));
       ASSERT_NEAR(f_host.actual_lhs(op_test), f_host.expected_lhs(op_test),
-                  epsilon);
+                  static_cast<double>(epsilon));
     }
   }
 #endif

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -240,11 +240,25 @@ struct FloatingPointComparison {
   }
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
   KOKKOS_FUNCTION
-  KE::half_t eps(KE::half_t) const { return KE::epsilon<KE::half_t>::value; }
+  KE::half_t eps(KE::half_t) const {
+// FIXME_NVHPC compile-time error
+#ifdef KOKKOS_COMPILER_NVHPC
+    return 0.0009765625F;
+#else
+    return KE::epsilon<KE::half_t>::value;
+#endif
+  }
 #endif
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
   KOKKOS_FUNCTION
-  KE::bhalf_t eps(KE::bhalf_t) const { return KE::epsilon<KE::bhalf_t>::value; }
+  KE::bhalf_t eps(KE::bhalf_t) const {
+// FIXME_NVHPC compile-time error
+#ifdef KOKKOS_COMPILER_NVHPC
+    return 0.0078125;
+#else
+    return KE::epsilon<KE::bhalf_t>::value;
+#endif
+  }
 #endif
   KOKKOS_FUNCTION
   double eps(float) const { return FLT_EPSILON; }

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -218,6 +218,8 @@ TEST(TEST_CATEGORY, numeric_traits_infinity) {
 }
 
 TEST(TEST_CATEGORY, numeric_traits_epsilon) {
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t, Epsilon>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Epsilon>();
   TestNumericTraits<TEST_EXECSPACE, float, Epsilon>();
   TestNumericTraits<TEST_EXECSPACE, double, Epsilon>();
   // FIXME_NVHPC long double not supported
@@ -228,6 +230,9 @@ TEST(TEST_CATEGORY, numeric_traits_epsilon) {
 }
 
 TEST(TEST_CATEGORY, numeric_traits_round_error) {
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t, RoundError>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t,
+                    RoundError>();
   TestNumericTraits<TEST_EXECSPACE, float, RoundError>();
   TestNumericTraits<TEST_EXECSPACE, double, RoundError>();
   // FIXME_NVHPC long double not supported
@@ -238,6 +243,8 @@ TEST(TEST_CATEGORY, numeric_traits_round_error) {
 }
 
 TEST(TEST_CATEGORY, numeric_traits_norm_min) {
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t, NormMin>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, NormMin>();
   TestNumericTraits<TEST_EXECSPACE, float, NormMin>();
   TestNumericTraits<TEST_EXECSPACE, double, NormMin>();
   // FIXME_NVHPC long double not supported
@@ -248,6 +255,8 @@ TEST(TEST_CATEGORY, numeric_traits_norm_min) {
 }
 
 TEST(TEST_CATEGORY, numeric_traits_denorm_min) {
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t, DenormMin>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, DenormMin>();
   TestNumericTraits<TEST_EXECSPACE, float, DenormMin>();
   TestNumericTraits<TEST_EXECSPACE, double, DenormMin>();
   // FIXME_NVHPC long double not supported
@@ -309,6 +318,8 @@ TEST(TEST_CATEGORY, numeric_traits_digits) {
   TestNumericTraits<TEST_EXECSPACE, unsigned long int, Digits>();
   TestNumericTraits<TEST_EXECSPACE, long long int, Digits>();
   TestNumericTraits<TEST_EXECSPACE, unsigned long long int, Digits>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t, Digits>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Digits>();
   TestNumericTraits<TEST_EXECSPACE, float, Digits>();
   TestNumericTraits<TEST_EXECSPACE, double, Digits>();
 #if !defined(KOKKOS_ENABLE_CUDA) || \
@@ -330,6 +341,8 @@ TEST(TEST_CATEGORY, numeric_traits_digits10) {
   TestNumericTraits<TEST_EXECSPACE, unsigned long int, Digits10>();
   TestNumericTraits<TEST_EXECSPACE, long long int, Digits10>();
   TestNumericTraits<TEST_EXECSPACE, unsigned long long int, Digits10>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t, Digits10>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Digits10>();
   TestNumericTraits<TEST_EXECSPACE, float, Digits10>();
   TestNumericTraits<TEST_EXECSPACE, double, Digits10>();
 #if !defined(KOKKOS_ENABLE_CUDA) || \
@@ -339,6 +352,10 @@ TEST(TEST_CATEGORY, numeric_traits_digits10) {
 }
 
 TEST(TEST_CATEGORY, numeric_traits_max_digits10) {
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t,
+                    MaxDigits10>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t,
+                    MaxDigits10>();
   TestNumericTraits<TEST_EXECSPACE, float, MaxDigits10>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxDigits10>();
 #if !defined(KOKKOS_ENABLE_CUDA) || \
@@ -359,6 +376,8 @@ TEST(TEST_CATEGORY, numeric_traits_radix) {
   TestNumericTraits<TEST_EXECSPACE, unsigned long int, Radix>();
   TestNumericTraits<TEST_EXECSPACE, long long int, Radix>();
   TestNumericTraits<TEST_EXECSPACE, unsigned long long int, Radix>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t, Radix>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Radix>();
   TestNumericTraits<TEST_EXECSPACE, float, Radix>();
   TestNumericTraits<TEST_EXECSPACE, double, Radix>();
 #if !defined(KOKKOS_ENABLE_CUDA) || \
@@ -368,6 +387,10 @@ TEST(TEST_CATEGORY, numeric_traits_radix) {
 }
 
 TEST(TEST_CATEGORY, numeric_traits_min_max_exponent) {
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t,
+                    MinExponent>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t,
+                    MaxExponent>();
   TestNumericTraits<TEST_EXECSPACE, float, MinExponent>();
   TestNumericTraits<TEST_EXECSPACE, float, MaxExponent>();
   TestNumericTraits<TEST_EXECSPACE, double, MinExponent>();
@@ -380,6 +403,10 @@ TEST(TEST_CATEGORY, numeric_traits_min_max_exponent) {
 }
 
 TEST(TEST_CATEGORY, numeric_traits_min_max_exponent10) {
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t,
+                    MinExponent10>();
+  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t,
+                    MinExponent10>();
   TestNumericTraits<TEST_EXECSPACE, float, MinExponent10>();
   TestNumericTraits<TEST_EXECSPACE, float, MaxExponent10>();
   TestNumericTraits<TEST_EXECSPACE, double, MinExponent10>();

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -255,8 +255,6 @@ TEST(TEST_CATEGORY, numeric_traits_norm_min) {
 }
 
 TEST(TEST_CATEGORY, numeric_traits_denorm_min) {
-  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t, DenormMin>();
-  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, DenormMin>();
   TestNumericTraits<TEST_EXECSPACE, float, DenormMin>();
   TestNumericTraits<TEST_EXECSPACE, double, DenormMin>();
   // FIXME_NVHPC long double not supported
@@ -352,10 +350,6 @@ TEST(TEST_CATEGORY, numeric_traits_digits10) {
 }
 
 TEST(TEST_CATEGORY, numeric_traits_max_digits10) {
-  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t,
-                    MaxDigits10>();
-  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t,
-                    MaxDigits10>();
   TestNumericTraits<TEST_EXECSPACE, float, MaxDigits10>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxDigits10>();
 #if !defined(KOKKOS_ENABLE_CUDA) || \
@@ -403,10 +397,6 @@ TEST(TEST_CATEGORY, numeric_traits_min_max_exponent) {
 }
 
 TEST(TEST_CATEGORY, numeric_traits_min_max_exponent10) {
-  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t,
-                    MinExponent10>();
-  TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t,
-                    MinExponent10>();
   TestNumericTraits<TEST_EXECSPACE, float, MinExponent10>();
   TestNumericTraits<TEST_EXECSPACE, float, MaxExponent10>();
   TestNumericTraits<TEST_EXECSPACE, double, MinExponent10>();

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -218,8 +218,10 @@ TEST(TEST_CATEGORY, numeric_traits_infinity) {
 }
 
 TEST(TEST_CATEGORY, numeric_traits_epsilon) {
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7 bit_comparison_type
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t, Epsilon>();
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Epsilon>();
+#endif
   TestNumericTraits<TEST_EXECSPACE, float, Epsilon>();
   TestNumericTraits<TEST_EXECSPACE, double, Epsilon>();
   // FIXME_NVHPC long double not supported
@@ -230,9 +232,11 @@ TEST(TEST_CATEGORY, numeric_traits_epsilon) {
 }
 
 TEST(TEST_CATEGORY, numeric_traits_round_error) {
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7 bit_comparison_type
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t, RoundError>();
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t,
                     RoundError>();
+#endif
   TestNumericTraits<TEST_EXECSPACE, float, RoundError>();
   TestNumericTraits<TEST_EXECSPACE, double, RoundError>();
   // FIXME_NVHPC long double not supported
@@ -243,8 +247,10 @@ TEST(TEST_CATEGORY, numeric_traits_round_error) {
 }
 
 TEST(TEST_CATEGORY, numeric_traits_norm_min) {
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC 23.7 bit_comparison_type
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t, NormMin>();
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, NormMin>();
+#endif
   TestNumericTraits<TEST_EXECSPACE, float, NormMin>();
   TestNumericTraits<TEST_EXECSPACE, double, NormMin>();
   // FIXME_NVHPC long double not supported


### PR DESCRIPTION
This is a follow up on #6543 also targeting 4.2 (would cherry-pick into the release candidate branch after merge into develop)
Daniel's PR fixed the `infinity` and `{quiet,signaling}_NaN` traits and this PR propose to also use the binary wrapper as a value type for the `finite_{min,max}`, `epsilon`, `norm_min`, and `round_error` traits.

The goal is to increase consistency between all distinguished values (that is do not mix and have some being float and other with the binary representation)