### PR TITLE
Add warp sync for Cuda parallel reduce to avoid race condition

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -244,10 +244,10 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
       if (CudaTraits::WarpSize < word_count.value) {
         __syncthreads();
       } else if (word_count.value > 1) {
-        // Inside cuda_single_inter_block_reduce_scan() above, shared[i] below
-        // might have been updated by a single thread within a warp without
-        // synchronization afterwards. Synchronize threads within warp to avoid
-        // potential racecondition.
+        // Inside cuda_single_inter_block_reduce_scan() and final() above,
+        // shared[i] below might have been updated by a single thread within a
+        // warp without synchronization afterwards. Synchronize threads within
+        // warp to avoid potential race condition.
         __syncwarp(0xffffffff);
       }
 


### PR DESCRIPTION
Potential race condition discovered by `compute-sanitizer --tool=racecheck` on a simple reduce using Cuda:
```
Real result;
Kokkos::parallel_reduce("simple_reduce", N, KOKKOS_LAMBDA(int, Real&) {
  // Do nothing;
}, result);
```
Basically, the value of `shared[i]` below `__syncwarp()` was being updated on a single thread within a warp in`Kokkos_Cuda_ReduceScan.hpp:349`, but no synchronization is guarenteed before reading `shared[i]` on (potentially) different threads.

Closes https://github.com/kokkos/kokkos/issues/6217.