### PR TITLE
Explicity pass template params to ZeroMemset for intel icpc compilers

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1359,7 +1359,7 @@ contiguous_fill_or_memset(
       && !std::is_same_v<ExecutionSpace, Kokkos::OpenMP>
 #endif
   )
-#if defined(KOKKOS_COMPILER_INTEL) && && (KOKKOS_COMPILER_INTEL < 2100)
+#if defined(KOKKOS_COMPILER_INTEL) && &&(KOKKOS_COMPILER_INTEL < 2100)
     // icpc needs extra ctad help to compile
     // See https://github.com/kokkos/kokkos/issues/6775
     ZeroMemset<ExecutionSpace, View<DT, DP...>>(exec_space, dst);
@@ -1397,7 +1397,7 @@ contiguous_fill_or_memset(
 // leading to the significant performance issues
 #ifndef KOKKOS_ARCH_A64FX
   if (Impl::is_zero_byte(value))
-#if defined(KOKKOS_COMPILER_INTEL) && && (KOKKOS_COMPILER_INTEL < 2100)
+#if defined(KOKKOS_COMPILER_INTEL) && &&(KOKKOS_COMPILER_INTEL < 2100)
     // icpc needs extra ctad help to compile
     // See https://github.com/kokkos/kokkos/issues/6775
     ZeroMemset<exec_space_type, ViewType>(exec, dst);

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1359,13 +1359,13 @@ contiguous_fill_or_memset(
       && !std::is_same_v<ExecutionSpace, Kokkos::OpenMP>
 #endif
   )
-#if defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL < 2100)
-    // icpc needs extra ctad help to compile
+    // FIXME intel/19 icpc fails to deduce template parameters here,
+    // resulting in compilation errors; explicitly passing the template 
+    // parameters to ZeroMemset helps workaround the issue
     // See https://github.com/kokkos/kokkos/issues/6775
-    ZeroMemset<ExecutionSpace, View<DT, DP...>>(exec_space, dst);
-#else
-    ZeroMemset(exec_space, dst);
-#endif
+    using ViewType        = View<DT, DP...>;
+    using exec_space_type = ExecutionSpace;
+    ZeroMemset<exec_space_type, ViewType>(exec_space, dst);
   else
     contiguous_fill(exec_space, dst, value);
 }
@@ -1397,13 +1397,11 @@ contiguous_fill_or_memset(
 // leading to the significant performance issues
 #ifndef KOKKOS_ARCH_A64FX
   if (Impl::is_zero_byte(value))
-#if defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL < 2100)
-    // icpc needs extra ctad help to compile
+    // FIXME intel/19 icpc fails to deduce template parameters here,
+    // resulting in compilation errors; explicitly passing the template 
+    // parameters to ZeroMemset helps workaround the issue
     // See https://github.com/kokkos/kokkos/issues/6775
     ZeroMemset<exec_space_type, ViewType>(exec, dst);
-#else
-    ZeroMemset(exec, dst);
-#endif
   else
 #endif
     contiguous_fill(exec, dst, value);

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1359,7 +1359,13 @@ contiguous_fill_or_memset(
       && !std::is_same_v<ExecutionSpace, Kokkos::OpenMP>
 #endif
   )
+#if defined(KOKKOS_COMPILER_INTEL) && && (KOKKOS_COMPILER_INTEL < 2100)
+    // icpc needs extra ctad help to compile
+    // See https://github.com/kokkos/kokkos/issues/6775
+    ZeroMemset<ExecutionSpace, View<DT, DP...>>(exec_space, dst);
+#else
     ZeroMemset(exec_space, dst);
+#endif
   else
     contiguous_fill(exec_space, dst, value);
 }
