### PR TITLE
Enable `{transform_}exclusive_scan` in place

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_FunctorsForExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FunctorsForExclusiveScan.hpp
@@ -47,8 +47,9 @@ struct ExclusiveScanDefaultFunctorForKnownNeutralElement {
   KOKKOS_FUNCTION
   void operator()(const IndexType i, ValueType& update,
                   const bool final_pass) const {
+    const auto tmp = m_first_from[i];
     if (final_pass) m_first_dest[i] = update + m_init_value;
-    update += m_first_from[i];
+    update += tmp;
   }
 };
 
@@ -73,6 +74,7 @@ struct ExclusiveScanDefaultFunctorWithValueWrapper {
   KOKKOS_FUNCTION
   void operator()(const IndexType i, value_type& update,
                   const bool final_pass) const {
+    const auto tmp = value_type{m_first_from[i], false};
     if (final_pass) {
       if (i == 0) {
         m_first_dest[i] = m_init_value;
@@ -81,7 +83,6 @@ struct ExclusiveScanDefaultFunctorWithValueWrapper {
       }
     }
 
-    const auto tmp = value_type{m_first_from[i], false};
     this->join(update, tmp);
   }
 
@@ -132,6 +133,7 @@ struct TransformExclusiveScanFunctorWithValueWrapper {
   KOKKOS_FUNCTION
   void operator()(const IndexType i, value_type& update,
                   const bool final_pass) const {
+    const auto tmp = value_type{m_unary_op(m_first_from[i]), false};
     if (final_pass) {
       if (i == 0) {
         // for both ExclusiveScan and TransformExclusiveScan,
@@ -142,7 +144,6 @@ struct TransformExclusiveScanFunctorWithValueWrapper {
       }
     }
 
-    const auto tmp = value_type{m_unary_op(m_first_from[i]), false};
     this->join(update, tmp);
   }
 
@@ -190,6 +191,7 @@ struct TransformExclusiveScanFunctorWithoutValueWrapper {
   KOKKOS_FUNCTION
   void operator()(const IndexType i, ValueType& update,
                   const bool final_pass) const {
+    const auto tmp = ValueType{m_unary_op(m_first_from[i])};
     if (final_pass) {
       if (i == 0) {
         // for both ExclusiveScan and TransformExclusiveScan,
@@ -200,7 +202,6 @@ struct TransformExclusiveScanFunctorWithoutValueWrapper {
       }
     }
 
-    const auto tmp = ValueType{m_unary_op(m_first_from[i])};
     this->join(update, tmp);
   }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
@@ -133,47 +133,6 @@ void my_host_exclusive_scan(it1 first, it1 last, it2 dest, ValType init,
   }
 }
 
-template <class ViewType1, class ViewType2, class ValueType, class BinaryOp>
-void verify_data(ViewType1 data_view,  // contains data
-                 ViewType2 test_view,  // the view to test
-                 ValueType init_value, BinaryOp bop) {
-  //! always careful because views might not be deep copyable
-
-  auto data_view_dc = create_deep_copyable_compatible_clone(data_view);
-  auto data_view_h =
-      create_mirror_view_and_copy(Kokkos::HostSpace(), data_view_dc);
-
-  using gold_view_value_type = typename ViewType2::value_type;
-  Kokkos::View<gold_view_value_type*, Kokkos::HostSpace> gold_h(
-      "goldh", data_view.extent(0));
-  my_host_exclusive_scan(KE::cbegin(data_view_h), KE::cend(data_view_h),
-                         KE::begin(gold_h), init_value, bop);
-
-  auto test_view_dc = create_deep_copyable_compatible_clone(test_view);
-  auto test_view_h =
-      create_mirror_view_and_copy(Kokkos::HostSpace(), test_view_dc);
-  if (test_view_h.extent(0) > 0) {
-    for (std::size_t i = 0; i < test_view_h.extent(0); ++i) {
-      // std::cout << i << " " << std::setprecision(15) << data_view_h(i) << " "
-      //           << gold_h(i) << " " << test_view_h(i) << " "
-      //           << std::abs(gold_h(i) - test_view_h(i)) << std::endl;
-      if (std::is_same<gold_view_value_type, int>::value) {
-        ASSERT_EQ(gold_h(i), test_view_h(i));
-      } else {
-        const auto error =
-            std::abs(static_cast<double>(gold_h(i) - test_view_h(i)));
-        if (error > 1e-10) {
-          std::cout << i << " " << std::setprecision(15) << data_view_h(i)
-                    << " " << gold_h(i) << " " << test_view_h(i) << " "
-                    << std::abs(static_cast<double>(gold_h(i) - test_view_h(i)))
-                    << std::endl;
-        }
-        EXPECT_LT(error, 1e-10);
-      }
-    }
-  }
-}
-
 template <class ValueType>
 struct MultiplyFunctor {
   KOKKOS_INLINE_FUNCTION
@@ -190,20 +149,65 @@ struct SumFunctor {
   }
 };
 
+
+struct VerifyData{
+
+  template <class ViewType1, class ViewType2, class ValueType, class BinaryOp>
+  void operator()(ViewType1 data_view,  // contains data
+                  ViewType2 test_view,  // the view to test
+                  ValueType init_value, 
+                  BinaryOp bop) 
+  {
+    //! always careful because views might not be deep copyable
+
+    auto data_view_dc = create_deep_copyable_compatible_clone(data_view);
+    auto data_view_h = create_mirror_view_and_copy(Kokkos::HostSpace(), data_view_dc);
+
+    using gold_view_value_type = typename ViewType2::value_type;
+    Kokkos::View<gold_view_value_type*, Kokkos::HostSpace> gold_h(
+        "goldh", data_view.extent(0));
+    my_host_exclusive_scan(KE::cbegin(data_view_h), KE::cend(data_view_h),
+                           KE::begin(gold_h), init_value, bop);
+
+    auto test_view_dc = create_deep_copyable_compatible_clone(test_view);
+    auto test_view_h = create_mirror_view_and_copy(Kokkos::HostSpace(), test_view_dc);
+    if (test_view_h.extent(0) > 0) {
+      for (std::size_t i = 0; i < test_view_h.extent(0); ++i) {
+
+        if (std::is_same<gold_view_value_type, int>::value) {
+          ASSERT_EQ(gold_h(i), test_view_h(i));
+        } else {
+          const auto error = std::abs(static_cast<double>(gold_h(i) - test_view_h(i)));
+          EXPECT_LT(error, 1e-10) << i << " " 
+             << std::setprecision(15) << error << static_cast<double>(test_view_h(i)) 
+             << " " << static_cast<double>(gold_h(i));
+        }
+      }
+    }
+  }
+
+  template <class ViewType1, class ViewType2, class ValueType>
+  void operator()(ViewType1 data_view,  // contains data
+                  ViewType2 test_view,  // the view to test
+                  ValueType init_value)
+  {
+    (*this)(data_view, test_view, init_value, SumFunctor<ValueType>());
+  } 
+};
+
+
 std::string value_type_to_string(int) { return "int"; }
 
 std::string value_type_to_string(double) { return "double"; }
 
-template <class Tag, class ValueType, class InfoType>
-void run_single_scenario_default_op(const InfoType& scenario_info,
-                                    ValueType init_value) {
-  using default_op           = SumFunctor<ValueType>;
+template <class Tag, class ValueType, class InfoType, class ...OpOrEmpty>
+void run_single_scenario(const InfoType& scenario_info,
+                          ValueType init_value,
+                          OpOrEmpty ... op_or_empty)
+{
+  // using default_op           = SumFunctor<ValueType>;
   const auto name            = std::get<0>(scenario_info);
   const std::size_t view_ext = std::get<1>(scenario_info);
-  // std::cout << "exclusive_scan default op: " << name << ", "
-  //           << view_tag_to_string(Tag{}) << ", "
-  //           << value_type_to_string(ValueType()) << ", "
-  //           << "init = " << init_value << std::endl;
 
   auto view_dest = create_view<ValueType>(Tag{}, view_ext, "exclusive_scan");
   auto view_from = create_view<ValueType>(Tag{}, view_ext, "exclusive_scan");
@@ -213,125 +217,140 @@ void run_single_scenario_default_op(const InfoType& scenario_info,
     fill_zero(view_dest);
     auto r = KE::exclusive_scan(exespace(), KE::cbegin(view_from),
                                 KE::cend(view_from), KE::begin(view_dest),
-                                init_value);
+                                init_value, 
+                                std::forward<OpOrEmpty>(op_or_empty)...);
     ASSERT_EQ(r, KE::end(view_dest));
-    verify_data(view_from, view_dest, init_value, default_op());
+    VerifyData()(view_from, view_dest, init_value, std::forward<OpOrEmpty>(op_or_empty)...);
   }
 
   {
     fill_zero(view_dest);
     auto r = KE::exclusive_scan("label", exespace(), KE::cbegin(view_from),
                                 KE::cend(view_from), KE::begin(view_dest),
-                                init_value);
+                                init_value, std::forward<OpOrEmpty>(op_or_empty)...);
     ASSERT_EQ(r, KE::end(view_dest));
-    verify_data(view_from, view_dest, init_value, default_op());
+    VerifyData()(view_from, view_dest, init_value, std::forward<OpOrEmpty>(op_or_empty)...);
   }
 
   {
     fill_zero(view_dest);
-    auto r = KE::exclusive_scan(exespace(), view_from, view_dest, init_value);
+    auto r = KE::exclusive_scan(exespace(), view_from, view_dest, init_value, 
+                                std::forward<OpOrEmpty>(op_or_empty)...);
     ASSERT_EQ(r, KE::end(view_dest));
-    verify_data(view_from, view_dest, init_value, default_op());
+    VerifyData()(view_from, view_dest, init_value, std::forward<OpOrEmpty>(op_or_empty)...);
   }
 
   {
     fill_zero(view_dest);
     auto r = KE::exclusive_scan("label", exespace(), view_from, view_dest,
-                                init_value);
+                                init_value, std::forward<OpOrEmpty>(op_or_empty)...);
     ASSERT_EQ(r, KE::end(view_dest));
-    verify_data(view_from, view_dest, init_value, default_op());
+    VerifyData()(view_from, view_dest, init_value, std::forward<OpOrEmpty>(op_or_empty)...);
   }
 
   Kokkos::fence();
 }
 
-template <class Tag, class ValueType, class InfoType, class BinaryOp>
-void run_single_scenario_custom_op(const InfoType& scenario_info,
-                                   ValueType init_value, BinaryOp bop) {
+template <class Tag, class ValueType, class InfoType, class ...OpOrEmpty>
+void run_single_scenario_inplace(const InfoType& scenario_info,
+                                    ValueType init_value,
+                                    OpOrEmpty ... op_or_empty) 
+{
   const auto name            = std::get<0>(scenario_info);
   const std::size_t view_ext = std::get<1>(scenario_info);
-  // std::cout << "exclusive_scan custom op: " << name << ", "
-  //           << view_tag_to_string(Tag{}) << ", "
-  //           << value_type_to_string(ValueType()) << ", "
-  //           << "init = " << init_value << std::endl;
 
-  auto view_dest = create_view<ValueType>(Tag{}, view_ext, "exclusive_scan");
-  auto view_from = create_view<ValueType>(Tag{}, view_ext, "exclusive_scan");
-  fill_view(view_from, name);
+  // since here we call the in-place operation, we need to use two views: 
+  // view1: filled according to what the scenario asks for, and is not modified 
+  // view2: filled according to what the scenario asks for, and used for the in-place op
+  // So after the op is done, view_2 should contain the result of doing exclusive scan
 
+  auto view1 = create_view<ValueType>(Tag{}, view_ext, "exclusive_scan_inplace_view1");
+  fill_view(view1, name);
+
+  auto view2 = create_view<ValueType>(Tag{}, view_ext, "exclusive_scan_inplace_view2");
   {
-    fill_zero(view_dest);
-    auto r = KE::exclusive_scan(exespace(), KE::cbegin(view_from),
-                                KE::cend(view_from), KE::begin(view_dest),
-                                init_value, bop);
-    ASSERT_EQ(r, KE::end(view_dest));
-    verify_data(view_from, view_dest, init_value, bop);
+    // view2 has to be filled every time because it is overwritten
+    fill_view(view2, name);
+    auto r = KE::exclusive_scan(exespace(), 
+                                KE::cbegin(view2), KE::cend(view2), KE::begin(view2), 
+                                init_value, 
+                                std::forward<OpOrEmpty>(op_or_empty)...);
+    ASSERT_EQ(r, KE::end(view2));
+    VerifyData()(view1, view2, init_value, std::forward<OpOrEmpty>(op_or_empty)...);
   }
 
   {
-    fill_zero(view_dest);
-    auto r = KE::exclusive_scan("label", exespace(), KE::cbegin(view_from),
-                                KE::cend(view_from), KE::begin(view_dest),
-                                init_value, bop);
-    ASSERT_EQ(r, KE::end(view_dest));
-    verify_data(view_from, view_dest, init_value, bop);
+    // view2 has to be filled every time because it is overwritten
+    fill_view(view2, name);
+    auto r = KE::exclusive_scan("label", exespace(), 
+                                KE::cbegin(view2), KE::cend(view2), 
+                                KE::begin(view2),
+                                init_value, 
+                                std::forward<OpOrEmpty>(op_or_empty)...);
+    ASSERT_EQ(r, KE::end(view2));
+    VerifyData()(view1, view2, init_value, std::forward<OpOrEmpty>(op_or_empty)...);
   }
 
   {
-    fill_zero(view_dest);
-    auto r =
-        KE::exclusive_scan(exespace(), view_from, view_dest, init_value, bop);
-    ASSERT_EQ(r, KE::end(view_dest));
-    verify_data(view_from, view_dest, init_value, bop);
+    // view2 has to be filled every time because it is overwritten
+    fill_view(view2, name);
+    auto r = KE::exclusive_scan(exespace(), view2, view2, init_value, 
+                                std::forward<OpOrEmpty>(op_or_empty)...);
+    ASSERT_EQ(r, KE::end(view2));
+    VerifyData()(view1, view2, init_value, std::forward<OpOrEmpty>(op_or_empty)...);
   }
 
   {
-    fill_zero(view_dest);
-    auto r = KE::exclusive_scan("label", exespace(), view_from, view_dest,
-                                init_value, bop);
-    ASSERT_EQ(r, KE::end(view_dest));
-    verify_data(view_from, view_dest, init_value, bop);
+    // view2 has to be filled every time because it is overwritten
+    fill_view(view2, name);
+    auto r = KE::exclusive_scan("label", exespace(), view2, view2,init_value, 
+                                std::forward<OpOrEmpty>(op_or_empty)...);
+    ASSERT_EQ(r, KE::end(view2));
+    VerifyData()(view1, view2, init_value, std::forward<OpOrEmpty>(op_or_empty)...);
   }
 
   Kokkos::fence();
 }
 
 template <class Tag, class ValueType>
-void run_exclusive_scan_all_scenarios() {
+void run_exclusive_scan_all_scenarios() 
+{
   const std::map<std::string, std::size_t> scenarios = {
       {"empty", 0},          {"one-element", 1}, {"two-elements-a", 2},
       {"two-elements-b", 2}, {"small-a", 9},     {"small-b", 13},
       {"medium", 1103},      {"large", 10513}};
 
-  for (const auto& it : scenarios) {
-    run_single_scenario_default_op<Tag, ValueType>(it, ValueType{0});
-    run_single_scenario_default_op<Tag, ValueType>(it, ValueType{1});
-    run_single_scenario_default_op<Tag, ValueType>(it, ValueType{-2});
-    run_single_scenario_default_op<Tag, ValueType>(it, ValueType{3});
+  for (const auto& it : scenarios) 
+  {
+    run_single_scenario<Tag, ValueType>(it, ValueType{0});
+    run_single_scenario<Tag, ValueType>(it, ValueType{1});
+    run_single_scenario<Tag, ValueType>(it, ValueType{-2});
+    run_single_scenario<Tag, ValueType>(it, ValueType{3});
+
+    run_single_scenario_inplace<Tag, ValueType>(it, ValueType{0});
+    run_single_scenario_inplace<Tag, ValueType>(it, ValueType{-2});
 
 #if !defined KOKKOS_ENABLE_OPENMPTARGET
     // custom multiply op is only run for small views otherwise it overflows
     if (it.first == "small-a" || it.first == "small-b") {
       using custom_bop_t = MultiplyFunctor<ValueType>;
-      run_single_scenario_custom_op<Tag, ValueType>(it, ValueType{0},
-                                                    custom_bop_t());
-      run_single_scenario_custom_op<Tag, ValueType>(it, ValueType{1},
-                                                    custom_bop_t());
-      run_single_scenario_custom_op<Tag, ValueType>(it, ValueType{-2},
-                                                    custom_bop_t());
-      run_single_scenario_custom_op<Tag, ValueType>(it, ValueType{3},
-                                                    custom_bop_t());
+      run_single_scenario<Tag, ValueType>(it, ValueType{0}, custom_bop_t());
+      run_single_scenario<Tag, ValueType>(it, ValueType{1}, custom_bop_t());
+      run_single_scenario<Tag, ValueType>(it, ValueType{-2},custom_bop_t());
+      run_single_scenario<Tag, ValueType>(it, ValueType{3}, custom_bop_t());
+
+      run_single_scenario_inplace<Tag, ValueType>(it, ValueType{0},  custom_bop_t());
+      run_single_scenario_inplace<Tag, ValueType>(it, ValueType{-2}, custom_bop_t());
     }
 
     using custom_bop_t = SumFunctor<ValueType>;
-    run_single_scenario_custom_op<Tag, ValueType>(it, ValueType{0},
-                                                  custom_bop_t());
-    run_single_scenario_custom_op<Tag, ValueType>(it, ValueType{1},
-                                                  custom_bop_t());
-    run_single_scenario_custom_op<Tag, ValueType>(it, ValueType{-2},
-                                                  custom_bop_t());
-    run_single_scenario_custom_op<Tag, ValueType>(it, ValueType{3},
-                                                  custom_bop_t());
+    run_single_scenario<Tag, ValueType>(it, ValueType{0}, custom_bop_t());
+    run_single_scenario<Tag, ValueType>(it, ValueType{1}, custom_bop_t());
+    run_single_scenario<Tag, ValueType>(it, ValueType{-2},custom_bop_t());
+    run_single_scenario<Tag, ValueType>(it, ValueType{3}, custom_bop_t());
+
+    run_single_scenario_inplace<Tag, ValueType>(it, ValueType{0},  custom_bop_t());
+    run_single_scenario_inplace<Tag, ValueType>(it, ValueType{-2}, custom_bop_t());
 #endif
   }
 }

--- a/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
@@ -210,43 +210,36 @@ void run_single_scenario(const InfoType& scenario_info, ValueType init_value,
 
   {
     fill_zero(view_dest);
-    auto r =
-        KE::exclusive_scan(exespace(), KE::cbegin(view_from),
-                           KE::cend(view_from), KE::begin(view_dest),
-                           init_value, std::forward<OpOrEmpty>(empty_or_op)...);
+    auto r = KE::exclusive_scan(exespace(), KE::cbegin(view_from),
+                                KE::cend(view_from), KE::begin(view_dest),
+                                init_value, empty_or_op...);
     ASSERT_EQ(r, KE::end(view_dest));
-    VerifyData()(view_from, view_dest, init_value,
-                 std::forward<OpOrEmpty>(empty_or_op)...);
+    VerifyData()(view_from, view_dest, init_value, empty_or_op...);
   }
 
   {
     fill_zero(view_dest);
-    auto r =
-        KE::exclusive_scan("label", exespace(), KE::cbegin(view_from),
-                           KE::cend(view_from), KE::begin(view_dest),
-                           init_value, std::forward<OpOrEmpty>(empty_or_op)...);
+    auto r = KE::exclusive_scan("label", exespace(), KE::cbegin(view_from),
+                                KE::cend(view_from), KE::begin(view_dest),
+                                init_value, empty_or_op...);
     ASSERT_EQ(r, KE::end(view_dest));
-    VerifyData()(view_from, view_dest, init_value,
-                 std::forward<OpOrEmpty>(empty_or_op)...);
+    VerifyData()(view_from, view_dest, init_value, empty_or_op...);
   }
 
   {
     fill_zero(view_dest);
     auto r = KE::exclusive_scan(exespace(), view_from, view_dest, init_value,
-                                std::forward<OpOrEmpty>(empty_or_op)...);
+                                empty_or_op...);
     ASSERT_EQ(r, KE::end(view_dest));
-    VerifyData()(view_from, view_dest, init_value,
-                 std::forward<OpOrEmpty>(empty_or_op)...);
+    VerifyData()(view_from, view_dest, init_value, empty_or_op...);
   }
 
   {
     fill_zero(view_dest);
-    auto r =
-        KE::exclusive_scan("label", exespace(), view_from, view_dest,
-                           init_value, std::forward<OpOrEmpty>(empty_or_op)...);
+    auto r = KE::exclusive_scan("label", exespace(), view_from, view_dest,
+                                init_value, empty_or_op...);
     ASSERT_EQ(r, KE::end(view_dest));
-    VerifyData()(view_from, view_dest, init_value,
-                 std::forward<OpOrEmpty>(empty_or_op)...);
+    VerifyData()(view_from, view_dest, init_value, empty_or_op...);
   }
 
   Kokkos::fence();
@@ -275,39 +268,34 @@ void run_single_scenario_inplace(const InfoType& scenario_info,
   {
     fill_view(view2, name);
     auto r = KE::exclusive_scan(exespace(), KE::cbegin(view2), KE::cend(view2),
-                                KE::begin(view2), init_value,
-                                std::forward<OpOrEmpty>(empty_or_op)...);
+                                KE::begin(view2), init_value, empty_or_op...);
     ASSERT_EQ(r, KE::end(view2));
-    VerifyData()(view1, view2, init_value,
-                 std::forward<OpOrEmpty>(empty_or_op)...);
+    VerifyData()(view1, view2, init_value, empty_or_op...);
   }
 
   {
     fill_view(view2, name);
     auto r = KE::exclusive_scan("label", exespace(), KE::cbegin(view2),
                                 KE::cend(view2), KE::begin(view2), init_value,
-                                std::forward<OpOrEmpty>(empty_or_op)...);
+                                empty_or_op...);
     ASSERT_EQ(r, KE::end(view2));
-    VerifyData()(view1, view2, init_value,
-                 std::forward<OpOrEmpty>(empty_or_op)...);
+    VerifyData()(view1, view2, init_value, empty_or_op...);
   }
 
   {
     fill_view(view2, name);
     auto r = KE::exclusive_scan(exespace(), view2, view2, init_value,
-                                std::forward<OpOrEmpty>(empty_or_op)...);
+                                empty_or_op...);
     ASSERT_EQ(r, KE::end(view2));
-    VerifyData()(view1, view2, init_value,
-                 std::forward<OpOrEmpty>(empty_or_op)...);
+    VerifyData()(view1, view2, init_value, empty_or_op...);
   }
 
   {
     fill_view(view2, name);
     auto r = KE::exclusive_scan("label", exespace(), view2, view2, init_value,
-                                std::forward<OpOrEmpty>(empty_or_op)...);
+                                empty_or_op...);
     ASSERT_EQ(r, KE::end(view2));
-    VerifyData()(view1, view2, init_value,
-                 std::forward<OpOrEmpty>(empty_or_op)...);
+    VerifyData()(view1, view2, init_value, empty_or_op...);
   }
 
   Kokkos::fence();

--- a/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
@@ -255,7 +255,7 @@ void run_single_scenario_inplace(const InfoType& scenario_info,
   // since here we call the in-place operation, we need to use two views:
   // view1: filled according to what the scenario asks for and is not modified
   // view2: filled according to what the scenario asks for and used for the
-  // in-place op Therefore, after the op is done, view_2 should contain the
+  // in-place op Therefore, after the op is done, view2 should contain the
   // result of doing exclusive scan NOTE: view2 is filled below every time
   // because the algorithm acts in place
 

--- a/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
@@ -176,7 +176,7 @@ struct VerifyData {
         } else {
           const auto error =
               std::abs(static_cast<double>(gold_h(i) - test_view_h(i)));
-          EXPECT_LT(error, 1e-10) << i << " " << std::setprecision(15) << error
+          ASSERT_LT(error, 1e-10) << i << " " << std::setprecision(15) << error
                                   << static_cast<double>(test_view_h(i)) << " "
                                   << static_cast<double>(gold_h(i));
         }

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamTransformExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamTransformExclusiveScan.cpp
@@ -108,7 +108,9 @@ struct TestFunctorA {
   }
 };
 
-template <class LayoutTag, class ValueType>
+struct InPlace {};
+
+template <class LayoutTag, class ValueType, class InPlaceOrVoid = void>
 void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
   /* description:
      use a rank-2 view randomly filled with values,
@@ -134,9 +136,6 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
   using space_t = Kokkos::DefaultExecutionSpace;
   Kokkos::TeamPolicy<space_t> policy(numTeams, Kokkos::AUTO());
 
-  // create the destination view
-  Kokkos::View<ValueType**> destView("destView", numTeams, numCols);
-
   // tranform_exclusive_scan returns an iterator so to verify that it is correct
   // each team stores the distance of the returned iterator from the beginning
   // of the interval that team operates on and then we check that these
@@ -156,12 +155,21 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
   rand_pool pool(lowerBound * upperBound);
   Kokkos::fill_random(initValuesView_h, pool, lowerBound, upperBound);
 
-  // use CTAD for functor
   auto initValuesView =
       Kokkos::create_mirror_view_and_copy(space_t(), initValuesView_h);
-  TestFunctorA fnc(sourceView, destView, distancesView, intraTeamSentinelView,
-                   initValuesView, binaryOp, unaryOp, apiId);
-  Kokkos::parallel_for(policy, fnc);
+
+  // create the destination view
+  Kokkos::View<ValueType**> destView("destView", numTeams, numCols);
+  if constexpr (std::is_same_v<InPlaceOrVoid, InPlace>) {
+    TestFunctorA fnc(sourceView, sourceView, distancesView,
+                     intraTeamSentinelView, initValuesView, binaryOp, unaryOp,
+                     apiId);
+    Kokkos::parallel_for(policy, fnc);
+  } else {
+    TestFunctorA fnc(sourceView, destView, distancesView, intraTeamSentinelView,
+                     initValuesView, binaryOp, unaryOp, apiId);
+    Kokkos::parallel_for(policy, fnc);
+  }
 
   // -----------------------------------------------
   // run cpp-std kernel and check
@@ -200,16 +208,21 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
 #undef transform_exclusive_scan
   }
 
-  auto dataViewAfterOp_h = create_host_space_copy(destView);
-  expect_equal_host_views(stdDestView, dataViewAfterOp_h);
+  if constexpr (std::is_same_v<InPlaceOrVoid, InPlace>) {
+    auto dataViewAfterOp_h = create_host_space_copy(sourceView);
+    expect_equal_host_views(stdDestView, dataViewAfterOp_h);
+  } else {
+    auto dataViewAfterOp_h = create_host_space_copy(destView);
+    expect_equal_host_views(stdDestView, dataViewAfterOp_h);
+  }
 }
 
-template <class LayoutTag, class ValueType>
+template <class LayoutTag, class ValueType, class InPlaceOrVoid = void>
 void run_all_scenarios() {
   for (int numTeams : teamSizesToTest) {
     for (const auto& numCols : {0, 1, 2, 13, 101, 1444, 8153}) {
       for (int apiId : {0, 1}) {
-        test_A<LayoutTag, ValueType>(numTeams, numCols, apiId);
+        test_A<LayoutTag, ValueType, InPlaceOrVoid>(numTeams, numCols, apiId);
       }
     }
   }
@@ -219,6 +232,10 @@ TEST(std_algorithms_transform_exclusive_scan_team_test, test) {
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();
   run_all_scenarios<StridedThreeRowsTag, unsigned>();
+
+  run_all_scenarios<DynamicTag, double, InPlace>();
+  run_all_scenarios<StridedTwoRowsTag, int, InPlace>();
+  run_all_scenarios<StridedThreeRowsTag, unsigned, InPlace>();
 }
 
 }  // namespace TeamTransformExclusiveScan

--- a/algorithms/unit_tests/TestStdAlgorithmsTransformExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTransformExclusiveScan.cpp
@@ -161,20 +161,13 @@ void verify_data(ViewType1 data_view,  // contains data
       create_mirror_view_and_copy(Kokkos::HostSpace(), test_view_dc);
   if (test_view_h.extent(0) > 0) {
     for (std::size_t i = 0; i < test_view_h.extent(0); ++i) {
-      // std::cout << i << " " << std::setprecision(15) << data_view_h(i) << " "
-      //           << gold_h(i) << " " << test_view_h(i) << " "
-      //           << std::abs(gold_h(i) - test_view_h(i)) << std::endl;
-
       if (std::is_same<gold_view_value_type, int>::value) {
         ASSERT_EQ(gold_h(i), test_view_h(i));
       } else {
         const auto error = std::abs(gold_h(i) - test_view_h(i));
-        if (error > 1e-10) {
-          std::cout << i << " " << std::setprecision(15) << data_view_h(i)
-                    << " " << gold_h(i) << " " << test_view_h(i) << " "
-                    << std::abs(gold_h(i) - test_view_h(i)) << std::endl;
-        }
-        EXPECT_LT(error, 1e-10);
+        ASSERT_LT(error, 1e-10) << i << " " << std::setprecision(15) << error
+                                << static_cast<double>(test_view_h(i)) << " "
+                                << static_cast<double>(gold_h(i));
       }
     }
     // std::cout << " last el: " << test_view_h(test_view_h.extent(0)-1) <<
@@ -206,17 +199,13 @@ void run_single_scenario(const InfoType& scenario_info, ValueType init_value,
                          BinaryOp bop, UnaryOp uop) {
   const auto name            = std::get<0>(scenario_info);
   const std::size_t view_ext = std::get<1>(scenario_info);
-  // std::cout << "transform_exclusive_scan custom op: " << name << ", "
-  //           << view_tag_to_string(Tag{}) << ", "
-  //           << value_type_to_string(ValueType()) << ", "
-  //           << "init = " << init_value << std::endl;
 
-  auto view_dest =
-      create_view<ValueType>(Tag{}, view_ext, "transform_exclusive_scan");
-  auto view_from =
-      create_view<ValueType>(Tag{}, view_ext, "transform_exclusive_scan");
+  auto view_from = create_view<ValueType>(Tag{}, view_ext,
+                                          "transform_exclusive_scan_view_from");
   fill_view(view_from, name);
 
+  auto view_dest = create_view<ValueType>(Tag{}, view_ext,
+                                          "transform_exclusive_scan_view_dest");
   {
     fill_zero(view_dest);
     auto r = KE::transform_exclusive_scan(
@@ -254,6 +243,65 @@ void run_single_scenario(const InfoType& scenario_info, ValueType init_value,
   Kokkos::fence();
 }
 
+template <class Tag, class ValueType, class InfoType, class BinaryOp,
+          class UnaryOp>
+void run_single_scenario_inplace(const InfoType& scenario_info,
+                                 ValueType init_value, BinaryOp bop,
+                                 UnaryOp uop) {
+  const auto name            = std::get<0>(scenario_info);
+  const std::size_t view_ext = std::get<1>(scenario_info);
+
+  // since here we call the in-place operation, we need to use two views:
+  // view1: filled according to what the scenario asks for and is not modified
+  // view2: filled according to what the scenario asks for and used for the
+  // in-place op Therefore, after the op is done, view_2 should contain the
+  // result of doing exclusive scan NOTE: view2 is filled below every time
+  // because the algorithm acts in place
+
+  auto view_1 = create_view<ValueType>(Tag{}, view_ext,
+                                       "transform_exclusive_scan_view_1");
+  fill_view(view_1, name);
+
+  auto view_2 = create_view<ValueType>(Tag{}, view_ext,
+                                       "transform_exclusive_scan_view_2");
+
+  {
+    fill_view(view_2, name);
+    auto r = KE::transform_exclusive_scan(exespace(), KE::cbegin(view_2),
+                                          KE::cend(view_2), KE::begin(view_2),
+                                          init_value, bop, uop);
+    ASSERT_EQ(r, KE::end(view_2));
+    verify_data(view_1, view_2, init_value, bop, uop);
+  }
+
+  {
+    fill_view(view_2, name);
+    auto r = KE::transform_exclusive_scan(
+        "label", exespace(), KE::cbegin(view_2), KE::cend(view_2),
+        KE::begin(view_2), init_value, bop, uop);
+    ASSERT_EQ(r, KE::end(view_2));
+    verify_data(view_1, view_2, init_value, bop, uop);
+  }
+
+  {
+    fill_view(view_2, name);
+    auto r = KE::transform_exclusive_scan(exespace(), view_2, view_2,
+                                          init_value, bop, uop);
+    ASSERT_EQ(r, KE::end(view_2));
+    verify_data(view_1, view_2, init_value, bop, uop);
+  }
+
+  {
+    fill_view(view_2, name);
+    auto r = KE::transform_exclusive_scan("label", exespace(), view_2, view_2,
+                                          init_value, bop, uop);
+    ASSERT_EQ(r, KE::end(view_2));
+    verify_data(view_1, view_2, init_value, bop, uop);
+  }
+
+  Kokkos::fence();
+}
+
 template <class Tag, class ValueType>
 void run_all_scenarios() {
   const std::map<std::string, std::size_t> scenarios = {
@@ -268,6 +316,11 @@ void run_all_scenarios() {
     run_single_scenario<Tag, ValueType>(it, ValueType{1}, bop_t(), uop_t());
     run_single_scenario<Tag, ValueType>(it, ValueType{-2}, bop_t(), uop_t());
     run_single_scenario<Tag, ValueType>(it, ValueType{3}, bop_t(), uop_t());
+
+    run_single_scenario_inplace<Tag, ValueType>(it, ValueType{0}, bop_t(),
+                                                uop_t());
+    run_single_scenario_inplace<Tag, ValueType>(it, ValueType{-2}, bop_t(),
+                                                uop_t());
   }
 }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsTransformExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTransformExclusiveScan.cpp
@@ -170,8 +170,6 @@ void verify_data(ViewType1 data_view,  // contains data
                                 << static_cast<double>(gold_h(i));
       }
     }
-    // std::cout << " last el: " << test_view_h(test_view_h.extent(0)-1) <<
-    // std::endl;
   }
 }
 
@@ -254,49 +252,49 @@ void run_single_scenario_inplace(const InfoType& scenario_info,
   // since here we call the in-place operation, we need to use two views:
   // view1: filled according to what the scenario asks for and is not modified
   // view2: filled according to what the scenario asks for and used for the
-  // in-place op Therefore, after the op is done, view_2 should contain the
+  // in-place op Therefore, after the op is done, view2 should contain the
   // result of doing exclusive scan NOTE: view2 is filled below every time
   // because the algorithm acts in place
 
-  auto view_1 = create_view<ValueType>(Tag{}, view_ext,
-                                       "transform_exclusive_scan_view_1");
-  fill_view(view_1, name);
+  auto view1 =
+      create_view<ValueType>(Tag{}, view_ext, "transform_exclusive_scan_view1");
+  fill_view(view1, name);
 
-  auto view_2 = create_view<ValueType>(Tag{}, view_ext,
-                                       "transform_exclusive_scan_view_2");
+  auto view2 =
+      create_view<ValueType>(Tag{}, view_ext, "transform_exclusive_scan_view2");
 
   {
-    fill_view(view_2, name);
-    auto r = KE::transform_exclusive_scan(exespace(), KE::cbegin(view_2),
-                                          KE::cend(view_2), KE::begin(view_2),
+    fill_view(view2, name);
+    auto r = KE::transform_exclusive_scan(exespace(), KE::cbegin(view2),
+                                          KE::cend(view2), KE::begin(view2),
                                           init_value, bop, uop);
-    ASSERT_EQ(r, KE::end(view_2));
-    verify_data(view_1, view_2, init_value, bop, uop);
+    ASSERT_EQ(r, KE::end(view2));
+    verify_data(view1, view2, init_value, bop, uop);
   }
 
   {
-    fill_view(view_2, name);
+    fill_view(view2, name);
     auto r = KE::transform_exclusive_scan(
-        "label", exespace(), KE::cbegin(view_2), KE::cend(view_2),
-        KE::begin(view_2), init_value, bop, uop);
-    ASSERT_EQ(r, KE::end(view_2));
-    verify_data(view_1, view_2, init_value, bop, uop);
+        "label", exespace(), KE::cbegin(view2), KE::cend(view2),
+        KE::begin(view2), init_value, bop, uop);
+    ASSERT_EQ(r, KE::end(view2));
+    verify_data(view1, view2, init_value, bop, uop);
   }
 
   {
-    fill_view(view_2, name);
-    auto r = KE::transform_exclusive_scan(exespace(), view_2, view_2,
-                                          init_value, bop, uop);
-    ASSERT_EQ(r, KE::end(view_2));
-    verify_data(view_1, view_2, init_value, bop, uop);
+    fill_view(view2, name);
+    auto r = KE::transform_exclusive_scan(exespace(), view2, view2, init_value,
+                                          bop, uop);
+    ASSERT_EQ(r, KE::end(view2));
+    verify_data(view1, view2, init_value, bop, uop);
   }
 
   {
-    fill_view(view_2, name);
-    auto r = KE::transform_exclusive_scan("label", exespace(), view_2, view_2,
+    fill_view(view2, name);
+    auto r = KE::transform_exclusive_scan("label", exespace(), view2, view2,
                                           init_value, bop, uop);
-    ASSERT_EQ(r, KE::end(view_2));
-    verify_data(view_1, view_2, init_value, bop, uop);
+    ASSERT_EQ(r, KE::end(view2));
+    verify_data(view1, view2, init_value, bop, uop);
   }
 
   Kokkos::fence();


### PR DESCRIPTION
currently Kokkos `exclusive_scan` does not work for in-place operation.
The c++ std says that exclusive_scan can support inplace, so this PR fixes the defect. 
 This PR fixes that and adds new tests.
While adding new tests, we also improve things to reduce duplication, use proper gtest << operator if needed, removing useless comments and adding new explanations.


### use case 

In ArborX, it is typical to do some some counting into a View, and then do a scan on that view to convert it to offsets. Creating a temporary extra view comes at the cost of additional memory and performance.
I don't think C++ standard says anything about whether it's allowable for `src` and `dst` to be the same.