### PR TITLE
Add jenkins multibranch pipeline options

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -8,7 +8,12 @@ pipeline {
     }
 
     options {
+        disableConcurrentBuilds(abortPrevious: true)
         timeout(time: 6, unit: 'HOURS')
+    }
+
+    triggers {
+        issueCommentTrigger('.*test this please.*')
     }
 
     stages {


### PR DESCRIPTION
This moves some options that previously were defined in the jenkins server to the `.jenkins` file.  We need this PR to be merged to be able to trigger the CI with a comment.