### PR TITLE
kokkos(profiling): do not finalize in any backend

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -304,8 +304,6 @@ void OpenMPInternal::finalize() {
   }
 
   m_initialized = false;
-
-  Kokkos::Profiling::finalize();
 }
 
 void OpenMPInternal::print_configuration(std::ostream &s) const {

--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -58,8 +58,6 @@ void SerialInternal::finalize() {
     m_thread_team_data.scratch_assign(nullptr, 0, 0, 0, 0, 0);
   }
 
-  Kokkos::Profiling::finalize();
-
   m_is_initialized = false;
 }
 

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -672,8 +672,6 @@ void ThreadsInternal::finalize() {
   s_threads_process.m_pool_size     = 1;
   s_threads_process.m_pool_fan_size = 0;
   s_threads_process.m_pool_state    = ThreadState::Inactive;
-
-  Kokkos::Profiling::finalize();
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
`Kokkos::Profiling::finalize` should only be called in `pre_finalize_internal`, as described in #6633.