@@ -1391,7 +1397,13 @@ contiguous_fill_or_memset(
 // leading to the significant performance issues
 #ifndef KOKKOS_ARCH_A64FX
   if (Impl::is_zero_byte(value))
+#if defined(KOKKOS_COMPILER_INTEL) && && (KOKKOS_COMPILER_INTEL < 2100)
+    // icpc needs extra ctad help to compile
+    // See https://github.com/kokkos/kokkos/issues/6775
+    ZeroMemset<exec_space_type, ViewType>(exec, dst);
+#else
     ZeroMemset(exec, dst);
+#endif
   else
 #endif
     contiguous_fill(exec, dst, value);

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1360,7 +1360,7 @@ contiguous_fill_or_memset(
 #endif
   )
     // FIXME intel/19 icpc fails to deduce template parameters here,
-    // resulting in compilation errors; explicitly passing the template 
+    // resulting in compilation errors; explicitly passing the template
     // parameters to ZeroMemset helps workaround the issue
     // See https://github.com/kokkos/kokkos/issues/6775
     ZeroMemset<ExecutionSpace, View<DT, DP...>>(exec_space, dst);
@@ -1396,7 +1396,7 @@ contiguous_fill_or_memset(
 #ifndef KOKKOS_ARCH_A64FX
   if (Impl::is_zero_byte(value))
     // FIXME intel/19 icpc fails to deduce template parameters here,
-    // resulting in compilation errors; explicitly passing the template 
+    // resulting in compilation errors; explicitly passing the template
     // parameters to ZeroMemset helps workaround the issue
     // See https://github.com/kokkos/kokkos/issues/6775
     ZeroMemset<exec_space_type, ViewType>(exec, dst);

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1359,7 +1359,7 @@ contiguous_fill_or_memset(
       && !std::is_same_v<ExecutionSpace, Kokkos::OpenMP>
 #endif
   )
-#if defined(KOKKOS_COMPILER_INTEL) && &&(KOKKOS_COMPILER_INTEL < 2100)
+#if defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL < 2100)
     // icpc needs extra ctad help to compile
     // See https://github.com/kokkos/kokkos/issues/6775
     ZeroMemset<ExecutionSpace, View<DT, DP...>>(exec_space, dst);
@@ -1397,7 +1397,7 @@ contiguous_fill_or_memset(
 // leading to the significant performance issues
 #ifndef KOKKOS_ARCH_A64FX
   if (Impl::is_zero_byte(value))
-#if defined(KOKKOS_COMPILER_INTEL) && &&(KOKKOS_COMPILER_INTEL < 2100)
+#if defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL < 2100)
     // icpc needs extra ctad help to compile
     // See https://github.com/kokkos/kokkos/issues/6775
     ZeroMemset<exec_space_type, ViewType>(exec, dst);

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1363,9 +1363,7 @@ contiguous_fill_or_memset(
     // resulting in compilation errors; explicitly passing the template 
     // parameters to ZeroMemset helps workaround the issue
     // See https://github.com/kokkos/kokkos/issues/6775
-    using ViewType        = View<DT, DP...>;
-    using exec_space_type = ExecutionSpace;
-    ZeroMemset<exec_space_type, ViewType>(exec_space, dst);
+    ZeroMemset<ExecutionSpace, View<DT, DP...>>(exec_space, dst);
   else
     contiguous_fill(exec_space, dst, value);
 }

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2917,9 +2917,19 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
             "Kokkos::View::initialization [" + name + "] via memset",
             Kokkos::Profiling::Experimental::device_id(space), &kpID);
       }
+#if defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL < 2100)
+      // icpc needs extra ctad help to compile
+      // See https://github.com/kokkos/kokkos/issues/6775
+      using ViewType = Kokkos::View<ValueType*, typename DeviceType::memory_space,
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+      (void)ZeroMemset<ExecSpace, ViewType>(
+          space, Kokkos::View<ValueType*, typename DeviceType::memory_space,
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n));
+#else
       (void)ZeroMemset(
           space, Kokkos::View<ValueType*, typename DeviceType::memory_space,
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n));
+#endif
 
       if (Kokkos::Profiling::profileLibraryLoaded()) {
         Kokkos::Profiling::endParallelFor(kpID);
@@ -3047,9 +3057,19 @@ struct ViewValueFunctor<DeviceType, ValueType, true /* is_scalar */> {
             Kokkos::Profiling::Experimental::device_id(space), &kpID);
       }
 
