### PR TITLE
Only copy data in UnorderedMap deep_copy

### DIFF
--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -856,8 +856,6 @@ class UnorderedMap {
                    std::is_same<std::remove_const_t<SValue>, value_type>::value>
   deep_copy_view(
       UnorderedMap<SKey, SValue, SDevice, Hasher, EqualTo> const &src) {
-    using src_type = UnorderedMap<SKey, SValue, SDevice, Hasher, EqualTo>;
-
     // To deep copy UnorderedMap, capacity must be identical
     KOKKOS_EXPECTS(capacity() == src.capacity());
 

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -805,56 +805,84 @@ class UnorderedMap {
     return *this;
   }
 
+  // Re-allocate the views of the calling UnorderedMap according to src
+  // capacity, and deep copy the src data.
   template <typename SKey, typename SValue, typename SDevice>
   std::enable_if_t<std::is_same<std::remove_const_t<SKey>, key_type>::value &&
                    std::is_same<std::remove_const_t<SValue>, value_type>::value>
   create_copy_view(
       UnorderedMap<SKey, SValue, SDevice, Hasher, EqualTo> const &src) {
     if (m_hash_lists.data() != src.m_hash_lists.data()) {
-      insertable_map_type tmp;
+      allocate_view(src);
+      deep_copy_view(src);
+    }
+  }
 
-      tmp.m_bounded_insert    = src.m_bounded_insert;
-      tmp.m_hasher            = src.m_hasher;
-      tmp.m_equal_to          = src.m_equal_to;
-      tmp.m_size()            = src.m_size();
-      tmp.m_available_indexes = bitset_type(src.capacity());
-      tmp.m_hash_lists        = size_type_view(
-          view_alloc(WithoutInitializing, "UnorderedMap hash list"),
-          src.m_hash_lists.extent(0));
-      tmp.m_next_index = size_type_view(
-          view_alloc(WithoutInitializing, "UnorderedMap next index"),
-          src.m_next_index.extent(0));
-      tmp.m_keys =
-          key_type_view(view_alloc(WithoutInitializing, "UnorderedMap keys"),
-                        src.m_keys.extent(0));
-      tmp.m_values = value_type_view(
-          view_alloc(WithoutInitializing, "UnorderedMap values"),
-          src.m_values.extent(0));
-      tmp.m_scalars = scalars_view("UnorderedMap scalars");
+  // Allocate views of the calling UnorderedMap with the same capacity as the
+  // src.
+  template <typename SKey, typename SValue, typename SDevice>
+  std::enable_if_t<std::is_same<std::remove_const_t<SKey>, key_type>::value &&
+                   std::is_same<std::remove_const_t<SValue>, value_type>::value>
+  allocate_view(
+      UnorderedMap<SKey, SValue, SDevice, Hasher, EqualTo> const &src) {
+    insertable_map_type tmp;
 
-      Kokkos::deep_copy(tmp.m_available_indexes, src.m_available_indexes);
+    tmp.m_bounded_insert    = src.m_bounded_insert;
+    tmp.m_hasher            = src.m_hasher;
+    tmp.m_equal_to          = src.m_equal_to;
+    tmp.m_size()            = src.m_size();
+    tmp.m_available_indexes = bitset_type(src.capacity());
+    tmp.m_hash_lists        = size_type_view(
+        view_alloc(WithoutInitializing, "UnorderedMap hash list"),
+        src.m_hash_lists.extent(0));
+    tmp.m_next_index = size_type_view(
+        view_alloc(WithoutInitializing, "UnorderedMap next index"),
+        src.m_next_index.extent(0));
+    tmp.m_keys =
+        key_type_view(view_alloc(WithoutInitializing, "UnorderedMap keys"),
+                      src.m_keys.extent(0));
+    tmp.m_values =
+        value_type_view(view_alloc(WithoutInitializing, "UnorderedMap values"),
+                        src.m_values.extent(0));
+    tmp.m_scalars = scalars_view("UnorderedMap scalars");
+
+    *this = tmp;
+  }
+
+  // Deep copy view data from src. This requires that the src capacity is
+  // identical to the capacity of the calling UnorderedMap.
+  template <typename SKey, typename SValue, typename SDevice>
+  std::enable_if_t<std::is_same<std::remove_const_t<SKey>, key_type>::value &&
+                   std::is_same<std::remove_const_t<SValue>, value_type>::value>
+  deep_copy_view(
+      UnorderedMap<SKey, SValue, SDevice, Hasher, EqualTo> const &src) {
+    using src_type = UnorderedMap<SKey, SValue, SDevice, Hasher, EqualTo>;
+
+    // To deep copy UnorderedMap, capacity must be identical
+    KOKKOS_EXPECTS(capacity() == src.capacity());
+
+    if (m_hash_lists.data() != src.m_hash_lists.data()) {
+      Kokkos::deep_copy(m_available_indexes, src.m_available_indexes);
 
       using raw_deep_copy =
           Kokkos::Impl::DeepCopy<typename device_type::memory_space,
                                  typename SDevice::memory_space>;
 
-      raw_deep_copy(tmp.m_hash_lists.data(), src.m_hash_lists.data(),
+      raw_deep_copy(m_hash_lists.data(), src.m_hash_lists.data(),
                     sizeof(size_type) * src.m_hash_lists.extent(0));
-      raw_deep_copy(tmp.m_next_index.data(), src.m_next_index.data(),
+      raw_deep_copy(m_next_index.data(), src.m_next_index.data(),
                     sizeof(size_type) * src.m_next_index.extent(0));
-      raw_deep_copy(tmp.m_keys.data(), src.m_keys.data(),
+      raw_deep_copy(m_keys.data(), src.m_keys.data(),
                     sizeof(key_type) * src.m_keys.extent(0));
       if (!is_set) {
-        raw_deep_copy(tmp.m_values.data(), src.m_values.data(),
+        raw_deep_copy(m_values.data(), src.m_values.data(),
                       sizeof(impl_value_type) * src.m_values.extent(0));
       }
-      raw_deep_copy(tmp.m_scalars.data(), src.m_scalars.data(),
+      raw_deep_copy(m_scalars.data(), src.m_scalars.data(),
                     sizeof(int) * num_scalars);
 
       Kokkos::fence(
-          "Kokkos::UnorderedMap::create_copy_view: fence after copy to tmp");
-
-      *this = tmp;
+          "Kokkos::UnorderedMap::deep_copy_view: fence after copy to dst.");
     }
   }
 
@@ -932,13 +960,29 @@ class UnorderedMap {
   friend struct Impl::UnorderedMapPrint;
 };
 
-// Specialization of deep_copy for two UnorderedMap objects.
+// Specialization of deep_copy() for two UnorderedMap objects.
 template <typename DKey, typename DT, typename DDevice, typename SKey,
           typename ST, typename SDevice, typename Hasher, typename EqualTo>
 inline void deep_copy(
     UnorderedMap<DKey, DT, DDevice, Hasher, EqualTo> &dst,
     const UnorderedMap<SKey, ST, SDevice, Hasher, EqualTo> &src) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   dst.create_copy_view(src);
+#else
+  dst.deep_copy_view(src);
+#endif
+}
+
+// Specialization of create_mirror() for an UnorderedMap object.
+template <typename Key, typename ValueType, typename Device, typename Hasher,
+          typename EqualTo>
+typename UnorderedMap<Key, ValueType, Device, Hasher, EqualTo>::HostMirror
+create_mirror(
+    const UnorderedMap<Key, ValueType, Device, Hasher, EqualTo> &src) {
+  typename UnorderedMap<Key, ValueType, Device, Hasher, EqualTo>::HostMirror
+      dst;
+  dst.allocate_view(src);
+  return dst;
 }
 
 }  // namespace Kokkos

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -68,7 +68,7 @@ struct TestInsert {
     } while (rehash_on_fail && failed_count > 0u);
 
     // Trigger the m_size mutable bug.
-    typename map_type::HostMirror map_h;
+    auto map_h = create_mirror(map);
     execution_space().fence();
     Kokkos::deep_copy(map_h, map);
     execution_space().fence();
@@ -367,7 +367,7 @@ void test_deep_copy(uint32_t num_nodes) {
     }
   }
 
-  host_map_type hmap;
+  auto hmap = create_mirror(map);
   Kokkos::deep_copy(hmap, map);
 
   ASSERT_EQ(map.size(), hmap.size());
@@ -380,6 +380,7 @@ void test_deep_copy(uint32_t num_nodes) {
   }
 
   map_type mmap;
+  mmap.allocate_view(hmap);
   Kokkos::deep_copy(mmap, hmap);
 
   const_map_type cmap = mmap;
@@ -424,7 +425,7 @@ TEST(TEST_CATEGORY, UnorderedMap_valid_empty) {
   Map n{};
   n = Map{m.capacity()};
   n.rehash(m.capacity());
-  Kokkos::deep_copy(n, m);
+  n.create_copy_view(m);
   ASSERT_TRUE(m.is_allocated());
   ASSERT_TRUE(n.is_allocated());
 }


### PR DESCRIPTION
Previously, `deep_copy(UnorderedMap,UnorderedMap)` acted much more similar to `create_mirror_view_and_copy()` which allocated the dst view and then deep_copy the data. Now deep_copy requires the capacity of the src and dst UnorderedMaps are identical and deep copies all data from src to dst.

Also changed
- Deprecated old behavior
- Separate `UnorderedMap::create_copy_view()` into `allocate_view()` and `deep_copy_view()`
- Create a `create_mirror(UnorderedMap)` specialization