### PR TITLE
simd: add compound assignments and reductions

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -751,6 +751,11 @@ class simd<double, simd_abi::avx2_fixed_size<4>> {
                                gen(std::integral_constant<std::size_t, 2>()),
                                gen(std::integral_constant<std::size_t, 3>()))) {
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -1011,6 +1016,11 @@ class simd<float, simd_abi::avx2_fixed_size<4>> {
                             gen(std::integral_constant<std::size_t, 1>()),
                             gen(std::integral_constant<std::size_t, 2>()),
                             gen(std::integral_constant<std::size_t, 3>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m128 const& value_in)
       : m_value(value_in) {}
@@ -1262,6 +1272,11 @@ class simd<float, simd_abi::avx2_fixed_size<8>> {
                                gen(std::integral_constant<std::size_t, 5>()),
                                gen(std::integral_constant<std::size_t, 6>()),
                                gen(std::integral_constant<std::size_t, 7>()))) {
+  }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m256 const& value_in)
@@ -1920,6 +1935,11 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
             gen(std::integral_constant<std::size_t, 1>()),
             gen(std::integral_constant<std::size_t, 2>()),
             gen(std::integral_constant<std::size_t, 3>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m256i const& value_in)
       : m_value(value_in) {}
@@ -2138,6 +2158,11 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
             gen(std::integral_constant<std::size_t, 1>()),
             gen(std::integral_constant<std::size_t, 2>()),
             gen(std::integral_constant<std::size_t, 3>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m256i const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1533,6 +1533,11 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
                                gen(std::integral_constant<std::size_t, 2>()),
                                gen(std::integral_constant<std::size_t, 3>()))) {
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m128i const& value_in)
       : m_value(value_in) {}
