### PR TITLE
Cleanup: remove unused `reduction_identity<Test::point_t>` specialization

### DIFF
--- a/core/unit_test/TestNonTrivialScalarTypes.hpp
+++ b/core/unit_test/TestNonTrivialScalarTypes.hpp
@@ -270,21 +270,5 @@ struct reduction_identity<Test::array_reduce<scalar_t, N>> {
     return Test::array_reduce<scalar_t, N>(t_red_ident::prod());
   }
 };
-
-template <>
-struct reduction_identity<Test::point_t> {
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static uint8_t sum() noexcept {
-    return 0;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static uint8_t prod() noexcept {
-    return 1;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static uint8_t max() noexcept {
-    return 0xff;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static uint8_t min() noexcept {
-    return 0x0;
-  }
-};
 }  // namespace Kokkos
 #endif  // TESTNONTRIVIALSCALARTYPES_HPP_


### PR DESCRIPTION
Address #6694
We thought the `reduction_identity` specialization for `point_t` looked fishy (e.g. the return type of the member functions is not `point_t`) when reviewing #5334 and were trying to understand why the `point_t` default constructor needed changes.  The answer was "it is never used".

Daniel recalled how custom reductions work in https://github.com/kokkos/kokkos/issues/6694#issuecomment-1875876600

For the record, `point_t` and the unnecessary specialization of `reduction_identity` were introduced in  #4156