### PR TITLE
Fix typo in cuda_func_set_attribute[s]_wrapper

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -447,10 +447,10 @@ class CudaInternal {
   }
 
   template <typename T, bool setCudaDevice = true>
-  cudaError_t cuda_func_set_attributes_wrapper(T* entry, cudaFuncAttribute attr,
-                                               int value) const {
+  cudaError_t cuda_func_set_attribute_wrapper(T* entry, cudaFuncAttribute attr,
+                                              int value) const {
     if constexpr (setCudaDevice) set_cuda_device();
-    return cudaFuncSetAttributes(entry, attr, value);
+    return cudaFuncSetAttribute(entry, attr, value);
   }
 
   template <bool setCudaDevice = true>

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -222,7 +222,7 @@ inline void configure_shmem_preference(const KernelFuncPtr& func,
   // FIXME_CUDA_MULTIPLE_DEVICES
   auto set_cache_config = [&] {
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (CudaInternal::singleton().cuda_func_set_attributes_wrapper(
+        (CudaInternal::singleton().cuda_func_set_attribute_wrapper(
             func, cudaFuncAttributePreferredSharedMemoryCarveout, carveout)));
     return carveout;
   };

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -184,6 +184,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         MDSpan
         MinMaxClamp
         NumericTraits
+        OccupancyControlTrait
         Other
         ParallelScanRangePolicy
         Printf

--- a/core/unit_test/TestCommonPolicyConstructors.hpp
+++ b/core/unit_test/TestCommonPolicyConstructors.hpp
@@ -108,6 +108,9 @@ void test_prefer_desired_occupancy(Policy policy) {
   test_policy_execution(policy_drop_occ);
 }
 
+// FIXME_MSVC_WITH_CUDA
+// This test doesn't compile with CUDA on Windows
+#if !(defined(_WIN32) && defined(KOKKOS_ENABLE_CUDA))
 TEST(TEST_CATEGORY, execution_policy_occupancy_and_hint) {
   test_prefer_desired_occupancy(DummyPolicy<>{});
   test_prefer_desired_occupancy(Kokkos::RangePolicy<>(0, 0));
@@ -115,6 +118,7 @@ TEST(TEST_CATEGORY, execution_policy_occupancy_and_hint) {
   test_prefer_desired_occupancy(
       Kokkos::MDRangePolicy<Kokkos::Rank<2>>{{0, 0}, {0, 0}});
 }
+#endif
 
 // Check that the policy size does not increase if the user does not specify the
 // occupancy (only pay for what you use).

--- a/core/unit_test/TestCommonPolicyConstructors.hpp
+++ b/core/unit_test/TestCommonPolicyConstructors.hpp
@@ -45,26 +45,10 @@ static_assert(check_semiregular<Kokkos::TeamPolicy<>>());
 static_assert(check_semiregular<Kokkos::MDRangePolicy<Kokkos::Rank<2>>>());
 
 // Assert that occupancy conversion and hints work properly.
-template <class... Properties>
-void test_policy_execution(const Kokkos::RangePolicy<Properties...>& policy) {
-  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int){});
-}
-template <class... Properties>
-void test_policy_execution(const Kokkos::TeamPolicy<Properties...>& policy) {
-  Kokkos::parallel_for(
-      policy,
-      KOKKOS_LAMBDA(
-          const typename Kokkos::TeamPolicy<Properties...>::member_type&){});
-}
-template <class... Properties>
-void test_policy_execution(const Kokkos::MDRangePolicy<Properties...>& policy) {
-  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int, int){});
-}
-template <class... Properties>
-void test_policy_execution(const DummyPolicy<Properties...>&) {}
-
 template <class Policy>
