### PR TITLE
SYCL: Unroll shuffle loops for top-level parallel_reduce and parallel_scan

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
@@ -48,7 +48,7 @@ void workgroup_scan(sycl::nd_item<dim> item, const FunctorType& final_reducer,
   shuffle_combine(4);
   shuffle_combine(8);
   shuffle_combine(16);
-  shuffle_combine(32);
+  KOKKOS_ASSERT(global_range <= 32);
 #else
   for (int stride = 1; stride < global_range; stride <<= 1) {
     auto tmp = sg.shuffle_up(local_value, stride);
@@ -93,7 +93,7 @@ void workgroup_scan(sycl::nd_item<dim> item, const FunctorType& final_reducer,
         shuffle_combine_sg(4);
         shuffle_combine_sg(8);
         shuffle_combine_sg(16);
-        shuffle_combine_sg(32);
+        KOKKOS_ASSERT(upper_bound <= 32);
 #else
         for (int stride = 1; stride < upper_bound; stride <<= 1) {
           auto tmp = sg.shuffle_up(local_sg_value, stride);

--- a/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
@@ -36,10 +36,25 @@ void workgroup_scan(sycl::nd_item<dim> item, const FunctorType& final_reducer,
   const int sg_group_id = sg.get_group_id()[0];
   const int id_in_sg    = sg.get_local_id()[0];
 
+#if defined(KOKKOS_ARCH_INTEL_GPU) || defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
+  auto shuffle_combine = [&](int stride) {
+    if (stride < global_range) {
+      auto tmp = sg.shuffle_up(local_value, stride);
+      if (id_in_sg >= stride) final_reducer.join(&local_value, &tmp);
+    }
+  };
+  shuffle_combine(1);
+  shuffle_combine(2);
+  shuffle_combine(4);
+  shuffle_combine(8);
+  shuffle_combine(16);
+  shuffle_combine(32);
+#else
   for (int stride = 1; stride < global_range; stride <<= 1) {
     auto tmp = sg.shuffle_up(local_value, stride);
     if (id_in_sg >= stride) final_reducer.join(&local_value, &tmp);
   }
+#endif
 
   const int max_subgroup_size = sg.get_max_local_range()[0];
   const int n_active_subgroups =
@@ -61,6 +76,25 @@ void workgroup_scan(sycl::nd_item<dim> item, const FunctorType& final_reducer,
         const auto upper_bound =
             std::min(local_range, n_active_subgroups - round * local_range);
         auto local_sg_value = local_mem[idx < n_active_subgroups ? idx : 0];
+#if defined(KOKKOS_ARCH_INTEL_GPU) || defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
+        auto shuffle_combine = [&](int stride) {
+          if (stride < upper_bound) {
+            auto tmp = sg.shuffle_up(local_sg_value, stride);
+            if (id_in_sg >= stride) {
+              if (idx < n_active_subgroups)
+                final_reducer.join(&local_sg_value, &tmp);
+              else
+                local_sg_value = tmp;
+            }
+          }
+        };
+        shuffle_combine(1);
+        shuffle_combine(2);
+        shuffle_combine(4);
+        shuffle_combine(8);
+        shuffle_combine(16);
+        shuffle_combine(32);
+#else
         for (int stride = 1; stride < upper_bound; stride <<= 1) {
           auto tmp = sg.shuffle_up(local_sg_value, stride);
           if (id_in_sg >= stride) {
@@ -70,6 +104,7 @@ void workgroup_scan(sycl::nd_item<dim> item, const FunctorType& final_reducer,
               local_sg_value = tmp;
           }
         }
+#endif
         if (idx < n_active_subgroups) {
           local_mem[idx] = local_sg_value;
           if (round > 0)

--- a/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
@@ -77,7 +77,7 @@ void workgroup_scan(sycl::nd_item<dim> item, const FunctorType& final_reducer,
             std::min(local_range, n_active_subgroups - round * local_range);
         auto local_sg_value = local_mem[idx < n_active_subgroups ? idx : 0];
 #if defined(KOKKOS_ARCH_INTEL_GPU) || defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
-        auto shuffle_combine = [&](int stride) {
+        auto shuffle_combine_sg = [&](int stride) {
           if (stride < upper_bound) {
             auto tmp = sg.shuffle_up(local_sg_value, stride);
             if (id_in_sg >= stride) {
@@ -88,12 +88,12 @@ void workgroup_scan(sycl::nd_item<dim> item, const FunctorType& final_reducer,
             }
           }
         };
-        shuffle_combine(1);
-        shuffle_combine(2);
-        shuffle_combine(4);
-        shuffle_combine(8);
-        shuffle_combine(16);
-        shuffle_combine(32);
+        shuffle_combine_sg(1);
+        shuffle_combine_sg(2);
+        shuffle_combine_sg(4);
+        shuffle_combine_sg(8);
+        shuffle_combine_sg(16);
+        shuffle_combine_sg(32);
 #else
         for (int stride = 1; stride < upper_bound; stride <<= 1) {
           auto tmp = sg.shuffle_up(local_sg_value, stride);

--- a/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
@@ -126,7 +126,7 @@ std::enable_if_t<use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(
   shuffle_combine(4);
   shuffle_combine(8);
   shuffle_combine(16);
-  shuffle_combine(32);
+  KOKKOS_ASSERT(local_range <= 32);
 #else
   for (unsigned int stride = 1; stride < local_range; stride <<= 1) {
     auto tmp = sg.shuffle_down(local_value, stride);
@@ -175,7 +175,7 @@ std::enable_if_t<use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(
     shuffle_combine_sg(4);
     shuffle_combine_sg(8);
     shuffle_combine_sg(16);
-    shuffle_combine_sg(32);
+    KOKKOS_ASSERT(local_range <= 32);
 #else
     for (unsigned int stride = 1; stride < local_range; stride <<= 1) {
       auto tmp = sg.shuffle_down(sg_value, stride);

--- a/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
@@ -107,13 +107,12 @@ std::enable_if_t<use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(
 
   // Perform the actual workgroup reduction in each subgroup
   // separately.
-  auto sg            = item.get_sub_group();
-  const int id_in_sg = sg.get_local_id()[0];
-  const auto local_range =
-      std::min<unsigned int>(sg.get_local_range()[0], max_size);
+  auto sg               = item.get_sub_group();
+  const int id_in_sg    = sg.get_local_id()[0];
+  const int local_range = std::min<int>(sg.get_local_range()[0], max_size);
 
   const auto upper_stride_bound =
-      std::min<unsigned int>(local_range - id_in_sg, max_size - local_id);
+      std::min<int>(local_range - id_in_sg, max_size - local_id);
 #if defined(KOKKOS_ARCH_INTEL_GPU) || defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
   auto shuffle_combine = [&](int stride) {
     if (stride < local_range) {
@@ -153,7 +152,7 @@ std::enable_if_t<use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(
     // the first subgroup, we first combine the items with a higher
     // index.
     if (n_active_subgroups > local_range) {
-      for (unsigned int offset = local_range; offset < n_active_subgroups;
+      for (int offset = local_range; offset < n_active_subgroups;
            offset += local_range)
         if (id_in_sg + offset < n_active_subgroups) {
           final_reducer.join(&sg_value, &local_mem[(id_in_sg + offset)]);

--- a/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
@@ -163,19 +163,19 @@ std::enable_if_t<use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(
 
     // Then, we proceed as before.
 #if defined(KOKKOS_ARCH_INTEL_GPU) || defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
-    auto shuffle_combine = [&](int stride) {
+    auto shuffle_combine_sg = [&](int stride) {
       if (stride < local_range) {
         auto tmp = sg.shuffle_down(sg_value, stride);
         if (id_in_sg + stride < n_active_subgroups)
           final_reducer.join(&sg_value, &tmp);
       }
     };
-    shuffle_combine(1);
-    shuffle_combine(2);
-    shuffle_combine(4);
-    shuffle_combine(8);
-    shuffle_combine(16);
-    shuffle_combine(32);
+    shuffle_combine_sg(1);
+    shuffle_combine_sg(2);
+    shuffle_combine_sg(4);
+    shuffle_combine_sg(8);
+    shuffle_combine_sg(16);
+    shuffle_combine_sg(32);
 #else
     for (unsigned int stride = 1; stride < local_range; stride <<= 1) {
       auto tmp = sg.shuffle_down(sg_value, stride);


### PR DESCRIPTION
Similar to #6562, unrolling the loops for shuffles improves performance significantly. For a simple dot product benchmark we are seeing on Intel PVC

| elements  | old shuffle (GB/s) | new shuffle (GB/s) | local memory (GB/s) |
| -- | -- | -- | -- |
| 2 |    0.00195408 | 0.00196642 | 0.00195283
| 4 |    0.00416202 | 0.00425014 | 0.00421528
| 8 |    0.00820138 | 0.00832427 | 0.0083891
| 16 |     0.0138029 | 0.0146039 | 0.0142298
| 32 |    0.0294672 | 0.0335499 | 0.0324571
| 64 |    0.0581855 | 0.064666 | 0.0623012
| 128 |  0.119849 | 0.133714 | 0.125332
| 256 |     0.229995 | 0.258772 | 0.237334
| 512 |    0.465701 | 0.509693 | 0.440304
| 1024 |  0.855585 | 1.01661 | 0.734111
| 2048 |    1.49275 | 1.72464 | 1.47962
| 4096 |    2.88409 | 3.56523 | 3.15379
| 8192 |    5.46391 | 6.73428 | 6.30253
| 16384 |    10.6889 | 13.2914 | 12.1061
| 32768 |   20.9248 | 26.2938 | 24.5314
| 65536 |   40.7319 | 49.5028 | 46.1789
| 131072 |   70.2748 | 95.7102 | 86.0199
| 262144 |     103.283 | 143.788 | 130.812
| 524288 |   160.729 | 289.661 | 259.618
| 1048576 |    219.284 | 402.79 | 349.205
| 2097152 |    420.953 | 750.37 | 656.928
| 4194304 |    776.545 | 1291.27 | 1196.56
| 8388608 |     1352.93 | 2073.44 | 1999.47
| 16777216 |   2125.82 | 2919.15 | 2990.47
| 33554432 |    1646.12 | 1686.77 | 1599.83
| 67108864 |    1621.1 | 1643.43 | 1587.29
| 134217728 |      1613.23 | 1607.5 | 1580.22
| 268435456 |    1533.8 | 1537.64 | 1532.46
| 536870912 |    1638.35 | 1641.31 | 1637.63
| 1073741824 |   1671.84 | 1670.2 | 1676.66

meaning that with this change we get similar performance between the local memory variant (needed for array reductions) and the shuffle variant. Thus, this allows for reviving the previously dead code path.
Note that `parallel_scan` only has a shuffle variant (and doesn't support array scans).