### PR TITLE
Adding `local_deep_copy_thread` for deep copy at threads level

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1850,9 +1850,10 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy_non_contiguous(
     const View<DT, DP...>& dst, const View<ST, SP...>& src,
     std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 1 &&
                       unsigned(ViewTraits<ST, SP...>::rank) == 1)>* = nullptr) {
-  auto policy = deep_copy_policy_helper(team, asked_policy, src.span());
-  Kokkos::parallel_for(policy,
-                       [&](const int& i) { dst.data()[i] = src.data()[i]; });
+  const size_t N = dst.extent(0);
+
+  auto policy = deep_copy_policy_helper(team, asked_policy, N);
+  Kokkos::parallel_for(policy, [&](const int& i) { dst(i) = src(i); });
 }
 
 template <class TeamType, class iType, class MemberType,

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1860,8 +1860,8 @@ template <class TeamType, class iType, class MemberType,
           template <class, class> class Policy, class DT, class... DP, class ST,
           class... SP>
 void KOKKOS_INLINE_FUNCTION local_deep_copy_non_contiguous(
-    const TeamType& team, Policy<iType, MemberType> asked_policy,
-    const View<DT, DP...>& dst, const View<ST, SP...>& src,
+    const TeamType& team, Policy<iType, MemberType>, const View<DT, DP...>& dst,
+    const View<ST, SP...>& src,
     std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 2 &&
                       unsigned(ViewTraits<ST, SP...>::rank) == 2)>* = nullptr) {
   auto policy = deep_copy_mdpolicy_helper<Kokkos::is_detected_v<

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1819,7 +1819,9 @@ template <class TeamType, class iType, class MemberType, class DT, class... DP,
           class ST, class... SP>
 void KOKKOS_INLINE_FUNCTION very_deep_copy(
     const TeamType& team,
-    Kokkos::Impl::ThreadVectorRangeBoundariesStruct<iType, MemberType> member,
+    [[maybe_unused]] Kokkos::Impl::ThreadVectorRangeBoundariesStruct<iType,
+                                                                     MemberType>
+        member,
     const View<DT, DP...>& dst, const View<ST, SP...>& src,
     std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 1 &&
                       unsigned(ViewTraits<ST, SP...>::rank) == 1)>* = nullptr) {
@@ -1847,7 +1849,9 @@ template <class TeamType, class iType, class MemberType, class DT, class... DP,
           class ST, class... SP>
 void KOKKOS_INLINE_FUNCTION very_deep_copy(
     TeamType team,
-    Kokkos::Impl::TeamThreadRangeBoundariesStruct<iType, MemberType> member,
+    [[maybe_unused]] Kokkos::Impl::TeamThreadRangeBoundariesStruct<iType,
+                                                                   MemberType>
+        member,
     const View<DT, DP...>& dst, const View<ST, SP...>& src,
     std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 1 &&
                       unsigned(ViewTraits<ST, SP...>::rank) == 1)>* = nullptr) {

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1814,6 +1814,8 @@ auto KOKKOS_INLINE_FUNCTION deep_copy_policy_helper(
   return Kokkos::ThreadVectorRange(team, length);
 }
 
+// Copy from a view to a view
+
 template <class TeamType, class iType, class MemberType,
           template <class, class> class Policy, class DT, class... DP, class ST,
           class... SP>
@@ -1983,6 +1985,164 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy_non_contiguous(
     dst(i0, i1, i2, i3, i4, i5, i6) = src(i0, i1, i2, i3, i4, i5, i6);
   });
 }
+
+// Copy from a scalar to a view
+
+template <class TeamType, class iType, class MemberType,
+          template <class, class> class Policy, class DT, class... DP>
+void KOKKOS_INLINE_FUNCTION deep_copy_contiguous(const TeamType& team,
+                                                 Policy<iType, MemberType>,
+                                                 const View<DT, DP...>& dst,
+                                                 typename ViewTraits<DT, DP...>::const_value_type& value) {
+  auto policy = deep_copy_policy_helper(
+      team, Policy<iType, MemberType>(team, 0), dst.span());
+  Kokkos::parallel_for(policy,
+                       [&](const int& i) { dst.data()[i] = value; });
+}
+
+template <class TeamType, class iType, class MemberType,
+          template <class, class> class Policy, class DT, class... DP>
+void KOKKOS_INLINE_FUNCTION local_deep_copy_non_contiguous(
+    const TeamType& team, Policy<iType, MemberType> asked_policy,
+    const View<DT, DP...>& dst, typename ViewTraits<DT, DP...>::const_value_type& value,
+    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 1)>* = nullptr) {
+  const size_t N = dst.extent(0);
+
+  auto policy = deep_copy_policy_helper(team, asked_policy, N);
+  Kokkos::parallel_for(policy, [&](const int& i) { dst(i) = value; });
+}
+
+template <class TeamType, class iType, class MemberType,
+          template <class, class> class Policy, class DT, class... DP>
+void KOKKOS_INLINE_FUNCTION local_deep_copy_non_contiguous(
+    const TeamType& team, Policy<iType, MemberType> asked_policy,
+    const View<DT, DP...>& dst, typename ViewTraits<DT, DP...>::const_value_type& value,
+    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 2)>* = nullptr) {
+  const size_t N = dst.extent(0) * dst.extent(1);
+
+  auto policy = deep_copy_policy_helper(team, asked_policy, N);
+  Kokkos::parallel_for(policy, [&](const int& i) {
+    int i0      = i % dst.extent(0);
+    int i1      = i / dst.extent(0);
+    dst(i0, i1) = value;
+  });
+}
+
+template <class TeamType, class iType, class MemberType,
+          template <class, class> class Policy, class DT, class... DP>
+void KOKKOS_INLINE_FUNCTION local_deep_copy_non_contiguous(
+    const TeamType& team, Policy<iType, MemberType> asked_policy,
+    const View<DT, DP...>& dst, typename ViewTraits<DT, DP...>::const_value_type& value,
+    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 3)>* = nullptr) {
+  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2);
+
+  auto policy = deep_copy_policy_helper(team, asked_policy, N);
+  Kokkos::parallel_for(policy, [&](const int& i) {
+    int i0          = i % dst.extent(0);
+    int itmp        = i / dst.extent(0);
+    int i1          = itmp % dst.extent(1);
+    int i2          = itmp / dst.extent(1);
+    dst(i0, i1, i2) = value;
+  });
+}
+
+template <class TeamType, class iType, class MemberType,
+          template <class, class> class Policy, class DT, class... DP>
+void KOKKOS_INLINE_FUNCTION local_deep_copy_non_contiguous(
+    const TeamType& team, Policy<iType, MemberType> asked_policy,
+    const View<DT, DP...>& dst, typename ViewTraits<DT, DP...>::const_value_type& value,
+    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 4)>* = nullptr) {
+  const size_t N =
+      dst.extent(0) * dst.extent(1) * dst.extent(2) * dst.extent(3);
+
+  auto policy = deep_copy_policy_helper(team, asked_policy, N);
+  Kokkos::parallel_for(policy, [&](const int& i) {
+    int i0              = i % dst.extent(0);
+    int itmp            = i / dst.extent(0);
+    int i1              = itmp % dst.extent(1);
+    itmp                = itmp / dst.extent(1);
+    int i2              = itmp % dst.extent(2);
+    int i3              = itmp / dst.extent(2);
+    dst(i0, i1, i2, i3) = value;
+  });
+}
+
+template <class TeamType, class iType, class MemberType,
+          template <class, class> class Policy, class DT, class... DP>
+void KOKKOS_INLINE_FUNCTION local_deep_copy_non_contiguous(
+    const TeamType& team, Policy<iType, MemberType> asked_policy,
+    const View<DT, DP...>& dst, typename ViewTraits<DT, DP...>::const_value_type& value,
+    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 5)>* = nullptr) {
+  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2) *
+                   dst.extent(3) * dst.extent(4);
+
+  auto policy = deep_copy_policy_helper(team, asked_policy, N);
+  Kokkos::parallel_for(policy, [&](const int& i) {
+    int i0                  = i % dst.extent(0);
+    int itmp                = i / dst.extent(0);
+    int i1                  = itmp % dst.extent(1);
+    itmp                    = itmp / dst.extent(1);
+    int i2                  = itmp % dst.extent(2);
+    itmp                    = itmp / dst.extent(2);
+    int i3                  = itmp % dst.extent(3);
+    int i4                  = itmp / dst.extent(3);
+    dst(i0, i1, i2, i3, i4) = value;
+  });
+}
+
+template <class TeamType, class iType, class MemberType,
+          template <class, class> class Policy, class DT, class... DP>
+void KOKKOS_INLINE_FUNCTION local_deep_copy_non_contiguous(
+    const TeamType& team, Policy<iType, MemberType> asked_policy,
+    const View<DT, DP...>& dst, typename ViewTraits<DT, DP...>::const_value_type& value,
+    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 6)>* = nullptr) {
+  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2) *
+                   dst.extent(3) * dst.extent(4) * dst.extent(5);
+
+  auto policy = deep_copy_policy_helper(team, asked_policy, N);
+  Kokkos::parallel_for(policy, [&](const int& i) {
+    int i0                      = i % dst.extent(0);
+    int itmp                    = i / dst.extent(0);
+    int i1                      = itmp % dst.extent(1);
+    itmp                        = itmp / dst.extent(1);
+    int i2                      = itmp % dst.extent(2);
+    itmp                        = itmp / dst.extent(2);
+    int i3                      = itmp % dst.extent(3);
+    itmp                        = itmp / dst.extent(3);
+    int i4                      = itmp % dst.extent(4);
+    int i5                      = itmp / dst.extent(4);
+    dst(i0, i1, i2, i3, i4, i5) = value;
+  });
+}
+
+template <class TeamType, class iType, class MemberType,
+          template <class, class> class Policy, class DT, class... DP>
+void KOKKOS_INLINE_FUNCTION local_deep_copy_non_contiguous(
+    const TeamType& team, Policy<iType, MemberType> asked_policy,
+    const View<DT, DP...>& dst, typename ViewTraits<DT, DP...>::const_value_type& value,
+    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 7)>* = nullptr) {
+  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2) *
+                   dst.extent(3) * dst.extent(4) * dst.extent(5) *
+                   dst.extent(6);
+
+  auto policy = deep_copy_policy_helper(team, asked_policy, N);
+  Kokkos::parallel_for(policy, [&](const int& i) {
+    int i0                          = i % dst.extent(0);
+    int itmp                        = i / dst.extent(0);
+    int i1                          = itmp % dst.extent(1);
+    itmp                            = itmp / dst.extent(1);
+    int i2                          = itmp % dst.extent(2);
+    itmp                            = itmp / dst.extent(2);
+    int i3                          = itmp % dst.extent(3);
+    itmp                            = itmp / dst.extent(3);
+    int i4                          = itmp % dst.extent(4);
+    itmp                            = itmp / dst.extent(4);
+    int i5                          = itmp % dst.extent(5);
+    int i6                          = itmp / dst.extent(5);
+    dst(i0, i1, i2, i3, i4, i5, i6) = value;
+  });
+}
+
 }  // namespace Impl
 
 //----------------------------------------------------------------------------
