### PR TITLE
Drop `KOKKOS_ENABLE_INTEL_MM_ALLOC` macro

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -568,14 +568,6 @@ void pre_initialize_internal(const Kokkos::InitializationSettings& settings) {
                                  "no");
 #endif
 
-#ifdef KOKKOS_ENABLE_INTEL_MM_ALLOC
-  declare_configuration_metadata("memory", "KOKKOS_ENABLE_INTEL_MM_ALLOC",
-                                 "yes");
-#else
-  declare_configuration_metadata("memory", "KOKKOS_ENABLE_INTEL_MM_ALLOC",
-                                 "no");
-#endif
-
 #ifdef KOKKOS_ENABLE_ASM
   declare_configuration_metadata("options", "KOKKOS_ENABLE_ASM", "yes");
 #else

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -20,21 +20,10 @@
 
 #include <Kokkos_Macros.hpp>
 
+#include <Kokkos_Atomic.hpp>
+#include <Kokkos_HostSpace.hpp>
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Tools.hpp>
-
-/*--------------------------------------------------------------------------*/
-
-#if (defined(KOKKOS_COMPILER_INTEL) || defined(KOKKOS_COMPILER_INTEL_LLVM)) && \
-    !defined(KOKKOS_ENABLE_CUDA)
-
-// Intel specialized allocator does not interoperate with CUDA memory allocation
-
-#define KOKKOS_ENABLE_INTEL_MM_ALLOC
-
-#endif
-
-/*--------------------------------------------------------------------------*/
 
 #include <cstddef>
 #include <cstdlib>
@@ -48,10 +37,6 @@
 #ifdef KOKKOS_COMPILER_INTEL
 #include <aligned_new>
 #endif
-
-#include <Kokkos_HostSpace.hpp>
-#include <impl/Kokkos_Error.hpp>
-#include <Kokkos_Atomic.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------


### PR DESCRIPTION
The `KOKKOS_ENABLE_INTEL_MM_ALLOC` macro has no effect since #6341
We should have removed it then.  It was an oversight.