### PR TITLE
GitHub CI: Test with AddressSanitizer

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -124,8 +124,6 @@ jobs:
           cmake --build builddir --parallel 2
           ccache -s
       - name: Tests
-        env:
-          ASAN_OPTIONS: allocator_may_return_null=1
         working-directory: builddir
         run: ctest --output-on-failure
       - name: Test linking against build dir

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -47,9 +47,17 @@ jobs:
             backend: 'OPENMP'
           - distro: 'ubuntu:latest'
             cxx: 'clang++'
+            cxx_extra_flags: '-fsanitize=address'
+            extra_linker_flags: '-fsanitize=address'
             cmake_build_type: 'RelWithDebInfo'
             backend: 'THREADS'
             clang-tidy: '-DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*"'
+          - distro: 'ubuntu:latest'
+            cxx: 'clang++'
+            cxx_extra_flags: '-fsanitize=address'
+            extra_linker_flags: '-fsanitize=address'
+            cmake_build_type: 'RelWithDebInfo'
+            backend: 'SERIAL'
           - distro: 'ubuntu:latest'
             cxx: 'g++'
             cmake_build_type: 'RelWithDebInfo'
@@ -106,6 +114,7 @@ jobs:
             -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
             -DKokkos_ENABLE_IMPL_MDSPAN=ON \
             -DCMAKE_CXX_FLAGS="-Werror ${{ matrix.cxx_extra_flags }}" \
+            -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.extra_linker_flags }}" \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }}
@@ -115,9 +124,12 @@ jobs:
           cmake --build builddir --parallel 2
           ccache -s
       - name: Tests
+        env:
+          ASAN_OPTIONS: allocator_may_return_null=1
         working-directory: builddir
         run: ctest --output-on-failure
       - name: Test linking against build dir
+        if: ${{ matrix.cxx_extra_flags != '-fsanitize=address' }}
         working-directory: example/build_cmake_installed
         run: |
           cmake -B builddir_buildtree -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} -DKokkos_ROOT=../../builddir
@@ -128,6 +140,7 @@ jobs:
       - name: Install
         run: sudo cmake --build builddir --target install
       - name: Test install
+        if: ${{ matrix.cxx_extra_flags != '-fsanitize=address' }}
         working-directory: example/build_cmake_installed
         run: |
           cmake -B builddir -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1540,14 +1540,7 @@ class TestViewAPI {
     typename const_multivector_type::const_type ccmvX(cmv);
   }
 
-// The test would fail with AddressSanitizer
-#if defined(__has_feature)
-#if __has_feature(address_sanitizer)
-  __attribute__((no_sanitize("address")))
-#endif
-#endif
-  static void
-  run_test_error() {
+  static void run_test_error() {
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
     if (std::is_same<typename dView1::memory_space,
                      Kokkos::Experimental::OpenMPTargetSpace>::value)

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1540,7 +1540,14 @@ class TestViewAPI {
     typename const_multivector_type::const_type ccmvX(cmv);
   }
 
-  static void run_test_error() {
+// The test would fail with AddressSanitizer
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+  __attribute__((no_sanitize("address")))
+#endif
+#endif
+  static void
+  run_test_error() {
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
     if (std::is_same<typename dView1::memory_space,
                      Kokkos::Experimental::OpenMPTargetSpace>::value)

--- a/core/unit_test/TestViewAPI_d.hpp
+++ b/core/unit_test/TestViewAPI_d.hpp
@@ -27,6 +27,12 @@ TEST(TEST_CATEGORY, view_api_d) {
 }
 
 TEST(TEST_CATEGORY, view_allocation_error) {
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+  GTEST_SKIP() << "AddressSanitzer detects allocating too much memory "
+                  "preventing our checks to run";
+#endif
+#endif
 #if ((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 3))
   GTEST_SKIP() << "ROCm 5.3 segfaults when trying to allocate too much memory";
 #endif

--- a/core/unit_test/TestViewAPI_d.hpp
+++ b/core/unit_test/TestViewAPI_d.hpp
@@ -27,12 +27,6 @@ TEST(TEST_CATEGORY, view_api_d) {
 }
 
 TEST(TEST_CATEGORY, view_allocation_error) {
-#if defined(__has_feature)
-#if __has_feature(address_sanitizer)
-  GTEST_SKIP() << "AddressSanitzer detects allocating too much memory "
-                  "preventing our checks to run";
-#endif
-#endif
 #if ((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 3))
   GTEST_SKIP() << "ROCm 5.3 segfaults when trying to allocate too much memory";
 #endif


### PR DESCRIPTION
Related to #6151 and #6674. AddressSanitizer would have detected problems in #6151 without #6674 (if only the `Serial` backend was enabled). Since we are treating atomics special if only the `Serial` backend was enabled (also see #6672), I added a build with AddressSanitizer that only enables `Serial`. I also enabled it for another build (with the `Threads` backend) for which it was convenient.