### PR TITLE
Drop unnecessary if-conditions in `Profiling::ProfilingSection`

### DIFF
--- a/core/src/Kokkos_Profiling_ProfileSection.hpp
+++ b/core/src/Kokkos_Profiling_ProfileSection.hpp
@@ -22,7 +22,6 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#include <impl/Kokkos_Profiling_Interface.hpp>
 #include <impl/Kokkos_Profiling.hpp>
 
 #include <string>

--- a/core/src/Kokkos_Profiling_ProfileSection.hpp
+++ b/core/src/Kokkos_Profiling_ProfileSection.hpp
@@ -36,28 +36,14 @@ class ProfilingSection {
   ProfilingSection& operator=(ProfilingSection const&) = delete;
 
   ProfilingSection(const std::string& sectionName) {
-    if (Kokkos::Profiling::profileLibraryLoaded()) {
-      Kokkos::Profiling::createProfileSection(sectionName, &secID);
-    }
+    Kokkos::Profiling::createProfileSection(sectionName, &secID);
   }
 
-  void start() {
-    if (Kokkos::Profiling::profileLibraryLoaded()) {
-      Kokkos::Profiling::startSection(secID);
-    }
-  }
+  void start() { Kokkos::Profiling::startSection(secID); }
 
-  void stop() {
-    if (Kokkos::Profiling::profileLibraryLoaded()) {
-      Kokkos::Profiling::stopSection(secID);
-    }
-  }
+  void stop() { Kokkos::Profiling::stopSection(secID); }
 
-  ~ProfilingSection() {
-    if (Kokkos::Profiling::profileLibraryLoaded()) {
-      Kokkos::Profiling::destroyProfileSection(secID);
-    }
-  }
+  ~ProfilingSection() { Kokkos::Profiling::destroyProfileSection(secID); }
 
  protected:
   uint32_t secID;


### PR DESCRIPTION
The `invoke_kokkosp_callback` internal handles the guarding for whether a tool library is loaded or not, and more importantly whether the tool actually handles sections at all.
https://github.com/kokkos/kokkos/blob/cbbe09b93db49e081ab4d400975aca8c007c4223/core/src/impl/Kokkos_Profiling.cpp#L477-L500

I don't think that the `if (Kokkos::Profiling::profileLibraryLoaded())` is needed but if the reviewers disagree then we probably should add it to `Profiling::ScopedRegion`.
https://github.com/kokkos/kokkos/blob/cbbe09b93db49e081ab4d400975aca8c007c4223/core/src/Kokkos_Profiling_ScopedRegion.hpp#L39-L42

Drive-by change: removed pointless header include