### PR TITLE
fix constness for views in std algorithms 

### DIFF
--- a/algorithms/src/std_algorithms/Kokkos_Copy.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Copy.hpp
@@ -50,7 +50,7 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto copy(const ExecutionSpace& ex,
           const ::Kokkos::View<DataType1, Properties1...>& source,
-          ::Kokkos::View<DataType2, Properties2...>& dest) {
+          const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -66,7 +66,7 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto copy(const std::string& label, const ExecutionSpace& ex,
           const ::Kokkos::View<DataType1, Properties1...>& source,
-          ::Kokkos::View<DataType2, Properties2...>& dest) {
+          const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -93,7 +93,7 @@ template <typename TeamHandleType, typename DataType1, typename... Properties1,
 KOKKOS_FUNCTION auto copy(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType1, Properties1...>& source,
-    ::Kokkos::View<DataType2, Properties2...>& dest) {
+    const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 

--- a/algorithms/src/std_algorithms/Kokkos_CopyBackward.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_CopyBackward.hpp
@@ -50,7 +50,7 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto copy_backward(const ExecutionSpace& ex,
                    const ::Kokkos::View<DataType1, Properties1...>& source,
-                   ::Kokkos::View<DataType2, Properties2...>& dest) {
+                   const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -65,7 +65,7 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto copy_backward(const std::string& label, const ExecutionSpace& ex,
                    const ::Kokkos::View<DataType1, Properties1...>& source,
-                   ::Kokkos::View<DataType2, Properties2...>& dest) {
+                   const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -92,7 +92,7 @@ template <typename TeamHandleType, typename DataType1, typename... Properties1,
 KOKKOS_FUNCTION auto copy_backward(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType1, Properties1...>& source,
-    ::Kokkos::View<DataType2, Properties2...>& dest) {
+    const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 

--- a/algorithms/src/std_algorithms/Kokkos_CopyIf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_CopyIf.hpp
@@ -54,7 +54,8 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto copy_if(const ExecutionSpace& ex,
              const ::Kokkos::View<DataType1, Properties1...>& source,
-             ::Kokkos::View<DataType2, Properties2...>& dest, Predicate pred) {
+             const ::Kokkos::View<DataType2, Properties2...>& dest,
+             Predicate pred) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -69,7 +70,8 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto copy_if(const std::string& label, const ExecutionSpace& ex,
              const ::Kokkos::View<DataType1, Properties1...>& source,
-             ::Kokkos::View<DataType2, Properties2...>& dest, Predicate pred) {
+             const ::Kokkos::View<DataType2, Properties2...>& dest,
+             Predicate pred) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -96,7 +98,7 @@ template <typename TeamHandleType, typename DataType1, typename... Properties1,
 KOKKOS_FUNCTION auto copy_if(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType1, Properties1...>& source,
-    ::Kokkos::View<DataType2, Properties2...>& dest, Predicate pred) {
+    const ::Kokkos::View<DataType2, Properties2...>& dest, Predicate pred) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 

--- a/algorithms/src/std_algorithms/Kokkos_CopyN.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_CopyN.hpp
@@ -51,7 +51,7 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto copy_n(const ExecutionSpace& ex,
             const ::Kokkos::View<DataType1, Properties1...>& source, Size count,
-            ::Kokkos::View<DataType2, Properties2...>& dest) {
+            const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -66,7 +66,7 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto copy_n(const std::string& label, const ExecutionSpace& ex,
             const ::Kokkos::View<DataType1, Properties1...>& source, Size count,
-            ::Kokkos::View<DataType2, Properties2...>& dest) {
+            const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -93,7 +93,7 @@ template <typename TeamHandleType, typename DataType1, typename... Properties1,
 KOKKOS_FUNCTION auto copy_n(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType1, Properties1...>& source, Size count,
-    ::Kokkos::View<DataType2, Properties2...>& dest) {
+    const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 

--- a/algorithms/src/std_algorithms/Kokkos_Equal.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Equal.hpp
@@ -80,7 +80,7 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 bool equal(const ExecutionSpace& ex,
            const ::Kokkos::View<DataType1, Properties1...>& view1,
-           ::Kokkos::View<DataType2, Properties2...>& view2) {
+           const ::Kokkos::View<DataType2, Properties2...>& view2) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view1);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view2);
 
@@ -96,7 +96,7 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 bool equal(const std::string& label, const ExecutionSpace& ex,
            const ::Kokkos::View<DataType1, Properties1...>& view1,
-           ::Kokkos::View<DataType2, Properties2...>& view2) {
+           const ::Kokkos::View<DataType2, Properties2...>& view2) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view1);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view2);
 
@@ -111,7 +111,7 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 bool equal(const ExecutionSpace& ex,
            const ::Kokkos::View<DataType1, Properties1...>& view1,
-           ::Kokkos::View<DataType2, Properties2...>& view2,
+           const ::Kokkos::View<DataType2, Properties2...>& view2,
            BinaryPredicateType predicate) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view1);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view2);
@@ -128,7 +128,7 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 bool equal(const std::string& label, const ExecutionSpace& ex,
            const ::Kokkos::View<DataType1, Properties1...>& view1,
-           ::Kokkos::View<DataType2, Properties2...>& view2,
+           const ::Kokkos::View<DataType2, Properties2...>& view2,
            BinaryPredicateType predicate) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view1);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view2);
@@ -227,7 +227,7 @@ template <typename TeamHandleType, typename DataType1, typename... Properties1,
 KOKKOS_FUNCTION bool equal(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType1, Properties1...>& view1,
-    ::Kokkos::View<DataType2, Properties2...>& view2) {
+    const ::Kokkos::View<DataType2, Properties2...>& view2) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view1);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view2);
 
