### PR TITLE
Deprecate `{Cuda,HIP}::detect_device_count()` and `Cuda::[detect_]device_arch()`

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -184,9 +184,6 @@ class Cuda {
   /// This matches the __CUDA_ARCH__ specification.
   static size_type device_arch();
 
-  //! Query device count.
-  static size_type detect_device_count();
-
   /** \brief  Detect the available devices and their architecture
    *          as defined by the __CUDA_ARCH__ specification.
    */

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -204,7 +204,7 @@ class Cuda {
     std::vector<unsigned> out;
     for (int i = 0; i < count; ++i) {
       cudaDeviceProp prop;
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceProperties(prop, i));
+      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceProperties(&prop, i));
       out.push_back(prop.major * 100 + prop.minor);
     }
     return out;

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -179,11 +179,6 @@ class Cuda {
   //! Initialize, telling the CUDA run-time library which device to use.
   static void impl_initialize(InitializationSettings const&);
 
-  /// \brief Cuda device architecture of the selected device.
-  ///
-  /// This matches the __CUDA_ARCH__ specification.
-  static size_type device_arch();
-
   cudaStream_t cuda_stream() const;
   int cuda_device() const;
   const cudaDeviceProp& cuda_device_prop() const;

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -198,7 +198,7 @@ class Cuda {
   /** \brief  Detect the available devices and their architecture
    *          as defined by the __CUDA_ARCH__ specification.
    */
-  KOKKOS_DEPRECATED static std::vector<unsigned> detect_device_arch() const {
+  KOKKOS_DEPRECATED static std::vector<unsigned> detect_device_arch() {
     int count;
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&count));
     std::vector<unsigned> out;

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -184,7 +184,7 @@ class Cuda {
   ///
   /// This matches the __CUDA_ARCH__ specification.
   KOKKOS_DEPRECATED static size_type device_arch() {
-    const cudaDeviceProp& cudaProp = cuda_device_prop();
+    const cudaDeviceProp& cudaProp = Cuda().cuda_device_prop();
     return cudaProp.major * 100 + cudaProp.minor;
   }
 

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -179,6 +179,38 @@ class Cuda {
   //! Initialize, telling the CUDA run-time library which device to use.
   static void impl_initialize(InitializationSettings const&);
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  /// \brief Cuda device architecture of the selected device.
+  ///
+  /// This matches the __CUDA_ARCH__ specification.
+  KOKKOS_DEPRECATED static size_type device_arch() {
+    const cudaDeviceProp& cudaProp = cuda_device_prop();
+    return cudaProp.major * 100 + cudaProp.minor;
+  }
+
+  //! Query device count.
+  KOKKOS_DEPRECATED static size_type detect_device_count() {
+    int count;
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&count));
+    return
+  }
+
+  /** \brief  Detect the available devices and their architecture
+   *          as defined by the __CUDA_ARCH__ specification.
+   */
+  KOKKOS_DEPRECATED static std::vector<unsigned> detect_device_arch() const {
+    int count;
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&count));
+    std::vector<unsigned> out;
+    for (int i = 0; i < count; ++i) {
+      cudaDeviceProp prop;
+      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceProperties(prop, i));
+      out.push_back(prop.major * 100 + prop.minor);
+    }
+    return out;
+  }
+#endif
+
   cudaStream_t cuda_stream() const;
   int cuda_device() const;
   const cudaDeviceProp& cuda_device_prop() const;

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -192,7 +192,7 @@ class Cuda {
   KOKKOS_DEPRECATED static size_type detect_device_count() {
     int count;
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&count));
-    return
+    return count;
   }
 
   /** \brief  Detect the available devices and their architecture

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -184,11 +184,6 @@ class Cuda {
   /// This matches the __CUDA_ARCH__ specification.
   static size_type device_arch();
 
-  /** \brief  Detect the available devices and their architecture
-   *          as defined by the __CUDA_ARCH__ specification.
-   */
-  static std::vector<unsigned> detect_device_arch();
-
   cudaStream_t cuda_stream() const;
   int cuda_device() const;
   const cudaDeviceProp& cuda_device_prop() const;

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -670,11 +670,6 @@ Kokkos::Cuda::initialize WARNING: Cuda is allocating into UVMSpace by default
                                              /*manage*/ true);
 }
 
