### PR TITLE
operator== for Kokkos::Array.

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -320,6 +320,26 @@ struct Array<T, KOKKOS_INVALID_INDEX, Array<>::strided> {
       : m_elem(arg_ptr), m_size(arg_size), m_stride(arg_stride) {}
 };
 
+template <typename T,
+          size_t LN, typename LP, 
+          size_t RN, typename RP>
+KOKKOS_INLINE_FUNCTION constexpr bool operator==(const Array<T, LN, LP>& lhs, 
+                                                 const Array<T, RN, RP>& rhs) {
+  if (lhs.size() != rhs.size()) return false;
+    for (int i = 0; i < (int)(lhs.size()); ++i) {
+      if (lhs[i] != rhs[i]) return false;
+    }
+    return true;
+}
+
+template <typename T,
+          size_t LN, typename LP, 
+          size_t RN, typename RP>
+KOKKOS_INLINE_FUNCTION constexpr bool operator!=(const Array<T, LN, LP>& lhs, 
+                                                 const Array<T, RN, RP>& rhs) {
+  return !(lhs == rhs);
+}
+
 }  // namespace Kokkos
 
 //<editor-fold desc="Support for structured binding">

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -320,23 +320,20 @@ struct Array<T, KOKKOS_INVALID_INDEX, Array<>::strided> {
       : m_elem(arg_ptr), m_size(arg_size), m_stride(arg_stride) {}
 };
 
