### PR TITLE
Guard `[MD]RangePolicy` precondition check for deprecated code 4

### DIFF
--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -333,8 +333,12 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
             "Kokkos::MDRangePolicy bounds error: The lower bound (" +
             std::to_string(m_lower[i]) + ") is greater than its upper bound (" +
             std::to_string(m_upper[i]) + ") in dimension " + std::to_string(i) +
-            ".";
+            ".\n";
+#if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
         Kokkos::abort(msg.c_str());
+#elif defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
+        Kokkos::Impl::log_warning(msg);
+#endif
       }
 
       if (m_tile[i] <= 0) {

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -128,7 +128,6 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   /** \brief  Total range */
   inline RangePolicy(const member_type work_begin, const member_type work_end)
       : RangePolicy(typename traits::execution_space(), work_begin, work_end) {
-    check_bounds_validity();
     set_auto_chunk_size();
   }
 
@@ -227,8 +226,12 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
       std::string msg = "Kokkos::RangePolicy bounds error: The lower bound (" +
                         std::to_string(m_begin) +
                         ") is greater than the upper bound (" +
-                        std::to_string(m_end) + ").";
+                        std::to_string(m_end) + ").\n";
+#if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
       Kokkos::abort(msg.c_str());
+#elif defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
+      Kokkos::Impl::log_warning(msg);
+#endif
     }
   }
 

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -231,6 +231,8 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
       Kokkos::abort(msg.c_str());
 #elif defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
       Kokkos::Impl::log_warning(msg);
+      m_begin = 0;
+      m_end   = 0;
 #endif
     }
   }

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -227,12 +227,13 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
                         std::to_string(m_begin) +
                         ") is greater than the upper bound (" +
                         std::to_string(m_end) + ").\n";
-#if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
       Kokkos::abort(msg.c_str());
-#elif defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
-      Kokkos::Impl::log_warning(msg);
+#endif
       m_begin = 0;
       m_end   = 0;
+#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
+      Kokkos::Impl::log_warning(msg);
 #endif
     }
   }

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -221,7 +221,7 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
     m_granularity_mask = m_granularity - 1;
   }
 
