### PR TITLE
Don't touch my records! (refactor Cuda/HIP/SYCL/Threads to not directly mess with `SharedAllocationRecord`)

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -77,7 +77,7 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
 
   ~GraphNodeKernelImpl() {
     if (m_driver_storage) {
-      Kokkos::kokkos_free<Kokkos::CudaSpace>(m_driver_storage);
+      Kokkos::CudaSpace().deallocate(m_driver_storage, sizeof(base_t));
     }
   }
 
@@ -92,8 +92,8 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
 
   Kokkos::ObservingRawPtr<base_t> allocate_driver_memory_buffer() const {
     KOKKOS_EXPECTS(m_driver_storage == nullptr)
-    m_driver_storage = Kokkos::kokkos_malloc<Kokkos::CudaSpace>(
-        "GraphNodeKernel global memory functor storage", sizeof(base_t));
+    m_driver_storage = static_cast<base_t*>(Kokkos::CudaSpace().allocate(
+        "GraphNodeKernel global memory functor storage", sizeof(base_t)));
     KOKKOS_ENSURES(m_driver_storage != nullptr)
     return m_driver_storage;
   }

--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -23,8 +23,7 @@
 
 #include <Kokkos_Graph_fwd.hpp>
 
-#include <impl/Kokkos_GraphImpl.hpp>    // GraphAccess needs to be complete
-#include <impl/Kokkos_SharedAlloc.hpp>  // SharedAllocationRecord
+#include <impl/Kokkos_GraphImpl.hpp>  // GraphAccess needs to be complete
 
 #include <Kokkos_Parallel.hpp>
 #include <Kokkos_Parallel_Reduce.hpp>
@@ -50,10 +49,6 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
   // covers and we're not modifying it
   Kokkos::ObservingRawPtr<const cudaGraph_t> m_graph_ptr    = nullptr;
   Kokkos::ObservingRawPtr<cudaGraphNode_t> m_graph_node_ptr = nullptr;
-  // Note: owned pointer to CudaSpace memory (used for global memory launches),
-  // which we're responsible for deallocating, but not responsible for calling
-  // its destructor.
-  using Record = Kokkos::Impl::SharedAllocationRecord<Kokkos::CudaSpace, void>;
   // Basically, we have to make this mutable for the same reasons that the
   // global kernel buffers in the Cuda instance are mutable...
   mutable Kokkos::OwningRawPtr<base_t> m_driver_storage = nullptr;
@@ -82,9 +77,7 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
 
   ~GraphNodeKernelImpl() {
     if (m_driver_storage) {
-      // We should be the only owner, but this is still the easiest way to
-      // allocate and deallocate aligned memory for these sorts of things
-      Record::decrement(Record::get_record(m_driver_storage));
+      Kokkos::kokkos_free<Kokkos::CudaSpace>(m_driver_storage);
     }
   }
 
