### PR TITLE
Add checks for unsafe implicit conversions in RangePolicy

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -115,18 +115,12 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
         m_granularity_mask(0) {}
 
   /** \brief  Total range */
-#if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) || \
-    defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
   template <typename IndexType1, typename IndexType2,
             std::enable_if_t<(std::is_convertible_v<IndexType1, member_type> &&
                               std::is_convertible_v<IndexType2, member_type>),
                              bool> = false>
   inline RangePolicy(const typename traits::execution_space& work_space,
                      const IndexType1 work_begin, const IndexType2 work_end)
-#else
-  inline RangePolicy(const typename traits::execution_space& work_space,
-                     const member_type work_begin, const member_type work_end)
-#endif
       : m_space(work_space),
         m_begin(work_begin),
         m_end(work_end),
@@ -139,22 +133,14 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   }
 
   /** \brief  Total range */
-#if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) || \
-    defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
   template <typename IndexType1, typename IndexType2,
             std::enable_if_t<(std::is_convertible_v<IndexType1, member_type> &&
                               std::is_convertible_v<IndexType2, member_type>),
                              bool> = false>
   inline RangePolicy(const IndexType1 work_begin, const IndexType2 work_end)
-#else
-  inline RangePolicy(const member_type work_begin, const member_type work_end)
-#endif
-      : RangePolicy(typename traits::execution_space(), work_begin, work_end) {
-  }
+      : RangePolicy(typename traits::execution_space(), work_begin, work_end) {}
 
   /** \brief  Total range */
-#if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) || \
-    defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
   template <typename IndexType1, typename IndexType2, typename... Args,
             std::enable_if_t<(std::is_convertible_v<IndexType1, member_type> &&
                               std::is_convertible_v<IndexType2, member_type>),
@@ -162,12 +148,6 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   inline RangePolicy(const typename traits::execution_space& work_space,
                      const IndexType1 work_begin, const IndexType2 work_end,
                      Args... args)
-#else
-  template <class... Args>
-  inline RangePolicy(const typename traits::execution_space& work_space,
-                     const member_type work_begin, const member_type work_end,
-                     Args... args)
-#endif
       : m_space(work_space),
         m_begin(work_begin),
         m_end(work_end),
@@ -181,22 +161,14 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   }
 
   /** \brief  Total range */
-#if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) || \
-    defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
   template <typename IndexType1, typename IndexType2, typename... Args,
             std::enable_if_t<(std::is_convertible_v<IndexType1, member_type> &&
                               std::is_convertible_v<IndexType2, member_type>),
                              bool> = false>
   inline RangePolicy(const IndexType1 work_begin, const IndexType2 work_end,
                      Args... args)
-#else
-  template <class... Args>
-  inline RangePolicy(const member_type work_begin, const member_type work_end,
-                     Args... args)
-#endif
       : RangePolicy(typename traits::execution_space(), work_begin, work_end,
-                    args...) {
-  }
+                    args...) {}
 
  private:
   inline void set() {}

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -132,10 +132,8 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
         m_end(work_end),
         m_granularity(0),
         m_granularity_mask(0) {
-#ifdef KOKKOS_ENABLE_DEBUG
     check_conversion_safety(work_begin);
     check_conversion_safety(work_end);
-#endif
     check_bounds_validity();
     set_auto_chunk_size();
   }
