### PR TITLE
HIP: Forgot to delete matching brace closing the namespace

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -419,5 +419,3 @@ void Kokkos::Impl::create_HIP_instances(std::vector<HIP> &instances) {
     instances[s] = HIP(stream, ManageStream::yes);
   }
 }
-
-}  // namespace Kokkos


### PR DESCRIPTION
Fix https://github.com/kokkos/kokkos/pull/6710/files#r1451637815

Saw this in the kokkos-tools CI
```
[ 64%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/HIP/Kokkos_HIP_DeepCopy.cpp.o
[ 67%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/HIP/Kokkos_HIP_Instance.cpp.o
/__w/kokkos-tools/kokkos-tools/kokkos/core/src/HIP/Kokkos_HIP_Instance.cpp:423:1: error: extraneous closing brace ('}')
}  // namespace Kokkos
^
1 error generated when compiling for gfx906.
gmake[2]: *** [core/src/CMakeFiles/kokkoscore.dir/build.make:328: core/src/CMakeFiles/kokkoscore.dir/HIP/Kokkos_HIP_Instance.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1059: core/src/CMakeFiles/kokkoscore.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
Error: Process completed with exit code 2.\
```

PS I have tested just as much as in the original PR
