### PR TITLE
simd: allow wider vector width for 32 bit types

### DIFF
--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -193,7 +193,8 @@ using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx2_fixed_size<4>,
 using data_type_set =
     data_types<std::int32_t, std::int64_t, std::uint64_t, double, float>;
 #elif defined(KOKKOS_ARCH_ARM_NEON)
-using host_abi_set = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>>;
+using host_abi_set = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>,
+                             simd_abi::neon_fixed_size<4>>;
 using data_type_set =
     data_types<std::int32_t, std::int64_t, std::uint64_t, double, float>;
 #else

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -183,7 +183,8 @@ template <typename... Ts>
 class data_types {};
 
 #if defined(KOKKOS_ARCH_AVX512XEON)
-using host_abi_set  = abi_set<simd_abi::scalar, simd_abi::avx512_fixed_size<8>>;
+using host_abi_set  = abi_set<simd_abi::scalar, simd_abi::avx512_fixed_size<8>,
+                             simd_abi::avx512_fixed_size<16>>;
 using data_type_set = data_types<std::int32_t, std::uint32_t, std::int64_t,
                                  std::uint64_t, double, float>;
 #elif defined(KOKKOS_ARCH_AVX2)

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -187,7 +187,8 @@ using host_abi_set  = abi_set<simd_abi::scalar, simd_abi::avx512_fixed_size<8>>;
 using data_type_set = data_types<std::int32_t, std::uint32_t, std::int64_t,
                                  std::uint64_t, double, float>;
 #elif defined(KOKKOS_ARCH_AVX2)
