### PR TITLE
tools(profiling): fix typo Kokkos_Tools_Optim[i]zationGoal

### DIFF
--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -154,7 +154,7 @@ enum Kokkos_Tools_OptimizationType {
   Kokkos_Tools_Maximize
 };
 
-struct Kokkos_Tools_OptimzationGoal {
+struct Kokkos_Tools_OptimizationGoal {
   size_t type_id;
   enum Kokkos_Tools_OptimizationType goal;
 };
@@ -220,7 +220,7 @@ typedef void (*Kokkos_Tools_contextBeginFunction)(const size_t);
 typedef void (*Kokkos_Tools_contextEndFunction)(
     const size_t, struct Kokkos_Tools_VariableValue);
 typedef void (*Kokkos_Tools_optimizationGoalDeclarationFunction)(
-    const size_t, const struct Kokkos_Tools_OptimzationGoal goal);
+    const size_t, const struct Kokkos_Tools_OptimizationGoal goal);
 
 struct Kokkos_Profiling_EventSet {
   Kokkos_Profiling_initFunction init;

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -226,7 +226,7 @@ using ValueType           = Kokkos_Tools_VariableInfo_ValueType;
 using CandidateValueType  = Kokkos_Tools_VariableInfo_CandidateValueType;
 using SetOrRange          = Kokkos_Tools_VariableInfo_SetOrRange;
 using VariableInfo        = Kokkos_Tools_VariableInfo;
-using OptimizationGoal    = Kokkos_Tools_OptimzationGoal;
+using OptimizationGoal    = Kokkos_Tools_OptimizationGoal;
 using TuningString        = Kokkos_Tools_Tuning_String;
 using VariableValue       = Kokkos_Tools_VariableValue;
 


### PR DESCRIPTION
This PR accompanies kokkos/kokkos-tools/pull/221.

It fixes the typo `Kokkos_Tools_OptimzationGoal` to `Kokkos_Tools_OptimizationGoal`.

### Risks

- No risk: For people fetching this change, there would be a clear compilation error if they relied on the old name. They would simply need to fix the typo on their side as well.
- Minor risk: For tools that have been compiled in the past, this might be a breaking change. However, we deem there are not so many tools out there that rely on this "optimization goal" feature. We could mitigate this risk by making the change enclosed in a "deprecated code" region.