### PR TITLE
Add runtime function to query the number of devices and make device ID consistent with `KOKKOS_VISIBLE_DEVICES`

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -221,10 +221,7 @@ void CudaInternal::print_configuration(std::ostream &s) const {
     << CUDA_VERSION / 1000 << "." << (CUDA_VERSION % 1000) / 10 << '\n';
 #endif
 
-  int count;
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&count));
-
-  for (int i = 0; i < count; ++i) {
+  for (int i : get_visible_devices()) {
     cudaDeviceProp prop;
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceProperties(&prop, i));
     s << "Kokkos::Cuda[ " << i << " ] " << prop.name << " capability "

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -27,6 +27,7 @@
 #include <HIP/Kokkos_HIP.hpp>
 #include <HIP/Kokkos_HIP_Space.hpp>
 #include <impl/Kokkos_CheckedIntegerOps.hpp>
+#include <impl/Kokkos_DeviceManagement.hpp>
 #include <impl/Kokkos_Error.hpp>
 
 /*--------------------------------------------------------------------------*/
@@ -89,10 +90,7 @@ void HIPInternal::print_configuration(std::ostream &s) const {
     << '\n';
 #endif
 
-  int hipDevCount;
-  KOKKOS_IMPL_HIP_SAFE_CALL(hipGetDeviceCount(&hipDevCount));
-
-  for (int i = 0; i < hipDevCount; ++i) {
+  for (int i : get_visible_devices()) {
     hipDeviceProp_t hipProp;
     KOKKOS_IMPL_HIP_SAFE_CALL(hipGetDeviceProperties(&hipProp, i));
     std::string gpu_type = hipProp.integrated == 1 ? "APU" : "dGPU";

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -102,6 +102,7 @@ void declare_configuration_metadata(const std::string& category,
 [[nodiscard]] bool is_finalized() noexcept;
 
 [[nodiscard]] int device_id() noexcept;
+[[nodiscard]] int num_devices() noexcept;
 [[nodiscard]] int num_threads() noexcept;
 
 bool show_warnings() noexcept;

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -198,7 +198,12 @@ std::vector<int> const& Kokkos::Impl::get_visible_devices() {
 }
 
 [[nodiscard]] int Kokkos::num_devices() noexcept {
-  return Impl::get_visible_devices().size();
+  if constexpr (std::is_same_v<DefaultExecutionSpace,
+                               DefaultHostExecutionSpace>) {
+    return -1;  // no GPU backend enabled
+  } else {
+    return Impl::get_visible_devices().size();
+  }
 }
 
 [[nodiscard]] int Kokkos::num_threads() noexcept {

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -167,6 +167,11 @@ bool is_valid_map_device_id_by(std::string const& x) {
 
 }  // namespace
 
+std::vector<int> const& Kokkos::Impl::get_visible_devices() {
+  static auto devices = get_visible_devices(get_device_count());
+  return devices;
+}
+
 [[nodiscard]] int Kokkos::device_id() noexcept {
 #if defined(KOKKOS_ENABLE_CUDA)
   int device = Cuda().cuda_device();
@@ -190,11 +195,6 @@ bool is_valid_map_device_id_by(std::string const& x) {
   }
   Kokkos::abort("implementation bug");
   return -1;
-}
-
-std::vector<int> const& Kokkos::Impl::get_visible_devices() {
-  static auto devices = get_visible_devices(get_device_count());
-  return devices;
 }
 
 [[nodiscard]] int Kokkos::num_threads() noexcept {

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -193,7 +193,7 @@ std::vector<int> const& Kokkos::Impl::get_visible_devices() {
       return i;
     }
   }
-  Kokkos::abort("implementation bug");
+  Kokkos::abort("Unexpected error: cannot determine device id");
   return -1;
 }
 

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -197,6 +197,10 @@ std::vector<int> const& Kokkos::Impl::get_visible_devices() {
   return -1;
 }
 
+[[nodiscard]] int Kokkos::num_devices() noexcept {
+  return Impl::get_visible_devices().size();
+}
+
 [[nodiscard]] int Kokkos::num_threads() noexcept {
   return DefaultHostExecutionSpace().concurrency();
 }

--- a/core/src/impl/Kokkos_DeviceManagement.hpp
+++ b/core/src/impl/Kokkos_DeviceManagement.hpp
@@ -25,8 +25,8 @@ namespace Impl {
 int get_gpu(const Kokkos::InitializationSettings& settings);
 // This declaration is provided for testing purposes only
 int get_ctest_gpu(int local_rank);
-// ditto
-std::vector<int> get_visible_devices(int device_count);
+std::vector<int> get_visible_devices(int device_count);  // test-only
+std::vector<int> const& get_visible_devices();           // use this instead
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -1235,12 +1235,10 @@ if (NOT KOKKOS_HAS_TRILINOS)
       INPUT TestDeviceAndThreads.py
       ${USE_SOURCE_PERMISSIONS_WHEN_SUPPORTED}
     )
-    if(NOT Kokkos_ENABLE_OPENMPTARGET)  # FIXME_OPENMPTARGET does not select the right device
-      add_test(
-        NAME Kokkos_CoreUnitTest_DeviceAndThreads
-        COMMAND ${Python3_EXECUTABLE} -m unittest -v $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py
-      )
-    endif()
+    add_test(
+      NAME Kokkos_CoreUnitTest_DeviceAndThreads
+      COMMAND ${Python3_EXECUTABLE} -m unittest -v $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py
+    )
   endif()
 endif()
 

--- a/core/unit_test/TestDeviceAndThreads.py
+++ b/core/unit_test/TestDeviceAndThreads.py
@@ -18,6 +18,7 @@
 import unittest
 import subprocess
 import platform
+import os
 
 PREFIX = "$<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>"
 EXECUTABLE = "$<TARGET_FILE_NAME:Kokkos_CoreUnitTest_DeviceAndThreads>"
@@ -65,6 +66,8 @@ class KokkosInitializationTestCase(unittest.TestCase):
                     "--kokkos-num-threads={}".format(num_threads)))
 
     def test_num_devices(self):
+        if "KOKKOS_VISIBLE_DEVICES" in os.environ:
+            self.skipTest("KOKKOS_VISIBLE_DEVICES environment variable is set")
         num_devices = GetFlag("num_devices")
         self.assertNotEqual(num_devices, 0)
         if num_devices == -1:
@@ -75,6 +78,8 @@ class KokkosInitializationTestCase(unittest.TestCase):
         self.assertGreaterEqual(device_id, 0)
 
     def test_device_id(self):
+        if "KOKKOS_VISIBLE_DEVICES" in os.environ:
+            self.skipTest("KOKKOS_VISIBLE_DEVICES environment variable is set")
         num_devices = GetFlag("num_devices")
         if num_devices == -1:
             self.assertEqual(-1, GetFlag("device_id"))

--- a/core/unit_test/TestDeviceAndThreads.py
+++ b/core/unit_test/TestDeviceAndThreads.py
@@ -71,11 +71,8 @@ class KokkosInitializationTestCase(unittest.TestCase):
         num_devices = GetFlag("num_devices")
         self.assertNotEqual(num_devices, 0)
         if num_devices == -1:
-            self.assertEqual(-1, GetFlag("device_id"))
             self.skipTest("no device backend enabled")
-        device_id = GetFlag("device_id")
-        self.assertLess(device_id, num_devices)
-        self.assertGreaterEqual(device_id, 0)
+        self.assertGreaterEqual(num_devices, 1)
 
     def test_device_id(self):
         if "KOKKOS_VISIBLE_DEVICES" in os.environ:

--- a/core/unit_test/TestDeviceAndThreads.py
+++ b/core/unit_test/TestDeviceAndThreads.py
@@ -64,13 +64,24 @@ class KokkosInitializationTestCase(unittest.TestCase):
                     "num_threads",
                     "--kokkos-num-threads={}".format(num_threads)))
 
+    def test_num_devices(self):
+        num_devices = GetFlag("num_devices")
+        self.assertNotEqual(num_devices, 0)
+        if num_devices == -1:
+            self.assertEqual(-1, GetFlag("device_id"))
+            self.skipTest("no device backend enabled")
+        device_id = GetFlag("device_id")
+        self.assertLess(device_id, num_devices)
+        self.assertGreaterEqual(device_id, 0)
+
     def test_device_id(self):
-        device_count = GetFlag("device_count")
-        if device_count == 0:
-            self.skipTest("no device detected")
+        num_devices = GetFlag("num_devices")
+        if num_devices == -1:
+            self.assertEqual(-1, GetFlag("device_id"))
+            self.skipTest("no device backend enabled")
         # by default use the first GPU available for execution
         self.assertEqual(0, GetFlag("device_id"))
-        for device_id in range(device_count):
+        for device_id in range(num_devices):
             self.assertEqual(
                 device_id,
                 GetFlag(

--- a/core/unit_test/UnitTest_DeviceAndThreads.cpp
+++ b/core/unit_test/UnitTest_DeviceAndThreads.cpp
@@ -19,22 +19,21 @@
 #include <string>
 #include <thread>
 
-int get_device_count() {
+int get_num_devices() {
+  int num_devices;
 #if defined(KOKKOS_ENABLE_CUDA)
-  int count;
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&count));
-  return count;
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&num_devices));
 #elif defined(KOKKOS_ENABLE_HIP)
-  int count;
-  KOKKOS_IMPL_HIP_SAFE_CALL(hipGetDevice(&count));
-  return count;
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipGetDevice(&num_devices));
 #elif defined(KOKKOS_ENABLE_OPENMPTARGET)