@@ -2182,24 +2342,42 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 /** \brief  Deep copy a value into a view.  */
-template <class TeamType, class DT, class... DP>
-void KOKKOS_INLINE_FUNCTION local_deep_copy_contiguous(
-    const TeamType& team, const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<std::is_same<typename ViewTraits<DT, DP...>::specialize,
-                                  void>::value>* = nullptr) {
-  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, dst.span()),
-                       [&](const int& i) { dst.data()[i] = value; });
-}
 //----------------------------------------------------------------------------
+template <class TeamType, class iType, class MemberType,
+          template <class, class> class Policy, class DT, class... DP>
+void KOKKOS_INLINE_FUNCTION deep_copy(const TeamType& team,
+                                      Policy<iType, MemberType> asked_policy,
+                                      const View<DT, DP...>& dst,
+                                      typename ViewTraits<DT, DP...>::const_value_type& value) {
+  if (dst.data() == nullptr) {
+    return;
+  }
+
+  constexpr auto need_barrier =
+      Kokkos::is_detected_v<Impl::boundary_has_team_member,
+                            Policy<iType, MemberType>>;
+
+  if constexpr (need_barrier) {
+    team.team_barrier();
+  }
+  if (dst.span_is_contiguous()) {
+    Impl::deep_copy_contiguous(team, asked_policy, dst, value);
+  } else {
+    Impl::local_deep_copy_non_contiguous(team, asked_policy, dst, value);
+  }
+  if constexpr (need_barrier) {
+    team.team_barrier();
+  }
+}
+
+//----------------------------------------------------------------------------
+// This is the historical local_deep_copy function
 template <class TeamType, class DT, class... DP>
-void KOKKOS_INLINE_FUNCTION local_deep_copy_contiguous_thread(
-    const TeamType& team, const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<std::is_same<typename ViewTraits<DT, DP...>::specialize,
-                                  void>::value>* = nullptr) {
-  Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, dst.span()),
-                       [&](const int& i) { dst.data()[i] = value; });
+void KOKKOS_INLINE_FUNCTION local_deep_copy(const TeamType& team,
+                                            const View<DT, DP...>& dst,
+                                            typename ViewTraits<DT, DP...>::const_value_type& value) {
+  Kokkos::Experimental::deep_copy(team, Kokkos::TeamVectorRange(team, 0), dst,
+                                  value);
 }
 //----------------------------------------------------------------------------
 template <class DT, class... DP>
