### PR TITLE
Kokkos_HIP.cpp: include Kokkos_Core.hpp to resolve errors

### DIFF
--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -18,6 +18,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE
 #endif
 
+#include <Kokkos_Core.hpp>
 #include <HIP/Kokkos_HIP.hpp>
 #include <HIP/Kokkos_HIP_Instance.hpp>
 


### PR DESCRIPTION
Resolves errors of form:
/home/jenkins/caraway-new/workspace/KokkosKernels_PullRequest_VEGA90A_ROCM560/kokkos/core/src/HIP/Kokkos_HIP.cpp:96:15: error: no member named 'hip_global_unique_token_locks' in namespace 'Kokkos::Impl'
  (void)Impl::hip_global_unique_token_locks(true);

Note: include of Kokkos_HIP_UniqueToken.hpp was insufficient as this triggered new errors: /home/ndellin/kokkos/core/src/HIP/Kokkos_HIP_UniqueToken.hpp:40:29: error: implicit instantiation of undefined template 'Kokkos::View<unsigned int *, Kokkos::HIPSpace>'
  View<uint32_t*, HIPSpace> m_locks;