-Cuda::size_type Cuda::device_arch() {
-  const cudaDeviceProp &cudaProp = cuda_device_prop();
-  return cudaProp.major * 100 + cudaProp.minor;
-}
-
 void Cuda::impl_finalize() { Impl::CudaInternal::singleton().finalize(); }
 
 Cuda::Cuda()

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -593,8 +593,10 @@ int Cuda::impl_is_initialized() {
 void Cuda::impl_initialize(InitializationSettings const &settings) {
   const int cuda_device_id = Impl::get_gpu(settings);
 
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceProperties(
-      &Impl::CudaInternal::m_deviceProp, cuda_device_id));
+  cudaDeviceProp cudaProp;
+  KOKKOS_IMPL_CUDA_SAFE_CALL(
+      cudaGetDeviceProperties(&cudaProp, cuda_device_id));
+  Impl::CudaInternal::m_deviceProp = cudaProp;
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(cuda_device_id));
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaDeviceSynchronize());
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -666,10 +666,6 @@ Cuda::size_type *cuda_internal_scratch_unified(const Cuda &instance,
 
 namespace Kokkos {
 
-Cuda::size_type Cuda::detect_device_count() {
-  return Impl::CudaInternalDevices::singleton().m_cudaDevCount;
-}
-
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 int Cuda::concurrency() {
 #else

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -593,7 +593,7 @@ int Cuda::impl_is_initialized() {
 void Cuda::impl_initialize(InitializationSettings const &settings) {
   const int cuda_device_id = Impl::get_gpu(settings);
 
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceProperties(&Impl::CudaInternal::m_deviceProp, cuda_device_id);
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceProperties(&Impl::CudaInternal::m_deviceProp, cuda_device_id));
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(cuda_device_id));
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaDeviceSynchronize());
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -593,7 +593,8 @@ int Cuda::impl_is_initialized() {
 void Cuda::impl_initialize(InitializationSettings const &settings) {
   const int cuda_device_id = Impl::get_gpu(settings);
 
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceProperties(&Impl::CudaInternal::m_deviceProp, cuda_device_id));
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceProperties(
+      &Impl::CudaInternal::m_deviceProp, cuda_device_id));
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(cuda_device_id));
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaDeviceSynchronize());
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -231,11 +231,11 @@ void CudaInternal::print_configuration(std::ostream &s) const {
   for (int i = 0; i < count; ++i) {
     cudaDeviceProp prop;
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceProperties(&prop, i));
-    s << "Kokkos::Cuda[ " << i << " ] " << prop[i].name << " capability "
-      << prop[i].major << "." << prop[i].minor
-      << ", Total Global Memory: " << human_memory_size(prop[i].totalGlobalMem)
+    s << "Kokkos::Cuda[ " << i << " ] " << prop.name << " capability "
+      << prop.major << "." << prop.minor
+      << ", Total Global Memory: " << human_memory_size(prop.totalGlobalMem)
       << ", Shared Memory per Block: "
-      << human_memory_size(prop[i].sharedMemPerBlock);
+      << human_memory_size(prop.sharedMemPerBlock);
     if (m_cudaDev == i) s << " : Selected";
     s << '\n';
   }

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -266,19 +266,6 @@ class CudaInternal {
   }
 
   template <bool setCudaDevice = true>
-  cudaError_t cuda_get_device_count_wrapper(int* count) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaGetDeviceCount(count);
-  }
-
-  template <bool setCudaDevice = true>
-  cudaError_t cuda_get_device_properties_wrapper(cudaDeviceProp* prop,
-                                                 int device) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaGetDeviceProperties(prop, device);
-  }
-
-  template <bool setCudaDevice = true>
   const char* cuda_get_error_name_wrapper(cudaError_t error) const {
     if constexpr (setCudaDevice) set_cuda_device();
     return cudaGetErrorName(error);

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -96,8 +96,6 @@ class HIP {
 
   //  static size_type device_arch();
 
-  static size_type detect_device_count();
-
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static int concurrency();
 #else

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -95,6 +95,14 @@ class HIP {
   static int impl_is_initialized();
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED static size_type detect_device_count() {
+    int count;
+    KOKKOS_IMPL_HIP_SAFE_CALL(hipGetDeviceCount(&count));
+    return count;
+  }
+#endif
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static int concurrency();
 #else
   int concurrency() const;

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -94,8 +94,6 @@ class HIP {
 
   static int impl_is_initialized();
 
-  //  static size_type device_arch();
-
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static int concurrency();
 #else

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -420,12 +420,4 @@ void Kokkos::Impl::create_HIP_instances(std::vector<HIP> &instances) {
   }
 }
 
-//----------------------------------------------------------------------------
-
-namespace Kokkos {
-HIP::size_type HIP::detect_device_count() {
-  int hipDevCount;
-  KOKKOS_IMPL_HIP_SAFE_CALL(hipGetDeviceCount(&hipDevCount));
-  return hipDevCount;
-}
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -131,9 +131,13 @@ void combine(Kokkos::Tools::InitArguments& out,
 
 int get_device_count() {
 #if defined(KOKKOS_ENABLE_CUDA)
-  return Kokkos::Cuda::detect_device_count();
+  int count;
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&count));
+  return count;
 #elif defined(KOKKOS_ENABLE_HIP)
-  return Kokkos::HIP::detect_device_count();
+  int count;
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipGetDeviceCount(&count));
+  return count;
 #elif defined(KOKKOS_ENABLE_SYCL)
   return sycl::device::get_devices(sycl::info::device_type::gpu).size();
 #elif defined(KOKKOS_ENABLE_OPENACC)


### PR DESCRIPTION
* Deprecate
  * `Cuda::detect_device_count()`
  * `Cuda::device_arch()`
  * `Cuda::detect_device_arch()`
  * `HIP::detect_device_count()`
* Inline getting the device count with CUDA and HIP (cannot be generic and indirection brings no benefit)
* Get rid of `CudaInternalDevices`
* Cleanup `Cuda::print_configuration`
* Get rid of a couple CUDA wrapper functions where setting the device made no sense   
  * `CudaIntenal::cuda_get_device_count_wrapper` 
  * `CudaIntenal::cuda_get_device_properties_wrapper ` 

