### PR TITLE
multi-GPU support: Add test for all policies

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -787,7 +787,7 @@ if(Kokkos_ENABLE_CUDA)
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     CoreUnitTest_CudaInterOpStreamsMultiGPU
     SOURCES
-      UnitTestMain.cpp
+      UnitTestMainInit.cpp
       cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
   )
   KOKKOS_ADD_EXECUTABLE_AND_TEST(

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -48,6 +48,8 @@ void test_policies(TEST_EXECSPACE exec0, Kokkos::View<int *, TEST_EXECSPACE> v0,
   Kokkos::deep_copy(exec, v, 5);
   Kokkos::deep_copy(exec0, v0, 5);
 
+  Kokkos::deep_copy(v, v0);
+
   int sum;
   int sum0;
 

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -16,28 +16,47 @@
 
 #include <TestCuda_Category.hpp>
 #include <Test_InterOp_Streams.hpp>
+#include <memory>
 
 namespace {
 
-std::array<TEST_EXECSPACE, 2> get_execution_spaces(int n_devices) {
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(0));
-  cudaStream_t stream0;
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamCreate(&stream0));
+struct StreamsAndDevices {
+  std::shared_ptr<std::array<cudaStream_t, 2>> streams;
+  std::array<int, 2> devices;
 
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(n_devices - 1));
-  cudaStream_t stream;
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamCreate(&stream));
+  StreamsAndDevices() {
+    int n_devices;
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&n_devices));
 
-  TEST_EXECSPACE exec0(stream0);
-  TEST_EXECSPACE exec(stream);
+    devices = {0, n_devices - 1};
+
+    streams = std::shared_ptr<std::array<cudaStream_t, 2>>(
+        new std::array<cudaStream_t, 2>{},
+        [this](std::array<cudaStream_t, 2> *s) {
+          for (int i = 0; i < 2; ++i) {
+            KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(devices[i]));
+            KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy((*s)[i]));
+          }
+        });
+    for (int i = 0; i < 2; ++i) {
+      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(devices[i]));
+      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamCreate(&((*streams)[i])));
+    }
+  }
+};
+
+std::array<TEST_EXECSPACE, 2> get_execution_spaces(
+    const StreamsAndDevices &streams_and_devices) {
+  TEST_EXECSPACE exec0((*streams_and_devices.streams)[0]);
+  TEST_EXECSPACE exec1((*streams_and_devices.streams)[1]);
 
   // Must return void to use ASSERT_EQ
   [&]() {
-    ASSERT_EQ(exec0.cuda_device(), 0);
-    ASSERT_EQ(exec.cuda_device(), n_devices - 1);
+    ASSERT_EQ(exec0.cuda_device(), streams_and_devices.devices[0]);
+    ASSERT_EQ(exec1.cuda_device(), streams_and_devices.devices[1]);
   }();
 
-  return {exec0, exec};
+  return {exec0, exec1};
 }
 
 // Test Interoperability with Cuda Streams
@@ -114,12 +133,10 @@ void test_policies(TEST_EXECSPACE exec0, Kokkos::View<int *, TEST_EXECSPACE> v0,
 }
 
 TEST(cuda_multi_gpu, managed_views) {
-  cudaStream_t stream0;
-  cudaStream_t stream;
-  int n_devices;
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&n_devices));
+  StreamsAndDevices streams_and_devices;
   {
-    std::array<TEST_EXECSPACE, 2> execs = get_execution_spaces(n_devices);
+    std::array<TEST_EXECSPACE, 2> execs =
+        get_execution_spaces(streams_and_devices);
 
     Kokkos::View<int *, TEST_EXECSPACE> view0(
         Kokkos::view_alloc("v0", execs[0]), 100);
@@ -127,23 +144,14 @@ TEST(cuda_multi_gpu, managed_views) {
                                              100);
 
     test_policies(execs[0], view0, execs[1], view);
-    stream0 = execs[0].cuda_stream();
-    stream  = execs[1].cuda_stream();
   }
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(0));
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(stream0));
-
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(n_devices - 1));
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(stream));
 }
 
 TEST(cuda_multi_gpu, unmanaged_views) {
-  cudaStream_t stream0;
-  cudaStream_t stream;
-  int n_devices;
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&n_devices));
+  StreamsAndDevices streams_and_devices;
   {
-    std::array<TEST_EXECSPACE, 2> execs = get_execution_spaces(n_devices);
+    std::array<TEST_EXECSPACE, 2> execs =
+        get_execution_spaces(streams_and_devices);
 
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(execs[0].cuda_device()));
     int *p0;
