### PR TITLE
Add bound checks in RangePolicy and MDRangePolicy

### DIFF
--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -30,6 +30,7 @@ static_assert(false,
 #include <impl/KokkosExp_Host_IterateTile.hpp>
 #include <Kokkos_ExecPolicy.hpp>
 #include <type_traits>
+#include <sstream>
 
 namespace Kokkos {
 
@@ -328,10 +329,13 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
     for (int i = rank_start; i != rank_end; i += increment) {
       const index_type length = m_upper[i] - m_lower[i];
 
-      if (m_upper[i] < m_lower[i])
-        Kokkos::abort(
-            "Kokkos::MDRangePolicy bounds error: One of the lower bounds is "
-            "greater than the upper bound of its rank.");
+      if (m_upper[i] < m_lower[i]) {
+        std::stringstream msg;
+        msg << "Kokkos::MDRangePolicy bounds error: The lower bound ("
+            << m_lower[i] << ") is greater than its upper bound (" << m_upper[i]
+            << ") in rank " << i + 1 << ".";
+        Kokkos::abort(msg.str().c_str());
+      }
 
       if (m_tile[i] <= 0) {
         m_tune_tile_size = true;

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -30,7 +30,6 @@ static_assert(false,
 #include <impl/KokkosExp_Host_IterateTile.hpp>
 #include <Kokkos_ExecPolicy.hpp>
 #include <type_traits>
-#include <sstream>
 
 namespace Kokkos {
 
@@ -330,11 +329,12 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
       const index_type length = m_upper[i] - m_lower[i];
 
       if (m_upper[i] < m_lower[i]) {
-        std::stringstream msg;
-        msg << "Kokkos::MDRangePolicy bounds error: The lower bound ("
-            << m_lower[i] << ") is greater than its upper bound (" << m_upper[i]
-            << ") in rank " << i + 1 << ".";
-        Kokkos::abort(msg.str().c_str());
+        std::string msg =
+            "Kokkos::MDRangePolicy bounds error: The lower bound (" +
+            std::to_string(m_lower[i]) + ") is greater than its upper bound (" +
+            std::to_string(m_upper[i]) + ") in rank " + std::to_string(i + 1) +
+            ".";
+        Kokkos::abort(msg.c_str());
       }
 
       if (m_tile[i] <= 0) {

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -327,6 +327,12 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
     }
     for (int i = rank_start; i != rank_end; i += increment) {
       const index_type length = m_upper[i] - m_lower[i];
+
+      if (m_upper[i] < m_lower[i])
+        Kokkos::abort(
+            "Kokkos::MDRangePolicy bounds error: One of the lower bounds is "
+            "greater than the upper bound of its rank.");
+
       if (m_tile[i] <= 0) {
         m_tune_tile_size = true;
         if ((inner_direction == Iterate::Right && (i < rank - 1)) ||

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -332,7 +332,7 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
         std::string msg =
             "Kokkos::MDRangePolicy bounds error: The lower bound (" +
             std::to_string(m_lower[i]) + ") is greater than its upper bound (" +
-            std::to_string(m_upper[i]) + ") in rank " + std::to_string(i + 1) +
+            std::to_string(m_upper[i]) + ") in dimension " + std::to_string(i) +
             ".";
         Kokkos::abort(msg.c_str());
       }

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -117,16 +117,18 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   inline RangePolicy(const typename traits::execution_space& work_space,
                      const member_type work_begin, const member_type work_end)
       : m_space(work_space),
-        m_begin(work_begin < work_end ? work_begin : 0),
-        m_end(work_begin < work_end ? work_end : 0),
+        m_begin(work_begin),
+        m_end(work_end),
         m_granularity(0),
         m_granularity_mask(0) {
+    check_bounds_validity();
     set_auto_chunk_size();
   }
 
   /** \brief  Total range */
   inline RangePolicy(const member_type work_begin, const member_type work_end)
       : RangePolicy(typename traits::execution_space(), work_begin, work_end) {
+    check_bounds_validity();
     set_auto_chunk_size();
   }
 
@@ -136,10 +138,11 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
                      const member_type work_begin, const member_type work_end,
                      Args... args)
       : m_space(work_space),
-        m_begin(work_begin < work_end ? work_begin : 0),
-        m_end(work_begin < work_end ? work_end : 0),
+        m_begin(work_begin),
+        m_end(work_end),
         m_granularity(0),
         m_granularity_mask(0) {
+    check_bounds_validity();
     set_auto_chunk_size();
     set(args...);
   }
@@ -149,6 +152,7 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   inline RangePolicy(const member_type work_begin, const member_type work_end,
                      Args... args)
       : RangePolicy(typename traits::execution_space(), work_begin, work_end) {
+    check_bounds_validity();
     set_auto_chunk_size();
     set(args...);
   }
@@ -216,6 +220,16 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
     }
     m_granularity      = new_chunk_size;
     m_granularity_mask = m_granularity - 1;
+  }
+
+  inline void check_bounds_validity() {
+    if (m_end < m_begin) {
+      std::string msg = "Kokkos::RangePolicy bounds error: The lower bound (" +
+                        std::to_string(m_begin) +
+                        ") is greater than the upper bound (" +
+                        std::to_string(m_end) + ").";
+      Kokkos::abort(msg.c_str());
+    }
   }
 
  public:

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -93,6 +93,25 @@ TEST(TEST_CATEGORY_DEATH, policy_bounds_unsafe_narrowing_conversions) {
       },
       "unsafe narrowing conversion");
 }
+
+TEST(TEST_CATEGORY_DEATH, policy_invalid_bounds) {
+  using Policy = Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<5>>;
+
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  ASSERT_DEATH(
+      {
+        (void)Policy({100, 100, 100, 100, 100}, {90, 90, 90, 90, 90});
+      },
+      "Kokkos::MDRangePolicy bounds error: One of the lower bounds is greater "
+      "than the upper bound of its rank.");
+
+  ASSERT_DEATH(
+      {
+        (void)Policy({100, 100, 100, 100, 100}, {105, 95, 100, 110, 105});
+      },
+      "Kokkos::MDRangePolicy bounds error: One of the lower bounds is greater "
+      "than the upper bound of its rank.");
+}
 #endif
 
 }  // namespace

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -98,13 +98,17 @@ TEST(TEST_CATEGORY_DEATH, policy_invalid_bounds) {
   using Policy = Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>;
 
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  auto dim = (Policy::inner_direction == Kokkos::Iterate::Right) ? 1 : 0;
+
   ASSERT_DEATH(
       {
         (void)Policy({100, 100}, {90, 90});
       },
       "Kokkos::MDRangePolicy bounds error: The lower bound \\(100\\) is "
       "greater "
-      "than its upper bound \\(90\\) in dimension 1\\.");
+      "than its upper bound \\(90\\) in dimension " +
+          std::to_string(dim) + "\\.");
 }
 #endif
 

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -95,24 +95,16 @@ TEST(TEST_CATEGORY_DEATH, policy_bounds_unsafe_narrowing_conversions) {
 }
 
 TEST(TEST_CATEGORY_DEATH, policy_invalid_bounds) {
-  using Policy = Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<5>>;
+  using Policy = Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>;
 
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_DEATH(
       {
-        (void)Policy({100, 100, 100, 100, 100}, {90, 90, 90, 90, 90});
+        (void)Policy({100, 100}, {90, 90});
       },
       "Kokkos::MDRangePolicy bounds error: The lower bound \\(100\\) is "
       "greater "
-      "than its upper bound \\(90\\) in rank 5\\.");
-
-  ASSERT_DEATH(
-      {
-        (void)Policy({100, 100, 100, 100, 100}, {105, 95, 100, 110, 105});
-      },
-      "Kokkos::MDRangePolicy bounds error: The lower bound \\(100\\) is "
-      "greater "
-      "than its upper bound \\(95\\) in rank 2\\.");
+      "than its upper bound \\(90\\) in dimension 1\\.");
 }
 #endif
 

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -102,15 +102,17 @@ TEST(TEST_CATEGORY_DEATH, policy_invalid_bounds) {
       {
         (void)Policy({100, 100, 100, 100, 100}, {90, 90, 90, 90, 90});
       },
-      "Kokkos::MDRangePolicy bounds error: One of the lower bounds is greater "
-      "than the upper bound of its rank.");
+      "Kokkos::MDRangePolicy bounds error: The lower bound \\(100\\) is "
+      "greater "
+      "than its upper bound \\(90\\) in rank 5\\.");
 
   ASSERT_DEATH(
       {
         (void)Policy({100, 100, 100, 100, 100}, {105, 95, 100, 110, 105});
       },
-      "Kokkos::MDRangePolicy bounds error: One of the lower bounds is greater "
-      "than the upper bound of its rank.");
+      "Kokkos::MDRangePolicy bounds error: The lower bound \\(100\\) is "
+      "greater "
+      "than its upper bound \\(95\\) in rank 2\\.");
 }
 #endif
 

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -106,8 +106,7 @@ TEST(TEST_CATEGORY_DEATH, policy_invalid_bounds) {
         (void)Policy({100, 100}, {90, 90});
       },
       "Kokkos::MDRangePolicy bounds error: The lower bound \\(100\\) is "
-      "greater "
-      "than its upper bound \\(90\\) in dimension " +
+      "greater than its upper bound \\(90\\) in dimension " +
           std::to_string(dim) + "\\.");
 }
 #endif

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -70,4 +70,17 @@ TEST(TEST_CATEGORY, range_policy_runtime_parameters) {
   }
 }
 
+TEST(TEST_CATEGORY_DEATH, range_policy_invalid_bounds) {
+  using Policy    = Kokkos::RangePolicy<TEST_EXECSPACE>;
+  using ChunkSize = Kokkos::ChunkSize;
+
+  ASSERT_DEATH({ (void)Policy(100, 90); },
+               "Kokkos::RangePolicy bounds error: The lower bound \\(100\\) is "
+               "greater than the upper bound \\(90\\)\\.");
+
+  ASSERT_DEATH({ (void)Policy(TEST_EXECSPACE(), 100, 90, ChunkSize(10)); },
+               "Kokkos::RangePolicy bounds error: The lower bound \\(100\\) is "
+               "greater than the upper bound \\(90\\)\\.");
+}
+
 }  // namespace


### PR DESCRIPTION
Resolves #6616.

Added a simple check in MDRangePolicy that checks if any of the `end index` is less than its corresponding `start index` for all ranks.