### PR TITLE
Trivial changes to `ProfilingSection`

### DIFF
--- a/core/src/Kokkos_Profiling_ProfileSection.hpp
+++ b/core/src/Kokkos_Profiling_ProfileSection.hpp
@@ -26,10 +26,11 @@
 
 #include <string>
 
-namespace Kokkos {
-namespace Profiling {
+namespace Kokkos::Profiling {
 
 class [[nodiscard]] ProfilingSection {
+  uint32_t sectionID;
+
  public:
   ProfilingSection(ProfilingSection const&) = delete;
   ProfilingSection& operator=(ProfilingSection const&) = delete;
@@ -38,21 +39,17 @@ class [[nodiscard]] ProfilingSection {
   [[nodiscard]]
 #endif
   explicit ProfilingSection(const std::string& sectionName) {
-    Kokkos::Profiling::createProfileSection(sectionName, &secID);
+    Kokkos::Profiling::createProfileSection(sectionName, &sectionID);
   }
 
-  void start() { Kokkos::Profiling::startSection(secID); }
+  void start() { Kokkos::Profiling::startSection(sectionID); }
 
-  void stop() { Kokkos::Profiling::stopSection(secID); }
+  void stop() { Kokkos::Profiling::stopSection(sectionID); }
 
-  ~ProfilingSection() { Kokkos::Profiling::destroyProfileSection(secID); }
-
- protected:
-  uint32_t secID;
+  ~ProfilingSection() { Kokkos::Profiling::destroyProfileSection(sectionID); }
 };
 
-}  // namespace Profiling
-}  // namespace Kokkos
+}  // namespace Kokkos::Profiling
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_CORE
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE


### PR DESCRIPTION
Nested namespace declaration, renaming of the private data member, and such.
Nothing user facing.  Just things that bothered me in #6690 and #6689 
Not a big deal if you don't agree.  Just figured I would propose it just in case.