### PR TITLE
Drop pointless `Impl::CudaExec` forward declaration that has no matching definition

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -46,7 +46,6 @@ static_assert(false,
 
 namespace Kokkos {
 namespace Impl {
-class CudaExec;
 class CudaInternal;
 }  // namespace Impl
 }  // namespace Kokkos


### PR DESCRIPTION
Clearly an oversight