### PR TITLE
Change the default execution policy behavior of the OpenACC backend

### DIFF
--- a/core/src/OpenACC/Kokkos_OpenACC_DeepCopy.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_DeepCopy.hpp
@@ -34,7 +34,7 @@ struct Kokkos::Impl::DeepCopy<Kokkos::Experimental::OpenACCSpace,
     // value checking is added as a safeguard. (The current NVHPC (V22.5)
     // supports OpenACC V2.7.)
     if (n > 0) {
-      acc_memcpy_device(dst, const_cast<void*>(src), n);
+      acc_memcpy_device_async(dst, const_cast<void*>(src), n, acc_async_noval);
     }
   }
   DeepCopy(const Kokkos::Experimental::OpenACC& exec, void* dst,
@@ -52,7 +52,7 @@ struct Kokkos::Impl::DeepCopy<Kokkos::Experimental::OpenACCSpace,
                               ExecutionSpace> {
   DeepCopy(void* dst, const void* src, size_t n) {
     if (n > 0) {
-      acc_memcpy_device(dst, const_cast<void*>(src), n);
+      acc_memcpy_device_async(dst, const_cast<void*>(src), n, acc_async_noval);
     }
   }
   DeepCopy(const ExecutionSpace& exec, void* dst, const void* src, size_t n) {
@@ -60,7 +60,7 @@ struct Kokkos::Impl::DeepCopy<Kokkos::Experimental::OpenACCSpace,
         "Kokkos::Impl::DeepCopy<OpenACCSpace, OpenACCSpace, "
         "ExecutionSpace>::DeepCopy: fence before copy");
     if (n > 0) {
-      acc_memcpy_device(dst, const_cast<void*>(src), n);
+      acc_memcpy_device_async(dst, const_cast<void*>(src), n, acc_async_noval);
     }
   }
 };
@@ -70,7 +70,9 @@ struct Kokkos::Impl::DeepCopy<Kokkos::Experimental::OpenACCSpace,
                               Kokkos::HostSpace,
                               Kokkos::Experimental::OpenACC> {
   DeepCopy(void* dst, const void* src, size_t n) {
-    if (n > 0) acc_memcpy_to_device(dst, const_cast<void*>(src), n);
+    if (n > 0)
+      acc_memcpy_to_device_async(dst, const_cast<void*>(src), n,
+                                 acc_async_noval);
   }
   DeepCopy(const Kokkos::Experimental::OpenACC& exec, void* dst,
            const void* src, size_t n) {
@@ -85,7 +87,8 @@ struct Kokkos::Impl::DeepCopy<Kokkos::Experimental::OpenACCSpace,
                               Kokkos::HostSpace, ExecutionSpace> {
   DeepCopy(void* dst, const void* src, size_t n) {
     if (n > 0) {
-      acc_memcpy_to_device(dst, const_cast<void*>(src), n);
+      acc_memcpy_to_device_async(dst, const_cast<void*>(src), n,
+                                 acc_async_noval);
     }
   }
   DeepCopy(const ExecutionSpace& exec, void* dst, const void* src, size_t n) {
@@ -93,7 +96,8 @@ struct Kokkos::Impl::DeepCopy<Kokkos::Experimental::OpenACCSpace,
         "Kokkos::Impl::DeepCopy<OpenACCSpace, HostSpace, "
         "ExecutionSpace>::DeepCopy: fence before copy");
     if (n > 0) {
-      acc_memcpy_to_device(dst, const_cast<void*>(src), n);
+      acc_memcpy_to_device_async(dst, const_cast<void*>(src), n,
+                                 acc_async_noval);
     }
   }
 };
@@ -104,7 +108,8 @@ struct Kokkos::Impl::DeepCopy<Kokkos::HostSpace,
                               Kokkos::Experimental::OpenACC> {
   DeepCopy(void* dst, const void* src, size_t n) {
     if (n > 0) {
-      acc_memcpy_from_device(dst, const_cast<void*>(src), n);
+      acc_memcpy_from_device_async(dst, const_cast<void*>(src), n,
+                                   acc_async_noval);
     }
   }
   DeepCopy(const Kokkos::Experimental::OpenACC& exec, void* dst,
@@ -120,14 +125,17 @@ template <class ExecutionSpace>
 struct Kokkos::Impl::DeepCopy<
     Kokkos::HostSpace, Kokkos::Experimental::OpenACCSpace, ExecutionSpace> {
   DeepCopy(void* dst, const void* src, size_t n) {
-    if (n > 0) acc_memcpy_from_device(dst, const_cast<void*>(src), n);
+    if (n > 0)
+      acc_memcpy_from_device_async(dst, const_cast<void*>(src), n,
+                                   acc_async_noval);
   }
   DeepCopy(const ExecutionSpace& exec, void* dst, const void* src, size_t n) {
     exec.fence(
         "Kokkos::Impl::DeepCopy<HostSpace, OpenACCSpace, "
         "ExecutionSpace>::DeepCopy: fence before copy");
     if (n > 0) {
-      acc_memcpy_from_device(dst, const_cast<void*>(src), n);
+      acc_memcpy_from_device_async(dst, const_cast<void*>(src), n,
+                                   acc_async_noval);
     }
   }
 };

--- a/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
@@ -35,7 +35,7 @@ class OpenACCInternal {
 
  public:
   static int m_acc_device_num;
-  int m_async_arg = acc_async_sync;
+  int m_async_arg = acc_async_noval;
 
   OpenACCInternal() = default;
 
@@ -43,7 +43,7 @@ class OpenACCInternal {
 
   bool verify_is_initialized(const char* const label) const;
 
-  void initialize(int async_arg = acc_async_sync);
+  void initialize(int async_arg = acc_async_noval);
   void finalize();
   bool is_initialized() const;
 

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp
@@ -136,6 +136,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         functor(i0, i1, val);                                                 \
       }                                                                       \
     }                                                                         \
+    acc_wait(async_arg);                                                      \
     aval = val;                                                               \
   }                                                                           \
                                                                               \
@@ -159,6 +160,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         functor(i0, i1, val);                                                 \
       }                                                                       \
     }                                                                         \
