### PR TITLE
Cleanup some CUDA error message handling

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -600,10 +600,8 @@ void Cuda::impl_initialize(InitializationSettings const &settings) {
   Impl::CudaInternal::m_cudaArch = Impl::cuda_kernel_arch(cuda_device_id);
 
   if (Impl::CudaInternal::m_cudaArch == 0) {
-    std::stringstream ss;
-    ss << "Kokkos::Cuda::initialize ERROR: likely mismatch of architecture\n";
-    std::string msg = ss.str();
-    Kokkos::abort(msg.c_str());
+    Kokkos::abort(
+        "Kokkos::Cuda::initialize ERROR: likely mismatch of architecture\n");
   }
 
   int compiled_major = Impl::CudaInternal::m_cudaArch / 100;

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -183,10 +183,8 @@ void cuda_stream_synchronize(
 void cuda_internal_error_throw(cudaError e, const char *name, const char *file,
                                const int line) {
   std::ostringstream out;
-  out << name << " error( "
-      << CudaInternal::singleton().cuda_get_error_name_wrapper<false>(e)
-      << "): "
-      << CudaInternal::singleton().cuda_get_error_string_wrapper<false>(e);
+  out << name << " error( " << cudaGetErrorName(e)
+      << "): " << cudaGetErrorString(e);
   if (file) {
     out << " " << file << ":" << line;
   }
@@ -196,10 +194,8 @@ void cuda_internal_error_throw(cudaError e, const char *name, const char *file,
 void cuda_internal_error_abort(cudaError e, const char *name, const char *file,
                                const int line) {
   std::ostringstream out;
-  out << name << " error( "
-      << CudaInternal::singleton().cuda_get_error_name_wrapper<false>(e)
-      << "): "
-      << CudaInternal::singleton().cuda_get_error_string_wrapper<false>(e);
+  out << name << " error( " << cudaGetErrorName(e)
+      << "): " << cudaGetErrorString(e);
   if (file) {
     out << " " << file << ":" << line;
   }

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -266,18 +266,6 @@ class CudaInternal {
   }
 
   template <bool setCudaDevice = true>
-  const char* cuda_get_error_name_wrapper(cudaError_t error) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaGetErrorName(error);
-  }
-
-  template <bool setCudaDevice = true>
-  const char* cuda_get_error_string_wrapper(cudaError_t error) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaGetErrorString(error);
-  }
-
-  template <bool setCudaDevice = true>
   cudaError_t cuda_get_last_error_wrapper() const {
     if constexpr (setCudaDevice) set_cuda_device();
     return cudaGetLastError();


### PR DESCRIPTION
* Get rid of unnecessary wrapper around the CUDA runtime API
  * `CudaInternal::cuda_get_error_name_wrapper`
  * `CudaInternal::cuda_get_error_string_wrapper`
* Do not create a `std::stringstream` to convert to `std::string` when the error message is known at compile time
