### PR TITLE
SYCL: Improve print_configuration

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -88,12 +88,13 @@ bool SYCL::impl_is_initialized() {
 void SYCL::impl_finalize() { Impl::SYCLInternal::singleton().finalize(); }
 
 void SYCL::print_configuration(std::ostream& os, bool verbose) const {
-  os << "Devices:\n";
-  os << "  KOKKOS_ENABLE_SYCL: yes\n";
-
   os << "\nRuntime Configuration:\n";
 
-  os << "macro  KOKKOS_ENABLE_SYCL : defined\n";
+#ifdef KOKKOS_ENABLE_ONEDPL
+  os << "macro  KOKKOS_ENABLE_ONEDPL : defined\n";
+#else
+  os << "macro  KOKKOS_ENABLE_ONEDPL : undefined\n";
+#endif
 #ifdef KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED
   os << "macro  KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED : defined\n";
 #else
@@ -104,17 +105,10 @@ void SYCL::print_configuration(std::ostream& os, bool verbose) const {
 #else
   os << "macro  SYCL_EXT_ONEAPI_DEVICE_GLOBAL : undefined\n";
 #endif
-
 #ifdef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
   os << "macro  KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES : defined\n";
 #else
   os << "macro  KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES : undefined\n";
-#endif
-
-#ifdef KOKKOS_ENABLE_ONEDPL
-  os << "macro  KOKKOS_ENABLE_ONEDPL : defined\n";
-#else
-  os << "macro  KOKKOS_ENABLE_ONEDPL : undefined\n";
 #endif
 
   int counter       = 0;

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -111,8 +111,28 @@ void SYCL::print_configuration(std::ostream& os, bool verbose) const {
   os << "macro  KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES : undefined\n";
 #endif
 
-  if (verbose)
+#ifdef KOKKOS_ENABLE_ONEDPL
+  os << "macro  KOKKOS_ENABLE_ONEDPL : defined\n";
+#else
+  os << "macro  KOKKOS_ENABLE_ONEDPL : undefined\n";
+#endif
+
+  int counter       = 0;
+  int active_device = Kokkos::device_id();
+  std::cout << "\nAvailable devices: \n";
+  std::vector<sycl::device> devices = Impl::get_sycl_devices();
+  for (const auto& device : devices) {
+    os << "[" << device.get_backend() << "]:gpu:" << counter << "] "
+       << device.get_info<sycl::info::device::name>();
+    if (counter == active_device) os << " : Selected";
+    os << '\n';
+    ++counter;
+  }
+
+  if (verbose) {
+    os << '\n';
     SYCL::impl_sycl_info(os, m_space_instance->m_queue->get_device());
+  }
 }
 
 void SYCL::fence(const std::string& name) const {

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -122,8 +122,20 @@ void SYCL::print_configuration(std::ostream& os, bool verbose) const {
   std::cout << "\nAvailable devices: \n";
   std::vector<sycl::device> devices = Impl::get_sycl_devices();
   for (const auto& device : devices) {
-    os << "[" << device.get_backend() << "]:gpu:" << counter << "] "
-       << device.get_info<sycl::info::device::name>();
+    std::string device_type;
+    switch (device.get_info<sycl::info::device::device_type>()) {
+      case sycl::info::device_type::cpu: device_type = "cpu"; break;
+      case sycl::info::device_type::gpu: device_type = "gpu"; break;
+      case sycl::info::device_type::accelerator:
+        device_type = "accelerator";
+        break;
+      case sycl::info::device_type::custom: device_type = "custom"; break;
+      case sycl::info::device_type::automatic: device_type = "automatic"; break;
+      case sycl::info::device_type::host: device_type = "host"; break;
+      case sycl::info::device_type::all: device_type = "all"; break;
+    }
+    os << "[" << device.get_backend() << "]:" << device_type << ':' << counter
+       << "] " << device.get_info<sycl::info::device::name>();
     if (counter == active_device) os << " : Selected";
     os << '\n';
     ++counter;


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/pull/6793#discussion_r1483265300, #6758, and #5419.

With this pull request we also print whether we are using `oneDPL` and print all (usable) devices trying to emulate the output from `sycl-ls`, also see https://github.com/kokkos/kokkos/pull/6758#issuecomment-1924433536.

Example (non-verbose):
```
Devices:
  KOKKOS_ENABLE_SYCL: yes

Runtime Configuration:
macro  KOKKOS_ENABLE_SYCL : defined
macro  KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED : defined
macro  SYCL_EXT_ONEAPI_DEVICE_GLOBAL : defined
macro  KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES : defined
macro  KOKKOS_ENABLE_ONEDPL : defined

Available devices: 
[ext_oneapi_level_zero]:gpu:0] Intel(R) Data Center GPU Max 1550 : Selected
[ext_oneapi_level_zero]:gpu:1] Intel(R) Data Center GPU Max 1550
[ext_oneapi_level_zero]:gpu:2] Intel(R) Data Center GPU Max 1550
[ext_oneapi_level_zero]:gpu:3] Intel(R) Data Center GPU Max 1550
[ext_oneapi_level_zero]:gpu:4] Intel(R) Data Center GPU Max 1550
[ext_oneapi_level_zero]:gpu:5] Intel(R) Data Center GPU Max 1550
```