-void test_prefer_desired_occupancy(Policy policy) {
+void test_prefer_desired_occupancy() {
+  Policy policy;
+
   using Kokkos::Experimental::DesiredOccupancy;
   using Kokkos::Experimental::MaximizeOccupancy;
   using Kokkos::Experimental::prefer;
@@ -76,49 +60,36 @@ void test_prefer_desired_occupancy(Policy policy) {
   auto const policy_still_no_occ = prefer(policy, MaximizeOccupancy{});
   static_assert(
       !decltype(policy_still_no_occ)::experimental_contains_desired_occupancy);
-  test_policy_execution(policy_still_no_occ);
 
   // MaximizeOccupancy -> DesiredOccupancy
   auto const policy_with_occ =
       prefer(policy_still_no_occ, DesiredOccupancy{33});
   static_assert(
       decltype(policy_with_occ)::experimental_contains_desired_occupancy);
-  EXPECT_EQ(policy_with_occ.impl_get_desired_occupancy().value(), 33);
-  test_policy_execution(policy_with_occ);
 
   // DesiredOccupancy -> DesiredOccupancy
   auto const policy_change_occ = prefer(policy_with_occ, DesiredOccupancy{24});
   static_assert(
       decltype(policy_change_occ)::experimental_contains_desired_occupancy);
-  EXPECT_EQ(policy_change_occ.impl_get_desired_occupancy().value(), 24);
-  test_policy_execution(policy_change_occ);
 
   // DesiredOccupancy -> DesiredOccupancy w/ hint
   auto policy_with_occ_and_hint = Kokkos::Experimental::require(
       policy_change_occ,
       Kokkos::Experimental::WorkItemProperty::HintLightWeight);
-  EXPECT_EQ(policy_with_occ_and_hint.impl_get_desired_occupancy().value(), 24);
-  test_policy_execution(policy_with_occ_and_hint);
 
   // DesiredOccupancy -> MaximizeOccupancy
   auto const policy_drop_occ =
       prefer(policy_with_occ_and_hint, MaximizeOccupancy{});
   static_assert(
       !decltype(policy_drop_occ)::experimental_contains_desired_occupancy);
-  test_policy_execution(policy_drop_occ);
 }
 
-// FIXME_MSVC_WITH_CUDA
-// This test doesn't compile with CUDA on Windows
-#if !(defined(_WIN32) && defined(KOKKOS_ENABLE_CUDA))
-TEST(TEST_CATEGORY, execution_policy_occupancy_and_hint) {
-  test_prefer_desired_occupancy(DummyPolicy<>{});
-  test_prefer_desired_occupancy(Kokkos::RangePolicy<>(0, 0));
-  test_prefer_desired_occupancy(Kokkos::TeamPolicy<>{0, Kokkos::AUTO});
-  test_prefer_desired_occupancy(
-      Kokkos::MDRangePolicy<Kokkos::Rank<2>>{{0, 0}, {0, 0}});
+void test_execution_policy_occupancy_and_hint() {
+  test_prefer_desired_occupancy<DummyPolicy<>>();
+  test_prefer_desired_occupancy<Kokkos::RangePolicy<>>();
+  test_prefer_desired_occupancy<Kokkos::TeamPolicy<>>();
+  test_prefer_desired_occupancy<Kokkos::MDRangePolicy<Kokkos::Rank<2>>>();
 }
-#endif
 
 // Check that the policy size does not increase if the user does not specify the
 // occupancy (only pay for what you use).

--- a/core/unit_test/TestCommonPolicyConstructors.hpp
+++ b/core/unit_test/TestCommonPolicyConstructors.hpp
@@ -66,16 +66,19 @@ void test_prefer_desired_occupancy() {
       prefer(policy_still_no_occ, DesiredOccupancy{33});
   static_assert(
       decltype(policy_with_occ)::experimental_contains_desired_occupancy);
+  EXPECT_EQ(policy_with_occ.impl_get_desired_occupancy().value(), 33);
 
   // DesiredOccupancy -> DesiredOccupancy
   auto const policy_change_occ = prefer(policy_with_occ, DesiredOccupancy{24});
   static_assert(
       decltype(policy_change_occ)::experimental_contains_desired_occupancy);
+  EXPECT_EQ(policy_change_occ.impl_get_desired_occupancy().value(), 24);
 
   // DesiredOccupancy -> DesiredOccupancy w/ hint
   auto policy_with_occ_and_hint = Kokkos::Experimental::require(
       policy_change_occ,
       Kokkos::Experimental::WorkItemProperty::HintLightWeight);
+  EXPECT_EQ(policy_with_occ_and_hint.impl_get_desired_occupancy().value(), 24);
 
   // DesiredOccupancy -> MaximizeOccupancy
   auto const policy_drop_occ =
@@ -84,7 +87,7 @@ void test_prefer_desired_occupancy() {
       !decltype(policy_drop_occ)::experimental_contains_desired_occupancy);
 }
 
-[[maybe_unused]] void test_execution_policy_occupancy_and_hint() {
+TEST(TEST_CATEGORY, execution_policy_occupancy_and_hint) {
   test_prefer_desired_occupancy<DummyPolicy<>>();
   test_prefer_desired_occupancy<Kokkos::RangePolicy<>>();
   test_prefer_desired_occupancy<Kokkos::TeamPolicy<>>();

--- a/core/unit_test/TestCommonPolicyConstructors.hpp
+++ b/core/unit_test/TestCommonPolicyConstructors.hpp
@@ -84,7 +84,7 @@ void test_prefer_desired_occupancy() {
       !decltype(policy_drop_occ)::experimental_contains_desired_occupancy);
 }
 
-void test_execution_policy_occupancy_and_hint() {
+[[maybe_unused]] void test_execution_policy_occupancy_and_hint() {
   test_prefer_desired_occupancy<DummyPolicy<>>();
   test_prefer_desired_occupancy<Kokkos::RangePolicy<>>();
   test_prefer_desired_occupancy<Kokkos::TeamPolicy<>>();

--- a/core/unit_test/TestOccupancyControlTrait.hpp
+++ b/core/unit_test/TestOccupancyControlTrait.hpp
@@ -18,12 +18,6 @@
 
 namespace {
 
-// Dummy policy for testing base class.
-template <class... Args>
-struct DummyPolicy : Kokkos::Impl::PolicyTraits<Args...> {
-  using execution_policy = DummyPolicy;
-};
-
 template <class... Properties>
 void test_policy_execution(const Kokkos::RangePolicy<Properties...>& policy) {
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int){});
@@ -39,8 +33,6 @@ template <class... Properties>
 void test_policy_execution(const Kokkos::MDRangePolicy<Properties...>& policy) {
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int, int){});
 }
-template <class... Properties>
-void test_policy_execution(const DummyPolicy<Properties...>&) {}
 
 template <class Policy>
 void test_prefer_desired_occupancy(Policy policy) {
@@ -56,19 +48,16 @@ void test_prefer_desired_occupancy(Policy policy) {
   // MaximizeOccupancy -> DesiredOccupancy
   auto const policy_with_occ =
       prefer(policy_still_no_occ, DesiredOccupancy{33});
-  EXPECT_EQ(policy_with_occ.impl_get_desired_occupancy().value(), 33);
   test_policy_execution(policy_with_occ);
 
   // DesiredOccupancy -> DesiredOccupancy
   auto const policy_change_occ = prefer(policy_with_occ, DesiredOccupancy{24});
-  EXPECT_EQ(policy_change_occ.impl_get_desired_occupancy().value(), 24);
   test_policy_execution(policy_change_occ);
 
   // DesiredOccupancy -> DesiredOccupancy w/ hint
   auto policy_with_occ_and_hint = Kokkos::Experimental::require(
       policy_change_occ,
       Kokkos::Experimental::WorkItemProperty::HintLightWeight);
-  EXPECT_EQ(policy_with_occ_and_hint.impl_get_desired_occupancy().value(), 24);
   test_policy_execution(policy_with_occ_and_hint);
 
   // DesiredOccupancy -> MaximizeOccupancy
@@ -81,7 +70,6 @@ void test_prefer_desired_occupancy(Policy policy) {
 // This test doesn't compile with CUDA on Windows
 #if !(defined(_WIN32) && defined(KOKKOS_ENABLE_CUDA))
 TEST(TEST_CATEGORY, occupancy_control) {
-  test_prefer_desired_occupancy(DummyPolicy<TEST_EXECSPACE>{});
   test_prefer_desired_occupancy(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1));
   test_prefer_desired_occupancy(
       Kokkos::TeamPolicy<TEST_EXECSPACE>{1, Kokkos::AUTO});

--- a/core/unit_test/TestOccupancyControlTrait.hpp
+++ b/core/unit_test/TestOccupancyControlTrait.hpp
@@ -77,15 +77,19 @@ void test_prefer_desired_occupancy(Policy policy) {
   test_policy_execution(policy_drop_occ);
 }
 
+TEST(TEST_CATEGORY, occupancy_control) {
 // FIXME_MSVC_WITH_CUDA
 // This test doesn't compile with CUDA on Windows
-#if !(defined(_WIN32) && defined(KOKKOS_ENABLE_CUDA))
-TEST(TEST_CATEGORY, occupancy_control) {
-  test_prefer_desired_occupancy(DummyPolicy<>{});
-  test_prefer_desired_occupancy(Kokkos::RangePolicy<>(0, 0));
-  test_prefer_desired_occupancy(Kokkos::TeamPolicy<>{0, Kokkos::AUTO});
-  test_prefer_desired_occupancy(
-      Kokkos::MDRangePolicy<Kokkos::Rank<2>>{{0, 0}, {0, 0}});
-}
+#if defined(_WIN32) && defined(KOKKOS_ENABLE_CUDA)
+  if constexpr (!std::is_same_v<TEST_EXECSPACE, Kokkos::Cuda>)
 #endif
+  {
+    test_prefer_desired_occupancy(DummyPolicy<TEST_EXECSPACE>{});
+    test_prefer_desired_occupancy(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 0));
+    test_prefer_desired_occupancy(
+        Kokkos::TeamPolicy<TEST_EXECSPACE>{0, Kokkos::AUTO});
+    test_prefer_desired_occupancy(
+        Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>{{0, 0}, {0, 0}});
+  }
+}
 }  // namespace

--- a/core/unit_test/TestOccupancyControlTrait.hpp
+++ b/core/unit_test/TestOccupancyControlTrait.hpp
@@ -77,19 +77,16 @@ void test_prefer_desired_occupancy(Policy policy) {
   test_policy_execution(policy_drop_occ);
 }
 
-TEST(TEST_CATEGORY, occupancy_control) {
 // FIXME_MSVC_WITH_CUDA
 // This test doesn't compile with CUDA on Windows
-#if defined(_WIN32) && defined(KOKKOS_ENABLE_CUDA)
-  if constexpr (!std::is_same_v<TEST_EXECSPACE, Kokkos::Cuda>)
-#endif
-  {
-    test_prefer_desired_occupancy(DummyPolicy<TEST_EXECSPACE>{});
-    test_prefer_desired_occupancy(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 0));
-    test_prefer_desired_occupancy(
-        Kokkos::TeamPolicy<TEST_EXECSPACE>{0, Kokkos::AUTO});
-    test_prefer_desired_occupancy(
-        Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>{{0, 0}, {0, 0}});
-  }
+#if !(defined(_WIN32) && defined(KOKKOS_ENABLE_CUDA))
+TEST(TEST_CATEGORY, occupancy_control) {
+  test_prefer_desired_occupancy(DummyPolicy<TEST_EXECSPACE>{});
+  test_prefer_desired_occupancy(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 0));
+  test_prefer_desired_occupancy(
+      Kokkos::TeamPolicy<TEST_EXECSPACE>{0, Kokkos::AUTO});
+  test_prefer_desired_occupancy(
+      Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>{{0, 0}, {0, 0}});
 }
+#endif
 }  // namespace

--- a/core/unit_test/TestOccupancyControlTrait.hpp
+++ b/core/unit_test/TestOccupancyControlTrait.hpp
@@ -82,11 +82,11 @@ void test_prefer_desired_occupancy(Policy policy) {
 #if !(defined(_WIN32) && defined(KOKKOS_ENABLE_CUDA))
 TEST(TEST_CATEGORY, occupancy_control) {
   test_prefer_desired_occupancy(DummyPolicy<TEST_EXECSPACE>{});
-  test_prefer_desired_occupancy(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 0));
+  test_prefer_desired_occupancy(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1));
   test_prefer_desired_occupancy(
-      Kokkos::TeamPolicy<TEST_EXECSPACE>{0, Kokkos::AUTO});
+      Kokkos::TeamPolicy<TEST_EXECSPACE>{1, Kokkos::AUTO});
   test_prefer_desired_occupancy(
-      Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>{{0, 0}, {0, 0}});
+      Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>{{0, 0}, {1, 1}});
 }
 #endif
 }  // namespace

