### PR TITLE
simd: temporarily skip simd reduction unit test for omptarget build

### DIFF
--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -172,6 +172,12 @@ TEST(simd, host_reductions) {
 }
 
 TEST(simd, device_reductions) {
+#ifdef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET
+  GTEST_SKIP()
+      << "skipping because of a non-deterministic failure reporting: "
+         "Failure to synchronize stream (nil): Error in "
+         "cuStreamSynchronize: an illegal memory access was encountered";
+#endif
   Kokkos::parallel_for(1, simd_device_reduction_functor());
 }
 


### PR DESCRIPTION
Related: #6574 

Based on recent CI outputs from few PRs, it seems that the simd reduction unit test is suddenly producing the same non-deterministic error in the same manner that the simd math ops tests were occasionally producing. Temporarily skipping the test for OpenMPTarget build in the interest of clearing the CI, until further triage.