### PR TITLE
OpenMP: Use `omp_get_nested` for older gcc versions

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -45,13 +45,13 @@ namespace Kokkos {
 namespace Impl {
 
 inline bool execute_in_serial(OpenMP const& space = OpenMP()) {
-// FIXME_OPENMP - `omp_get_max_active_levels` fails with gcc version lower
-// than 11.1.0
+// The default value returned by `omp_get_max_active_levels` with gcc version lower
+// than 11.1.0 is 2147483647 instead of 1.
 #if (!defined(KOKKOS_COMPILER_GNU) || KOKKOS_COMPILER_GNU >= 1110) && \
     _OPENMP >= 201511
-  int is_nested = omp_get_max_active_levels() > 1;
+  bool is_nested = omp_get_max_active_levels() > 1;
 #else
-  int is_nested = omp_get_nested();
+  bool is_nested = static_cast<bool>(omp_get_nested());
 #endif
   return (OpenMP::in_parallel(space) && !(is_nested && (omp_get_level() == 1)));
 }

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -45,6 +45,9 @@ namespace Kokkos {
 namespace Impl {
 
 inline bool execute_in_serial(OpenMP const& space = OpenMP()) {
+  // FIXME_OPENMP - `omp_get_max_active_levels` fails with gcc version lower
+  // than 11.2.0
+#if KOKKOS_COMPILER_GNU >= 1120
   return (OpenMP::in_parallel(space) && !(
 #if _OPENMP >= 201511
                                             (omp_get_max_active_levels() > 1)
@@ -52,6 +55,10 @@ inline bool execute_in_serial(OpenMP const& space = OpenMP()) {
                                             omp_get_nested()
 #endif
                                             && (omp_get_level() == 1)));
+#else
+  return (OpenMP::in_parallel(space) &&
+          !(omp_get_nested() && (omp_get_level() == 1)));
+#endif
 }
 
 }  // namespace Impl

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -45,8 +45,8 @@ namespace Kokkos {
 namespace Impl {
 
 inline bool execute_in_serial(OpenMP const& space = OpenMP()) {
-// The default value returned by `omp_get_max_active_levels` with gcc version lower
-// than 11.1.0 is 2147483647 instead of 1.
+// The default value returned by `omp_get_max_active_levels` with gcc version
+// lower than 11.1.0 is 2147483647 instead of 1.
 #if (!defined(KOKKOS_COMPILER_GNU) || KOKKOS_COMPILER_GNU >= 1110) && \
     _OPENMP >= 201511
   bool is_nested = omp_get_max_active_levels() > 1;

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -47,7 +47,7 @@ namespace Impl {
 inline bool execute_in_serial(OpenMP const& space = OpenMP()) {
   // FIXME_OPENMP - `omp_get_max_active_levels` fails with gcc version lower
   // than 11.2.0
-#if KOKKOS_COMPILER_GNU >= 1120
+#if KOKKOS_COMPILER_GNU >= 1110
   return (OpenMP::in_parallel(space) && !(
 #if _OPENMP >= 201511
                                             (omp_get_max_active_levels() > 1)

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -45,20 +45,15 @@ namespace Kokkos {
 namespace Impl {
 
 inline bool execute_in_serial(OpenMP const& space = OpenMP()) {
-  // FIXME_OPENMP - `omp_get_max_active_levels` fails with gcc version lower
-  // than 11.2.0
-#if KOKKOS_COMPILER_GNU >= 1110
-  return (OpenMP::in_parallel(space) && !(
-#if _OPENMP >= 201511
-                                            (omp_get_max_active_levels() > 1)
+// FIXME_OPENMP - `omp_get_max_active_levels` fails with gcc version lower
+// than 11.1.0
+#if (!defined(KOKKOS_COMPILER_GNU) || KOKKOS_COMPILER_GNU >= 1110) && \
+    _OPENMP >= 201511
+  int is_nested = omp_get_max_active_levels() > 1;
 #else
-                                            omp_get_nested()
+  int is_nested = omp_get_nested();
 #endif
-                                            && (omp_get_level() == 1)));
-#else
-  return (OpenMP::in_parallel(space) &&
-          !(omp_get_nested() && (omp_get_level() == 1)));
-#endif
+  return (OpenMP::in_parallel(space) && !(is_nested && (omp_get_level() == 1)));
 }
 
 }  // namespace Impl


### PR DESCRIPTION
`omp_get_max_active_level` fails with gcc versions lower than 11.2.0. 
So reverting to the prior implementation which was changed here #6666 

This fixes the issue seen in #6670 