+#if defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL < 2100)
+      // icpc needs extra ctad help to compile
+      // See https://github.com/kokkos/kokkos/issues/6775
+      using ViewType = Kokkos::View<ValueType*, typename DeviceType::memory_space,
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+      (void)ZeroMemset<ExecSpace, ViewType>(
+          space, Kokkos::View<ValueType*, typename DeviceType::memory_space,
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n));
+#else
       (void)ZeroMemset(
           space, Kokkos::View<ValueType*, typename DeviceType::memory_space,
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n));
+#endif
 
       if (Kokkos::Profiling::profileLibraryLoaded()) {
         Kokkos::Profiling::endParallelFor(kpID);

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2917,20 +2917,9 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
             "Kokkos::View::initialization [" + name + "] via memset",
             Kokkos::Profiling::Experimental::device_id(space), &kpID);
       }
-#if defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL < 2100)
-      // icpc needs extra ctad help to compile
-      // See https://github.com/kokkos/kokkos/issues/6775
-      using ViewType =
-          Kokkos::View<ValueType*, typename DeviceType::memory_space,
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-      (void)ZeroMemset<ExecSpace, ViewType>(
-          space, Kokkos::View<ValueType*, typename DeviceType::memory_space,
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n));
-#else
       (void)ZeroMemset(
           space, Kokkos::View<ValueType*, typename DeviceType::memory_space,
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n));
-#endif
 
       if (Kokkos::Profiling::profileLibraryLoaded()) {
         Kokkos::Profiling::endParallelFor(kpID);
@@ -3058,20 +3047,9 @@ struct ViewValueFunctor<DeviceType, ValueType, true /* is_scalar */> {
             Kokkos::Profiling::Experimental::device_id(space), &kpID);
       }
 
-#if defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL < 2100)
-      // icpc needs extra ctad help to compile
-      // See https://github.com/kokkos/kokkos/issues/6775
-      using ViewType =
-          Kokkos::View<ValueType*, typename DeviceType::memory_space,
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-      (void)ZeroMemset<ExecSpace, ViewType>(
-          space, Kokkos::View<ValueType*, typename DeviceType::memory_space,
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n));
-#else
       (void)ZeroMemset(
           space, Kokkos::View<ValueType*, typename DeviceType::memory_space,
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n));
-#endif
 
       if (Kokkos::Profiling::profileLibraryLoaded()) {
         Kokkos::Profiling::endParallelFor(kpID);

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2920,8 +2920,9 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
 #if defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL < 2100)
       // icpc needs extra ctad help to compile
       // See https://github.com/kokkos/kokkos/issues/6775
-      using ViewType = Kokkos::View<ValueType*, typename DeviceType::memory_space,
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+      using ViewType =
+          Kokkos::View<ValueType*, typename DeviceType::memory_space,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
       (void)ZeroMemset<ExecSpace, ViewType>(
           space, Kokkos::View<ValueType*, typename DeviceType::memory_space,
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n));
@@ -3060,8 +3061,9 @@ struct ViewValueFunctor<DeviceType, ValueType, true /* is_scalar */> {
 #if defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL < 2100)
       // icpc needs extra ctad help to compile
       // See https://github.com/kokkos/kokkos/issues/6775
-      using ViewType = Kokkos::View<ValueType*, typename DeviceType::memory_space,
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+      using ViewType =
+          Kokkos::View<ValueType*, typename DeviceType::memory_space,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
       (void)ZeroMemset<ExecSpace, ViewType>(
           space, Kokkos::View<ValueType*, typename DeviceType::memory_space,
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n));


### PR DESCRIPTION
Avoid apparent CTAD issue with older icpc intel compilers
Resolves issue https://github.com/kokkos/kokkos/issues/6775