@@ -175,10 +173,8 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
         m_end(work_end),
         m_granularity(0),
         m_granularity_mask(0) {
-#ifdef KOKKOS_ENABLE_DEBUG
     check_conversion_safety(work_begin);
     check_conversion_safety(work_end);
-#endif
     check_bounds_validity();
     set_auto_chunk_size();
     set(args...);

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -28,6 +28,7 @@ static_assert(false,
 #include <impl/Kokkos_AnalyzePolicy.hpp>
 #include <Kokkos_Concepts.hpp>
 #include <typeinfo>
+#include <limits>
 
 //----------------------------------------------------------------------------
 
@@ -129,6 +130,25 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   inline RangePolicy(const member_type work_begin, const member_type work_end)
       : RangePolicy(typename traits::execution_space(), work_begin, work_end) {}
 
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  template <typename IndexType,
+            std::enable_if_t<(std::is_integral_v<IndexType> &&
+                              !std::is_same_v<IndexType, member_type> &&
+                              std::is_convertible_v<IndexType, member_type>),
+                             bool> = false>
+  inline RangePolicy(const IndexType work_begin, const IndexType work_end)
+      : m_space(typename traits::execution_space()),
+        m_begin(work_begin),
+        m_end(work_end),
+        m_granularity(0),
+        m_granularity_mask(0) {
+    check_conversion_safety(work_begin);
+    check_conversion_safety(work_end);
+    check_bounds_validity();
+    set_auto_chunk_size();
+  }
+#endif
+
   /** \brief  Total range */
   template <class... Args>
   inline RangePolicy(const typename traits::execution_space& work_space,
@@ -150,6 +170,27 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
                      Args... args)
       : RangePolicy(typename traits::execution_space(), work_begin, work_end,
                     args...) {}
+
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  template <typename IndexType, typename... Args,
+            std::enable_if_t<(std::is_integral_v<IndexType> &&
+                              !std::is_same_v<IndexType, member_type> &&
+                              std::is_convertible_v<IndexType, member_type>),
+                             bool> = false>
+  inline RangePolicy(const IndexType work_begin, const IndexType work_end,
+                     Args... args)
+      : m_space(typename traits::execution_space()),
+        m_begin(work_begin),
+        m_end(work_end),
+        m_granularity(0),
+        m_granularity_mask(0) {
+    check_conversion_safety(work_begin);
+    check_conversion_safety(work_end);
+    check_bounds_validity();
+    set_auto_chunk_size();
+    set(args...);
+  }
+#endif
 
  private:
   inline void set() {}
@@ -227,6 +268,40 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
 #endif
       m_begin = 0;
       m_end   = 0;
+#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
+      Kokkos::Impl::log_warning(msg);
+#endif
+    }
+  }
+
+  template <typename IndexType>
+  void check_conversion_safety(IndexType bound) {
+    std::string msg =
+        "Kokkos::RangePolicy bound type error: unsafe implicit conversion may "
+        "not preserve the original value.\n";
+    bool warn = false;
+
+    if constexpr (std::is_signed_v<IndexType> !=
+                  std::is_signed_v<member_type>) {
+      // check signed to unsigned
+      if constexpr (std::is_signed_v<IndexType>)
+        warn |= (bound < static_cast<IndexType>(
+                             std::numeric_limits<member_type>::min()));
+
+      // check unsigned to signed
+      if constexpr (std::is_signed_v<member_type>)
+        warn |= (bound > static_cast<IndexType>(
+                             std::numeric_limits<member_type>::max()));
+    }
+
+    // check narrowing
+    warn |= (static_cast<IndexType>(static_cast<member_type>(bound)) != bound);
+
+    if (warn) {
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+      Kokkos::abort(msg.c_str());
+#endif
+
 #ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
       Kokkos::Impl::log_warning(msg);
 #endif

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -129,7 +129,7 @@ TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {
   using IntPolicy     = Kokkos::RangePolicy<TEST_EXECSPACE, IntIndexType>;
 
 #ifndef KOKKOS_ENABLE_DEBUG
-  gtest_skip();
+  GTEST_SKIP();
 #endif
 
   std::string msg =
@@ -177,6 +177,7 @@ TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {
 #else
     ASSERT_TRUE(::testing::internal::GetCapturedStderr().empty());
     (void)msg;
+    (void)get_error_msg;
 #endif
   }
   {
@@ -193,6 +194,7 @@ TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {
 #else
     ASSERT_TRUE(::testing::internal::GetCapturedStderr().empty());
     (void)msg;
+    (void)get_error_msg;
 #endif
   }
 #endif

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -128,10 +128,6 @@ TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {
   using UIntPolicy    = Kokkos::RangePolicy<TEST_EXECSPACE, UIntIndexType>;
   using IntPolicy     = Kokkos::RangePolicy<TEST_EXECSPACE, IntIndexType>;
 
-#ifndef KOKKOS_ENABLE_DEBUG
-  GTEST_SKIP();
-#endif
-
   std::string msg =
       "Kokkos::RangePolicy bound type error: an unsafe implicit conversion is "
       "performed on a bound (), which may not preserve its original value.\n";


### PR DESCRIPTION
Resolves #6709 

Added checks in RangePolicy to detect non value-preserving implicit conversions between input bounds and the policy's `IndexType`.

Cases considered:
 - `signed` arg type to `unsigned` index types
 - `unsigned` arg type to `signed` index types
 - Narrowing conversions