### PR TITLE
kokkos(unique): fix allocation of temporary view to enforce using the provided space instance and skip initialization 

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_Unique.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Unique.hpp
@@ -105,7 +105,9 @@ IteratorType unique_exespace_impl(const std::string& label,
       // using the same algorithm used for unique_copy but we now move things
       using value_type    = typename IteratorType::value_type;
       using tmp_view_type = Kokkos::View<value_type*, ExecutionSpace>;
-      tmp_view_type tmp_view("std_unique_tmp_view", num_elements_to_explore);
+      tmp_view_type tmp_view(Kokkos::view_alloc(ex, Kokkos::WithoutInitializing,
+                                                "std_unique_tmp_view"),
+                             num_elements_to_explore);
 
       // scan extent is: num_elements_to_explore - 1
       // for same reason as the one explained in unique_copy


### PR DESCRIPTION
This PR is extracted from #6584 as requested by @dalg24.