### PR TITLE
Fix incorrect macro guard `#ifdef KOKKOS_ENABLE_DEPRECATED{ -> _CODE}_4`

### DIFF
--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -57,7 +57,7 @@ class HIP {
   //! \name Functions that all Kokkos devices must implement.
   //@{
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION static int in_parallel() {
 #if defined(__HIP_DEVICE_COMPILE__)
     return true;


### PR DESCRIPTION
Fix typo from #6582