@@ -243,7 +243,7 @@ template <typename TeamHandleType, typename DataType1, typename... Properties1,
 KOKKOS_FUNCTION bool equal(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType1, Properties1...>& view1,
-    ::Kokkos::View<DataType2, Properties2...>& view2,
+    const ::Kokkos::View<DataType2, Properties2...>& view2,
     BinaryPredicateType predicate) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view1);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view2);

--- a/algorithms/src/std_algorithms/Kokkos_LexicographicalCompare.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_LexicographicalCompare.hpp
@@ -54,7 +54,7 @@ template <
 bool lexicographical_compare(
     const ExecutionSpace& ex,
     const ::Kokkos::View<DataType1, Properties1...>& view1,
-    ::Kokkos::View<DataType2, Properties2...>& view2) {
+    const ::Kokkos::View<DataType2, Properties2...>& view2) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view1);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view2);
 
@@ -71,7 +71,7 @@ template <
 bool lexicographical_compare(
     const std::string& label, const ExecutionSpace& ex,
     const ::Kokkos::View<DataType1, Properties1...>& view1,
-    ::Kokkos::View<DataType2, Properties2...>& view2) {
+    const ::Kokkos::View<DataType2, Properties2...>& view2) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view1);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view2);
 
@@ -112,7 +112,8 @@ template <
 bool lexicographical_compare(
     const ExecutionSpace& ex,
     const ::Kokkos::View<DataType1, Properties1...>& view1,
-    ::Kokkos::View<DataType2, Properties2...>& view2, ComparatorType comp) {
+    const ::Kokkos::View<DataType2, Properties2...>& view2,
+    ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view1);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view2);
 
@@ -129,7 +130,8 @@ template <
 bool lexicographical_compare(
     const std::string& label, const ExecutionSpace& ex,
     const ::Kokkos::View<DataType1, Properties1...>& view1,
-    ::Kokkos::View<DataType2, Properties2...>& view2, ComparatorType comp) {
+    const ::Kokkos::View<DataType2, Properties2...>& view2,
+    ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view1);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view2);
 
