### PR TITLE
Do not negate the dependent true traits helper

### DIFF
--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp
@@ -31,8 +31,7 @@ template <class Functor, class Reducer, class Policy,
 struct OpenACCParallelReduceMDRangeHelper {
   OpenACCParallelReduceMDRangeHelper(Functor const&, Reducer const&,
                                      Policy const&) {
-    static_assert(!Kokkos::Impl::always_true<Functor>::value,
-                  "not implemented");
+    static_assert(std::is_void_v<Functor>, "not implemented");
   }
 };
 }  // namespace Kokkos::Experimental::Impl

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp
@@ -31,7 +31,8 @@ template <class Functor, class Reducer, class Policy,
 struct OpenACCParallelReduceMDRangeHelper {
   OpenACCParallelReduceMDRangeHelper(Functor const&, Reducer const&,
                                      Policy const&) {
-    static_assert(std::is_void_v<Functor>, "not implemented");
+    static_assert(Kokkos::Impl::always_false<Functor>::value,
+                  "not implemented");
   }
 };
 }  // namespace Kokkos::Experimental::Impl

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp
@@ -31,7 +31,8 @@ template <class Functor, class Reducer, class Policy,
           bool = std::is_arithmetic_v<typename Reducer::value_type>>
 struct OpenACCParallelReduceHelper {
   OpenACCParallelReduceHelper(Functor const&, Reducer const&, Policy const&) {
-    static_assert(std::is_void_v<Functor>, "not implemented");
+    static_assert(Kokkos::Impl::always_false<Functor>::value,
+                  "not implemented");
   }
 };
 

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp
@@ -31,8 +31,7 @@ template <class Functor, class Reducer, class Policy,
           bool = std::is_arithmetic_v<typename Reducer::value_type>>
 struct OpenACCParallelReduceHelper {
   OpenACCParallelReduceHelper(Functor const&, Reducer const&, Policy const&) {
-    static_assert(!Kokkos::Impl::always_true<Functor>::value,
-                  "not implemented");
+    static_assert(std::is_void_v<Functor>, "not implemented");
   }
 };
 

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
@@ -40,8 +40,7 @@ template <class Functor, class Reducer, class Policy,
 struct OpenACCParallelReduceTeamHelper {
   OpenACCParallelReduceTeamHelper(Functor const&, Reducer const&,
                                   Policy const&) {
-    static_assert(!Kokkos::Impl::always_true<Functor>::value,
-                  "not implemented");
+    static_assert(std::is_void_v<Functor>, "not implemented");
   }
 };
 
@@ -129,8 +128,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
     const Impl::TeamThreadRangeBoundariesStruct<iType, Impl::OpenACCTeamMember>&
         loop_boundaries,
     const Lambda& lambda, const JoinType& join, ValueType& init_result) {
-  static_assert(!Kokkos::Impl::always_true<Lambda>::value,
-                "custom reduction is not implemented");
+  static_assert(std::is_void_v<Lambda>, "custom reduction is not implemented");
 }
 
 // Hierarchical Parallelism -> Thread vector level implementation
@@ -140,8 +138,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
     const Impl::ThreadVectorRangeBoundariesStruct<
         iType, Impl::OpenACCTeamMember>& loop_boundaries,
     const Lambda& lambda, const JoinType& join, ValueType& init_result) {
-  static_assert(!Kokkos::Impl::always_true<Lambda>::value,
-                "custom reduction is not implemented");
+  static_assert(std::is_void_v<Lambda>, "custom reduction is not implemented");
 }
 
 }  // namespace Kokkos

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
@@ -40,7 +40,8 @@ template <class Functor, class Reducer, class Policy,
 struct OpenACCParallelReduceTeamHelper {
   OpenACCParallelReduceTeamHelper(Functor const&, Reducer const&,
                                   Policy const&) {
-    static_assert(std::is_void_v<Functor>, "not implemented");
+    static_assert(Kokkos::Impl::always_false<Functor>::value,
+                  "not implemented");
   }
 };
 
@@ -128,7 +129,8 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
     const Impl::TeamThreadRangeBoundariesStruct<iType, Impl::OpenACCTeamMember>&
         loop_boundaries,
     const Lambda& lambda, const JoinType& join, ValueType& init_result) {
-  static_assert(std::is_void_v<Lambda>, "custom reduction is not implemented");
+  static_assert(Kokkos::Impl::always_false<Lambda>::value,
+                "custom reduction is not implemented");
 }
 
 // Hierarchical Parallelism -> Thread vector level implementation
