### PR TITLE
SYCL: Error out on initialization if the backend is different from ext_oneapi_*

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -102,6 +102,30 @@ void SYCLInternal::initialize(const sycl::device& d) {
 void SYCLInternal::initialize(const sycl::queue& q) {
   KOKKOS_EXPECTS(!is_initialized());
 
+  {
+#if defined(KOKKOS_ARCH_INTEL_GPU) || defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU) || \
+    defined(KOKKOS_ARCH_AMD_GPU)
+#if defined(KOKKOS_ARCH_INTEL_GPU)
+    sycl::backend backend      = sycl::backend::ext_oneapi_level_zero;
+    std::string backend_string = "sycl::backend::ext_oneapi_level_zero";
+#elif defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
+    sycl::backend backend      = sycl::backend::ext_oneapi_cuda;
+    std::string backend_string = "sycl::backend::ext_oneapi_cuda";
+#elif defined(KOKKOS_ARCH_AMD_GPU)
+    sycl::backend backend      = sycl::backend::ext_oneapi_hip;
+    std::string backend_string = "sycl::backend::ext_oneapi_hip";
+#endif
+    if (q.get_backend() != backend) {
+      const std::string error =
+          std::string(
+              "The SYCL execution space instance was initialized with an "
+              "unsupported backend type! For this GPU architecture, only ") +
+          backend_string + " is supported.";
+      Kokkos::abort(error.c_str());
+    }
+#endif
+  }
+
   if (was_finalized)
     Kokkos::abort("Calling SYCL::initialize after SYCL::finalize is illegal\n");
 


### PR DESCRIPTION
Related to #6758. We know that we only really support `ext_oneapi_*` backends and want to diagnose if the user specified anything else.