### PR TITLE
Drop 2-arguments `ZeroMemset` constructor overloads

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
@@ -33,15 +33,6 @@ struct ZeroMemset<Kokkos::Cuda, View<T, P...>> {
                  dst.data(), 0,
                  dst.size() * sizeof(typename View<T, P...>::value_type))));
   }
-
-  ZeroMemset(const View<T, P...>& dst,
-             typename View<T, P...>::const_value_type&) {
-    // FIXME_CUDA_MULTIPLE_DEVICES
-    KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (Kokkos::Impl::CudaInternal::singleton().cuda_memset_wrapper(
-            dst.data(), 0,
-            dst.size() * sizeof(typename View<T, P...>::value_type))));
-  }
 };
 
 }  // namespace Impl

--- a/core/src/HIP/Kokkos_HIP_ZeroMemset.hpp
+++ b/core/src/HIP/Kokkos_HIP_ZeroMemset.hpp
@@ -31,13 +31,6 @@ struct ZeroMemset<HIP, View<T, P...>> {
         dst.data(), 0, dst.size() * sizeof(typename View<T, P...>::value_type),
         exec_space.hip_stream()));
   }
-
-  ZeroMemset(const View<T, P...>& dst,
-             typename View<T, P...>::const_value_type&) {
-    KOKKOS_IMPL_HIP_SAFE_CALL(
-        hipMemset(dst.data(), 0,
-                  dst.size() * sizeof(typename View<T, P...>::value_type)));
-  }
 };
 
 }  // namespace Impl

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1386,15 +1386,16 @@ contiguous_fill_or_memset(
     typename ViewTraits<DT, DP...>::const_value_type& value) {
   using ViewType        = View<DT, DP...>;
   using exec_space_type = typename ViewType::execution_space;
+  exec_space_type exec;
 
 // On A64FX memset seems to do the wrong thing with regards to first touch
 // leading to the significant performance issues
 #ifndef KOKKOS_ARCH_A64FX
   if (Impl::is_zero_byte(value))
-    ZeroMemset<exec_space_type, View<DT, DP...>>(dst, value);
+    ZeroMemset<exec_space_type, View<DT, DP...>>(exec, dst, value);
   else
 #endif
-    contiguous_fill(exec_space_type(), dst, value);
+    contiguous_fill(exec, dst, value);
 }
 
 template <class DT, class... DP>

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1360,7 +1360,7 @@ contiguous_fill_or_memset(
       && !std::is_same_v<ExecutionSpace, Kokkos::OpenMP>
 #endif
   )
-    ZeroMemset<ExecutionSpace, View<DT, DP...>>(exec_space, dst, value);
+    ZeroMemset(exec_space, dst, value);
   else
     contiguous_fill(exec_space, dst, value);
 }
@@ -1392,7 +1392,7 @@ contiguous_fill_or_memset(
 // leading to the significant performance issues
 #ifndef KOKKOS_ARCH_A64FX
   if (Impl::is_zero_byte(value))
-    ZeroMemset<exec_space_type, View<DT, DP...>>(exec, dst, value);
+    ZeroMemset(exec, dst, value);
   else
 #endif
     contiguous_fill(exec, dst, value);

--- a/core/src/SYCL/Kokkos_SYCL_ZeroMemset.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ZeroMemset.hpp
@@ -35,12 +35,6 @@ struct ZeroMemset<Kokkos::Experimental::SYCL, View<T, P...>> {
         ->m_queue->ext_oneapi_submit_barrier(std::vector<sycl::event>{event});
 #endif
   }
-
-  ZeroMemset(const View<T, P...>& dst,
-             typename View<T, P...>::const_value_type&) {
-    Experimental::Impl::SYCLInternal::singleton().m_queue->memset(
-        dst.data(), 0, dst.size() * sizeof(typename View<T, P...>::value_type));
-  }
 };
 
 }  // namespace Impl

--- a/core/src/Serial/Kokkos_Serial_ZeroMemset.hpp
+++ b/core/src/Serial/Kokkos_Serial_ZeroMemset.hpp
@@ -34,14 +34,12 @@ template <class T, class... P>
 struct ZeroMemset<
     std::conditional_t<!std::is_same<Serial, DefaultHostExecutionSpace>::value,
                        Serial, DummyExecutionSpace>,
-    View<T, P...>>
-    : public ZeroMemset<DefaultHostExecutionSpace, View<T, P...>> {
-  using Base = ZeroMemset<DefaultHostExecutionSpace, View<T, P...>>;
-  using Base::Base;
-
+    View<T, P...>> {
   ZeroMemset(const Serial&, const View<T, P...>& dst,
-             typename View<T, P...>::const_value_type& value)
-      : Base(dst, value) {}
+             typename View<T, P...>::const_value_type& value) {
+    using ValueType = typename View<T, P...>::value_type;
+    std::memset(dst.data(), 0, sizeof(ValueType) * dst.size());
+  }
 };
 
 }  // namespace Impl

--- a/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
+++ b/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
@@ -36,12 +36,6 @@ struct ZeroMemset<HostSpace::execution_space, View<T, P...>> {
     using ValueType = typename View<T, P...>::value_type;
     std::memset(dst.data(), 0, sizeof(ValueType) * dst.size());
   }
-
-  ZeroMemset(const View<T, P...>& dst,
-             typename View<T, P...>::const_value_type&) {
-    using ValueType = typename View<T, P...>::value_type;
-    std::memset(dst.data(), 0, sizeof(ValueType) * dst.size());
-  }
 };
 
 }  // end namespace Impl

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2917,9 +2917,7 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
             "Kokkos::View::initialization [" + name + "] via memset",
             Kokkos::Profiling::Experimental::device_id(space), &kpID);
       }
-      (void)ZeroMemset<
-          ExecSpace, Kokkos::View<ValueType*, typename DeviceType::memory_space,
-                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>>(
+      (void)ZeroMemset(
           space,
           Kokkos::View<ValueType*, typename DeviceType::memory_space,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n),
@@ -3055,9 +3053,7 @@ struct ViewValueFunctor<DeviceType, ValueType, true /* is_scalar */> {
             Kokkos::Profiling::Experimental::device_id(space), &kpID);
       }
 
-      (void)ZeroMemset<
-          ExecSpace, Kokkos::View<ValueType*, typename DeviceType::memory_space,
-                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>>(
+      (void)ZeroMemset(
           space,
           Kokkos::View<ValueType*, typename DeviceType::memory_space,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n),


### PR DESCRIPTION
Rational: Only used once at a place where we should have passed a default-constructed execution space to be consistent with what we do in the else-clause when we call `contiguous_fill`.
The Cuda 2-args `ZeroMemset` was problematic for the multi-gpu support (see https://github.com/kokkos/kokkos/pull/6737#discussion_r1471959006).

This work supersedes https://github.com/kokkos/kokkos/pull/6187

Drive-by change: leverage CTAD when calling ZeroMemset to improve code readability.