### PR TITLE
`Kokkos_HostThreadTeam.hpp`: reference the team member 

### DIFF
--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -885,7 +885,7 @@ KOKKOS_INLINE_FUNCTION
     closure(i, accum, false);
   }
 
-  auto team_member = loop_boundaries.thread;
+  auto & team_member = loop_boundaries.thread;
 
   // 'accum' output is the exclusive prefix sum
   accum = team_member.team_scan(accum);


### PR DESCRIPTION
reference the thread rather than copying it

failures in the CI are expected, see #6601 and #6604 