@@ -160,13 +168,6 @@ TEST(cuda_multi_gpu, unmanaged_views) {
     test_policies(execs[0], view0, execs[1], view);
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(p0));
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(p));
-    stream0 = execs[0].cuda_stream();
-    stream  = execs[1].cuda_stream();
   }
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(0));
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(stream0));
-
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(n_devices - 1));
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(stream));
 }
 }  // namespace

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -18,12 +18,8 @@
 #include <Test_InterOp_Streams.hpp>
 
 namespace {
-TEST(cuda, multi_gpu) {
-  Kokkos::initialize();
 
-  int n_devices;
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&n_devices));
-
+std::array<TEST_EXECSPACE, 2> get_execution_spaces(int n_devices) {
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(0));
   cudaStream_t stream0;
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamCreate(&stream0));
@@ -32,14 +28,139 @@ TEST(cuda, multi_gpu) {
   cudaStream_t stream;
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamCreate(&stream));
 
-  {
-    TEST_EXECSPACE space0(stream0);
-    ASSERT_EQ(space0.cuda_device(), 0);
-    TEST_EXECSPACE space(stream);
-    ASSERT_EQ(space.cuda_device(), n_devices - 1);
-  }
-  Kokkos::finalize();
+  TEST_EXECSPACE exec0(stream0);
+  TEST_EXECSPACE exec(stream);
 
