### PR TITLE
Fix SharedAllocationRecord to allocate using the correct execution space instance

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.hpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.hpp
@@ -168,6 +168,16 @@ class CudaUVMSpace {
   ~CudaUVMSpace()                                  = default;
 
   /**\brief  Allocate untracked memory in the cuda space */
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace&, const size_t arg_alloc_size) const {
+    return allocate(arg_alloc_size);
+  }
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace&, const char* arg_label,
+                 const size_t arg_alloc_size,
+                 const size_t arg_logical_size = 0) const {
+    return allocate(arg_label, arg_alloc_size, arg_logical_size);
+  }
   void* allocate(const size_t arg_alloc_size) const;
   void* allocate(const char* arg_label, const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;
@@ -250,6 +260,16 @@ class CudaHostPinnedSpace {
   ~CudaHostPinnedSpace()                                         = default;
 
   /**\brief  Allocate untracked memory in the space */
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace&, const size_t arg_alloc_size) const {
+    return allocate(arg_alloc_size);
+  }
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace&, const char* arg_label,
+                 const size_t arg_alloc_size,
+                 const size_t arg_logical_size = 0) const {
+    return allocate(arg_label, arg_alloc_size, arg_logical_size);
+  }
   void* allocate(const size_t arg_alloc_size) const;
   void* allocate(const char* arg_label, const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;

--- a/core/src/HIP/Kokkos_HIP_Space.hpp
+++ b/core/src/HIP/Kokkos_HIP_Space.hpp
@@ -65,6 +65,15 @@ class HIPSpace {
   ~HIPSpace()                              = default;
 
   /**\brief  Allocate untracked memory in the hip space */
+  // FIXME_HIP Use execution space instance
+  void* allocate(const HIP&, const size_t arg_alloc_size) const {
+    return allocate(arg_alloc_size);
+  }
+  // FIXME_HIP Use execution space instance
+  void* allocate(const HIP&, const char* arg_label, const size_t arg_alloc_size,
+                 const size_t arg_logical_size = 0) const {
+    return allocate(arg_label, arg_alloc_size, arg_logical_size);
+  }
   void* allocate(const size_t arg_alloc_size) const;
   void* allocate(const char* arg_label, const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;
@@ -125,6 +134,16 @@ class HIPHostPinnedSpace {
   ~HIPHostPinnedSpace()                                        = default;
 
   /**\brief  Allocate untracked memory in the space */
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace&, const size_t arg_alloc_size) const {
+    return allocate(arg_alloc_size);
+  }
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace&, const char* arg_label,
+                 const size_t arg_alloc_size,
+                 const size_t arg_logical_size = 0) const {
+    return allocate(arg_label, arg_alloc_size, arg_logical_size);
+  }
   void* allocate(const size_t arg_alloc_size) const;
   void* allocate(const char* arg_label, const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;
@@ -188,6 +207,16 @@ class HIPManagedSpace {
   ~HIPManagedSpace()                                     = default;
 
   /**\brief  Allocate untracked memory in the space */
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace&, const size_t arg_alloc_size) const {
+    return allocate(arg_alloc_size);
+  }
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace&, const char* arg_label,
+                 const size_t arg_alloc_size,
+                 const size_t arg_logical_size = 0) const {
+    return allocate(arg_label, arg_alloc_size, arg_logical_size);
+  }
   void* allocate(const size_t arg_alloc_size) const;
   void* allocate(const char* arg_label, const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -93,6 +93,16 @@ class HostSpace {
 #endif
 
   /**\brief  Allocate untracked memory in the space */
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace&, const size_t arg_alloc_size) const {
+    return allocate(arg_alloc_size);
+  }
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace&, const char* arg_label,
+                 const size_t arg_alloc_size,
+                 const size_t arg_logical_size = 0) const {
+    return allocate(arg_label, arg_alloc_size, arg_logical_size);
+  }
   void* allocate(const size_t arg_alloc_size) const;
   void* allocate(const char* arg_label, const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.hpp
@@ -98,6 +98,16 @@ class OpenMPTargetSpace {
   ~OpenMPTargetSpace()                                   = default;
 
   /**\brief  Allocate untracked memory in the space */
+  // FIXME_OPENMPTARGET Use execution space instance
+  void* allocate(const OpenMPTarget&, const size_t arg_alloc_size) const {
+    return allocate(arg_alloc_size);
+  }
+  // FIXME_OPENMPTARGET Use execution space instance
+  void* allocate(const OpenMPTarget&, const char* arg_label,
+                 const size_t arg_alloc_size,
+                 const size_t arg_logical_size = 0) const {
+    return allocate(arg_label, arg_alloc_size, arg_logical_size);
+  }
   void* allocate(const size_t arg_alloc_size) const;
   void* allocate(const char* arg_label, const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;

--- a/core/src/SYCL/Kokkos_SYCL_Space.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.hpp
@@ -82,6 +82,19 @@ class SYCLSharedUSMSpace {
   SYCLSharedUSMSpace();
   explicit SYCLSharedUSMSpace(sycl::queue queue);
 
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace&, const size_t arg_alloc_size) const {
+    return allocate(arg_alloc_size);
+  }
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace&, const char* arg_label,
+                 const size_t arg_alloc_size,
+                 const size_t arg_logical_size = 0) const {
+    return allocate(arg_label, arg_alloc_size, arg_logical_size);
+  }
+  void* allocate(const SYCL& exec_space, const char* arg_label,
+                 const size_t arg_alloc_size,
+                 const size_t arg_logical_size = 0) const;
   void* allocate(const SYCL& exec_space,
                  const std::size_t arg_alloc_size) const;
   void* allocate(const SYCL& exec_space, const char* arg_label,
@@ -113,6 +126,16 @@ class SYCLHostUSMSpace {
   SYCLHostUSMSpace();
   explicit SYCLHostUSMSpace(sycl::queue queue);
 
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace&, const size_t arg_alloc_size) const {
+    return allocate(arg_alloc_size);
+  }
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace&, const char* arg_label,
+                 const size_t arg_alloc_size,
+                 const size_t arg_logical_size = 0) const {
+    return allocate(arg_label, arg_alloc_size, arg_logical_size);
+  }
   void* allocate(const SYCL& exec_space,
                  const std::size_t arg_alloc_size) const;
   void* allocate(const SYCL& exec_space, const char* arg_label,

--- a/core/src/SYCL/Kokkos_SYCL_Space.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.hpp
@@ -92,9 +92,6 @@ class SYCLSharedUSMSpace {
                  const size_t arg_logical_size = 0) const {
     return allocate(arg_label, arg_alloc_size, arg_logical_size);
   }
-  void* allocate(const SYCL& exec_space, const char* arg_label,
-                 const size_t arg_alloc_size,
-                 const size_t arg_logical_size = 0) const;
   void* allocate(const SYCL& exec_space,
                  const std::size_t arg_alloc_size) const;
   void* allocate(const SYCL& exec_space, const char* arg_label,

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -252,14 +252,14 @@ class SharedAllocationRecordCommon : public SharedAllocationRecord<void, void> {
   ~SharedAllocationRecordCommon();
   template <class ExecutionSpace>
   SharedAllocationRecordCommon(
-      ExecutionSpace const&, MemorySpace const& space, std::string const& label,
-      std::size_t alloc_size,
+      ExecutionSpace const& exec, MemorySpace const& space,
+      std::string const& label, std::size_t alloc_size,
       record_base_t::function_type dealloc = &deallocate)
       : SharedAllocationRecord<void, void>(
 #ifdef KOKKOS_ENABLE_DEBUG
             &s_root_record,
 #endif
-            checked_allocation_with_header(space, label, alloc_size),
+            checked_allocation_with_header(exec, space, label, alloc_size),
             sizeof(SharedAllocationHeader) + alloc_size, dealloc, label),
         m_space(space) {
     auto& header = *SharedAllocationRecord<void, void>::m_alloc_ptr;
@@ -315,7 +315,7 @@ class HostInaccessibleSharedAllocationRecordCommon
 #ifdef KOKKOS_ENABLE_DEBUG
             &s_root_record,
 #endif
-            checked_allocation_with_header(space, label, alloc_size),
+            checked_allocation_with_header(exec, space, label, alloc_size),
             sizeof(SharedAllocationHeader) + alloc_size, dealloc, label),
         m_space(space) {
     SharedAllocationHeader header;


### PR DESCRIPTION
Since https://github.com/kokkos/kokkos/pull/6738 we are not using the correct execution space instance for allocating anymore. This pull request fixes this behavior by again forwarding the execution space instance argument in the `SharedAllocationCommon` constructor to `checked_allocation_with_header`.

Before that pull request, only some memory spaces implemented `allocate(ExecutionSpace, ...)` because only some of them could actually take advantage of using a particular execution space instance. That's why only some of them forwarded the execution space instance in the `SharedAllocationCommon` constructor.

With the unification of all the `SharedAllocationCommon` implementations in #6738, we now have to implement `allocate(ExecutionSpace,...)` for all memory spaces which is what this pull request does. The ones missing were:
- `CudaUVMSpace`
- `CudaHostPinnedSpace`
- `HIPSpace`
- `HIPHostPinnedSpace`
- `HIPManagedSpace`
- `HostSpace`
- `OpenMPTargetSpace`
- `SYCLSharedUSMSpace`
- `SYCLHostUSMSpace`

Note that I decided to only implement the overload for the single possible execution space instance type if there is only one. All the others are just templated on an arbitrary execution space type.



This pull request is particularly important for multi-GPU support since we would otherwise allocate on the wrong device.