+    acc_wait(async_arg);                                                      \
     aval = val;                                                               \
   }                                                                           \
                                                                               \
@@ -188,6 +190,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         }                                                                     \
       }                                                                       \
     }                                                                         \
+    acc_wait(async_arg);                                                      \
     aval = val;                                                               \
   }                                                                           \
                                                                               \
@@ -217,6 +220,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         }                                                                     \
       }                                                                       \
     }                                                                         \
+    acc_wait(async_arg);                                                      \
     aval = val;                                                               \
   }                                                                           \
                                                                               \
@@ -248,6 +252,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         }                                                                     \
       }                                                                       \
     }                                                                         \
+    acc_wait(async_arg);                                                      \
     aval = val;                                                               \
   }                                                                           \
                                                                               \
@@ -279,6 +284,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         }                                                                     \
       }                                                                       \
     }                                                                         \
+    acc_wait(async_arg);                                                      \
     aval = val;                                                               \
   }                                                                           \
                                                                               \
@@ -314,6 +320,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         }                                                                     \
       }                                                                       \
     }                                                                         \
+    acc_wait(async_arg);                                                      \
     aval = val;                                                               \
   }                                                                           \
                                                                               \
@@ -349,6 +356,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         }                                                                     \
       }                                                                       \
     }                                                                         \
+    acc_wait(async_arg);                                                      \
     aval = val;                                                               \
   }                                                                           \
                                                                               \
@@ -388,6 +396,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         }                                                                     \
       }                                                                       \
     }                                                                         \
+    acc_wait(async_arg);                                                      \
     aval = val;                                                               \
   }                                                                           \
                                                                               \
@@ -427,6 +436,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         }                                                                     \
       }                                                                       \
     }                                                                         \
+    acc_wait(async_arg);                                                      \
     aval = val;                                                               \
   }                                                                           \
   }  // namespace Kokkos::Experimental::Impl

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp
@@ -140,6 +140,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         functor(i, val);                                                  \
       }                                                                   \
     }                                                                     \
+    acc_wait(async_arg);                                                  \
     aval = val;                                                           \
   }                                                                       \
                                                                           \
@@ -169,6 +170,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         functor(i, val);                                                  \
       }                                                                   \
     }                                                                     \
+    acc_wait(async_arg);                                                  \
     aval = val;                                                           \
   }                                                                       \
   }  // namespace Kokkos::Experimental::Impl

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
@@ -394,6 +394,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
                                         vector_length);                    \
       functor(team, val);                                                  \
     }                                                                      \
+    acc_wait(async_arg);                                                   \
     aval = val;                                                            \
   }                                                                        \
   }  // namespace Kokkos::Experimental::Impl


### PR DESCRIPTION
Change the default execution policy behavior of the OpenACC backend from synchronous to asynchronous executions.

- Change the default OpenACC async_arg value from acc_async_sync to acc_async_noval.
- Add acc_wait(async_arg) to scalar reduction operations (parallel_reduce()).