### PR TITLE
Fix threads loop in `Kokkos_CoreUnitTest_DeviceAndThreads`

### DIFF
--- a/core/unit_test/TestDeviceAndThreads.py
+++ b/core/unit_test/TestDeviceAndThreads.py
@@ -30,7 +30,7 @@ def GetFlag(flag, *extra_args):
     return int(p.stdout)
 
 def GetNumThreads(max_threads):
-    for x in [1, 2, 3, 5, 7]:
+    for x in [1, 2, 4, 6, 8]:
         if x >= max_threads:
             break
         yield x

--- a/core/unit_test/TestDeviceAndThreads.py
+++ b/core/unit_test/TestDeviceAndThreads.py
@@ -17,7 +17,7 @@
 
 import unittest
 import subprocess
-import psutil
+import os #psutil
 
 PREFIX = "$<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>"
 EXECUTABLE = "$<TARGET_FILE_NAME:Kokkos_CoreUnitTest_DeviceAndThreads>"
@@ -31,7 +31,16 @@ def GetFlag(flag, *extra_args):
     return int(p.stdout)
 
 def GetNumThreads(max_threads):
-    phys_cores_count = psutil.cpu_count(logical=False)
+    #phys_cores_count = psutil.cpu_count(logical=False)
+    args = ['sysctl', '-n', 'hw.physicalcpu_max']
+    if os.name == 'nt':
+        args = ['wmic', 'cpu', 'get', 'NumberOfCores']
+
+    result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output = result.stdout.decode('utf-8')
+    phys_cores_count = int(output)
+    print(phys_cores_count)
+
     looplist = [1] + [i*phys_cores_count for i in [1,2,3,4,5,6,7]]
     for x in looplist:
         if x >= max_threads:

--- a/core/unit_test/TestDeviceAndThreads.py
+++ b/core/unit_test/TestDeviceAndThreads.py
@@ -17,7 +17,7 @@
 
 import unittest
 import subprocess
-import platform #psutil
+import platform
 
 PREFIX = "$<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>"
 EXECUTABLE = "$<TARGET_FILE_NAME:Kokkos_CoreUnitTest_DeviceAndThreads>"
@@ -31,7 +31,6 @@ def GetFlag(flag, *extra_args):
     return int(p.stdout)
 
 def GetNumThreads(max_threads):
-    #phys_cores_count = psutil.cpu_count(logical=False)
     args = []
     name = platform.system()
     if name == 'Darwin':

--- a/core/unit_test/TestDeviceAndThreads.py
+++ b/core/unit_test/TestDeviceAndThreads.py
@@ -32,7 +32,7 @@ def GetFlag(flag, *extra_args):
 
 def GetNumThreads(max_threads):
     #phys_cores_count = psutil.cpu_count(logical=False)
-    args = ['sysctl', '-n', 'hw.physicalcpu_max']
+    args = ['nproc', '--all'] #'sysctl', '-n', 'hw.physicalcpu_max']
     if os.name == 'nt':
         args = ['wmic', 'cpu', 'get', 'NumberOfCores']
 

--- a/core/unit_test/TestDeviceAndThreads.py
+++ b/core/unit_test/TestDeviceAndThreads.py
@@ -17,7 +17,7 @@
 
 import unittest
 import subprocess
-import os #psutil
+import platform #psutil
 
 PREFIX = "$<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>"
 EXECUTABLE = "$<TARGET_FILE_NAME:Kokkos_CoreUnitTest_DeviceAndThreads>"
@@ -32,15 +32,18 @@ def GetFlag(flag, *extra_args):
 
 def GetNumThreads(max_threads):
     #phys_cores_count = psutil.cpu_count(logical=False)
-    args = ['nproc', '--all'] #'sysctl', '-n', 'hw.physicalcpu_max']
-    if os.name == 'nt':
+    args = []
+    name = platform.system()
+    if name == 'Darwin':
+        args = ['sysctl', '-n', 'hw.physicalcpu_max']
+    elif name == 'Linux':
+        args = ['nproc', '--all']
+    else:
         args = ['wmic', 'cpu', 'get', 'NumberOfCores']
 
     result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output = result.stdout.decode('utf-8')
     phys_cores_count = int(output)
-    print(phys_cores_count)
-
     looplist = [1] + [i*phys_cores_count for i in [1,2,3,4,5,6,7]]
     for x in looplist:
         if x >= max_threads:

--- a/core/unit_test/TestDeviceAndThreads.py
+++ b/core/unit_test/TestDeviceAndThreads.py
@@ -17,6 +17,7 @@
 
 import unittest
 import subprocess
