### PR TITLE
Let `Profiling::ProfilingSection(std::string)` constructor be explicit and nodiscard

### DIFF
--- a/core/src/Kokkos_Profiling_ProfileSection.hpp
+++ b/core/src/Kokkos_Profiling_ProfileSection.hpp
@@ -29,11 +29,14 @@
 namespace Kokkos {
 namespace Profiling {
 
-class ProfilingSection {
+class [[nodiscard]] ProfilingSection {
  public:
   ProfilingSection(ProfilingSection const&) = delete;
   ProfilingSection& operator=(ProfilingSection const&) = delete;
 
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(nodiscard) >= 201907
+  [[nodiscard]]
+#endif
   ProfilingSection(const std::string& sectionName) {
     Kokkos::Profiling::createProfileSection(sectionName, &secID);
   }

--- a/core/src/Kokkos_Profiling_ProfileSection.hpp
+++ b/core/src/Kokkos_Profiling_ProfileSection.hpp
@@ -37,7 +37,7 @@ class [[nodiscard]] ProfilingSection {
 #if defined(__has_cpp_attribute) && __has_cpp_attribute(nodiscard) >= 201907
   [[nodiscard]]
 #endif
-  ProfilingSection(const std::string& sectionName) {
+  explicit ProfilingSection(const std::string& sectionName) {
     Kokkos::Profiling::createProfileSection(sectionName, &secID);
   }
 


### PR DESCRIPTION
Rational: mostly consistency

This aligns with what we did for `ScopedRegion`
https://github.com/kokkos/kokkos/blob/2ac06ce637bfa4f236bd1dbc83dadca9e2206075/core/src/Kokkos_Profiling_ScopedRegion.hpp#L31-L38

The nodiscard attribute will warn on a common beginner error to "forget" to give the scope guard variable a name (although admittedly creating a section without calling start/stop is unlikely so that error would not occur in practice).

If we do any change at all, we might as well mark the constructor as explicit.