@@ -1736,6 +1741,11 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m256i const& value_in)
       : m_value(value_in) {}

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -298,6 +298,11 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
                                gen(std::integral_constant<std::size_t, 6>()),
                                gen(std::integral_constant<std::size_t, 7>()))) {
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -587,6 +592,11 @@ class simd<float, simd_abi::avx512_fixed_size<8>> {
                                gen(std::integral_constant<std::size_t, 5>()),
                                gen(std::integral_constant<std::size_t, 6>()),
                                gen(std::integral_constant<std::size_t, 7>()))) {
+  }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
@@ -1134,6 +1144,11 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -1559,6 +1574,11 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -1970,6 +1990,11 @@ class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m512i const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
@@ -2179,6 +2204,11 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
       simd<std::int64_t, abi_type> const& other)
       : m_value(static_cast<__m512i>(other)) {}

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -873,6 +873,11 @@ class simd<float, simd_abi::avx512_fixed_size<16>> {
                            gen(std::integral_constant<std::size_t, 13>()),
                            gen(std::integral_constant<std::size_t, 14>()),
                            gen(std::integral_constant<std::size_t, 15>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -1364,6 +1369,11 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
             gen(std::integral_constant<std::size_t, 13>()),
             gen(std::integral_constant<std::size_t, 14>()),
             gen(std::integral_constant<std::size_t, 15>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -1789,6 +1799,11 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
             gen(std::integral_constant<std::size_t, 13>()),
             gen(std::integral_constant<std::size_t, 14>()),
             gen(std::integral_constant<std::size_t, 15>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -3216,7 +3231,17 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
   }
 };
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t hmax(
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    std::int32_t
+    hmax(const_where_expression<
+         simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+         simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  return _mm512_mask_reduce_max_epi32(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
     const_where_expression<
         simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
         simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
@@ -3225,7 +3250,17 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t hmin(
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    std::int32_t
+    hmin(const_where_expression<
+         simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+         simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  return _mm512_mask_reduce_min_epi32(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
     const_where_expression<
         simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
         simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
@@ -3234,7 +3269,33 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t hmax(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
+    const_where_expression<
+        simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
+        simd<std::int32_t, simd_abi::avx512_fixed_size<16>>> const& x) {
+  return _mm512_mask_reduce_max_epi32(static_cast<__mmask16>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
+    const_where_expression<
+        simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
+        simd<std::int32_t, simd_abi::avx512_fixed_size<16>>> const& x) {
+  return _mm512_mask_reduce_min_epi32(static_cast<__mmask16>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    std::uint32_t
+    hmax(const_where_expression<
+         simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+         simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  return _mm512_mask_reduce_max_epu32(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
     const_where_expression<
         simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
         simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
@@ -3243,7 +3304,17 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t hmin(
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    std::uint32_t
+    hmin(const_where_expression<
+         simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+         simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  return _mm512_mask_reduce_min_epu32(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
     const_where_expression<
         simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
         simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
@@ -3252,7 +3323,32 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t hmax(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
+    const_where_expression<
+        simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
+        simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>> const& x) {
+  return _mm512_mask_reduce_max_epu32(static_cast<__mmask16>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
+    const_where_expression<
+        simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
+        simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>> const& x) {
+  return _mm512_mask_reduce_min_epu32(static_cast<__mmask16>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    std::int64_t
+    hmax(const_where_expression<
+         simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+         simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  return _mm512_mask_reduce_max_epi64(static_cast<__mmask8>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce_max(
     const_where_expression<
         simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
         simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
@@ -3260,7 +3356,16 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
                                       static_cast<__m512i>(x.impl_get_value()));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t hmin(
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    std::int64_t
+    hmin(const_where_expression<
+         simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+         simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  return _mm512_mask_reduce_min_epi64(static_cast<__mmask8>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce_min(
     const_where_expression<
         simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
         simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
@@ -3268,7 +3373,16 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
                                       static_cast<__m512i>(x.impl_get_value()));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t hmax(
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    std::uint64_t
+    hmax(const_where_expression<
+         simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+         simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  return _mm512_mask_reduce_max_epu64(static_cast<__mmask8>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce_max(
     const_where_expression<
         simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
         simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
@@ -3276,7 +3390,16 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
                                       static_cast<__m512i>(x.impl_get_value()));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t hmin(
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    std::uint64_t
+    hmin(const_where_expression<
+         simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+         simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  return _mm512_mask_reduce_min_epu64(static_cast<__mmask8>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce_min(
     const_where_expression<
         simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
         simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
@@ -3284,7 +3407,15 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
                                       static_cast<__m512i>(x.impl_get_value()));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double hmax(
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double
+hmax(const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+                            simd<double, simd_abi::avx512_fixed_size<8>>> const&
+         x) {
+  return _mm512_mask_reduce_max_pd(static_cast<__mmask8>(x.impl_get_mask()),
+                                   static_cast<__m512d>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_max(
     const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
                            simd<double, simd_abi::avx512_fixed_size<8>>> const&
         x) {
@@ -3292,7 +3423,15 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
                                    static_cast<__m512d>(x.impl_get_value()));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double hmin(
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double
+hmin(const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+                            simd<double, simd_abi::avx512_fixed_size<8>>> const&
+         x) {
+  return _mm512_mask_reduce_min_pd(static_cast<__mmask8>(x.impl_get_mask()),
+                                   static_cast<__m512d>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_min(
     const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
                            simd<double, simd_abi::avx512_fixed_size<8>>> const&
         x) {
@@ -3300,7 +3439,16 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
                                    static_cast<__m512d>(x.impl_get_value()));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float hmax(
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
+hmax(const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+                            simd<float, simd_abi::avx512_fixed_size<8>>> const&
+         x) {
+  return _mm512_mask_reduce_max_ps(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
     const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
                            simd<float, simd_abi::avx512_fixed_size<8>>> const&
         x) {
@@ -3309,13 +3457,38 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
       _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float hmin(
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
+hmin(const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+                            simd<float, simd_abi::avx512_fixed_size<8>>> const&
+         x) {
+  return _mm512_mask_reduce_min_ps(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
     const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
                            simd<float, simd_abi::avx512_fixed_size<8>>> const&
         x) {
   return _mm512_mask_reduce_min_ps(
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
+    const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<16>>,
+                           simd<float, simd_abi::avx512_fixed_size<16>>> const&
+        x) {
+  return _mm512_mask_reduce_max_ps(static_cast<__mmask16>(x.impl_get_mask()),
+                                   static_cast<__m512>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
+    const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<16>>,
+                           simd<float, simd_abi::avx512_fixed_size<16>>> const&
+        x) {
+  return _mm512_mask_reduce_min_ps(static_cast<__mmask16>(x.impl_get_mask()),
+                                   static_cast<__m512>(x.impl_get_value()));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
@@ -3326,6 +3499,15 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
   return _mm512_mask_reduce_add_epi32(
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
+    const_where_expression<
+        simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
+        simd<std::int32_t, simd_abi::avx512_fixed_size<16>>> const& x,
+    std::int32_t, std::plus<>) {
+  return _mm512_mask_reduce_add_epi32(static_cast<__mmask16>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce(
@@ -3354,6 +3536,15 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
   return _mm512_mask_reduce_add_ps(
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
+    const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<16>>,
+                           simd<float, simd_abi::avx512_fixed_size<16>>> const&
+        x,
+    float, std::plus<>) {
+  return _mm512_mask_reduce_add_ps(static_cast<__mmask16>(x.impl_get_mask()),
+                                   static_cast<__m512>(x.impl_get_value()));
 }
 
 }  // namespace Experimental

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -3225,12 +3225,107 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
 
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t hmin(
+    const_where_expression<
+        simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+        simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  return _mm512_mask_reduce_min_epi32(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t hmax(
+    const_where_expression<
+        simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+        simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  return _mm512_mask_reduce_max_epu32(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t hmin(
+    const_where_expression<
+        simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+        simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  return _mm512_mask_reduce_min_epu32(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t hmax(
+    const_where_expression<
+        simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+        simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  return _mm512_mask_reduce_max_epi64(static_cast<__mmask8>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t hmin(
+    const_where_expression<
+        simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+        simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  return _mm512_mask_reduce_min_epi64(static_cast<__mmask8>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t hmax(
+    const_where_expression<
+        simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+        simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  return _mm512_mask_reduce_max_epu64(static_cast<__mmask8>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t hmin(
+    const_where_expression<
+        simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+        simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  return _mm512_mask_reduce_min_epu64(static_cast<__mmask8>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double hmax(
+    const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+                           simd<double, simd_abi::avx512_fixed_size<8>>> const&
+        x) {
+  return _mm512_mask_reduce_max_pd(static_cast<__mmask8>(x.impl_get_mask()),
+                                   static_cast<__m512d>(x.impl_get_value()));
+}
+
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double hmin(
     const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
                            simd<double, simd_abi::avx512_fixed_size<8>>> const&
         x) {
   return _mm512_mask_reduce_min_pd(static_cast<__mmask8>(x.impl_get_mask()),
                                    static_cast<__m512d>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float hmax(
+    const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+                           simd<float, simd_abi::avx512_fixed_size<8>>> const&
+        x) {
+  return _mm512_mask_reduce_max_ps(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float hmin(
+    const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+                           simd<float, simd_abi::avx512_fixed_size<8>>> const&
+        x) {
+  return _mm512_mask_reduce_min_ps(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
+    const_where_expression<
+        simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+        simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x,
+    std::int32_t, std::plus<>) {
+  return _mm512_mask_reduce_add_epi32(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce(
@@ -3249,6 +3344,16 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
     double, std::plus<>) {
   return _mm512_mask_reduce_add_pd(static_cast<__mmask8>(x.impl_get_mask()),
                                    static_cast<__m512d>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
+    const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+                           simd<float, simd_abi::avx512_fixed_size<8>>> const&
+        x,
+    float, std::plus<>) {
+  return _mm512_mask_reduce_add_ps(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
 }
 
 }  // namespace Experimental

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -3237,19 +3237,25 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
     hmax(const_where_expression<
          simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
          simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<std::int32_t>::max();
+  }
   return _mm512_mask_reduce_max_epi32(
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
-    const_where_expression<
-        simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-        simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
+reduce_max(
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
+    simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::int32_t>::max();
+  }
   return _mm512_mask_reduce_max_epi32(
-      static_cast<__mmask8>(x.impl_get_mask()),
-      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
+      static_cast<__mmask8>(m),
+      _mm512_castsi256_si512(static_cast<__m256i>(v)));
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -3258,35 +3264,47 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
     hmin(const_where_expression<
          simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
          simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<std::int32_t>::min();
+  }
   return _mm512_mask_reduce_min_epi32(
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
-    const_where_expression<
-        simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-        simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
+reduce_min(
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
+    simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::int32_t>::min();
+  }
   return _mm512_mask_reduce_min_epi32(
-      static_cast<__mmask8>(x.impl_get_mask()),
-      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
+      static_cast<__mmask8>(m),
+      _mm512_castsi256_si512(static_cast<__m256i>(v)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
-    const_where_expression<
-        simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
-        simd<std::int32_t, simd_abi::avx512_fixed_size<16>>> const& x) {
-  return _mm512_mask_reduce_max_epi32(static_cast<__mmask16>(x.impl_get_mask()),
-                                      static_cast<__m512i>(x.impl_get_value()));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
+reduce_max(simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
+           simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
+               m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::int32_t>::max();
+  }
+  return _mm512_mask_reduce_max_epi32(static_cast<__mmask16>(m),
+                                      static_cast<__m512i>(v));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
-    const_where_expression<
-        simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
-        simd<std::int32_t, simd_abi::avx512_fixed_size<16>>> const& x) {
-  return _mm512_mask_reduce_min_epi32(static_cast<__mmask16>(x.impl_get_mask()),
-                                      static_cast<__m512i>(x.impl_get_value()));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
+reduce_min(simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
+           simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
+               m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::int32_t>::min();
+  }
+  return _mm512_mask_reduce_min_epi32(static_cast<__mmask16>(m),
+                                      static_cast<__m512i>(v));
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -3295,19 +3313,25 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
     hmax(const_where_expression<
          simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
          simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<std::uint32_t>::max();
+  }
   return _mm512_mask_reduce_max_epu32(
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
-    const_where_expression<
-        simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
-        simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
+reduce_max(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& v,
+           simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+               m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::uint32_t>::max();
+  }
   return _mm512_mask_reduce_max_epu32(
-      static_cast<__mmask8>(x.impl_get_mask()),
-      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
+      static_cast<__mmask8>(m),
+      _mm512_castsi256_si512(static_cast<__m256i>(v)));
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -3316,35 +3340,47 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
     hmin(const_where_expression<
          simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
          simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<std::uint32_t>::min();
+  }
   return _mm512_mask_reduce_min_epu32(
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
-    const_where_expression<
-        simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
-        simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
+reduce_min(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& v,
+           simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+               m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::uint32_t>::min();
+  }
   return _mm512_mask_reduce_min_epu32(
-      static_cast<__mmask8>(x.impl_get_mask()),
-      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
+      static_cast<__mmask8>(m),
+      _mm512_castsi256_si512(static_cast<__m256i>(v)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
-    const_where_expression<
-        simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
-        simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>> const& x) {
-  return _mm512_mask_reduce_max_epu32(static_cast<__mmask16>(x.impl_get_mask()),
-                                      static_cast<__m512i>(x.impl_get_value()));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
+reduce_max(simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& v,
+           simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
+               m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::uint32_t>::max();
+  }
+  return _mm512_mask_reduce_max_epu32(static_cast<__mmask16>(m),
+                                      static_cast<__m512i>(v));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
-    const_where_expression<
-        simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
-        simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>> const& x) {
-  return _mm512_mask_reduce_min_epu32(static_cast<__mmask16>(x.impl_get_mask()),
-                                      static_cast<__m512i>(x.impl_get_value()));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
+reduce_min(simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& v,
+           simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
+               m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::uint32_t>::min();
+  }
+  return _mm512_mask_reduce_min_epu32(static_cast<__mmask16>(m),
+                                      static_cast<__m512i>(v));
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -3353,17 +3389,23 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
     hmax(const_where_expression<
          simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
          simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<std::int64_t>::max();
+  }
   return _mm512_mask_reduce_max_epi64(static_cast<__mmask8>(x.impl_get_mask()),
                                       static_cast<__m512i>(x.impl_get_value()));
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce_max(
-    const_where_expression<
-        simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-        simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
-  return _mm512_mask_reduce_max_epi64(static_cast<__mmask8>(x.impl_get_mask()),
-                                      static_cast<__m512i>(x.impl_get_value()));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int64_t
+reduce_max(
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
+    simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::int64_t>::max();
+  }
+  return _mm512_mask_reduce_max_epi64(static_cast<__mmask8>(m),
+                                      static_cast<__m512i>(v));
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -3372,17 +3414,23 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
     hmin(const_where_expression<
          simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
          simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<std::int64_t>::min();
+  }
   return _mm512_mask_reduce_min_epi64(static_cast<__mmask8>(x.impl_get_mask()),
                                       static_cast<__m512i>(x.impl_get_value()));
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce_min(
-    const_where_expression<
-        simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-        simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
-  return _mm512_mask_reduce_min_epi64(static_cast<__mmask8>(x.impl_get_mask()),
-                                      static_cast<__m512i>(x.impl_get_value()));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int64_t
+reduce_min(
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
+    simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::int64_t>::min();
+  }
+  return _mm512_mask_reduce_min_epi64(static_cast<__mmask8>(m),
+                                      static_cast<__m512i>(v));
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -3391,17 +3439,23 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
     hmax(const_where_expression<
          simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
          simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<std::uint64_t>::max();
+  }
   return _mm512_mask_reduce_max_epu64(static_cast<__mmask8>(x.impl_get_mask()),
                                       static_cast<__m512i>(x.impl_get_value()));
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce_max(
-    const_where_expression<
-        simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
-        simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
-  return _mm512_mask_reduce_max_epu64(static_cast<__mmask8>(x.impl_get_mask()),
-                                      static_cast<__m512i>(x.impl_get_value()));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint64_t
+reduce_max(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& v,
+           simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+               m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::uint64_t>::max();
+  }
+  return _mm512_mask_reduce_max_epu64(static_cast<__mmask8>(m),
+                                      static_cast<__m512i>(v));
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -3410,17 +3464,23 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
     hmin(const_where_expression<
          simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
          simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<std::uint64_t>::min();
+  }
   return _mm512_mask_reduce_min_epu64(static_cast<__mmask8>(x.impl_get_mask()),
                                       static_cast<__m512i>(x.impl_get_value()));
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce_min(
-    const_where_expression<
-        simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
-        simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
-  return _mm512_mask_reduce_min_epu64(static_cast<__mmask8>(x.impl_get_mask()),
-                                      static_cast<__m512i>(x.impl_get_value()));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint64_t
+reduce_min(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& v,
+           simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+               m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::uint64_t>::min();
+  }
+  return _mm512_mask_reduce_min_epu64(static_cast<__mmask8>(m),
+                                      static_cast<__m512i>(v));
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -3428,17 +3488,22 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
 hmax(const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
                             simd<double, simd_abi::avx512_fixed_size<8>>> const&
          x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<double>::max();
+  }
   return _mm512_mask_reduce_max_pd(static_cast<__mmask8>(x.impl_get_mask()),
                                    static_cast<__m512d>(x.impl_get_value()));
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_max(
-    const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-                           simd<double, simd_abi::avx512_fixed_size<8>>> const&
-        x) {
-  return _mm512_mask_reduce_max_pd(static_cast<__mmask8>(x.impl_get_mask()),
-                                   static_cast<__m512d>(x.impl_get_value()));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr double reduce_max(
+    simd<double, simd_abi::avx512_fixed_size<8>> const& v,
+    simd_mask<double, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<double>::max();
+  }
+  return _mm512_mask_reduce_max_pd(static_cast<__mmask8>(m),
+                                   static_cast<__m512d>(v));
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -3446,17 +3511,22 @@ hmax(const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
 hmin(const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
                             simd<double, simd_abi::avx512_fixed_size<8>>> const&
          x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<double>::min();
+  }
   return _mm512_mask_reduce_min_pd(static_cast<__mmask8>(x.impl_get_mask()),
                                    static_cast<__m512d>(x.impl_get_value()));
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_min(
-    const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-                           simd<double, simd_abi::avx512_fixed_size<8>>> const&
-        x) {
-  return _mm512_mask_reduce_min_pd(static_cast<__mmask8>(x.impl_get_mask()),
-                                   static_cast<__m512d>(x.impl_get_value()));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr double reduce_min(
+    simd<double, simd_abi::avx512_fixed_size<8>> const& v,
+    simd_mask<double, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<double>::min();
+  }
+  return _mm512_mask_reduce_min_pd(static_cast<__mmask8>(m),
+                                   static_cast<__m512d>(v));
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -3464,19 +3534,23 @@ hmin(const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
 hmax(const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
                             simd<float, simd_abi::avx512_fixed_size<8>>> const&
          x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<float>::max();
+  }
   return _mm512_mask_reduce_max_ps(
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
-    const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-                           simd<float, simd_abi::avx512_fixed_size<8>>> const&
-        x) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float reduce_max(
+    simd<float, simd_abi::avx512_fixed_size<8>> const& v,
+    simd_mask<float, simd_abi::avx512_fixed_size<8>> m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<float>::max();
+  }
   return _mm512_mask_reduce_max_ps(
-      static_cast<__mmask8>(x.impl_get_mask()),
-      _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
+      static_cast<__mmask8>(m), _mm512_castps256_ps512(static_cast<__m256>(v)));
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -3484,91 +3558,110 @@ hmax(const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
 hmin(const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
                             simd<float, simd_abi::avx512_fixed_size<8>>> const&
          x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<float>::min();
+  }
   return _mm512_mask_reduce_min_ps(
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
-    const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-                           simd<float, simd_abi::avx512_fixed_size<8>>> const&
-        x) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float reduce_min(
+    simd<float, simd_abi::avx512_fixed_size<8>> const& v,
+    simd_mask<float, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<float>::min();
+  }
   return _mm512_mask_reduce_min_ps(
-      static_cast<__mmask8>(x.impl_get_mask()),
-      _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
+      static_cast<__mmask8>(m), _mm512_castps256_ps512(static_cast<__m256>(v)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
-    const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<16>>,
-                           simd<float, simd_abi::avx512_fixed_size<16>>> const&
-        x) {
-  return _mm512_mask_reduce_max_ps(static_cast<__mmask16>(x.impl_get_mask()),
-                                   static_cast<__m512>(x.impl_get_value()));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float reduce_max(
+    simd<float, simd_abi::avx512_fixed_size<16>> const& v,
+    simd_mask<float, simd_abi::avx512_fixed_size<16>> m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<float>::max();
+  }
+  return _mm512_mask_reduce_max_ps(static_cast<__mmask16>(m),
+                                   static_cast<__m512>(v));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
-    const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<16>>,
-                           simd<float, simd_abi::avx512_fixed_size<16>>> const&
-        x) {
-  return _mm512_mask_reduce_min_ps(static_cast<__mmask16>(x.impl_get_mask()),
-                                   static_cast<__m512>(x.impl_get_value()));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float reduce_min(
+    simd<float, simd_abi::avx512_fixed_size<16>> const& v,
+    simd_mask<float, simd_abi::avx512_fixed_size<16>> const& m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<float>::min();
+  }
+  return _mm512_mask_reduce_min_ps(static_cast<__mmask16>(m),
+                                   static_cast<__m512>(v));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
-    const_where_expression<
-        simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-        simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x,
-    std::int32_t, std::plus<>) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
+reduce(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
+       simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& m,
+       std::int32_t identity, std::plus<>) noexcept {
+  if (none_of(m)) {
+    return identity;
+  }
   return _mm512_mask_reduce_add_epi32(
-      static_cast<__mmask8>(x.impl_get_mask()),
-      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
+      static_cast<__mmask8>(m),
+      _mm512_castsi256_si512(static_cast<__m256i>(v)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
-    const_where_expression<
-        simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
-        simd<std::int32_t, simd_abi::avx512_fixed_size<16>>> const& x,
-    std::int32_t, std::plus<>) {
-  return _mm512_mask_reduce_add_epi32(static_cast<__mmask16>(x.impl_get_mask()),
-                                      static_cast<__m512i>(x.impl_get_value()));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
+reduce(simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
+       simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& m,
+       std::int32_t identity, std::plus<>) noexcept {
+  if (none_of(m)) {
+    return identity;
+  }
+  return _mm512_mask_reduce_add_epi32(static_cast<__mmask16>(m),
+                                      static_cast<__m512i>(v));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce(
-    const_where_expression<
-        simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-        simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x,
-    std::int64_t, std::plus<>) {
-  return _mm512_mask_reduce_add_epi64(static_cast<__mmask8>(x.impl_get_mask()),
-                                      static_cast<__m512i>(x.impl_get_value()));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int64_t
+reduce(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
+       simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& m,
+       std::int64_t identity, std::plus<>) noexcept {
+  if (none_of(m)) {
+    return identity;
+  }
+  return _mm512_mask_reduce_add_epi64(static_cast<__mmask8>(m),
+                                      static_cast<__m512i>(v));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
-    const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-                           simd<double, simd_abi::avx512_fixed_size<8>>> const&
-        x,
-    double, std::plus<>) {
-  return _mm512_mask_reduce_add_pd(static_cast<__mmask8>(x.impl_get_mask()),
-                                   static_cast<__m512d>(x.impl_get_value()));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr double reduce(
+    simd<double, simd_abi::avx512_fixed_size<8>> const& v,
+    simd_mask<double, simd_abi::avx512_fixed_size<8>> const& m, double identity,
+    std::plus<>) noexcept {
+  if (none_of(m)) {
+    return identity;
+  }
+  return _mm512_mask_reduce_add_pd(static_cast<__mmask8>(m),
+                                   static_cast<__m512d>(v));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
-    const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-                           simd<float, simd_abi::avx512_fixed_size<8>>> const&
-        x,
-    float, std::plus<>) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float reduce(
+    simd<float, simd_abi::avx512_fixed_size<8>> const& v,
+    simd_mask<float, simd_abi::avx512_fixed_size<8>> const& m, float identity,
+    std::plus<>) noexcept {
+  if (none_of(m)) {
+    return identity;
+  }
   return _mm512_mask_reduce_add_ps(
-      static_cast<__mmask8>(x.impl_get_mask()),
-      _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
+      static_cast<__mmask8>(m), _mm512_castps256_ps512(static_cast<__m256>(v)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
-    const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<16>>,
-                           simd<float, simd_abi::avx512_fixed_size<16>>> const&
-        x,
-    float, std::plus<>) {
-  return _mm512_mask_reduce_add_ps(static_cast<__mmask16>(x.impl_get_mask()),
-                                   static_cast<__m512>(x.impl_get_value()));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float reduce(
+    simd<float, simd_abi::avx512_fixed_size<16>> const& v,
+    simd_mask<float, simd_abi::avx512_fixed_size<16>> const& m, float identity,
+    std::plus<>) noexcept {
+  if (none_of(m)) {
+    return identity;
+  }
+  return _mm512_mask_reduce_add_ps(static_cast<__mmask16>(m),
+                                   static_cast<__m512>(v));
 }
 
 }  // namespace Experimental

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -3231,6 +3231,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
   }
 };
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     std::int32_t
     hmax(const_where_expression<
@@ -3240,6 +3241,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
+#endif
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
     const_where_expression<
@@ -3250,6 +3252,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     std::int32_t
     hmin(const_where_expression<
@@ -3259,6 +3262,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
+#endif
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
     const_where_expression<
@@ -3285,6 +3289,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
                                       static_cast<__m512i>(x.impl_get_value()));
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     std::uint32_t
     hmax(const_where_expression<
@@ -3294,6 +3299,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
+#endif
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
     const_where_expression<
@@ -3304,6 +3310,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     std::uint32_t
     hmin(const_where_expression<
@@ -3313,6 +3320,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
+#endif
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
     const_where_expression<
@@ -3339,6 +3347,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
                                       static_cast<__m512i>(x.impl_get_value()));
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     std::int64_t
     hmax(const_where_expression<
@@ -3347,6 +3356,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
   return _mm512_mask_reduce_max_epi64(static_cast<__mmask8>(x.impl_get_mask()),
                                       static_cast<__m512i>(x.impl_get_value()));
 }
+#endif
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce_max(
     const_where_expression<
@@ -3356,6 +3366,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
                                       static_cast<__m512i>(x.impl_get_value()));
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     std::int64_t
     hmin(const_where_expression<
@@ -3364,6 +3375,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
   return _mm512_mask_reduce_min_epi64(static_cast<__mmask8>(x.impl_get_mask()),
                                       static_cast<__m512i>(x.impl_get_value()));
 }
+#endif
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce_min(
     const_where_expression<
@@ -3373,6 +3385,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
                                       static_cast<__m512i>(x.impl_get_value()));
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     std::uint64_t
     hmax(const_where_expression<
@@ -3381,6 +3394,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
   return _mm512_mask_reduce_max_epu64(static_cast<__mmask8>(x.impl_get_mask()),
                                       static_cast<__m512i>(x.impl_get_value()));
 }
+#endif
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce_max(
     const_where_expression<
@@ -3390,6 +3404,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
                                       static_cast<__m512i>(x.impl_get_value()));
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     std::uint64_t
     hmin(const_where_expression<
@@ -3398,6 +3413,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
   return _mm512_mask_reduce_min_epu64(static_cast<__mmask8>(x.impl_get_mask()),
                                       static_cast<__m512i>(x.impl_get_value()));
 }
+#endif
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce_min(
     const_where_expression<
@@ -3407,6 +3423,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
                                       static_cast<__m512i>(x.impl_get_value()));
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double
 hmax(const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
                             simd<double, simd_abi::avx512_fixed_size<8>>> const&
@@ -3414,6 +3431,7 @@ hmax(const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
   return _mm512_mask_reduce_max_pd(static_cast<__mmask8>(x.impl_get_mask()),
                                    static_cast<__m512d>(x.impl_get_value()));
 }
+#endif
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_max(
     const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
@@ -3423,6 +3441,7 @@ hmax(const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
                                    static_cast<__m512d>(x.impl_get_value()));
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double
 hmin(const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
                             simd<double, simd_abi::avx512_fixed_size<8>>> const&
@@ -3430,6 +3449,7 @@ hmin(const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
   return _mm512_mask_reduce_min_pd(static_cast<__mmask8>(x.impl_get_mask()),
                                    static_cast<__m512d>(x.impl_get_value()));
 }
+#endif
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_min(
     const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
@@ -3439,6 +3459,7 @@ hmin(const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
                                    static_cast<__m512d>(x.impl_get_value()));
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
 hmax(const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
                             simd<float, simd_abi::avx512_fixed_size<8>>> const&
@@ -3447,6 +3468,7 @@ hmax(const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
 }
+#endif
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
     const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
@@ -3457,6 +3479,7 @@ hmax(const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
       _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
 hmin(const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
                             simd<float, simd_abi::avx512_fixed_size<8>>> const&
@@ -3465,6 +3488,7 @@ hmin(const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
 }
+#endif
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
     const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -228,6 +228,13 @@ KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator*=(
   return lhs;
 }
 
+template <class T, class Abi,
+          std::enable_if_t<std::is_integral_v<T>, bool> = false>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator/(
+    Experimental::simd<T, Abi> const& lhs, Experimental::simd<T, Abi> const& rhs) {
+  return Experimental::simd<T,Abi>([&](std::size_t i) { return lhs[i] / rhs[i]; });
+}
+
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator/(

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -332,6 +332,89 @@ template <typename T>
   return Kokkos::round(x);
 }
 
+// fallback implementations of simd reductions:
+
+template <class T, class Abi, class BinaryOperation = std::plus<>>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+    const simd<T, Abi>& x, BinaryOperation binary_op = {}) {
+  auto v = where(true, x);
+  return reduce(v, binary_op);
+}
+
+template <class T, class Abi, class BinaryOperation>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+    const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
+    T identity_element, BinaryOperation binary_op) {
+  if (none_of(mask)) return identity_element;
+  auto v = where(mask, x);
+  return reduce(v, binary_op);
+}
+
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+    const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
+    std::plus<> binary_op = {}) noexcept {
+  return reduce(x, mask, T(0), binary_op);
+}
+
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+    const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
+    std::multiplies<> binary_op) noexcept {
+  return reduce(x, mask, T(0), binary_op);
+}
+
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+    const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
+    std::bit_and<> binary_op) noexcept {
+  return reduce(x, mask, 0, binary_op);
+}
+
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+    const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
+    std::bit_or<> binary_op) noexcept {
+  return reduce(x, mask, 0, binary_op);
+}
+
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+    const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
+    std::bit_xor<> binary_op) noexcept {
+  return reduce(x, mask, 0, binary_op);
+}
+
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
+    const simd<T, Abi>& x) noexcept {
+  auto v = where(true, x);
+  return hmin(v);
+}
+
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
+    const simd<T, Abi>& x,
+    const typename simd<T, Abi>::mask_type& mask) noexcept {
+  auto v = where(mask, x);
+  return hmin(v);
+}
+
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
+    const simd<T, Abi>& x) noexcept {
+  auto v = where(true, x);
+  return hmax(v);
+}
+
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
+    const simd<T, Abi>& x,
+    const typename simd<T, Abi>::mask_type& mask) noexcept {
+  auto v = where(mask, x);
+  return hmax(v);
+}
+
 }  // namespace Experimental
 }  // namespace Kokkos
 

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -389,7 +389,7 @@ template <class T, class Abi>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
     const simd<T, Abi>& x) noexcept {
   auto v = where(true, x);
-  return hmin(v);
+  return reduce_min(v);
 }
 
 template <class T, class Abi>
@@ -397,14 +397,14 @@ template <class T, class Abi>
     const simd<T, Abi>& x,
     const typename simd<T, Abi>::mask_type& mask) noexcept {
   auto v = where(mask, x);
-  return hmin(v);
+  return reduce_min(v);
 }
 
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
     const simd<T, Abi>& x) noexcept {
   auto v = where(true, x);
-  return hmax(v);
+  return reduce_max(v);
 }
 
 template <class T, class Abi>
@@ -412,7 +412,7 @@ template <class T, class Abi>
     const simd<T, Abi>& x,
     const typename simd<T, Abi>::mask_type& mask) noexcept {
   auto v = where(mask, x);
-  return hmax(v);
+  return reduce_max(v);
 }
 
 }  // namespace Experimental

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -231,8 +231,10 @@ KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator*=(
 template <class T, class Abi,
           std::enable_if_t<std::is_integral_v<T>, bool> = false>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator/(
-    Experimental::simd<T, Abi> const& lhs, Experimental::simd<T, Abi> const& rhs) {
-  return Experimental::simd<T,Abi>([&](std::size_t i) { return lhs[i] / rhs[i]; });
+    Experimental::simd<T, Abi> const& lhs,
+    Experimental::simd<T, Abi> const& rhs) {
+  return Experimental::simd<T, Abi>(
+      [&](std::size_t i) { return lhs[i] / rhs[i]; });
 }
 
 template <class T, class U, class Abi,
@@ -264,6 +266,20 @@ template <class M, class T, class U>
 KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator/=(
     where_expression<M, T>& lhs, U&& rhs) {
   lhs = lhs.value() / std::forward<U>(rhs);
+  return lhs;
+}
+
+template <class T, class U, class Abi>
+KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>& operator>>=(simd<T, Abi>& lhs,
+                                                      U&& rhs) {
+  lhs = lhs >> std::forward<U>(rhs);
+  return lhs;
+}
+
+template <class T, class U, class Abi>
+KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>& operator<<=(simd<T, Abi>& lhs,
+                                                      U&& rhs) {
+  lhs = lhs << std::forward<U>(rhs);
   return lhs;
 }
 

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -317,19 +317,19 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi>& operator<<=(
 // fallback implementations of reductions across simd_mask:
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool all_of(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr bool all_of(
     simd_mask<T, Abi> const& a) {
   return a == simd_mask<T, Abi>(true);
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool any_of(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr bool any_of(
     simd_mask<T, Abi> const& a) {
   return a != simd_mask<T, Abi>(false);
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool none_of(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr bool none_of(
     simd_mask<T, Abi> const& a) {
   return a == simd_mask<T, Abi>(false);
 }
@@ -352,93 +352,88 @@ template <typename T>
 template <class T, class Abi, class BinaryOperation = std::plus<>>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
     const simd<T, Abi>& x, BinaryOperation binary_op = {}) {
-  auto v = where(true, x);
-  return reduce(v, binary_op);
+  return reduce(x, simd<T, Abi>::mask_type(true), T(0), binary_op);
 }
 
-template <class T, class Abi, class BinaryOperation>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
-    const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
-    T identity_element, BinaryOperation binary_op) {
-  if (none_of(mask)) return identity_element;
-  auto v = where(mask, x);
-  return reduce(v, binary_op);
-}
+// template <class T, class Abi, class BinaryOperation>
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
+//     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
+//     T identity_element, BinaryOperation binary_op) {
+//   if (none_of(mask)) return identity_element;
+//   return reduce(x, mask, identity_element, binary_op);
+// }
 
-template <
-    class T, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
-    const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
-    std::plus<> binary_op = {}) noexcept {
-  return reduce(x, mask, T(0), binary_op);
-}
+// template <
+//     class T, class Abi,
+//     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
+//     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
+//     std::plus<> binary_op = {}) noexcept {
+//   return reduce(x, mask, T(0), binary_op);
+// }
 
-template <
-    class T, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
-    const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
-    std::multiplies<> binary_op) noexcept {
-  return reduce(x, mask, T(0), binary_op);
-}
+// template <
+//     class T, class Abi,
+//     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
+//     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
+//     std::multiplies<> binary_op) noexcept {
+//   return reduce(x, mask, T(0), binary_op);
+// }
 
-template <
-    class T, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
-    const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
-    std::bit_and<> binary_op) noexcept {
-  return reduce(x, mask, 0, binary_op);
-}
+// template <
+//     class T, class Abi,
+//     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
+//     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
+//     std::bit_and<> binary_op) noexcept {
+//   return reduce(x, mask, 0, binary_op);
+// }
 
-template <
-    class T, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
-    const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
-    std::bit_or<> binary_op) noexcept {
-  return reduce(x, mask, 0, binary_op);
-}
+// template <
+//     class T, class Abi,
+//     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
+//     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
+//     std::bit_or<> binary_op) noexcept {
+//   return reduce(x, mask, 0, binary_op);
+// }
 
-template <
-    class T, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
-    const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
-    std::bit_xor<> binary_op) noexcept {
-  return reduce(x, mask, 0, binary_op);
-}
+// template <
+//     class T, class Abi,
+//     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
+//     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
+//     std::bit_xor<> binary_op) noexcept {
+//   return reduce(x, mask, 0, binary_op);
+// }
 
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_min(
     const simd<T, Abi>& x) noexcept {
-  auto v = where(true, x);
-  return reduce_min(v);
+  return reduce_min(x, simd<T, Abi>::mask_type(true));
 }
 
-template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_min(
-    const simd<T, Abi>& x,
-    const typename simd<T, Abi>::mask_type& mask) noexcept {
-  auto v = where(mask, x);
-  return reduce_min(v);
-}
+// template <class T, class Abi>
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_min(
+//     const simd<T, Abi>& x,
+//     const typename simd<T, Abi>::mask_type& mask) noexcept {
+//   return reduce_min(x, mask);
+// }
 
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_max(
     const simd<T, Abi>& x) noexcept {
   auto v = where(true, x);
-  return reduce_max(v);
+  return reduce_max(x, simd<T, Abi>::mask_type(true));
 }
 
-template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_max(
-    const simd<T, Abi>& x,
-    const typename simd<T, Abi>::mask_type& mask) noexcept {
-  auto v = where(mask, x);
-  return reduce_max(v);
-}
+// template <class T, class Abi>
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_max(
+//     const simd<T, Abi>& x,
+//     const typename simd<T, Abi>::mask_type& mask) noexcept {
+//   return reduce_max(x, mask);
+// }
 
 }  // namespace Experimental
 }  // namespace Kokkos

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -355,71 +355,11 @@ template <class T, class Abi, class BinaryOperation = std::plus<>>
   return reduce(x, simd<T, Abi>::mask_type(true), T(0), binary_op);
 }
 
-// template <class T, class Abi, class BinaryOperation>
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
-//     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
-//     T identity_element, BinaryOperation binary_op) {
-//   if (none_of(mask)) return identity_element;
-//   return reduce(x, mask, identity_element, binary_op);
-// }
-
-// template <
-//     class T, class Abi,
-//     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
-//     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
-//     std::plus<> binary_op = {}) noexcept {
-//   return reduce(x, mask, T(0), binary_op);
-// }
-
-// template <
-//     class T, class Abi,
-//     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
-//     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
-//     std::multiplies<> binary_op) noexcept {
-//   return reduce(x, mask, T(0), binary_op);
-// }
-
-// template <
-//     class T, class Abi,
-//     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
-//     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
-//     std::bit_and<> binary_op) noexcept {
-//   return reduce(x, mask, 0, binary_op);
-// }
-
-// template <
-//     class T, class Abi,
-//     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
-//     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
-//     std::bit_or<> binary_op) noexcept {
-//   return reduce(x, mask, 0, binary_op);
-// }
-
-// template <
-//     class T, class Abi,
-//     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
-//     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
-//     std::bit_xor<> binary_op) noexcept {
-//   return reduce(x, mask, 0, binary_op);
-// }
-
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_min(
     const simd<T, Abi>& x) noexcept {
   return reduce_min(x, simd<T, Abi>::mask_type(true));
 }
-
-// template <class T, class Abi>
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_min(
-//     const simd<T, Abi>& x,
-//     const typename simd<T, Abi>::mask_type& mask) noexcept {
-//   return reduce_min(x, mask);
-// }
 
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_max(
@@ -427,13 +367,6 @@ template <class T, class Abi>
   auto v = where(true, x);
   return reduce_max(x, simd<T, Abi>::mask_type(true));
 }
-
-// template <class T, class Abi>
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_max(
-//     const simd<T, Abi>& x,
-//     const typename simd<T, Abi>::mask_type& mask) noexcept {
-//   return reduce_max(x, mask);
-// }
 
 }  // namespace Experimental
 }  // namespace Kokkos

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -25,6 +25,10 @@ namespace Kokkos {
 
 namespace Experimental {
 
+namespace simd_abi {
+class scalar;
+}
+
 template <class T, class Abi>
 class simd;
 
@@ -134,7 +138,7 @@ template <class T>
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator+(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
     Experimental::simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] + rhs);
   return Experimental::simd<result_member, Abi>(lhs) +
@@ -143,16 +147,18 @@ template <class T, class U, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator+(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
     U lhs, Experimental::simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs + rhs[0]);
   return Experimental::simd<result_member, Abi>(lhs) +
          Experimental::simd<result_member, Abi>(rhs);
 }
 
-template <class T, class U, class Abi>
-KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>& operator+=(simd<T, Abi>& lhs,
-                                                     U&& rhs) {
+template <
+    class T, class U, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi>& operator+=(
+    simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs + std::forward<U>(rhs);
   return lhs;
 }
@@ -166,7 +172,7 @@ KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator+=(
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator-(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
     Experimental::simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] - rhs);
   return Experimental::simd<result_member, Abi>(lhs) -
@@ -175,22 +181,24 @@ template <class T, class U, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator-(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
     U lhs, Experimental::simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs - rhs[0]);
   return Experimental::simd<result_member, Abi>(lhs) -
          Experimental::simd<result_member, Abi>(rhs);
 }
 
-template <class T, class U, class Abi>
-KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>& operator-=(simd<T, Abi>& lhs,
-                                                     U&& rhs) {
+template <
+    class T, class U, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi>& operator-=(
+    simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs - std::forward<U>(rhs);
   return lhs;
 }
 
 template <class M, class T, class U>
-KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator-=(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION where_expression<M, T>& operator-=(
     where_expression<M, T>& lhs, U&& rhs) {
   lhs = lhs.value() - std::forward<U>(rhs);
   return lhs;
@@ -198,7 +206,7 @@ KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator-=(
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator*(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
     Experimental::simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] * rhs);
   return Experimental::simd<result_member, Abi>(lhs) *
@@ -207,22 +215,24 @@ template <class T, class U, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator*(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
     U lhs, Experimental::simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs * rhs[0]);
   return Experimental::simd<result_member, Abi>(lhs) *
          Experimental::simd<result_member, Abi>(rhs);
 }
 
-template <class T, class U, class Abi>
-KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>& operator*=(simd<T, Abi>& lhs,
-                                                     U&& rhs) {
+template <
+    class T, class U, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi>& operator*=(
+    simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs * std::forward<U>(rhs);
   return lhs;
 }
 
 template <class M, class T, class U>
-KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator*=(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION where_expression<M, T>& operator*=(
     where_expression<M, T>& lhs, U&& rhs) {
   lhs = lhs.value() * std::forward<U>(rhs);
   return lhs;
@@ -230,7 +240,7 @@ KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator*=(
 
 template <class T, class Abi,
           std::enable_if_t<std::is_integral_v<T>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator/(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
     Experimental::simd<T, Abi> const& lhs,
     Experimental::simd<T, Abi> const& rhs) {
   return Experimental::simd<T, Abi>(
@@ -239,7 +249,7 @@ template <class T, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator/(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
     Experimental::simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] / rhs);
   return Experimental::simd<result_member, Abi>(lhs) /
@@ -248,37 +258,43 @@ template <class T, class U, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator/(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
     U lhs, Experimental::simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs / rhs[0]);
   return Experimental::simd<result_member, Abi>(lhs) /
          Experimental::simd<result_member, Abi>(rhs);
 }
 
-template <class T, class U, class Abi>
-KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>& operator/=(simd<T, Abi>& lhs,
-                                                     U&& rhs) {
+template <
+    class T, class U, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi>& operator/=(
+    simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs / std::forward<U>(rhs);
   return lhs;
 }
 
 template <class M, class T, class U>
-KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator/=(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION where_expression<M, T>& operator/=(
     where_expression<M, T>& lhs, U&& rhs) {
   lhs = lhs.value() / std::forward<U>(rhs);
   return lhs;
 }
 
-template <class T, class U, class Abi>
-KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>& operator>>=(simd<T, Abi>& lhs,
-                                                      U&& rhs) {
+template <
+    class T, class U, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi>& operator>>=(
+    simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs >> std::forward<U>(rhs);
   return lhs;
 }
 
-template <class T, class U, class Abi>
-KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>& operator<<=(simd<T, Abi>& lhs,
-                                                      U&& rhs) {
+template <
+    class T, class U, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi>& operator<<=(
+    simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs << std::forward<U>(rhs);
   return lhs;
 }
@@ -332,17 +348,16 @@ template <typename T>
   return Kokkos::round(x);
 }
 
-// fallback implementations of simd reductions:
-
+// common implementations of host only simd reductions:
 template <class T, class Abi, class BinaryOperation = std::plus<>>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
     const simd<T, Abi>& x, BinaryOperation binary_op = {}) {
   auto v = where(true, x);
   return reduce(v, binary_op);
 }
 
 template <class T, class Abi, class BinaryOperation>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
     T identity_element, BinaryOperation binary_op) {
   if (none_of(mask)) return identity_element;
@@ -350,50 +365,60 @@ template <class T, class Abi, class BinaryOperation>
   return reduce(v, binary_op);
 }
 
-template <class T, class Abi>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+template <
+    class T, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
     std::plus<> binary_op = {}) noexcept {
   return reduce(x, mask, T(0), binary_op);
 }
 
-template <class T, class Abi>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+template <
+    class T, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
     std::multiplies<> binary_op) noexcept {
   return reduce(x, mask, T(0), binary_op);
 }
 
-template <class T, class Abi>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+template <
+    class T, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
     std::bit_and<> binary_op) noexcept {
   return reduce(x, mask, 0, binary_op);
 }
 
-template <class T, class Abi>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+template <
+    class T, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
     std::bit_or<> binary_op) noexcept {
   return reduce(x, mask, 0, binary_op);
 }
 
-template <class T, class Abi>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+template <
+    class T, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
     const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask,
     std::bit_xor<> binary_op) noexcept {
   return reduce(x, mask, 0, binary_op);
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_min(
     const simd<T, Abi>& x) noexcept {
   auto v = where(true, x);
   return reduce_min(v);
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_min(
     const simd<T, Abi>& x,
     const typename simd<T, Abi>::mask_type& mask) noexcept {
   auto v = where(mask, x);
@@ -401,14 +426,14 @@ template <class T, class Abi>
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_max(
     const simd<T, Abi>& x) noexcept {
   auto v = where(true, x);
   return reduce_max(v);
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_max(
     const simd<T, Abi>& x,
     const typename simd<T, Abi>::mask_type& mask) noexcept {
   auto v = where(mask, x);

--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -32,6 +32,7 @@ class simd_mask;
 template <class M, class T>
 class const_where_expression;
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <typename T, typename Abi>
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 hmin(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
@@ -55,6 +56,7 @@ hmax(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
   }
   return result;
 }
+#endif
 
 template <typename T, typename Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T

--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -23,6 +23,10 @@ namespace Kokkos {
 
 namespace Experimental {
 
+namespace simd_abi {
+class scalar;
+}
+
 template <class T, class Abi>
 class simd;
 
@@ -58,7 +62,9 @@ hmax(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
 }
 #endif
 
-template <typename T, typename Abi>
+template <
+    typename T, typename Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 reduce_min(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
   auto const& v = x.impl_get_value();
@@ -70,7 +76,9 @@ reduce_min(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
   return result;
 }
 
-template <class T, class Abi>
+template <
+    class T, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 reduce_max(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
   auto const& v = x.impl_get_value();
@@ -82,7 +90,9 @@ reduce_max(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
   return result;
 }
 
-template <class T, class Abi, class BinaryOperation = std::plus<>>
+template <
+    class T, class Abi, class BinaryOperation = std::plus<>,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 reduce(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x,
        BinaryOperation op = {}) {
@@ -95,7 +105,9 @@ reduce(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x,
   return result;
 }
 
-template <class T, class Abi>
+template <
+    class T, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 reduce(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x, T,
        std::plus<>) {

--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -33,7 +33,7 @@ template <class M, class T>
 class const_where_expression;
 
 template <typename T, typename Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 hmin(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
   auto const& v = x.impl_get_value();
   auto const& m = x.impl_get_mask();
@@ -45,8 +45,32 @@ hmin(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 hmax(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
+  auto const& v = x.impl_get_value();
+  auto const& m = x.impl_get_mask();
+  auto result   = Kokkos::reduction_identity<T>::max();
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    if (m[i]) result = Kokkos::max(result, v[i]);
+  }
+  return result;
+}
+
+template <typename T, typename Abi>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+reduce_min(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
+  auto const& v = x.impl_get_value();
+  auto const& m = x.impl_get_mask();
+  auto result   = Kokkos::reduction_identity<T>::min();
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    if (m[i]) result = Kokkos::min(result, v[i]);
+  }
+  return result;
+}
+
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+reduce_max(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
   auto const& v = x.impl_get_value();
   auto const& m = x.impl_get_mask();
   auto result   = Kokkos::reduction_identity<T>::max();

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -492,6 +492,11 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
     m_value = vsetq_lane_f64(gen(std::integral_constant<std::size_t, 1>()),
                              m_value, 1);
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       float64x2_t const& value_in)
       : m_value(value_in) {}
@@ -743,6 +748,11 @@ class simd<float, simd_abi::neon_fixed_size<2>> {
                             m_value, 0);
     m_value = vset_lane_f32(gen(std::integral_constant<std::size_t, 1>()),
                             m_value, 1);
+  }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       float32x2_t const& value_in)
@@ -1237,6 +1247,11 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
     m_value = vset_lane_s32(gen(std::integral_constant<std::size_t, 1>()),
                             m_value, 1);
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       int32x2_t const& value_in)
       : m_value(value_in) {}
@@ -1669,6 +1684,11 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
     m_value = vsetq_lane_s64(gen(std::integral_constant<std::size_t, 1>()),
                              m_value, 1);
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       int64x2_t const& value_in)
       : m_value(value_in) {}
@@ -1879,6 +1899,11 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
                              m_value, 0);
     m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 1>()),
                              m_value, 1);
+  }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       uint64x2_t const& value_in)

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -1004,6 +1004,11 @@ class simd<float, simd_abi::neon_fixed_size<4>> {
     m_value = vsetq_lane_f32(gen(std::integral_constant<std::size_t, 3>()),
                              m_value, 3);
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       float32x4_t const& value_in)
       : m_value(value_in) {}
@@ -1471,6 +1476,11 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
                              m_value, 2);
     m_value = vsetq_lane_s32(gen(std::integral_constant<std::size_t, 3>()),
                              m_value, 3);
+  }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       int32x4_t const& value_in)
@@ -2711,6 +2721,173 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
                   static_cast<uint64x2_t>(m_value)));
   }
 };
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
+    const_where_expression<
+        simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
+        simd<std::int32_t, simd_abi::neon_fixed_size<2>>> const& x) {
+  return vminv_s32(static_cast<int32x2_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
+    const_where_expression<
+        simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
+        simd<std::int32_t, simd_abi::neon_fixed_size<2>>> const& x) {
+  return vmaxv_s32(static_cast<int32x2_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
+    const_where_expression<
+        simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
+        simd<std::int32_t, simd_abi::neon_fixed_size<2>>> const& x,
+    std::int32_t, std::plus<>) {
+  return vaddv_s32(static_cast<int32x2_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
+    const_where_expression<
+        simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
+        simd<std::int32_t, simd_abi::neon_fixed_size<4>>> const& x) {
+  return vminvq_s32(static_cast<int32x4_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
+    const_where_expression<
+        simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
+        simd<std::int32_t, simd_abi::neon_fixed_size<4>>> const& x) {
+  return vmaxvq_s32(static_cast<int32x4_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
+    const_where_expression<
+        simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
+        simd<std::int32_t, simd_abi::neon_fixed_size<4>>> const& x,
+    std::int32_t, std::plus<>) {
+  return vaddvq_s32(static_cast<int32x4_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
+    const_where_expression<
+        simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>>,
+        simd<std::uint32_t, simd_abi::neon_fixed_size<2>>> const& x) {
+  return vminv_u32(static_cast<uint32x2_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
+    const_where_expression<
+        simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>>,
+        simd<std::uint32_t, simd_abi::neon_fixed_size<2>>> const& x) {
+  return vmaxv_u32(static_cast<uint32x2_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce(
+    const_where_expression<
+        simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>>,
+        simd<std::uint32_t, simd_abi::neon_fixed_size<2>>> const& x,
+    std::uint32_t, std::plus<>) {
+  return vaddv_u32(static_cast<uint32x2_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
+    const_where_expression<
+        simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>>,
+        simd<std::uint32_t, simd_abi::neon_fixed_size<4>>> const& x) {
+  return vminvq_u32(static_cast<uint32x4_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
+    const_where_expression<
+        simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>>,
+        simd<std::uint32_t, simd_abi::neon_fixed_size<4>>> const& x) {
+  return vmaxvq_u32(static_cast<uint32x4_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce(
+    const_where_expression<
+        simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>>,
+        simd<std::uint32_t, simd_abi::neon_fixed_size<4>>> const& x,
+    std::uint32_t, std::plus<>) {
+  return vaddvq_u32(static_cast<uint32x4_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce(
+    const_where_expression<
+        simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
+        simd<std::int64_t, simd_abi::neon_fixed_size<2>>> const& x,
+    std::int64_t, std::plus<>) {
+  return vaddvq_s64(static_cast<int64x2_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce(
+    const_where_expression<
+        simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
+        simd<std::uint64_t, simd_abi::neon_fixed_size<2>>> const& x,
+    std::uint64_t, std::plus<>) {
+  return vaddvq_u64(static_cast<uint64x2_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_min(
+    const_where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
+                           simd<double, simd_abi::neon_fixed_size<2>>> const&
+        x) {
+  return vminvq_f64(static_cast<float64x2_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_max(
+    const_where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
+                           simd<double, simd_abi::neon_fixed_size<2>>> const&
+        x) {
+  return vmaxvq_f64(static_cast<float64x2_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
+    const_where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
+                           simd<double, simd_abi::neon_fixed_size<2>>> const& x,
+    double, std::plus<>) {
+  return vaddvq_f64(static_cast<float64x2_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
+    const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
+                           simd<float, simd_abi::neon_fixed_size<2>>> const&
+        x) {
+  return vminv_f32(static_cast<float32x2_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
+    const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
+                           simd<float, simd_abi::neon_fixed_size<2>>> const&
+        x) {
+  return vmaxv_f32(static_cast<float32x2_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
+    const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
+                           simd<float, simd_abi::neon_fixed_size<2>>> const& x,
+    float, std::plus<>) {
+  return vaddv_f32(static_cast<float32x2_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
+    const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<4>>,
+                           simd<float, simd_abi::neon_fixed_size<4>>> const&
+        x) {
+  return vminvq_f32(static_cast<float32x4_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
+    const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<4>>,
+                           simd<float, simd_abi::neon_fixed_size<4>>> const&
+        x) {
+  return vmaxvq_f32(static_cast<float32x4_t>(x.impl_get_value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
+    const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<4>>,
+                           simd<float, simd_abi::neon_fixed_size<4>>> const& x,
+    float, std::plus<>) {
+  return vaddvq_f32(static_cast<float32x4_t>(x.impl_get_value()));
+}
 
 }  // namespace Experimental
 }  // namespace Kokkos

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -2722,172 +2722,195 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
   }
 };
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
-    const_where_expression<
-        simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
-        simd<std::int32_t, simd_abi::neon_fixed_size<2>>> const& x) {
-  return vminv_s32(static_cast<int32x2_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
+// reduce_min(
+//         simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& v,
+//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& m)
+//         noexcept {
+//   return vminv_s32(static_cast<int32x2_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
-    const_where_expression<
-        simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
-        simd<std::int32_t, simd_abi::neon_fixed_size<2>>> const& x) {
-  return vmaxv_s32(static_cast<int32x2_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
+// reduce_max(
+//         simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& v,
+//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& m)
+//         noexcept {
+//   return vmaxv_s32(static_cast<int32x2_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
-    const_where_expression<
-        simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
-        simd<std::int32_t, simd_abi::neon_fixed_size<2>>> const& x,
-    std::int32_t, std::plus<>) {
-  return vaddv_s32(static_cast<int32x2_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
+// reduce(
+//         simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& v,
+//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& m,
+//     std::int32_t identity, std::plus<>) noexcept {
+//   if (none_of(m)) return identity;
+//   return vaddv_s32(static_cast<int32x2_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
-    const_where_expression<
-        simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
-        simd<std::int32_t, simd_abi::neon_fixed_size<4>>> const& x) {
-  return vminvq_s32(static_cast<int32x4_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
+// reduce_min(
+//         simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& v,
+//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& m)
+//         noexcept {
+//   return vminvq_s32(static_cast<int32x4_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
-    const_where_expression<
-        simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
-        simd<std::int32_t, simd_abi::neon_fixed_size<4>>> const& x) {
-  return vmaxvq_s32(static_cast<int32x4_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
+// reduce_max(
+//         simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& v,
+//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> m) noexcept {
+//   return vmaxvq_s32(static_cast<int32x4_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
-    const_where_expression<
-        simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
-        simd<std::int32_t, simd_abi::neon_fixed_size<4>>> const& x,
-    std::int32_t, std::plus<>) {
-  return vaddvq_s32(static_cast<int32x4_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
+// reduce(
+//         simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& v,
+//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& m,
+//     std::int32_t identity, std::plus<>) noexcept {
+//   if (none_of(m)) return identity;
+//   return vaddvq_s32(static_cast<int32x4_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
-    const_where_expression<
-        simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>>,
-        simd<std::uint32_t, simd_abi::neon_fixed_size<2>>> const& x) {
-  return vminv_u32(static_cast<uint32x2_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
+// reduce_min(
+//         simd<std::uint32_t, simd_abi::neon_fixed_size<2>> const& v,
+//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>> const& m)
+//         noexcept {
+//   return vminv_u32(static_cast<uint32x2_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
-    const_where_expression<
-        simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>>,
-        simd<std::uint32_t, simd_abi::neon_fixed_size<2>>> const& x) {
-  return vmaxv_u32(static_cast<uint32x2_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
+// reduce_max(
+//         simd<std::uint32_t, simd_abi::neon_fixed_size<2>> const& v,
+//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>> const& m)
+//         noexcept {
+//   return vmaxv_u32(static_cast<uint32x2_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce(
-    const_where_expression<
-        simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>>,
-        simd<std::uint32_t, simd_abi::neon_fixed_size<2>>> const& x,
-    std::uint32_t, std::plus<>) {
-  return vaddv_u32(static_cast<uint32x2_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
+// reduce(
+//         simd<std::uint32_t, simd_abi::neon_fixed_size<2>> const& v,
+//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>> const& m,
+//     std::uint32_t identity, std::plus<>) noexcept {
+//   if (none_of(m)) return identity;
+//   return vaddv_u32(static_cast<uint32x2_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
-    const_where_expression<
-        simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>>,
-        simd<std::uint32_t, simd_abi::neon_fixed_size<4>>> const& x) {
-  return vminvq_u32(static_cast<uint32x4_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
+// reduce_min(
+//         simd<std::uint32_t, simd_abi::neon_fixed_size<4>> const& v,
+//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>> const& m)
+//         noexcept {
+//   return vminvq_u32(static_cast<uint32x4_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
-    const_where_expression<
-        simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>>,
-        simd<std::uint32_t, simd_abi::neon_fixed_size<4>>> const& x) {
-  return vmaxvq_u32(static_cast<uint32x4_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
+// reduce_max(
+//         simd<std::uint32_t, simd_abi::neon_fixed_size<4>> const& v,
+//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>> const& m)
+//         noexcept {
+//   return vmaxvq_u32(static_cast<uint32x4_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce(
-    const_where_expression<
-        simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>>,
-        simd<std::uint32_t, simd_abi::neon_fixed_size<4>>> const& x,
-    std::uint32_t, std::plus<>) {
-  return vaddvq_u32(static_cast<uint32x4_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
+// reduce(
+//         simd<std::uint32_t, simd_abi::neon_fixed_size<4>> const& v,
+//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>> const& m,
+//     std::uint32_t identity, std::plus<>) noexcept {
+//   if (none_of(m)) return identity;
+//   return vaddvq_u32(static_cast<uint32x4_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce(
-    const_where_expression<
-        simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
-        simd<std::int64_t, simd_abi::neon_fixed_size<2>>> const& x,
-    std::int64_t, std::plus<>) {
-  return vaddvq_s64(static_cast<int64x2_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int64_t
+// reduce(
+//         simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& v,
+//         simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& m,
+//     std::int64_t identity, std::plus<>) noexcept {
+//   if (none_of(m)) return identity;
+//   return vaddvq_s64(static_cast<int64x2_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce(
-    const_where_expression<
-        simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
-        simd<std::uint64_t, simd_abi::neon_fixed_size<2>>> const& x,
-    std::uint64_t, std::plus<>) {
-  return vaddvq_u64(static_cast<uint64x2_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint64_t
+// reduce(
+//         simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& v,
+//         simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& m,
+//     std::uint64_t identity, std::plus<>) noexcept {
+//   return vaddvq_u64(static_cast<uint64x2_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_min(
-    const_where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
-                           simd<double, simd_abi::neon_fixed_size<2>>> const&
-        x) {
-  return vminvq_f64(static_cast<float64x2_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr double
+// reduce_min(
+//     simd < double, simd_abi::neon_fixed_size < 2 >> const& v,
+//     simd_mask<double, simd_abi::neon_fixed_size<2>> const& m) noexcept {
+//   return vminvq_f64(static_cast<float64x2_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_max(
-    const_where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
-                           simd<double, simd_abi::neon_fixed_size<2>>> const&
-        x) {
-  return vmaxvq_f64(static_cast<float64x2_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr double
+// reduce_max(
+//                            simd<double, simd_abi::neon_fixed_size<2>> const&
+//                            v,
+//     simd_mask<double, simd_abi::neon_fixed_size<2>> const& m) noexcept {
+//   return vmaxvq_f64(static_cast<float64x2_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
-    const_where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
-                           simd<double, simd_abi::neon_fixed_size<2>>> const& x,
-    double, std::plus<>) {
-  return vaddvq_f64(static_cast<float64x2_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr double reduce(
+//                            simd<double, simd_abi::neon_fixed_size<2>> const&
+//                            v,
+//     simd_mask<double, simd_abi::neon_fixed_size<2>> const& m,
+//     double identity, std::plus<>) noexcept {
+//   if (none_of(m)) return identity;
+//   return vaddvq_f64(static_cast<float64x2_t>(x.impl_get_value()));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
-    const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
-                           simd<float, simd_abi::neon_fixed_size<2>>> const&
-        x) {
-  return vminv_f32(static_cast<float32x2_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float
+// reduce_min(
+//                            simd<float, simd_abi::neon_fixed_size<2>> const&
+//                            v,
+//     simd_mask<float, simd_abi::neon_fixed_size<2>> const& m) noexcept {
+//   return vminv_f32(static_cast<float32x2_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
-    const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
-                           simd<float, simd_abi::neon_fixed_size<2>>> const&
-        x) {
-  return vmaxv_f32(static_cast<float32x2_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float
+// reduce_max(
+//                            simd<float, simd_abi::neon_fixed_size<2>> const&
+//                            v,
+//     simd_mask<float, simd_abi::neon_fixed_size<2>> const& m) noexcept {
+//   return vmaxv_f32(static_cast<float32x2_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
-    const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
-                           simd<float, simd_abi::neon_fixed_size<2>>> const& x,
-    float, std::plus<>) {
-  return vaddv_f32(static_cast<float32x2_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float reduce(
+//                            simd<float, simd_abi::neon_fixed_size<2>> const&
+//                            v,
+//     simd_mask<float, simd_abi::neon_fixed_size<2>> const& m,
+//     float identity, std::plus<>) noexcept {
+//   if (none_of(m)) return identity;
+//   return vaddv_f32(static_cast<float32x2_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
-    const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<4>>,
-                           simd<float, simd_abi::neon_fixed_size<4>>> const&
-        x) {
-  return vminvq_f32(static_cast<float32x4_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float
+// reduce_min(
+//                            simd<float, simd_abi::neon_fixed_size<4>> const&
+//                            v,
+//     simd_mask<float, simd_abi::neon_fixed_size<4>> const& m) noexcept {
+//   return vminvq_f32(static_cast<float32x4_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
-    const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<4>>,
-                           simd<float, simd_abi::neon_fixed_size<4>>> const&
-        x) {
-  return vmaxvq_f32(static_cast<float32x4_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float
+// reduce_max(
+//                            simd<float, simd_abi::neon_fixed_size<4>> const&
+//                            const& v
+//     simd_mask<float, simd_abi::neon_fixed_size<4>> const& m) noexcept {
+//   return vmaxvq_f32(static_cast<float32x4_t>(v));
+// }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
-    const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<4>>,
-                           simd<float, simd_abi::neon_fixed_size<4>>> const& x,
-    float, std::plus<>) {
-  return vaddvq_f32(static_cast<float32x4_t>(x.impl_get_value()));
-}
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float reduce(
+//                            simd<float, simd_abi::neon_fixed_size<4>> const&
+//                            v,
+//     simd_mask<float, simd_abi::neon_fixed_size<4>> const& m,
+//     float identity, std::plus<>) noexcept {
+//   if (none_of(m)) return identity;
+//   return vaddvq_f32(static_cast<float32x4_t>(v));
+// }
 
 }  // namespace Experimental
 }  // namespace Kokkos

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -426,6 +426,7 @@ reduce(const_where_expression<simd_mask<T, simd_abi::scalar>,
              : identity_element;
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class T>
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION T
 hmax(const_where_expression<simd_mask<T, simd_abi::scalar>,
@@ -434,6 +435,7 @@ hmax(const_where_expression<simd_mask<T, simd_abi::scalar>,
              ? static_cast<T>(x.impl_get_value())
              : Kokkos::reduction_identity<T>::max();
 }
+#endif
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
@@ -444,6 +446,7 @@ reduce_max(const_where_expression<simd_mask<T, simd_abi::scalar>,
              : Kokkos::reduction_identity<T>::max();
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class T>
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION T
 hmin(const_where_expression<simd_mask<T, simd_abi::scalar>,
@@ -452,6 +455,7 @@ hmin(const_where_expression<simd_mask<T, simd_abi::scalar>,
              ? static_cast<T>(x.impl_get_value())
              : Kokkos::reduction_identity<T>::min();
 }
+#endif
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -427,7 +427,7 @@ reduce(const_where_expression<simd_mask<T, simd_abi::scalar>,
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION T
 hmax(const_where_expression<simd_mask<T, simd_abi::scalar>,
                             simd<T, simd_abi::scalar>> const& x) {
   return static_cast<bool>(x.impl_get_mask())
@@ -437,8 +437,26 @@ hmax(const_where_expression<simd_mask<T, simd_abi::scalar>,
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
+reduce_max(const_where_expression<simd_mask<T, simd_abi::scalar>,
+                                  simd<T, simd_abi::scalar>> const& x) {
+  return static_cast<bool>(x.impl_get_mask())
+             ? static_cast<T>(x.impl_get_value())
+             : Kokkos::reduction_identity<T>::max();
+}
+
+template <class T>
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION T
 hmin(const_where_expression<simd_mask<T, simd_abi::scalar>,
                             simd<T, simd_abi::scalar>> const& x) {
+  return static_cast<bool>(x.impl_get_mask())
+             ? static_cast<T>(x.impl_get_value())
+             : Kokkos::reduction_identity<T>::min();
+}
+
+template <class T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
+reduce_min(const_where_expression<simd_mask<T, simd_abi::scalar>,
+                                  simd<T, simd_abi::scalar>> const& x) {
   return static_cast<bool>(x.impl_get_mask())
              ? static_cast<T>(x.impl_get_value())
              : Kokkos::reduction_identity<T>::min();

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -120,6 +120,9 @@ class simd<T, simd_abi::scalar> {
                 bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit simd(G&& gen) noexcept
       : m_value(gen(0)) {}
+  template <typename FlagType>
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit simd(T const* ptr, FlagType)
+      : m_value(*ptr) {}
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator T() const {
     return m_value;
   }

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -348,51 +348,55 @@ KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> condition(
 }
 
 template <class T, class BinaryOperation>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
-reduce(Experimental::simd<T, Experimental::simd_abi::scalar> const& x,
-       BinaryOperation binary_op) {
-  auto v = where(true, x);
-  return reduce(v, T(0), binary_op);
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+    Experimental::simd<T, Experimental::simd_abi::scalar> const& x,
+    Experimental::simd_mask<T, Experimental::simd_abi::scalar> const& mask,
+    T identity, BinaryOperation) noexcept {
+  if (!mask) return identity;
+  return x[0];
 }
 
 template <class T, class BinaryOperation>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
-reduce(Experimental::simd<T, Experimental::simd_abi::scalar> const& x,
-       Experimental::simd_mask<T, Experimental::simd_abi::scalar> const& mask,
-       BinaryOperation binary_op) {
-  if (!mask) return T(0);
-  auto v = where(mask, x);
-  return reduce(v, T(0), binary_op);
-}
-
-template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
-reduce_min(Experimental::simd<T, Experimental::simd_abi::scalar> const& x) {
-  auto v = where(true, x);
-  return reduce_min(v);
-}
-
-template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T reduce_min(
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
     Experimental::simd<T, Experimental::simd_abi::scalar> const& x,
-    Experimental::simd_mask<T, Experimental::simd_abi::scalar> const& mask) {
-  auto v = where(mask, x);
-  return reduce_min(v);
+    BinaryOperation binary_op) noexcept {
+  return reduce(
+      x, Experimental::simd<T, Experimental::simd_abi::scalar>::mask_type(true),
+      T(0), binary_op);
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
-reduce_max(Experimental::simd<T, Experimental::simd_abi::scalar> const& x) {
-  auto v = where(true, x);
-  return reduce_max(v);
-}
-
-template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T reduce_max(
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
     Experimental::simd<T, Experimental::simd_abi::scalar> const& x,
-    Experimental::simd_mask<T, Experimental::simd_abi::scalar> const& mask) {
-  auto v = where(mask, x);
-  return reduce_max(v);
+    Experimental::simd_mask<T, Experimental::simd_abi::scalar> const&
+        mask) noexcept {
+  if (!mask) return Kokkos::reduction_identity<T>::min();
+  return x[0];
+}
+
+template <class T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
+    Experimental::simd<T, Experimental::simd_abi::scalar> const& x) noexcept {
+  return reduce_min(
+      x,
+      Experimental::simd<T, Experimental::simd_abi::scalar>::mask_type(true));
+}
+
+template <class T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
+    Experimental::simd<T, Experimental::simd_abi::scalar> const& x,
+    Experimental::simd_mask<T, Experimental::simd_abi::scalar> const&
+        mask) noexcept {
+  if (!mask) return Kokkos::reduction_identity<T>::max();
+  return x[0];
+}
+
+template <class T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
+    Experimental::simd<T, Experimental::simd_abi::scalar> const& x) noexcept {
+  return reduce_max(
+      x,
+      Experimental::simd<T, Experimental::simd_abi::scalar>::mask_type(true));
 }
 
 template <class T>
@@ -512,24 +516,6 @@ template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION bool none_of(
     simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const& a) {
   return a == simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(false);
-}
-
-template <class T, class BinaryOperation>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
-reduce(const_where_expression<simd_mask<T, simd_abi::scalar>,
-                              simd<T, simd_abi::scalar>> const& x,
-       T identity_element, BinaryOperation) {
-  return static_cast<bool>(x.impl_get_mask())
-             ? static_cast<T>(x.impl_get_value())
-             : identity_element;
-}
-
-template <class T, class BinaryOperation>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
-reduce(const_where_expression<simd_mask<T, simd_abi::scalar>,
-                              simd<T, simd_abi::scalar>> const& x,
-       BinaryOperation op) {
-  return reduce(x, T(0), op);
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -247,6 +247,18 @@ class shift_right {
   }
 };
 
+class shift_right_eq {
+ public:
+  template <typename T, typename U>
+  auto& on_host(T&& a, U&& b) const {
+    return a >>= b;
+  }
+  template <typename T, typename U>
+  KOKKOS_INLINE_FUNCTION auto& on_device(T&& a, U&& b) const {
+    return a >>= b;
+  }
+};
+
 class shift_left {
  public:
   template <typename T, typename U>
@@ -256,6 +268,18 @@ class shift_left {
   template <typename T, typename U>
   KOKKOS_INLINE_FUNCTION auto on_device(T&& a, U&& b) const {
     return a << b;
+  }
+};
+
+class shift_left_eq {
+ public:
+  template <typename T, typename U>
+  auto& on_host(T&& a, U&& b) const {
+    return a <<= b;
+  }
+  template <typename T, typename U>
+  KOKKOS_INLINE_FUNCTION auto& on_device(T&& a, U&& b) const {
+    return a <<= b;
   }
 };
 

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -31,6 +31,18 @@ class plus {
   }
 };
 
+class plus_eq {
+ public:
+  template <class T>
+  auto& on_host(T&& a, T&& b) const {
+    return a += b;
+  }
+  template <class T>
+  KOKKOS_INLINE_FUNCTION auto& on_device(T&& a, T&& b) const {
+    return a += b;
+  }
+};
+
 class minus {
  public:
   template <class T>
@@ -40,6 +52,18 @@ class minus {
   template <class T>
   KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
     return a - b;
+  }
+};
+
+class minus_eq {
+ public:
+  template <class T>
+  auto& on_host(T&& a, T&& b) const {
+    return a -= b;
+  }
+  template <class T>
+  KOKKOS_INLINE_FUNCTION auto& on_device(T&& a, T&& b) const {
+    return a -= b;
   }
 };
 
@@ -55,6 +79,18 @@ class multiplies {
   }
 };
 
+class multiplies_eq {
+ public:
+  template <class T>
+  auto& on_host(T&& a, T&& b) const {
+    return a *= b;
+  }
+  template <class T>
+  KOKKOS_INLINE_FUNCTION auto& on_device(T&& a, T&& b) const {
+    return a *= b;
+  }
+};
+
 class divides {
  public:
   template <class T>
@@ -64,6 +100,18 @@ class divides {
   template <class T>
   KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
     return a / b;
+  }
+};
+
+class divides_eq {
+ public:
+  template <class T>
+  auto& on_host(T&& a, T&& b) const {
+    return a /= b;
+  }
+  template <class T>
+  KOKKOS_INLINE_FUNCTION auto& on_device(T&& a, T&& b) const {
+    return a /= b;
   }
 };
 

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -335,12 +335,12 @@ template <typename BinaryOperation = std::plus<>>
 class reduce_where_expr {
  public:
   template <typename T, typename MaskType>
-  KOKKOS_INLINE_FUNCTION auto on_host(T const& a, MaskType mask) const {
+  auto on_host(T const& a, MaskType mask) const {
     auto w = Kokkos::Experimental::where(mask, a);
     return Kokkos::Experimental::reduce(w, BinaryOperation());
   }
   template <typename T, typename MaskType>
-  KOKKOS_INLINE_FUNCTION auto on_host_serial(T const& a, MaskType mask) const {
+  auto on_host_serial(T const& a, MaskType mask) const {
     auto w        = Kokkos::Experimental::where(mask, a);
     auto const& v = w.impl_get_value();
     auto const& m = w.impl_get_mask();
@@ -373,11 +373,11 @@ class reduce_where_expr {
 class reduce_min {
  public:
   template <typename T, typename MaskType>
-  KOKKOS_INLINE_FUNCTION auto on_host(T const& a, MaskType mask) const {
+  auto on_host(T const& a, MaskType mask) const {
     return Kokkos::Experimental::reduce_min(a, mask);
   }
   template <typename T, typename MaskType>
-  KOKKOS_INLINE_FUNCTION auto on_host_serial(T const& a, MaskType mask) const {
+  auto on_host_serial(T const& a, MaskType mask) const {
     auto w        = Kokkos::Experimental::where(mask, a);
     auto const& v = w.impl_get_value();
     auto const& m = w.impl_get_mask();
@@ -409,11 +409,11 @@ class reduce_min {
 class reduce_max {
  public:
   template <typename T, typename MaskType>
-  KOKKOS_INLINE_FUNCTION auto on_host(T const& a, MaskType mask) const {
+  auto on_host(T const& a, MaskType mask) const {
     return Kokkos::Experimental::reduce_max(a, mask);
   }
   template <typename T, typename MaskType>
-  KOKKOS_INLINE_FUNCTION auto on_host_serial(T const& a, MaskType mask) const {
+  auto on_host_serial(T const& a, MaskType mask) const {
     auto w        = Kokkos::Experimental::where(mask, a);
     auto const& v = w.impl_get_value();
     auto const& m = w.impl_get_mask();
@@ -446,11 +446,11 @@ template <typename BinaryOperation = std::plus<>>
 class reduce {
  public:
   template <typename T, typename MaskType>
-  KOKKOS_INLINE_FUNCTION auto on_host(T const& a, MaskType mask) const {
+  auto on_host(T const& a, MaskType mask) const {
     return Kokkos::Experimental::reduce(a, mask, BinaryOperation());
   }
   template <typename T, typename MaskType>
-  KOKKOS_INLINE_FUNCTION auto on_host_serial(T const& a, MaskType mask) const {
+  auto on_host_serial(T const& a, MaskType mask) const {
     return reduce_where_expr<BinaryOperation>().on_host_serial(a, mask);
   }
 

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -331,86 +331,6 @@ class log_op {
   }
 };
 
-class hmin {
- public:
-  template <typename T, typename MaskType = bool>
-  KOKKOS_INLINE_FUNCTION auto on_host(T const& a, MaskType mask = true) const {
-    auto w = Kokkos::Experimental::where(mask, a);
-    return Kokkos::Experimental::hmin(w);
-  }
-  template <typename T, typename MaskType = bool>
-  KOKKOS_INLINE_FUNCTION auto on_host_serial(T const& a,
-                                             MaskType mask = true) const {
-    auto w        = Kokkos::Experimental::where(mask, a);
-    auto const& v = w.impl_get_value();
-    auto const& m = w.impl_get_mask();
-    auto result   = v[0];
-    for (std::size_t i = 1; i < v.size(); ++i) {
-      if (m[i]) result = Kokkos::min(result, v[i]);
-    }
-    return result;
-  }
-
-  template <typename T, typename MaskType = bool>
-  KOKKOS_INLINE_FUNCTION auto on_device(T const& a,
-                                        MaskType mask = true) const {
-    auto w = Kokkos::Experimental::where(mask, a);
-    return Kokkos::Experimental::hmin(w);
-  }
-  template <typename T, typename MaskType = bool>
-  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a,
-                                               MaskType mask = true) const {
-    auto w        = Kokkos::Experimental::where(mask, a);
-    auto const& v = w.impl_get_value();
-    auto const& m = w.impl_get_mask();
-    auto result   = v[0];
-    for (std::size_t i = 1; i < v.size(); ++i) {
-      if (m[i]) result = Kokkos::min(result, v[i]);
-    }
-    return result;
-  }
-};
-
-class hmax {
- public:
-  template <typename T, typename MaskType = bool>
-  KOKKOS_INLINE_FUNCTION auto on_host(T const& a, MaskType mask = true) const {
-    auto w = Kokkos::Experimental::where(mask, a);
-    return Kokkos::Experimental::hmax(w);
-  }
-  template <typename T, typename MaskType = bool>
-  KOKKOS_INLINE_FUNCTION auto on_host_serial(T const& a,
-                                             MaskType mask = true) const {
-    auto w        = Kokkos::Experimental::where(mask, a);
-    auto const& v = w.impl_get_value();
-    auto const& m = w.impl_get_mask();
-    auto result   = v[0];
-    for (std::size_t i = 1; i < v.size(); ++i) {
-      if (m[i]) result = Kokkos::max(result, v[i]);
-    }
-    return result;
-  }
-
-  template <typename T, typename MaskType = bool>
-  KOKKOS_INLINE_FUNCTION auto on_device(T const& a,
-                                        MaskType mask = true) const {
-    auto w = Kokkos::Experimental::where(mask, a);
-    return Kokkos::Experimental::hmax(w);
-  }
-  template <typename T, typename MaskType = bool>
-  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a,
-                                               MaskType mask = true) const {
-    auto w        = Kokkos::Experimental::where(mask, a);
-    auto const& v = w.impl_get_value();
-    auto const& m = w.impl_get_mask();
-    auto result   = v[0];
-    for (std::size_t i = 1; i < v.size(); ++i) {
-      if (m[i]) result = Kokkos::max(result, v[i]);
-    }
-    return result;
-  }
-};
-
 template <typename BinaryOperation = std::plus<>>
 class reduce_where_expr {
  public:
@@ -458,7 +378,14 @@ class reduce_min {
   }
   template <typename T, typename MaskType>
   KOKKOS_INLINE_FUNCTION auto on_host_serial(T const& a, MaskType mask) const {
-    return hmin().on_host_serial(a, mask);
+    auto w        = Kokkos::Experimental::where(mask, a);
+    auto const& v = w.impl_get_value();
+    auto const& m = w.impl_get_mask();
+    auto result   = v[0];
+    for (std::size_t i = 1; i < v.size(); ++i) {
+      if (m[i]) result = Kokkos::min(result, v[i]);
+    }
+    return result;
   }
 
   template <typename T, typename MaskType>
@@ -468,7 +395,14 @@ class reduce_min {
   template <typename T, typename MaskType>
   KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a,
                                                MaskType mask) const {
-    return hmin().on_device_serial(a, mask);
+    auto w        = Kokkos::Experimental::where(mask, a);
+    auto const& v = w.impl_get_value();
+    auto const& m = w.impl_get_mask();
+    auto result   = v[0];
+    for (std::size_t i = 1; i < v.size(); ++i) {
+      if (m[i]) result = Kokkos::min(result, v[i]);
+    }
+    return result;
   }
 };
 
@@ -480,7 +414,14 @@ class reduce_max {
   }
   template <typename T, typename MaskType>
   KOKKOS_INLINE_FUNCTION auto on_host_serial(T const& a, MaskType mask) const {
-    return hmax().on_host_serial(a, mask);
+    auto w        = Kokkos::Experimental::where(mask, a);
+    auto const& v = w.impl_get_value();
+    auto const& m = w.impl_get_mask();
+    auto result   = v[0];
+    for (std::size_t i = 1; i < v.size(); ++i) {
+      if (m[i]) result = Kokkos::max(result, v[i]);
+    }
+    return result;
   }
 
   template <typename T, typename MaskType>
@@ -490,7 +431,14 @@ class reduce_max {
   template <typename T, typename MaskType>
   KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a,
                                                MaskType mask) const {
-    return hmax().on_device_serial(a, mask);
+    auto w        = Kokkos::Experimental::where(mask, a);
+    auto const& v = w.impl_get_value();
+    auto const& m = w.impl_get_mask();
+    auto result   = v[0];
+    for (std::size_t i = 1; i < v.size(); ++i) {
+      if (m[i]) result = Kokkos::max(result, v[i]);
+    }
+    return result;
   }
 };
 

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -29,6 +29,9 @@ void host_check_math_op_one_loader(BinaryOp binary_op, std::size_t n,
   for (std::size_t i = 0; i < n; i += width) {
     std::size_t const nremaining = n - i;
     std::size_t const nlanes     = Kokkos::min(nremaining, width);
+    if ((std::is_same_v<BinaryOp, divides> ||
+         std::is_same_v<BinaryOp, divides_eq>)&&nremaining < width)
+      continue;
     simd_type first_arg;
     bool const loaded_first_arg =
         loader.host_load(first_args + i, nlanes, first_arg);
@@ -44,6 +47,7 @@ void host_check_math_op_one_loader(BinaryOp binary_op, std::size_t n,
         expected_result[lane] =
             binary_op.on_host(T(first_arg[lane]), T(second_arg[lane]));
     }
+    loader.host_load(first_args + i, nlanes, first_arg);
     simd_type const computed_result = binary_op.on_host(first_arg, second_arg);
     host_check_equality(expected_result, computed_result, nlanes);
   }
@@ -90,8 +94,14 @@ template <typename Abi, typename DataType, size_t n>
 inline void host_check_all_math_ops(const DataType (&first_args)[n],
                                     const DataType (&second_args)[n]) {
   host_check_math_op_all_loaders<Abi>(plus(), n, first_args, second_args);
+  host_check_math_op_all_loaders<Abi>(plus_eq(), n, first_args, second_args);
   host_check_math_op_all_loaders<Abi>(minus(), n, first_args, second_args);
+  host_check_math_op_all_loaders<Abi>(minus_eq(), n, first_args, second_args);
   host_check_math_op_all_loaders<Abi>(multiplies(), n, first_args, second_args);
+  host_check_math_op_all_loaders<Abi>(multiplies_eq(), n, first_args,
+                                      second_args);
+  host_check_math_op_all_loaders<Abi>(divides(), n, first_args, second_args);
+  host_check_math_op_all_loaders<Abi>(divides_eq(), n, first_args, second_args);
   host_check_math_op_all_loaders<Abi>(absolutes(), n, first_args);
 
   host_check_math_op_all_loaders<Abi>(floors(), n, first_args);
@@ -101,8 +111,6 @@ inline void host_check_all_math_ops(const DataType (&first_args)[n],
 
   // TODO: Place fallback implementations for all simd integer types
   if constexpr (std::is_floating_point_v<DataType>) {
-    host_check_math_op_all_loaders<Abi>(divides(), n, first_args, second_args);
-
 #if defined(__INTEL_COMPILER) && \
     (defined(KOKKOS_ARCH_AVX2) || defined(KOKKOS_ARCH_AVX512XEON))
     host_check_math_op_all_loaders<Abi>(cbrt_op(), n, first_args);
@@ -176,6 +184,9 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_one_loader(
   for (std::size_t i = 0; i < n; i += width) {
     std::size_t const nremaining = n - i;
     std::size_t const nlanes     = Kokkos::min(nremaining, width);
+    if ((std::is_same_v<BinaryOp, divides> ||
+         std::is_same_v<BinaryOp, divides_eq>)&&nremaining < width)
+      continue;
     simd_type first_arg;
     bool const loaded_first_arg =
         loader.device_load(first_args + i, nlanes, first_arg);
@@ -188,6 +199,7 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_one_loader(
       expected_result[lane] =
           binary_op.on_device(first_arg[lane], second_arg[lane]);
     }
+    loader.device_load(first_args + i, nlanes, first_arg);
     simd_type const computed_result =
         binary_op.on_device(first_arg, second_arg);
     device_check_equality(expected_result, computed_result, nlanes);
@@ -231,8 +243,15 @@ template <typename Abi, typename DataType, size_t n>
 KOKKOS_INLINE_FUNCTION void device_check_all_math_ops(
     const DataType (&first_args)[n], const DataType (&second_args)[n]) {
   device_check_math_op_all_loaders<Abi>(plus(), n, first_args, second_args);
+  device_check_math_op_all_loaders<Abi>(plus_eq(), n, first_args, second_args);
   device_check_math_op_all_loaders<Abi>(minus(), n, first_args, second_args);
+  device_check_math_op_all_loaders<Abi>(minus_eq(), n, first_args, second_args);
   device_check_math_op_all_loaders<Abi>(multiplies(), n, first_args,
+                                        second_args);
+  device_check_math_op_all_loaders<Abi>(multiplies_eq(), n, first_args,
+                                        second_args);
+  device_check_math_op_all_loaders<Abi>(divides(), n, first_args, second_args);
+  device_check_math_op_all_loaders<Abi>(divides_eq(), n, first_args,
                                         second_args);
   device_check_math_op_all_loaders<Abi>(absolutes(), n, first_args);
 
@@ -240,11 +259,6 @@ KOKKOS_INLINE_FUNCTION void device_check_all_math_ops(
   device_check_math_op_all_loaders<Abi>(ceils(), n, first_args);
   device_check_math_op_all_loaders<Abi>(rounds(), n, first_args);
   device_check_math_op_all_loaders<Abi>(truncates(), n, first_args);
-
-  if constexpr (std::is_floating_point_v<DataType>) {
-    device_check_math_op_all_loaders<Abi>(divides(), n, first_args,
-                                          second_args);
-  }
 }
 
 template <typename Abi, typename DataType>

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -57,8 +57,6 @@ inline void host_check_reduction_all_loaders(ReductionOp reduce_op,
 
 template <typename Abi, typename DataType, size_t n>
 inline void host_check_all_reductions(const DataType (&args)[n]) {
-  host_check_reduction_all_loaders<Abi>(hmin(), n, args);
-  host_check_reduction_all_loaders<Abi>(hmax(), n, args);
   host_check_reduction_all_loaders<Abi>(reduce_where_expr<std::plus<>>(), n,
                                         args);
   host_check_reduction_all_loaders<Abi>(reduce_where_expr<std::multiplies<>>(),
@@ -138,8 +136,6 @@ KOKKOS_INLINE_FUNCTION void device_check_reduction_all_loaders(
 template <typename Abi, typename DataType, size_t n>
 KOKKOS_INLINE_FUNCTION void device_check_all_reductions(
     const DataType (&args)[n]) {
-  device_check_reduction_all_loaders<Abi>(hmin(), n, args);
-  device_check_reduction_all_loaders<Abi>(hmax(), n, args);
   device_check_reduction_all_loaders<Abi>(reduce_where_expr<std::plus<>>(), n,
                                           args);
   device_check_reduction_all_loaders<Abi>(

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -36,11 +36,16 @@ inline void host_check_reduction_one_loader(ReductionOp reduce_op,
     if (!loaded_arg) continue;
 
     mask_type mask(false);
+    T identity    = 12;
+    auto expected = reduce_op.on_host_serial(arg, identity, mask);
+    auto computed = reduce_op.on_host(arg, identity, mask);
+    gtest_checker().equality(expected, computed);
+
     for (std::size_t j = 0; j < n; ++j) {
       mask[j] = true;
     }
-    auto expected = reduce_op.on_host_serial(arg, mask);
-    auto computed = reduce_op.on_host(arg, mask);
+    expected = reduce_op.on_host_serial(arg, identity, mask);
+    computed = reduce_op.on_host(arg, identity, mask);
 
     gtest_checker().equality(expected, computed);
   }
@@ -57,11 +62,6 @@ inline void host_check_reduction_all_loaders(ReductionOp reduce_op,
 
 template <typename Abi, typename DataType, size_t n>
 inline void host_check_all_reductions(const DataType (&args)[n]) {
-  host_check_reduction_all_loaders<Abi>(reduce_where_expr<std::plus<>>(), n,
-                                        args);
-  host_check_reduction_all_loaders<Abi>(reduce_where_expr<std::multiplies<>>(),
-                                        n, args);
-
   host_check_reduction_all_loaders<Abi>(reduce_min(), n, args);
   host_check_reduction_all_loaders<Abi>(reduce_max(), n, args);
   host_check_reduction_all_loaders<Abi>(reduce<std::plus<>>(), n, args);
@@ -114,11 +114,16 @@ KOKKOS_INLINE_FUNCTION void device_check_reduction_one_loader(
     if (!loaded_arg) continue;
 
     mask_type mask(false);
+    T identity    = 12;
+    auto expected = reduce_op.on_device_serial(arg, identity, mask);
+    auto computed = reduce_op.on_device(arg, identity, mask);
+    kokkos_checker().equality(expected, computed);
+
     for (std::size_t j = 0; j < n; ++j) {
       mask[j] = true;
     }
-    auto expected = reduce_op.on_device_serial(arg, mask);
-    auto computed = reduce_op.on_device(arg, mask);
+    expected = reduce_op.on_device_serial(arg, identity, mask);
+    computed = reduce_op.on_device(arg, identity, mask);
 
     kokkos_checker().equality(expected, computed);
   }
@@ -136,11 +141,6 @@ KOKKOS_INLINE_FUNCTION void device_check_reduction_all_loaders(
 template <typename Abi, typename DataType, size_t n>
 KOKKOS_INLINE_FUNCTION void device_check_all_reductions(
     const DataType (&args)[n]) {
-  device_check_reduction_all_loaders<Abi>(reduce_where_expr<std::plus<>>(), n,
-                                          args);
-  device_check_reduction_all_loaders<Abi>(
-      reduce_where_expr<std::multiplies<>>(), n, args);
-
   device_check_reduction_all_loaders<Abi>(reduce_min(), n, args);
   device_check_reduction_all_loaders<Abi>(reduce_max(), n, args);
   device_check_reduction_all_loaders<Abi>(reduce<std::plus<>>(), n, args);

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -39,9 +39,8 @@ inline void host_check_reduction_one_loader(ReductionOp reduce_op,
     for (std::size_t j = 0; j < n; ++j) {
       mask[j] = true;
     }
-    auto value    = where(mask, arg);
-    auto expected = reduce_op.on_host_serial(value);
-    auto computed = reduce_op.on_host(value);
+    auto expected = reduce_op.on_host_serial(arg, mask);
+    auto computed = reduce_op.on_host(arg, mask);
 
     gtest_checker().equality(expected, computed);
   }
@@ -60,7 +59,15 @@ template <typename Abi, typename DataType, size_t n>
 inline void host_check_all_reductions(const DataType (&args)[n]) {
   host_check_reduction_all_loaders<Abi>(hmin(), n, args);
   host_check_reduction_all_loaders<Abi>(hmax(), n, args);
-  host_check_reduction_all_loaders<Abi>(reduce(), n, args);
+  host_check_reduction_all_loaders<Abi>(reduce_where_expr<std::plus<>>(), n,
+                                        args);
+  host_check_reduction_all_loaders<Abi>(reduce_where_expr<std::multiplies<>>(),
+                                        n, args);
+
+  host_check_reduction_all_loaders<Abi>(reduce_min(), n, args);
+  host_check_reduction_all_loaders<Abi>(reduce_max(), n, args);
+  host_check_reduction_all_loaders<Abi>(reduce<std::plus<>>(), n, args);
+  host_check_reduction_all_loaders<Abi>(reduce<std::multiplies<>>(), n, args);
 }
 
 template <typename Abi, typename DataType>
@@ -112,9 +119,8 @@ KOKKOS_INLINE_FUNCTION void device_check_reduction_one_loader(
     for (std::size_t j = 0; j < n; ++j) {
       mask[j] = true;
     }
-    auto value    = where(mask, arg);
-    auto expected = reduce_op.on_device_serial(value);
-    auto computed = reduce_op.on_device(value);
+    auto expected = reduce_op.on_device_serial(arg, mask);
+    auto computed = reduce_op.on_device(arg, mask);
 
     kokkos_checker().equality(expected, computed);
   }
@@ -134,7 +140,15 @@ KOKKOS_INLINE_FUNCTION void device_check_all_reductions(
     const DataType (&args)[n]) {
   device_check_reduction_all_loaders<Abi>(hmin(), n, args);
   device_check_reduction_all_loaders<Abi>(hmax(), n, args);
-  device_check_reduction_all_loaders<Abi>(reduce(), n, args);
+  device_check_reduction_all_loaders<Abi>(reduce_where_expr<std::plus<>>(), n,
+                                          args);
+  device_check_reduction_all_loaders<Abi>(
+      reduce_where_expr<std::multiplies<>>(), n, args);
+
+  device_check_reduction_all_loaders<Abi>(reduce_min(), n, args);
+  device_check_reduction_all_loaders<Abi>(reduce_max(), n, args);
+  device_check_reduction_all_loaders<Abi>(reduce<std::plus<>>(), n, args);
+  device_check_reduction_all_loaders<Abi>(reduce<std::multiplies<>>(), n, args);
 }
 
 template <typename Abi, typename DataType>

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -43,7 +43,7 @@ inline void host_check_shift_on_one_loader(ShiftOp shift_op,
           shift_op.on_host(value, static_cast<int>(shift_by[i]));
       EXPECT_EQ(value, value);
     }
-
+    loader.host_load(test_vals, width, simd_vals);
     simd_type const computed_result =
         shift_op.on_host(simd_vals, static_cast<int>(shift_by[i]));
     host_check_equality(expected_result, computed_result, width);
@@ -70,6 +70,7 @@ inline void host_check_shift_by_lanes_on_one_loader(
         shift_op.on_host(value, static_cast<int>(shift_by[lane]));
     EXPECT_EQ(value, value);
   }
+  loader.host_load(test_vals, width, simd_vals);
   simd_type const computed_result = shift_op.on_host(simd_vals, shift_by);
   host_check_equality(expected_result, computed_result, width);
 }
@@ -124,13 +125,23 @@ inline void host_check_shift_ops() {
 
       host_check_shift_op_all_loaders<Abi>(shift_right(), test_vals, shift_by,
                                            num_cases);
+      host_check_shift_op_all_loaders<Abi>(shift_right_eq(), test_vals,
+                                           shift_by, num_cases);
       host_check_shift_op_all_loaders<Abi>(shift_left(), test_vals, shift_by,
+                                           num_cases);
+      host_check_shift_op_all_loaders<Abi>(shift_left_eq(), test_vals, shift_by,
                                            num_cases);
 
       if constexpr (std::is_signed_v<DataType>) {
         for (std::size_t i = 0; i < width; ++i) test_vals[i] *= -1;
         host_check_shift_op_all_loaders<Abi>(shift_right(), test_vals, shift_by,
                                              num_cases);
+        host_check_shift_op_all_loaders<Abi>(shift_right_eq(), test_vals,
+                                             shift_by, num_cases);
+        host_check_shift_op_all_loaders<Abi>(shift_left(), test_vals, shift_by,
+                                             num_cases);
+        host_check_shift_op_all_loaders<Abi>(shift_left_eq(), test_vals,
+                                             shift_by, num_cases);
       }
     }
   }
@@ -245,12 +256,22 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_ops() {
 
       device_check_shift_op_all_loaders<Abi>(shift_right(), test_vals, shift_by,
                                              num_cases);
+      device_check_shift_op_all_loaders<Abi>(shift_right_eq(), test_vals,
+                                             shift_by, num_cases);
       device_check_shift_op_all_loaders<Abi>(shift_left(), test_vals, shift_by,
                                              num_cases);
+      device_check_shift_op_all_loaders<Abi>(shift_left_eq(), test_vals,
+                                             shift_by, num_cases);
 
       if constexpr (std::is_signed_v<DataType>) {
         for (std::size_t i = 0; i < width; ++i) test_vals[i] *= -1;
         device_check_shift_op_all_loaders<Abi>(shift_right(), test_vals,
+                                               shift_by, num_cases);
+        device_check_shift_op_all_loaders<Abi>(shift_right_eq(), test_vals,
+                                               shift_by, num_cases);
+        device_check_shift_op_all_loaders<Abi>(shift_left(), test_vals,
+                                               shift_by, num_cases);
+        device_check_shift_op_all_loaders<Abi>(shift_left_eq(), test_vals,
                                                shift_by, num_cases);
       }
     }

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -43,7 +43,6 @@ inline void host_check_shift_on_one_loader(ShiftOp shift_op,
           shift_op.on_host(value, static_cast<int>(shift_by[i]));
       EXPECT_EQ(value, value);
     }
-    loader.host_load(test_vals, width, simd_vals);
     simd_type const computed_result =
         shift_op.on_host(simd_vals, static_cast<int>(shift_by[i]));
     host_check_equality(expected_result, computed_result, width);
@@ -70,7 +69,6 @@ inline void host_check_shift_by_lanes_on_one_loader(
         shift_op.on_host(value, static_cast<int>(shift_by[lane]));
     EXPECT_EQ(value, value);
   }
-  loader.host_load(test_vals, width, simd_vals);
   simd_type const computed_result = shift_op.on_host(simd_vals, shift_by);
   host_check_equality(expected_result, computed_result, width);
 }
@@ -174,10 +172,10 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_on_one_loader(
     simd_type expected_result;
 
     for (std::size_t lane = 0; lane < width; ++lane) {
-      expected_result[lane] = shift_op.on_device(DataType(simd_vals[lane]),
-                                                 static_cast<int>(shift_by[i]));
+      DataType value = simd_vals[lane];
+      expected_result[lane] =
+          shift_op.on_device(value, static_cast<int>(shift_by[i]));
     }
-
     simd_type const computed_result =
         shift_op.on_device(simd_vals, static_cast<int>(shift_by[i]));
     device_check_equality(expected_result, computed_result, width);
@@ -197,8 +195,9 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_by_lanes_on_one_loader(
   simd_type expected_result;
 
   for (std::size_t lane = 0; lane < width; ++lane) {
-    expected_result[lane] = shift_op.on_device(
-        DataType(simd_vals[lane]), static_cast<int>(shift_by[lane]));
+    DataType value = simd_vals[lane];
+    expected_result[lane] =
+        shift_op.on_device(value, static_cast<int>(shift_by[lane]));
   }
   simd_type const computed_result = shift_op.on_device(simd_vals, shift_by);
   device_check_equality(expected_result, computed_result, width);

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -138,10 +138,6 @@ inline void host_check_shift_ops() {
                                              num_cases);
         host_check_shift_op_all_loaders<Abi>(shift_right_eq(), test_vals,
                                              shift_by, num_cases);
-        host_check_shift_op_all_loaders<Abi>(shift_left(), test_vals, shift_by,
-                                             num_cases);
-        host_check_shift_op_all_loaders<Abi>(shift_left_eq(), test_vals,
-                                             shift_by, num_cases);
       }
     }
   }
@@ -268,10 +264,6 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_ops() {
         device_check_shift_op_all_loaders<Abi>(shift_right(), test_vals,
                                                shift_by, num_cases);
         device_check_shift_op_all_loaders<Abi>(shift_right_eq(), test_vals,
-                                               shift_by, num_cases);
-        device_check_shift_op_all_loaders<Abi>(shift_left(), test_vals,
-                                               shift_by, num_cases);
-        device_check_shift_op_all_loaders<Abi>(shift_left_eq(), test_vals,
                                                shift_by, num_cases);
       }
     }


### PR DESCRIPTION
This PR adds following functions that are described in [p1928r7](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p1928r7.pdf):

- Compound assignments
    - `simd<T, Abi>& operator/=(simd<T, Abi>& lhs, U&& rhs)` (enabled)
    - `simd<T, Abi>& operator>>=(simd<T, Abi>& lhs, U&& rhs)` (added)
    - `simd<T, Abi>& operator<<=(simd<T, Abi>& lhs, U&& rhs)` (added)

- Constructor that accepts a pointer to the src memory
    - `constexpr explicit simd(value_type const* ptr, FlagType flag)`

- Fallback simd reducers
    - `constexpr T reduce(const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask, T identity_element, BinaryOperation binary_op)`
    - `constexpr T reduce(const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask, std::plus<> binary_op = {}) noexcept`
    - `constexpr T reduce(const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask, std::bit_and<> binary_op) noexcept`
    - `constexpr T reduce(const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask, std::bit_or<> binary_op) noexcept`
    - `constexpr T reduce(const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask, std::bit_xor<> binary_op) noexcept`
    - `constexpr T reduce_min(const simd<T, Abi>& x) noexcept`
    - `constexpr T reduce_min(const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask) noexcept`
    - `constexpr T reduce_max(const simd<T, Abi>& x) noexcept`
    - `constexpr T reduce_max(const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask) noexcept`

- `Max`, `Min`, `Sum` reducers for AVX512
    - `T reduce_min(const simd<T, Abi>& x)`
    - `T reduce_max(const simd<T, Abi>& x)`
    - `T reduce(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x, T, std::plus<>)`

- Deprecated `hmin` and `hmax` in favor of `reduce_min` and `reduce_max`