### PR TITLE
Threads: add missing broadcast to TeamThreadRange parallel_scan

### DIFF
--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -1001,8 +1001,10 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     lambda(i, scan_val, false);
   }
 
+  auto team_member = loop_bounds.thread;
+
   // 'scan_val' output is the exclusive prefix sum
-  scan_val = loop_bounds.thread.team_scan(scan_val);
+  scan_val = team_member.team_scan(scan_val);
 
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
 #pragma ivdep
@@ -1011,6 +1013,8 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
        i += loop_bounds.increment) {
     lambda(i, scan_val, true);
   }
+
+  team_member.team_broadcast(scan_val, team_member.team_size() - 1);
 
   return_val = scan_val;
 }

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -1001,7 +1001,7 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     lambda(i, scan_val, false);
   }
 
-  auto team_member = loop_bounds.thread;
+  auto & team_member = loop_bounds.thread;
 
   // 'scan_val' output is the exclusive prefix sum
   scan_val = team_member.team_scan(scan_val);


### PR DESCRIPTION
Fixes some of the failures for the threads backend seen for example in https://github.com/kokkos/kokkos/actions/runs/6881218385/job/18717130472?pr=6600

Related to https://github.com/kokkos/kokkos/issues/6470