@@ -99,13 +92,8 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
 
   Kokkos::ObservingRawPtr<base_t> allocate_driver_memory_buffer() const {
     KOKKOS_EXPECTS(m_driver_storage == nullptr)
-
-    auto* record = Record::allocate(
-        Kokkos::CudaSpace{}, "GraphNodeKernel global memory functor storage",
-        sizeof(base_t));
-
-    Record::increment(record);
-    m_driver_storage = reinterpret_cast<base_t*>(record->data());
+    m_driver_storage = Kokkos::kokkos_malloc<Kokkos::CudaSpace>(
+        "GraphNodeKernel global memory functor storage", sizeof(base_t));
     KOKKOS_ENSURES(m_driver_storage != nullptr)
     return m_driver_storage;
   }

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -341,7 +341,7 @@ Cuda::size_type *CudaInternal::scratch_flags(const std::size_t size) const {
     auto mem_space = Kokkos::CudaSpace::impl_create(m_cudaDev, m_stream);
 
     if (m_scratchFlags) {
-      mem_space.free(m_scratchFlags);
+      mem_space.deallocate(m_scratchFlags, std::size_t(-1));  // FIXME
     }
 
     std::size_t alloc_size =
@@ -364,7 +364,7 @@ Cuda::size_type *CudaInternal::scratch_space(const std::size_t size) const {
     auto mem_space = Kokkos::CudaSpace::impl_create(m_cudaDev, m_stream);
 
     if (m_scratchSpace) {
-      mem_space.free(m_scratchSpace);
+      mem_space.deallocate(m_scratchSpace, std::size_t(-1));  // FIXME
     }
 
     std::size_t alloc_size =
@@ -385,7 +385,7 @@ Cuda::size_type *CudaInternal::scratch_unified(const std::size_t size) const {
         Kokkos::CudaHostPinnedSpace::impl_create(m_cudaDev, m_stream);
 
     if (m_scratchUnified) {
-      mem_space.free(m_scratchUnified);
+      mem_space.deallocate(m_scratchUnified, std::size_t(-1));  // FIXME
     }
 
     std::size_t alloc_size =
@@ -404,7 +404,7 @@ Cuda::size_type *CudaInternal::scratch_functor(const std::size_t size) const {
     auto mem_space = Kokkos::CudaSpace::impl_create(m_cudaDev, m_stream);
 
     if (m_scratchFunctor) {
-      mem_space.free(m_scratchFunctor);
+      mem_space.deallocate(m_scratchFunctor, std::size_t(-1));  // FIXME
     }
 
     m_scratchFunctor = mem_space.allocate("Kokkos::InternalScratchFunctor",
@@ -466,11 +466,11 @@ void CudaInternal::finalize() {
     auto cuda_mem_space = Kokkos::CudaSpace::impl_create(m_cudaDev, m_stream);
     auto host_mem_space =
         Kokkos::CudaHostPinnedSpace::impl_create(m_cudaDev, m_stream);
-    cuda_mem_space.free(m_scratchFlags);
-    cuda_mem_space.free(m_scratchSpace);
-    host_mem_space.free(m_scratchUnified);
+    cuda_mem_space.deallocate(m_scratchFlags, std::size_t(-1));    // FIXME
+    cuda_mem_space.deallocate(m_scratchSpace, std::size_t(-1));    // FIXME
+    host_mem_space.deallocate(m_scratchUnified, std::size_t(-1));  // FIXME
     if (m_scratchFunctorSize > 0) {
-      cuda_mem_space.free(m_scratchFunctor);
+      cuda_mem_space.deallocate(m_scratchFunctor, std::size_t(-1));  // FIXME
     }
   }
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -346,8 +346,8 @@ Cuda::size_type *CudaInternal::scratch_flags(const std::size_t size) const {
 
     std::size_t alloc_size =
         multiply_overflow_abort(m_scratchFlagsCount, sizeScratchGrain);
-    m_scratchFlags =
-        mem_space.allocate("Kokkos::InternalScratchFlags", alloc_size);
+    m_scratchFlags = static_cast<size_type *>(
+        mem_space.allocate("Kokkos::InternalScratchFlags", alloc_size));
 
     KOKKOS_IMPL_CUDA_SAFE_CALL(
         (cuda_memset_wrapper(m_scratchFlags, 0, alloc_size)));
@@ -369,8 +369,8 @@ Cuda::size_type *CudaInternal::scratch_space(const std::size_t size) const {
 
     std::size_t alloc_size =
         multiply_overflow_abort(m_scratchSpaceCount, sizeScratchGrain);
-    m_scratchSpace =
-        mem_space.allocate("Kokkos::InternalScratchSpace", alloc_size);
+    m_scratchSpace = static_cast<size_type *>(
+        mem_space.allocate("Kokkos::InternalScratchSpace", alloc_size));
   }
 
   return m_scratchSpace;
@@ -390,8 +390,8 @@ Cuda::size_type *CudaInternal::scratch_unified(const std::size_t size) const {
 
     std::size_t alloc_size =
         multiply_overflow_abort(m_scratchUnifiedCount, sizeScratchGrain);
-    m_scratchUnified =
-        mem_space.allocate("Kokkos::InternalScratchUnified", alloc_size);
+    m_scratchUnified = static_cast<size_type *>(
+        mem_space.allocate("Kokkos::InternalScratchUnified", alloc_size));
   }
 
   return m_scratchUnified;
@@ -407,8 +407,8 @@ Cuda::size_type *CudaInternal::scratch_functor(const std::size_t size) const {
       mem_space.deallocate(m_scratchFunctor, std::size_t(-1));  // FIXME
     }
 
-    m_scratchFunctor = mem_space.allocate("Kokkos::InternalScratchFunctor",
-                                          m_scratchFunctorSize);
+    m_scratchFunctor = static_cast<size_type *>(mem_space.allocate(
+        "Kokkos::InternalScratchFunctor", m_scratchFunctorSize));
   }
 
   return m_scratchFunctor;

--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -58,7 +58,7 @@ class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
 
   ~GraphNodeKernelImpl() {
     if (m_driver_storage) {
-      Kokkos::kokkos_free<Kokkos::HIPSpace>(m_driver_storage);
+      Kokkos::HIPSpace().deallocate(m_driver_storage, sizeof(base_t));
     }
   }
 
@@ -76,8 +76,8 @@ class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
 
   Kokkos::ObservingRawPtr<base_t> allocate_driver_memory_buffer() const {
     KOKKOS_EXPECTS(m_driver_storage == nullptr);
-    Kokkos::kokkos_malloc<Kokkos::HIPSpace>(
-        "GraphNodeKernel global memory functor storage", sizeof(base_t));
+    m_driver_storage = static_cast<base_t*>(Kokkos::HIPSpace().allocate(
+        "GraphNodeKernel global memory functor storage", sizeof(base_t)));
     KOKKOS_ENSURES(m_driver_storage != nullptr);
     return m_driver_storage;
   }

--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -26,7 +26,6 @@
 #include <Kokkos_Parallel_Reduce.hpp>
 #include <Kokkos_PointerOwnership.hpp>
 
-#include <HIP/Kokkos_HIP_SharedAllocationRecord.hpp>
 #include <HIP/Kokkos_HIP_GraphNode_Impl.hpp>
 
 namespace Kokkos {
@@ -43,7 +42,6 @@ class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
   using base_t =
       typename PatternImplSpecializationFromTag<PatternTag, Functor, Policy,
                                                 Args..., Kokkos::HIP>::type;
-  using Record = Kokkos::Impl::SharedAllocationRecord<Kokkos::HIPSpace, void>;
 
   // TODO use the name and executionspace
   template <typename PolicyDeduced, typename... ArgsDeduced>
@@ -60,7 +58,7 @@ class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
 
   ~GraphNodeKernelImpl() {
     if (m_driver_storage) {
-      Record::decrement(Record::get_record(m_driver_storage));
+      Kokkos::kokkos_free<Kokkos::HIPSpace>(m_driver_storage);
     }
   }
 
@@ -78,15 +76,9 @@ class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
 
   Kokkos::ObservingRawPtr<base_t> allocate_driver_memory_buffer() const {
     KOKKOS_EXPECTS(m_driver_storage == nullptr);
-
-    auto* record = Record::allocate(
-        Kokkos::HIPSpace{}, "GraphNodeKernel global memory functor storage",
-        sizeof(base_t));
-
-    Record::increment(record);
-    m_driver_storage = reinterpret_cast<base_t*>(record->data());
+    Kokkos::kokkos_malloc<Kokkos::HIPSpace>(
+        "GraphNodeKernel global memory functor storage", sizeof(base_t));
     KOKKOS_ENSURES(m_driver_storage != nullptr);
-
     return m_driver_storage;
   }
 

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -201,8 +201,8 @@ Kokkos::HIP::size_type *HIPInternal::scratch_space(const std::size_t size) {
 
     std::size_t alloc_size =
         multiply_overflow_abort(m_scratchSpaceCount, sizeScratchGrain);
-    m_scratchSpace =
-        mem_space.allocate("Kokkos::InternalScratchSpace", alloc_size);
+    m_scratchSpace = static_cast<size_type *>(
+        mem_space.allocate("Kokkos::InternalScratchSpace", alloc_size));
   }
 
   return m_scratchSpace;
@@ -221,8 +221,8 @@ Kokkos::HIP::size_type *HIPInternal::scratch_flags(const std::size_t size) {
 
     std::size_t alloc_size =
         multiply_overflow_abort(m_scratchFlagsCount, sizeScratchGrain);
-    m_scratchFlags =
-        mem_space.allocate("Kokkos::InternalScratchFlags", alloc_size);
+    m_scratchFlags = static_cast<size_type *>(
+        mem_space.allocate("Kokkos::InternalScratchFlags", alloc_size));
 
     KOKKOS_IMPL_HIP_SAFE_CALL(hipMemset(m_scratchFlags, 0, alloc_size));
   }
@@ -244,10 +244,10 @@ Kokkos::HIP::size_type *HIPInternal::stage_functor_for_execution(
                                 std::size_t(-1));  // FIXME
     }
 
-    m_scratchFunctor = device_mem_space.allocate(
-        "Kokkos::InternalScratchFunctor", m_scratchFunctorSize);
-    m_scratchFunctorHost = host_mem_space.allocate(
-        "Kokkos::InternalScratchFunctorHost", m_scratchFunctorSize);
+    m_scratchFunctor     = static_cast<size_type *>(device_mem_space.allocate(
+        "Kokkos::InternalScratchFunctor", m_scratchFunctorSize));
+    m_scratchFunctorHost = static_cast<size_type *>(host_mem_space.allocate(
+        "Kokkos::InternalScratchFunctorHost", m_scratchFunctorSize));
   }
 
   // When using HSA_XNACK=1, it is necessary to copy the driver to the host to

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -196,7 +196,7 @@ Kokkos::HIP::size_type *HIPInternal::scratch_space(const std::size_t size) {
     Kokkos::HIPSpace mem_space;
 
     if (m_scratchSpace) {
-      mem_space.free(m_scratchSpace);
+      mem_space.deallocate(m_scratchSpace, std::size_t(-1));  // FIXME
     }
 
     std::size_t alloc_size =
@@ -216,7 +216,7 @@ Kokkos::HIP::size_type *HIPInternal::scratch_flags(const std::size_t size) {
     Kokkos::HIPSpace mem_space;
 
     if (m_scratchFlags) {
-      mem_space.free(m_scratchFlags);
+      mem_space.deallocate(m_scratchFlags, std::size_t(-1));  // FIXME
     }
 
     std::size_t alloc_size =
@@ -239,8 +239,9 @@ Kokkos::HIP::size_type *HIPInternal::stage_functor_for_execution(
     Kokkos::HIPHostPinnedSpace host_mem_space;
 
     if (m_scratchFunctor) {
-      device_mem_space.free(m_scratchFunctor);
-      host_mem_space.free(m_scratchFunctorHost);
+      device_mem_space.deallocate(m_scratchFunctor, std::size_t(-1));  // FIXME
+      host_mem_space.deallocate(m_scratchFunctorHost,
+                                std::size_t(-1));  // FIXME
     }
 
     m_scratchFunctor = device_mem_space.allocate(
@@ -312,13 +313,14 @@ void HIPInternal::finalize() {
   if (nullptr != m_scratchSpace || nullptr != m_scratchFlags) {
     Kokkos::HIPSpace device_mem_space;
 
-    device_mem_space.free(m_scratchFlags);
-    device_mem_space.free(m_scratchSpace);
+    device_mem_space.deallocate(m_scratchFlags, std::size_t(-1));  // FIXME
+    device_mem_space.deallocate(m_scratchSpace, std::size_t(-1));  // FIXME
 
     if (m_scratchFunctorSize > 0) {
-      device_mem_space.free(m_scratchFunctor);
+      device_mem_space.deallocate(m_scratchFunctor, std::size_t(-1));  // FIXME
       Kokkos::HIPHostPinnedSpace host_mem_space;
-      host_mem_space.free(m_scratchFunctorHost);
+      host_mem_space.deallocate(m_scratchFunctorHost,
+                                std::size_t(-1));  // FIXME
     }
   }
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -199,11 +199,14 @@ void SYCLInternal::finalize() {
   auto device_mem_space = SYCLDeviceUSMSpace(*m_queue);
   auto host_mem_space   = SYCLHostUSMSpace(*m_queue);
   if (nullptr != m_scratchSpace)
-    device_mem_space.deallocate(m_scratchSpace, std::size_t(-1));  // FIXME
+    device_mem_space.deallocate(m_scratchSpace,
+                                m_scratchSpaceCount * sizeScratchGrain);
   if (nullptr != m_scratchHost)
-    host_mem_space.deallocate(m_scratchHost, std::size_t(-1));  // FIXME
+    host_mem_space.deallocate(m_scratchHost,
+                              m_scratchHostCount * sizeScratchGrain);
   if (nullptr != m_scratchFlags)
-    device_mem_space.deallocate(m_scratchFlags, std::size_t(-1));  // FIXME
+    device_mem_space.deallocate(m_scratchFlags,
+                                m_scratchFlagsCount * sizeScratchGrain);
   m_syclDev           = -1;
   m_scratchSpaceCount = 0;
   m_scratchSpace      = nullptr;
@@ -233,12 +236,13 @@ void SYCLInternal::finalize() {
 sycl::device_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {
   if (verify_is_initialized("scratch_space") &&
       m_scratchSpaceCount < scratch_count(size)) {
-    m_scratchSpaceCount = scratch_count(size);
-
     auto mem_space = Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue);
 
     if (nullptr != m_scratchSpace)
-      mem_space.deallocate(m_scratchSpace, std::size_t(-1));  // FIXME
+      mem_space.deallocate(m_scratchSpace,
+                           m_scratchSpaceCount * sizeScratchGrain);
+
+    m_scratchSpaceCount = scratch_count(size);
 
     std::size_t alloc_size = Kokkos::Impl::multiply_overflow_abort(
         m_scratchSpaceCount, sizeScratchGrain);
@@ -252,12 +256,13 @@ sycl::device_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {
 sycl::host_ptr<void> SYCLInternal::scratch_host(const std::size_t size) {
   if (verify_is_initialized("scratch_unified") &&
       m_scratchHostCount < scratch_count(size)) {
-    m_scratchHostCount = scratch_count(size);
-
     auto mem_space = Kokkos::Experimental::SYCLHostUSMSpace(*m_queue);
 
     if (nullptr != m_scratchHost)
-      mem_space.deallocate(m_scratchHost, std::size_t(-1));  // FIXME
+      mem_space.deallocate(m_scratchHost,
+                           m_scratchHostCount * sizeScratchGrain);
+
+    m_scratchHostCount = scratch_count(size);
 
     std::size_t alloc_size = Kokkos::Impl::multiply_overflow_abort(
         m_scratchHostCount, sizeScratchGrain);
@@ -271,12 +276,13 @@ sycl::host_ptr<void> SYCLInternal::scratch_host(const std::size_t size) {
 sycl::device_ptr<void> SYCLInternal::scratch_flags(const std::size_t size) {
   if (verify_is_initialized("scratch_flags") &&
       m_scratchFlagsCount < scratch_count(size)) {
-    m_scratchFlagsCount = scratch_count(size);
-
     auto mem_space = Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue);
 
     if (nullptr != m_scratchFlags)
-      mem_space.deallocate(m_scratchFlags, std::size_t(-1));  // FIXME
+      mem_space.deallocate(m_scratchFlags,
+                           m_scratchFlagsCount * sizeScratchGrain);
+
+    m_scratchFlagsCount = scratch_count(size);
 
     std::size_t alloc_size = Kokkos::Impl::multiply_overflow_abort(
         m_scratchFlagsCount, sizeScratchGrain);

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -242,8 +242,8 @@ sycl::device_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {
 
     std::size_t alloc_size = Kokkos::Impl::multiply_overflow_abort(
         m_scratchSpaceCount, sizeScratchGrain);
-    m_scratchSpace = mem_space.allocate(
-        "Kokkos::Experimental::SYCL::InternalScratchSpace", alloc_size);
+    m_scratchSpace = static_cast<size_type*>(mem_space.allocate(
+        "Kokkos::Experimental::SYCL::InternalScratchSpace", alloc_size));
   }
 
   return m_scratchSpace;
@@ -261,8 +261,8 @@ sycl::host_ptr<void> SYCLInternal::scratch_host(const std::size_t size) {
 
     std::size_t alloc_size = Kokkos::Impl::multiply_overflow_abort(
         m_scratchHostCount, sizeScratchGrain);
-    m_scratchHost = mem_space.allocate(
-        "Kokkos::Experimental::SYCL::InternalScratchHost", alloc_size);
+    m_scratchHost = static_cast<size_type*>(mem_space.allocate(
+        "Kokkos::Experimental::SYCL::InternalScratchHost", alloc_size));
   }
 
   return m_scratchHost;
@@ -280,8 +280,8 @@ sycl::device_ptr<void> SYCLInternal::scratch_flags(const std::size_t size) {
 
     std::size_t alloc_size = Kokkos::Impl::multiply_overflow_abort(
         m_scratchFlagsCount, sizeScratchGrain);
-    m_scratchFlags = mem_space.allocate(
-        "Kokkos::Experimental::SYCL::InternalScratchFlags", alloc_size);
+    m_scratchFlags = static_cast<size_type*>(mem_space.allocate(
+        "Kokkos::Experimental::SYCL::InternalScratchFlags", alloc_size));
   }
   auto memset_event = m_queue->memset(m_scratchFlags, 0,
                                       m_scratchFlagsCount * sizeScratchGrain);

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -198,9 +198,12 @@ void SYCLInternal::finalize() {
 
   auto device_mem_space = SYCLDeviceUSMSpace(*m_queue);
   auto host_mem_space   = SYCLHostUSMSpace(*m_queue);
-  if (nullptr != m_scratchSpace) device_mem_space.free(m_scratchSpace);
-  if (nullptr != m_scratchHost) host_mem_space.free(m_scratchHost);
-  if (nullptr != m_scratchFlags) device_mem_space.free(m_scratchFlags);
+  if (nullptr != m_scratchSpace)
+    device_mem_space.deallocate(m_scratchSpace, std::size_t(-1));  // FIXME
+  if (nullptr != m_scratchHost)
+    host_mem_space.deallocate(m_scratchHost, std::size_t(-1));  // FIXME
+  if (nullptr != m_scratchFlags)
+    device_mem_space.deallocate(m_scratchFlags, std::size_t(-1));  // FIXME
   m_syclDev           = -1;
   m_scratchSpaceCount = 0;
   m_scratchSpace      = nullptr;
@@ -234,7 +237,8 @@ sycl::device_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {
 
     auto mem_space = Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue);
 
-    if (nullptr != m_scratchSpace) mem_space.free(m_scratchSpace);
+    if (nullptr != m_scratchSpace)
+      mem_space.deallocate(m_scratchSpace, std::size_t(-1));  // FIXME
 
     std::size_t alloc_size = Kokkos::Impl::multiply_overflow_abort(
         m_scratchSpaceCount, sizeScratchGrain);
@@ -252,7 +256,8 @@ sycl::host_ptr<void> SYCLInternal::scratch_host(const std::size_t size) {
 
     auto mem_space = Kokkos::Experimental::SYCLHostUSMSpace(*m_queue);
 
-    if (nullptr != m_scratchHost) mem_space.free(m_scratchHost);
+    if (nullptr != m_scratchHost)
+      mem_space.deallocate(m_scratchHost, std::size_t(-1));  // FIXME
 
     std::size_t alloc_size = Kokkos::Impl::multiply_overflow_abort(
         m_scratchHostCount, sizeScratchGrain);
@@ -270,7 +275,8 @@ sycl::device_ptr<void> SYCLInternal::scratch_flags(const std::size_t size) {
 
     auto mem_space = Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue);
 
-    if (nullptr != m_scratchFlags) mem_space.free(m_scratchFlags);
+    if (nullptr != m_scratchFlags)
+      mem_space.deallocate(m_scratchFlags, std::size_t(-1));  // FIXME
 
     std::size_t alloc_size = Kokkos::Impl::multiply_overflow_abort(
         m_scratchFlagsCount, sizeScratchGrain);
@@ -325,7 +331,7 @@ size_t SYCLInternal::USMObjectMem<Kind>::reserve(size_t n) {
 
   if (m_capacity < n) {
     AllocationSpace alloc_space(*m_q);
-    if (m_data) alloc_space.free(m_data);
+    if (m_data) alloc_space.deallocate(m_data, m_capacity);
 
     m_data =
         alloc_space.allocate("Kokkos::Experimental::SYCL::USMObjectMem", n);
@@ -344,7 +350,7 @@ void SYCLInternal::USMObjectMem<Kind>::reset() {
     // This implies a fence since this class is not copyable
     // and deallocating implies a fence across all registered queues.
     AllocationSpace alloc_space(*m_q);
-    alloc_space.free(m_data);
+    alloc_space.deallocate(m_data, m_capacity);
 
     m_capacity = 0;
     m_data     = nullptr;


### PR DESCRIPTION
Was using `Impl::SharedAllocationRecord` to allocate and incrementing/decrementing the reference counter by hand, once.
Besides avoiding the spread/abuse of implementations details, this refactor get rid of the internal deep copies when retrieving records which are problematic in the context of multiple GPUs.

I propose to ban the direct use of `SharedAllocationRecord` in backends implementation in favor of explicit memory management.