### PR TITLE
Improve weak test and make sure OpenACC throws on allocation failures

### DIFF
--- a/core/src/OpenACC/Kokkos_OpenACCSpace.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.cpp
@@ -69,13 +69,15 @@ void *Kokkos::Experimental::OpenACCSpace::impl_allocate(
 
   if (!ptr) {
     size_t alignment = 1;  // OpenACC does not handle alignment
-    using Kokkos::Experimental::RawMemoryAllocationFailure::FailureMode;
-    auto failure_mode = arg_alloc_size > 0 ? FailureMode::OutOfMemoryError
-                                           : FailureMode::InvalidAllocationSize;
-    using Kokkos::Experimental::RawMemoryAllocationFailure::AllocationMechanism;
-    auto alloc_mechanism = AllocationMechanism::OpenACCMalloc;
-    throw Kokkos::Experimental::RawMemoryAllocationFailure(
-        arg_alloc_size, alignment, failure_mode, alloc_mechanism);
+    using Kokkos::Experimental::RawMemoryAllocationFailure;
+    auto failure_mode =
+        arg_alloc_size > 0
+            ? RawMemoryAllocationFailure::FailureMode::OutOfMemoryError
+            : RawMemoryAllocationFailure::FailureMode::InvalidAllocationSize;
+    auto alloc_mechanism =
+        RawMemoryAllocationFailure::AllocationMechanism::OpenACCMalloc;
+    throw RawMemoryAllocationFailure(arg_alloc_size, alignment, failure_mode,
+                                     alloc_mechanism);
   }
 
   if (Kokkos::Profiling::profileLibraryLoaded()) {

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -58,7 +58,8 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
     HIPMallocManaged,
     SYCLMallocDevice,
     SYCLMallocShared,
-    SYCLMallocHost
+    SYCLMallocHost,
+    OpenACCMalloc,
   };
 
  private:

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1553,6 +1553,7 @@ class TestViewAPI {
                      Kokkos::CudaUVMSpace>::value)
       return;
 #endif
+    bool did_throw  = false;
     auto alloc_size = std::numeric_limits<size_t>::max() - 42;
     try {
       auto should_always_fail = dView1("hello_world_failure", alloc_size);
@@ -1584,7 +1585,9 @@ class TestViewAPI {
                             "because of an unknown error.", msg);
       }
 #endif
+      did_throw = true;
     }
+    ASSERT_TRUE(did_throw);
   }
 };
 

--- a/core/unit_test/TestViewAPI_d.hpp
+++ b/core/unit_test/TestViewAPI_d.hpp
@@ -36,6 +36,11 @@ TEST(TEST_CATEGORY, view_allocation_error) {
 #if ((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 3))
   GTEST_SKIP() << "ROCm 5.3 segfaults when trying to allocate too much memory";
 #endif
+#if defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
+    GTEST_SKIP() << "acc_malloc() not properly returning nullptr";
+  }
+#endif
   TestViewAPI<double, TEST_EXECSPACE>::run_test_error();
 }
 


### PR DESCRIPTION
Fix OpenACC build failure in the CI following the merge of #6617 and reported in https://github.com/kokkos/kokkos/pull/6725#issuecomment-1899464941
(not tested)