### PR TITLE
Improve "deep_copy: no copy mechanism" exception message

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -22,6 +22,7 @@ static_assert(false,
 #ifndef KOKKOS_COPYVIEWS_HPP_
 #define KOKKOS_COPYVIEWS_HPP_
 #include <string>
+#include <sstream>
 #include <Kokkos_Parallel.hpp>
 #include <KokkosExp_MDRangePolicy.hpp>
 #include <Kokkos_Layout.hpp>

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -614,15 +614,15 @@ void view_copy(const DstType& dst, const SrcType& src) {
 
   if (!DstExecCanAccessSrc && !SrcExecCanAccessDst) {
     std::ostringstream ss;
-    ss << "Error: Kokkos::deep_copy with no available copy mechanism: ";
-    ss << "from src (\"" << src.label() << "\") to dst (\"" << dst.label()
-       << "\").\n";
-    ss << "There is no common execution space that can access both src's "
-          "space\n";
-    ss << "(" << src_memory_space().name() << ") and dst's space ("
-       << dst_memory_space().name() << "), ";
-    ss << "so src and dst\n";
-    ss << "must be contiguous and have the same layout.\n";
+    ss << "Error: Kokkos::deep_copy with no available copy mechanism: "
+       << "from source view (\"" << src.label() << "\") to destination view (\""
+       << dst.label() << "\").\n"
+       << "There is no common execution space that can access both source's "
+          "space\n"
+       << "(" << src_memory_space().name() << ") and destination's space ("
+       << dst_memory_space().name() << "), "
+       << "so source and destination\n"
+       << "must be contiguous and have the same layout.\n";
     Kokkos::Impl::throw_runtime_exception(ss.str());
   }
 

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -612,12 +612,17 @@ void view_copy(const DstType& dst, const SrcType& src) {
   };
 
   if (!DstExecCanAccessSrc && !SrcExecCanAccessDst) {
-    std::string message(
-        "Error: Kokkos::deep_copy with no available copy mechanism: ");
-    message += src.label();
-    message += " to ";
-    message += dst.label();
-    Kokkos::Impl::throw_runtime_exception(message);
+    std::ostringstream ss;
+    ss << "Error: Kokkos::deep_copy with no available copy mechanism: ";
+    ss << "from src (\"" << src.label() << "\") to dst (\"" << dst.label()
+       << "\").\n";
+    ss << "There is no common execution space that can access both src's "
+          "space\n";
+    ss << "(" << src_memory_space().name() << ") and dst's space ("
+       << dst_memory_space().name() << "), ";
+    ss << "so src and dst\n";
+    ss << "must be contiguous and have the same layout.\n";
+    Kokkos::Impl::throw_runtime_exception(ss.str());
   }
 
   // Figure out iteration order in case we need it

--- a/core/unit_test/TestViewCopy_a.hpp
+++ b/core/unit_test/TestViewCopy_a.hpp
@@ -147,6 +147,40 @@ TEST(TEST_CATEGORY, view_copy_tests) {
       Kokkos::deep_copy(s_a, hs_a);
       ASSERT_TRUE(run_check(s_a, 6));
     }
+  } else {
+    // These copies won't succeed, but they should each throw
+    // an exception whose message contains the view labels,
+    // and the names of the views' memory spaces.
+    //
+    // Note: original a,b both have the same device type,
+    // and their mirrors have the same device type.
+    using memory_space        = typename decltype(a)::memory_space;
+    using mirror_memory_space = typename decltype(h_a)::memory_space;
+    bool threw                = false;
+    std::string msg;
+    try {
+      Kokkos::deep_copy(hs_b, s_b);
+    } catch (std::exception& e) {
+      threw = true;
+      msg   = e.what();
+    }
+    ASSERT_TRUE(threw);
+    ASSERT_NE(msg.find(hs_b.label()), std::string::npos);
+    ASSERT_NE(msg.find(s_b.label()), std::string::npos);
+    ASSERT_NE(msg.find(memory_space().name()), std::string::npos);
+    ASSERT_NE(msg.find(mirror_memory_space().name()), std::string::npos);
+    threw = false;
+    try {
+      Kokkos::deep_copy(s_a, hs_a);
+    } catch (std::exception& e) {
+      threw = true;
+      msg   = e.what();
+    }
+    ASSERT_TRUE(threw);
+    ASSERT_NE(msg.find(s_a.label()), std::string::npos);
+    ASSERT_NE(msg.find(hs_a.label()), std::string::npos);
+    ASSERT_NE(msg.find(memory_space().name()), std::string::npos);
+    ASSERT_NE(msg.find(mirror_memory_space().name()), std::string::npos);
   }
 
   // Contiguous copies


### PR DESCRIPTION
The cases where deep_copy can't be used can be confusing to newer users. This was just brought up at KUG, and I also see a recent issue about it.

Since these cases - cross-space copies with incompatible layouts or non-contiguous - all come down to a single point in the code, so it makes sense to provide some more info in this error message.

Tested with a deep_copy between two non-contiguous subviews.

Before:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Error: Kokkos::deep_copy with no available copy mechanism: v2 to v1
```

After:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Error: Kokkos::deep_copy with no available copy mechanism: from src ("v2") to dst ("v1").
There is no common execution space that can access both src's space
(Host) and dst's space (Cuda), so src and dst
must be contiguous and have the same layout.
```

We could even add more info: which view(s) are noncontiguous? What the strides are? But this is already long for an exception message.