### PR TITLE
UnorderedMap: promote `invalid_index` to public and use `Experimental::finite_max_v` for its value

### DIFF
--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -254,6 +254,9 @@ class UnorderedMap {
   static constexpr bool is_modifiable_map = has_const_key && !has_const_value;
   static constexpr bool is_const_map      = has_const_key && has_const_value;
 
+  static constexpr size_type invalid_index =
+      Experimental::finite_max_v<size_type>;
+
   using insert_result = UnorderedMapInsertResult;
 
   using HostMirror =
@@ -263,7 +266,6 @@ class UnorderedMap {
   //@}
 
  private:
-  enum : size_type { invalid_index = ~static_cast<size_type>(0) };
 
   using impl_value_type = std::conditional_t<is_set, int, declared_value_type>;
 


### PR DESCRIPTION
As discussed in #6610 with @masterleinad, it makes sense that `Kokkos::UnorderedMap::invalid_index` is promoted to a `public` member, because `Kokkos::UnorderedMap::find` must be able to return a distinguished value to denote that no element with the given key could be found. As `Kokkos::UnorderedMap::find` is `public`, so does ``Kokkos::UnorderedMap::invalid_index`.

As discussed with @dalg24, the value of `invalid_index` is now computed with the nice `Kokkos::Experimental::finite_max_v` that is more robust against the type than `~static_cast<type>(0)`.