### PR TITLE
Drop DualView converting copy assignment operator

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -292,15 +292,6 @@ class DualView : public ViewTraits<DataType, Properties...> {
         d_view(src.d_view),
         h_view(src.h_view) {}
 
-  //! Copy assignment operator (shallow copy assignment)
-  template <typename DT, typename... DP>
-  DualView& operator=(const DualView<DT, DP...>& src) {
-    modified_flags = src.modified_flags;
-    d_view         = src.d_view;
-    h_view         = src.h_view;
-    return *this;
-  }
-
   //! Subview constructor
   template <class DT, class... DP, class Arg0, class... Args>
   DualView(const DualView<DT, DP...>& src, const Arg0& arg0, Args... args)


### PR DESCRIPTION
Following up on https://github.com/kokkos/kokkos/pull/6474/files#r1416594907

As far as I can tell, it is unnecessary, we already have a converting constructor and a regular copy assignment operator.

https://godbolt.org/z/zehfP4brM

