### PR TITLE
Moving a View outside a parallel region should not increase the use count

### DIFF
--- a/core/src/impl/Kokkos_ViewTracker.hpp
+++ b/core/src/impl/Kokkos_ViewTracker.hpp
@@ -42,12 +42,18 @@ struct ViewTracker {
 
   track_type m_tracker;
 
-  KOKKOS_INLINE_FUNCTION
-  ViewTracker() : m_tracker() {}
+  KOKKOS_DEFAULTED_FUNCTION
+  ViewTracker() = default;
 
   KOKKOS_INLINE_FUNCTION
   ViewTracker(const ViewTracker& vt) noexcept
       : m_tracker(vt.m_tracker, view_traits::is_managed) {}
+
+  KOKKOS_DEFAULTED_FUNCTION
+  ViewTracker(ViewTracker&&) = default;
+
+  KOKKOS_DEFAULTED_FUNCTION
+  ViewTracker& operator=(ViewTracker&&) = default;
 
   KOKKOS_INLINE_FUNCTION
   explicit ViewTracker(const ParentView& vt) noexcept : m_tracker() {

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -240,6 +240,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       ViewMapping_b
       ViewMapping_subview
       ViewMemoryAccessViolation
+      ViewMove
       ViewOfClass
       ViewResize
       WorkGraph

--- a/core/unit_test/TestViewMove.hpp
+++ b/core/unit_test/TestViewMove.hpp
@@ -1,0 +1,58 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+// Check that moving a View outside a parallel region does not increase the
+// number of views managing the allocation.
+template <class ViewType>
+void test_moving_view_does_not_change_use_count(ViewType v) {
+  auto* const ptr = v.data();
+  auto const cnt  = v.use_count();
+
+  ViewType w(std::move(v));  // move construction
+  EXPECT_EQ(w.use_count(), cnt);
+  EXPECT_EQ(w.data(), ptr);
+
+  v = std::move(w);  // move assignment
+  EXPECT_EQ(v.use_count(), cnt);
+  EXPECT_EQ(v.data(), ptr);
+}
+
+TEST(TEST_CATEGORY, view_move_and_use_count) {
+  using ExecutionSpace = TEST_EXECSPACE;
+
+  test_moving_view_does_not_change_use_count(
+      Kokkos::View<int, ExecutionSpace>("v0"));
+
+  test_moving_view_does_not_change_use_count(
+      Kokkos::View<float*, ExecutionSpace>("v1", 1));
+
+  Kokkos::View<double**, ExecutionSpace> v2("v2", 1, 2);
+  test_moving_view_does_not_change_use_count(
+      Kokkos::View<double**, ExecutionSpace>(v2.data(), v2.extent(0),
+                                             v2.extent(1)));
+  test_moving_view_does_not_change_use_count(
+      Kokkos::View<double**, ExecutionSpace,
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>(
+          v2.data(), v2.extent(0), v2.extent(1)));
+}
+
+}  // namespace


### PR DESCRIPTION
Initially reported here https://github.com/kokkos/kokkos/pull/6619#issuecomment-1831402112

`ViewTracker` has a user-defined copy constructor which prevents the compiler to generate the move constructor and a move assignment operator.  This means that the view reference counter increases when the view is moved which leads to resources not being released (that is memory leak).

This PR fixes the issue and ensures that use count is not increased when a view is moved.