+  return {exec0, exec};
+}
+
+// Test Interoperability with Cuda Streams
+void test_policies(TEST_EXECSPACE exec0, Kokkos::View<int *, TEST_EXECSPACE> v0,
+                   TEST_EXECSPACE exec, Kokkos::View<int *, TEST_EXECSPACE> v) {
+  using MemorySpace = typename TEST_EXECSPACE::memory_space;
+
+  Kokkos::deep_copy(exec, v, 5);
+  Kokkos::deep_copy(exec0, v0, 5);
+
+  int sum;
+  int sum0;
+
+  Kokkos::parallel_for("Test::cuda::raw_cuda_stream::Range_0",
+                       Kokkos::RangePolicy<TEST_EXECSPACE>(exec0, 0, 100),
+                       Test::FunctorRange<MemorySpace>(v0));
+  Kokkos::parallel_for("Test::cuda::raw_cuda_stream::Range",
+                       Kokkos::RangePolicy<TEST_EXECSPACE>(exec, 0, 100),
+                       Test::FunctorRange<MemorySpace>(v));
+  Kokkos::parallel_reduce(
+      "Test::cuda::raw_cuda_stream::RangeReduce_0",
+      Kokkos::RangePolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 2>>(exec0,
+                                                                        0, 100),
+      Test::FunctorRangeReduce<MemorySpace>(v0), sum0);
+  Kokkos::parallel_reduce(
+      "Test::cuda::raw_cuda_stream::RangeReduce",
+      Kokkos::RangePolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 2>>(exec, 0,
+                                                                        100),
+      Test::FunctorRangeReduce<MemorySpace>(v), sum);
+  ASSERT_EQ(600, sum0);
+  ASSERT_EQ(600, sum);
+
+  Kokkos::parallel_for("Test::cuda::raw_cuda_stream::MDRange_0",
+                       Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
+                           exec0, {0, 0}, {10, 10}),
+                       Test::FunctorMDRange<MemorySpace>(v0));
+  Kokkos::parallel_for("Test::cuda::raw_cuda_stream::MDRange",
+                       Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
+                           exec, {0, 0}, {10, 10}),
+                       Test::FunctorMDRange<MemorySpace>(v));
+  Kokkos::parallel_reduce("Test::cuda::raw_cuda_stream::MDRangeReduce_0",
+                          Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>,
+                                                Kokkos::LaunchBounds<128, 2>>(
+                              exec0, {0, 0}, {10, 10}),
+                          Test::FunctorMDRangeReduce<MemorySpace>(v0), sum0);
+  Kokkos::parallel_reduce("Test::cuda::raw_cuda_stream::MDRangeReduce",
+                          Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>,
+                                                Kokkos::LaunchBounds<128, 2>>(
+                              exec, {0, 0}, {10, 10}),
+                          Test::FunctorMDRangeReduce<MemorySpace>(v), sum);
+  ASSERT_EQ(700, sum0);
+  ASSERT_EQ(700, sum);
+
+  Kokkos::parallel_for("Test::cuda::raw_cuda_stream::Team_0",
+                       Kokkos::TeamPolicy<TEST_EXECSPACE>(exec0, 10, 10),
+                       Test::FunctorTeam<MemorySpace, TEST_EXECSPACE>(v0));
+  Kokkos::parallel_for("Test::cuda::raw_cuda_stream::Team",
+                       Kokkos::TeamPolicy<TEST_EXECSPACE>(exec, 10, 10),
+                       Test::FunctorTeam<MemorySpace, TEST_EXECSPACE>(v));
+  Kokkos::parallel_reduce(
+      "Test::cuda::raw_cuda_stream::Team_0",
+      Kokkos::TeamPolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 2>>(exec0,
+                                                                       10, 10),
+      Test::FunctorTeamReduce<MemorySpace, TEST_EXECSPACE>(v0), sum0);
+  Kokkos::parallel_reduce(
+      "Test::cuda::raw_cuda_stream::Team",
+      Kokkos::TeamPolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 2>>(exec, 10,
+                                                                       10),
+      Test::FunctorTeamReduce<MemorySpace, TEST_EXECSPACE>(v), sum);
+  ASSERT_EQ(800, sum0);
+  ASSERT_EQ(800, sum);
+}
+
+TEST(cuda_multi_gpu, managed_views) {
+  cudaStream_t stream0;
+  cudaStream_t stream;
+  int n_devices;
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&n_devices));
+  {
+    std::array<TEST_EXECSPACE, 2> execs = get_execution_spaces(n_devices);
+
+    ASSERT_EQ(execs[0].cuda_device(), 0);
+    Kokkos::View<int *, TEST_EXECSPACE> view0(
+        Kokkos::view_alloc("v0", execs[0]), 100);
+    ASSERT_EQ(execs[1].cuda_device(), n_devices - 1);
+    Kokkos::View<int *, TEST_EXECSPACE> view(Kokkos::view_alloc("v", execs[1]),
+                                             100);
+
+    test_policies(execs[0], view0, execs[1], view);
+    stream0 = execs[0].cuda_stream();
+    stream  = execs[1].cuda_stream();
+  }
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(0));
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(stream0));
+
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(n_devices - 1));
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(stream));
+}
+
+TEST(cuda_multi_gpu, unmanaged_views) {
+  cudaStream_t stream0;
+  cudaStream_t stream;
+  int n_devices;
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&n_devices));
+  {
+    std::array<TEST_EXECSPACE, 2> execs = get_execution_spaces(n_devices);
+
+    int device0 = execs[0].cuda_device();
+    ASSERT_EQ(device0, 0);
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(device0));
+    int *p0;
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        cudaMalloc(reinterpret_cast<void **>(&p0), sizeof(int) * 100));
+    Kokkos::View<int *, TEST_EXECSPACE> view0(p0, 100);
+
+    int device = execs[1].cuda_device();
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(device));
+    ASSERT_EQ(device, n_devices - 1);
+    int *p;
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        cudaMalloc(reinterpret_cast<void **>(&p), sizeof(int) * 100));
+    Kokkos::View<int *, TEST_EXECSPACE> view(p, 100);
+
+    test_policies(execs[0], view0, execs[1], view);
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(p0));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(p));
+    stream0 = execs[0].cuda_stream();
+    stream  = execs[1].cuda_stream();
+  }
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(0));
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(stream0));
 


### PR DESCRIPTION
This should be the last step for #6091. In particular, this pull request extends the test in `TestCuda_interOp_StreamsMultiGPU.cpp` to test all policies by effectively copying the test in `TestCuda_InterOp_Streams.cpp` and running all the kernels on the default device and the last visible device (as reported by `cudaGetDevciceCount`) using managed and unmanaged `View`s.

Future steps are:
- arbitrary size atomics, see https://github.com/desul/desul/pull/110 and https://github.com/kokkos/kokkos/pull/6469.
- ~~managed Views (requires storing the device id in `SharedAllocationRecord`).~~