### PR TITLE
Add test for current CTAD support with RangePolicy

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -86,6 +86,7 @@ SET(COMPILE_ONLY_SOURCES
   TestDetectionIdiom.cpp
   TestBitManipulation.cpp
   TestInterOp.cpp
+  TestRangePolicyCTAD.cpp
   TestStringManipulation.cpp
   TestVersionMacros.cpp
   TestViewRank.cpp

--- a/core/unit_test/TestRangePolicyCTAD.cpp
+++ b/core/unit_test/TestRangePolicyCTAD.cpp
@@ -1,0 +1,89 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+namespace {
+
+struct TestRangePolicyCTAD {
+  struct ImplicitlyConvertibleToDefaultExecutionSpace {
+    [[maybe_unused]] operator Kokkos::DefaultExecutionSpace() const;
+  };
+  static_assert(!Kokkos::is_execution_space_v<
+                ImplicitlyConvertibleToDefaultExecutionSpace>);
+
+  [[maybe_unused]] static inline Kokkos::DefaultExecutionSpace des;
+  [[maybe_unused]] static inline ImplicitlyConvertibleToDefaultExecutionSpace
+      nes;
+
+  [[maybe_unused]] static inline int64_t i64;
+  [[maybe_unused]] static inline int32_t i32;
+  [[maybe_unused]] static inline Kokkos::ChunkSize cs{0};
+
+  // RangePolicy()
+
+  // Workaround for gcc 8.4 bug, as
+  //    static_assert(std::is_same_v<Kokkos::RangePolicy<>,
+  //                                 decltype(Kokkos::RangePolicy())>);
+  // gives us:
+  //    error: cannot deduce template arguments for ‘RangePolicy’ from ()
+  //    error: template argument 2 is invalid
+  [[maybe_unused]] static inline Kokkos::RangePolicy rp{};
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rp)>);
+
+  // RangePolicy(index_type, index_type)
+
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>,
+                               decltype(Kokkos::RangePolicy(i64, i64))>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>,
+                               decltype(Kokkos::RangePolicy(i32, i32))>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>,
+                               decltype(Kokkos::RangePolicy(i32, i64))>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>,
+                               decltype(Kokkos::RangePolicy(i64, i32))>);
+
+  // RangePolicy(index_type, index_type, Args...)
+
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>,
+                               decltype(Kokkos::RangePolicy(i64, i64, cs))>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>,
+                               decltype(Kokkos::RangePolicy(i32, i32, cs))>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>,
+                               decltype(Kokkos::RangePolicy(i32, i64, cs))>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>,
+                               decltype(Kokkos::RangePolicy(i64, i32, cs))>);
+
+  // RangePolicy(execution_space, index_type, index_type)
+
+  // none (ambiguous deduction for template arguments)
+
+  // RangePolicy(execution_space, index_type, index_type, Args...)
+
+  static_assert(
+      std::is_same_v<Kokkos::RangePolicy<>,
+                     decltype(Kokkos::RangePolicy(des, i64, i64, cs))>);
+  static_assert(
+      std::is_same_v<Kokkos::RangePolicy<>,
+                     decltype(Kokkos::RangePolicy(des, i32, i32, cs))>);
+  static_assert(
+      std::is_same_v<Kokkos::RangePolicy<>,
+                     decltype(Kokkos::RangePolicy(nes, i64, i64, cs))>);
+  static_assert(
+      std::is_same_v<Kokkos::RangePolicy<>,
+                     decltype(Kokkos::RangePolicy(nes, i32, i32, cs))>);
+};  // TestRangePolicyCTAD struct
+
+}  // namespace

--- a/core/unit_test/TestRangePolicyCTAD.cpp
+++ b/core/unit_test/TestRangePolicyCTAD.cpp
@@ -19,7 +19,7 @@
 namespace {
 
 template <class... Args>
-using PolicyMaker = decltype(Kokkos::RangePolicy(std::declval<Args>()...));
+using PolicyMaker = decltype(::Kokkos::RangePolicy(std::declval<Args>()...));
 
 template <class Policy, class... Args>
 inline constexpr bool IsSamePolicy =
@@ -42,7 +42,12 @@ struct TestRangePolicyCTAD {
 
   // RangePolicy()
 
+  // Guard against GGC 8.4 bug
+  // error: cannot deduce template arguments for ‘RangePolicy’ from ()
+  // error: template argument 2 is invalid
+#if !defined(KOKKOS_COMPILER_GNU) || (KOKKOS_COMPILER_GNU > 900)
   KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<> /*, no argument */);
+#endif
 
   // RangePolicy(index_type, index_type)
 

--- a/core/unit_test/TestRangePolicyCTAD.cpp
+++ b/core/unit_test/TestRangePolicyCTAD.cpp
@@ -54,6 +54,7 @@ struct TestRangePolicyCTAD {
 
   // RangePolicy(index_type, index_type)
 
+#if !defined(KOKKOS_COMPILER_NVCC) || KOKKOS_COMPILER_NVCC >= 1120
   KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, i64, i64);
   KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, i64, i32);
   KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, i32, i64);
@@ -76,6 +77,7 @@ struct TestRangePolicyCTAD {
   KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, des, i32, i32, cs);
   KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, nes, i64, i64, cs);
   KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, nes, i32, i32, cs);
+#endif
 };  // TestRangePolicyCTAD struct
 
 // To eliminate maybe_unused warning on some compilers

--- a/core/unit_test/TestRangePolicyCTAD.cpp
+++ b/core/unit_test/TestRangePolicyCTAD.cpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #include <Kokkos_Core.hpp>
+#include "Kokkos_Core_fwd.hpp"
 
 namespace {
 
@@ -29,7 +30,9 @@ inline constexpr bool IsSamePolicy =
 
 struct TestRangePolicyCTAD {
   struct ImplicitlyConvertibleToDefaultExecutionSpace {
-    [[maybe_unused]] operator Kokkos::DefaultExecutionSpace() const;
+    operator Kokkos::DefaultExecutionSpace() const {
+      return Kokkos::DefaultExecutionSpace();
+    }
   };
   static_assert(!Kokkos::is_execution_space_v<
                 ImplicitlyConvertibleToDefaultExecutionSpace>);
@@ -74,5 +77,9 @@ struct TestRangePolicyCTAD {
   KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, nes, i64, i64, cs);
   KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, nes, i32, i32, cs);
 };  // TestRangePolicyCTAD struct
+
+// To eliminate maybe_unused warning on some compilers
+const Kokkos::DefaultExecutionSpace des =
+    TestRangePolicyCTAD::ImplicitlyConvertibleToDefaultExecutionSpace();
 
 }  // namespace


### PR DESCRIPTION
Extracted from #5517
Intended as a base for discussion when adding deduction guides in a follow up PR.

Adding a compile-only test to showcase what currently works before we make changes.