### PR TITLE
OpenMPTarget on Intel GPUs update

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsTeamCopyIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamCopyIf.cpp
@@ -166,6 +166,10 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_copy_if_team_test, test) {
+// FIXME_OPENMPTARGET
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
+  GTEST_SKIP() << "the test is know to fail with OpenMPTarget on Intel GPUs";
+#endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();
   run_all_scenarios<StridedThreeRowsTag, unsigned>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamCopyIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamCopyIf.cpp
@@ -168,7 +168,7 @@ void run_all_scenarios() {
 TEST(std_algorithms_copy_if_team_test, test) {
 // FIXME_OPENMPTARGET
 #if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "the test is know to fail with OpenMPTarget on Intel GPUs";
+  GTEST_SKIP() << "the test is known to fail with OpenMPTarget on Intel GPUs";
 #endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamExclusiveScan.cpp
@@ -254,6 +254,10 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_exclusive_scan_team_test, test) {
+// FIXME_OPENMPTARGET
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
+  GTEST_SKIP() << "the test is know to fail with OpenMPTarget on Intel GPUs";
+#endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();
   run_all_scenarios<StridedThreeRowsTag, unsigned>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamExclusiveScan.cpp
@@ -256,7 +256,7 @@ void run_all_scenarios() {
 TEST(std_algorithms_exclusive_scan_team_test, test) {
 // FIXME_OPENMPTARGET
 #if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "the test is know to fail with OpenMPTarget on Intel GPUs";
+  GTEST_SKIP() << "the test is known to fail with OpenMPTarget on Intel GPUs";
 #endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamInclusiveScan.cpp
@@ -279,6 +279,10 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_inclusive_scan_team_test, test) {
+// FIXME_OPENMPTARGET
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
+  GTEST_SKIP() << "the test is know to fail with OpenMPTarget on Intel GPUs";
+#endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();
   run_all_scenarios<StridedThreeRowsTag, unsigned>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamInclusiveScan.cpp
@@ -281,7 +281,7 @@ void run_all_scenarios() {
 TEST(std_algorithms_inclusive_scan_team_test, test) {
 // FIXME_OPENMPTARGET
 #if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "the test is know to fail with OpenMPTarget on Intel GPUs";
+  GTEST_SKIP() << "the test is known to fail with OpenMPTarget on Intel GPUs";
 #endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamRemoveCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamRemoveCopy.cpp
@@ -212,6 +212,10 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_remove_copy_team_test, test) {
+// FIXME_OPENMPTARGET
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
+  GTEST_SKIP() << "the test is know to fail with OpenMPTarget on Intel GPUs";
+#endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();
   run_all_scenarios<StridedThreeRowsTag, unsigned>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamRemoveCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamRemoveCopy.cpp
@@ -214,7 +214,7 @@ void run_all_scenarios() {
 TEST(std_algorithms_remove_copy_team_test, test) {
 // FIXME_OPENMPTARGET
 #if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "the test is know to fail with OpenMPTarget on Intel GPUs";
+  GTEST_SKIP() << "the test is known to fail with OpenMPTarget on Intel GPUs";
 #endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamRemoveCopyIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamRemoveCopyIf.cpp
@@ -170,7 +170,7 @@ void run_all_scenarios() {
 TEST(std_algorithms_remove_copy_if_team_test, test) {
 // FIXME_OPENMPTARGET
 #if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "the test is know to fail with OpenMPTarget on Intel GPUs";
+  GTEST_SKIP() << "the test is known to fail with OpenMPTarget on Intel GPUs";
 #endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamRemoveCopyIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamRemoveCopyIf.cpp
@@ -168,6 +168,10 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_remove_copy_if_team_test, test) {
+// FIXME_OPENMPTARGET
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
+  GTEST_SKIP() << "the test is know to fail with OpenMPTarget on Intel GPUs";
+#endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();
   run_all_scenarios<StridedThreeRowsTag, unsigned>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamUniqueCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamUniqueCopy.cpp
@@ -186,6 +186,10 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_unique_copy_team_test, test) {
+  // FIXME_OPENMPTARGET
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
+  GTEST_SKIP() << "the test is know to fail with OpenMPTarget on Intel GPUs";
+#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedTwoRowsTag, int>();
   run_all_scenarios<StridedThreeRowsTag, int>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamUniqueCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamUniqueCopy.cpp
@@ -188,7 +188,7 @@ void run_all_scenarios() {
 TEST(std_algorithms_unique_copy_team_test, test) {
   // FIXME_OPENMPTARGET
 #if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "the test is know to fail with OpenMPTarget on Intel GPUs";
+  GTEST_SKIP() << "the test is known to fail with OpenMPTarget on Intel GPUs";
 #endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedTwoRowsTag, int>();

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -776,30 +776,35 @@ IF (KOKKOS_ENABLE_OPENMPTARGET)
     COMPILER_SPECIFIC_FLAGS(
       IntelLLVM -fopenmp-targets=spir64 -D__STRICT_ANSI__
     )
-  ELSEIF(KOKKOS_ARCH_INTEL_GEN9)
-    COMPILER_SPECIFIC_FLAGS(
-      IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device gen9" -D__STRICT_ANSI__
+  ELSE()
+    COMPILER_SPECIFIC_OPTIONS(
+      IntelLLVM -fopenmp-targets=spir64_gen
     )
-  ELSEIF(KOKKOS_ARCH_INTEL_GEN11)
-    COMPILER_SPECIFIC_FLAGS(
-      IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device gen11" -D__STRICT_ANSI__
+    IF(KOKKOS_ARCH_INTEL_GEN9)
+      COMPILER_SPECIFIC_LINK_OPTIONS(
+        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device gen9" -D__STRICT_ANSI__
+      )
+    ELSEIF(KOKKOS_ARCH_INTEL_GEN11)
+      COMPILER_SPECIFIC_LINK_OPTIONS(
+        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device gen11" -D__STRICT_ANSI__
+      )
+    ELSEIF(KOKKOS_ARCH_INTEL_GEN12LP)
+      COMPILER_SPECIFIC_LINK_OPTIONS(
+        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device gen12lp" -D__STRICT_ANSI__
+      )
+    ELSEIF(KOKKOS_ARCH_INTEL_DG1)
+      COMPILER_SPECIFIC_LINK_OPTIONS(
+        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device dg1" -D__STRICT_ANSI__
+      )
+    ELSEIF(KOKKOS_ARCH_INTEL_XEHP)
+      COMPILER_SPECIFIC_LINK_OPTIONS(
+        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device 12.50.4" -D__STRICT_ANSI__
+      )
+    ELSEIF(KOKKOS_ARCH_INTEL_PVC)
+      COMPILER_SPECIFIC_LINK_OPTIONS(
+        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device 12.60.7" -D__STRICT_ANSI__
     )
-  ELSEIF(KOKKOS_ARCH_INTEL_GEN12LP)
-    COMPILER_SPECIFIC_FLAGS(
-      IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device gen12lp" -D__STRICT_ANSI__
-    )
-  ELSEIF(KOKKOS_ARCH_INTEL_DG1)
-    COMPILER_SPECIFIC_FLAGS(
-      IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device dg1" -D__STRICT_ANSI__
-    )
-  ELSEIF(KOKKOS_ARCH_INTEL_XEHP)
-    COMPILER_SPECIFIC_FLAGS(
-      IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device 12.50.4" -D__STRICT_ANSI__
-    )
-  ELSEIF(KOKKOS_ARCH_INTEL_PVC)
-    COMPILER_SPECIFIC_FLAGS(
-      IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device 12.60.7" -D__STRICT_ANSI__
-    )
+    ENDIF()
   ENDIF()
 ENDIF()
 

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -778,31 +778,31 @@ IF (KOKKOS_ENABLE_OPENMPTARGET)
     )
   ELSE()
     COMPILER_SPECIFIC_OPTIONS(
-      IntelLLVM -fopenmp-targets=spir64_gen
+      IntelLLVM -fopenmp-targets=spir64_gen -D__STRICT_ANSI__
     )
     IF(KOKKOS_ARCH_INTEL_GEN9)
       COMPILER_SPECIFIC_LINK_OPTIONS(
-        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device gen9" -D__STRICT_ANSI__
+        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device gen9"
       )
     ELSEIF(KOKKOS_ARCH_INTEL_GEN11)
       COMPILER_SPECIFIC_LINK_OPTIONS(
-        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device gen11" -D__STRICT_ANSI__
+        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device gen11"
       )
     ELSEIF(KOKKOS_ARCH_INTEL_GEN12LP)
       COMPILER_SPECIFIC_LINK_OPTIONS(
-        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device gen12lp" -D__STRICT_ANSI__
+        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device gen12lp"
       )
     ELSEIF(KOKKOS_ARCH_INTEL_DG1)
       COMPILER_SPECIFIC_LINK_OPTIONS(
-        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device dg1" -D__STRICT_ANSI__
+        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device dg1"
       )
     ELSEIF(KOKKOS_ARCH_INTEL_XEHP)
       COMPILER_SPECIFIC_LINK_OPTIONS(
-        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device 12.50.4" -D__STRICT_ANSI__
+        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device 12.50.4"
       )
     ELSEIF(KOKKOS_ARCH_INTEL_PVC)
       COMPILER_SPECIFIC_LINK_OPTIONS(
-        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device 12.60.7" -D__STRICT_ANSI__
+        IntelLLVM -fopenmp-targets=spir64_gen -Xopenmp-target-backend "-device 12.60.7"
     )
     ENDIF()
   ENDIF()

--- a/core/unit_test/TestMathematicalSpecialFunctions.hpp
+++ b/core/unit_test/TestMathematicalSpecialFunctions.hpp
@@ -1967,31 +1967,61 @@ TEST(TEST_CATEGORY, mathspecialfunc_errorfunc) {
 #endif
 
 TEST(TEST_CATEGORY, mathspecialfunc_cbesselj0y0) {
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
+    GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
+                    "Intel GPUs";
+#endif
   TestComplexBesselJ0Y0Function<TEST_EXECSPACE> test;
   test.testit();
 }
 
 TEST(TEST_CATEGORY, mathspecialfunc_cbesselj1y1) {
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
+    GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
+                    "Intel GPUs";
+#endif
   TestComplexBesselJ1Y1Function<TEST_EXECSPACE> test;
   test.testit();
 }
 
 TEST(TEST_CATEGORY, mathspecialfunc_cbesseli0k0) {
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
+    GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
+                    "Intel GPUs";
+#endif
   TestComplexBesselI0K0Function<TEST_EXECSPACE> test;
   test.testit();
 }
 
 TEST(TEST_CATEGORY, mathspecialfunc_cbesseli1k1) {
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
+    GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
+                    "Intel GPUs";
+#endif
   TestComplexBesselI1K1Function<TEST_EXECSPACE> test;
   test.testit();
 }
 
 TEST(TEST_CATEGORY, mathspecialfunc_cbesselh1stkind) {
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
+    GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
+                    "Intel GPUs";
+#endif
   TestComplexBesselH1Function<TEST_EXECSPACE> test;
   test.testit();
 }
 
 TEST(TEST_CATEGORY, mathspecialfunc_cbesselh2ndkind) {
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
+    GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
+                    "Intel GPUs";
+#endif
   TestComplexBesselH2Function<TEST_EXECSPACE> test;
   test.testit();
 }

--- a/core/unit_test/TestMathematicalSpecialFunctions.hpp
+++ b/core/unit_test/TestMathematicalSpecialFunctions.hpp
@@ -1970,7 +1970,7 @@ TEST(TEST_CATEGORY, mathspecialfunc_cbesselj0y0) {
 #if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
-                    "Intel GPUs";
+                    "Intel GPUs";  // FIXME_OPENMPTARGET
 #endif
   TestComplexBesselJ0Y0Function<TEST_EXECSPACE> test;
   test.testit();
@@ -1980,7 +1980,7 @@ TEST(TEST_CATEGORY, mathspecialfunc_cbesselj1y1) {
 #if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
-                    "Intel GPUs";
+                    "Intel GPUs";  // FIXME_OPENMPTARGET
 #endif
   TestComplexBesselJ1Y1Function<TEST_EXECSPACE> test;
   test.testit();
@@ -1990,7 +1990,7 @@ TEST(TEST_CATEGORY, mathspecialfunc_cbesseli0k0) {
 #if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
-                    "Intel GPUs";
+                    "Intel GPUs";  // FIXME_OPENMPTARGET
 #endif
   TestComplexBesselI0K0Function<TEST_EXECSPACE> test;
   test.testit();
@@ -2000,7 +2000,7 @@ TEST(TEST_CATEGORY, mathspecialfunc_cbesseli1k1) {
 #if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
-                    "Intel GPUs";
+                    "Intel GPUs";  // FIXME_OPENMPTARGET
 #endif
   TestComplexBesselI1K1Function<TEST_EXECSPACE> test;
   test.testit();
@@ -2010,7 +2010,7 @@ TEST(TEST_CATEGORY, mathspecialfunc_cbesselh1stkind) {
 #if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
-                    "Intel GPUs";
+                    "Intel GPUs";  // FIXME_OPENMPTARGET
 #endif
   TestComplexBesselH1Function<TEST_EXECSPACE> test;
   test.testit();
@@ -2020,7 +2020,7 @@ TEST(TEST_CATEGORY, mathspecialfunc_cbesselh2ndkind) {
 #if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
-                    "Intel GPUs";
+                    "Intel GPUs";  // FIXME_OPENMPTARGET
 #endif
   TestComplexBesselH2Function<TEST_EXECSPACE> test;
   test.testit();

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -210,8 +210,8 @@ TEST(TEST_CATEGORY, numeric_traits_infinity) {
 #endif
   TestNumericTraits<TEST_EXECSPACE, float, Infinity>();
   TestNumericTraits<TEST_EXECSPACE, double, Infinity>();
-  // FIXME_NVHPC long double not supported, 23.7 long double
-  // FIXME_OPENMPTARGET
+  // FIXME_NVHPC 23.7 long double
+  // FIXME_OPENMPTARGET long double on Intel GPUs
 #if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
     (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, Infinity>();
@@ -225,7 +225,7 @@ TEST(TEST_CATEGORY, numeric_traits_epsilon) {
 #endif
   TestNumericTraits<TEST_EXECSPACE, float, Epsilon>();
   TestNumericTraits<TEST_EXECSPACE, double, Epsilon>();
-  // FIXME_NVHPC long double not supported, 23.7 long double
+  // FIXME_NVHPC 23.7 long double
 #if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
     (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, Epsilon>();
@@ -240,7 +240,7 @@ TEST(TEST_CATEGORY, numeric_traits_round_error) {
 #endif
   TestNumericTraits<TEST_EXECSPACE, float, RoundError>();
   TestNumericTraits<TEST_EXECSPACE, double, RoundError>();
-  // FIXME_NVHPC long double not supported, 23.7 long double
+  // FIXME_NVHPC 23.7 long double
 #if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
     (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, RoundError>();
@@ -254,7 +254,7 @@ TEST(TEST_CATEGORY, numeric_traits_norm_min) {
 #endif
   TestNumericTraits<TEST_EXECSPACE, float, NormMin>();
   TestNumericTraits<TEST_EXECSPACE, double, NormMin>();
-  // FIXME_NVHPC long double not supported, 23.7 long double
+  // FIXME_NVHPC 23.7 long double
 #if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
     (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, NormMin>();
@@ -264,7 +264,7 @@ TEST(TEST_CATEGORY, numeric_traits_norm_min) {
 TEST(TEST_CATEGORY, numeric_traits_denorm_min) {
   TestNumericTraits<TEST_EXECSPACE, float, DenormMin>();
   TestNumericTraits<TEST_EXECSPACE, double, DenormMin>();
-  // FIXME_NVHPC long double not supported, 23.7 long double
+  // FIXME_NVHPC 23.7 long double
 #if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
     (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, DenormMin>();
@@ -303,8 +303,8 @@ TEST(TEST_CATEGORY, numeric_traits_finite_min_max) {
   TestNumericTraits<TEST_EXECSPACE, float, FiniteMax>();
   TestNumericTraits<TEST_EXECSPACE, double, FiniteMin>();
   TestNumericTraits<TEST_EXECSPACE, double, FiniteMax>();
-  // FIXME_NVHPC long double not supported, 23.7 long double
-  // FIXME_OPENMPTARGET
+  // FIXME_NVHPC 23.7 long double
+  // FIXME_OPENMPTARGET long double on Intel GPUs
 #if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
     (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, FiniteMin>();
@@ -329,8 +329,8 @@ TEST(TEST_CATEGORY, numeric_traits_digits) {
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Digits>();
   TestNumericTraits<TEST_EXECSPACE, float, Digits>();
   TestNumericTraits<TEST_EXECSPACE, double, Digits>();
-  // FIXME_NVHPC long double not supported, 23.7 long double
-  // FIXME_OPENMPTARGET
+  // FIXME_NVHPC 23.7 long double
+  // FIXME_OPENMPTARGET long double on Intel GPUs
 #if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
     (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, Digits>();
@@ -354,8 +354,8 @@ TEST(TEST_CATEGORY, numeric_traits_digits10) {
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Digits10>();
   TestNumericTraits<TEST_EXECSPACE, float, Digits10>();
   TestNumericTraits<TEST_EXECSPACE, double, Digits10>();
-  // FIXME_NVHPC long double not supported, 23.7 long double
-  // FIXME_OPENMPTARGET
+  // FIXME_NVHPC 23.7 long double
+  // FIXME_OPENMPTARGET long double on Intel GPUs
 #if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
     (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, Digits10>();
@@ -365,8 +365,8 @@ TEST(TEST_CATEGORY, numeric_traits_digits10) {
 TEST(TEST_CATEGORY, numeric_traits_max_digits10) {
   TestNumericTraits<TEST_EXECSPACE, float, MaxDigits10>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxDigits10>();
-  // FIXME_NVHPC long double not supported, 23.7 long double
-  // FIXME_OPENMPTARGET
+  // FIXME_NVHPC 23.7 long double
+  // FIXME_OPENMPTARGET long double on Intel GPUs
 #if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
     (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, MaxDigits10>();
@@ -389,8 +389,8 @@ TEST(TEST_CATEGORY, numeric_traits_radix) {
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Radix>();
   TestNumericTraits<TEST_EXECSPACE, float, Radix>();
   TestNumericTraits<TEST_EXECSPACE, double, Radix>();
-  // FIXME_NVHPC long double not supported, 23.7 long double
-  // FIXME_OPENMPTARGET
+  // FIXME_NVHPC 23.7 long double
+  // FIXME_OPENMPTARGET long double on Intel GPUs
 #if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
     (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, Radix>();
@@ -406,8 +406,8 @@ TEST(TEST_CATEGORY, numeric_traits_min_max_exponent) {
   TestNumericTraits<TEST_EXECSPACE, float, MaxExponent>();
   TestNumericTraits<TEST_EXECSPACE, double, MinExponent>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxExponent>();
-  // FIXME_NVHPC long double not supported, 23.7 long double
-  // FIXME_OPENMPTARGET
+  // FIXME_NVHPC 23.7 long double
+  // FIXME_OPENMPTARGET long double on Intel GPUs
 #if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
     (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, MinExponent>();
@@ -420,8 +420,8 @@ TEST(TEST_CATEGORY, numeric_traits_min_max_exponent10) {
   TestNumericTraits<TEST_EXECSPACE, float, MaxExponent10>();
   TestNumericTraits<TEST_EXECSPACE, double, MinExponent10>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxExponent10>();
-  // FIXME_NVHPC long double not supported, 23.7 long double
-  // FIXME_OPENMPTARGET
+  // FIXME_NVHPC 23.7 long double
+  // FIXME_OPENMPTARGET long double on Intel GPUs
 #if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
     (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, MinExponent10>();
@@ -441,8 +441,8 @@ TEST(TEST_CATEGORY, numeric_traits_quiet_and_signaling_nan) {
   TestNumericTraits<TEST_EXECSPACE, float, SignalingNaN>();
   TestNumericTraits<TEST_EXECSPACE, double, QuietNaN>();
   TestNumericTraits<TEST_EXECSPACE, double, SignalingNaN>();
-  // FIXME_NVHPC long double not supported, 23.7 long double
-  // FIXME_OPENMPTARGET
+  // FIXME_NVHPC 23.7 long double
+  // FIXME_OPENMPTARGET long double on Intel GPUs
 #if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
     (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, QuietNaN>();

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -210,9 +210,10 @@ TEST(TEST_CATEGORY, numeric_traits_infinity) {
 #endif
   TestNumericTraits<TEST_EXECSPACE, float, Infinity>();
   TestNumericTraits<TEST_EXECSPACE, double, Infinity>();
-  // FIXME_NVHPC long double not supported
-#if !defined(KOKKOS_ENABLE_CUDA) || \
-    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double
+  // FIXME_NVHPC long double not supported, 23.7 long double
+  // FIXME_OPENMPTARGET
+#if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
+    (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, Infinity>();
 #endif
 }
@@ -224,9 +225,9 @@ TEST(TEST_CATEGORY, numeric_traits_epsilon) {
 #endif
   TestNumericTraits<TEST_EXECSPACE, float, Epsilon>();
   TestNumericTraits<TEST_EXECSPACE, double, Epsilon>();
-  // FIXME_NVHPC long double not supported
-#if !defined(KOKKOS_ENABLE_CUDA) || \
-    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
+  // FIXME_NVHPC long double not supported, 23.7 long double
+#if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
+    (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, Epsilon>();
 #endif
 }
@@ -239,9 +240,9 @@ TEST(TEST_CATEGORY, numeric_traits_round_error) {
 #endif
   TestNumericTraits<TEST_EXECSPACE, float, RoundError>();
   TestNumericTraits<TEST_EXECSPACE, double, RoundError>();
-  // FIXME_NVHPC long double not supported
-#if !defined(KOKKOS_ENABLE_CUDA) || \
-    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
+  // FIXME_NVHPC long double not supported, 23.7 long double
+#if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
+    (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, RoundError>();
 #endif
 }
@@ -253,9 +254,9 @@ TEST(TEST_CATEGORY, numeric_traits_norm_min) {
 #endif
   TestNumericTraits<TEST_EXECSPACE, float, NormMin>();
   TestNumericTraits<TEST_EXECSPACE, double, NormMin>();
-  // FIXME_NVHPC long double not supported
-#if !defined(KOKKOS_ENABLE_CUDA) || \
-    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
+  // FIXME_NVHPC long double not supported, 23.7 long double
+#if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
+    (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, NormMin>();
 #endif
 }
@@ -263,9 +264,9 @@ TEST(TEST_CATEGORY, numeric_traits_norm_min) {
 TEST(TEST_CATEGORY, numeric_traits_denorm_min) {
   TestNumericTraits<TEST_EXECSPACE, float, DenormMin>();
   TestNumericTraits<TEST_EXECSPACE, double, DenormMin>();
-  // FIXME_NVHPC long double not supported
-#if !defined(KOKKOS_ENABLE_CUDA) || \
-    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
+  // FIXME_NVHPC long double not supported, 23.7 long double
+#if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
+    (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, DenormMin>();
 #endif
 }
@@ -302,8 +303,10 @@ TEST(TEST_CATEGORY, numeric_traits_finite_min_max) {
   TestNumericTraits<TEST_EXECSPACE, float, FiniteMax>();
   TestNumericTraits<TEST_EXECSPACE, double, FiniteMin>();
   TestNumericTraits<TEST_EXECSPACE, double, FiniteMax>();
-#if !defined(KOKKOS_ENABLE_CUDA) || \
-    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
+  // FIXME_NVHPC long double not supported, 23.7 long double
+  // FIXME_OPENMPTARGET
+#if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
+    (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, FiniteMin>();
   TestNumericTraits<TEST_EXECSPACE, long double, FiniteMax>();
 #endif
@@ -326,8 +329,10 @@ TEST(TEST_CATEGORY, numeric_traits_digits) {
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Digits>();
   TestNumericTraits<TEST_EXECSPACE, float, Digits>();
   TestNumericTraits<TEST_EXECSPACE, double, Digits>();
-#if !defined(KOKKOS_ENABLE_CUDA) || \
-    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
+  // FIXME_NVHPC long double not supported, 23.7 long double
+  // FIXME_OPENMPTARGET
+#if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
+    (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, Digits>();
 #endif
 }
@@ -349,8 +354,10 @@ TEST(TEST_CATEGORY, numeric_traits_digits10) {
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Digits10>();
   TestNumericTraits<TEST_EXECSPACE, float, Digits10>();
   TestNumericTraits<TEST_EXECSPACE, double, Digits10>();
-#if !defined(KOKKOS_ENABLE_CUDA) || \
-    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
+  // FIXME_NVHPC long double not supported, 23.7 long double
+  // FIXME_OPENMPTARGET
+#if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
+    (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, Digits10>();
 #endif
 }
@@ -358,8 +365,10 @@ TEST(TEST_CATEGORY, numeric_traits_digits10) {
 TEST(TEST_CATEGORY, numeric_traits_max_digits10) {
   TestNumericTraits<TEST_EXECSPACE, float, MaxDigits10>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxDigits10>();
-#if !defined(KOKKOS_ENABLE_CUDA) || \
-    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
+  // FIXME_NVHPC long double not supported, 23.7 long double
+  // FIXME_OPENMPTARGET
+#if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
+    (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, MaxDigits10>();
 #endif
 }
@@ -380,8 +389,10 @@ TEST(TEST_CATEGORY, numeric_traits_radix) {
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Radix>();
   TestNumericTraits<TEST_EXECSPACE, float, Radix>();
   TestNumericTraits<TEST_EXECSPACE, double, Radix>();
-#if !defined(KOKKOS_ENABLE_CUDA) || \
-    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
+  // FIXME_NVHPC long double not supported, 23.7 long double
+  // FIXME_OPENMPTARGET
+#if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
+    (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, Radix>();
 #endif
 }
@@ -395,8 +406,10 @@ TEST(TEST_CATEGORY, numeric_traits_min_max_exponent) {
   TestNumericTraits<TEST_EXECSPACE, float, MaxExponent>();
   TestNumericTraits<TEST_EXECSPACE, double, MinExponent>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxExponent>();
-#if !defined(KOKKOS_ENABLE_CUDA) || \
-    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
+  // FIXME_NVHPC long double not supported, 23.7 long double
+  // FIXME_OPENMPTARGET
+#if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
+    (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, MinExponent>();
   TestNumericTraits<TEST_EXECSPACE, long double, MaxExponent>();
 #endif
@@ -407,8 +420,10 @@ TEST(TEST_CATEGORY, numeric_traits_min_max_exponent10) {
   TestNumericTraits<TEST_EXECSPACE, float, MaxExponent10>();
   TestNumericTraits<TEST_EXECSPACE, double, MinExponent10>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxExponent10>();
-#if !defined(KOKKOS_ENABLE_CUDA) || \
-    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
+  // FIXME_NVHPC long double not supported, 23.7 long double
+  // FIXME_OPENMPTARGET
+#if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
+    (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, MinExponent10>();
   TestNumericTraits<TEST_EXECSPACE, long double, MaxExponent10>();
 #endif
@@ -426,8 +441,10 @@ TEST(TEST_CATEGORY, numeric_traits_quiet_and_signaling_nan) {
   TestNumericTraits<TEST_EXECSPACE, float, SignalingNaN>();
   TestNumericTraits<TEST_EXECSPACE, double, QuietNaN>();
   TestNumericTraits<TEST_EXECSPACE, double, SignalingNaN>();
-#if !defined(KOKKOS_ENABLE_CUDA) || \
-    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double:
+  // FIXME_NVHPC long double not supported, 23.7 long double
+  // FIXME_OPENMPTARGET
+#if (!defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_NVHPC)) && \
+    (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, QuietNaN>();
   TestNumericTraits<TEST_EXECSPACE, long double, SignalingNaN>();
 #endif


### PR DESCRIPTION
This pull request updates the linker flags for OpenMPTarget on Intel GPUs matching what we are doing for SYCL and disables failing tests. Interestingly, we see problems both for SYCL and OpenMPTarget with the bessel functions but we have more failures with the latter.

I reported the test failures to Argonne folks.