### PR TITLE
Get rid of print statements in parallel algorithms unit tests

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsIsSorted.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsIsSorted.cpp
@@ -146,7 +146,7 @@ void run_single_scenario(const InfoType& scenario_info) {
   resultsA[3]     = KE::is_sorted("label", exespace(), view);
   const auto allA = std::all_of(resultsA.cbegin(), resultsA.cend(),
                                 [=](bool v) { return v == gold; });
-  EXPECT_TRUE(allA);
+  EXPECT_TRUE(allA) << name << ", " << view_tag_to_string(Tag{});
 
 #if !defined KOKKOS_ENABLE_OPENMPTARGET
   CustomLessThanComparator<ValueType, ValueType> comp;
@@ -159,7 +159,7 @@ void run_single_scenario(const InfoType& scenario_info) {
   resultsB[3]     = KE::is_sorted("label", exespace(), view, comp);
   const auto allB = std::all_of(resultsB.cbegin(), resultsB.cend(),
                                 [=](bool v) { return v == gold; });
-  EXPECT_TRUE(allB);
+  EXPECT_TRUE(allB) << name << ", " << view_tag_to_string(Tag{});
 #endif
 
   Kokkos::fence();
@@ -172,9 +172,6 @@ void run_is_sorted_all_scenarios() {
       {"two-elements-b", 2}, {"small-a", 9},     {"small-b", 13},
       {"medium-a", 1003},    {"medium-b", 1003}, {"large-a", 101513},
       {"large-b", 101513}};
-
-  std::cout << "is_sorted: " << view_tag_to_string(Tag{})
-            << ", all overloads \n";
 
   for (const auto& it : scenarios) {
     run_single_scenario<Tag, ValueType>(it);

--- a/algorithms/unit_tests/TestStdAlgorithmsIsSortedUntil.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsIsSortedUntil.cpp
@@ -145,10 +145,10 @@ void run_single_scenario(const InfoType& scenario_info) {
       KE::is_sorted_until("label", exespace(), KE::begin(view), KE::end(view));
   auto r3 = KE::is_sorted_until(exespace(), view);
   auto r4 = KE::is_sorted_until("label", exespace(), view);
-  ASSERT_EQ(r1, gold);
-  ASSERT_EQ(r2, gold);
-  ASSERT_EQ(r3, gold);
-  ASSERT_EQ(r4, gold);
+  ASSERT_EQ(r1, gold) << name << ", " << view_tag_to_string(Tag{});
+  ASSERT_EQ(r2, gold) << name << ", " << view_tag_to_string(Tag{});
+  ASSERT_EQ(r3, gold) << name << ", " << view_tag_to_string(Tag{});
+  ASSERT_EQ(r4, gold) << name << ", " << view_tag_to_string(Tag{});
 
 #if !defined KOKKOS_ENABLE_OPENMPTARGET
   CustomLessThanComparator<ValueType, ValueType> comp;
@@ -160,10 +160,10 @@ void run_single_scenario(const InfoType& scenario_info) {
   auto r8 = KE::is_sorted_until("label", exespace(), view, comp);
 #endif
 
-  ASSERT_EQ(r1, gold);
-  ASSERT_EQ(r2, gold);
-  ASSERT_EQ(r3, gold);
-  ASSERT_EQ(r4, gold);
+  ASSERT_EQ(r1, gold) << name << ", " << view_tag_to_string(Tag{});
+  ASSERT_EQ(r2, gold) << name << ", " << view_tag_to_string(Tag{});
+  ASSERT_EQ(r3, gold) << name << ", " << view_tag_to_string(Tag{});
+  ASSERT_EQ(r4, gold) << name << ", " << view_tag_to_string(Tag{});
 
   Kokkos::fence();
 }
@@ -175,9 +175,6 @@ void run_is_sorted_until_all_scenarios() {
       {"two-elements-b", 2}, {"small-a", 9},     {"small-b", 13},
       {"medium-a", 1003},    {"medium-b", 1003}, {"large-a", 101513},
       {"large-b", 101513}};
-
-  std::cout << "is_sorted_until: " << view_tag_to_string(Tag{})
-            << ", all overloads \n";
 
   for (const auto& it : scenarios) {
     run_single_scenario<Tag, ValueType>(it);

--- a/algorithms/unit_tests/TestStdReducers.cpp
+++ b/algorithms/unit_tests/TestStdReducers.cpp
@@ -83,9 +83,6 @@ auto run_min_or_max_test(ViewType view, StdReducersTestEnumOrder enValue) {
   static_assert(std::is_same<ExeSpace, Kokkos::HostSpace>::value,
                 "test is only enabled for HostSpace");
 
-  std::cout << "checking reduction with order: " << order_to_string(enValue)
-            << "\n";
-
   using view_value_type = typename ViewType::value_type;
   using reducer_type    = std::conditional_t<
       (flag == 0), Kokkos::MaxFirstLoc<view_value_type, IndexType, ExeSpace>,
@@ -132,18 +129,24 @@ TEST(std_algorithms_reducers, max_first_loc) {
 
   const auto pair1 = run_min_or_max_test<0, hostspace, index_type>(
       view_h, StdReducersTestEnumOrder::LeftToRight);
-  ASSERT_EQ(pair1.first, gold_value);
-  ASSERT_EQ(pair1.second, gold_location);
+  ASSERT_EQ(pair1.first, gold_value)
+      << order_to_string(StdReducersTestEnumOrder::LeftToRight);
+  ASSERT_EQ(pair1.second, gold_location)
+      << order_to_string(StdReducersTestEnumOrder::LeftToRight);
 
   const auto pair2 = run_min_or_max_test<0, hostspace, index_type>(
       view_h, StdReducersTestEnumOrder::RightToLeft);
-  ASSERT_EQ(pair2.first, gold_value);
-  ASSERT_EQ(pair2.second, gold_location);
+  ASSERT_EQ(pair2.first, gold_value)
+      << order_to_string(StdReducersTestEnumOrder::RightToLeft);
+  ASSERT_EQ(pair2.second, gold_location)
+      << order_to_string(StdReducersTestEnumOrder::RightToLeft);
 
   const auto pair3 = run_min_or_max_test<0, hostspace, index_type>(
       view_h, StdReducersTestEnumOrder::Random);
-  ASSERT_EQ(pair3.first, gold_value);
-  ASSERT_EQ(pair3.second, gold_location);
+  ASSERT_EQ(pair3.first, gold_value)
+      << order_to_string(StdReducersTestEnumOrder::Random);
+  ASSERT_EQ(pair3.second, gold_location)
+      << order_to_string(StdReducersTestEnumOrder::Random);
 }
 
 TEST(std_algorithms_reducers, min_first_loc) {
@@ -191,9 +194,6 @@ void run_min_max_test(ViewType view, StdReducersTestEnumOrder enValue,
   static_assert(std::is_same<ExeSpace, Kokkos::HostSpace>::value,
                 "test is only enabled for HostSpace");
 
-  std::cout << "checking reduction with order: " << order_to_string(enValue)
-            << "\n";
-
   using view_value_type = typename ViewType::value_type;
   using reducer_type =
       Kokkos::MinMaxFirstLastLoc<view_value_type, IndexType, ExeSpace>;
@@ -212,10 +212,10 @@ void run_min_max_test(ViewType view, StdReducersTestEnumOrder enValue,
                  reduction_value_type{view(index), view(index), index, index});
   }
 
-  ASSERT_EQ(red_result.min_val, gold_values.first);
-  ASSERT_EQ(red_result.max_val, gold_values.second);
-  ASSERT_EQ(red_result.min_loc, gold_locs.first);
-  ASSERT_EQ(red_result.max_loc, gold_locs.second);
+  ASSERT_EQ(red_result.min_val, gold_values.first) << order_to_string(enValue);
+  ASSERT_EQ(red_result.max_val, gold_values.second) << order_to_string(enValue);
+  ASSERT_EQ(red_result.min_loc, gold_locs.first) << order_to_string(enValue);
+  ASSERT_EQ(red_result.max_loc, gold_locs.second) << order_to_string(enValue);
 }
 
 TEST(std_algorithms_reducers, min_max_first_last_loc) {


### PR DESCRIPTION
Partial fix for #4463 

Spotted
```
27: [----------] 3 tests from std_algorithms_reducers
27: [ RUN      ] std_algorithms_reducers.max_first_loc
27: checking reduction with order: LeftToRight
27: checking reduction with order: RightToLeft
27: checking reduction with order: Random
27: [       OK ] std_algorithms_reducers.max_first_loc (0 ms)
27: [ RUN      ] std_algorithms_reducers.min_first_loc
27: checking reduction with order: LeftToRight
27: checking reduction with order: RightToLeft
27: checking reduction with order: Random
27: [       OK ] std_algorithms_reducers.min_first_loc (0 ms)
27: [ RUN      ] std_algorithms_reducers.min_max_first_last_loc
27: checking reduction with order: LeftToRight
27: checking reduction with order: RightToLeft
27: checking reduction with order: Random
27: [       OK ] std_algorithms_reducers.min_max_first_last_loc (0 ms)
27: [----------] 3 tests from std_algorithms_reducers (0 ms total)
```
and
```
31: [----------] 2 tests from std_algorithms_sorting_ops_test
31: [ RUN      ] std_algorithms_sorting_ops_test.is_sorted
31: is_sorted: dynamic_view, all overloads
31: is_sorted: stride2_view, all overloads
31: is_sorted: stride3_view, all overloads
31: [       OK ] std_algorithms_sorting_ops_test.is_sorted (9 ms)
31: [ RUN      ] std_algorithms_sorting_ops_test.is_sorted_until
31: is_sorted_until: dynamic_view, all overloads
31: is_sorted_until: stride2_view, all overloads
31: is_sorted_until: stride3_view, all overloads
31: [       OK ] std_algorithms_sorting_ops_test.is_sorted_until (4 ms)
31: [----------] 2 tests from std_algorithms_sorting_ops_test (14 ms total)
```
in the build logs.

Prefer native GTest support to inject custom failure messages.