@@ -2210,394 +2388,6 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy_contiguous(
                                   void>::value>* = nullptr) {
   for (size_t i = 0; i < dst.span(); ++i) {
     dst.data()[i] = value;
-  }
-}
-//----------------------------------------------------------------------------
-template <class TeamType, class DT, class... DP>
-void KOKKOS_INLINE_FUNCTION local_deep_copy_thread(
-    const TeamType& team, const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 1)>* = nullptr) {
-  if (dst.data() == nullptr) {
-    return;
-  }
-
-  const size_t N = dst.extent(0);
-
-  Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, N),
-                       [&](const int& i) { dst(i) = value; });
-}
-//----------------------------------------------------------------------------
-template <class TeamType, class DT, class... DP>
-void KOKKOS_INLINE_FUNCTION local_deep_copy(
-    const TeamType& team, const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 1)>* = nullptr) {
-  if (dst.data() == nullptr) {
-    return;
-  }
-
-  const size_t N = dst.extent(0);
-
-  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N),
-                       [&](const int& i) { dst(i) = value; });
-}
-//----------------------------------------------------------------------------
-template <class TeamType, class DT, class... DP>
-void KOKKOS_INLINE_FUNCTION local_deep_copy_thread(
-    const TeamType& team, const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 2)>* = nullptr) {
-  if (dst.data() == nullptr) {
-    return;
-  }
-
-  const size_t N = dst.extent(0) * dst.extent(1);
-
-  if (dst.span_is_contiguous()) {
-    local_deep_copy_contiguous(team, dst, value);
-  } else {
-    Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, N), [&](const int& i) {
-      int i0      = i % dst.extent(0);
-      int i1      = i / dst.extent(0);
-      dst(i0, i1) = value;
-    });
-  }
-}
-//----------------------------------------------------------------------------
-template <class TeamType, class DT, class... DP>
-void KOKKOS_INLINE_FUNCTION local_deep_copy(
-    const TeamType& team, const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 2)>* = nullptr) {
-  if (dst.data() == nullptr) {
-    return;
-  }
-
-  const size_t N = dst.extent(0) * dst.extent(1);
-
-  if (dst.span_is_contiguous()) {
-    team.team_barrier();
-    local_deep_copy_contiguous(team, dst, value);
-    team.team_barrier();
-  } else {
-    team.team_barrier();
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
-      int i0      = i % dst.extent(0);
-      int i1      = i / dst.extent(0);
-      dst(i0, i1) = value;
-    });
-    team.team_barrier();
-  }
-}
-//----------------------------------------------------------------------------
-template <class TeamType, class DT, class... DP>
-void KOKKOS_INLINE_FUNCTION local_deep_copy_thread(
-    const TeamType& team, const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 3)>* = nullptr) {
-  if (dst.data() == nullptr) {
-    return;
-  }
-
-  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2);
-
-  if (dst.span_is_contiguous()) {
-    local_deep_copy_contiguous_thread(team, dst, value);
-  } else {
-    Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, N), [&](const int& i) {
-      int i0          = i % dst.extent(0);
-      int itmp        = i / dst.extent(0);
-      int i1          = itmp % dst.extent(1);
-      int i2          = itmp / dst.extent(1);
-      dst(i0, i1, i2) = value;
-    });
-  }
-}
-//----------------------------------------------------------------------------
-template <class TeamType, class DT, class... DP>
-void KOKKOS_INLINE_FUNCTION local_deep_copy(
-    const TeamType& team, const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 3)>* = nullptr) {
-  if (dst.data() == nullptr) {
-    return;
-  }
-
-  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2);
-
-  if (dst.span_is_contiguous()) {
-    team.team_barrier();
-    local_deep_copy_contiguous(team, dst, value);
-    team.team_barrier();
-  } else {
-    team.team_barrier();
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
-      int i0          = i % dst.extent(0);
-      int itmp        = i / dst.extent(0);
-      int i1          = itmp % dst.extent(1);
-      int i2          = itmp / dst.extent(1);
-      dst(i0, i1, i2) = value;
-    });
-    team.team_barrier();
-  }
-}
-//----------------------------------------------------------------------------
-template <class TeamType, class DT, class... DP>
-void KOKKOS_INLINE_FUNCTION local_deep_copy_thread(
-    const TeamType& team, const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 4)>* = nullptr) {
-  if (dst.data() == nullptr) {
-    return;
-  }
-
-  const size_t N =
-      dst.extent(0) * dst.extent(1) * dst.extent(2) * dst.extent(3);
-
-  if (dst.span_is_contiguous()) {
-    local_deep_copy_contiguous_thread(team, dst, value);
-  } else {
-    Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, N), [&](const int& i) {
-      int i0              = i % dst.extent(0);
-      int itmp            = i / dst.extent(0);
-      int i1              = itmp % dst.extent(1);
-      itmp                = itmp / dst.extent(1);
-      int i2              = itmp % dst.extent(2);
-      int i3              = itmp / dst.extent(2);
-      dst(i0, i1, i2, i3) = value;
-    });
-  }
-}
-//----------------------------------------------------------------------------
-template <class TeamType, class DT, class... DP>
-void KOKKOS_INLINE_FUNCTION local_deep_copy(
-    const TeamType& team, const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 4)>* = nullptr) {
-  if (dst.data() == nullptr) {
-    return;
-  }
-
-  const size_t N =
-      dst.extent(0) * dst.extent(1) * dst.extent(2) * dst.extent(3);
-
-  if (dst.span_is_contiguous()) {
-    team.team_barrier();
-    local_deep_copy_contiguous(team, dst, value);
-    team.team_barrier();
-  } else {
-    team.team_barrier();
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
-      int i0              = i % dst.extent(0);
-      int itmp            = i / dst.extent(0);
-      int i1              = itmp % dst.extent(1);
-      itmp                = itmp / dst.extent(1);
-      int i2              = itmp % dst.extent(2);
-      int i3              = itmp / dst.extent(2);
-      dst(i0, i1, i2, i3) = value;
-    });
-    team.team_barrier();
-  }
-}
-//----------------------------------------------------------------------------
-template <class TeamType, class DT, class... DP>
-void KOKKOS_INLINE_FUNCTION local_deep_copy_thread(
-    const TeamType& team, const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 5)>* = nullptr) {
-  if (dst.data() == nullptr) {
-    return;
-  }
-
-  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2) *
-                   dst.extent(3) * dst.extent(4);
-
-  if (dst.span_is_contiguous()) {
-    local_deep_copy_contiguous_thread(team, dst, value);
-  } else {
-    Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, N), [&](const int& i) {
-      int i0                  = i % dst.extent(0);
-      int itmp                = i / dst.extent(0);
-      int i1                  = itmp % dst.extent(1);
-      itmp                    = itmp / dst.extent(1);
-      int i2                  = itmp % dst.extent(2);
-      itmp                    = itmp / dst.extent(2);
-      int i3                  = itmp % dst.extent(3);
-      int i4                  = itmp / dst.extent(3);
-      dst(i0, i1, i2, i3, i4) = value;
-    });
-  }
-}
-//----------------------------------------------------------------------------
-template <class TeamType, class DT, class... DP>
-void KOKKOS_INLINE_FUNCTION local_deep_copy(
-    const TeamType& team, const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 5)>* = nullptr) {
-  if (dst.data() == nullptr) {
-    return;
-  }
-
-  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2) *
-                   dst.extent(3) * dst.extent(4);
-
-  if (dst.span_is_contiguous()) {
-    team.team_barrier();
-    local_deep_copy_contiguous(team, dst, value);
-    team.team_barrier();
-  } else {
-    team.team_barrier();
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
-      int i0                  = i % dst.extent(0);
-      int itmp                = i / dst.extent(0);
-      int i1                  = itmp % dst.extent(1);
-      itmp                    = itmp / dst.extent(1);
-      int i2                  = itmp % dst.extent(2);
-      itmp                    = itmp / dst.extent(2);
-      int i3                  = itmp % dst.extent(3);
-      int i4                  = itmp / dst.extent(3);
-      dst(i0, i1, i2, i3, i4) = value;
-    });
-    team.team_barrier();
-  }
-}
-//----------------------------------------------------------------------------
-template <class TeamType, class DT, class... DP>
-void KOKKOS_INLINE_FUNCTION local_deep_copy_thread(
-    const TeamType& team, const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 6)>* = nullptr) {
-  if (dst.data() == nullptr) {
-    return;
-  }
-
-  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2) *
-                   dst.extent(3) * dst.extent(4) * dst.extent(5);
-
-  if (dst.span_is_contiguous()) {
-    local_deep_copy_contiguous_thread(team, dst, value);
-  } else {
-    Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, N), [&](const int& i) {
-      int i0                      = i % dst.extent(0);
-      int itmp                    = i / dst.extent(0);
-      int i1                      = itmp % dst.extent(1);
-      itmp                        = itmp / dst.extent(1);
-      int i2                      = itmp % dst.extent(2);
-      itmp                        = itmp / dst.extent(2);
-      int i3                      = itmp % dst.extent(3);
-      itmp                        = itmp / dst.extent(3);
-      int i4                      = itmp % dst.extent(4);
-      int i5                      = itmp / dst.extent(4);
-      dst(i0, i1, i2, i3, i4, i5) = value;
-    });
-  }
-}
-//----------------------------------------------------------------------------
-template <class TeamType, class DT, class... DP>
-void KOKKOS_INLINE_FUNCTION local_deep_copy(
-    const TeamType& team, const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 6)>* = nullptr) {
-  if (dst.data() == nullptr) {
-    return;
-  }
-
-  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2) *
-                   dst.extent(3) * dst.extent(4) * dst.extent(5);
-
-  if (dst.span_is_contiguous()) {
-    team.team_barrier();
-    local_deep_copy_contiguous(team, dst, value);
-    team.team_barrier();
-  } else {
-    team.team_barrier();
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
-      int i0                      = i % dst.extent(0);
-      int itmp                    = i / dst.extent(0);
-      int i1                      = itmp % dst.extent(1);
-      itmp                        = itmp / dst.extent(1);
-      int i2                      = itmp % dst.extent(2);
-      itmp                        = itmp / dst.extent(2);
-      int i3                      = itmp % dst.extent(3);
-      itmp                        = itmp / dst.extent(3);
-      int i4                      = itmp % dst.extent(4);
-      int i5                      = itmp / dst.extent(4);
-      dst(i0, i1, i2, i3, i4, i5) = value;
-    });
-    team.team_barrier();
-  }
-}
-//----------------------------------------------------------------------------
-template <class TeamType, class DT, class... DP>
-void KOKKOS_INLINE_FUNCTION local_deep_copy_thread(
-    const TeamType& team, const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 7)>* = nullptr) {
-  if (dst.data() == nullptr) {
-    return;
-  }
-
-  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2) *
-                   dst.extent(3) * dst.extent(4) * dst.extent(5) *
-                   dst.extent(6);
-
-  if (dst.span_is_contiguous()) {
-    local_deep_copy_contiguous_thread(team, dst, value);
-  } else {
-    Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, N), [&](const int& i) {
-      int i0                          = i % dst.extent(0);
-      int itmp                        = i / dst.extent(0);
-      int i1                          = itmp % dst.extent(1);
-      itmp                            = itmp / dst.extent(1);
-      int i2                          = itmp % dst.extent(2);
-      itmp                            = itmp / dst.extent(2);
-      int i3                          = itmp % dst.extent(3);
-      itmp                            = itmp / dst.extent(3);
-      int i4                          = itmp % dst.extent(4);
-      itmp                            = itmp / dst.extent(4);
-      int i5                          = itmp % dst.extent(5);
-      int i6                          = itmp / dst.extent(5);
-      dst(i0, i1, i2, i3, i4, i5, i6) = value;
-    });
-  }
-}
-//----------------------------------------------------------------------------
-template <class TeamType, class DT, class... DP>
-void KOKKOS_INLINE_FUNCTION local_deep_copy(
-    const TeamType& team, const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<(unsigned(ViewTraits<DT, DP...>::rank) == 7)>* = nullptr) {
-  if (dst.data() == nullptr) {
-    return;
-  }
-
-  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2) *
-                   dst.extent(3) * dst.extent(4) * dst.extent(5) *
-                   dst.extent(6);
-
-  if (dst.span_is_contiguous()) {
-    team.team_barrier();
-    local_deep_copy_contiguous(team, dst, value);
-    team.team_barrier();
-  } else {
-    team.team_barrier();
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
-      int i0                          = i % dst.extent(0);
-      int itmp                        = i / dst.extent(0);
-      int i1                          = itmp % dst.extent(1);
-      itmp                            = itmp / dst.extent(1);
-      int i2                          = itmp % dst.extent(2);
-      itmp                            = itmp / dst.extent(2);
-      int i3                          = itmp % dst.extent(3);
-      itmp                            = itmp / dst.extent(3);
-      int i4                          = itmp % dst.extent(4);
-      itmp                            = itmp / dst.extent(4);
-      int i5                          = itmp % dst.extent(5);
-      int i6                          = itmp / dst.extent(5);
-      dst(i0, i1, i2, i3, i4, i5, i6) = value;
-    });
-    team.team_barrier();
   }
 }
 //----------------------------------------------------------------------------

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -287,7 +287,7 @@ struct DeepCopy;
 
 template <class ViewType, class Layout = typename ViewType::array_layout,
           class ExecSpace = typename ViewType::execution_space,
