### PR TITLE
Drop guards to accommodate external code defining `KOKKOS_ASSERT`

### DIFF
--- a/core/src/Kokkos_Assert.hpp
+++ b/core/src/Kokkos_Assert.hpp
@@ -44,9 +44,6 @@
               __LINE__) " \n");                                                \
     }                                                                          \
   }
-// some projects already define this for themselves, so don't mess
-// them up
-#ifndef KOKKOS_ASSERT
 #define KOKKOS_ASSERT(...)                                                     \
   {                                                                            \
     if (!bool(__VA_ARGS__)) {                                                  \
@@ -58,8 +55,7 @@
               __LINE__) " \n");                                                \
     }                                                                          \
   }
-#endif  // ifndef KOKKOS_ASSERT
-#else   // not debug mode
+#else  // not debug mode
 #define KOKKOS_EXPECTS(...)
 #define KOKKOS_ENSURES(...)
 #ifndef KOKKOS_ASSERT


### PR DESCRIPTION
We have published our [compatibility guidelines](https://kokkos.github.io/kokkos-core-wiki/ProgrammingGuide/Compatibility.html) for about a year and that is clearly not something we want to support anymore.

I labelled it as "deprecate" but this is really just us dropping support for it.