### PR TITLE
Make Kokkos::Tools::Impl::begin_parallel_* internally specializable

### DIFF
--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -135,7 +135,9 @@ inline void parallel_for(const std::string& str, const ExecPolicy& policy,
   uint64_t kpID = 0;
 
   ExecPolicy inner_policy = policy;
-  Kokkos::Tools::Impl::begin_parallel_for(inner_policy, functor, str, kpID);
+  Kokkos::Tools::Impl::ParallelForToolsHook<
+      FunctorType, ExecPolicy>::begin_parallel_for(inner_policy, functor, str,
+                                                   kpID);
 
   Kokkos::Impl::shared_allocation_tracking_disable();
   Impl::ParallelFor<FunctorType, ExecPolicy> closure(functor, inner_policy);
@@ -143,7 +145,9 @@ inline void parallel_for(const std::string& str, const ExecPolicy& policy,
 
   closure.execute();
 
-  Kokkos::Tools::Impl::end_parallel_for(inner_policy, functor, str, kpID);
+  Kokkos::Tools::Impl::ParallelForToolsHook<
+      FunctorType, ExecPolicy>::end_parallel_for(inner_policy, functor, str,
+                                                 kpID);
 }
 
 template <class ExecPolicy, class FunctorType>
@@ -350,7 +354,7 @@ inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
                           const FunctorType& functor) {
   uint64_t kpID                = 0;
   ExecutionPolicy inner_policy = policy;
-  Kokkos::Tools::Impl::begin_parallel_scan(inner_policy, functor, str, kpID);
+  Kokkos::Tools::Impl::ParallelScanToolsHook< FunctorType, ExecutionPolicy >::begin_parallel_scan(inner_policy, functor, str, kpID);
 
   Kokkos::Impl::shared_allocation_tracking_disable();
   Impl::ParallelScan<FunctorType, ExecutionPolicy> closure(functor,
@@ -359,7 +363,7 @@ inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
 
   closure.execute();
 
-  Kokkos::Tools::Impl::end_parallel_scan(inner_policy, functor, str, kpID);
+  Kokkos::Tools::Impl::ParallelScanToolsHook< FunctorType, ExecutionPolicy >::end_parallel_scan(inner_policy, functor, str, kpID);
 }
 
 template <class ExecutionPolicy, class FunctorType>
@@ -395,7 +399,7 @@ inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
                           ReturnType& return_value) {
   uint64_t kpID                = 0;
   ExecutionPolicy inner_policy = policy;
-  Kokkos::Tools::Impl::begin_parallel_scan(inner_policy, functor, str, kpID);
+  Kokkos::Tools::Impl::ParallelScanToolsHook< FunctorType, ExecutionPolicy >::begin_parallel_scan(inner_policy, functor, str, kpID);
 
   if constexpr (Kokkos::is_view<ReturnType>::value) {
     Kokkos::Impl::shared_allocation_tracking_disable();
@@ -413,7 +417,7 @@ inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
     closure.execute();
   }
 
-  Kokkos::Tools::Impl::end_parallel_scan(inner_policy, functor, str, kpID);
+  Kokkos::Tools::Impl::ParallelScanToolsHook< FunctorType, ExecutionPolicy >::end_parallel_scan(inner_policy, functor, str, kpID);
 
   if (!Kokkos::is_view<ReturnType>::value)
     policy.space().fence(

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -354,7 +354,9 @@ inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
                           const FunctorType& functor) {
   uint64_t kpID                = 0;
   ExecutionPolicy inner_policy = policy;
-  Kokkos::Tools::Impl::ParallelScanToolsHook< FunctorType, ExecutionPolicy >::begin_parallel_scan(inner_policy, functor, str, kpID);
+  Kokkos::Tools::Impl::ParallelScanToolsHook<
+      FunctorType, ExecutionPolicy>::begin_parallel_scan(inner_policy, functor,
+                                                         str, kpID);
 
   Kokkos::Impl::shared_allocation_tracking_disable();
   Impl::ParallelScan<FunctorType, ExecutionPolicy> closure(functor,
@@ -363,7 +365,9 @@ inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
 
   closure.execute();
 
-  Kokkos::Tools::Impl::ParallelScanToolsHook< FunctorType, ExecutionPolicy >::end_parallel_scan(inner_policy, functor, str, kpID);
+  Kokkos::Tools::Impl::ParallelScanToolsHook<
+      FunctorType, ExecutionPolicy>::end_parallel_scan(inner_policy, functor,
+                                                       str, kpID);
 }
 
 template <class ExecutionPolicy, class FunctorType>
@@ -399,7 +403,9 @@ inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
                           ReturnType& return_value) {
   uint64_t kpID                = 0;
   ExecutionPolicy inner_policy = policy;
-  Kokkos::Tools::Impl::ParallelScanToolsHook< FunctorType, ExecutionPolicy >::begin_parallel_scan(inner_policy, functor, str, kpID);
+  Kokkos::Tools::Impl::ParallelScanToolsHook<
+      FunctorType, ExecutionPolicy>::begin_parallel_scan(inner_policy, functor,
+                                                         str, kpID);
 
   if constexpr (Kokkos::is_view<ReturnType>::value) {
     Kokkos::Impl::shared_allocation_tracking_disable();
@@ -417,7 +423,9 @@ inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
     closure.execute();
   }
 
-  Kokkos::Tools::Impl::ParallelScanToolsHook< FunctorType, ExecutionPolicy >::end_parallel_scan(inner_policy, functor, str, kpID);
+  Kokkos::Tools::Impl::ParallelScanToolsHook<
+      FunctorType, ExecutionPolicy>::end_parallel_scan(inner_policy, functor,
+                                                       str, kpID);
 
   if (!Kokkos::is_view<ReturnType>::value)
     policy.space().fence(

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1503,11 +1503,10 @@ struct ParallelReduceAdaptor {
         PolicyType,
         typename Impl::FunctorPolicyExecutionSpace<
             FunctorType, PolicyType>::execution_space>;
-    uint64_t kpID           = 0;
+    uint64_t kpID = 0;
 
     PolicyType inner_policy = policy;
-    ToolsHookType::begin_parallel_reduce(
-        inner_policy, functor, label, kpID);
+    ToolsHookType::begin_parallel_reduce(inner_policy, functor, label, kpID);
     Kokkos::Impl::shared_allocation_tracking_disable();
     CombinedFunctorReducer functor_reducer(
         functor, typename Analysis::Reducer(
@@ -1522,8 +1521,7 @@ struct ParallelReduceAdaptor {
     Kokkos::Impl::shared_allocation_tracking_enable();
     closure.execute();
 
-    ToolsHookType::end_parallel_reduce(
-        inner_policy, functor, label, kpID);
+    ToolsHookType::end_parallel_reduce(inner_policy, functor, label, kpID);
   }
 
   static constexpr bool is_array_reduction =

--- a/core/src/impl/Kokkos_Tools_Generic.hpp
+++ b/core/src/impl/Kokkos_Tools_Generic.hpp
@@ -353,126 +353,145 @@ void report_policy_results(const size_t /**tuning_context*/,
 
 namespace Impl {
 
-template <class ExecPolicy, class FunctorType>
-void begin_parallel_for(ExecPolicy& policy, FunctorType& functor,
-                        const std::string& label, uint64_t& kpID) {
-  if (Kokkos::Tools::profileLibraryLoaded()) {
-    Kokkos::Impl::ParallelConstructName<FunctorType,
-                                        typename ExecPolicy::work_tag>
-        name(label);
-    Kokkos::Tools::beginParallelFor(
-        name.get(), Kokkos::Profiling::Experimental::device_id(policy.space()),
-        &kpID);
-  }
+template <class FunctorType, class ExecPolicy,
+          class ExecutionSpace =
+              typename ::Kokkos::Impl::FunctorPolicyExecutionSpace<
+                  FunctorType, ExecPolicy>::execution_space>
+struct ParallelForToolsHook {
+  static void begin_parallel_for(const ExecPolicy& policy,
+                                 const FunctorType& functor,
+                                 const std::string& label, uint64_t& kpID) {
+    if (Kokkos::Tools::profileLibraryLoaded()) {
+      Kokkos::Impl::ParallelConstructName<FunctorType,
+                                          typename ExecPolicy::work_tag>
+          name(label);
+      Kokkos::Tools::beginParallelFor(
+          name.get(),
+          Kokkos::Profiling::Experimental::device_id(policy.space()), &kpID);
+    }
 #ifdef KOKKOS_ENABLE_TUNING
-  size_t context_id = Kokkos::Tools::Experimental::get_new_context_id();
-  if (Kokkos::tune_internals()) {
-    Experimental::Impl::tune_policy(context_id, label, policy, functor,
-                                    Kokkos::ParallelForTag{});
-  }
+    size_t context_id = Kokkos::Tools::Experimental::get_new_context_id();
+    if (Kokkos::tune_internals()) {
+      Experimental::Impl::tune_policy(context_id, label, policy, functor,
+                                      Kokkos::ParallelForTag{});
+    }
 #else
-  (void)functor;
+    (void)functor;
 #endif
-}
+  }
 
-template <class ExecPolicy, class FunctorType>
-void end_parallel_for(ExecPolicy& policy, FunctorType& functor,
-                      const std::string& label, uint64_t& kpID) {
-  if (Kokkos::Tools::profileLibraryLoaded()) {
-    Kokkos::Tools::endParallelFor(kpID);
-  }
+  static void end_parallel_for(const ExecPolicy& policy,
+                               const FunctorType& functor,
+                               const std::string& label, uint64_t& kpID) {
+    if (Kokkos::Tools::profileLibraryLoaded()) {
+      Kokkos::Tools::endParallelFor(kpID);
+    }
 #ifdef KOKKOS_ENABLE_TUNING
-  size_t context_id = Kokkos::Tools::Experimental::get_current_context_id();
-  if (Kokkos::tune_internals()) {
-    Experimental::Impl::report_policy_results(
-        context_id, label, policy, functor, Kokkos::ParallelForTag{});
-  }
+    size_t context_id = Kokkos::Tools::Experimental::get_current_context_id();
+    if (Kokkos::tune_internals()) {
+      Experimental::Impl::report_policy_results(
+          context_id, label, policy, functor, Kokkos::ParallelForTag{});
+    }
 #else
-  (void)policy;
-  (void)functor;
-  (void)label;
+    (void)policy;
+    (void)functor;
+    (void)label;
 #endif
-}
+  }
+};
 
-template <class ExecPolicy, class FunctorType>
-void begin_parallel_scan(ExecPolicy& policy, FunctorType& functor,
-                         const std::string& label, uint64_t& kpID) {
-  if (Kokkos::Tools::profileLibraryLoaded()) {
-    Kokkos::Impl::ParallelConstructName<FunctorType,
-                                        typename ExecPolicy::work_tag>
-        name(label);
-    Kokkos::Tools::beginParallelScan(
-        name.get(), Kokkos::Profiling::Experimental::device_id(policy.space()),
-        &kpID);
-  }
+template <class FunctorType, class ExecPolicy,
+          class ExecutionSpace =
+              typename ::Kokkos::Impl::FunctorPolicyExecutionSpace<
+                  FunctorType, ExecPolicy>::execution_space>
+struct ParallelScanToolsHook {
+  static void begin_parallel_scan(const ExecPolicy& policy,
+                                  const FunctorType& functor,
+                                  const std::string& label, uint64_t& kpID) {
+    if (Kokkos::Tools::profileLibraryLoaded()) {
+      Kokkos::Impl::ParallelConstructName<FunctorType,
+                                          typename ExecPolicy::work_tag>
+          name(label);
+      Kokkos::Tools::beginParallelScan(
+          name.get(),
+          Kokkos::Profiling::Experimental::device_id(policy.space()), &kpID);
+    }
 #ifdef KOKKOS_ENABLE_TUNING
-  size_t context_id = Kokkos::Tools::Experimental::get_new_context_id();
-  if (Kokkos::tune_internals()) {
-    Experimental::Impl::tune_policy(context_id, label, policy, functor,
-                                    Kokkos::ParallelScanTag{});
-  }
+    size_t context_id = Kokkos::Tools::Experimental::get_new_context_id();
+    if (Kokkos::tune_internals()) {
+      Experimental::Impl::tune_policy(context_id, label, policy, functor,
+                                      Kokkos::ParallelScanTag{});
+    }
 #else
-  (void)functor;
+    (void)functor;
 #endif
-}
+  }
 
-template <class ExecPolicy, class FunctorType>
-void end_parallel_scan(ExecPolicy& policy, FunctorType& functor,
-                       const std::string& label, uint64_t& kpID) {
-  if (Kokkos::Tools::profileLibraryLoaded()) {
-    Kokkos::Tools::endParallelScan(kpID);
-  }
+  static void end_parallel_scan(const ExecPolicy& policy,
+                                const FunctorType& functor,
+                                const std::string& label, uint64_t& kpID) {
+    if (Kokkos::Tools::profileLibraryLoaded()) {
+      Kokkos::Tools::endParallelScan(kpID);
+    }
 #ifdef KOKKOS_ENABLE_TUNING
-  size_t context_id = Kokkos::Tools::Experimental::get_current_context_id();
-  if (Kokkos::tune_internals()) {
-    Experimental::Impl::report_policy_results(
-        context_id, label, policy, functor, Kokkos::ParallelScanTag{});
-  }
+    size_t context_id = Kokkos::Tools::Experimental::get_current_context_id();
+    if (Kokkos::tune_internals()) {
+      Experimental::Impl::report_policy_results(
+          context_id, label, policy, functor, Kokkos::ParallelScanTag{});
+    }
 #else
-  (void)policy;
-  (void)functor;
-  (void)label;
+    (void)policy;
+    (void)functor;
+    (void)label;
 #endif
-}
-
-template <class ReducerType, class ExecPolicy, class FunctorType>
-void begin_parallel_reduce(ExecPolicy& policy, FunctorType& functor,
-                           const std::string& label, uint64_t& kpID) {
-  if (Kokkos::Tools::profileLibraryLoaded()) {
-    Kokkos::Impl::ParallelConstructName<FunctorType,
-                                        typename ExecPolicy::work_tag>
-        name(label);
-    Kokkos::Tools::beginParallelReduce(
-        name.get(), Kokkos::Profiling::Experimental::device_id(policy.space()),
-        &kpID);
   }
-#ifdef KOKKOS_ENABLE_TUNING
-  size_t context_id = Kokkos::Tools::Experimental::get_new_context_id();
-  Experimental::Impl::ReductionSwitcher<ReducerType>::tune(
-      context_id, label, policy, functor, Kokkos::ParallelReduceTag{});
-#else
-  (void)functor;
-#endif
-}
+};
 
-template <class ReducerType, class ExecPolicy, class FunctorType>
-void end_parallel_reduce(ExecPolicy& policy, FunctorType& functor,
-                         const std::string& label, uint64_t& kpID) {
-  if (Kokkos::Tools::profileLibraryLoaded()) {
-    Kokkos::Tools::endParallelReduce(kpID);
-  }
+template <class CombinedFunctorReducerType, class ExecPolicy,
+          class ExecutionSpace>
+struct ParallelReduceToolsHook {
+  using functor_type = typename CombinedFunctorReducerType::functor_type;
+  using reducer_type = typename CombinedFunctorReducerType::reducer_type;
+
+  static void begin_parallel_reduce(const ExecPolicy& policy,
+                                    const functor_type& functor,
+                                    const std::string& label, uint64_t& kpID) {
+    if (Kokkos::Tools::profileLibraryLoaded()) {
+      Kokkos::Impl::ParallelConstructName<functor_type,
+                                          typename ExecPolicy::work_tag>
+          name(label);
+      Kokkos::Tools::beginParallelReduce(
+          name.get(),
+          Kokkos::Profiling::Experimental::device_id(policy.space()), &kpID);
+    }
 #ifdef KOKKOS_ENABLE_TUNING
-  size_t context_id = Kokkos::Tools::Experimental::get_current_context_id();
-  if (Kokkos::tune_internals()) {
-    Experimental::Impl::report_policy_results(
+    size_t context_id = Kokkos::Tools::Experimental::get_new_context_id();
+    Experimental::Impl::ReductionSwitcher<reducer_type>::tune(
         context_id, label, policy, functor, Kokkos::ParallelReduceTag{});
-  }
 #else
-  (void)policy;
-  (void)functor;
-  (void)label;
+    (void)functor;
 #endif
-}
+  }
+
+  static void end_parallel_reduce(const ExecPolicy& policy,
+                                  const functor_type& functor,
+                                  const std::string& label, uint64_t& kpID) {
+    if (Kokkos::Tools::profileLibraryLoaded()) {
+      Kokkos::Tools::endParallelReduce(kpID);
+    }
+#ifdef KOKKOS_ENABLE_TUNING
+    size_t context_id = Kokkos::Tools::Experimental::get_current_context_id();
+    if (Kokkos::tune_internals()) {
+      Experimental::Impl::report_policy_results(
+          context_id, label, policy, functor, Kokkos::ParallelReduceTag{});
+    }
+#else
+    (void)policy;
+    (void)functor;
+    (void)label;
+#endif
+  }
+};
 
 }  // end namespace Impl
 


### PR DESCRIPTION
The rational for these changes are for both Kokkos Resilience and Kokkos Tools.

In Kokkos Resilience, we extend Kokkos with custom execution spaces that are resilient (i.e. ResOpenMP). We internally dispatch to the base execution space (OpenMP), duplicating or triplicating the kernel. This breaks Kokkos Tools because Kokkos Tools sees two begin_parallel_* in a row. This change will allow Kokkos Resilience (or also Kokkos Tools) to specialize these begin and end hooks depending on the execution space. That way, Kokkos Resilience (for example) could implement a no-op for the outer begin/end hooks. The intention is, because everything is in Impl, is that this should **never** be specialized by users.

**Design** I changed the template parameters to be identical to those that we use for specializing `Parallel*`. I did this so that the implementation can have the same specialization control as the `Parallel*` construct.