-          int Rank = ViewType::rank, typename iType = int64_t>
+          int Rank = ViewType::rank, typename iType = int64_t, unsigned Nested = 0>
 struct ViewFill;
 
 template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -14,6 +14,8 @@
 //
 //@HEADER
 
+#include "../../algorithms/unit_tests/TestSort.hpp"
+
 #include <gtest/gtest.h>
 
 #include <sstream>
@@ -63,10 +65,6 @@ void impl_test_local_deepcopy_teampolicy_rank_1(const int N) {
   // Allocate matrices on device.
   ViewType A("A", N, N);
   ViewType B("B", N, N);
-
-  // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
 
   using team_policy = Kokkos::TeamPolicy<ExecSpace>;
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
@@ -127,12 +125,11 @@ void impl_test_local_deepcopy_teampolicy_rank_1(const int N) {
         Kokkos::Experimental::local_deep_copy(teamMember, subDst, 20.0);
       });
 
-  Kokkos::deep_copy(h_B, B);
-
   double sum_all = 0.0;
-  for (size_t i = 0; i < B.span(); i++) {
-    sum_all += h_B.data()[i];
-  }
+  Kokkos::parallel_reduce(
+      "Check B", B.span(),
+      KOKKOS_LAMBDA(int i, double& lsum) { lsum += B.data()[i]; },
+      Kokkos::Sum<double>(sum_all));
 
   ASSERT_EQ(sum_all, 20.0 * N * N);
 }
@@ -143,10 +140,6 @@ void impl_test_local_deepcopy_teampolicy_rank_2(const int N) {
   // Allocate matrices on device.
   ViewType A("A", N, N, N);
   ViewType B("B", N, N, N);
-
-  // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   initialize_array(A);
@@ -208,12 +201,11 @@ void impl_test_local_deepcopy_teampolicy_rank_2(const int N) {
         Kokkos::Experimental::local_deep_copy(teamMember, subDst, 20.0);
       });
 
-  Kokkos::deep_copy(h_B, B);
-
   double sum_all = 0.0;
-  for (size_t i = 0; i < B.span(); i++) {
-    sum_all += h_B.data()[i];
-  }
+  Kokkos::parallel_reduce(
+      "Check B", B.span(),
+      KOKKOS_LAMBDA(int i, double& lsum) { lsum += B.data()[i]; },
+      Kokkos::Sum<double>(sum_all));
 
   ASSERT_EQ(sum_all, 20.0 * N * N * N);
 }
@@ -224,10 +216,6 @@ void impl_test_local_deepcopy_teampolicy_rank_3(const int N) {
   // Allocate matrices on device.
   ViewType A("A", N, N, N, N);
   ViewType B("B", N, N, N, N);
-
-  // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   initialize_array(A);
@@ -292,12 +280,11 @@ void impl_test_local_deepcopy_teampolicy_rank_3(const int N) {
         Kokkos::Experimental::local_deep_copy(teamMember, subDst, 20.0);
       });
 
-  Kokkos::deep_copy(h_B, B);
-
   double sum_all = 0.0;
-  for (size_t i = 0; i < B.span(); i++) {
-    sum_all += h_B.data()[i];
-  }
+  Kokkos::parallel_reduce(
+      "Check B", B.span(),
+      KOKKOS_LAMBDA(int i, double& lsum) { lsum += B.data()[i]; },
+      Kokkos::Sum<double>(sum_all));
 
   ASSERT_EQ(sum_all, 20.0 * N * N * N * N);
 }
@@ -308,10 +295,6 @@ void impl_test_local_deepcopy_teampolicy_rank_4(const int N) {
   // Allocate matrices on device.
   ViewType A("A", N, N, N, N, N);
   ViewType B("B", N, N, N, N, N);
-
-  // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   initialize_array(A);
@@ -378,12 +361,11 @@ void impl_test_local_deepcopy_teampolicy_rank_4(const int N) {
         Kokkos::Experimental::local_deep_copy(teamMember, subDst, 20.0);
       });
 
-  Kokkos::deep_copy(h_B, B);
-
   double sum_all = 0.0;
-  for (size_t i = 0; i < B.span(); i++) {
-    sum_all += h_B.data()[i];
-  }
+  Kokkos::parallel_reduce(
+      "Check B", B.span(),
+      KOKKOS_LAMBDA(int i, double& lsum) { lsum += B.data()[i]; },
+      Kokkos::Sum<double>(sum_all));
 
   ASSERT_EQ(sum_all, 20.0 * N * N * N * N * N);
 }
@@ -394,10 +376,6 @@ void impl_test_local_deepcopy_teampolicy_rank_5(const int N) {
   // Allocate matrices on device.
   ViewType A("A", N, N, N, N, N, N);
   ViewType B("B", N, N, N, N, N, N);
-
-  // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   initialize_array(A);
@@ -467,12 +445,11 @@ void impl_test_local_deepcopy_teampolicy_rank_5(const int N) {
         Kokkos::Experimental::local_deep_copy(teamMember, subDst, 20.0);
       });
 
-  Kokkos::deep_copy(h_B, B);
-
   double sum_all = 0.0;
-  for (size_t i = 0; i < B.span(); i++) {
-    sum_all += h_B.data()[i];
-  }
+  Kokkos::parallel_reduce(
+      "Check B", B.span(),
+      KOKKOS_LAMBDA(int i, double& lsum) { lsum += B.data()[i]; },
+      Kokkos::Sum<double>(sum_all));
 
   ASSERT_EQ(sum_all, 20.0 * N * N * N * N * N * N);
 }
@@ -483,10 +460,6 @@ void impl_test_local_deepcopy_teampolicy_rank_6(const int N) {
   // Allocate matrices on device.
   ViewType A("A", N, N, N, N, N, N, N);
   ViewType B("B", N, N, N, N, N, N, N);
-
-  // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   initialize_array(A);
@@ -541,9 +514,6 @@ void impl_test_local_deepcopy_teampolicy_rank_6(const int N) {
         Kokkos::Experimental::local_deep_copy(teamMember, subDst, subSrc);
       });
 
