### PR TITLE
Get rid of `ZeroMemset`'s silly trailing value argument

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
@@ -25,8 +25,8 @@ namespace Impl {
 
 template <class T, class... P>
 struct ZeroMemset<Kokkos::Cuda, View<T, P...>> {
-  ZeroMemset(const Kokkos::Cuda& exec_space_instance, const View<T, P...>& dst,
-             typename View<T, P...>::const_value_type&) {
+  ZeroMemset(const Kokkos::Cuda& exec_space_instance,
+             const View<T, P...>& dst) {
     KOKKOS_IMPL_CUDA_SAFE_CALL(
         (exec_space_instance.impl_internal_space_instance()
              ->cuda_memset_async_wrapper(

--- a/core/src/HIP/Kokkos_HIP_ZeroMemset.hpp
+++ b/core/src/HIP/Kokkos_HIP_ZeroMemset.hpp
@@ -25,8 +25,7 @@ namespace Impl {
 
 template <class T, class... P>
 struct ZeroMemset<HIP, View<T, P...>> {
-  ZeroMemset(const HIP& exec_space, const View<T, P...>& dst,
-             typename View<T, P...>::const_value_type&) {
+  ZeroMemset(const HIP& exec_space, const View<T, P...>& dst) {
     KOKKOS_IMPL_HIP_SAFE_CALL(hipMemsetAsync(
         dst.data(), 0, dst.size() * sizeof(typename View<T, P...>::value_type),
         exec_space.hip_stream()));

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1338,8 +1338,8 @@ template <typename ExecutionSpace, class ViewType>
 struct ZeroMemset {
   ZeroMemset(const ExecutionSpace& exec_space, const ViewType& dst) {
     using ValueType = typename ViewType::value_type;
-    alignas(alignof(
-        ValueType)) char zero_initialized_storage[sizeof(ValueType)] = {};
+    alignas(alignof(ValueType)) unsigned char
+        zero_initialized_storage[sizeof(ValueType)] = {};
     contiguous_fill(exec_space, dst,
                     *reinterpret_cast<ValueType*>(zero_initialized_storage));
   }

--- a/core/src/SYCL/Kokkos_SYCL_ZeroMemset.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ZeroMemset.hpp
@@ -26,8 +26,7 @@ namespace Impl {
 template <class T, class... P>
 struct ZeroMemset<Kokkos::Experimental::SYCL, View<T, P...>> {
   ZeroMemset(const Kokkos::Experimental::SYCL& exec_space,
-             const View<T, P...>& dst,
-             typename View<T, P...>::const_value_type&) {
+             const View<T, P...>& dst) {
     auto event = exec_space.impl_internal_space_instance()->m_queue->memset(
         dst.data(), 0, dst.size() * sizeof(typename View<T, P...>::value_type));
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES

--- a/core/src/Serial/Kokkos_Serial_ZeroMemset.hpp
+++ b/core/src/Serial/Kokkos_Serial_ZeroMemset.hpp
@@ -36,8 +36,7 @@ struct ZeroMemset<
     std::conditional_t<!std::is_same<Serial, DefaultHostExecutionSpace>::value,
                        Serial, DummyExecutionSpace>,
     View<T, P...>> {
-  ZeroMemset(const Serial&, const View<T, P...>& dst,
-             typename View<T, P...>::const_value_type&) {
+  ZeroMemset(const Serial&, const View<T, P...>& dst) {
     using ValueType = typename View<T, P...>::value_type;
     std::memset(dst.data(), 0, sizeof(ValueType) * dst.size());
   }

--- a/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
+++ b/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
@@ -26,8 +26,7 @@ namespace Impl {
 
 template <class T, class... P>
 struct ZeroMemset<HostSpace::execution_space, View<T, P...>> {
-  ZeroMemset(const HostSpace::execution_space& exec, const View<T, P...>& dst,
-             typename View<T, P...>::const_value_type&) {
+  ZeroMemset(const HostSpace::execution_space& exec, const View<T, P...>& dst) {
     // Host spaces, except for HPX, are synchronous and we need to fence for HPX
     // since we can't properly enqueue a std::memset otherwise.
     // We can't use exec.fence() directly since we don't have a full definition

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2918,10 +2918,8 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
             Kokkos::Profiling::Experimental::device_id(space), &kpID);
       }
       (void)ZeroMemset(
-          space,
-          Kokkos::View<ValueType*, typename DeviceType::memory_space,
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n),
-          value);
+          space, Kokkos::View<ValueType*, typename DeviceType::memory_space,
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n));
 
       if (Kokkos::Profiling::profileLibraryLoaded()) {
         Kokkos::Profiling::endParallelFor(kpID);
@@ -3050,10 +3048,8 @@ struct ViewValueFunctor<DeviceType, ValueType, true /* is_scalar */> {
       }
 
       (void)ZeroMemset(
-          space,
-          Kokkos::View<ValueType*, typename DeviceType::memory_space,
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n),
-          value);
+          space, Kokkos::View<ValueType*, typename DeviceType::memory_space,
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n));
 
       if (Kokkos::Profiling::profileLibraryLoaded()) {
         Kokkos::Profiling::endParallelFor(kpID);


### PR DESCRIPTION
Follow up on #6764 
`ZeroMemset` was talking a trailing value argument that was ignored in virtually all implementation and intended to be all bits set to zero.  This PR drops that value argument.
I think this is more intuitive.

`ZeroMemset(exec, v, /*ignored=*/ValueType(0)) -> ZeroMemset(exec, v)`