### PR TITLE
unorderedmap: missing `space` instance for erasure and rehash ops

### DIFF
--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -130,10 +130,11 @@ class Bitset {
 
   /// set all bits to 1
   /// can only be called from the host
-  void set() {
-    Kokkos::deep_copy(m_blocks, ~0u);
+  void set(const execution_space& exec) {
+    Kokkos::deep_copy(exec, m_blocks, ~0u);
 
     if (m_last_block_mask) {
+      exec.fence("todo message");
       // clear the unused bits in the last block
       Kokkos::Impl::DeepCopy<typename Device::memory_space, Kokkos::HostSpace>(
           m_blocks.data() + (m_blocks.extent(0) - 1u), &m_last_block_mask,
@@ -146,11 +147,11 @@ class Bitset {
 
   /// set all bits to 0
   /// can only be called from the host
-  void reset() { Kokkos::deep_copy(m_blocks, 0u); }
+  void reset(const execution_space& exec) { Kokkos::deep_copy(exec, m_blocks, 0u); }
 
   /// set all bits to 0
   /// can only be called from the host
-  void clear() { Kokkos::deep_copy(m_blocks, 0u); }
+  void clear(const execution_space& exec) { Kokkos::deep_copy(exec, m_blocks, 0u); }
 
   /// set i'th bit to 1
   /// can only be called from the device


### PR DESCRIPTION
This PR is extracted from #6584 as requested by @dalg24.

It adds a `space` instance argument to map erasure and rehash operators for `Kokkos::UnorderedMap`.

~~It also makes `invalid_index` public, otherwise it cannot be used by client code, though the `invalid_index` is used *e.g.* by `Kokkos::UnorderedMap::find`.~~ Topic moved to #6641.