### PR TITLE
Remove deprecation warning for AllocationMechanism for gcc <11.0 

### DIFF
--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -75,12 +75,19 @@ class HostSpace {
   /**\brief  Non-default memory space instance to choose allocation mechansim,
    * if available */
 
-  enum KOKKOS_DEPRECATED AllocationMechanism {
-    STD_MALLOC,
-    POSIX_MEMALIGN,
-    POSIX_MMAP,
-    INTEL_MM_ALLOC
-  };
+#if defined(KOKKOS_COMPILER_GNU) && KOKKOS_COMPILER_GNU < 1100
+  // We see deprecation warnings even when not using the deprecated
+  // HostSpace constructor below when using gcc before release 11.
+  enum
+#else
+  enum KOKKOS_DEPRECATED
+#endif
+      AllocationMechanism {
+        STD_MALLOC,
+        POSIX_MEMALIGN,
+        POSIX_MMAP,
+        INTEL_MM_ALLOC
+      };
 
   KOKKOS_DEPRECATED
   explicit HostSpace(const AllocationMechanism&);


### PR DESCRIPTION
Related to the conversation in https://kokkosteam.slack.com/archives/C5BGU5NDQ/p1701727560890859.
We see deprecation warnings for GCC versions before release 11 every time a compilation unit includes `Kokkos_HostSpace.hpp`.
This pull request proposes removing the deprecation attribute for `AllocationMechanism` to avoid these warnings. It seems very unlikely that the enum would be used without the `HostSpace` constructor in question that still has the deprecation attribute.