-  inline void check_bounds_validity() {
+  void check_bounds_validity() {
     if (m_end < m_begin) {
       std::string msg = "Kokkos::RangePolicy bounds error: The lower bound (" +
                         std::to_string(m_begin) +

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -21,10 +21,11 @@
 #include <cstring>
 #include <cstdlib>
 
-#include <ostream>
+#include <iostream>
 #include <sstream>
 #include <iomanip>
 #include <stdexcept>
+#include <Kokkos_Core.hpp>  // show_warnings
 #include <impl/Kokkos_Error.hpp>
 #include <Cuda/Kokkos_Cuda_Error.hpp>
 
@@ -36,6 +37,12 @@ namespace Impl {
 
 void throw_runtime_exception(const std::string &msg) {
   throw std::runtime_error(msg);
+}
+
+void log_warning(const std::string &msg) {
+  if (show_warnings()) {
+    std::cerr << msg << std::flush;
+  }
 }
 
 std::string human_memory_size(size_t arg_bytes) {
@@ -64,7 +71,8 @@ std::string human_memory_size(size_t arg_bytes) {
 
 void Experimental::RawMemoryAllocationFailure::print_error_message(
     std::ostream &o) const {
-  o << "Allocation of size " << Impl::human_memory_size(m_attempted_size);
+  o << "Allocation of size "
+    << ::Kokkos::Impl::human_memory_size(m_attempted_size);
   o << " failed";
   switch (m_failure_mode) {
     case FailureMode::OutOfMemoryError:

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -28,6 +28,8 @@ namespace Impl {
 
 [[noreturn]] void throw_runtime_exception(const std::string &msg);
 
+void log_warning(const std::string &msg);
+
 std::string human_memory_size(size_t arg_bytes);
 
 }  // namespace Impl

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -105,7 +105,7 @@ TEST(TEST_CATEGORY_DEATH, policy_invalid_bounds) {
   std::string msg1 =
       "Kokkos::MDRangePolicy bounds error: The lower bound (100) is greater "
       "than its upper bound (90) in dimension " +
-      std::to_string(dim0) + ".\n";
+      std::to_string(dim0);
 
   std::string msg2 =
       "Kokkos::MDRangePolicy bounds error: The lower bound (100) is greater "
@@ -118,6 +118,8 @@ TEST(TEST_CATEGORY_DEATH, policy_invalid_bounds) {
   if (!Kokkos::show_warnings()) {
     GTEST_SKIP() << "Kokkos warning messages are disabled";
   }
+
+  msg1 += ".\n";  // would trip the death test error msg matching in some builds
 
   ::testing::internal::CaptureStderr();
   (void)Policy({100, 100}, {90, 90});

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -18,6 +18,8 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <regex>
+
 namespace {
 
 template <class IndexType>
@@ -105,7 +107,7 @@ TEST(TEST_CATEGORY_DEATH, policy_invalid_bounds) {
   std::string msg1 =
       "Kokkos::MDRangePolicy bounds error: The lower bound (100) is greater "
       "than its upper bound (90) in dimension " +
-      std::to_string(dim0);
+      std::to_string(dim0) + ".\n";
 
   std::string msg2 =
       "Kokkos::MDRangePolicy bounds error: The lower bound (100) is greater "
@@ -113,13 +115,14 @@ TEST(TEST_CATEGORY_DEATH, policy_invalid_bounds) {
       std::to_string(dim1) + ".\n";
 
 #if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
+  // escape the parentheses in the regex to match the error message
+  msg1 = std::regex_replace(msg1, std::regex("\\(|\\)"), "\\$&");
+  (void)msg2;
   ASSERT_DEATH({ (void)Policy({100, 100}, {90, 90}); }, msg1);
 #else
   if (!Kokkos::show_warnings()) {
     GTEST_SKIP() << "Kokkos warning messages are disabled";
   }
-
-  msg1 += ".\n";  // would trip the death test error msg matching in some builds
 
   ::testing::internal::CaptureStderr();
   (void)Policy({100, 100}, {90, 90});

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -125,7 +125,8 @@ TEST(TEST_CATEGORY_DEATH, policy_invalid_bounds) {
   ASSERT_EQ(::testing::internal::GetCapturedStderr(), msg1 + msg2);
 #else
   ASSERT_TRUE(::testing::internal::GetCapturedStderr().empty());
-  (void)msg;
+  (void)msg1;
+  (void)msg2;
 #endif
 
 #endif

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -102,16 +102,18 @@ TEST(TEST_CATEGORY_DEATH, policy_invalid_bounds) {
   auto [dim0, dim1] = (Policy::inner_direction == Kokkos::Iterate::Right)
                           ? std::make_pair(1, 0)
                           : std::make_pair(0, 1);
-  std::string msg =
+  std::string msg1 =
       "Kokkos::MDRangePolicy bounds error: The lower bound (100) is greater "
       "than its upper bound (90) in dimension " +
-      std::to_string(dim0) + ".\n" +
+      std::to_string(dim0) + ".\n";
+
+  std::string msg2 =
       "Kokkos::MDRangePolicy bounds error: The lower bound (100) is greater "
       "than its upper bound (90) in dimension " +
       std::to_string(dim1) + ".\n";
 
 #if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
-  ASSERT_DEATH({ (void)Policy({100, 100}, {90, 90}); }, msg);
+  ASSERT_DEATH({ (void)Policy({100, 100}, {90, 90}); }, msg1);
 #else
   if (!Kokkos::show_warnings()) {
     GTEST_SKIP() << "Kokkos warning messages are disabled";
@@ -120,7 +122,7 @@ TEST(TEST_CATEGORY_DEATH, policy_invalid_bounds) {
   ::testing::internal::CaptureStderr();
   (void)Policy({100, 100}, {90, 90});
 #ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-  ASSERT_EQ(::testing::internal::GetCapturedStderr(), msg);
+  ASSERT_EQ(::testing::internal::GetCapturedStderr(), msg1 + msg2);
 #else
   ASSERT_TRUE(::testing::internal::GetCapturedStderr().empty());
   (void)msg;

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -76,13 +76,15 @@ TEST(TEST_CATEGORY_DEATH, range_policy_invalid_bounds) {
 
   std::string msg =
       "Kokkos::RangePolicy bounds error: The lower bound (100) is greater than "
-      "the upper bound (90).\n";
+      "the upper bound (90)";
 #ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
   ASSERT_DEATH({ (void)Policy(100, 90); }, msg);
 
   ASSERT_DEATH({ (void)Policy(TEST_EXECSPACE(), 100, 90, ChunkSize(10)); },
                msg);
 #else
+  msg += ".\n";  // would trip the death test error msg matching in some builds
+
   if (!Kokkos::show_warnings()) {
     GTEST_SKIP() << "Kokkos warning messages are disabled";
   }

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -75,8 +75,8 @@ TEST(TEST_CATEGORY_DEATH, range_policy_invalid_bounds) {
   using ChunkSize = Kokkos::ChunkSize;
 
   char msg[] =
-      R"WARNING(Kokkos::RangePolicy bounds error: The lower bound (100) is greater than the upper bound (90).
-)WARNING";
+      "Kokkos::RangePolicy bounds error: The lower bound (100) is greater than "
+      "the upper bound (90).\n";
 #ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
   ASSERT_DEATH({ (void)Policy(100, 90); }, msg);
 

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -18,6 +18,8 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <regex>
+
 namespace {
 
 TEST(TEST_CATEGORY, range_policy_runtime_parameters) {
@@ -76,14 +78,15 @@ TEST(TEST_CATEGORY_DEATH, range_policy_invalid_bounds) {
 
   std::string msg =
       "Kokkos::RangePolicy bounds error: The lower bound (100) is greater than "
-      "the upper bound (90)";
+      "the upper bound (90).\n";
 #ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  // escape the parentheses in the regex to match the error message
+  msg = std::regex_replace(msg, std::regex("\\(|\\)"), "\\$&");
   ASSERT_DEATH({ (void)Policy(100, 90); }, msg);
 
   ASSERT_DEATH({ (void)Policy(TEST_EXECSPACE(), 100, 90, ChunkSize(10)); },
                msg);
 #else
-  msg += ".\n";  // would trip the death test error msg matching in some builds
 
   if (!Kokkos::show_warnings()) {
     GTEST_SKIP() << "Kokkos warning messages are disabled";

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -87,23 +87,31 @@ TEST(TEST_CATEGORY_DEATH, range_policy_invalid_bounds) {
     GTEST_SKIP() << "Kokkos warning messages are disabled";
   }
 
-  ::testing::internal::CaptureStderr();
-  (void)Policy(100, 90);
+  {
+    ::testing::internal::CaptureStderr();
+    Policy policy(100, 90);
+    ASSERT_EQ((int)policy.begin(), 0);
+    ASSERT_EQ((int)policy.end(), 0);
 #ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-  ASSERT_STREQ(::testing::internal::GetCapturedStderr().c_str(), msg);
+    ASSERT_STREQ(::testing::internal::GetCapturedStderr().c_str(), msg);
 #else
-  ASSERT_TRUE(::testing::internal::GetCapturedStderr().empty());
-  (void)msg;
+    ASSERT_TRUE(::testing::internal::GetCapturedStderr().empty());
+    (void)msg;
 #endif
+  }
 
-  ::testing::internal::CaptureStderr();
-  (void)Policy(TEST_EXECSPACE(), 100, 90, ChunkSize(10));
+  {
+    ::testing::internal::CaptureStderr();
+    Policy policy(TEST_EXECSPACE(), 100, 90, ChunkSize(10));
+    ASSERT_EQ((int)policy.begin(), 0);
+    ASSERT_EQ((int)policy.end(), 0);
 #ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-  ASSERT_STREQ(::testing::internal::GetCapturedStderr().c_str(), msg);
+    ASSERT_STREQ(::testing::internal::GetCapturedStderr().c_str(), msg);
 #else
-  ASSERT_TRUE(::testing::internal::GetCapturedStderr().empty());
-  (void)msg;
+    ASSERT_TRUE(::testing::internal::GetCapturedStderr().empty());
+    (void)msg;
 #endif
+  }
 
 #endif
 }

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -74,7 +74,7 @@ TEST(TEST_CATEGORY_DEATH, range_policy_invalid_bounds) {
   using Policy    = Kokkos::RangePolicy<TEST_EXECSPACE>;
   using ChunkSize = Kokkos::ChunkSize;
 
-  char msg[] =
+  std::string msg =
       "Kokkos::RangePolicy bounds error: The lower bound (100) is greater than "
       "the upper bound (90).\n";
 #ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -93,7 +93,7 @@ TEST(TEST_CATEGORY_DEATH, range_policy_invalid_bounds) {
     ASSERT_EQ((int)policy.begin(), 0);
     ASSERT_EQ((int)policy.end(), 0);
 #ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-    ASSERT_STREQ(::testing::internal::GetCapturedStderr().c_str(), msg);
+    ASSERT_EQ(::testing::internal::GetCapturedStderr(), msg);
 #else
     ASSERT_TRUE(::testing::internal::GetCapturedStderr().empty());
     (void)msg;
@@ -106,7 +106,7 @@ TEST(TEST_CATEGORY_DEATH, range_policy_invalid_bounds) {
     ASSERT_EQ((int)policy.begin(), 0);
     ASSERT_EQ((int)policy.end(), 0);
 #ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-    ASSERT_STREQ(::testing::internal::GetCapturedStderr().c_str(), msg);
+    ASSERT_EQ(::testing::internal::GetCapturedStderr(), msg);
 #else
     ASSERT_TRUE(::testing::internal::GetCapturedStderr().empty());
     (void)msg;


### PR DESCRIPTION
Fixup for #6617 that I merged a bit hastily

This is a breaking change so we need to guard it with `#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4`.
I opted for raising warnings otherwise and did some cleanup to avoid duplicated warning messages.