-  Kokkos::deep_copy(h_A, A);
-  Kokkos::deep_copy(h_B, B);
-
   ASSERT_TRUE(equals(A, B));
 
   // Fill
@@ -559,12 +529,11 @@ void impl_test_local_deepcopy_teampolicy_rank_6(const int N) {
         Kokkos::Experimental::local_deep_copy(teamMember, subDst, 20.0);
       });
 
-  Kokkos::deep_copy(h_B, B);
-
   double sum_all = 0.0;
-  for (size_t i = 0; i < B.span(); i++) {
-    sum_all += h_B.data()[i];
-  }
+  Kokkos::parallel_reduce(
+      "Check B", B.span(),
+      KOKKOS_LAMBDA(int i, double& lsum) { lsum += B.data()[i]; },
+      Kokkos::Sum<double>(sum_all));
 
   ASSERT_EQ(sum_all, 20.0 * N * N * N * N * N * N * N);
 }
@@ -575,10 +544,6 @@ void impl_test_local_deepcopy_teampolicy_rank_7(const int N) {
   // Allocate matrices on device.
   ViewType A("A", N, N, N, N, N, N, N, N);
   ViewType B("B", N, N, N, N, N, N, N, N);
-
-  // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   initialize_array(A);
@@ -633,9 +598,6 @@ void impl_test_local_deepcopy_teampolicy_rank_7(const int N) {
         Kokkos::Experimental::local_deep_copy(teamMember, subDst, subSrc);
       });
 
-  Kokkos::deep_copy(h_A, A);
-  Kokkos::deep_copy(h_B, B);
-
   ASSERT_TRUE(equals(A, B));
 
   // Fill
@@ -651,12 +613,11 @@ void impl_test_local_deepcopy_teampolicy_rank_7(const int N) {
         Kokkos::Experimental::local_deep_copy(teamMember, subDst, 20.0);
       });
 
-  Kokkos::deep_copy(h_B, B);
-
   double sum_all = 0.0;
-  for (size_t i = 0; i < B.span(); i++) {
-    sum_all += h_B.data()[i];
-  }
+  Kokkos::parallel_reduce(
+      "Check B", B.span(),
+      KOKKOS_LAMBDA(int i, double& lsum) { lsum += B.data()[i]; },
+      Kokkos::Sum<double>(sum_all));
 
   ASSERT_EQ(sum_all, 20.0 * N * N * N * N * N * N * N * N);
 }

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -51,20 +51,53 @@ void view_init(ViewType& view) {
   Kokkos::fence();
 }
 
