### PR TITLE
Provide new public headers `<Kokkos_Clamp.hpp>` and `<Kokkos_MinMax.hpp>`

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -28,7 +28,6 @@
 #include <Cuda/Kokkos_Cuda_KernelLaunch.hpp>
 #include <Cuda/Kokkos_Cuda_ReduceScan.hpp>
 #include <Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp>
-#include <Kokkos_MinMaxClamp.hpp>
 
 #include <impl/Kokkos_Tools.hpp>
 #include <typeinfo>

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -28,7 +28,6 @@
 #include <Cuda/Kokkos_Cuda_KernelLaunch.hpp>
 #include <Cuda/Kokkos_Cuda_ReduceScan.hpp>
 #include <Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp>
-#include <Kokkos_MinMaxClamp.hpp>
 
 #include <impl/Kokkos_Tools.hpp>
 #include <typeinfo>

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -32,7 +32,7 @@
 #include <Cuda/Kokkos_Cuda_ReduceScan.hpp>
 #include <Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp>
 #include <Cuda/Kokkos_Cuda_Team.hpp>
-#include <Kokkos_MinMaxClamp.hpp>
+#include <Kokkos_MinMax.hpp>
 #include <Kokkos_Vectorization.hpp>
 
 #include <impl/Kokkos_Tools.hpp>

--- a/core/src/HIP/Kokkos_HIP_TeamPolicyInternal.hpp
+++ b/core/src/HIP/Kokkos_HIP_TeamPolicyInternal.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_HIP_TEAM_POLICY_INTERNAL_HPP
 #define KOKKOS_HIP_TEAM_POLICY_INTERNAL_HPP
 
-#include <Kokkos_MinMaxClamp.hpp>
+#include <Kokkos_MinMax.hpp>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/Kokkos_Clamp.hpp
+++ b/core/src/Kokkos_Clamp.hpp
@@ -1,0 +1,41 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_CLAMP_HPP
+#define KOKKOS_CLAMP_HPP
+
+#include <Kokkos_Macros.hpp>
+
+namespace Kokkos {
+
+template <class T>
+constexpr KOKKOS_INLINE_FUNCTION const T& clamp(const T& value, const T& lo,
+                                                const T& hi) {
+  KOKKOS_EXPECTS(!(hi < lo));
+  return (value < lo) ? lo : (hi < value) ? hi : value;
+}
+
+template <class T, class ComparatorType>
+constexpr KOKKOS_INLINE_FUNCTION const T& clamp(const T& value, const T& lo,
+                                                const T& hi,
+                                                ComparatorType comp) {
+  KOKKOS_EXPECTS(!comp(hi, lo));
+  return comp(value, lo) ? lo : comp(hi, value) ? hi : value;
+}
+
+}  // namespace Kokkos
+
+#endif

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -47,7 +47,8 @@
 #include <Kokkos_Half.hpp>
 #include <Kokkos_AnonymousSpace.hpp>
 #include <Kokkos_Pair.hpp>
-#include <Kokkos_MinMaxClamp.hpp>
+#include <Kokkos_Clamp.hpp>
+#include <Kokkos_MinMax.hpp>
 #include <Kokkos_MathematicalConstants.hpp>
 #include <Kokkos_MathematicalFunctions.hpp>
 #include <Kokkos_MathematicalSpecialFunctions.hpp>

--- a/core/src/Kokkos_MinMax.hpp
+++ b/core/src/Kokkos_MinMax.hpp
@@ -14,8 +14,8 @@
 //
 //@HEADER
 
-#ifndef KOKKOS_MIN_MAX_CLAMP_HPP
-#define KOKKOS_MIN_MAX_CLAMP_HPP
+#ifndef KOKKOS_MIN_MAX_HPP
+#define KOKKOS_MIN_MAX_HPP
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Pair.hpp>
@@ -23,22 +23,6 @@
 #include <initializer_list>
 
 namespace Kokkos {
-
-// clamp
-template <class T>
-constexpr KOKKOS_INLINE_FUNCTION const T& clamp(const T& value, const T& lo,
-                                                const T& hi) {
-  KOKKOS_EXPECTS(!(hi < lo));
-  return (value < lo) ? lo : (hi < value) ? hi : value;
-}
-
-template <class T, class ComparatorType>
-constexpr KOKKOS_INLINE_FUNCTION const T& clamp(const T& value, const T& lo,
-                                                const T& hi,
-                                                ComparatorType comp) {
-  KOKKOS_EXPECTS(!comp(hi, lo));
-  return comp(value, lo) ? lo : comp(hi, value) ? hi : value;
-}
 
 // max
 template <class T>

--- a/core/src/Kokkos_MinMaxClamp.hpp
+++ b/core/src/Kokkos_MinMaxClamp.hpp
@@ -14,11 +14,6 @@
 //
 //@HEADER
 
-#ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-#include <Kokkos_Macros.hpp>
-static_assert(false,
-              "Including non-public Kokkos header files is not allowed.");
-#endif
 #ifndef KOKKOS_MIN_MAX_CLAMP_HPP
 #define KOKKOS_MIN_MAX_CLAMP_HPP
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -39,7 +39,7 @@ static_assert(false,
 #ifdef KOKKOS_ENABLE_IMPL_MDSPAN
 #include <View/MDSpan/Kokkos_MDSpan_Extents.hpp>
 #endif
-#include <Kokkos_MinMaxClamp.hpp>
+#include <Kokkos_MinMax.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------


### PR DESCRIPTION
These are useful universal utility function that are helpful to downstream apps. Right now, the apps' choice is to either write one of their own, or bring the full `Kokkos_Core.hpp`. 