### PR TITLE
Kokkos::DualView(semantics): allow moving host and device views into a dual view

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -318,10 +318,14 @@ class DualView : public ViewTraits<DataType, Properties...> {
   ///
   /// \param d_view_ Device View
   /// \param h_view_ Host View (must have type t_host = t_dev::HostMirror)
-  DualView(const t_dev& d_view_, const t_host& h_view_)
-      : modified_flags(t_modified_flags("DualView::modified_flags")),
-        d_view(d_view_),
-        h_view(h_view_) {
+  template <typename dev_t, typename host_t,
+    typename = std::enable_if_t<std::is_same_v<std::decay_t<dev_t>, t_dev>>,
+    typename = std::enable_if_t<std::is_same_v<std::decay_t<host_t>, t_host>>
+  >
+  DualView(dev_t&& d_view_, host_t&& h_view_)
+      : modified_flags("DualView::modified_flags"),
+        d_view(std::forward<dev_t>(d_view_)),
+        h_view(std::forward<host_t>(h_view_)) {
     if (int(d_view.rank) != int(h_view.rank) ||
         d_view.extent(0) != h_view.extent(0) ||
         d_view.extent(1) != h_view.extent(1) ||

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -611,6 +611,30 @@ TEST(TEST_CATEGORY,
                hvt::device_type::execution_space::name());
 }
 
+/**
+ * @test This test checks the construction of a dual view from its host and device views.
+ *
+ * More specifically, it prepares host and device views, and then move them to a new dual view.
+ */
+TEST(TEST_CATEGORY, dualview_from_host_and_device_views) {
+  using dual_view_t = Kokkos::DualView<int*, ExecSpace>;
+  using t_dev       = typename dual_view_t::t_dev;
+  using t_host      = typename dual_view_t::t_host;
+
+  t_dev  d_view("device view", 5);
+  t_host h_view("host view", 5);
+
+  dual_view_t dual(std::move(d_view), std::move(h_view));
+
+  EXPECT_TRUE(dual.is_allocated());
+
+  EXPECT_FALSE(d_view.is_allocated());
+  EXPECT_FALSE(h_view.is_allocated());
+
+  EXPECT_EQ(dual.h_view.use_count(), 1);
+  EXPECT_EQ(dual.d_view.use_count(), 1);
+}
+
 }  // anonymous namespace
 }  // namespace Test
 


### PR DESCRIPTION
This PR enhances the `Kokkos::DualView` constructor taking the host and device views by allowing it to take moving views.

This PR needs #6619.