### PR TITLE
Fixup use provided execution space when copying host inaccessible reduction result

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -872,8 +872,8 @@ class ParallelReduce<CombinedFunctorReducerType,
             }
           } else {
             const int size = m_functor_reducer.get_reducer().value_size();
-            DeepCopy<HostSpace, CudaSpace>(m_policy.space(), m_result_ptr,
-                                           m_scratch_space, size);
+            DeepCopy<HostSpace, CudaSpace, Cuda>(m_policy.space(), m_result_ptr,
+                                                 m_scratch_space, size);
           }
         }
       }

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -872,7 +872,8 @@ class ParallelReduce<CombinedFunctorReducerType,
             }
           } else {
             const int size = m_functor_reducer.get_reducer().value_size();
-            DeepCopy<HostSpace, CudaSpace>(m_result_ptr, m_scratch_space, size);
+            DeepCopy<HostSpace, CudaSpace>(m_policy.space(), m_result_ptr,
+                                           m_scratch_space, size);
           }
         }
       }

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
@@ -271,7 +271,8 @@ class ParallelReduce<CombinedFunctorReducerType,
 
         if (m_result_ptr) {
           const int size = reducer.value_size();
-          DeepCopy<HostSpace, HIPSpace>(m_result_ptr, m_scratch_space, size);
+          DeepCopy<HostSpace, HIPSpace>(m_policy.space(), m_result_ptr,
+                                        m_scratch_space, size);
         }
       }
     } else {

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
@@ -271,8 +271,8 @@ class ParallelReduce<CombinedFunctorReducerType,
 
         if (m_result_ptr) {
           const int size = reducer.value_size();
-          DeepCopy<HostSpace, HIPSpace>(m_policy.space(), m_result_ptr,
-                                        m_scratch_space, size);
+          DeepCopy<HostSpace, HIPSpace, HIP>(m_policy.space(), m_result_ptr,
+                                             m_scratch_space, size);
         }
       }
     } else {

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Range.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Range.hpp
@@ -238,7 +238,8 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
 
       if (!base_t::m_result_ptr_device_accessible) {
         const int size = base_t::m_functor_reducer.get_reducer().value_size();
-        DeepCopy<HostSpace, Kokkos::Experimental::OpenMPTargetSpace>(
+        DeepCopy<HostSpace, Kokkos::Experimental::OpenMPTargetSpace,
+                 Kokkos::Experimental::OpenMPTarget>(
             base_t::m_policy.space(), base_t::m_result_ptr,
             chunk_values.data() + (n_chunks - 1), size);
       }

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Range.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Range.hpp
@@ -239,7 +239,8 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
       if (!base_t::m_result_ptr_device_accessible) {
         const int size = base_t::m_functor_reducer.get_reducer().value_size();
         DeepCopy<HostSpace, Kokkos::Experimental::OpenMPTargetSpace>(
-            base_t::m_result_ptr, chunk_values.data() + (n_chunks - 1), size);
+            base_t::m_policy.space(), base_t::m_result_ptr,
+            chunk_values.data() + (n_chunks - 1), size);
       }
     } else if (!base_t::m_result_ptr_device_accessible) {
       base_t::m_functor_reducer.get_reducer().init(base_t::m_result_ptr);


### PR DESCRIPTION
Spotted when auditing use of 2-arguments `Impl::DeepCopy` throughout the codebase.