### PR TITLE
SYCL: Filter GPU devices

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -265,8 +265,6 @@ std::vector<sycl::device> get_sycl_devices() {
                                      return d.get_backend() != backend;
                                    }),
                     gpu_devices.end());
-  if (gpu_devices.empty())
-    Kokkos::abort("Error: no GPU available for execution.\n");
 #endif
   return gpu_devices;
 }

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -142,8 +142,8 @@ void SYCL::impl_static_fence(const std::string& name) {
 }
 
 void SYCL::impl_initialize(InitializationSettings const& settings) {
-  std::vector<sycl::device> gpu_devices =
-      sycl::device::get_devices(sycl::info::device_type::gpu);
+  std::vector<sycl::device> gpu_devices = Impl::get_sycl_devices();
+
   // If the device id is not specified and there are no GPUs, sidestep Kokkos
   // device selection and use whatever is available (if no GPU architecture is
   // specified).

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -201,6 +201,8 @@ inline std::vector<sycl::device> get_sycl_devices() {
                                      return d.get_backend() != backend;
                                    }),
                     gpu_devices.end());
+  if (gpu_devices.empty())
+    Kokkos::abort("Error: no GPU available for execution.\n");
 #endif
   return gpu_devices;
 }

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -182,6 +182,29 @@ std::vector<SYCL> partition_space(const SYCL& sycl_space,
         sycl::queue(context, device, sycl::property::queue::in_order()));
   return instances;
 }
+
+namespace Impl {
+inline std::vector<sycl::device> get_sycl_devices() {
+  std::vector<sycl::device> gpu_devices =
+      sycl::device::get_devices(sycl::info::device_type::gpu);
+#if defined(KOKKOS_ARCH_INTEL_GPU) || defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU) || \
+    defined(KOKKOS_ARCH_AMD_GPU)
+#if defined(KOKKOS_ARCH_INTEL_GPU)
+  sycl::backend backend = sycl::backend::ext_oneapi_level_zero;
+#elif defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
+  sycl::backend backend = sycl::backend::ext_oneapi_cuda;
+#elif defined(KOKKOS_ARCH_AMD_GPU)
+  sycl::backend backend = sycl::backend::ext_oneapi_hip;
+#endif
+  gpu_devices.erase(std::remove_if(gpu_devices.begin(), gpu_devices.end(),
+                                   [backend](const sycl::device& d) {
+                                     return d.get_backend() != backend;
+                                   }),
+                    gpu_devices.end());
+#endif
+  return gpu_devices;
+}
+}  // namespace Impl
 }  // namespace Experimental
 
 }  // namespace Kokkos

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -184,28 +184,7 @@ std::vector<SYCL> partition_space(const SYCL& sycl_space,
 }
 
 namespace Impl {
-inline std::vector<sycl::device> get_sycl_devices() {
-  std::vector<sycl::device> gpu_devices =
-      sycl::device::get_devices(sycl::info::device_type::gpu);
-#if defined(KOKKOS_ARCH_INTEL_GPU) || defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU) || \
-    defined(KOKKOS_ARCH_AMD_GPU)
-#if defined(KOKKOS_ARCH_INTEL_GPU)
-  sycl::backend backend = sycl::backend::ext_oneapi_level_zero;
-#elif defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
-  sycl::backend backend = sycl::backend::ext_oneapi_cuda;
-#elif defined(KOKKOS_ARCH_AMD_GPU)
-  sycl::backend backend = sycl::backend::ext_oneapi_hip;
-#endif
-  gpu_devices.erase(std::remove_if(gpu_devices.begin(), gpu_devices.end(),
-                                   [backend](const sycl::device& d) {
-                                     return d.get_backend() != backend;
-                                   }),
-                    gpu_devices.end());
-  if (gpu_devices.empty())
-    Kokkos::abort("Error: no GPU available for execution.\n");
-#endif
-  return gpu_devices;
-}
+std::vector<sycl::device> get_sycl_devices();
 }  // namespace Impl
 }  // namespace Experimental
 

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -137,7 +137,7 @@ int get_device_count() {
   KOKKOS_IMPL_HIP_SAFE_CALL(hipGetDeviceCount(&count));
   return count;
 #elif defined(KOKKOS_ENABLE_SYCL)
-  return sycl::device::get_devices(sycl::info::device_type::gpu).size();
+  return Kokkos::Experimental::Impl::get_sycl_devices().size();
 #elif defined(KOKKOS_ENABLE_OPENACC)
   return acc_get_num_devices(
       Kokkos::Experimental::Impl::OpenACC_Traits::dev_type);


### PR DESCRIPTION
The discussion in https://kokkosteam.slack.com/archives/C5BGU5NDQ/p1705683106903069 shows that users might accidentally use SYCL backends that we don't actively support. This pull request filters the `sycl::device`s so that only the `sycl::backend::ext_oneapi_*` ones are visible if a device architecture is enabled in the configuration.