-using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx2_fixed_size<4>>;
+using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx2_fixed_size<4>,
+                             simd_abi::avx2_fixed_size<8>>;
 using data_type_set =
     data_types<std::int32_t, std::int64_t, std::uint64_t, double, float>;
 #elif defined(KOKKOS_ARCH_ARM_NEON)

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -237,7 +237,13 @@ class simd_mask<float, simd_abi::avx2_fixed_size<8>> {
     __m256& m_mask;
     int m_lane;
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __m256 bit_mask() const {
+      // FIXME_HIP ROCm 5.6, 5.7, and 6.0 can't compile with the intrinsic used
+      // here.
+#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
+      return _mm256_cvtepi32_ps(_mm256_setr_epi32(
+#else
       return _mm256_castsi256_ps(_mm256_setr_epi32(
+#endif
           -std::int32_t(m_lane == 0), -std::int32_t(m_lane == 1),
           -std::int32_t(m_lane == 2), -std::int32_t(m_lane == 3),
           -std::int32_t(m_lane == 4), -std::int32_t(m_lane == 5),

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -229,6 +229,100 @@ class simd_mask<float, simd_abi::avx2_fixed_size<4>> {
 };
 
 template <>
+class simd_mask<float, simd_abi::avx2_fixed_size<8>> {
+  __m256 m_value;
+
+ public:
+  class reference {
+    __m256& m_mask;
+    int m_lane;
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __m256 bit_mask() const {
+      return _mm256_castsi256_ps(_mm256_setr_epi32(
+          -std::int32_t(m_lane == 0), -std::int32_t(m_lane == 1),
+          -std::int32_t(m_lane == 2), -std::int32_t(m_lane == 3),
+          -std::int32_t(m_lane == 4), -std::int32_t(m_lane == 5),
+          -std::int32_t(m_lane == 6), -std::int32_t(m_lane == 7)));
+    }
+
+   public:
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(__m256& mask_arg,
+                                                    int lane_arg)
+        : m_mask(mask_arg), m_lane(lane_arg) {}
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
+    operator=(bool value) const {
+      if (value) {
+        m_mask = _mm256_or_ps(bit_mask(), m_mask);
+      } else {
+        m_mask = _mm256_andnot_ps(bit_mask(), m_mask);
+      }
+      return *this;
+    }
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
+      return (_mm256_movemask_ps(m_mask) & (1 << m_lane)) != 0;
+    }
+  };
+  using value_type = bool;
+  using abi_type   = simd_abi::avx2_fixed_size<8>;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+      : m_value(_mm256_castsi256_ps(_mm256_set1_epi32(-std::int32_t(value)))) {}
+  template <class G,
+            std::enable_if_t<
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+      G&& gen) noexcept
+      : m_value(_mm256_castsi256_ps(_mm256_setr_epi32(
+            -std::int32_t(gen(std::integral_constant<std::size_t, 0>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 1>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 2>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 3>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 4>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 5>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 6>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 7>()))))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+      __m256 const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reference(m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return static_cast<value_type>(
+        reference(const_cast<__m256&>(m_value), int(i)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
+  operator||(simd_mask const& other) const {
+    return simd_mask(_mm256_or_ps(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
+  operator&&(simd_mask const& other) const {
+    return simd_mask(_mm256_and_ps(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
+    auto const true_value = static_cast<__m256>(simd_mask(true));
+    return simd_mask(_mm256_andnot_ps(m_value, true_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
+      simd_mask const& other) const {
+    return _mm256_movemask_ps(m_value) == _mm256_movemask_ps(other.m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
+      simd_mask const& other) const {
+    return !operator==(other);
+  }
+};
+
+template <>
 class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   __m128i m_value;
 
@@ -317,6 +411,109 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       simd_mask const& other) const {
     return _mm_movemask_ps(_mm_castsi128_ps(m_value)) ==
            _mm_movemask_ps(_mm_castsi128_ps(other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
+      simd_mask const& other) const {
+    return !operator==(other);
+  }
+};
+
+template <>
+class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
+  __m256i m_value;
+
+ public:
+  class reference {
+    __m256i& m_mask;
+    int m_lane;
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __m256i bit_mask() const {
+      return _mm256_setr_epi32(
+          -std::int32_t(m_lane == 0), -std::int32_t(m_lane == 1),
+          -std::int32_t(m_lane == 2), -std::int32_t(m_lane == 3),
+          -std::int32_t(m_lane == 4), -std::int32_t(m_lane == 5),
+          -std::int32_t(m_lane == 6), -std::int32_t(m_lane == 7));
+    }
+
+   public:
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(__m256i& mask_arg,
+                                                    int lane_arg)
+        : m_mask(mask_arg), m_lane(lane_arg) {}
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
+    operator=(bool value) const {
+      if (value) {
+        m_mask = _mm256_or_si256(bit_mask(), m_mask);
+      } else {
+        m_mask = _mm256_andnot_si256(bit_mask(), m_mask);
+      }
+      return *this;
+    }
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
+      return (_mm256_movemask_ps(_mm256_castsi256_ps(m_mask)) &
+              (1 << m_lane)) != 0;
+    }
+  };
+  using value_type = bool;
+  using abi_type   = simd_abi::avx2_fixed_size<8>;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask()                 = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(simd_mask const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(simd_mask&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+      : m_value(_mm256_set1_epi32(-std::int32_t(value))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+      __m256i const& value_in)
+      : m_value(value_in) {}
+  template <class G,
+            std::enable_if_t<
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+      G&& gen) noexcept
+      : m_value(_mm256_setr_epi32(
+            -std::int32_t(gen(std::integral_constant<std::size_t, 0>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 1>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 2>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 3>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 4>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 5>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 6>())),
+            -std::int32_t(gen(std::integral_constant<std::size_t, 7>())))) {}
+  template <class U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
+      simd_mask<U, abi_type> const& other) {
+    for (std::size_t i = 0; i < size(); ++i) (*this)[i] = other[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reference(m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return static_cast<value_type>(
+        reference(const_cast<__m256i&>(m_value), int(i)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
+  operator||(simd_mask const& other) const {
+    return simd_mask(_mm256_or_si256(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
+  operator&&(simd_mask const& other) const {
+    return simd_mask(_mm256_and_si256(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
+    auto const true_value = static_cast<__m256i>(simd_mask(true));
+    return simd_mask(_mm256_andnot_si256(m_value, true_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
+      simd_mask const& other) const {
+    return _mm256_movemask_ps(_mm256_castsi256_ps(m_value)) ==
+           _mm256_movemask_ps(_mm256_castsi256_ps(other.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
       simd_mask const& other) const {
@@ -1031,6 +1228,264 @@ namespace Experimental {
 }
 
 template <>
+class simd<float, simd_abi::avx2_fixed_size<8>> {
+  __m256 m_value;
+
+ public:
+  using value_type = float;
+  using abi_type   = simd_abi::avx2_fixed_size<8>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+  template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                         bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm256_set1_ps(value_type(value))) {}
+  template <typename G,
+            std::enable_if_t<
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(G&& gen)
+      : m_value(_mm256_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
+                               gen(std::integral_constant<std::size_t, 1>()),
+                               gen(std::integral_constant<std::size_t, 2>()),
+                               gen(std::integral_constant<std::size_t, 3>()),
+                               gen(std::integral_constant<std::size_t, 4>()),
+                               gen(std::integral_constant<std::size_t, 5>()),
+                               gen(std::integral_constant<std::size_t, 6>()),
+                               gen(std::integral_constant<std::size_t, 7>()))) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      __m256 const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm256_loadu_ps(ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = _mm256_load_ps(ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_storeu_ps(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    _mm256_store_ps(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256()
+      const {
+    return m_value;
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_mul_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_div_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_add_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_sub_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
+                                   static_cast<__m256>(rhs), _CMP_LT_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
+                                   static_cast<__m256>(rhs), _CMP_GT_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
+                                   static_cast<__m256>(rhs), _CMP_LE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
+                                   static_cast<__m256>(rhs), _CMP_GE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
+                                   static_cast<__m256>(rhs), _CMP_EQ_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
+                                   static_cast<__m256>(rhs), _CMP_NEQ_OS));
+  }
+};
+
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::avx2_fixed_size<8>>
+copysign(
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
+        a,
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
+        b) {
+  __m256 const sign_mask = _mm256_set1_ps(-0.0);
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_xor_ps(_mm256_andnot_ps(sign_mask, static_cast<__m256>(a)),
+                    _mm256_and_ps(sign_mask, static_cast<__m256>(b))));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    abs(Experimental::simd<
+        float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  __m256 const sign_mask = _mm256_set1_ps(-0.0);
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_andnot_ps(sign_mask, static_cast<__m256>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    floor(Experimental::simd<
+          float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_round_ps(static_cast<__m256>(a),
+                      (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    ceil(Experimental::simd<
+         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_round_ps(static_cast<__m256>(a),
+                      (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    round(Experimental::simd<
+          float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_round_ps(static_cast<__m256>(a),
+                      (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    trunc(Experimental::simd<
+          float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_round_ps(static_cast<__m256>(a),
+                      (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    sqrt(Experimental::simd<
+         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_sqrt_ps(static_cast<__m256>(a)));
+}
+
+#ifdef __INTEL_COMPILER
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    cbrt(Experimental::simd<
+         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_cbrt_ps(static_cast<__m256>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    exp(Experimental::simd<
+        float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_exp_ps(static_cast<__m256>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    log(Experimental::simd<
+        float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_log_ps(static_cast<__m256>(a)));
+}
+
+#endif
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::avx2_fixed_size<8>>
+fma(Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
+        a,
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
+        b,
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
+        c) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_fmadd_ps(static_cast<__m256>(a), static_cast<__m256>(b),
+                      static_cast<__m256>(c)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::avx2_fixed_size<8>>
+max(Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
+        a,
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
+        b) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_max_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::avx2_fixed_size<8>>
+min(Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
+        a,
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
+        b) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_min_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
+}
+
+namespace Experimental {
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<float, simd_abi::avx2_fixed_size<8>>
+    condition(simd_mask<float, simd_abi::avx2_fixed_size<8>> const& a,
+              simd<float, simd_abi::avx2_fixed_size<8>> const& b,
+              simd<float, simd_abi::avx2_fixed_size<8>> const& c) {
+  return simd<float, simd_abi::avx2_fixed_size<8>>(_mm256_blendv_ps(
+      static_cast<__m256>(c), static_cast<__m256>(b), static_cast<__m256>(a)));
+}
+
+template <>
 class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   __m128i m_value;
 
@@ -1227,6 +1682,207 @@ namespace Experimental {
       _mm_blendv_ps(_mm_castsi128_ps(static_cast<__m128i>(c)),
                     _mm_castsi128_ps(static_cast<__m128i>(b)),
                     _mm_castsi128_ps(static_cast<__m128i>(a)))));
+}
+
+template <>
+class simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
+  __m256i m_value;
+
+ public:
+  using value_type = std::int32_t;
+  using abi_type   = simd_abi::avx2_fixed_size<8>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm256_set1_epi32(value_type(value))) {}
+  template <class G,
+            std::enable_if_t<
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      G&& gen) noexcept
+      : m_value(
+            _mm256_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
+                              gen(std::integral_constant<std::size_t, 1>()),
+                              gen(std::integral_constant<std::size_t, 2>()),
+                              gen(std::integral_constant<std::size_t, 3>()),
+                              gen(std::integral_constant<std::size_t, 4>()),
+                              gen(std::integral_constant<std::size_t, 5>()),
+                              gen(std::integral_constant<std::size_t, 6>()),
+                              gen(std::integral_constant<std::size_t, 7>()))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      __m256i const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    // FIXME_HIP ROCm 5.6, 5.7, and 6.0 can't compile with the intrinsic used
+    // here.
+#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
+    m_value = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(ptr));
+#else
+    m_value = _mm256_maskload_epi32(ptr, static_cast<__m256i>(mask_type(true)));
+#endif
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    // FIXME_HIP ROCm 5.6, 5.7, and 6.0 can't compile with the intrinsic used
+    // here.
+#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
+    m_value = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(ptr));
+#else
+    m_value = _mm256_maskload_epi32(ptr, static_cast<__m256i>(mask_type(true)));
+#endif
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask_type(true)), m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, vector_aligned_tag) const {
+    _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask_type(true)), m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
+      const {
+    return m_value;
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpeq_epi32(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpgt_epi32(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return !(lhs >= rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return (lhs < rhs) || (lhs == rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return (lhs > rhs) || (lhs == rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return !(lhs == rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
+                                   static_cast<__m256i>(rhs)));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_srav_epi32(static_cast<__m256i>(lhs),
+                                  static_cast<__m256i>(rhs)));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+                                  static_cast<__m256i>(rhs)));
+  }
+};
+
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>>
+    abs(Experimental::simd<
+        std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  __m256i const rhs = static_cast<__m256i>(a);
+  return Experimental::simd<std::int32_t,
+                            Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_abs_epi32(rhs));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    floor(Experimental::simd<
+          std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    ceil(Experimental::simd<
+         std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    round(Experimental::simd<
+          std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    trunc(Experimental::simd<
+          std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+      _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
+}
+
+namespace Experimental {
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
+    condition(simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& a,
+              simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& b,
+              simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& c) {
+  return simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(_mm256_castps_si256(
+      _mm256_blendv_ps(_mm256_castsi256_ps(static_cast<__m256i>(c)),
+                       _mm256_castsi256_ps(static_cast<__m256i>(b)),
+                       _mm256_castsi256_ps(static_cast<__m256i>(a)))));
 }
 
 template <>
@@ -1514,6 +2170,16 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                     static_cast<__m256i>(mask_type(true)));
 #endif
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_maskstore_epi64(reinterpret_cast<long long*>(ptr),
+                           static_cast<__m256i>(mask_type(true)), m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    _mm256_maskstore_epi64(reinterpret_cast<long long*>(ptr),
+                           static_cast<__m256i>(mask_type(true)), m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
       const {
@@ -1822,6 +2488,94 @@ class where_expression<simd_mask<float, simd_abi::avx2_fixed_size<4>>,
 };
 
 template <>
+class const_where_expression<simd_mask<float, simd_abi::avx2_fixed_size<8>>,
+                             simd<float, simd_abi::avx2_fixed_size<8>>> {
+ public:
+  using abi_type   = simd_abi::avx2_fixed_size<8>;
+  using value_type = simd<float, abi_type>;
+  using mask_type  = simd_mask<float, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(float* mem, element_aligned_tag) const {
+    _mm256_maskstore_ps(mem, _mm256_castps_si256(static_cast<__m256>(m_mask)),
+                        static_cast<__m256>(m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(float* mem, vector_aligned_tag) const {
+    _mm256_maskstore_ps(mem, _mm256_castps_si256(static_cast<__m256>(m_mask)),
+                        static_cast<__m256>(m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      float* mem,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& index) const {
+    for (std::size_t lane = 0; lane < value_type::size(); ++lane) {
+      if (m_mask[lane]) mem[index[lane]] = m_value[lane];
+    }
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
+  impl_get_value() const {
+    return m_value;
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
+  impl_get_mask() const {
+    return m_mask;
+  }
+};
+
+template <>
+class where_expression<simd_mask<float, simd_abi::avx2_fixed_size<8>>,
+                       simd<float, simd_abi::avx2_fixed_size<8>>>
+    : public const_where_expression<
+          simd_mask<float, simd_abi::avx2_fixed_size<8>>,
+          simd<float, simd_abi::avx2_fixed_size<8>>> {
+ public:
+  where_expression(
+      simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask_arg,
+      simd<float, simd_abi::avx2_fixed_size<8>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(float const* mem, element_aligned_tag) {
+    m_value = value_type(_mm256_maskload_ps(
+        mem, _mm256_castps_si256(static_cast<__m256>(m_mask))));
+  }
+  void copy_from(float const* mem, vector_aligned_tag) {
+    m_value = value_type(_mm256_maskload_ps(
+        mem, _mm256_castps_si256(static_cast<__m256>(m_mask))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      float const* mem,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& index) {
+    m_value = value_type(_mm256_mask_i32gather_ps(
+        static_cast<__m256>(m_value), mem, static_cast<__m256i>(index),
+        static_cast<__m256>(m_mask), 4));
+  }
+  template <class U,
+            std::enable_if_t<std::is_convertible_v<
+                                 U, simd<float, simd_abi::avx2_fixed_size<8>>>,
+                             bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<float, simd_abi::avx2_fixed_size<8>>>(
+            std::forward<U>(x));
+    m_value = simd<float, simd_abi::avx2_fixed_size<8>>(_mm256_blendv_ps(
+        static_cast<__m256>(m_value), static_cast<__m256>(x_as_value_type),
+        static_cast<__m256>(m_mask)));
+  }
+};
+
+template <>
 class const_where_expression<
     simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
     simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
@@ -1920,6 +2674,109 @@ class where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
         _mm_blendv_ps(_mm_castsi128_ps(static_cast<__m128i>(m_value)),
                       _mm_castsi128_ps(static_cast<__m128i>(x_as_value_type)),
                       _mm_castsi128_ps(static_cast<__m128i>(m_mask)))));
+  }
+};
+
+template <>
+class const_where_expression<
+    simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
+    simd<std::int32_t, simd_abi::avx2_fixed_size<8>>> {
+ public:
+  using abi_type   = simd_abi::avx2_fixed_size<8>;
+  using value_type = simd<std::int32_t, abi_type>;
+  using mask_type  = simd_mask<std::int32_t, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::int32_t* mem, element_aligned_tag) const {
+    _mm256_maskstore_epi32(mem, static_cast<__m256i>(m_mask),
+                           static_cast<__m256i>(m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::int32_t* mem, vector_aligned_tag) const {
+    _mm256_maskstore_epi32(mem, static_cast<__m256i>(m_mask),
+                           static_cast<__m256i>(m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      std::int32_t* mem,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& index) const {
+    for (std::size_t lane = 0; lane < value_type::size(); ++lane) {
+      if (m_mask[lane]) mem[index[lane]] = m_value[lane];
+    }
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
+  impl_get_value() const {
+    return m_value;
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
+  impl_get_mask() const {
+    return m_mask;
+  }
+};
+
+template <>
+class where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
+                       simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+    : public const_where_expression<
+          simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
+          simd<std::int32_t, simd_abi::avx2_fixed_size<8>>> {
+ public:
+  where_expression(
+      simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask_arg,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<8>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::int32_t const* mem, element_aligned_tag) {
+#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
+    __m256i tmp = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(mem));
+    m_value = value_type(_mm256_and_si256(tmp, static_cast<__m256i>(m_mask)));
+#else
+    m_value =
+        value_type(_mm256_maskload_epi32(mem, static_cast<__m256i>(m_mask)));
+#endif
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::int32_t const* mem, vector_aligned_tag) {
+#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
+    __m256i tmp = _mm256_load_si256(reinterpret_cast<__m256i const*>(mem));
+    m_value = value_type(_mm256_and_si256(tmp, static_cast<__m256i>(m_mask)));
+#else
+    m_value =
+        value_type(_mm256_maskload_epi32(mem, static_cast<__m256i>(m_mask)));
+#endif
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      std::int32_t const* mem,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& index) {
+    m_value = value_type(_mm256_mask_i32gather_epi32(
+        static_cast<__m256i>(m_value), mem, static_cast<__m256i>(index),
+        static_cast<__m256i>(m_mask), 4));
+  }
+  template <
+      class U,
+      std::enable_if_t<std::is_convertible_v<
+                           U, simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>,
+                       bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>(
+            std::forward<U>(x));
+    m_value = simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(
+        _mm256_castps_si256(_mm256_blendv_ps(
+            _mm256_castsi256_ps(static_cast<__m256i>(m_value)),
+            _mm256_castsi256_ps(static_cast<__m256i>(x_as_value_type)),
+            _mm256_castsi256_ps(static_cast<__m256i>(m_mask)))));
   }
 };
 

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1003,11 +1003,11 @@ class simd<float, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
-  template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                          bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
       : m_value(_mm_set1_ps(value_type(value))) {}
-  template <typename G,
+  template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
@@ -1250,11 +1250,11 @@ class simd<float, simd_abi::avx2_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
-  template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                          bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
       : m_value(_mm256_set1_ps(value_type(value))) {}
-  template <typename G,
+  template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1004,7 +1004,7 @@ class simd<float, simd_abi::avx2_fixed_size<4>> {
     return 4;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                         bool> = false>
+                                      bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
       : m_value(_mm_set1_ps(value_type(value))) {}
   template <class G,
@@ -1251,7 +1251,7 @@ class simd<float, simd_abi::avx2_fixed_size<8>> {
     return 8;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                         bool> = false>
+                                      bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
       : m_value(_mm256_set1_ps(value_type(value))) {}
   template <class G,

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1755,8 +1755,8 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
       value_type* ptr, element_aligned_tag) const {
     _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask_type(true)), m_value);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, vector_aligned_tag) const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
     _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask_type(true)), m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -140,6 +140,122 @@ class simd_mask<T, simd_abi::avx512_fixed_size<8>> {
   }
 };
 
+template <class T>
+class simd_mask<T, simd_abi::avx512_fixed_size<16>> {
+  __mmask16 m_value;
+
+ public:
+  class reference {
+    __mmask16& m_mask;
+    int m_lane;
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __mmask16 bit_mask() const {
+      return __mmask16(std::int32_t(1 << m_lane));
+    }
+
+   public:
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(__mmask16& mask_arg,
+                                                    int lane_arg)
+        : m_mask(mask_arg), m_lane(lane_arg) {}
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
+    operator=(bool value) const {
+      if (value) {
+        m_mask |= bit_mask();
+      } else {
+        m_mask &= ~bit_mask();
+      }
+      return *this;
+    }
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
+      return (m_mask & bit_mask()) != 0;
+    }
+  };
+  using value_type                                  = bool;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+      : m_value(-std::int32_t(value)) {}
+  template <class U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
+      simd_mask<U, simd_abi::avx512_fixed_size<16>> const& other)
+      : m_value(static_cast<__mmask16>(other)) {}
+  template <class G,
+            std::enable_if_t<
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(G&& gen) : m_value(false) {
+    reference(m_value, int(0)) =
+        static_cast<bool>(gen(std::integral_constant<std::size_t, 0>()));
+    reference(m_value, int(1)) =
+        static_cast<bool>(gen(std::integral_constant<std::size_t, 1>()));
+    reference(m_value, int(2)) =
+        static_cast<bool>(gen(std::integral_constant<std::size_t, 2>()));
+    reference(m_value, int(3)) =
+        static_cast<bool>(gen(std::integral_constant<std::size_t, 3>()));
+    reference(m_value, int(4)) =
+        static_cast<bool>(gen(std::integral_constant<std::size_t, 4>()));
+    reference(m_value, int(5)) =
+        static_cast<bool>(gen(std::integral_constant<std::size_t, 5>()));
+    reference(m_value, int(6)) =
+        static_cast<bool>(gen(std::integral_constant<std::size_t, 6>()));
+    reference(m_value, int(7)) =
+        static_cast<bool>(gen(std::integral_constant<std::size_t, 7>()));
+    reference(m_value, int(8)) =
+        static_cast<bool>(gen(std::integral_constant<std::size_t, 8>()));
+    reference(m_value, int(9)) =
+        static_cast<bool>(gen(std::integral_constant<std::size_t, 9>()));
+    reference(m_value, int(10)) =
+        static_cast<bool>(gen(std::integral_constant<std::size_t, 10>()));
+    reference(m_value, int(11)) =
+        static_cast<bool>(gen(std::integral_constant<std::size_t, 11>()));
+    reference(m_value, int(12)) =
+        static_cast<bool>(gen(std::integral_constant<std::size_t, 12>()));
+    reference(m_value, int(13)) =
+        static_cast<bool>(gen(std::integral_constant<std::size_t, 13>()));
+    reference(m_value, int(14)) =
+        static_cast<bool>(gen(std::integral_constant<std::size_t, 14>()));
+    reference(m_value, int(15)) =
+        static_cast<bool>(gen(std::integral_constant<std::size_t, 15>()));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 16;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+      __mmask16 const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __mmask16()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reference(m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    auto const bit_mask = __mmask16(std::int32_t(1 << i));
+    return (m_value & bit_mask) != 0;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
+  operator||(simd_mask const& other) const {
+    return simd_mask(_kor_mask16(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
+  operator&&(simd_mask const& other) const {
+    return simd_mask(_kand_mask16(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
+    static const __mmask16 true_value(static_cast<__mmask16>(simd_mask(true)));
+    return simd_mask(_kxor_mask16(true_value, m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
+      simd_mask const& other) const {
+    return m_value == other.m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
+      simd_mask const& other) const {
+    return m_value != other.m_value;
+  }
+};
+
 template <>
 class simd<double, simd_abi::avx512_fixed_size<8>> {
   __m512d m_value;
@@ -701,6 +817,280 @@ simd<float, simd_abi::avx512_fixed_size<8>> condition(
 }
 
 template <>
+class simd<float, simd_abi::avx512_fixed_size<16>> {
+  __m512 m_value;
+
+ public:
+  using value_type = float;
+  using abi_type   = simd_abi::avx512_fixed_size<16>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 16;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm512_set1_ps(value_type(value))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      __m512 const& value_in)
+      : m_value(value_in) {}
+  template <class G,
+            std::enable_if_t<
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(G&& gen)
+      : m_value(
+            _mm512_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
+                           gen(std::integral_constant<std::size_t, 1>()),
+                           gen(std::integral_constant<std::size_t, 2>()),
+                           gen(std::integral_constant<std::size_t, 3>()),
+                           gen(std::integral_constant<std::size_t, 4>()),
+                           gen(std::integral_constant<std::size_t, 5>()),
+                           gen(std::integral_constant<std::size_t, 6>()),
+                           gen(std::integral_constant<std::size_t, 7>()),
+                           gen(std::integral_constant<std::size_t, 8>()),
+                           gen(std::integral_constant<std::size_t, 9>()),
+                           gen(std::integral_constant<std::size_t, 10>()),
+                           gen(std::integral_constant<std::size_t, 11>()),
+                           gen(std::integral_constant<std::size_t, 12>()),
+                           gen(std::integral_constant<std::size_t, 13>()),
+                           gen(std::integral_constant<std::size_t, 14>()),
+                           gen(std::integral_constant<std::size_t, 15>()))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm512_loadu_ps(ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = _mm512_load_ps(ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm512_storeu_ps(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    _mm512_store_ps(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512()
+      const {
+    return m_value;
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(_mm512_sub_ps(_mm512_set1_ps(0.0), m_value));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm512_mul_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm512_div_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm512_add_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm512_sub_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LT_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GT_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_EQ_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_NEQ_OS));
+  }
+};
+
+}  // namespace Experimental
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
+copysign(Experimental::simd<
+             float, Experimental::simd_abi::avx512_fixed_size<16>> const& a,
+         Experimental::simd<
+             float, Experimental::simd_abi::avx512_fixed_size<16>> const& b) {
+  __m512 const sign_mask = _mm512_set1_ps(-0.0);
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_xor_ps(_mm512_andnot_ps(sign_mask, static_cast<__m512>(a)),
+                    _mm512_and_ps(sign_mask, static_cast<__m512>(b))));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>> abs(
+    Experimental::simd<
+        float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  __m512 const sign_mask = _mm512_set1_ps(-0.0);
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_andnot_ps(sign_mask, static_cast<__m512>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
+    floor(Experimental::simd<
+          float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  __m512 const val = static_cast<__m512>(a);
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_roundscale_ps(val, _MM_FROUND_TO_NEG_INF));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
+    ceil(Experimental::simd<
+         float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  __m512 const val = static_cast<__m512>(a);
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_roundscale_ps(val, _MM_FROUND_TO_POS_INF));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
+    round(Experimental::simd<
+          float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  __m512 const val = static_cast<__m512>(a);
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_roundscale_ps(val, _MM_FROUND_TO_NEAREST_INT));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
+    trunc(Experimental::simd<
+          float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  __m512 const val = static_cast<__m512>(a);
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_roundscale_ps(val, _MM_FROUND_TO_ZERO));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>> sqrt(
+    Experimental::simd<
+        float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_sqrt_ps(static_cast<__m512>(a)));
+}
+
+#ifdef __INTEL_COMPILER
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>> cbrt(
+    Experimental::simd<
+        float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_cbrt_ps(static_cast<__m512>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>> exp(
+    Experimental::simd<
+        float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_exp_ps(static_cast<__m512>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>> log(
+    Experimental::simd<
+        float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_log_ps(static_cast<__m512>(a)));
+}
+
+#endif
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>> fma(
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<16>> const& a,
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<16>> const& b,
+    Experimental::simd<
+        float, Experimental::simd_abi::avx512_fixed_size<16>> const& c) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_fmadd_ps(static_cast<__m512>(a), static_cast<__m512>(b),
+                      static_cast<__m512>(c)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>> max(
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<16>> const& a,
+    Experimental::simd<
+        float, Experimental::simd_abi::avx512_fixed_size<16>> const& b) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_max_ps(static_cast<__m512>(a), static_cast<__m512>(b)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>> min(
+    Experimental::simd<float,
+                       Experimental::simd_abi::avx512_fixed_size<16>> const& a,
+    Experimental::simd<
+        float, Experimental::simd_abi::avx512_fixed_size<16>> const& b) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_min_ps(static_cast<__m512>(a), static_cast<__m512>(b)));
+}
+
+namespace Experimental {
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx512_fixed_size<16>> condition(
+    simd_mask<float, simd_abi::avx512_fixed_size<16>> const& a,
+    simd<float, simd_abi::avx512_fixed_size<16>> const& b,
+    simd<float, simd_abi::avx512_fixed_size<16>> const& c) {
+  return simd<float, simd_abi::avx512_fixed_size<16>>(
+      _mm512_mask_blend_ps(static_cast<__mmask16>(a), static_cast<__m512>(c),
+                           static_cast<__m512>(b)));
+}
+
+template <>
 class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
   __m256i m_value;
 
@@ -908,6 +1298,222 @@ namespace Experimental {
 }
 
 template <>
+class simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
+  __m512i m_value;
+
+ public:
+  using value_type = std::int32_t;
+  using abi_type   = simd_abi::avx512_fixed_size<16>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 16;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm512_set1_epi32(value_type(value))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      __m512i const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint64_t, abi_type> const& other);
+  template <class G,
+            std::enable_if_t<
+                // basically, can you do { value_type r =
+                // gen(std::integral_constant<std::size_t, i>()); }
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      G&& gen) noexcept
+      : m_value(_mm512_setr_epi32(
+            gen(std::integral_constant<std::size_t, 0>()),
+            gen(std::integral_constant<std::size_t, 1>()),
+            gen(std::integral_constant<std::size_t, 2>()),
+            gen(std::integral_constant<std::size_t, 3>()),
+            gen(std::integral_constant<std::size_t, 4>()),
+            gen(std::integral_constant<std::size_t, 5>()),
+            gen(std::integral_constant<std::size_t, 6>()),
+            gen(std::integral_constant<std::size_t, 7>()),
+            gen(std::integral_constant<std::size_t, 8>()),
+            gen(std::integral_constant<std::size_t, 9>()),
+            gen(std::integral_constant<std::size_t, 10>()),
+            gen(std::integral_constant<std::size_t, 11>()),
+            gen(std::integral_constant<std::size_t, 12>()),
+            gen(std::integral_constant<std::size_t, 13>()),
+            gen(std::integral_constant<std::size_t, 14>()),
+            gen(std::integral_constant<std::size_t, 15>()))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm512_mask_storeu_epi32(ptr, static_cast<__mmask16>(mask_type(true)),
+                             m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    _mm512_mask_store_epi32(ptr, static_cast<__mmask16>(mask_type(true)),
+                            m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm512_mask_loadu_epi32(
+        _mm512_set1_epi32(0), static_cast<__mmask16>(mask_type(true)), ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = _mm512_mask_load_epi32(
+        _mm512_set1_epi32(0), static_cast<__mmask16>(mask_type(true)), ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
+      const {
+    return m_value;
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(_mm512_sub_epi32(_mm512_set1_epi32(0), m_value));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
+                                   static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
+        _mm512_add_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
+        _mm512_sub_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epi32_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epi32_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epi32_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epi32_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmpeq_epi32_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmpneq_epi32_mask(static_cast<__m512i>(lhs),
+                                              static_cast<__m512i>(rhs)));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm512_srai_epi32(static_cast<__m512i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm512_srav_epi32(static_cast<__m512i>(lhs),
+                                  static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm512_slli_epi32(static_cast<__m512i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm512_sllv_epi32(static_cast<__m512i>(lhs),
+                                  static_cast<__m512i>(rhs)));
+  }
+};
+
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>>
+abs(Experimental::simd<
+    std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  __m512i const rhs = static_cast<__m512i>(a);
+  return Experimental::simd<std::int32_t,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_abs_epi32(rhs));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::avx512_fixed_size<16>>
+floor(Experimental::simd<
+      std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_cvtepi32_ps(static_cast<__m512i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::avx512_fixed_size<16>>
+ceil(Experimental::simd<
+     std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_cvtepi32_ps(static_cast<__m512i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::avx512_fixed_size<16>>
+round(Experimental::simd<
+      std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_cvtepi32_ps(static_cast<__m512i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::avx512_fixed_size<16>>
+trunc(Experimental::simd<
+      std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_cvtepi32_ps(static_cast<__m512i>(a)));
+}
+
+namespace Experimental {
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int32_t, simd_abi::avx512_fixed_size<16>>
+    condition(simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& a,
+              simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& b,
+              simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& c) {
+  return simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
+      _mm512_mask_blend_epi32(static_cast<__mmask16>(a),
+                              static_cast<__m512i>(c),
+                              static_cast<__m512i>(b)));
+}
+
+template <>
 class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
   __m256i m_value;
 
@@ -960,16 +1566,6 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
   operator[](std::size_t i) const {
     return reinterpret_cast<value_type const*>(&m_value)[i];
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       element_aligned_tag) {
-    m_value = _mm256_mask_loadu_epi32(
-        _mm256_set1_epi32(0), static_cast<__mmask8>(mask_type(true)), ptr);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       vector_aligned_tag) {
-    m_value = _mm256_mask_load_epi32(
-        _mm256_set1_epi32(0), static_cast<__mmask8>(mask_type(true)), ptr);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
     _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
@@ -980,10 +1576,21 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
     _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
                             m_value);
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm256_mask_loadu_epi32(
+        _mm256_set1_epi32(0), static_cast<__mmask8>(mask_type(true)), ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = _mm256_mask_load_epi32(
+        _mm256_set1_epi32(0), static_cast<__mmask8>(mask_type(true)), ptr);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
       const {
     return m_value;
   }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
       simd const& lhs, simd const& rhs) noexcept {
     return simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
@@ -1106,6 +1713,217 @@ namespace Experimental {
   return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
                               static_cast<__m256i>(b)));
+}
+
+template <>
+class simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
+  __m512i m_value;
+
+ public:
+  using value_type = std::uint32_t;
+  using abi_type   = simd_abi::avx512_fixed_size<16>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 16;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm512_set1_epi32(
+            Kokkos::bit_cast<std::int32_t>(value_type(value)))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      __m512i const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& other)
+      : m_value(static_cast<__m512i>(other)) {}
+  template <class G,
+            std::enable_if_t<
+                // basically, can you do { value_type r =
+                // gen(std::integral_constant<std::size_t, i>()); }
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      G&& gen) noexcept
+      : m_value(_mm512_setr_epi32(
+            gen(std::integral_constant<std::size_t, 0>()),
+            gen(std::integral_constant<std::size_t, 1>()),
+            gen(std::integral_constant<std::size_t, 2>()),
+            gen(std::integral_constant<std::size_t, 3>()),
+            gen(std::integral_constant<std::size_t, 4>()),
+            gen(std::integral_constant<std::size_t, 5>()),
+            gen(std::integral_constant<std::size_t, 6>()),
+            gen(std::integral_constant<std::size_t, 7>()),
+            gen(std::integral_constant<std::size_t, 8>()),
+            gen(std::integral_constant<std::size_t, 9>()),
+            gen(std::integral_constant<std::size_t, 10>()),
+            gen(std::integral_constant<std::size_t, 11>()),
+            gen(std::integral_constant<std::size_t, 12>()),
+            gen(std::integral_constant<std::size_t, 13>()),
+            gen(std::integral_constant<std::size_t, 14>()),
+            gen(std::integral_constant<std::size_t, 15>()))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm512_mask_loadu_epi32(
+        _mm512_set1_epi32(0), static_cast<__mmask16>(mask_type(true)), ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = _mm512_mask_load_epi32(
+        _mm512_set1_epi32(0), static_cast<__mmask16>(mask_type(true)), ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm512_mask_storeu_epi32(ptr, static_cast<__mmask16>(mask_type(true)),
+                             m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    _mm512_mask_store_epi32(ptr, static_cast<__mmask16>(mask_type(true)),
+                            m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
+      const {
+    return m_value;
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
+                                   static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm512_add_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm512_sub_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epu32_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epu32_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epu32_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epu32_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmpeq_epu32_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm512_cmpneq_epu32_mask(static_cast<__m512i>(lhs),
+                                              static_cast<__m512i>(rhs)));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm512_srli_epi32(static_cast<__m512i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm512_srlv_epi32(static_cast<__m512i>(lhs),
+                                  static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm512_slli_epi32(static_cast<__m512i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm512_sllv_epi32(static_cast<__m512i>(lhs),
+                                  static_cast<__m512i>(rhs)));
+  }
+};
+
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>>
+abs(Experimental::simd<
+    std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return a;
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::avx512_fixed_size<16>>
+floor(Experimental::simd<
+      std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_cvtepu32_ps(static_cast<__m512i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::avx512_fixed_size<16>>
+ceil(Experimental::simd<
+     std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_cvtepu32_ps(static_cast<__m512i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::avx512_fixed_size<16>>
+round(Experimental::simd<
+      std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_cvtepu32_ps(static_cast<__m512i>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::avx512_fixed_size<16>>
+trunc(Experimental::simd<
+      std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return Experimental::simd<float,
+                            Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_cvtepu32_ps(static_cast<__m512i>(a)));
+}
+
+namespace Experimental {
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>
+    condition(
+        simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& a,
+        simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& b,
+        simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& c) {
+  return simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>(
+      _mm512_mask_blend_epi32(static_cast<__mmask16>(a),
+                              static_cast<__m512i>(c),
+                              static_cast<__m512i>(b)));
 }
 
 template <>
@@ -1717,6 +2535,95 @@ class where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
 };
 
 template <>
+class const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<16>>,
+                             simd<float, simd_abi::avx512_fixed_size<16>>> {
+ public:
+  using abi_type   = simd_abi::avx512_fixed_size<16>;
+  using value_type = simd<float, abi_type>;
+  using mask_type  = simd_mask<float, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(float* mem, element_aligned_tag) const {
+    _mm512_mask_storeu_ps(mem, static_cast<__mmask16>(m_mask),
+                          static_cast<__m512>(m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(float* mem, vector_aligned_tag) const {
+    _mm512_mask_store_ps(mem, static_cast<__mmask16>(m_mask),
+                         static_cast<__m512>(m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      float* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) const {
+    _mm512_mask_i32scatter_ps(mem, static_cast<__mmask16>(m_mask),
+                              static_cast<__m512i>(index),
+                              static_cast<__m512>(m_value), 4);
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
+  impl_get_value() const {
+    return m_value;
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
+  impl_get_mask() const {
+    return m_mask;
+  }
+};
+
+template <>
+class where_expression<simd_mask<float, simd_abi::avx512_fixed_size<16>>,
+                       simd<float, simd_abi::avx512_fixed_size<16>>>
+    : public const_where_expression<
+          simd_mask<float, simd_abi::avx512_fixed_size<16>>,
+          simd<float, simd_abi::avx512_fixed_size<16>>> {
+ public:
+  where_expression(
+      simd_mask<float, simd_abi::avx512_fixed_size<16>> const& mask_arg,
+      simd<float, simd_abi::avx512_fixed_size<16>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(float const* mem, element_aligned_tag) {
+    m_value = value_type(_mm512_mask_loadu_ps(
+        _mm512_set1_ps(0.0), static_cast<__mmask16>(m_mask), mem));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(float const* mem, vector_aligned_tag) {
+    m_value = value_type(_mm512_mask_load_ps(
+        _mm512_set1_ps(0.0), static_cast<__mmask16>(m_mask), mem));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      float const* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) {
+    m_value = value_type(_mm512_mask_i32gather_ps(
+        static_cast<__m512>(m_value), static_cast<__mmask16>(m_mask),
+        static_cast<__m512i>(index), mem, 4));
+  }
+  template <class U, std::enable_if_t<
+                         std::is_convertible_v<
+                             U, simd<float, simd_abi::avx512_fixed_size<16>>>,
+                         bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<float, simd_abi::avx512_fixed_size<16>>>(
+            std::forward<U>(x));
+    m_value = simd<float, simd_abi::avx512_fixed_size<16>>(_mm512_mask_blend_ps(
+        static_cast<__mmask16>(m_mask), static_cast<__m512>(m_value),
+        static_cast<__m512>(x_as_value_type)));
+  }
+};
+
+template <>
 class const_where_expression<
     simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
     simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> {
@@ -1812,6 +2719,98 @@ class where_expression<simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
 
 template <>
 class const_where_expression<
+    simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
+    simd<std::int32_t, simd_abi::avx512_fixed_size<16>>> {
+ public:
+  using abi_type   = simd_abi::avx512_fixed_size<16>;
+  using value_type = simd<std::int32_t, abi_type>;
+  using mask_type  = simd_mask<std::int32_t, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::int32_t* mem, element_aligned_tag) const {
+    _mm512_mask_storeu_epi32(mem, static_cast<__mmask16>(m_mask),
+                             static_cast<__m512i>(m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::int32_t* mem, vector_aligned_tag) const {
+    _mm512_mask_store_epi32(mem, static_cast<__mmask16>(m_mask),
+                            static_cast<__m512i>(m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      std::int32_t* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) const {
+    _mm512_mask_i32scatter_epi32(mem, static_cast<__mmask16>(m_mask),
+                                 static_cast<__m512i>(index),
+                                 static_cast<__m512i>(m_value), 4);
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
+  impl_get_value() const {
+    return m_value;
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
+  impl_get_mask() const {
+    return m_mask;
+  }
+};
+
+template <>
+class where_expression<simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
+                       simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+    : public const_where_expression<
+          simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
+          simd<std::int32_t, simd_abi::avx512_fixed_size<16>>> {
+ public:
+  where_expression(
+      simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask_arg,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<16>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::int32_t const* mem, element_aligned_tag) {
+    m_value = value_type(_mm512_mask_loadu_epi32(
+        _mm512_set1_epi32(0), static_cast<__mmask16>(m_mask), mem));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::int32_t const* mem, vector_aligned_tag) {
+    m_value = value_type(_mm512_mask_load_epi32(
+        _mm512_set1_epi32(0), static_cast<__mmask16>(m_mask), mem));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      std::int32_t const* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) {
+    m_value = value_type(_mm512_mask_i32gather_epi32(
+        static_cast<__m512i>(m_value), static_cast<__mmask16>(m_mask),
+        static_cast<__m512i>(index), mem, 4));
+  }
+  template <class U,
+            std::enable_if_t<
+                std::is_convertible_v<
+                    U, simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>(
+            std::forward<U>(x));
+    m_value = simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
+        _mm512_mask_blend_epi32(static_cast<__mmask16>(m_mask),
+                                static_cast<__m512i>(m_value),
+                                static_cast<__m512i>(x_as_value_type)));
+  }
+};
+
+template <>
+class const_where_expression<
     simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
     simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> {
  public:
@@ -1902,6 +2901,99 @@ class where_expression<simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
         _mm256_mask_blend_epi32(static_cast<__mmask8>(m_mask),
                                 static_cast<__m256i>(m_value),
                                 static_cast<__m256i>(x_as_value_type)));
+  }
+};
+
+template <>
+class const_where_expression<
+    simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>> {
+ public:
+  using abi_type   = simd_abi::avx512_fixed_size<16>;
+  using value_type = simd<std::uint32_t, abi_type>;
+  using mask_type  = simd_mask<std::uint32_t, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::uint32_t* mem, element_aligned_tag) const {
+    _mm512_mask_storeu_epi32(mem, static_cast<__mmask16>(m_mask),
+                             static_cast<__m512i>(m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::uint32_t* mem, vector_aligned_tag) const {
+    _mm512_mask_store_epi32(mem, static_cast<__mmask16>(m_mask),
+                            static_cast<__m512i>(m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      std::uint32_t* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) const {
+    _mm512_mask_i32scatter_epi32(mem, static_cast<__mmask16>(m_mask),
+                                 static_cast<__m512i>(index),
+                                 static_cast<__m512i>(m_value), 4);
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
+  impl_get_value() const {
+    return m_value;
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
+  impl_get_mask() const {
+    return m_mask;
+  }
+};
+
+template <>
+class where_expression<
+    simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+    : public const_where_expression<
+          simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
+          simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>> {
+ public:
+  where_expression(
+      simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask_arg,
+      simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::uint32_t const* mem, element_aligned_tag) {
+    m_value = value_type(_mm512_mask_loadu_epi32(
+        _mm512_set1_epi32(0), static_cast<__mmask16>(m_mask), mem));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::uint32_t const* mem, vector_aligned_tag) {
+    m_value = value_type(_mm512_mask_load_epi32(
+        _mm512_set1_epi32(0), static_cast<__mmask16>(m_mask), mem));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      std::uint32_t const* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) {
+    m_value = value_type(_mm512_mask_i32gather_epi32(
+        static_cast<__m512i>(m_value), static_cast<__mmask16>(m_mask),
+        static_cast<__m512i>(index), mem, 4));
+  }
+  template <class U,
+            std::enable_if_t<
+                std::is_convertible_v<
+                    U, simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>(
+            std::forward<U>(x));
+    m_value = simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>(
+        _mm512_mask_blend_epi32(static_cast<__mmask16>(m_mask),
+                                static_cast<__m512i>(m_value),
+                                static_cast<__m512i>(x_as_value_type)));
   }
 };
 

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -109,7 +109,8 @@ class neon_mask<Derived, 64, 2> {
     operator[](1) = bool(other[1]);
   }
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(neon_mask<U, 64,2> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(
+      neon_mask<U, 64, 2> const& other)
       : neon_mask(static_cast<uint64x2_t>(other)) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
@@ -211,10 +212,12 @@ class neon_mask<Derived, 32, 2> {
         m_value, 1);
   }
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(neon_mask<U, 64, 2> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(
+      neon_mask<U, 64, 2> const& other)
       : m_value(vqmovn_u64(static_cast<uint64x2_t>(other))) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(neon_mask<U, 32, 2> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(
+      neon_mask<U, 32, 2> const& other)
       : m_value(static_cast<uint32x2_t>(other)) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
@@ -1013,8 +1016,8 @@ class simd<float, simd_abi::neon_fixed_size<4>> {
       value_type* ptr, element_aligned_tag) const {
     vst1q_f32(ptr, m_value);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, vector_aligned_tag) const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
     vst1q_f32(ptr, m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit
@@ -1258,8 +1261,8 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
       value_type* ptr, element_aligned_tag) const {
     vst1_s32(ptr, m_value);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, vector_aligned_tag) const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
     vst1_s32(ptr, m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator int32x2_t()

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -42,11 +42,11 @@ class neon_fixed_size {};
 
 namespace Impl {
 
-template <class Derived, int Bits>
+template <class Derived, int Bits, int Size>
 class neon_mask;
 
 template <class Derived>
-class neon_mask<Derived, 64> {
+class neon_mask<Derived, 64, 2> {
   uint64x2_t m_value;
 
  public:
@@ -104,12 +104,12 @@ class neon_mask<Derived, 64> {
   }
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(
-      neon_mask<U, 32> const& other) {
+      neon_mask<U, 32, 2> const& other) {
     operator[](0) = bool(other[0]);
     operator[](1) = bool(other[1]);
   }
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(neon_mask<U, 64> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(neon_mask<U, 64,2> const& other)
       : neon_mask(static_cast<uint64x2_t>(other)) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
@@ -158,7 +158,7 @@ class neon_mask<Derived, 64> {
 };
 
 template <class Derived>
-class neon_mask<Derived, 32> {
+class neon_mask<Derived, 32, 2> {
   uint32x2_t m_value;
 
  public:
@@ -211,10 +211,10 @@ class neon_mask<Derived, 32> {
         m_value, 1);
   }
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(neon_mask<U, 64> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(neon_mask<U, 64, 2> const& other)
       : m_value(vqmovn_u64(static_cast<uint64x2_t>(other))) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(neon_mask<U, 32> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(neon_mask<U, 32, 2> const& other)
       : m_value(static_cast<uint32x2_t>(other)) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
@@ -260,14 +260,125 @@ class neon_mask<Derived, 32> {
   }
 };
 
+template <class Derived>
+class neon_mask<Derived, 32, 4> {
+  uint32x4_t m_value;
+
+ public:
+  class reference {
+    uint32x4_t& m_mask;
+    int m_lane;
+
+   public:
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(uint32x4_t& mask_arg,
+                                                    int lane_arg)
+        : m_mask(mask_arg), m_lane(lane_arg) {}
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
+    operator=(bool value) const {
+      switch (m_lane) {
+        case 0:
+          m_mask = vsetq_lane_u32(value ? 0xFFFFFFFFU : 0, m_mask, 0);
+          break;
+        case 1:
+          m_mask = vsetq_lane_u32(value ? 0xFFFFFFFFU : 0, m_mask, 1);
+          break;
+        case 2:
+          m_mask = vsetq_lane_u32(value ? 0xFFFFFFFFU : 0, m_mask, 2);
+          break;
+        case 3:
+          m_mask = vsetq_lane_u32(value ? 0xFFFFFFFFU : 0, m_mask, 3);
+          break;
+      }
+      return *this;
+    }
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
+      switch (m_lane) {
+        case 0: return vgetq_lane_u32(m_mask, 0) != 0;
+        case 1: return vgetq_lane_u32(m_mask, 1) != 0;
+        case 2: return vgetq_lane_u32(m_mask, 2) != 0;
+        case 3: return vgetq_lane_u32(m_mask, 3) != 0;
+      }
+      return false;
+    }
+  };
+  using value_type          = bool;
+  using abi_type            = simd_abi::neon_fixed_size<4>;
+  using implementation_type = uint32x4_t;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit neon_mask(value_type value)
+      : m_value(vmovq_n_u32(value ? 0xFFFFFFFFU : 0)) {}
+  template <class G,
+            std::enable_if_t<
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit neon_mask(
+      G&& gen) noexcept {
+    m_value = vsetq_lane_u32(
+        (gen(std::integral_constant<std::size_t, 0>()) ? 0xFFFFFFFFU : 0),
+        m_value, 0);
+    m_value = vsetq_lane_u32(
+        (gen(std::integral_constant<std::size_t, 1>()) ? 0xFFFFFFFFU : 0),
+        m_value, 1);
+    m_value = vsetq_lane_u32(
+        (gen(std::integral_constant<std::size_t, 2>()) ? 0xFFFFFFFFU : 0),
+        m_value, 2);
+    m_value = vsetq_lane_u32(
+        (gen(std::integral_constant<std::size_t, 3>()) ? 0xFFFFFFFFU : 0),
+        m_value, 3);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 4;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit neon_mask(
+      uint32x4_t const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator uint32x4_t()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reference(m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return static_cast<value_type>(
+        reference(const_cast<uint32x4_t&>(m_value), int(i)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Derived
+  operator||(neon_mask const& other) const {
+    return Derived(vorrq_u32(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Derived
+  operator&&(neon_mask const& other) const {
+    return Derived(vandq_u32(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Derived operator!() const {
+    auto const true_value = static_cast<uint32x4_t>(neon_mask(true));
+    return Derived(veorq_u32(m_value, true_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
+      neon_mask const& other) const {
+    uint32x4_t const elementwise_equality = vceqq_u32(m_value, other.m_value);
+    uint64x2_t const overall_equality_neon =
+        vreinterpretq_u64_u32(elementwise_equality);
+    return (overall_equality_neon[0] == 0xFFFFFFFFFFFFFFFFULL) &&
+           (overall_equality_neon[1] == 0xFFFFFFFFFFFFFFFFULL);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
+      neon_mask const& other) const {
+    return !operator==(other);
+  }
+};
+
 }  // namespace Impl
 
 template <class T>
 class simd_mask<T, simd_abi::neon_fixed_size<2>>
     : public Impl::neon_mask<simd_mask<T, simd_abi::neon_fixed_size<2>>,
-                             sizeof(T) * 8> {
+                             sizeof(T) * 8, 2> {
   using base_type = Impl::neon_mask<simd_mask<T, simd_abi::neon_fixed_size<2>>,
-                                    sizeof(T) * 8>;
+                                    sizeof(T) * 8, 2>;
 
  public:
   using implementation_type = typename base_type::implementation_type;
@@ -277,6 +388,35 @@ class simd_mask<T, simd_abi::neon_fixed_size<2>>
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
       simd_mask<U, simd_abi::neon_fixed_size<2>> const& other)
+      : base_type(other) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+      implementation_type const& value)
+      : base_type(value) {}
+  template <class G,
+            std::enable_if_t<
+                std::is_invocable_r_v<typename base_type::value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+      G&& gen) noexcept
+      : base_type(gen) {}
+};
+
+template <class T>
+class simd_mask<T, simd_abi::neon_fixed_size<4>>
+    : public Impl::neon_mask<simd_mask<T, simd_abi::neon_fixed_size<4>>,
+                             sizeof(T) * 8, 4> {
+  using base_type = Impl::neon_mask<simd_mask<T, simd_abi::neon_fixed_size<4>>,
+                                    sizeof(T) * 8, 4>;
+
+ public:
+  using implementation_type = typename base_type::implementation_type;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(bool value)
+      : base_type(value) {}
+  template <class U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
+      simd_mask<U, simd_abi::neon_fixed_size<4>> const& other)
       : base_type(other) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
       implementation_type const& value)
@@ -789,6 +929,256 @@ namespace Experimental {
 }
 
 template <>
+class simd<float, simd_abi::neon_fixed_size<4>> {
+  float32x4_t m_value;
+
+ public:
+  using value_type = float;
+  using abi_type   = simd_abi::neon_fixed_size<4>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  class reference {
+    float32x4_t& m_value;
+    int m_lane;
+
+   public:
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(float32x4_t& value_arg,
+                                                    int lane_arg)
+        : m_value(value_arg), m_lane(lane_arg) {}
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
+    operator=(float value) const {
+      switch (m_lane) {
+        case 0: m_value = vsetq_lane_f32(value, m_value, 0); break;
+        case 1: m_value = vsetq_lane_f32(value, m_value, 1); break;
+        case 2: m_value = vsetq_lane_f32(value, m_value, 2); break;
+        case 3: m_value = vsetq_lane_f32(value, m_value, 3); break;
+      }
+      return *this;
+    }
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator float() const {
+      switch (m_lane) {
+        case 0: return vgetq_lane_f32(m_value, 0);
+        case 1: return vgetq_lane_f32(m_value, 1);
+        case 2: return vgetq_lane_f32(m_value, 2);
+        case 3: return vgetq_lane_f32(m_value, 3);
+      }
+      return 0;
+    }
+  };
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 4;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(vmovq_n_f32(value_type(value))) {}
+  template <class G,
+            std::enable_if_t<
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(G&& gen) {
+    m_value = vsetq_lane_f32(gen(std::integral_constant<std::size_t, 0>()),
+                             m_value, 0);
+    m_value = vsetq_lane_f32(gen(std::integral_constant<std::size_t, 1>()),
+                             m_value, 1);
+    m_value = vsetq_lane_f32(gen(std::integral_constant<std::size_t, 2>()),
+                             m_value, 2);
+    m_value = vsetq_lane_f32(gen(std::integral_constant<std::size_t, 3>()),
+                             m_value, 3);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      float32x4_t const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reference(m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reference(const_cast<simd*>(this)->m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = vld1q_f32(ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = vld1q_f32(ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    vst1q_f32(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, vector_aligned_tag) const {
+    vst1q_f32(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit
+  operator float32x4_t() const {
+    return m_value;
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(vnegq_f32(m_value));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vmulq_f32(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vdivq_f32(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vaddq_f32(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vsubq_f32(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vcltq_f32(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vcgtq_f32(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vcleq_f32(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vcgeq_f32(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vceqq_f32(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return !(lhs == rhs);
+  }
+};
+
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+    abs(Experimental::simd<
+        float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+      vabsq_f32(static_cast<float32x4_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+    floor(Experimental::simd<
+          float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+      vrndmq_f32(static_cast<float32x4_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+    ceil(Experimental::simd<
+         float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+      vrndpq_f32(static_cast<float32x4_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+    round(Experimental::simd<
+          float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+      vrndxq_f32(static_cast<float32x4_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+    trunc(Experimental::simd<
+          float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+      vrndq_f32(static_cast<float32x4_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::neon_fixed_size<4>>
+copysign(
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
+        a,
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
+        b) {
+  uint32x4_t const sign_mask = vreinterpretq_u32_f32(vmovq_n_f32(-0.0));
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+      vreinterpretq_f32_u32(vorrq_u32(
+          vreinterpretq_u32_f32(static_cast<float32x4_t>(abs(a))),
+          vandq_u32(sign_mask,
+                    vreinterpretq_u32_f32(static_cast<float32x4_t>(b))))));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+    sqrt(Experimental::simd<
+         float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+      vsqrtq_f32(static_cast<float32x4_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::neon_fixed_size<4>>
+fma(Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
+        a,
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
+        b,
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
+        c) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+      vfmaq_f32(static_cast<float32x4_t>(c), static_cast<float32x4_t>(b),
+                static_cast<float32x4_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::neon_fixed_size<4>>
+max(Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
+        a,
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
+        b) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+      vmaxq_f32(static_cast<float32x4_t>(a), static_cast<float32x4_t>(b)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+    float, Experimental::simd_abi::neon_fixed_size<4>>
+min(Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
+        a,
+    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
+        b) {
+  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+      vminq_f32(static_cast<float32x4_t>(a), static_cast<float32x4_t>(b)));
+}
+
+namespace Experimental {
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<float, simd_abi::neon_fixed_size<4>>
+    condition(simd_mask<float, simd_abi::neon_fixed_size<4>> const& a,
+              simd<float, simd_abi::neon_fixed_size<4>> const& b,
+              simd<float, simd_abi::neon_fixed_size<4>> const& c) {
+  return simd<float, simd_abi::neon_fixed_size<4>>(
+      vbslq_f32(static_cast<uint32x4_t>(a), static_cast<float32x4_t>(b),
+                static_cast<float32x4_t>(c)));
+}
+
+template <>
 class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
   int32x2_t m_value;
 
@@ -868,8 +1258,8 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
       value_type* ptr, element_aligned_tag) const {
     vst1_s32(ptr, m_value);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
-                                                     vector_aligned_tag) const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, vector_aligned_tag) const {
     vst1_s32(ptr, m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator int32x2_t()
@@ -998,6 +1388,226 @@ namespace Experimental {
   return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
       vbsl_s32(static_cast<uint32x2_t>(a), static_cast<int32x2_t>(b),
                static_cast<int32x2_t>(c)));
+}
+
+template <>
+class simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
+  int32x4_t m_value;
+
+ public:
+  using value_type = std::int32_t;
+  using abi_type   = simd_abi::neon_fixed_size<4>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  class reference {
+    int32x4_t& m_value;
+    int m_lane;
+
+   public:
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(int32x4_t& value_arg,
+                                                    int lane_arg)
+        : m_value(value_arg), m_lane(lane_arg) {}
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
+    operator=(std::int32_t value) const {
+      switch (m_lane) {
+        case 0: m_value = vsetq_lane_s32(value, m_value, 0); break;
+        case 1: m_value = vsetq_lane_s32(value, m_value, 1); break;
+        case 2: m_value = vsetq_lane_s32(value, m_value, 2); break;
+        case 3: m_value = vsetq_lane_s32(value, m_value, 3); break;
+      }
+      return *this;
+    }
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator std::int32_t() const {
+      switch (m_lane) {
+        case 0: return vgetq_lane_s32(m_value, 0);
+        case 1: return vgetq_lane_s32(m_value, 1);
+        case 2: return vgetq_lane_s32(m_value, 2);
+        case 3: return vgetq_lane_s32(m_value, 3);
+      }
+      return 0;
+    }
+  };
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 4;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(vmovq_n_s32(value_type(value))) {}
+  template <class G,
+            std::enable_if_t<
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      G&& gen) noexcept {
+    m_value = vsetq_lane_s32(gen(std::integral_constant<std::size_t, 0>()),
+                             m_value, 0);
+    m_value = vsetq_lane_s32(gen(std::integral_constant<std::size_t, 1>()),
+                             m_value, 1);
+    m_value = vsetq_lane_s32(gen(std::integral_constant<std::size_t, 2>()),
+                             m_value, 2);
+    m_value = vsetq_lane_s32(gen(std::integral_constant<std::size_t, 3>()),
+                             m_value, 3);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      int32x4_t const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint64_t, abi_type> const& other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reference(m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reference(const_cast<simd*>(this)->m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = vld1q_s32(ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = vld1q_s32(ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    vst1q_s32(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    vst1q_s32(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator int32x4_t()
+      const {
+    return m_value;
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(vnegq_s32(m_value));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        vsubq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        vaddq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        vmulq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        vceqq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        vcgtq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        vcltq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        vcleq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        vcgeq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return !(lhs == rhs);
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return simd(vshlq_s32(static_cast<int32x4_t>(lhs),
+                          vnegq_s32(vmovq_n_s32(std::int32_t(rhs)))));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vshlq_s32(static_cast<int32x4_t>(lhs),
+                          vnegq_s32(static_cast<int32x4_t>(rhs))));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return simd(
+        vshlq_s32(static_cast<int32x4_t>(lhs), vmovq_n_s32(std::int32_t(rhs))));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        vshlq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
+  }
+};
+
+}  // namespace Experimental
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
+    abs(Experimental::simd<
+        std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+  return Experimental::simd<std::int32_t,
+                            Experimental::simd_abi::neon_fixed_size<4>>(
+      vabsq_s32(static_cast<int32x4_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
+    floor(Experimental::simd<
+          std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+  return a;
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
+    ceil(Experimental::simd<
+         std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+  return a;
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
+    round(Experimental::simd<
+          std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+  return a;
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
+    trunc(Experimental::simd<
+          std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+  return a;
+}
+
+namespace Experimental {
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int32_t, simd_abi::neon_fixed_size<4>>
+    condition(simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& a,
+              simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& b,
+              simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& c) {
+  return simd<std::int32_t, simd_abi::neon_fixed_size<4>>(
+      vbslq_s32(static_cast<uint32x4_t>(a), static_cast<int32x4_t>(b),
+                static_cast<int32x4_t>(c)));
 }
 
 template <>
@@ -1594,6 +2204,106 @@ class where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
 };
 
 template <>
+class const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<4>>,
+                             simd<float, simd_abi::neon_fixed_size<4>>> {
+ public:
+  using abi_type   = simd_abi::neon_fixed_size<4>;
+  using value_type = simd<float, abi_type>;
+  using mask_type  = simd_mask<float, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(float* mem, element_aligned_tag) const {
+    if (m_mask[0]) mem[0] = m_value[0];
+    if (m_mask[1]) mem[1] = m_value[1];
+    if (m_mask[2]) mem[2] = m_value[2];
+    if (m_mask[3]) mem[3] = m_value[3];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(float* mem, vector_aligned_tag) const {
+    if (m_mask[0]) mem[0] = m_value[0];
+    if (m_mask[1]) mem[1] = m_value[1];
+    if (m_mask[2]) mem[2] = m_value[2];
+    if (m_mask[3]) mem[3] = m_value[3];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      float* mem,
+      simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) const {
+    if (m_mask[0]) mem[index[0]] = m_value[0];
+    if (m_mask[1]) mem[index[1]] = m_value[1];
+    if (m_mask[2]) mem[index[2]] = m_value[2];
+    if (m_mask[3]) mem[index[3]] = m_value[3];
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
+  impl_get_value() const {
+    return m_value;
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
+  impl_get_mask() const {
+    return m_mask;
+  }
+};
+
+template <>
+class where_expression<simd_mask<float, simd_abi::neon_fixed_size<4>>,
+                       simd<float, simd_abi::neon_fixed_size<4>>>
+    : public const_where_expression<
+          simd_mask<float, simd_abi::neon_fixed_size<4>>,
+          simd<float, simd_abi::neon_fixed_size<4>>> {
+ public:
+  where_expression(
+      simd_mask<float, simd_abi::neon_fixed_size<4>> const& mask_arg,
+      simd<float, simd_abi::neon_fixed_size<4>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(float const* mem, element_aligned_tag) {
+    if (m_mask[0]) m_value[0] = mem[0];
+    if (m_mask[1]) m_value[1] = mem[1];
+    if (m_mask[2]) m_value[2] = mem[2];
+    if (m_mask[3]) m_value[3] = mem[3];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(float const* mem, vector_aligned_tag) {
+    if (m_mask[0]) m_value[0] = mem[0];
+    if (m_mask[1]) m_value[1] = mem[1];
+    if (m_mask[2]) m_value[2] = mem[2];
+    if (m_mask[3]) m_value[3] = mem[3];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      float const* mem,
+      simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) {
+    if (m_mask[0]) m_value[0] = mem[index[0]];
+    if (m_mask[1]) m_value[1] = mem[index[1]];
+    if (m_mask[2]) m_value[2] = mem[index[2]];
+    if (m_mask[3]) m_value[3] = mem[index[3]];
+  }
+  template <class U,
+            std::enable_if_t<std::is_convertible_v<
+                                 U, simd<float, simd_abi::neon_fixed_size<4>>>,
+                             bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<float, simd_abi::neon_fixed_size<4>>>(
+            std::forward<U>(x));
+    m_value = static_cast<simd<float, simd_abi::neon_fixed_size<4>>>(
+        vbslq_f32(static_cast<uint32x4_t>(m_mask),
+                  static_cast<float32x4_t>(x_as_value_type),
+                  static_cast<float32x4_t>(m_value)));
+  }
+};
+
+template <>
 class const_where_expression<
     simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
     simd<std::int32_t, simd_abi::neon_fixed_size<2>>> {
@@ -1683,6 +2393,108 @@ class where_expression<simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
         vbsl_s32(static_cast<uint32x2_t>(m_mask),
                  static_cast<int32x2_t>(x_as_value_type),
                  static_cast<int32x2_t>(m_value)));
+  }
+};
+
+template <>
+class const_where_expression<
+    simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
+    simd<std::int32_t, simd_abi::neon_fixed_size<4>>> {
+ public:
+  using abi_type   = simd_abi::neon_fixed_size<4>;
+  using value_type = simd<std::int32_t, abi_type>;
+  using mask_type  = simd_mask<std::int32_t, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::int32_t* mem, element_aligned_tag) const {
+    if (m_mask[0]) mem[0] = m_value[0];
+    if (m_mask[1]) mem[1] = m_value[1];
+    if (m_mask[2]) mem[2] = m_value[2];
+    if (m_mask[3]) mem[3] = m_value[3];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::int32_t* mem, vector_aligned_tag) const {
+    if (m_mask[0]) mem[0] = m_value[0];
+    if (m_mask[1]) mem[1] = m_value[1];
+    if (m_mask[2]) mem[2] = m_value[2];
+    if (m_mask[3]) mem[3] = m_value[3];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      std::int32_t* mem,
+      simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) const {
+    if (m_mask[0]) mem[index[0]] = m_value[0];
+    if (m_mask[1]) mem[index[1]] = m_value[1];
+    if (m_mask[2]) mem[index[2]] = m_value[2];
+    if (m_mask[3]) mem[index[3]] = m_value[3];
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
+  impl_get_value() const {
+    return m_value;
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
+  impl_get_mask() const {
+    return m_mask;
+  }
+};
+
+template <>
+class where_expression<simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
+                       simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+    : public const_where_expression<
+          simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
+          simd<std::int32_t, simd_abi::neon_fixed_size<4>>> {
+ public:
+  where_expression(
+      simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask_arg,
+      simd<std::int32_t, simd_abi::neon_fixed_size<4>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::int32_t const* mem, element_aligned_tag) {
+    if (m_mask[0]) m_value[0] = mem[0];
+    if (m_mask[1]) m_value[1] = mem[1];
+    if (m_mask[2]) m_value[2] = mem[2];
+    if (m_mask[3]) m_value[3] = mem[3];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::int32_t const* mem, vector_aligned_tag) {
+    if (m_mask[0]) m_value[0] = mem[0];
+    if (m_mask[1]) m_value[1] = mem[1];
+    if (m_mask[2]) m_value[2] = mem[2];
+    if (m_mask[3]) m_value[3] = mem[3];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      std::int32_t const* mem,
+      simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) {
+    if (m_mask[0]) m_value[0] = mem[index[0]];
+    if (m_mask[1]) m_value[1] = mem[index[1]];
+    if (m_mask[2]) m_value[2] = mem[index[2]];
+    if (m_mask[3]) m_value[3] = mem[index[3]];
+  }
+  template <
+      class U,
+      std::enable_if_t<
+          std::is_convertible_v<U, simd<int32_t, simd_abi::neon_fixed_size<4>>>,
+          bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<int32_t, simd_abi::neon_fixed_size<4>>>(
+            std::forward<U>(x));
+    m_value = static_cast<simd<int32_t, simd_abi::neon_fixed_size<4>>>(
+        vbslq_s32(static_cast<uint32x4_t>(m_mask),
+                  static_cast<int32x4_t>(x_as_value_type),
+                  static_cast<int32x4_t>(m_value)));
   }
 };
 

--- a/simd/unit_tests/CMakeLists.txt
+++ b/simd/unit_tests/CMakeLists.txt
@@ -1,7 +1,9 @@
 KOKKOS_INCLUDE_DIRECTORIES(${KOKKOS_SOURCE_DIR}/simd/unit_tests/include)
 
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  UnitTest_SIMD
-  SOURCES
-  UnitTestMain.cpp
-  TestSIMD.cpp)
+IF((NOT (Kokkos_ENABLE_CUDA AND WIN32)))
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    UnitTest_SIMD
+    SOURCES
+    UnitTestMain.cpp
+    TestSIMD.cpp)
+ENDIF()

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -181,6 +181,10 @@ class load_as_scalars {
   }
 };
 
+// Simple check to loosely test that T is a complete type.
+// Some capabilities are only defined for specific data type and abi pairs (i.e.
+// extended vector width); this is used to exclude pairs that
+// are not defined from being tested.
 template <typename T, typename = void>
 constexpr bool is_type_v = false;
 

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -181,4 +181,10 @@ class load_as_scalars {
   }
 };
 
+template <typename T, typename = void>
+constexpr bool is_type_v = false;
+
+template <typename T>
+constexpr bool is_type_v<T, decltype(void(sizeof(T)))> = true;
+
 #endif

--- a/simd/unit_tests/include/TestSIMD_Condition.hpp
+++ b/simd/unit_tests/include/TestSIMD_Condition.hpp
@@ -22,21 +22,23 @@
 
 template <typename Abi, typename DataType>
 inline void host_check_condition() {
-  using simd_type = typename Kokkos::Experimental::simd<DataType, Abi>;
-  using mask_type = typename simd_type::mask_type;
+  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+    using simd_type = typename Kokkos::Experimental::simd<DataType, Abi>;
+    using mask_type = typename simd_type::mask_type;
 
-  auto condition_op = [](mask_type const& mask, simd_type const& a,
-                         simd_type const& b) {
-    return Kokkos::Experimental::condition(mask, a, b);
-  };
+    auto condition_op = [](mask_type const& mask, simd_type const& a,
+                           simd_type const& b) {
+      return Kokkos::Experimental::condition(mask, a, b);
+    };
 
-  simd_type value_a(16);
-  simd_type value_b(20);
+    simd_type value_a(16);
+    simd_type value_b(20);
 
-  auto condition_result = condition_op(mask_type(false), value_a, value_b);
-  EXPECT_TRUE(all_of(condition_result == value_b));
-  condition_result = condition_op(mask_type(true), value_a, value_b);
-  EXPECT_TRUE(all_of(condition_result == value_a));
+    auto condition_result = condition_op(mask_type(false), value_a, value_b);
+    EXPECT_TRUE(all_of(condition_result == value_b));
+    condition_result = condition_op(mask_type(true), value_a, value_b);
+    EXPECT_TRUE(all_of(condition_result == value_a));
+  }
 }
 
 template <typename Abi, typename... DataTypes>
@@ -54,22 +56,24 @@ inline void host_check_condition_all_abis(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_condition() {
-  using simd_type = typename Kokkos::Experimental::simd<DataType, Abi>;
-  using mask_type = typename simd_type::mask_type;
-  kokkos_checker checker;
+  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+    using simd_type = typename Kokkos::Experimental::simd<DataType, Abi>;
+    using mask_type = typename simd_type::mask_type;
+    kokkos_checker checker;
 
-  auto condition_op = [](mask_type const& mask, simd_type const& a,
-                         simd_type const& b) {
-    return Kokkos::Experimental::condition(mask, a, b);
-  };
+    auto condition_op = [](mask_type const& mask, simd_type const& a,
+                           simd_type const& b) {
+      return Kokkos::Experimental::condition(mask, a, b);
+    };
 
-  simd_type value_a(16);
-  simd_type value_b(20);
+    simd_type value_a(16);
+    simd_type value_b(20);
 
-  auto condition_result = condition_op(mask_type(false), value_a, value_b);
-  checker.truth(all_of(condition_result == value_b));
-  condition_result = condition_op(mask_type(true), value_a, value_b);
-  checker.truth(all_of(condition_result == value_a));
+    auto condition_result = condition_op(mask_type(false), value_a, value_b);
+    checker.truth(all_of(condition_result == value_b));
+    condition_result = condition_op(mask_type(true), value_a, value_b);
+    checker.truth(all_of(condition_result == value_a));
+  }
 }
 
 template <typename Abi, typename... DataTypes>

--- a/simd/unit_tests/include/TestSIMD_Conversions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Conversions.hpp
@@ -22,40 +22,42 @@
 
 template <typename Abi>
 inline void host_check_conversions() {
-  {
-    auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
-    auto b = Kokkos::Experimental::simd<std::int64_t, Abi>(a);
-    EXPECT_TRUE(all_of(b == decltype(b)(1)));
-  }
-  {
-    auto a = Kokkos::Experimental::simd<std::int32_t, Abi>(1);
-    auto b = Kokkos::Experimental::simd<std::uint64_t, Abi>(a);
-    EXPECT_TRUE(all_of(b == decltype(b)(1)));
-  }
-  {
-    auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
-    auto b = Kokkos::Experimental::simd<std::int32_t, Abi>(a);
-    EXPECT_TRUE(all_of(b == decltype(b)(1)));
-  }
-  {
-    auto a = Kokkos::Experimental::simd_mask<double, Abi>(true);
-    auto b = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(a);
-    EXPECT_TRUE(b == decltype(b)(true));
-  }
-  {
-    auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-    auto b = Kokkos::Experimental::simd_mask<std::uint64_t, Abi>(a);
-    EXPECT_TRUE(b == decltype(b)(true));
-  }
-  {
-    auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-    auto b = Kokkos::Experimental::simd_mask<std::int64_t, Abi>(a);
-    EXPECT_TRUE(b == decltype(b)(true));
-  }
-  {
-    auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-    auto b = Kokkos::Experimental::simd_mask<double, Abi>(a);
-    EXPECT_TRUE(b == decltype(b)(true));
+  if constexpr (is_type_v<Kokkos::Experimental::simd<uint64_t, Abi>>) {
+    {
+      auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
+      auto b = Kokkos::Experimental::simd<std::int64_t, Abi>(a);
+      EXPECT_TRUE(all_of(b == decltype(b)(1)));
+    }
+    {
+      auto a = Kokkos::Experimental::simd<std::int32_t, Abi>(1);
+      auto b = Kokkos::Experimental::simd<std::uint64_t, Abi>(a);
+      EXPECT_TRUE(all_of(b == decltype(b)(1)));
+    }
+    {
+      auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
+      auto b = Kokkos::Experimental::simd<std::int32_t, Abi>(a);
+      EXPECT_TRUE(all_of(b == decltype(b)(1)));
+    }
+    {
+      auto a = Kokkos::Experimental::simd_mask<double, Abi>(true);
+      auto b = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(a);
+      EXPECT_TRUE(b == decltype(b)(true));
+    }
+    {
+      auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+      auto b = Kokkos::Experimental::simd_mask<std::uint64_t, Abi>(a);
+      EXPECT_TRUE(b == decltype(b)(true));
+    }
+    {
+      auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+      auto b = Kokkos::Experimental::simd_mask<std::int64_t, Abi>(a);
+      EXPECT_TRUE(b == decltype(b)(true));
+    }
+    {
+      auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+      auto b = Kokkos::Experimental::simd_mask<double, Abi>(a);
+      EXPECT_TRUE(b == decltype(b)(true));
+    }
   }
 }
 
@@ -67,41 +69,43 @@ inline void host_check_conversions_all_abis(
 
 template <typename Abi>
 KOKKOS_INLINE_FUNCTION void device_check_conversions() {
-  kokkos_checker checker;
-  {
-    auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
-    auto b = Kokkos::Experimental::simd<std::int64_t, Abi>(a);
-    checker.truth(all_of(b == decltype(b)(1)));
-  }
-  {
-    auto a = Kokkos::Experimental::simd<std::int32_t, Abi>(1);
-    auto b = Kokkos::Experimental::simd<std::uint64_t, Abi>(a);
-    checker.truth(all_of(b == decltype(b)(1)));
-  }
-  {
-    auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
-    auto b = Kokkos::Experimental::simd<std::int32_t, Abi>(a);
-    checker.truth(all_of(b == decltype(b)(1)));
-  }
-  {
-    auto a = Kokkos::Experimental::simd_mask<double, Abi>(true);
-    auto b = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(a);
-    checker.truth(b == decltype(b)(true));
-  }
-  {
-    auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-    auto b = Kokkos::Experimental::simd_mask<std::uint64_t, Abi>(a);
-    checker.truth(b == decltype(b)(true));
-  }
-  {
-    auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-    auto b = Kokkos::Experimental::simd_mask<std::int64_t, Abi>(a);
-    checker.truth(b == decltype(b)(true));
-  }
-  {
-    auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-    auto b = Kokkos::Experimental::simd_mask<double, Abi>(a);
-    checker.truth(b == decltype(b)(true));
+  if constexpr (is_type_v<Kokkos::Experimental::simd<uint64_t, Abi>>) {
+    kokkos_checker checker;
+    {
+      auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
+      auto b = Kokkos::Experimental::simd<std::int64_t, Abi>(a);
+      checker.truth(all_of(b == decltype(b)(1)));
+    }
+    {
+      auto a = Kokkos::Experimental::simd<std::int32_t, Abi>(1);
+      auto b = Kokkos::Experimental::simd<std::uint64_t, Abi>(a);
+      checker.truth(all_of(b == decltype(b)(1)));
+    }
+    {
+      auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
+      auto b = Kokkos::Experimental::simd<std::int32_t, Abi>(a);
+      checker.truth(all_of(b == decltype(b)(1)));
+    }
+    {
+      auto a = Kokkos::Experimental::simd_mask<double, Abi>(true);
+      auto b = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(a);
+      checker.truth(b == decltype(b)(true));
+    }
+    {
+      auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+      auto b = Kokkos::Experimental::simd_mask<std::uint64_t, Abi>(a);
+      checker.truth(b == decltype(b)(true));
+    }
+    {
+      auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+      auto b = Kokkos::Experimental::simd_mask<std::int64_t, Abi>(a);
+      checker.truth(b == decltype(b)(true));
+    }
+    {
+      auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+      auto b = Kokkos::Experimental::simd_mask<double, Abi>(a);
+      checker.truth(b == decltype(b)(true));
+    }
   }
 }
 

--- a/simd/unit_tests/include/TestSIMD_MaskOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MaskOps.hpp
@@ -22,25 +22,27 @@
 
 template <typename Abi, typename DataType>
 inline void host_check_mask_ops() {
-  using mask_type = Kokkos::Experimental::simd_mask<DataType, Abi>;
+  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+    using mask_type = Kokkos::Experimental::simd_mask<DataType, Abi>;
 
-  EXPECT_FALSE(none_of(mask_type(true)));
-  EXPECT_TRUE(none_of(mask_type(false)));
-  EXPECT_TRUE(all_of(mask_type(true)));
-  EXPECT_FALSE(all_of(mask_type(false)));
-  EXPECT_TRUE(any_of(mask_type(true)));
-  EXPECT_FALSE(any_of(mask_type(false)));
+    EXPECT_FALSE(none_of(mask_type(true)));
+    EXPECT_TRUE(none_of(mask_type(false)));
+    EXPECT_TRUE(all_of(mask_type(true)));
+    EXPECT_FALSE(all_of(mask_type(false)));
+    EXPECT_TRUE(any_of(mask_type(true)));
+    EXPECT_FALSE(any_of(mask_type(false)));
 
-  for (std::size_t i = 0; i < mask_type::size(); ++i) {
-    mask_type test_mask(KOKKOS_LAMBDA(std::size_t j) { return i == j; });
+    for (std::size_t i = 0; i < mask_type::size(); ++i) {
+      mask_type test_mask(KOKKOS_LAMBDA(std::size_t j) { return i == j; });
 
-    EXPECT_TRUE(any_of(test_mask));
-    EXPECT_FALSE(none_of(test_mask));
+      EXPECT_TRUE(any_of(test_mask));
+      EXPECT_FALSE(none_of(test_mask));
 
-    if constexpr (mask_type::size() > 1) {
-      EXPECT_FALSE(all_of(test_mask));
-    } else {
-      EXPECT_TRUE(all_of(test_mask));
+      if constexpr (mask_type::size() > 1) {
+        EXPECT_FALSE(all_of(test_mask));
+      } else {
+        EXPECT_TRUE(all_of(test_mask));
+      }
     }
   }
 }
@@ -60,25 +62,27 @@ inline void host_check_mask_ops_all_abis(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_mask_ops() {
-  using mask_type = Kokkos::Experimental::simd_mask<DataType, Abi>;
-  kokkos_checker checker;
-  checker.truth(!none_of(mask_type(true)));
-  checker.truth(none_of(mask_type(false)));
-  checker.truth(all_of(mask_type(true)));
-  checker.truth(!all_of(mask_type(false)));
-  checker.truth(any_of(mask_type(true)));
-  checker.truth(!any_of(mask_type(false)));
+  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+    using mask_type = Kokkos::Experimental::simd_mask<DataType, Abi>;
+    kokkos_checker checker;
+    checker.truth(!none_of(mask_type(true)));
+    checker.truth(none_of(mask_type(false)));
+    checker.truth(all_of(mask_type(true)));
+    checker.truth(!all_of(mask_type(false)));
+    checker.truth(any_of(mask_type(true)));
+    checker.truth(!any_of(mask_type(false)));
 
-  for (std::size_t i = 0; i < mask_type::size(); ++i) {
-    mask_type test_mask(KOKKOS_LAMBDA(std::size_t j) { return i == j; });
+    for (std::size_t i = 0; i < mask_type::size(); ++i) {
+      mask_type test_mask(KOKKOS_LAMBDA(std::size_t j) { return i == j; });
 
-    checker.truth(any_of(test_mask));
-    checker.truth(!none_of(test_mask));
+      checker.truth(any_of(test_mask));
+      checker.truth(!none_of(test_mask));
 
-    if constexpr (mask_type::size() > 1) {
-      checker.truth(!all_of(test_mask));
-    } else {
-      checker.truth(all_of(test_mask));
+      if constexpr (mask_type::size() > 1) {
+        checker.truth(!all_of(test_mask));
+      } else {
+        checker.truth(all_of(test_mask));
+      }
     }
   }
 }

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -121,31 +121,33 @@ inline void host_check_abi_size() {
 
 template <typename Abi, typename DataType>
 inline void host_check_math_ops() {
-  constexpr size_t n = 11;
-  constexpr size_t alignment =
-      Kokkos::Experimental::simd<DataType, Abi>::size() * sizeof(DataType);
+  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+    constexpr size_t n = 11;
+    constexpr size_t alignment =
+        Kokkos::Experimental::simd<DataType, Abi>::size() * sizeof(DataType);
 
-  host_check_abi_size<Abi, DataType>();
+    host_check_abi_size<Abi, DataType>();
 
-  if constexpr (!std::is_integral_v<DataType>) {
-    alignas(alignment) DataType const first_args[n] = {
-        0.1, 0.4, 0.5, 0.7, 1.0, 1.5, -2.0, 10.0, 0.0, 1.2, -2.8};
-    alignas(alignment) DataType const second_args[n] = {
-        1.0, 0.2, 1.1, 1.8, -0.1, -3.0, -2.4, 1.0, 13.0, -3.2, -2.1};
-    host_check_all_math_ops<Abi>(first_args, second_args);
-  } else {
-    if constexpr (std::is_signed_v<DataType>) {
-      alignas(alignment)
-          DataType const first_args[n] = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
-      alignas(alignment) DataType const second_args[n] = {1,  2, 1,  1,  1, -3,
-                                                          -2, 1, 13, -3, -2};
+    if constexpr (!std::is_integral_v<DataType>) {
+      alignas(alignment) DataType const first_args[n] = {
+          0.1, 0.4, 0.5, 0.7, 1.0, 1.5, -2.0, 10.0, 0.0, 1.2, -2.8};
+      alignas(alignment) DataType const second_args[n] = {
+          1.0, 0.2, 1.1, 1.8, -0.1, -3.0, -2.4, 1.0, 13.0, -3.2, -2.1};
       host_check_all_math_ops<Abi>(first_args, second_args);
     } else {
-      alignas(alignment)
-          DataType const first_args[n] = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
-      alignas(alignment)
-          DataType const second_args[n] = {1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2};
-      host_check_all_math_ops<Abi>(first_args, second_args);
+      if constexpr (std::is_signed_v<DataType>) {
+        alignas(alignment) DataType const first_args[n] = {1,  2,  -1, 10, 0, 1,
+                                                           -2, 10, 0,  1,  -2};
+        alignas(alignment) DataType const second_args[n] = {
+            1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2};
+        host_check_all_math_ops<Abi>(first_args, second_args);
+      } else {
+        alignas(alignment)
+            DataType const first_args[n] = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
+        alignas(alignment)
+            DataType const second_args[n] = {1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2};
+        host_check_all_math_ops<Abi>(first_args, second_args);
+      }
     }
   }
 }
@@ -253,25 +255,27 @@ KOKKOS_INLINE_FUNCTION void device_check_abi_size() {
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_math_ops() {
-  constexpr size_t n = 11;
+  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+    constexpr size_t n = 11;
 
-  device_check_abi_size<Abi, DataType>();
+    device_check_abi_size<Abi, DataType>();
 
-  if constexpr (!std::is_integral_v<DataType>) {
-    DataType const first_args[n]  = {0.1,  0.4,  0.5, 0.7, 1.0, 1.5,
-                                    -2.0, 10.0, 0.0, 1.2, -2.8};
-    DataType const second_args[n] = {1.0,  0.2, 1.1,  1.8,  -0.1, -3.0,
-                                     -2.4, 1.0, 13.0, -3.2, -2.1};
-    device_check_all_math_ops<Abi>(first_args, second_args);
-  } else {
-    if constexpr (std::is_signed_v<DataType>) {
-      DataType const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
-      DataType const second_args[n] = {1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2};
+    if constexpr (!std::is_integral_v<DataType>) {
+      DataType const first_args[n]  = {0.1,  0.4,  0.5, 0.7, 1.0, 1.5,
+                                      -2.0, 10.0, 0.0, 1.2, -2.8};
+      DataType const second_args[n] = {1.0,  0.2, 1.1,  1.8,  -0.1, -3.0,
+                                       -2.4, 1.0, 13.0, -3.2, -2.1};
       device_check_all_math_ops<Abi>(first_args, second_args);
     } else {
-      DataType const first_args[n]  = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
-      DataType const second_args[n] = {1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2};
-      device_check_all_math_ops<Abi>(first_args, second_args);
+      if constexpr (std::is_signed_v<DataType>) {
+        DataType const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
+        DataType const second_args[n] = {1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2};
+        device_check_all_math_ops<Abi>(first_args, second_args);
+      } else {
+        DataType const first_args[n]  = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
+        DataType const second_args[n] = {1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2};
+        device_check_all_math_ops<Abi>(first_args, second_args);
+      }
     }
   }
 }

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -122,7 +122,7 @@ inline void host_check_abi_size() {
 template <typename Abi, typename DataType>
 inline void host_check_math_ops() {
   if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
-    constexpr size_t n = 11;
+    constexpr size_t n = 16;
     constexpr size_t alignment =
         Kokkos::Experimental::simd<DataType, Abi>::size() * sizeof(DataType);
 
@@ -130,22 +130,24 @@ inline void host_check_math_ops() {
 
     if constexpr (!std::is_integral_v<DataType>) {
       alignas(alignment) DataType const first_args[n] = {
-          0.1, 0.4, 0.5, 0.7, 1.0, 1.5, -2.0, 10.0, 0.0, 1.2, -2.8};
+          0.1, 0.4, 0.5,  0.7, 1.0, 1.5,  -2.0, 10.0,
+          0.0, 1.2, -2.8, 3.0, 4.0, -0.1, 5.0,  -0.2};
       alignas(alignment) DataType const second_args[n] = {
-          1.0, 0.2, 1.1, 1.8, -0.1, -3.0, -2.4, 1.0, 13.0, -3.2, -2.1};
+          1.0,  0.2,  1.1,  1.8, -0.1,  -3.0, -2.4, 1.0,
+          13.0, -3.2, -2.1, 3.0, -15.0, -0.5, -0.2};
       host_check_all_math_ops<Abi>(first_args, second_args);
     } else {
       if constexpr (std::is_signed_v<DataType>) {
-        alignas(alignment) DataType const first_args[n] = {1,  2,  -1, 10, 0, 1,
-                                                           -2, 10, 0,  1,  -2};
+        alignas(alignment) DataType const first_args[n] = {
+            1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2, 10, -15, 7, 2, -10};
         alignas(alignment) DataType const second_args[n] = {
             1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2};
         host_check_all_math_ops<Abi>(first_args, second_args);
       } else {
-        alignas(alignment)
-            DataType const first_args[n] = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
-        alignas(alignment)
-            DataType const second_args[n] = {1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2};
+        alignas(alignment) DataType const first_args[n] = {
+            1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2, 11, 5, 8, 2, 14};
+        alignas(alignment) DataType const second_args[n] = {
+            1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2, 3, 6, 20, 5, 14};
         host_check_all_math_ops<Abi>(first_args, second_args);
       }
     }
@@ -256,24 +258,30 @@ KOKKOS_INLINE_FUNCTION void device_check_abi_size() {
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_math_ops() {
   if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
-    constexpr size_t n = 11;
+    constexpr size_t n = 16;
 
     device_check_abi_size<Abi, DataType>();
 
     if constexpr (!std::is_integral_v<DataType>) {
-      DataType const first_args[n]  = {0.1,  0.4,  0.5, 0.7, 1.0, 1.5,
-                                      -2.0, 10.0, 0.0, 1.2, -2.8};
-      DataType const second_args[n] = {1.0,  0.2, 1.1,  1.8,  -0.1, -3.0,
-                                       -2.4, 1.0, 13.0, -3.2, -2.1};
+      DataType const first_args[n]  = {0.1,  0.4,  0.5, 0.7, 1.0,  1.5,
+                                      -2.0, 10.0, 0.0, 1.2, -2.8, 3.0,
+                                      4.0,  -0.1, 5.0, -0.2};
+      DataType const second_args[n] = {1.0,  0.2,  1.1,   1.8,  -0.1,
+                                       -3.0, -2.4, 1.0,   13.0, -3.2,
+                                       -2.1, 3.0,  -15.0, -0.5, -0.2};
       device_check_all_math_ops<Abi>(first_args, second_args);
     } else {
       if constexpr (std::is_signed_v<DataType>) {
-        DataType const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
-        DataType const second_args[n] = {1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2};
+        DataType const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10,
+                                        0, 1, -2, -3, 7, 4, -9, -15};
+        DataType const second_args[n] = {1,  2,  1,  1,  1,   -3, -2, 1,
+                                         13, -3, -2, 10, -15, 7,  2,  -10};
         device_check_all_math_ops<Abi>(first_args, second_args);
       } else {
-        DataType const first_args[n]  = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
-        DataType const second_args[n] = {1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2};
+        DataType const first_args[n]  = {1, 2, 1, 10, 0, 1, 2, 10,
+                                        0, 1, 2, 11, 5, 8, 2, 14};
+        DataType const second_args[n] = {1,  2, 1, 1, 1, 3,  2, 1,
+                                         13, 3, 2, 3, 6, 20, 5, 14};
         device_check_all_math_ops<Abi>(first_args, second_args);
       }
     }

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -65,14 +65,16 @@ inline void host_check_all_reductions(const DataType (&args)[n]) {
 
 template <typename Abi, typename DataType>
 inline void host_check_reductions() {
-  constexpr size_t n = 11;
+  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+    constexpr size_t n = 11;
 
-  if constexpr (std::is_signed_v<DataType>) {
-    DataType const args[n] = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
-    host_check_all_reductions<Abi>(args);
-  } else {
-    DataType const args[n] = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
-    host_check_all_reductions<Abi>(args);
+    if constexpr (std::is_signed_v<DataType>) {
+      DataType const args[n] = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
+      host_check_all_reductions<Abi>(args);
+    } else {
+      DataType const args[n] = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
+      host_check_all_reductions<Abi>(args);
+    }
   }
 }
 
@@ -135,14 +137,16 @@ KOKKOS_INLINE_FUNCTION void device_check_all_reductions(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_reductions() {
-  constexpr size_t n = 11;
+  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+    constexpr size_t n = 11;
 
-  if constexpr (std::is_signed_v<DataType>) {
-    DataType const args[n] = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
-    device_check_all_reductions<Abi>(args);
-  } else {
-    DataType const args[n] = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
-    device_check_all_reductions<Abi>(args);
+    if constexpr (std::is_signed_v<DataType>) {
+      DataType const args[n] = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
+      device_check_all_reductions<Abi>(args);
+    } else {
+      DataType const args[n] = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
+      device_check_all_reductions<Abi>(args);
+    }
   }
 }
 

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -66,13 +66,15 @@ inline void host_check_all_reductions(const DataType (&args)[n]) {
 template <typename Abi, typename DataType>
 inline void host_check_reductions() {
   if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
-    constexpr size_t n = 11;
+    constexpr size_t n = 16;
 
     if constexpr (std::is_signed_v<DataType>) {
-      DataType const args[n] = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
+      DataType const args[n] = {1, 2, -1, 10,  0, 1,  -2,  10,
+                                0, 1, -2, -15, 5, 17, -22, 20};
       host_check_all_reductions<Abi>(args);
     } else {
-      DataType const args[n] = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
+      DataType const args[n] = {1, 2, 1, 10, 0, 1,  2,  10,
+                                0, 1, 2, 15, 5, 17, 22, 20};
       host_check_all_reductions<Abi>(args);
     }
   }
@@ -138,13 +140,15 @@ KOKKOS_INLINE_FUNCTION void device_check_all_reductions(
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_reductions() {
   if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
-    constexpr size_t n = 11;
+    constexpr size_t n = 16;
 
     if constexpr (std::is_signed_v<DataType>) {
-      DataType const args[n] = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
+      DataType const args[n] = {1, 2, -1, 10,  0, 1,  -2,  10,
+                                0, 1, -2, -15, 5, 17, -22, 20};
       device_check_all_reductions<Abi>(args);
     } else {
-      DataType const args[n] = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
+      DataType const args[n] = {1, 2, 1, 10, 0, 1,  2,  10,
+                                0, 1, 2, 15, 5, 17, 22, 20};
       device_check_all_reductions<Abi>(args);
     }
   }

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -103,34 +103,36 @@ inline void host_check_shift_op_all_loaders(ShiftOp shift_op,
 
 template <typename Abi, typename DataType>
 inline void host_check_shift_ops() {
-  if constexpr (std::is_integral_v<DataType>) {
-    using simd_type                 = Kokkos::Experimental::simd<DataType, Abi>;
-    constexpr std::size_t width     = simd_type::size();
-    constexpr std::size_t num_cases = 8;
-    constexpr size_t alignment =
-        Kokkos::Experimental::simd<DataType, Abi>::size() * sizeof(DataType);
+  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+    if constexpr (std::is_integral_v<DataType>) {
+      using simd_type             = Kokkos::Experimental::simd<DataType, Abi>;
+      constexpr std::size_t width = simd_type::size();
+      constexpr std::size_t num_cases = 8;
+      constexpr size_t alignment =
+          Kokkos::Experimental::simd<DataType, Abi>::size() * sizeof(DataType);
 
-    DataType max = std::numeric_limits<DataType>::max();
+      DataType max = std::numeric_limits<DataType>::max();
 
-    alignas(alignment) DataType shift_by[num_cases] = {
-        0, 1, 3, width / 2, width / 2 + 1, width - 1, width, width + 1};
-    alignas(alignment) DataType test_vals[width];
-    for (std::size_t i = 0; i < width; ++i) {
-      DataType inc = max / width;
-      test_vals[i] = i * inc + 1;
-    }
+      alignas(alignment) DataType shift_by[num_cases] = {
+          0, 1, 3, width / 2, width / 2 + 1, width - 1, width, width + 1};
+      alignas(alignment) DataType test_vals[width];
+      for (std::size_t i = 0; i < width; ++i) {
+        DataType inc = max / width;
+        test_vals[i] = i * inc + 1;
+      }
 
-    host_check_shift_op_all_loaders<Abi>(shift_right(), test_vals, shift_by,
-                                         num_cases);
-    host_check_shift_op_all_loaders<Abi>(shift_left(), test_vals, shift_by,
-                                         num_cases);
-
-    if constexpr (std::is_signed_v<DataType>) {
-      for (std::size_t i = 0; i < width; ++i) test_vals[i] *= -1;
       host_check_shift_op_all_loaders<Abi>(shift_right(), test_vals, shift_by,
                                            num_cases);
       host_check_shift_op_all_loaders<Abi>(shift_left(), test_vals, shift_by,
                                            num_cases);
+
+      if constexpr (std::is_signed_v<DataType>) {
+        for (std::size_t i = 0; i < width; ++i) test_vals[i] *= -1;
+        host_check_shift_op_all_loaders<Abi>(shift_right(), test_vals, shift_by,
+                                             num_cases);
+        host_check_shift_op_all_loaders<Abi>(shift_left(), test_vals, shift_by,
+                                             num_cases);
+      }
     }
   }
 }
@@ -224,33 +226,35 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_op_all_loaders(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_shift_ops() {
-  if constexpr (std::is_integral_v<DataType>) {
-    using simd_type                 = Kokkos::Experimental::simd<DataType, Abi>;
-    constexpr std::size_t width     = simd_type::size();
-    constexpr std::size_t num_cases = 8;
+  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+    if constexpr (std::is_integral_v<DataType>) {
+      using simd_type             = Kokkos::Experimental::simd<DataType, Abi>;
+      constexpr std::size_t width = simd_type::size();
+      constexpr std::size_t num_cases = 8;
 
-    DataType max = Kokkos::reduction_identity<DataType>::max();
+      DataType max = Kokkos::reduction_identity<DataType>::max();
 
-    DataType shift_by[num_cases] = {
-        0, 1, 3, width / 2, width / 2 + 1, width - 1, width, width + 1};
-    DataType test_vals[width];
+      DataType shift_by[num_cases] = {
+          0, 1, 3, width / 2, width / 2 + 1, width - 1, width, width + 1};
+      DataType test_vals[width];
 
-    for (std::size_t i = 0; i < width; ++i) {
-      DataType inc = max / width;
-      test_vals[i] = i * inc + 1;
-    }
+      for (std::size_t i = 0; i < width; ++i) {
+        DataType inc = max / width;
+        test_vals[i] = i * inc + 1;
+      }
 
-    device_check_shift_op_all_loaders<Abi>(shift_right(), test_vals, shift_by,
-                                           num_cases);
-    device_check_shift_op_all_loaders<Abi>(shift_left(), test_vals, shift_by,
-                                           num_cases);
-
-    if constexpr (std::is_signed_v<DataType>) {
-      for (std::size_t i = 0; i < width; ++i) test_vals[i] *= -1;
       device_check_shift_op_all_loaders<Abi>(shift_right(), test_vals, shift_by,
                                              num_cases);
       device_check_shift_op_all_loaders<Abi>(shift_left(), test_vals, shift_by,
                                              num_cases);
+
+      if constexpr (std::is_signed_v<DataType>) {
+        for (std::size_t i = 0; i < width; ++i) test_vals[i] *= -1;
+        device_check_shift_op_all_loaders<Abi>(shift_right(), test_vals,
+                                               shift_by, num_cases);
+        device_check_shift_op_all_loaders<Abi>(shift_left(), test_vals,
+                                               shift_by, num_cases);
+      }
     }
   }
 }

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -107,13 +107,14 @@ inline void host_check_shift_ops() {
     if constexpr (std::is_integral_v<DataType>) {
       using simd_type             = Kokkos::Experimental::simd<DataType, Abi>;
       constexpr std::size_t width = simd_type::size();
-      constexpr std::size_t num_cases = 8;
+      constexpr std::size_t num_cases = 16;
       constexpr size_t alignment =
           Kokkos::Experimental::simd<DataType, Abi>::size() * sizeof(DataType);
 
       DataType max = std::numeric_limits<DataType>::max();
 
       alignas(alignment) DataType shift_by[num_cases] = {
+          0, 1, 3, width / 2, width / 2 + 1, width - 1, width, width + 1,
           0, 1, 3, width / 2, width / 2 + 1, width - 1, width, width + 1};
       alignas(alignment) DataType test_vals[width];
       for (std::size_t i = 0; i < width; ++i) {
@@ -230,11 +231,12 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_ops() {
     if constexpr (std::is_integral_v<DataType>) {
       using simd_type             = Kokkos::Experimental::simd<DataType, Abi>;
       constexpr std::size_t width = simd_type::size();
-      constexpr std::size_t num_cases = 8;
+      constexpr std::size_t num_cases = 16;
 
       DataType max = Kokkos::reduction_identity<DataType>::max();
 
       DataType shift_by[num_cases] = {
+          0, 1, 3, width / 2, width / 2 + 1, width - 1, width, width + 1,
           0, 1, 3, width / 2, width / 2 + 1, width - 1, width, width + 1};
       DataType test_vals[width];
 

--- a/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
+++ b/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
@@ -28,7 +28,8 @@ inline void host_check_where_expr_scatter_to() {
     using mask_type  = typename simd_type::mask_type;
 
     std::size_t nlanes = simd_type::size();
-    DataType init[]    = {11, 13, 17, 19, 23, 29, 31, 37};
+    DataType init[]    = {11, 13, 17, 19, 23, 29, 31, 37,
+                       53, 71, 79, 83, 89, 93, 97, 103};
     simd_type src;
     src.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
@@ -36,7 +37,7 @@ inline void host_check_where_expr_scatter_to() {
       mask_type mask(true);
       mask[idx] = false;
 
-      DataType dst[8] = {0};
+      DataType dst[simd_type::size()] = {0};
       index_type index;
       simd_type expected_result;
       for (std::size_t i = 0; i < nlanes; ++i) {
@@ -62,7 +63,8 @@ inline void host_check_where_expr_gather_from() {
     using mask_type  = typename simd_type::mask_type;
 
     std::size_t nlanes = simd_type::size();
-    DataType src[]     = {11, 13, 17, 19, 23, 29, 31, 37};
+    DataType src[]     = {11, 13, 17, 19, 23, 29, 31, 37,
+                      53, 71, 79, 83, 89, 93, 97, 103};
 
     for (std::size_t idx = 0; idx < nlanes; ++idx) {
       mask_type mask(true);
@@ -110,7 +112,8 @@ KOKKOS_INLINE_FUNCTION void device_check_where_expr_scatter_to() {
     using mask_type  = typename simd_type::mask_type;
 
     std::size_t nlanes = simd_type::size();
-    DataType init[]    = {11, 13, 17, 19, 23, 29, 31, 37};
+    DataType init[]    = {11, 13, 17, 19, 23, 29, 31, 37,
+                       53, 71, 79, 83, 89, 93, 97, 103};
     simd_type src;
     src.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
@@ -118,7 +121,7 @@ KOKKOS_INLINE_FUNCTION void device_check_where_expr_scatter_to() {
       mask_type mask(true);
       mask[idx] = false;
 
-      DataType dst[8] = {0};
+      DataType dst[simd_type::size()] = {0};
       index_type index;
       simd_type expected_result;
       for (std::size_t i = 0; i < nlanes; ++i) {
@@ -143,7 +146,8 @@ KOKKOS_INLINE_FUNCTION void device_check_where_expr_gather_from() {
   using mask_type  = typename simd_type::mask_type;
 
   std::size_t nlanes = simd_type::size();
-  DataType src[]     = {11, 13, 17, 19, 23, 29, 31, 37};
+  DataType src[]     = {11, 13, 17, 19, 23, 29, 31, 37,
+                    53, 71, 79, 83, 89, 93, 97, 103};
 
   for (std::size_t idx = 0; idx < nlanes; ++idx) {
     mask_type mask(true);

--- a/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
+++ b/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
@@ -22,60 +22,64 @@
 
 template <typename Abi, typename DataType>
 inline void host_check_where_expr_scatter_to() {
-  using simd_type  = Kokkos::Experimental::simd<DataType, Abi>;
-  using index_type = Kokkos::Experimental::simd<std::int32_t, Abi>;
-  using mask_type  = typename simd_type::mask_type;
+  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+    using simd_type  = Kokkos::Experimental::simd<DataType, Abi>;
+    using index_type = Kokkos::Experimental::simd<std::int32_t, Abi>;
+    using mask_type  = typename simd_type::mask_type;
 
-  std::size_t nlanes = simd_type::size();
-  DataType init[]    = {11, 13, 17, 19, 23, 29, 31, 37};
-  simd_type src;
-  src.copy_from(init, Kokkos::Experimental::simd_flag_default);
+    std::size_t nlanes = simd_type::size();
+    DataType init[]    = {11, 13, 17, 19, 23, 29, 31, 37};
+    simd_type src;
+    src.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
-  for (std::size_t idx = 0; idx < nlanes; ++idx) {
-    mask_type mask(true);
-    mask[idx] = false;
+    for (std::size_t idx = 0; idx < nlanes; ++idx) {
+      mask_type mask(true);
+      mask[idx] = false;
 
-    DataType dst[8] = {0};
-    index_type index;
-    simd_type expected_result;
-    for (std::size_t i = 0; i < nlanes; ++i) {
-      dst[i]             = (2 + (i * 2));
-      index[i]           = i;
-      expected_result[i] = (mask[i]) ? src[index[i]] : dst[i];
+      DataType dst[8] = {0};
+      index_type index;
+      simd_type expected_result;
+      for (std::size_t i = 0; i < nlanes; ++i) {
+        dst[i]             = (2 + (i * 2));
+        index[i]           = i;
+        expected_result[i] = (mask[i]) ? src[index[i]] : dst[i];
+      }
+      where(mask, src).scatter_to(dst, index);
+
+      simd_type dst_simd;
+      dst_simd.copy_from(dst, Kokkos::Experimental::simd_flag_default);
+
+      host_check_equality(expected_result, dst_simd, nlanes);
     }
-    where(mask, src).scatter_to(dst, index);
-
-    simd_type dst_simd;
-    dst_simd.copy_from(dst, Kokkos::Experimental::simd_flag_default);
-
-    host_check_equality(expected_result, dst_simd, nlanes);
   }
 }
 
 template <typename Abi, typename DataType>
 inline void host_check_where_expr_gather_from() {
-  using simd_type  = Kokkos::Experimental::simd<DataType, Abi>;
-  using index_type = Kokkos::Experimental::simd<std::int32_t, Abi>;
-  using mask_type  = typename simd_type::mask_type;
+  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+    using simd_type  = Kokkos::Experimental::simd<DataType, Abi>;
+    using index_type = Kokkos::Experimental::simd<std::int32_t, Abi>;
+    using mask_type  = typename simd_type::mask_type;
 
-  std::size_t nlanes = simd_type::size();
-  DataType src[]     = {11, 13, 17, 19, 23, 29, 31, 37};
+    std::size_t nlanes = simd_type::size();
+    DataType src[]     = {11, 13, 17, 19, 23, 29, 31, 37};
 
-  for (std::size_t idx = 0; idx < nlanes; ++idx) {
-    mask_type mask(true);
-    mask[idx] = false;
+    for (std::size_t idx = 0; idx < nlanes; ++idx) {
+      mask_type mask(true);
+      mask[idx] = false;
 
-    simd_type dst;
-    index_type index;
-    simd_type expected_result;
-    for (std::size_t i = 0; i < nlanes; ++i) {
-      dst[i]             = (2 + (i * 2));
-      index[i]           = i;
-      expected_result[i] = (mask[i]) ? src[index[i]] : dst[i];
+      simd_type dst;
+      index_type index;
+      simd_type expected_result;
+      for (std::size_t i = 0; i < nlanes; ++i) {
+        dst[i]             = (2 + (i * 2));
+        index[i]           = i;
+        expected_result[i] = (mask[i]) ? src[index[i]] : dst[i];
+      }
+      where(mask, dst).gather_from(src, index);
+
+      host_check_equality(expected_result, dst, nlanes);
     }
-    where(mask, dst).gather_from(src, index);
-
-    host_check_equality(expected_result, dst, nlanes);
   }
 }
 
@@ -100,33 +104,35 @@ inline void host_check_where_expr_all_abis(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_where_expr_scatter_to() {
-  using simd_type  = Kokkos::Experimental::simd<DataType, Abi>;
-  using index_type = Kokkos::Experimental::simd<std::int32_t, Abi>;
-  using mask_type  = typename simd_type::mask_type;
+  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+    using simd_type  = Kokkos::Experimental::simd<DataType, Abi>;
+    using index_type = Kokkos::Experimental::simd<std::int32_t, Abi>;
+    using mask_type  = typename simd_type::mask_type;
 
-  std::size_t nlanes = simd_type::size();
-  DataType init[]    = {11, 13, 17, 19, 23, 29, 31, 37};
-  simd_type src;
-  src.copy_from(init, Kokkos::Experimental::simd_flag_default);
+    std::size_t nlanes = simd_type::size();
+    DataType init[]    = {11, 13, 17, 19, 23, 29, 31, 37};
+    simd_type src;
+    src.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
-  for (std::size_t idx = 0; idx < nlanes; ++idx) {
-    mask_type mask(true);
-    mask[idx] = false;
+    for (std::size_t idx = 0; idx < nlanes; ++idx) {
+      mask_type mask(true);
+      mask[idx] = false;
 
-    DataType dst[8] = {0};
-    index_type index;
-    simd_type expected_result;
-    for (std::size_t i = 0; i < nlanes; ++i) {
-      dst[i]             = (2 + (i * 2));
-      index[i]           = i;
-      expected_result[i] = (mask[i]) ? src[index[i]] : dst[i];
+      DataType dst[8] = {0};
+      index_type index;
+      simd_type expected_result;
+      for (std::size_t i = 0; i < nlanes; ++i) {
+        dst[i]             = (2 + (i * 2));
+        index[i]           = i;
+        expected_result[i] = (mask[i]) ? src[index[i]] : dst[i];
+      }
+      where(mask, src).scatter_to(dst, index);
+
+      simd_type dst_simd;
+      dst_simd.copy_from(dst, Kokkos::Experimental::simd_flag_default);
+
+      device_check_equality(expected_result, dst_simd, nlanes);
     }
-    where(mask, src).scatter_to(dst, index);
-
-    simd_type dst_simd;
-    dst_simd.copy_from(dst, Kokkos::Experimental::simd_flag_default);
-
-    device_check_equality(expected_result, dst_simd, nlanes);
   }
 }
 


### PR DESCRIPTION
Currently in Kokkos SIMD, all simd types use a uniformly set size per simd backend. This size is determined by the size of the largest simd register available in a simd backend divided by 64 (bit). However, 32 bit types can take advantage of this and pack twice as much of data than 64 bit types could in a given simd register.

This PR adds simd types with wider vector for:

- `AVX2`: `float`, `int32_t` (size 8)
- `AVX512`: `float`, `int32_t`, `uint32_t` (size 16)
- `NEON`: `float`, `int32_t` (size 4)