@@ -138,7 +140,8 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
     const Impl::ThreadVectorRangeBoundariesStruct<
         iType, Impl::OpenACCTeamMember>& loop_boundaries,
     const Lambda& lambda, const JoinType& join, ValueType& init_result) {
-  static_assert(std::is_void_v<Lambda>, "custom reduction is not implemented");
+  static_assert(Kokkos::Impl::always_false<Lambda>::value,
+                "custom reduction is not implemented");
 }
 
 }  // namespace Kokkos

--- a/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
@@ -82,7 +82,7 @@ class OpenACCTeamMember {
   // FIXME_OPENACC: team_broadcast() is not implemented.
   template <class ValueType>
   KOKKOS_FUNCTION void team_broadcast(ValueType& value, int thread_id) const {
-    static_assert(!Kokkos::Impl::always_true<ValueType>::value,
+    static_assert(std::is_void_v<ValueType>,
                   "Kokkos Error: team_broadcast() is not implemented for the "
                   "OpenACC backend");
     return ValueType();
@@ -99,7 +99,7 @@ class OpenACCTeamMember {
   template <class ValueType, class JoinOp>
   KOKKOS_FUNCTION ValueType team_reduce(const ValueType& value,
                                         const JoinOp& op_in) const {
-    static_assert(!Kokkos::Impl::always_true<ValueType>::value,
+    static_assert(std::is_void_v<ValueType>,
                   "Kokkos Error: team_reduce() is not implemented for the "
                   "OpenACC backend");
     return ValueType();
@@ -110,7 +110,7 @@ class OpenACCTeamMember {
   KOKKOS_FUNCTION ArgType team_scan(const ArgType& /*value*/,
                                     ArgType* const /*global_accum*/) const {
     static_assert(
-        !Kokkos::Impl::always_true<ArgType>::value,
+        std::is_void_v<ArgType>,
         "Kokkos Error: team_scan() is not implemented for the OpenACC backend");
     return ArgType();
   }

--- a/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
@@ -82,7 +82,7 @@ class OpenACCTeamMember {
   // FIXME_OPENACC: team_broadcast() is not implemented.
   template <class ValueType>
   KOKKOS_FUNCTION void team_broadcast(ValueType& value, int thread_id) const {
-    static_assert(std::is_void_v<ValueType>,
+    static_assert(Kokkos::Impl::always_false<ValueType>::value,
                   "Kokkos Error: team_broadcast() is not implemented for the "
                   "OpenACC backend");
     return ValueType();
@@ -99,7 +99,7 @@ class OpenACCTeamMember {
   template <class ValueType, class JoinOp>
   KOKKOS_FUNCTION ValueType team_reduce(const ValueType& value,
                                         const JoinOp& op_in) const {
-    static_assert(std::is_void_v<ValueType>,
+    static_assert(Kokkos::Impl::always_false<ValueType>::value,
                   "Kokkos Error: team_reduce() is not implemented for the "
                   "OpenACC backend");
     return ValueType();
@@ -110,7 +110,7 @@ class OpenACCTeamMember {
   KOKKOS_FUNCTION ArgType team_scan(const ArgType& /*value*/,
                                     ArgType* const /*global_accum*/) const {
     static_assert(
-        std::is_void_v<ArgType>,
+        Kokkos::Impl::always_false<ArgType>::value,
         "Kokkos Error: team_scan() is not implemented for the OpenACC backend");
     return ArgType();
   }

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -49,6 +49,11 @@ struct integral_constant {
 template <typename... Is>
 struct always_true : std::true_type {};
 
+// type-dependent expression that is always false intended for use in
+// static_assert to check "we should never get there"
+template <typename... Deps>
+struct always_false : std::false_type {};
+
 //==============================================================================
 
 #if defined(__cpp_lib_type_identity)


### PR DESCRIPTION
This came up in some other work and I don't want to see that practice spread so I am replacing it with a better alternative.

I considered adding an `Impl::always_false` traits but there is a number of things I don't like with `always_true` (starting with the fact it is variadic).

I suggest to assert that the argument type is `void` which would not be legal C++.