### PR TITLE
Use team_size_max to fix "Team size too large" error in reducer test

### DIFF
--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -373,8 +373,6 @@ struct TestReducers {
     }
 #endif
 
-    using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
-
     Scalar sum_scalar;
     Kokkos::View<Scalar, ExecSpace> sum_view("result");
     Kokkos::deep_copy(sum_view, Scalar(1));

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -418,7 +418,7 @@ struct TestReducers {
           Kokkos::TeamPolicy<ExecSpace>(league_size, team_size), tnf);
       auto result_h =
           Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), result);
-      for (auto i = 0; i < result_h.extent(0); ++i) {
+      for (int i = 0; i < result_h.extent_int(0); ++i) {
         ASSERT_EQ(result_h(i), reference_sum) << "N: " << N;
       }
     }

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -396,9 +396,6 @@ struct TestReducers {
       const int league_size = 1;
       Kokkos::View<Scalar*, ExecSpace> result("result", league_size);
       TeamSumNestedFunctor tnf(f, league_size, 0, result);
-      auto team_size_max = Kokkos::TeamPolicy<ExecSpace>(league_size, 1)
-                               .team_size_max(tnf, Kokkos::ParallelForTag());
-      auto team_size = std::min(team_size_max, TEST_EXECSPACE().concurrency());
       Kokkos::parallel_for(
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
           Kokkos::TeamPolicy<ExecSpace>(1, Kokkos::AUTO),


### PR DESCRIPTION
A recently added reducer test was using a teamsize that was too large in some configurations. Using `TeamPolicy::team_size_max()` as a upper bound to ensure team size is not too large.

I also reorganized the test to use a functor and changed the test with league size 10 to store results in a view size 10 since previously the result was stored in a dim-0 view and wa just being overwritten by the last team to store it. Maybe the test was supposed to have league size 1?

Closes https://github.com/kokkos/kokkos/issues/6699