### PR TITLE
unorderedmap: adding missing constexpr

### DIFF
--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -352,9 +352,9 @@ class UnorderedMap {
     m_keys = key_type_view(Kokkos::Impl::append_to_label(prop_copy, " - keys"),
                            capacity());
 
-    m_values =
-        value_type_view(Kokkos::Impl::append_to_label(prop_copy, " - values"),
-                        is_set ? 0 : capacity());
+    if constexpr (!is_set)
+      m_values = value_type_view(
+          Kokkos::Impl::append_to_label(prop_copy, " - values"), capacity());
 
     m_scalars =
         scalars_view(Kokkos::Impl::append_to_label(prop_copy, " - scalars"));
@@ -526,7 +526,8 @@ class UnorderedMap {
   ///                       Kokkos::UnorderedMapInsertOpTypes for more ops.
   template <typename InsertOpType = default_op_type>
   KOKKOS_INLINE_FUNCTION insert_result
-  insert(key_type const &k, impl_value_type const &v = impl_value_type(),
+  insert(key_type const &k,
+         [[maybe_unused]] impl_value_type const &v   = impl_value_type(),
          [[maybe_unused]] InsertOpType arg_insert_op = InsertOpType()) const {
     if constexpr (is_set) {
       static_assert(std::is_same_v<InsertOpType, default_op_type>,
@@ -652,7 +653,7 @@ class UnorderedMap {
             m_keys[new_index] = k;
 #endif
 
-            if (!is_set) {
+            if constexpr (!is_set) {
               KOKKOS_NONTEMPORAL_PREFETCH_STORE(&m_values[new_index]);
 #ifdef KOKKOS_ENABLE_SYCL
               Kokkos::atomic_store(&m_values[new_index], v);
@@ -844,7 +845,7 @@ class UnorderedMap {
                     sizeof(size_type) * src.m_next_index.extent(0));
       raw_deep_copy(tmp.m_keys.data(), src.m_keys.data(),
                     sizeof(key_type) * src.m_keys.extent(0));
-      if (!is_set) {
+      if constexpr (!is_set) {
         raw_deep_copy(tmp.m_values.data(), src.m_values.data(),
                       sizeof(impl_value_type) * src.m_values.extent(0));
       }

--- a/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
+++ b/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
@@ -88,7 +88,7 @@ struct UnorderedMapErase {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(size_type i) const {
-    const size_type invalid_index = map_type::invalid_index;
+    constexpr size_type invalid_index = map_type::invalid_index;
 
     size_type curr = m_map.m_hash_lists(i);
     size_type next = invalid_index;
@@ -98,7 +98,7 @@ struct UnorderedMapErase {
       next                     = m_map.m_next_index[curr];
       m_map.m_next_index[curr] = invalid_index;
       m_map.m_keys[curr]       = key_type();
-      if (m_map.is_set) m_map.m_values[curr] = value_type();
+      if constexpr (map_type::is_set) m_map.m_values[curr] = value_type();
       curr                  = next;
       m_map.m_hash_lists(i) = next;
     }
@@ -117,7 +117,7 @@ struct UnorderedMapErase {
           m_map.m_next_index[prev] = next;
           m_map.m_next_index[curr] = invalid_index;
           m_map.m_keys[curr]       = key_type();
-          if (map_type::is_set) m_map.m_values[curr] = value_type();
+          if constexpr (map_type::is_set) m_map.m_values[curr] = value_type();
         }
         curr = next;
       }
@@ -232,7 +232,7 @@ struct UnorderedMapPrint {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(size_type i) const {
-    const size_type invalid_index = map_type::invalid_index;
+    constexpr size_type invalid_index = map_type::invalid_index;
 
     uint32_t list = m_map.m_hash_lists(i);
     for (size_type curr = list, ii = 0; curr != invalid_index;


### PR DESCRIPTION
This PR adds missing `constexpr` in `Kokkos::UnorderedMap`.