@@ -161,7 +163,7 @@ template <class TeamHandleType, class DataType1, class... Properties1,
 KOKKOS_FUNCTION bool lexicographical_compare(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType1, Properties1...>& view1,
-    ::Kokkos::View<DataType2, Properties2...>& view2) {
+    const ::Kokkos::View<DataType2, Properties2...>& view2) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view1);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view2);
 
@@ -187,7 +189,8 @@ template <class TeamHandleType, class DataType1, class... Properties1,
 KOKKOS_FUNCTION bool lexicographical_compare(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType1, Properties1...>& view1,
-    ::Kokkos::View<DataType2, Properties2...>& view2, ComparatorType comp) {
+    const ::Kokkos::View<DataType2, Properties2...>& view2,
+    ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view1);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view2);
 

--- a/algorithms/src/std_algorithms/Kokkos_Move.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Move.hpp
@@ -50,7 +50,7 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto move(const ExecutionSpace& ex,
           const ::Kokkos::View<DataType1, Properties1...>& source,
-          ::Kokkos::View<DataType2, Properties2...>& dest) {
+          const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -64,7 +64,7 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto move(const std::string& label, const ExecutionSpace& ex,
           const ::Kokkos::View<DataType1, Properties1...>& source,
-          ::Kokkos::View<DataType2, Properties2...>& dest) {
+          const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -92,7 +92,7 @@ template <typename TeamHandleType, typename DataType1, typename... Properties1,
 KOKKOS_FUNCTION auto move(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType1, Properties1...>& source,
-    ::Kokkos::View<DataType2, Properties2...>& dest) {
+    const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 

--- a/algorithms/src/std_algorithms/Kokkos_MoveBackward.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_MoveBackward.hpp
@@ -41,7 +41,7 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto move_backward(const ExecutionSpace& ex,
                    const ::Kokkos::View<DataType1, Properties1...>& source,
-                   ::Kokkos::View<DataType2, Properties2...>& dest) {
+                   const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -65,7 +65,7 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto move_backward(const std::string& label, const ExecutionSpace& ex,
                    const ::Kokkos::View<DataType1, Properties1...>& source,
-                   ::Kokkos::View<DataType2, Properties2...>& dest) {
+                   const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -94,7 +94,7 @@ template <typename TeamHandleType, typename DataType1, typename... Properties1,
 KOKKOS_FUNCTION auto move_backward(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType1, Properties1...>& source,
-    ::Kokkos::View<DataType2, Properties2...>& dest) {
+    const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 

--- a/algorithms/src/std_algorithms/Kokkos_ReverseCopy.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ReverseCopy.hpp
@@ -50,7 +50,7 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto reverse_copy(const ExecutionSpace& ex,
                   const ::Kokkos::View<DataType1, Properties1...>& source,
-                  ::Kokkos::View<DataType2, Properties2...>& dest) {
+                  const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -65,7 +65,7 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto reverse_copy(const std::string& label, const ExecutionSpace& ex,
                   const ::Kokkos::View<DataType1, Properties1...>& source,
-                  ::Kokkos::View<DataType2, Properties2...>& dest) {
+                  const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -94,7 +94,7 @@ template <typename TeamHandleType, typename DataType1, typename... Properties1,
 KOKKOS_FUNCTION auto reverse_copy(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType1, Properties1...>& source,
-    ::Kokkos::View<DataType2, Properties2...>& dest) {
+    const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 

--- a/algorithms/src/std_algorithms/Kokkos_SwapRanges.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_SwapRanges.hpp
@@ -40,7 +40,7 @@ template <typename ExecutionSpace, typename DataType1, typename... Properties1,
           std::enable_if_t<is_execution_space_v<ExecutionSpace>, int> = 0>
 auto swap_ranges(const ExecutionSpace& ex,
                  const ::Kokkos::View<DataType1, Properties1...>& source,
-                 ::Kokkos::View<DataType2, Properties2...>& dest) {
+                 const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -64,7 +64,7 @@ template <typename ExecutionSpace, typename DataType1, typename... Properties1,
           std::enable_if_t<is_execution_space_v<ExecutionSpace>, int> = 0>
 auto swap_ranges(const std::string& label, const ExecutionSpace& ex,
                  const ::Kokkos::View<DataType1, Properties1...>& source,
-                 ::Kokkos::View<DataType2, Properties2...>& dest) {
+                 const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -94,7 +94,7 @@ template <typename TeamHandleType, typename DataType1, typename... Properties1,
 KOKKOS_FUNCTION auto swap_ranges(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType1, Properties1...>& source,
-    ::Kokkos::View<DataType2, Properties2...>& dest) {
+    const ::Kokkos::View<DataType2, Properties2...>& dest) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 

--- a/algorithms/src/std_algorithms/Kokkos_Transform.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Transform.hpp
@@ -58,7 +58,7 @@ template <typename ExecutionSpace, typename DataType1, typename... Properties1,
           std::enable_if_t<is_execution_space_v<ExecutionSpace>, int> = 0>
 auto transform(const ExecutionSpace& ex,
                const ::Kokkos::View<DataType1, Properties1...>& source,
-               ::Kokkos::View<DataType2, Properties2...>& dest,
+               const ::Kokkos::View<DataType2, Properties2...>& dest,
                UnaryOperation unary_op) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
@@ -73,7 +73,7 @@ template <typename ExecutionSpace, typename DataType1, typename... Properties1,
           std::enable_if_t<is_execution_space_v<ExecutionSpace>, int> = 0>
 auto transform(const std::string& label, const ExecutionSpace& ex,
                const ::Kokkos::View<DataType1, Properties1...>& source,
-               ::Kokkos::View<DataType2, Properties2...>& dest,
+               const ::Kokkos::View<DataType2, Properties2...>& dest,
                UnaryOperation unary_op) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
@@ -119,7 +119,7 @@ template <typename ExecutionSpace, typename DataType1, typename... Properties1,
 auto transform(const ExecutionSpace& ex,
                const ::Kokkos::View<DataType1, Properties1...>& source1,
                const ::Kokkos::View<DataType2, Properties2...>& source2,
-               ::Kokkos::View<DataType3, Properties3...>& dest,
+               const ::Kokkos::View<DataType3, Properties3...>& dest,
                BinaryOperation binary_op) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source1);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source2);
@@ -137,7 +137,7 @@ template <typename ExecutionSpace, typename DataType1, typename... Properties1,
 auto transform(const std::string& label, const ExecutionSpace& ex,
                const ::Kokkos::View<DataType1, Properties1...>& source1,
                const ::Kokkos::View<DataType2, Properties2...>& source2,
-               ::Kokkos::View<DataType3, Properties3...>& dest,
+               const ::Kokkos::View<DataType3, Properties3...>& dest,
                BinaryOperation binary_op) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source1);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source2);
@@ -174,7 +174,8 @@ template <typename TeamHandleType, typename DataType1, typename... Properties1,
 KOKKOS_FUNCTION auto transform(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType1, Properties1...>& source,
-    ::Kokkos::View<DataType2, Properties2...>& dest, UnaryOperation unary_op) {
+    const ::Kokkos::View<DataType2, Properties2...>& dest,
+    UnaryOperation unary_op) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(dest);
 
@@ -207,7 +208,7 @@ KOKKOS_FUNCTION auto transform(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType1, Properties1...>& source1,
     const ::Kokkos::View<DataType2, Properties2...>& source2,
-    ::Kokkos::View<DataType3, Properties3...>& dest,
+    const ::Kokkos::View<DataType3, Properties3...>& dest,
     BinaryOperation binary_op) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source1);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(source2);


### PR DESCRIPTION
as pointed out in https://github.com/kokkos/kokkos/pull/6801#discussion_r1488242863, this PR fixes all instances so that a View is always taken by `const & `