### PR TITLE
Fix TestThreadVectorMDRangeParallelReduce

### DIFF
--- a/core/unit_test/TestTeamMDRange.hpp
+++ b/core/unit_test/TestTeamMDRange.hpp
@@ -1432,8 +1432,8 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
                   vectorSum += v(leagueRank, i, j, k);
                 },
                 threadSum);
-
-            teamSum += threadSum;
+            Kokkos::single(Kokkos::PerThread(team),
+                           [&]() { teamSum += threadSum; });
           });
 
           leagueSum += teamSum;
@@ -1497,7 +1497,8 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
                 },
                 threadSum);
 
-            teamSum += threadSum;
+            Kokkos::single(Kokkos::PerThread(team),
+                           [&]() { teamSum += threadSum; });
           });
 
           leagueSum += teamSum;
@@ -1562,7 +1563,8 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
                 },
                 threadSum);
 
-            teamSum += threadSum;
+            Kokkos::single(Kokkos::PerThread(team),
+                           [&]() { teamSum += threadSum; });
           });
 
           leagueSum += teamSum;
@@ -1632,7 +1634,8 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
                 },
                 threadSum);
 
-            teamSum += threadSum;
+            Kokkos::single(Kokkos::PerThread(team),
+                           [&]() { teamSum += threadSum; });
           });
 
           leagueSum += teamSum;
@@ -1706,7 +1709,8 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
                 },
                 threadSum);
 
-            teamSum += threadSum;
+            Kokkos::single(Kokkos::PerThread(team),
+                           [&]() { teamSum += threadSum; });
           });
 
           leagueSum += teamSum;

--- a/core/unit_test/TestTeamMDRange.hpp
+++ b/core/unit_test/TestTeamMDRange.hpp
@@ -1416,15 +1416,14 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
 #endif
                                       ),
         KOKKOS_LAMBDA(TeamType const& team, DataType& leagueSum) {
-          auto leagueRank  = team.league_rank();
-          DataType teamSum = 0;
+          auto leagueRank = team.league_rank();
 
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto threadVectorRange =
               Kokkos::ThreadVectorMDRange<Kokkos::Rank<2, Direction>, TeamType>(
                   team, n1, n2);
 
-          Kokkos::parallel_for(teamThreadRange, [=, &teamSum](const int& i) {
+          Kokkos::parallel_for(teamThreadRange, [=, &leagueSum](const int& i) {
             DataType threadSum = 0;
             Kokkos::parallel_reduce(
                 threadVectorRange,
@@ -1433,10 +1432,8 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
                 },
                 threadSum);
             Kokkos::single(Kokkos::PerThread(team),
-                           [&]() { teamSum += threadSum; });
+                           [&]() { leagueSum += threadSum; });
           });
-
-          leagueSum += teamSum;
         },
         finalSum);
 
@@ -1479,15 +1476,14 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
 #endif
                                       ),
         KOKKOS_LAMBDA(TeamType const& team, DataType& leagueSum) {
-          auto leagueRank  = team.league_rank();
-          DataType teamSum = 0;
+          auto leagueRank = team.league_rank();
 
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto threadVectorRange =
               Kokkos::ThreadVectorMDRange<Kokkos::Rank<3, Direction>, TeamType>(
                   team, n1, n2, n3);
 
-          Kokkos::parallel_for(teamThreadRange, [=, &teamSum](const int& i) {
+          Kokkos::parallel_for(teamThreadRange, [=, &leagueSum](const int& i) {
             DataType threadSum = 0;
             Kokkos::parallel_reduce(
                 threadVectorRange,
@@ -1498,10 +1494,8 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
                 threadSum);
 
             Kokkos::single(Kokkos::PerThread(team),
-                           [&]() { teamSum += threadSum; });
+                           [&]() { leagueSum += threadSum; });
           });
-
-          leagueSum += teamSum;
         },
         finalSum);
 
@@ -1545,15 +1539,14 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
 #endif
                                       ),
         KOKKOS_LAMBDA(TeamType const& team, DataType& leagueSum) {
-          auto leagueRank  = team.league_rank();
-          DataType teamSum = 0;
+          auto leagueRank = team.league_rank();
 
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto threadVectorRange =
               Kokkos::ThreadVectorMDRange<Kokkos::Rank<4, Direction>, TeamType>(
                   team, n1, n2, n3, n4);
 
-          Kokkos::parallel_for(teamThreadRange, [=, &teamSum](const int& i) {
+          Kokkos::parallel_for(teamThreadRange, [=, &leagueSum](const int& i) {
             DataType threadSum = 0;
             Kokkos::parallel_reduce(
                 threadVectorRange,
@@ -1564,10 +1557,8 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
                 threadSum);
 
             Kokkos::single(Kokkos::PerThread(team),
-                           [&]() { teamSum += threadSum; });
+                           [&]() { leagueSum += threadSum; });
           });
-
-          leagueSum += teamSum;
         },
         finalSum);
 
@@ -1616,15 +1607,14 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
 #endif
                                       ),
         KOKKOS_LAMBDA(TeamType const& team, DataType& leagueSum) {
-          auto leagueRank  = team.league_rank();
-          DataType teamSum = 0;
+          auto leagueRank = team.league_rank();
 
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto threadVectorRange =
               Kokkos::ThreadVectorMDRange<Kokkos::Rank<5, Direction>, TeamType>(
                   team, n1, n2, n3, n4, n5);
 
-          Kokkos::parallel_for(teamThreadRange, [=, &teamSum](const int& i) {
+          Kokkos::parallel_for(teamThreadRange, [=, &leagueSum](const int& i) {
             DataType threadSum = 0;
             Kokkos::parallel_reduce(
                 threadVectorRange,
@@ -1635,10 +1625,8 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
                 threadSum);
 
             Kokkos::single(Kokkos::PerThread(team),
-                           [&]() { teamSum += threadSum; });
+                           [&]() { leagueSum += threadSum; });
           });
-
-          leagueSum += teamSum;
         },
         finalSum);
 
@@ -1691,15 +1679,14 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
 #endif
                                       ),
         KOKKOS_LAMBDA(TeamType const& team, DataType& leagueSum) {
-          auto leagueRank  = team.league_rank();
-          DataType teamSum = 0;
+          auto leagueRank = team.league_rank();
 
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto threadVectorRange =
               Kokkos::ThreadVectorMDRange<Kokkos::Rank<6, Direction>, TeamType>(
                   team, n1, n2, n3, n4, n5, n6);
 
-          Kokkos::parallel_for(teamThreadRange, [=, &teamSum](const int& i) {
+          Kokkos::parallel_for(teamThreadRange, [=, &leagueSum](const int& i) {
             DataType threadSum = 0;
             Kokkos::parallel_reduce(
                 threadVectorRange,
@@ -1710,10 +1697,8 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
                 threadSum);
 
             Kokkos::single(Kokkos::PerThread(team),
-                           [&]() { teamSum += threadSum; });
+                           [&]() { leagueSum += threadSum; });
           });
-
-          leagueSum += teamSum;
         },
         finalSum);
 


### PR DESCRIPTION
Fixes #6720. We only want to add the contribution once per thread.
Updating `teamSum` within a `parallel_for` `TeamThreadRange` should lead to race conditions anyway. I'm surprised that we didn't see problems with other backends.