-  return omp_get_num_devices();
+  num_devices = omp_get_num_devices();
 #elif defined(KOKKOS_ENABLE_OPENACC)
-  return acc_get_num_devices(acc_get_device_type());
+  num_devices = acc_get_num_devices(acc_get_device_type());
 #else
-  return 0;
+  num_devices = -1;
 #endif
+  assert(num_devices == Kokkos::num_devices());
+  return num_devices;
 }
 
 int get_device_id() {
@@ -44,9 +43,9 @@ int get_device_id() {
 #elif defined(KOKKOS_ENABLE_HIP)
   KOKKOS_IMPL_HIP_SAFE_CALL(hipGetDevice(&device_id));
 #elif defined(KOKKOS_ENABLE_OPENMPTARGET)
-  device_id = omp_get_device_num();
+  device_id   = omp_get_device_num();
 #elif defined(KOKKOS_ENABLE_OPENACC)
-  device_id = acc_get_device_num(acc_get_device_type());
+  device_id   = acc_get_device_num(acc_get_device_type());
 #elif defined(KOKKOS_ENABLE_SYCL)
   // FIXME_SYCL ?
   assert(false);
@@ -98,7 +97,7 @@ int print_flag(std::string const& flag) {
   KOKKOS_TEST_PRINT_FLAG(num_threads);
   KOKKOS_TEST_PRINT_FLAG(max_threads);
   KOKKOS_TEST_PRINT_FLAG(device_id);
-  KOKKOS_TEST_PRINT_FLAG(device_count);
+  KOKKOS_TEST_PRINT_FLAG(num_devices);
   KOKKOS_TEST_PRINT_FLAG(disable_warnings);
   KOKKOS_TEST_PRINT_FLAG(tune_internals);
   KOKKOS_TEST_PRINT_FLAG(hwloc_enabled);

--- a/core/unit_test/UnitTest_DeviceAndThreads.cpp
+++ b/core/unit_test/UnitTest_DeviceAndThreads.cpp
@@ -29,6 +29,8 @@ int get_num_devices() {
   num_devices = omp_get_num_devices();
 #elif defined(KOKKOS_ENABLE_OPENACC)
   num_devices = acc_get_num_devices(acc_get_device_type());
+#elif defined(KOKKOS_ENABLE_SYCL)
+  num_devices = sycl::device::get_devices(sycl::info::device_type::gpu).size();
 #else
   num_devices = -1;
 #endif
@@ -47,11 +49,13 @@ int get_device_id() {
 #elif defined(KOKKOS_ENABLE_OPENACC)
   device_id   = acc_get_device_num(acc_get_device_type());
 #elif defined(KOKKOS_ENABLE_SYCL)
-  // FIXME_SYCL ?
-  assert(false);
-  return -2;
+  // Not able to query the underlying runtime because there is no such thing as
+  // device currently being used with SYCL.  We go through the Kokkos runtime
+  // which makes the assert below pointless but it still let us check that
+  // Kokkos selected the device we asked for from the Python tests.
+  device_id = Kokkos::device_id();
 #else
-  device_id = -1;
+  device_id   = -1;
 #endif
   assert(device_id == Kokkos::device_id());
   return device_id;

--- a/core/unit_test/UnitTest_DeviceAndThreads.cpp
+++ b/core/unit_test/UnitTest_DeviceAndThreads.cpp
@@ -24,7 +24,7 @@ int get_num_devices() {
 #if defined(KOKKOS_ENABLE_CUDA)
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&num_devices));
 #elif defined(KOKKOS_ENABLE_HIP)
-  KOKKOS_IMPL_HIP_SAFE_CALL(hipGetDevice(&num_devices));
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipGetDeviceCount(&num_devices));
 #elif defined(KOKKOS_ENABLE_OPENMPTARGET)
   num_devices = omp_get_num_devices();
 #elif defined(KOKKOS_ENABLE_OPENACC)


### PR DESCRIPTION
`Kokkos::num_devices()` is intended as a replacement for `{Cuda,HIP}::detect_device_count()` deprecated in #6710 
I propose to make it legal to call it before `Kokkos::initialize` so it may be leveraged to select what GPU to use.

This PR also fixes a defect in `Kokkos::device_id()` when the `KOKKOS_VISIBLE_DEVICES` environment variable is set.
The Kokkos runtime was returning the device id according to the underlying backend runtime but not taking into consideration whether the devices were masked out.  This was an oversight when we introduced it in #5855 (first released in 4.1)
Assume the current system has 4 GPUs, the table below shows the value returned by the `device_id()` runtime
initialization settings | current | this PR
--- | --- | ---
\<none\> | 0 | 0
`device_id=1` | 1 | 1
`KOKKOS_VISIBLE_DEVICES=0` | 0 | 0
`KOKKOS_VISIBLE_DEVICES=3` | 3 | 0
`KOKKOS_VISIBLE_DEVICES=1,0` | 1 | 0
`device_id=1` `KOKKOS_VISIBLE_DEVICES=1,0` | 0 | 1

I also went ahead and masked out devices in `{Cuda,HIP}::print_config`