### PR TITLE
CI: Don't use rocm-docker runners

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -22,7 +22,7 @@ pipeline {
                 dockerfile {
                     filename 'Dockerfile.clang'
                     dir 'scripts/docker'
-                    label 'nvidia-docker || rocm-docker || docker'
+                    label 'nvidia-docker || docker'
                     args '-v /tmp/ccache.kokkos:/tmp/ccache'
                 }
             }

--- a/.jenkins
+++ b/.jenkins
@@ -135,82 +135,82 @@ pipeline {
                         }
                     }
                 }
-                stage('HIP-ROCm-5.2') {
-                    agent {
-                        dockerfile {
-                            filename 'Dockerfile.hipcc'
-                            dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:5.2'
-                            label 'rocm-docker && vega'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
-                        }
-                    }
-                    environment {
-                        OMP_NUM_THREADS = 8
-                        OMP_MAX_ACTIVE_LEVELS = 3
-                        OMP_PLACES = 'threads'
-                        OMP_PROC_BIND = 'spread'
-                    }
-                    steps {
-                        sh 'ccache --zero-stats'
-                        sh 'echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig'
-                        sh '''rm -rf build && mkdir -p build && cd build && \
-                              cmake \
-                                -DCMAKE_BUILD_TYPE=Debug \
-                                -DCMAKE_CXX_COMPILER=hipcc \
-                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument -DNDEBUG" \
-                                -DCMAKE_CXX_STANDARD=17 \
-                                -DKokkos_ARCH_NATIVE=ON \
-                                -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
-                                -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF \
-                                -DKokkos_ENABLE_TESTS=ON \
-                                -DKokkos_ENABLE_BENCHMARKS=ON \
-                                -DKokkos_ENABLE_HIP=ON \
-                                -DKokkos_ENABLE_OPENMP=ON \
-                                -DKokkos_ENABLE_HIP_MULTIPLE_KERNEL_INSTANTIATIONS=ON \
-                              .. && \
-                              make -j8 && ctest --verbose'''
-                    }
-                    post {
-                        always {
-                            sh 'ccache --show-stats'
-                        }
-                    }
-                }
-                stage('HIP-ROCm-5.6-C++20') {
-                    agent {
-                        dockerfile {
-                            filename 'Dockerfile.hipcc'
-                            dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:5.6'
-                            label 'rocm-docker && vega'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
-                        }
-                    }
-                    steps {
-                        sh 'ccache --zero-stats'
-                        sh '''rm -rf build && mkdir -p build && cd build && \
-                              cmake \
-                                -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-                                -DCMAKE_CXX_COMPILER=hipcc \
-                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument" \
-                                -DCMAKE_CXX_STANDARD=20 \
-                                -DKokkos_ARCH_NATIVE=ON \
-                                -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
-                                -DKokkos_ENABLE_DEPRECATED_CODE_4=ON \
-                                -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
-                                -DKokkos_ENABLE_TESTS=ON \
-                                -DKokkos_ENABLE_BENCHMARKS=ON \
-                                -DKokkos_ENABLE_HIP=ON \
-                              .. && \
-                              make -j8 && ctest --verbose'''
-                    }
-                    post {
-                        always {
-                            sh 'ccache --show-stats'
-                        }
-                    }
-                }
+//                stage('HIP-ROCm-5.2') {
+//                    agent {
+//                        dockerfile {
+//                            filename 'Dockerfile.hipcc'
+//                            dir 'scripts/docker'
+//                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:5.2'
+//                            label 'rocm-docker && vega'
+//                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
+//                        }
+//                    }
+//                    environment {
+//                        OMP_NUM_THREADS = 8
+//                        OMP_MAX_ACTIVE_LEVELS = 3
+//                        OMP_PLACES = 'threads'
+//                        OMP_PROC_BIND = 'spread'
+//                    }
+//                    steps {
+//                        sh 'ccache --zero-stats'
+//                        sh 'echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig'
+//                        sh '''rm -rf build && mkdir -p build && cd build && \
+//                              cmake \
+//                                -DCMAKE_BUILD_TYPE=Debug \
+//                                -DCMAKE_CXX_COMPILER=hipcc \
+//                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument -DNDEBUG" \
+//                                -DCMAKE_CXX_STANDARD=17 \
+//                                -DKokkos_ARCH_NATIVE=ON \
+//                                -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
+//                                -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF \
+//                                -DKokkos_ENABLE_TESTS=ON \
+//                                -DKokkos_ENABLE_BENCHMARKS=ON \
+//                                -DKokkos_ENABLE_HIP=ON \
+//                                -DKokkos_ENABLE_OPENMP=ON \
+//                                -DKokkos_ENABLE_HIP_MULTIPLE_KERNEL_INSTANTIATIONS=ON \
+//                              .. && \
+//                              make -j8 && ctest --verbose'''
+//                    }
+//                    post {
+//                        always {
+//                            sh 'ccache --show-stats'
+//                        }
+//                    }
+//                }
+//                stage('HIP-ROCm-5.6-C++20') {
+//                    agent {
+//                        dockerfile {
+//                            filename 'Dockerfile.hipcc'
+//                            dir 'scripts/docker'
+//                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:5.6'
+//                            label 'rocm-docker && vega'
+//                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
+//                        }
+//                    }
+//                    steps {
+//                        sh 'ccache --zero-stats'
+//                        sh '''rm -rf build && mkdir -p build && cd build && \
+//                              cmake \
+//                                -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+//                                -DCMAKE_CXX_COMPILER=hipcc \
+//                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument" \
+//                                -DCMAKE_CXX_STANDARD=20 \
+//                                -DKokkos_ARCH_NATIVE=ON \
+//                                -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
+//                                -DKokkos_ENABLE_DEPRECATED_CODE_4=ON \
+//                                -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
+//                                -DKokkos_ENABLE_TESTS=ON \
+//                                -DKokkos_ENABLE_BENCHMARKS=ON \
+//                                -DKokkos_ENABLE_HIP=ON \
+//                              .. && \
+//                              make -j8 && ctest --verbose'''
+//                    }
+//                    post {
+//                        always {
+//                            sh 'ccache --show-stats'
+//                        }
+//                    }
+//                }
 /*
                 stage('OPENMPTARGET-ROCm-5.2') {
                     agent {


### PR DESCRIPTION
The `rocm-docker` runners are not working right now and cause spurious CI failures. In particular, the `clang-format` check is failing when running on those machines preventing from any other `jenkins` CI to run. Thus, this pull request proposes to
- not use `rocm-docker` for `clang-fromat`. We should have enough other runners so we don't need to burden these scarce resources with it.
- disable `HIP` CI for now until those machines are working again.