### PR TITLE
Avoid calling wrapper functions with singleton for Cuda

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -43,8 +43,8 @@
 cudaStream_t Kokkos::Impl::cuda_get_deep_copy_stream() {
   static cudaStream_t s = nullptr;
   if (s == nullptr) {
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(Cuda().cuda_device()));
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamCreate(&s));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (CudaInternal::singleton().cuda_stream_create_wrapper(&s)));
   }
   return s;
 }
@@ -67,8 +67,8 @@ static std::atomic<int> num_uvm_allocations(0);
 }  // namespace
 
 void DeepCopyCuda(void *dst, const void *src, size_t n) {
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(Cuda().cuda_device()));
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemcpy(dst, src, n, cudaMemcpyDefault));
+  KOKKOS_IMPL_CUDA_SAFE_CALL((CudaInternal::singleton().cuda_memcpy_wrapper(
+      dst, src, n, cudaMemcpyDefault)));
 }
 
 void DeepCopyAsyncCuda(const Cuda &instance, void *dst, const void *src,
@@ -81,7 +81,8 @@ void DeepCopyAsyncCuda(const Cuda &instance, void *dst, const void *src,
 void DeepCopyAsyncCuda(void *dst, const void *src, size_t n) {
   cudaStream_t s = cuda_get_deep_copy_stream();
   KOKKOS_IMPL_CUDA_SAFE_CALL(
-      cudaMemcpyAsync(dst, src, n, cudaMemcpyDefault, s));
+      (CudaInternal::singleton().cuda_memcpy_async_wrapper(
+          dst, src, n, cudaMemcpyDefault, s)));
   Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Cuda>(
       "Kokkos::Impl::DeepCopyAsyncCuda: Deep Copy Stream Sync",
       Kokkos::Tools::Experimental::SpecialSynchronizationCases::

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -145,13 +145,13 @@ void cuda_device_synchronize(const std::string &name) {
       // annotate with __host__ silence a clang warning about using
       // cudaDeviceSynchronize in device code
       [] __host__() {
-        KOKKOS_IMPL_CUDA_SAFE_CALL(
-            (CudaInternal::singleton().cuda_device_synchronize_wrapper()));
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(Cuda().cuda_device()));
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaDeviceSynchronize());
       });
 #else
       []() {
-        KOKKOS_IMPL_CUDA_SAFE_CALL(
-            (CudaInternal::singleton().cuda_device_synchronize_wrapper()));
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(Cuda().cuda_device()));
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaDeviceSynchronize());
       });
 #endif
 }
@@ -165,18 +165,6 @@ void cuda_stream_synchronize(const cudaStream_t stream, const CudaInternal *ptr,
       [&]() {
         KOKKOS_IMPL_CUDA_SAFE_CALL(
             (ptr->cuda_stream_synchronize_wrapper(stream)));
-      });
-}
-
-void cuda_stream_synchronize(
-    const cudaStream_t stream,
-    Kokkos::Tools::Experimental::SpecialSynchronizationCases reason,
-    const std::string &name) {
-  Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Cuda>(
-      name, reason, [&]() {
-        KOKKOS_IMPL_CUDA_SAFE_CALL(
-            (Impl::CudaInternal::singleton().cuda_stream_synchronize_wrapper(
-                stream)));
       });
 }
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -145,13 +145,13 @@ void cuda_device_synchronize(const std::string &name) {
       // annotate with __host__ silence a clang warning about using
       // cudaDeviceSynchronize in device code
       [] __host__() {
-        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(Cuda().cuda_device()));
-        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaDeviceSynchronize());
+        KOKKOS_IMPL_CUDA_SAFE_CALL(
+            (CudaInternal::singleton().cuda_device_synchronize_wrapper()));
       });
 #else
       []() {
-        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(Cuda().cuda_device()));
-        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaDeviceSynchronize());
+        KOKKOS_IMPL_CUDA_SAFE_CALL(
+            (CudaInternal::singleton().cuda_device_synchronize_wrapper()));
       });
 #endif
 }

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -136,9 +136,8 @@ const cudaFuncAttributes& get_cuda_kernel_func_attributes(
   // by leveraging static variable initialization rules
   auto wrap_get_attributes = [&]() -> cudaFuncAttributes {
     cudaFuncAttributes attr;
-    KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (CudaInternal::singleton().cuda_func_get_attributes_wrapper(&attr,
-                                                                    func)));
+    // KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(cuda_device));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFuncGetAttributes(&attr, func));
     return attr;
   };
   static cudaFuncAttributes func_attr = wrap_get_attributes();