--- a/core/unit_test/TestOccupancyControlTrait.hpp
+++ b/core/unit_test/TestOccupancyControlTrait.hpp
@@ -1,0 +1,91 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+namespace {
+
+// Dummy policy for testing base class.
+template <class... Args>
+struct DummyPolicy : Kokkos::Impl::PolicyTraits<Args...> {
+  using execution_policy = DummyPolicy;
+};
+
+template <class... Properties>
+void test_policy_execution(const Kokkos::RangePolicy<Properties...>& policy) {
+  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int){});
+}
+template <class... Properties>
+void test_policy_execution(const Kokkos::TeamPolicy<Properties...>& policy) {
+  Kokkos::parallel_for(
+      policy,
+      KOKKOS_LAMBDA(
+          const typename Kokkos::TeamPolicy<Properties...>::member_type&){});
+}
+template <class... Properties>
+void test_policy_execution(const Kokkos::MDRangePolicy<Properties...>& policy) {
+  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int, int){});
+}
+template <class... Properties>
+void test_policy_execution(const DummyPolicy<Properties...>&) {}
+
+template <class Policy>
+void test_prefer_desired_occupancy(Policy policy) {
+  using Kokkos::Experimental::DesiredOccupancy;
+  using Kokkos::Experimental::MaximizeOccupancy;
+  using Kokkos::Experimental::prefer;
+  using Kokkos::Experimental::WorkItemProperty;
+
+  // MaximizeOccupancy -> MaximizeOccupancy
+  auto const policy_still_no_occ = prefer(policy, MaximizeOccupancy{});
+  test_policy_execution(policy_still_no_occ);
+
+  // MaximizeOccupancy -> DesiredOccupancy
+  auto const policy_with_occ =
+      prefer(policy_still_no_occ, DesiredOccupancy{33});
+  EXPECT_EQ(policy_with_occ.impl_get_desired_occupancy().value(), 33);
+  test_policy_execution(policy_with_occ);
+
+  // DesiredOccupancy -> DesiredOccupancy
+  auto const policy_change_occ = prefer(policy_with_occ, DesiredOccupancy{24});
+  EXPECT_EQ(policy_change_occ.impl_get_desired_occupancy().value(), 24);
+  test_policy_execution(policy_change_occ);
+
+  // DesiredOccupancy -> DesiredOccupancy w/ hint
+  auto policy_with_occ_and_hint = Kokkos::Experimental::require(
+      policy_change_occ,
+      Kokkos::Experimental::WorkItemProperty::HintLightWeight);
+  EXPECT_EQ(policy_with_occ_and_hint.impl_get_desired_occupancy().value(), 24);
+  test_policy_execution(policy_with_occ_and_hint);
+
+  // DesiredOccupancy -> MaximizeOccupancy
+  auto const policy_drop_occ =
+      prefer(policy_with_occ_and_hint, MaximizeOccupancy{});
+  test_policy_execution(policy_drop_occ);
+}
+
+// FIXME_MSVC_WITH_CUDA
+// This test doesn't compile with CUDA on Windows
+#if !(defined(_WIN32) && defined(KOKKOS_ENABLE_CUDA))
+TEST(TEST_CATEGORY, occupancy_control) {
+  test_prefer_desired_occupancy(DummyPolicy<>{});
+  test_prefer_desired_occupancy(Kokkos::RangePolicy<>(0, 0));
+  test_prefer_desired_occupancy(Kokkos::TeamPolicy<>{0, Kokkos::AUTO});
+  test_prefer_desired_occupancy(
+      Kokkos::MDRangePolicy<Kokkos::Rank<2>>{{0, 0}, {0, 0}});
+}
+#endif
+}  // namespace


### PR DESCRIPTION
Fixes #6780. https://github.com/kokkos/kokkos/commit/4d8629f26c introduced `cuda_func_set_attributes_wrapper` which should have been `cuda_func_set_attribute_wrapper` and mapping to `cudaFuncSetAttribute` instead of `cudaFuncSetAttributes`. Our CI didn't detect that typo since we were never executing a kernel with `DesiredOccupancy`.
This pull request fixes that. The test was changed to not use default constructed policies since that created problems with `MDRange` (division by zero) and this test isn't designed to test that. Whether default constructed policy instances should be usable or not is a separate question and out-of-scope for this pull request.