### PR TITLE
Clean up shift_{right, left}_team_impl

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_ShiftLeft.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ShiftLeft.hpp
@@ -126,10 +126,11 @@ KOKKOS_FUNCTION IteratorType shift_left_team_impl(
   // execution space impl because for this team impl we are
   // within a parallel region, so for now we solve serially
 
-  const std::size_t numElementsToMove =
+  using difference_type = typename IteratorType::difference_type;
+  const difference_type numElementsToMove =
       ::Kokkos::Experimental::distance(first + n, last);
   Kokkos::single(Kokkos::PerTeam(teamHandle), [=]() {
-    for (std::size_t i = 0; i < numElementsToMove; ++i) {
+    for (difference_type i = 0; i < numElementsToMove; ++i) {
       first[i] = std::move(first[i + n]);
     }
   });


### PR DESCRIPTION
I was running SonarCloud on my fork to try it out and one of the bugs reported was https://sonarcloud.io/project/issues?resolved=false&types=BUG&id=masterleinad_kokkos&open=AY2p6YQlbq2DzqS7mbTl.
We basically use a unary minus operator on an unsigned type (std::size_t) and pass that to another signed type for iterator access to access an element before the one the iterator points to. With conversion between signed and unsigned types, this might not work correctly, see https://godbolt.org/z/6o3f4qY7T.
I also noticed that `StdShiftRightTeamSingleFunctor` isn't used at all.