-template <typename T,
-          size_t LN, typename LP, 
-          size_t RN, typename RP>
-KOKKOS_INLINE_FUNCTION constexpr bool operator==(const Array<T, LN, LP>& lhs, 
-                                                 const Array<T, RN, RP>& rhs) {
-  if (lhs.size() != rhs.size()) return false;
-    for (int i = 0; i < (int)(lhs.size()); ++i) {
-      if (lhs[i] != rhs[i]) return false;
-    }
-    return true;
+template <typename T, size_t N>
+KOKKOS_INLINE_FUNCTION constexpr bool operator==(const Array<T, N, void>& lhs,
+                                                 const Array<T, N, void>& rhs) {
+  // The cast to int is necessary to avoid a warning about a pointless
+  // comparison with zero in the case that an unsigned type is used.
+  for (int i = 0; i < static_cast<int>(lhs.size()); ++i) {
+    if (lhs[i] != rhs[i]) return false;
+  }
+  return true;
 }
 
-template <typename T,
-          size_t LN, typename LP, 
-          size_t RN, typename RP>
-KOKKOS_INLINE_FUNCTION constexpr bool operator!=(const Array<T, LN, LP>& lhs, 
-                                                 const Array<T, RN, RP>& rhs) {
+template <typename T, size_t N>
+KOKKOS_INLINE_FUNCTION constexpr bool operator!=(const Array<T, N, void>& lhs,
+                                                 const Array<T, N, void>& rhs) {
   return !(lhs == rhs);
 }
 

--- a/core/unit_test/TestArrayOps.hpp
+++ b/core/unit_test/TestArrayOps.hpp
@@ -92,6 +92,84 @@ TEST(TEST_CATEGORY, array_element_access) {
   ASSERT_EQ(ca.data()[index], a[index]);
 }
 
+TEST(TEST_CATEGORY, array_operator_equal) {
+  using A = Kokkos::Array<int, 2>;
+  constexpr A a{{3, 5}};
+  constexpr A b{{3, 5}};
+  constexpr A c{{5, 3}};
+
+  static_assert(a == b);
+  static_assert(!(a == c));
+  static_assert(a != c);
+
+  ASSERT_TRUE(a == b);
+  ASSERT_FALSE(a == c);
+  ASSERT_TRUE(a != c);
+
+  using E = Kokkos::Array<int, 0>;
+  constexpr E e;
+  constexpr E f;
+
+  static_assert(e == f);
+  static_assert(!(e != f));
+
+  ASSERT_TRUE(e == f);
+  ASSERT_FALSE(e != f);
+
+  static_assert(a != e);
+
+  ASSERT_TRUE(a != e);
+
+  using AC =
+    Kokkos::Array<int, KOKKOS_INVALID_INDEX, Kokkos::Array<>::contiguous>;
+
+  int ac_[] = {3, 5};
+  const AC ac(ac_, std::size(ac_));
+  int bc_[] = {3, 5};
+  const AC bc(bc_, std::size(bc_));
+
+  int dc_[] = {11, 13, 17, 19};
+  const AC dc(dc_, std::size(dc_));
+
+  ASSERT_TRUE(ac == bc);
+  ASSERT_TRUE(ac != dc);
+
+  ASSERT_TRUE(ac == a);
+  ASSERT_FALSE(ac == e);
+
+  const AC ec(nullptr, 0);
+  const AC fc(nullptr, 0);
+
+  ASSERT_TRUE(ec == fc);
+  ASSERT_FALSE(ec != fc);
+
+  ASSERT_FALSE(a == ec);
+  ASSERT_TRUE(e == ec);
+  ASSERT_FALSE(ac == ec);
+
+  using AS =
+    Kokkos::Array<int, KOKKOS_INVALID_INDEX, Kokkos::Array<>::strided>;
+
+  int as_[] = {3, 5, 7, 11, 13, 17, 19};
+  constexpr size_t asStride = 2;
+  const AS as(as_, std::size(as_) / asStride, asStride);
+  int bs_[] = {3, 5, 7, 11, 13, 17, 19};
+  constexpr size_t bsStride = 2;
+  const AS bs(bs_, std::size(bs_) / bsStride, bsStride);
+
+  int ds_[] = {3, 13, 5, 19};
+  constexpr size_t dsStride = 2;
+  const AS ds(ds_, std::size(ds_) / dsStride, dsStride);
+
+  ASSERT_TRUE(as == bs);
+  ASSERT_TRUE(as != ds);
+
+  ASSERT_TRUE(a == ds);
+  ASSERT_FALSE(e == as);
+  ASSERT_TRUE(ac == ds);
+  ASSERT_FALSE(ec == as);
+}
+
 TEST(TEST_CATEGORY, array_zero_capacity) {
   using A = Kokkos::Array<int, 0>;
   A e;

--- a/core/unit_test/TestArrayOps.hpp
+++ b/core/unit_test/TestArrayOps.hpp
@@ -115,59 +115,6 @@ TEST(TEST_CATEGORY, array_operator_equal) {
 
   ASSERT_TRUE(e == f);
   ASSERT_FALSE(e != f);
-
-  static_assert(a != e);
-
-  ASSERT_TRUE(a != e);
-
-  using AC =
-    Kokkos::Array<int, KOKKOS_INVALID_INDEX, Kokkos::Array<>::contiguous>;
-
-  int ac_[] = {3, 5};
-  const AC ac(ac_, std::size(ac_));
-  int bc_[] = {3, 5};
-  const AC bc(bc_, std::size(bc_));
-
-  int dc_[] = {11, 13, 17, 19};
-  const AC dc(dc_, std::size(dc_));
-
-  ASSERT_TRUE(ac == bc);
-  ASSERT_TRUE(ac != dc);
-
-  ASSERT_TRUE(ac == a);
-  ASSERT_FALSE(ac == e);
-
-  const AC ec(nullptr, 0);
-  const AC fc(nullptr, 0);
-
-  ASSERT_TRUE(ec == fc);
-  ASSERT_FALSE(ec != fc);
-
-  ASSERT_FALSE(a == ec);
-  ASSERT_TRUE(e == ec);
-  ASSERT_FALSE(ac == ec);
-
-  using AS =
-    Kokkos::Array<int, KOKKOS_INVALID_INDEX, Kokkos::Array<>::strided>;
-
-  int as_[] = {3, 5, 7, 11, 13, 17, 19};
-  constexpr size_t asStride = 2;
-  const AS as(as_, std::size(as_) / asStride, asStride);
-  int bs_[] = {3, 5, 7, 11, 13, 17, 19};
-  constexpr size_t bsStride = 2;
-  const AS bs(bs_, std::size(bs_) / bsStride, bsStride);
-
-  int ds_[] = {3, 13, 5, 19};
-  constexpr size_t dsStride = 2;
-  const AS ds(ds_, std::size(ds_) / dsStride, dsStride);
-
-  ASSERT_TRUE(as == bs);
-  ASSERT_TRUE(as != ds);
-
-  ASSERT_TRUE(a == ds);
-  ASSERT_FALSE(e == as);
-  ASSERT_TRUE(ac == ds);
-  ASSERT_FALSE(ec == as);
 }
 
 TEST(TEST_CATEGORY, array_zero_capacity) {


### PR DESCRIPTION
This PR adds `operator==` to `Kokkos::Array`. 

The implementation is outside the class and it is templated. This way, it can be used to check equality between the different specialisations of `Kokkos::Array` (primary, zero size, contiguous, strided).