+import psutil
 
 PREFIX = "$<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>"
 EXECUTABLE = "$<TARGET_FILE_NAME:Kokkos_CoreUnitTest_DeviceAndThreads>"
@@ -30,7 +31,9 @@ def GetFlag(flag, *extra_args):
     return int(p.stdout)
 
 def GetNumThreads(max_threads):
-    for x in [1, 2, 4, 6, 8]:
+    phys_cores_count = psutil.cpu_count(logical=False)
+    looplist = [1] + [i*phys_cores_count for i in [1,2,3,4,5,6,7]]
+    for x in looplist:
         if x >= max_threads:
             break
         yield x

--- a/core/unit_test/TestDeviceAndThreads.py
+++ b/core/unit_test/TestDeviceAndThreads.py
@@ -43,7 +43,9 @@ def GetNumThreads(max_threads):
     result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output = result.stdout.decode('utf-8')
     phys_cores_count = int(output)
-    looplist = [1] + [i*phys_cores_count for i in [1,2,3,4,5,6,7]]
+    looplist = [1] + [i*phys_cores_count for i in [1,2,3,4,5,6,7]] \
+        if GetFlag("hwloc_enabled") else [1,2,3,4,5]
+
     for x in looplist:
         if x >= max_threads:
             break

--- a/core/unit_test/UnitTest_DeviceAndThreads.cpp
+++ b/core/unit_test/UnitTest_DeviceAndThreads.cpp
@@ -68,6 +68,14 @@ int get_max_threads() {
 #endif
 }
 
+int get_hwloc_enabled() {
+#ifdef KOKKOS_ENABLE_HWLOC
+  return 1;
+#else
+  return 0;
+#endif
+}
+
 int get_num_threads() {
   int const num_threads = Kokkos::DefaultHostExecutionSpace().concurrency();
   assert(num_threads == Kokkos::num_threads());
@@ -93,6 +101,7 @@ int print_flag(std::string const& flag) {
   KOKKOS_TEST_PRINT_FLAG(device_count);
   KOKKOS_TEST_PRINT_FLAG(disable_warnings);
   KOKKOS_TEST_PRINT_FLAG(tune_internals);
+  KOKKOS_TEST_PRINT_FLAG(hwloc_enabled);
 
 #undef KOKKOS_TEST_PRINT_FLAG
 


### PR DESCRIPTION
after #6601 will be merged, the last (currently) issue with the threads CI remaining is: 
```
test_device_id (TestDeviceAndThreads.KokkosInitializationTestCase) ... skipped 'no device detected'
test_disable_warnings (TestDeviceAndThreads.KokkosInitializationTestCase) ... ok
test_num_threads (TestDeviceAndThreads.KokkosInitializationTestCase) ... ERROR
test_tune_internals (TestDeviceAndThreads.KokkosInitializationTestCase) ... ok

======================================================================
ERROR: test_num_threads (TestDeviceAndThreads.KokkosInitializationTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/kokkos/kokkos/builddir/core/unit_test/TestDeviceAndThreads.py", line 47, in test_num_threads
    GetFlag(
  File "/__w/kokkos/kokkos/builddir/core/unit_test/TestDeviceAndThreads.py", line 29, in GetFlag
    raise Exception(p.stderr.decode("utf-8"))
Exception: terminate called after throwing an instance of 'std::runtime_error'
  what():  Kokkos::Threads::initialize HWLOC ERROR(s) : thread_count(3) imbalanced among cores(2)
```

It is hitting the constraint imposed internally on the imbalance. 
Currently, the loop over threads in the test is
```py
def GetNumThreads(max_threads):
    for x in [1, 2, 3, 5, 7]:
        if x >= max_threads:
            break
        yield x
    yield max_threads
# ...

def test_num_threads(self):
    max_threads = GetFlag("max_threads")
    if max_threads == 1:
        self.skipTest("no host parallel backend enabled")
    for num_threads in GetNumThreads(max_threads):
        val = GetFlag("num_threads", "--kokkos-num-threads={}".format(num_threads))
        self.assertEqual(num_threads, GetFlag("num_threads", "--kokkos-num-threads={}".format(num_threads)))
```       

# Solution (also based on comments below) 

I am using now a loop over threads based on the physical core count like so:
```
looplist = [1] + [i*phys_cores_count for i in [1,2,3,4,5,6,7]]
```
The phys core count is detected via system calls to the running OS.

Note: we could just use the python package `psutil` via `phys_cores_count = psutil.cpu_count(logical=False)` but doing that triggered an error because that package was not found in the python installation. 