-// Helper function to create a std::array filled with a given value
-template <typename T, size_t Rank>
-constexpr auto make_array(T value) -> std::array<T, Rank> {
-  std::array<T, Rank> a;
-  for (auto& x : a) x = value;
-  return a;
+// Create a view with a given label and dimensions
+template <typename ViewType>
+typename std::enable_if<(ViewType::rank == 1), ViewType>::type view_create(
+    std::string label, const int N) {
+  return ViewType(label, N);
 }
 
-// Create a view with a given label and dimensions
-template <typename ViewType, unsigned Rank = unsigned(ViewType::rank)>
-ViewType view_create(std::string label, const int N) {
-  const auto dimensions =
-      std::tuple_cat(std::make_tuple(label), make_array<int, Rank>(N));
-  return std::make_from_tuple<ViewType>(dimensions);
+template <typename ViewType>
+typename std::enable_if<(ViewType::rank == 2), ViewType>::type view_create(
+    std::string label, const int N) {
+  return ViewType(label, N, N);
+}
+
+template <typename ViewType>
+typename std::enable_if<(ViewType::rank == 3), ViewType>::type view_create(
+    std::string label, const int N) {
+  return ViewType(label, N, N, N);
+}
+
+template <typename ViewType>
+typename std::enable_if<(ViewType::rank == 4), ViewType>::type view_create(
+    std::string label, const int N) {
+  return ViewType(label, N, N, N, N);
+}
+
+template <typename ViewType>
+typename std::enable_if<(ViewType::rank == 5), ViewType>::type view_create(
+    std::string label, const int N) {
+  return ViewType(label, N, N, N, N, N);
+}
+
+template <typename ViewType>
+typename std::enable_if<(ViewType::rank == 6), ViewType>::type view_create(
+    std::string label, const int N) {
+  return ViewType(label, N, N, N, N, N, N);
+}
+
+template <typename ViewType>
+typename std::enable_if<(ViewType::rank == 7), ViewType>::type view_create(
+    std::string label, const int N) {
+  return ViewType(label, N, N, N, N, N, N, N);
+}
+
+template <typename ViewType>
+typename std::enable_if<(ViewType::rank == 8), ViewType>::type view_create(
+    std::string label, const int N) {
+  return ViewType(label, N, N, N, N, N, N, N, N);
 }
 
 // Extract a subview from a view to run our tests

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -175,8 +175,9 @@ void test_local_deepcopy_thread(ViewType A, ViewType B, const int N) {
                   extract_subview(A, lid, Kokkos::make_pair(start, stop));
               auto subDst =
                   extract_subview(B, lid, Kokkos::make_pair(start, stop));
-              Kokkos::Experimental::local_deep_copy_thread(teamMember, subDst,
-                                                           subSrc);
+              Kokkos::Experimental::deep_copy(
+                  teamMember, Kokkos::ThreadVectorRange(teamMember, 0), subDst,
+                  subSrc);
               // No wait for local_deep_copy_thread
             });
       });

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -300,8 +300,8 @@ void test_local_deepcopy_scalar_range(
 
 template <typename ViewType, typename ExecSpace>
 void run_team_policy(const int N) {
-  auto A = view_create<ViewType>("A", N);
-  auto B = view_create<ViewType>("B", N);
+  ViewType A = view_create<ViewType>("A", N);
+  ViewType B = view_create<ViewType>("B", N);
 
   // Initialize A matrix.
   view_init(A);
@@ -315,8 +315,8 @@ void run_team_policy(const int N) {
 
 template <typename ViewType, typename ExecSpace>
 void run_range_policy(const int N) {
-  auto A = view_create<ViewType>("A", N);
-  auto B = view_create<ViewType>("B", N);
+  ViewType A = view_create<ViewType>("A", N);
+  ViewType B = view_create<ViewType>("B", N);
 
   // Initialize A matrix.
   view_init(A);

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -31,9 +31,11 @@ template <typename ViewType>
 bool view_check_equals(const ViewType& lhs, const ViewType& rhs) {
   int result = 1;
 
+  using exec_space = typename ViewType::execution_space;
+
   auto reducer = Kokkos::LAnd<int>(result);
   Kokkos::parallel_reduce(
-      "view check equals", lhs.span(),
+      "view check equals", Kokkos::RangePolicy<exec_space>(0, lhs.span()),
       KOKKOS_LAMBDA(int i, int& local_result) {
         local_result = (lhs.data()[i] == rhs.data()[i]) && local_result;
       },
@@ -45,8 +47,10 @@ bool view_check_equals(const ViewType& lhs, const ViewType& rhs) {
 
 template <typename ViewType>
 void view_init(ViewType& view) {
+  using exec_space = typename ViewType::execution_space;
+
   Kokkos::parallel_for(
-      "initialize array", view.span(),
+      "initialize array", Kokkos::RangePolicy<exec_space>(0, view.span()),
       KOKKOS_LAMBDA(int i) { view.data()[i] = i; });
   Kokkos::fence();
 }
@@ -162,9 +166,11 @@ void reset(ViewType B) {
 template <typename ViewType>
 bool check_sum(ViewType B, const int N,
                typename ViewType::value_type fill_value) {
+  using exec_space = typename ViewType::execution_space;
+
   double sum_all = 0;
   Kokkos::parallel_reduce(
-      "Check B", B.span(),
+      "Check B", Kokkos::RangePolicy<exec_space>(0, B.span()),
       KOKKOS_LAMBDA(int i, double& lsum) { lsum += B.data()[i]; },
       Kokkos::Sum<double>(sum_all));
 
@@ -280,7 +286,7 @@ void test_local_deepcopy_scalar_range(
 
   double sum_all = 0.0;
   Kokkos::parallel_reduce(
-      "Check B", B.span(),
+      "Check B", Kokkos::RangePolicy<ExecSpace>(0, B.span()),
       KOKKOS_LAMBDA(int i, double& lsum) { lsum += B.data()[i]; },
       Kokkos::Sum<double>(sum_all));
 

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -133,7 +133,7 @@ bool check_sum(ViewType B, const int N,
       Kokkos::Sum<double>(sum_all));
 
   auto correct_sum = fill_value;
-  for (auto i = 0; i < ViewType::rank; i++) {
+  for (size_t i = 0; i < ViewType::rank; ++i) {
     correct_sum *= N;
   }
 

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -42,6 +42,52 @@ void impl_test_local_deepcopy_teampolicy_rank_1(const int N) {
   using team_policy = Kokkos::TeamPolicy<ExecSpace>;
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
+  // Test local_deep_copy_thread
+  // Each thread copies a subview of A into B
+  Kokkos::parallel_for(
+      team_policy(N, Kokkos::AUTO),
+      KOKKOS_LAMBDA(const member_type& teamMember) {
+        int lid = teamMember.league_rank();  // returns a number between 0 and N
+        auto thread_number = teamMember.league_size();
+        auto unitsOfWork   = N / thread_number;
+        if (N % thread_number) {
+          unitsOfWork += 1;
+        }
+        auto numberOfBatches = N / unitsOfWork;
+        Kokkos::parallel_for(
+            Kokkos::TeamThreadRange(teamMember, numberOfBatches),
+            [=](const int indexWithinBatch) {
+              const int idx = indexWithinBatch;
+
+              auto start  = idx * unitsOfWork;
+              auto stop   = (idx + 1) * unitsOfWork;
+              stop        = Kokkos::clamp(stop, 0, N);
+              auto subSrc = Kokkos::subview(A, 1, 1, 1, 1, 1, 1, lid,
+                                            std::pair(start, stop));
+              auto subDst = Kokkos::subview(B, 1, 1, 1, 1, 1, 1, lid,
+                                            std::pair(start, stop));
+              Kokkos::Experimental::local_deep_copy_thread(teamMember, subDst,
+                                                           subSrc);
+              // No wait for local_deep_copy_thread
+            });
+      });
+
+  Kokkos::deep_copy(h_A, A);
+  Kokkos::deep_copy(h_B, B);
+
+  bool test = true;
+  for (size_t i = 0; i < A.span(); i++) {
+    if (h_A.data()[i] != h_B.data()[i]) {
+      test = false;
+      break;
+    }
+  }
+
+  ASSERT_EQ(test, true);
+
+  // Fill
+  Kokkos::deep_copy(B, 0.0);
+
   // Deep Copy
   Kokkos::parallel_for(
       team_policy(N, Kokkos::AUTO),
@@ -55,7 +101,7 @@ void impl_test_local_deepcopy_teampolicy_rank_1(const int N) {
   Kokkos::deep_copy(h_A, A);
   Kokkos::deep_copy(h_B, B);
 
-  bool test = true;
+  test = true;
   for (size_t i = 0; i < A.span(); i++) {
     if (h_A.data()[i] != h_B.data()[i]) {
       test = false;
@@ -104,6 +150,52 @@ void impl_test_local_deepcopy_teampolicy_rank_2(const int N) {
   using team_policy = Kokkos::TeamPolicy<ExecSpace>;
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
+  // Test local_deep_copy_thread
+  // Each thread copies a subview of A into B
+  Kokkos::parallel_for(
+      team_policy(N, Kokkos::AUTO),
+      KOKKOS_LAMBDA(const member_type& teamMember) {
+        int lid = teamMember.league_rank();  // returns a number between 0 and N
+        auto thread_number = teamMember.league_size();
+        auto unitsOfWork   = N / thread_number;
+        if (N % thread_number) {
+          unitsOfWork += 1;
+        }
+        auto numberOfBatches = N / unitsOfWork;
+        Kokkos::parallel_for(
+            Kokkos::TeamThreadRange(teamMember, numberOfBatches),
+            [=](const int indexWithinBatch) {
+              const int idx = indexWithinBatch;
+
+              auto start  = idx * unitsOfWork;
+              auto stop   = (idx + 1) * unitsOfWork;
+              stop        = Kokkos::clamp(stop, 0, N);
+              auto subSrc = Kokkos::subview(
+                  A, 1, 1, 1, 1, 1, lid, std::pair(start, stop), Kokkos::ALL());
+              auto subDst = Kokkos::subview(
+                  B, 1, 1, 1, 1, 1, lid, std::pair(start, stop), Kokkos::ALL());
+              Kokkos::Experimental::local_deep_copy_thread(teamMember, subDst,
+                                                           subSrc);
+              // No wait for local_deep_copy_thread
+            });
+      });
+
+  Kokkos::deep_copy(h_A, A);
+  Kokkos::deep_copy(h_B, B);
+
+  bool test = true;
+  for (size_t i = 0; i < A.span(); i++) {
+    if (h_A.data()[i] != h_B.data()[i]) {
+      test = false;
+      break;
+    }
+  }
+
+  ASSERT_EQ(test, true);
+
+  // Fill
+  Kokkos::deep_copy(B, 0.0);
+
   // Deep Copy
   Kokkos::parallel_for(
       team_policy(N, Kokkos::AUTO),
@@ -119,7 +211,7 @@ void impl_test_local_deepcopy_teampolicy_rank_2(const int N) {
   Kokkos::deep_copy(h_A, A);
   Kokkos::deep_copy(h_B, B);
 
-  bool test = true;
+  test = true;
   for (size_t i = 0; i < A.span(); i++) {
     if (h_A.data()[i] != h_B.data()[i]) {
       test = false;
@@ -169,6 +261,54 @@ void impl_test_local_deepcopy_teampolicy_rank_3(const int N) {
   using team_policy = Kokkos::TeamPolicy<ExecSpace>;
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
+  // Test local_deep_copy_thread
+  // Each thread copies a subview of A into B
+  Kokkos::parallel_for(
+      team_policy(N, Kokkos::AUTO),
+      KOKKOS_LAMBDA(const member_type& teamMember) {
+        int lid = teamMember.league_rank();  // returns a number between 0 and N
+        auto thread_number = teamMember.league_size();
+        auto unitsOfWork   = N / thread_number;
+        if (N % thread_number) {
+          unitsOfWork += 1;
+        }
+        auto numberOfBatches = N / unitsOfWork;
+        Kokkos::parallel_for(
+            Kokkos::TeamThreadRange(teamMember, numberOfBatches),
+            [=](const int indexWithinBatch) {
+              const int idx = indexWithinBatch;
+
+              auto start = idx * unitsOfWork;
+              auto stop  = (idx + 1) * unitsOfWork;
+              stop       = Kokkos::clamp(stop, 0, N);
+              auto subSrc =
+                  Kokkos::subview(A, 1, 1, 1, 1, lid, std::pair(start, stop),
+                                  Kokkos::ALL(), Kokkos::ALL());
+              auto subDst =
+                  Kokkos::subview(B, 1, 1, 1, 1, lid, std::pair(start, stop),
+                                  Kokkos::ALL(), Kokkos::ALL());
+              Kokkos::Experimental::local_deep_copy_thread(teamMember, subDst,
+                                                           subSrc);
+              // No wait for local_deep_copy_thread
+            });
+      });
+
+  Kokkos::deep_copy(h_A, A);
+  Kokkos::deep_copy(h_B, B);
+
+  bool test = true;
+  for (size_t i = 0; i < A.span(); i++) {
+    if (h_A.data()[i] != h_B.data()[i]) {
+      test = false;
+      break;
+    }
+  }
+
+  ASSERT_EQ(test, true);
+
+  // Fill
+  Kokkos::deep_copy(B, 0.0);
+
   // Deep Copy
   Kokkos::parallel_for(
       team_policy(N, Kokkos::AUTO),
@@ -184,7 +324,7 @@ void impl_test_local_deepcopy_teampolicy_rank_3(const int N) {
   Kokkos::deep_copy(h_A, A);
   Kokkos::deep_copy(h_B, B);
 
-  bool test = true;
+  test = true;
   for (size_t i = 0; i < A.span(); i++) {
     if (h_A.data()[i] != h_B.data()[i]) {
       test = false;
@@ -234,6 +374,54 @@ void impl_test_local_deepcopy_teampolicy_rank_4(const int N) {
   using team_policy = Kokkos::TeamPolicy<ExecSpace>;
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
+  // Test local_deep_copy_thread
+  // Each thread copies a subview of A into B
+  Kokkos::parallel_for(
+      team_policy(N, Kokkos::AUTO),
+      KOKKOS_LAMBDA(const member_type& teamMember) {
+        int lid = teamMember.league_rank();  // returns a number between 0 and N
+        auto thread_number = teamMember.league_size();
+        auto unitsOfWork   = N / thread_number;
+        if (N % thread_number) {
+          unitsOfWork += 1;
+        }
+        auto numberOfBatches = N / unitsOfWork;
+        Kokkos::parallel_for(
+            Kokkos::TeamThreadRange(teamMember, numberOfBatches),
+            [=](const int indexWithinBatch) {
+              const int idx = indexWithinBatch;
+
+              auto start = idx * unitsOfWork;
+              auto stop  = (idx + 1) * unitsOfWork;
+              stop       = Kokkos::clamp(stop, 0, N);
+              auto subSrc =
+                  Kokkos::subview(A, 1, 1, 1, lid, std::pair(start, stop),
+                                  Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+              auto subDst =
+                  Kokkos::subview(B, 1, 1, 1, lid, std::pair(start, stop),
+                                  Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+              Kokkos::Experimental::local_deep_copy_thread(teamMember, subDst,
+                                                           subSrc);
+              // No wait for local_deep_copy_thread
+            });
+      });
+
+  Kokkos::deep_copy(h_A, A);
+  Kokkos::deep_copy(h_B, B);
+
+  bool test = true;
+  for (size_t i = 0; i < A.span(); i++) {
+    if (h_A.data()[i] != h_B.data()[i]) {
+      test = false;
+      break;
+    }
+  }
+
+  ASSERT_EQ(test, true);
+
+  // Fill
+  Kokkos::deep_copy(B, 0.0);
+
   // Deep Copy
   Kokkos::parallel_for(
       team_policy(N, Kokkos::AUTO),
@@ -251,7 +439,7 @@ void impl_test_local_deepcopy_teampolicy_rank_4(const int N) {
   Kokkos::deep_copy(h_A, A);
   Kokkos::deep_copy(h_B, B);
 
-  bool test = true;
+  test = true;
   for (size_t i = 0; i < A.span(); i++) {
     if (h_A.data()[i] != h_B.data()[i]) {
       test = false;
@@ -303,6 +491,54 @@ void impl_test_local_deepcopy_teampolicy_rank_5(const int N) {
   using team_policy = Kokkos::TeamPolicy<ExecSpace>;
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
+  // Test local_deep_copy_thread
+  // Each thread copies a subview of A into B
+  Kokkos::parallel_for(
+      team_policy(N, Kokkos::AUTO),
+      KOKKOS_LAMBDA(const member_type& teamMember) {
+        int lid = teamMember.league_rank();  // returns a number between 0 and N
+        auto thread_number = teamMember.league_size();
+        auto unitsOfWork   = N / thread_number;
+        if (N % thread_number) {
+          unitsOfWork += 1;
+        }
+        auto numberOfBatches = N / unitsOfWork;
+        Kokkos::parallel_for(
+            Kokkos::TeamThreadRange(teamMember, numberOfBatches),
+            [=](const int indexWithinBatch) {
+              const int idx = indexWithinBatch;
+
+              auto start  = idx * unitsOfWork;
+              auto stop   = (idx + 1) * unitsOfWork;
+              stop        = Kokkos::clamp(stop, 0, N);
+              auto subSrc = Kokkos::subview(
+                  A, 1, 1, lid, std::pair(start, stop), Kokkos::ALL(),
+                  Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+              auto subDst = Kokkos::subview(
+                  B, 1, 1, lid, std::pair(start, stop), Kokkos::ALL(),
+                  Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+              Kokkos::Experimental::local_deep_copy_thread(teamMember, subDst,
+                                                           subSrc);
+              // No wait for local_deep_copy_thread
+            });
+      });
+
+  Kokkos::deep_copy(h_A, A);
+  Kokkos::deep_copy(h_B, B);
+
+  bool test = true;
+  for (size_t i = 0; i < A.span(); i++) {
+    if (h_A.data()[i] != h_B.data()[i]) {
+      test = false;
+      break;
+    }
+  }
+
+  ASSERT_EQ(test, true);
+
+  // Fill
+  Kokkos::deep_copy(B, 0.0);
+
   // Deep Copy
   Kokkos::parallel_for(
       team_policy(N, Kokkos::AUTO),
@@ -320,7 +556,7 @@ void impl_test_local_deepcopy_teampolicy_rank_5(const int N) {
   Kokkos::deep_copy(h_A, A);
   Kokkos::deep_copy(h_B, B);
 
-  bool test = true;
+  test = true;
   for (size_t i = 0; i < A.span(); i++) {
     if (h_A.data()[i] != h_B.data()[i]) {
       test = false;
@@ -372,6 +608,54 @@ void impl_test_local_deepcopy_teampolicy_rank_6(const int N) {
   using team_policy = Kokkos::TeamPolicy<ExecSpace>;
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
+  // Test local_deep_copy_thread
+  // Each thread copies a subview of A into B
+  Kokkos::parallel_for(
+      team_policy(N, Kokkos::AUTO),
+      KOKKOS_LAMBDA(const member_type& teamMember) {
+        int lid = teamMember.league_rank();  // returns a number between 0 and N
+        auto thread_number = teamMember.league_size();
+        auto unitsOfWork   = N / thread_number;
+        if (N % thread_number) {
+          unitsOfWork += 1;
+        }
+        auto numberOfBatches = N / unitsOfWork;
+        Kokkos::parallel_for(
+            Kokkos::TeamThreadRange(teamMember, numberOfBatches),
+            [=](const int indexWithinBatch) {
+              const int idx = indexWithinBatch;
+
+              auto start  = idx * unitsOfWork;
+              auto stop   = (idx + 1) * unitsOfWork;
+              stop        = Kokkos::clamp(stop, 0, N);
+              auto subSrc = Kokkos::subview(
+                  A, 1, lid, std::pair(start, stop), Kokkos::ALL(),
+                  Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+              auto subDst = Kokkos::subview(
+                  B, 1, lid, std::pair(start, stop), Kokkos::ALL(),
+                  Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+              Kokkos::Experimental::local_deep_copy_thread(teamMember, subDst,
+                                                           subSrc);
+              // No wait for local_deep_copy_thread
+            });
+      });
+
+  Kokkos::deep_copy(h_A, A);
+  Kokkos::deep_copy(h_B, B);
+
+  bool test = true;
+  for (size_t i = 0; i < A.span(); i++) {
+    if (h_A.data()[i] != h_B.data()[i]) {
+      test = false;
+      break;
+    }
+  }
+
+  ASSERT_EQ(test, true);
+
+  // Fill
+  Kokkos::deep_copy(B, 0.0);
+
   // Deep Copy
   Kokkos::parallel_for(
       team_policy(N, Kokkos::AUTO),
@@ -389,7 +673,7 @@ void impl_test_local_deepcopy_teampolicy_rank_6(const int N) {
   Kokkos::deep_copy(h_A, A);
   Kokkos::deep_copy(h_B, B);
 
-  bool test = true;
+  test = true;
   for (size_t i = 0; i < A.span(); i++) {
     if (h_A.data()[i] != h_B.data()[i]) {
       test = false;
@@ -438,6 +722,54 @@ void impl_test_local_deepcopy_teampolicy_rank_7(const int N) {
   using team_policy = Kokkos::TeamPolicy<ExecSpace>;
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
+  // Test local_deep_copy_thread
+  // Each thread copies a subview of A into B
+  Kokkos::parallel_for(
+      team_policy(N, Kokkos::AUTO),
+      KOKKOS_LAMBDA(const member_type& teamMember) {
+        int lid = teamMember.league_rank();  // returns a number between 0 and N
+        auto thread_number = teamMember.league_size();
+        auto unitsOfWork   = N / thread_number;
+        if (N % thread_number) {
+          unitsOfWork += 1;
+        }
+        auto numberOfBatches = N / unitsOfWork;
+        Kokkos::parallel_for(
+            Kokkos::TeamThreadRange(teamMember, numberOfBatches),
+            [=](const int indexWithinBatch) {
+              const int idx = indexWithinBatch;
+
+              auto start  = idx * unitsOfWork;
+              auto stop   = (idx + 1) * unitsOfWork;
+              stop        = Kokkos::clamp(stop, 0, N);
+              auto subSrc = Kokkos::subview(
+                  A, lid, std::pair(start, stop), Kokkos::ALL(), Kokkos::ALL(),
+                  Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+              auto subDst = Kokkos::subview(
+                  B, lid, std::pair(start, stop), Kokkos::ALL(), Kokkos::ALL(),
+                  Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+              Kokkos::Experimental::local_deep_copy_thread(teamMember, subDst,
+                                                           subSrc);
+              // No wait for local_deep_copy_thread
+            });
+      });
+
+  Kokkos::deep_copy(h_A, A);
+  Kokkos::deep_copy(h_B, B);
+
+  bool test = true;
+  for (size_t i = 0; i < A.span(); i++) {
+    if (h_A.data()[i] != h_B.data()[i]) {
+      test = false;
+      break;
+    }
+  }
+
+  ASSERT_EQ(test, true);
+
+  // Fill
+  Kokkos::deep_copy(B, 0.0);
+
   // Deep Copy
   Kokkos::parallel_for(
       team_policy(N, Kokkos::AUTO),
@@ -455,7 +787,7 @@ void impl_test_local_deepcopy_teampolicy_rank_7(const int N) {
   Kokkos::deep_copy(h_A, A);
   Kokkos::deep_copy(h_B, B);
 
-  bool test = true;
+  test = true;
   for (size_t i = 0; i < A.span(); i++) {
     if (h_A.data()[i] != h_B.data()[i]) {
       test = false;

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -38,6 +38,8 @@ bool view_check_equals(const ViewType& lhs, const ViewType& rhs) {
         local_result = (lhs.data()[i] == rhs.data()[i]) && local_result;
       },
       reducer);
+
+  Kokkos::fence();
   return (result);
 }
 
@@ -46,6 +48,7 @@ void view_init(ViewType& view) {
   Kokkos::parallel_for(
       "initialize array", view.span(),
       KOKKOS_LAMBDA(int i) { view.data()[i] = i; });
+  Kokkos::fence();
 }
 
 // Helper function to create a std::array filled with a given value
@@ -178,6 +181,7 @@ void test_local_deepcopy_thread(ViewType A, ViewType B, const int N) {
             });
       });
 
+  Kokkos::fence();
   ASSERT_TRUE(view_check_equals(A, B));
 }
 
@@ -195,6 +199,7 @@ void test_local_deepcopy(ViewType A, ViewType B, const int N) {
         Kokkos::Experimental::local_deep_copy(teamMember, subDst, subSrc);
       });
 
+  Kokkos::fence();
   ASSERT_TRUE(view_check_equals(A, B));
 }
 
@@ -208,6 +213,7 @@ void test_local_deepcopy_range(ViewType A, ViewType B, const int N) {
         Kokkos::Experimental::local_deep_copy(subDst, subSrc);
       });
 
+  Kokkos::fence();
   ASSERT_TRUE(view_check_equals(A, B));
 }
 
@@ -225,6 +231,7 @@ void test_local_deepcopy_scalar(ViewType B, const int N,
         Kokkos::Experimental::local_deep_copy(teamMember, subDst, fill_value);
       });
 
+  Kokkos::fence();
   ASSERT_TRUE(check_sum(B, N, fill_value));
 }
 
@@ -243,6 +250,7 @@ void test_local_deepcopy_scalar_range(
       KOKKOS_LAMBDA(int i, double& lsum) { lsum += B.data()[i]; },
       Kokkos::Sum<double>(sum_all));
 
+  Kokkos::fence();
   ASSERT_TRUE(check_sum(B, N, fill_value));
 }
 

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -65,16 +65,57 @@ ViewType view_create(std::string label, const int N) {
 }
 
 // Extract a subview from a view to run our tests
-template <typename ViewType, typename Bounds,
-          unsigned Rank = unsigned(ViewType::rank)>
-KOKKOS_INLINE_FUNCTION auto extract_subview(ViewType& src, int lid,
-                                            Bounds bounds) {
-  static_assert(Rank > 1, "Rank must be greater than 1");
-  const auto dimensions =
-      std::tuple_cat(std::make_tuple(src, lid, bounds),
-                     make_array<Kokkos::ALL_t, Rank - 2>(Kokkos::ALL));
-  return std::apply([](auto&&... xs) { return Kokkos::subview(xs...); },
-                    dimensions);
+template <typename ViewType, typename Bounds>
+KOKKOS_INLINE_FUNCTION auto extract_subview(
+    ViewType& src, int lid, Bounds bounds,
+    std::enable_if_t<unsigned(ViewType::rank) == 2>* = nullptr) {
+  return Kokkos::subview(src, lid, bounds);
+}
+
+template <typename ViewType, typename Bounds>
+KOKKOS_INLINE_FUNCTION auto extract_subview(
+    ViewType& src, int lid, Bounds bounds,
+    std::enable_if_t<unsigned(ViewType::rank) == 3>* = nullptr) {
+  return Kokkos::subview(src, lid, bounds, Kokkos::ALL);
+}
+
+template <typename ViewType, typename Bounds>
+KOKKOS_INLINE_FUNCTION auto extract_subview(
+    ViewType& src, int lid, Bounds bounds,
+    std::enable_if_t<unsigned(ViewType::rank) == 4>* = nullptr) {
+  return Kokkos::subview(src, lid, bounds, Kokkos::ALL, Kokkos::ALL);
+}
+
+template <typename ViewType, typename Bounds>
+KOKKOS_INLINE_FUNCTION auto extract_subview(
+    ViewType& src, int lid, Bounds bounds,
+    std::enable_if_t<unsigned(ViewType::rank) == 5>* = nullptr) {
+  return Kokkos::subview(src, lid, bounds, Kokkos::ALL, Kokkos::ALL,
+                         Kokkos::ALL);
+}
+
+template <typename ViewType, typename Bounds>
+KOKKOS_INLINE_FUNCTION auto extract_subview(
+    ViewType& src, int lid, Bounds bounds,
+    std::enable_if_t<unsigned(ViewType::rank) == 6>* = nullptr) {
+  return Kokkos::subview(src, lid, bounds, Kokkos::ALL, Kokkos::ALL,
+                         Kokkos::ALL, Kokkos::ALL);
+}
+
+template <typename ViewType, typename Bounds>
+KOKKOS_INLINE_FUNCTION auto extract_subview(
+    ViewType& src, int lid, Bounds bounds,
+    std::enable_if_t<unsigned(ViewType::rank) == 7>* = nullptr) {
+  return Kokkos::subview(src, lid, bounds, Kokkos::ALL, Kokkos::ALL,
+                         Kokkos::ALL, Kokkos::ALL, Kokkos::ALL);
+}
+
+template <typename ViewType, typename Bounds>
+KOKKOS_INLINE_FUNCTION auto extract_subview(
+    ViewType& src, int lid, Bounds bounds,
+    std::enable_if_t<unsigned(ViewType::rank) == 8>* = nullptr) {
+  return Kokkos::subview(src, lid, bounds, Kokkos::ALL, Kokkos::ALL,
+                         Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL);
 }
 
 template <typename ViewType>


### PR DESCRIPTION
#6705 asks for the feature, making the use of thread level scratch easier.

@crtrott proposal to be able to call all the deep copy functionalities with `deep_copy` instead of `local_deep_copy` for nested contexts is not implemented in this PR.

Most of the work in this PR is about refactoring local_deep_copy tests. By itself `local_deep_copy_thread` implementation is basically just a naive copy and paste of `local_deep_copy`. We cannot directly template with policies as they are functions that take the iteration space in argument and we need to set it internally (the length of the view).

Few related remarks:
1. I think `local_deep_copy*` functions should be hardened, their only check is if the two views share the same rank. Copying from a smaller view should result in out-of-bounds accesses. Do we have to do a premature return or an assert or do we need a better error handling?

2. `local_deep_copy` decompositions of indices does not take into account the view layout. I am not sure if the smart decomposition always makes sense performance-wise.

3. `local_deep_copy_contiguous` can be related to ~~`std::copy`~~ `Kokkos::Experimental::copy` from algorithm