@@ -221,9 +220,9 @@ inline void configure_shmem_preference(const KernelFuncPtr& func,
   // Set the carveout, but only call it once per kernel or when it changes
   // FIXME_CUDA_MULTIPLE_DEVICES
   auto set_cache_config = [&] {
-    KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (CudaInternal::singleton().cuda_func_set_attributes_wrapper(
-            func, cudaFuncAttributePreferredSharedMemoryCarveout, carveout)));
+    // KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(cuda_device));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFuncSetAttributes(
+        func, cudaFuncAttributePreferredSharedMemoryCarveout, carveout));
     return carveout;
   };
   // Store the value in a static variable so we only reset if needed

--- a/core/src/Cuda/Kokkos_Cuda_Task.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Task.hpp
@@ -225,8 +225,9 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::Cuda, QueueType>> {
   // FIXME_CUDA_MULTIPLE_DEVICES
   static void execute(scheduler_type const& scheduler) {
     const int shared_per_warp = 2048;
+    const Kokkos::Cuda exec   = scheduler.get_execution_space();
     const int multi_processor_count =
-        scheduler.get_execution_space().cuda_device_prop().multiProcessorCount;
+        exec.cuda_device_prop().multiProcessorCount;
     const dim3 grid(multi_processor_count, 1, 1);
     const dim3 block(1, Kokkos::Impl::CudaTraits::WarpSize, warps_per_block);
     const int shared_total    = shared_per_warp * warps_per_block;
@@ -247,34 +248,33 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::Cuda, QueueType>> {
     // Query the stack size, in bytes:
 
     size_t previous_stack_size = 0;
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(exec.cuda_device()));
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (CudaInternal::singleton().cuda_device_get_limit_wrapper(
-            &previous_stack_size, cudaLimitStackSize)));
+        cudaDeviceGetLimit(&previous_stack_size, cudaLimitStackSize));
 
     // If not large enough then set the stack size, in bytes:
 
     const size_t larger_stack_size = 1 << 11;
 
     if (previous_stack_size < larger_stack_size) {
+      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(exec.cuda_device()));
       KOKKOS_IMPL_CUDA_SAFE_CALL(
-          (CudaInternal::singleton().cuda_device_set_limit_wrapper(
-              cudaLimitStackSize, larger_stack_size)));
+          cudaDeviceSetLimit(cudaLimitStackSize, larger_stack_size));
     }
 
     cuda_task_queue_execute<<<grid, block, shared_total, stream>>>(
         scheduler, shared_per_warp);
 
-    KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (CudaInternal::singleton().cuda_get_last_error_wrapper()));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetLastError());
 
     Impl::cuda_device_synchronize(
         "Kokkos::Impl::TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::"
         "Cuda>::execute: Post Task Execution");
 
     if (previous_stack_size < larger_stack_size) {
+      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(exec.cuda_device()));
       KOKKOS_IMPL_CUDA_SAFE_CALL(
-          (CudaInternal::singleton().cuda_device_set_limit_wrapper(
-              cudaLimitStackSize, previous_stack_size)));
+          cudaDeviceSetLimit(cudaLimitStackSize, previous_stack_size));
     }
   }
 
@@ -302,8 +302,7 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::Cuda, QueueType>> {
     set_cuda_task_base_apply_function_pointer<TaskType>
         <<<1, 1>>>(ptr_ptr, dtor_ptr);
 
-    KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (CudaInternal::singleton().cuda_get_last_error_wrapper()));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetLastError());
     Impl::cuda_device_synchronize(
         "Kokkos::Impl::TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::"
         "Cuda>::execute: Post Get Function Pointer for Tasks");
