### PR TITLE
Fixup cast tolerance to double before printing

### DIFF
--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -293,7 +293,7 @@ struct FloatingPointComparison {
     bool ar = absolute(fpv) < abs_tol;
     if (!ar) {
       Kokkos::printf("absolute value exceeds tolerance [|%e| > %e]\n",
-                     (double)fpv, abs_tol);
+                     (double)fpv, (double)abs_tol);
     }
 
     return ar;
@@ -314,7 +314,7 @@ struct FloatingPointComparison {
       bool ar         = abs_diff == 0 || rel_diff < rel_tol;
       if (!ar) {
         Kokkos::printf("relative difference exceeds tolerance [%e > %e]\n",
-                       (double)rel_diff, rel_tol);
+                       (double)rel_diff, (double)rel_tol);
       }
 
       return ar;


### PR DESCRIPTION
Fix #6698 
Bug introduced in #6647 and broke the SYCL build on Jenkins
```
/opt/intel/oneapi/compiler/2023.0.0/linux/bin-llvm/../include/sycl/ext/oneapi/experimental/builtins.hpp:89:10: error: cannot compile this non-scalar arg to printf yet
  return ::printf(__format, args...);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [core/unit_test/CMakeFiles/Kokkos_CoreUnitTest_SYCL1A.dir/build.make:538: core/unit_test/CMakeFiles/Kokkos_CoreUnitTest_SYCL1A.dir/sycl/TestSYCL_MathematicalFunctions1.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2059: core/unit_test/CMakeFiles/Kokkos_CoreUnitTest_SYCL1A.dir/all] Error 2