### PR TITLE
Avoid unnecessary zero-memset of the scratch flags in SYCL

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -350,6 +350,9 @@ Cuda::size_type *CudaInternal::scratch_flags(const std::size_t size) const {
     m_scratchFlags = static_cast<size_type *>(
         mem_space.allocate("Kokkos::InternalScratchFlags", alloc_size));
 
+    // We only zero-initialiaze the allocation when we actually allocate.
+    // It's the responsibility of the features using scratch_flags,
+    // namely parallel_reduce and parallel_scan, to reset the used values to 0.
     KOKKOS_IMPL_CUDA_SAFE_CALL(
         (cuda_memset_wrapper(m_scratchFlags, 0, alloc_size)));
   }

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -350,7 +350,7 @@ Cuda::size_type *CudaInternal::scratch_flags(const std::size_t size) const {
     m_scratchFlags = static_cast<size_type *>(
         mem_space.allocate("Kokkos::InternalScratchFlags", alloc_size));
 
-    // We only zero-initialiaze the allocation when we actually allocate.
+    // We only zero-initialize the allocation when we actually allocate.
     // It's the responsibility of the features using scratch_flags,
     // namely parallel_reduce and parallel_scan, to reset the used values to 0.
     KOKKOS_IMPL_CUDA_SAFE_CALL(

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -226,6 +226,9 @@ Kokkos::HIP::size_type *HIPInternal::scratch_flags(const std::size_t size) {
     m_scratchFlags = static_cast<size_type *>(
         mem_space.allocate("Kokkos::InternalScratchFlags", alloc_size));
 
+    // We only zero-initialiaze the allocation when we actually allocate.
+    // It's the responsibility of the features using scratch_flags,
+    // namely parallel_reduce and parallel_scan, to reset the used values to 0.
     KOKKOS_IMPL_HIP_SAFE_CALL(hipMemset(m_scratchFlags, 0, alloc_size));
   }
 

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -226,7 +226,7 @@ Kokkos::HIP::size_type *HIPInternal::scratch_flags(const std::size_t size) {
     m_scratchFlags = static_cast<size_type *>(
         mem_space.allocate("Kokkos::InternalScratchFlags", alloc_size));
 
-    // We only zero-initialiaze the allocation when we actually allocate.
+    // We only zero-initialize the allocation when we actually allocate.
     // It's the responsibility of the features using scratch_flags,
     // namely parallel_reduce and parallel_scan, to reset the used values to 0.
     KOKKOS_IMPL_HIP_SAFE_CALL(hipMemset(m_scratchFlags, 0, alloc_size));

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -289,7 +289,7 @@ sycl::device_ptr<void> SYCLInternal::scratch_flags(const std::size_t size) {
     m_scratchFlags = static_cast<size_type*>(mem_space.allocate(
         "Kokkos::Experimental::SYCL::InternalScratchFlags", alloc_size));
 
-    // We only zero-initialiaze the allocation when we actually allocate.
+    // We only zero-initialize the allocation when we actually allocate.
     // It's the responsibility of the features using scratch_flags,
     // namely parallel_reduce and parallel_scan, to reset the used values to 0.
     auto memset_event = m_queue->memset(m_scratchFlags, 0,

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -288,12 +288,16 @@ sycl::device_ptr<void> SYCLInternal::scratch_flags(const std::size_t size) {
         m_scratchFlagsCount, sizeScratchGrain);
     m_scratchFlags = static_cast<size_type*>(mem_space.allocate(
         "Kokkos::Experimental::SYCL::InternalScratchFlags", alloc_size));
-  }
-  auto memset_event = m_queue->memset(m_scratchFlags, 0,
-                                      m_scratchFlagsCount * sizeScratchGrain);
+
+    // We only zero-initialiaze the allocation when we actually allocate.
+    // It's the responsibility of the features using scratch_flags,
+    // namely parallel_reduce and parallel_scan, to reset the used values to 0.
+    auto memset_event = m_queue->memset(m_scratchFlags, 0,
+                                        m_scratchFlagsCount * sizeScratchGrain);
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
-  m_queue->ext_oneapi_submit_barrier(std::vector{memset_event});
+    m_queue->ext_oneapi_submit_barrier(std::vector{memset_event});
 #endif
+  }
 
   return m_scratchFlags;
 }

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
@@ -234,6 +234,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                 }
                 item.barrier(sycl::access::fence_space::local_space);
                 if (num_teams_done[0] == n_wgroups) {
+                  if (local_id == 0) *scratch_flags = 0;
                   if (local_id >= static_cast<int>(n_wgroups))
                     reducer.init(&local_mem[local_id * value_count]);
                   else {
@@ -279,6 +280,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                 }
                 item.barrier(sycl::access::fence_space::local_space);
                 if (num_teams_done[0] == n_wgroups) {
+                  if (local_id == 0) *scratch_flags = 0;
                   if (local_id >= static_cast<int>(n_wgroups))
                     reducer.init(&local_value);
                   else {

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
@@ -177,6 +177,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                 }
                 item.barrier(sycl::access::fence_space::local_space);
                 if (num_teams_done[0] == n_wgroups) {
+                  if (local_id == 0) *scratch_flags = 0;
                   if (local_id >= n_wgroups)
                     reducer.init(&local_mem[local_id * value_count]);
                   else {
@@ -219,6 +220,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                 }
                 item.barrier(sycl::access::fence_space::local_space);
                 if (num_teams_done[0] == n_wgroups) {
+                  if (local_id == 0) *scratch_flags = 0;
                   if (local_id >= n_wgroups)
                     reducer.init(&local_value);
                   else {

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -229,6 +229,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                   }
                   sycl::group_barrier(item.get_group());
                   if (num_teams_done[0] == n_wgroups) {
+                    if (local_id == 0) *scratch_flags = 0;
                     if (local_id >= n_wgroups)
                       reducer.init(&local_mem[local_id * value_count]);
                     else {
@@ -281,6 +282,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                   }
                   item.barrier(sycl::access::fence_space::local_space);
                   if (num_teams_done[0] == n_wgroups) {
+                    if (local_id == 0) *scratch_flags = 0;
                     if (local_id >= n_wgroups)
                       reducer.init(&local_value);
                     else {

--- a/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
@@ -187,6 +187,7 @@ class ParallelScanSYCLBase {
             }
             item.barrier(sycl::access::fence_space::global_space);
             if (num_teams_done[0] == n_wgroups) {
+              if (local_id == 0) *scratch_flags = 0;
               value_type total;
               reducer.init(&total);
 


### PR DESCRIPTION
I spotted this oddity in #6732 
SYCL does properly set the flags to zero https://github.com/kokkos/kokkos/blob/34973c77309cb8af20fae065dea7e44146b22aed/core/src/SYCL/Kokkos_SYCL_Instance.cpp#L292-L293

It might very well be that the zero-memset is not needed.