@@ -468,10 +467,9 @@ class TaskQueueSpecializationConstrained<
   static void execute(scheduler_type const& scheduler) {
     const int shared_per_warp = 2048;
     const int warps_per_block = 4;
+    const Kokkos::Cuda exec   = Cuda();  // FIXME_CUDA_MULTIPLE_DEVICES
     const int multi_processor_count =
-        // FIXME not sure why this didn't work
-        // scheduler.get_execution_space().cuda_device_prop().multiProcessorCount;
-        CudaInternal::singleton().m_deviceProp.multiProcessorCount;
+        exec.impl_internal_space_instance()->m_deviceProp.multiProcessorCount;
     const dim3 grid(multi_processor_count, 1, 1);
     // const dim3 grid( 1 , 1 , 1 );
     const dim3 block(1, Kokkos::Impl::CudaTraits::WarpSize, warps_per_block);
@@ -488,34 +486,33 @@ class TaskQueueSpecializationConstrained<
     // Query the stack size, in bytes:
 
     size_t previous_stack_size = 0;
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(exec.cuda_device()));
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (CudaInternal::singleton().cuda_device_get_limit_wrapper(
-            &previous_stack_size, cudaLimitStackSize)));
+        cudaDeviceGetLimit(&previous_stack_size, cudaLimitStackSize));
 
     // If not large enough then set the stack size, in bytes:
 
     const size_t larger_stack_size = 2048;
 
     if (previous_stack_size < larger_stack_size) {
+      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(exec.cuda_device()));
       KOKKOS_IMPL_CUDA_SAFE_CALL(
-          (CudaInternal::singleton().cuda_device_set_limit_wrapper(
-              cudaLimitStackSize, larger_stack_size)));
+          cudaDeviceSetLimit(cudaLimitStackSize, larger_stack_size));
     }
 
     cuda_task_queue_execute<<<grid, block, shared_total, stream>>>(
         scheduler, shared_per_warp);
 
-    KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (CudaInternal::singleton().cuda_get_last_error_wrapper()));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetLastError());
 
     Impl::cuda_device_synchronize(
         "Kokkos::Impl::TaskQueueSpecializationConstrained<SimpleTaskScheduler<"
         "Kokkos::Cuda>::execute: Post Execute Task");
 
     if (previous_stack_size < larger_stack_size) {
+      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(exec.cuda_device()));
       KOKKOS_IMPL_CUDA_SAFE_CALL(
-          (CudaInternal::singleton().cuda_device_set_limit_wrapper(
-              cudaLimitStackSize, previous_stack_size)));
+          cudaDeviceSetLimit(cudaLimitStackSize, previous_stack_size));
     }
   }
 
@@ -538,8 +535,7 @@ class TaskQueueSpecializationConstrained<
     set_cuda_task_base_apply_function_pointer<TaskType>
         <<<1, 1>>>(ptr_ptr, dtor_ptr);
 
-    KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (CudaInternal::singleton().cuda_get_last_error_wrapper()));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetLastError());
     Impl::cuda_device_synchronize(
         "Kokkos::Impl::TaskQueueSpecializationConstrained<SimpleTaskScheduler<"
         "Kokkos::Cuda>::get_function_pointer: Post Get Function Pointer");

--- a/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
@@ -36,11 +36,10 @@ struct ZeroMemset<Kokkos::Cuda, View<T, P...>> {
 
   ZeroMemset(const View<T, P...>& dst,
              typename View<T, P...>::const_value_type&) {
-    // FIXME_CUDA_MULTIPLE_DEVICES
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(Cuda().cuda_device()));
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (Kokkos::Impl::CudaInternal::singleton().cuda_memset_wrapper(
-            dst.data(), 0,
-            dst.size() * sizeof(typename View<T, P...>::value_type))));
+        cudaMemset(dst.data(), 0,
+                   dst.size() * sizeof(typename View<T, P...>::value_type)));
   }
 };
 


### PR DESCRIPTION
Related to #6091. This pull request replaces all instances of calling `CudaInternal::singleton` with a wrapper since these places are possibly using the wrong device. It seems better to be explicit even in cases where we want to use the default execution space instance/the default device.

I would go through unused wrapper functions and remove them in a follow-up pull request.