### PR TITLE
Avoid calling wrapper functions with singleton in Kokkos_CudaSpace.cpp where we want a different device

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Error.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Error.hpp
@@ -27,10 +27,6 @@
 namespace Kokkos {
 namespace Impl {
 
-void cuda_stream_synchronize(
-    const cudaStream_t stream,
-    Kokkos::Tools::Experimental::SpecialSynchronizationCases reason,
-    const std::string& name);
 void cuda_device_synchronize(const std::string& name);
 void cuda_stream_synchronize(const cudaStream_t stream,
                              const std::string& name);

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -168,18 +168,6 @@ void cuda_stream_synchronize(const cudaStream_t stream, const CudaInternal *ptr,
       });
 }
 
-void cuda_stream_synchronize(
-    const cudaStream_t stream,
-    Kokkos::Tools::Experimental::SpecialSynchronizationCases reason,
-    const std::string &name) {
-  Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Cuda>(
-      name, reason, [&]() {
-        KOKKOS_IMPL_CUDA_SAFE_CALL(
-            (Impl::CudaInternal::singleton().cuda_stream_synchronize_wrapper(
-                stream)));
-      });
-}
-
 void cuda_internal_error_throw(cudaError e, const char *name, const char *file,
                                const int line) {
   std::ostringstream out;


### PR DESCRIPTION
Extracted from #6737.  This pull request replaces all instances of calling CudaInternal::singleton with a wrapper in `Kokkos_CudaSpace.cpp` where we can get the correct device id (all other places should be fine using the singleton anyway).

We inline `cuda_stream_synchronize` with `Kokkos::Tools::Experimental::SpecialSynchronizationCases` since that is only used in one place and doesn't provide a `device_id` parameter.