### PR TITLE
Use omp_get_max_active_levels() when supported

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -45,8 +45,13 @@ namespace Kokkos {
 namespace Impl {
 
 inline bool execute_in_serial(OpenMP const& space = OpenMP()) {
-  return (OpenMP::in_parallel(space) &&
-          !(omp_get_nested() && (omp_get_level() == 1)));
+  return (OpenMP::in_parallel(space) && !(
+#if _OPENMP >= 201511
+                                            (omp_get_max_active_levels() > 1)
+#else
+                                            omp_get_nested()
+#endif
+                                            && (omp_get_level() == 1)));
 }
 
 }  // namespace Impl


### PR DESCRIPTION
Similar to https://github.com/kokkos/kokkos/pull/2843 (and fixed in https://github.com/kokkos/kokkos/pull/3142), `omp_get_max_active_levels` exists OpenMP 4.5, see [openmp.org/wp-content/uploads/openmp-4.5.pdf](https://www.openmp.org/wp-content/uploads/openmp-4.5.pdf) page 248, and `omp_get_nested` has been deprecated since.
Extracted from #6151.