### PR TITLE
Fix TestNumericTriats.hpp for SYCL with bfloat16 support

### DIFF
--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -110,8 +110,8 @@ struct TestNumericTraits {
 
   KOKKOS_FUNCTION void operator()(Epsilon, int, int& e) const {
     using Kokkos::Experimental::epsilon;
-    auto const eps = epsilon<T>::value;
-    auto const one = T(1);
+    T const eps = epsilon<T>::value;
+    T const one = 1;
     // Avoid higher precision intermediate representation
     compare() = one + eps;
     e += (int)!(compare() != one);


### PR DESCRIPTION
Fixes #6607. The problem is that the compiler provided overloads
```
[...]
  template <typename T>                                                        \
  friend type operator op(const T &lhs, const bfloat16 &rhs) {                 \
    return type{static_cast<float>(lhs) op static_cast<float>(rhs)};           \
  }
  OP(bfloat16, +)
  OP(bfloat16, -)
  OP(bfloat16, *)
  OP(bfloat16, /)
[...]
```
are the best match for
```
eps / 2;
```
when eps has type `BitComparisonWrapper<...>`. Just fixing the tests to cast `epsilon` to `bhalf_t` seems to be the easiest fix. Ultimately, this issue is similar to the problems we are seeing for comparisons where we ultimately added these for `BitComparisonWrapper<...>`. Duplicating all operators and math functions for that type doesn't seem feasible and thus this pull request just proposes to fix the test and we should probably note in the documentation that we are returning an `impl_type` that is supposed to be cast to `half_t` before doing anything else with it.