### PR TITLE
Fix deep copy when filling Rank-7 views

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -221,6 +221,8 @@ struct ViewFill<ViewType, Layout, ExecSpace, 7, iType> {
   ViewFill(const ViewType& a_, typename ViewType::const_value_type& val_,
            const ExecSpace& space)
       : a(a_), val(val_) {
+    // MDRangePolicy is not supported for 7D views
+    // Iterate separately over extent(2)
     Kokkos::parallel_for("Kokkos::ViewFill-7D",
                          policy_type(space, {0, 0, 0, 0, 0, 0},
                                      {a.extent(0), a.extent(1), a.extent(3),
@@ -249,6 +251,8 @@ struct ViewFill<ViewType, Layout, ExecSpace, 8, iType> {
   ViewFill(const ViewType& a_, typename ViewType::const_value_type& val_,
            const ExecSpace& space)
       : a(a_), val(val_) {
+    // MDRangePolicy is not supported for 8D views
+    // Iterate separately over extent(2) and extent(4)
     Kokkos::parallel_for("Kokkos::ViewFill-8D",
                          policy_type(space, {0, 0, 0, 0, 0, 0},
                                      {a.extent(0), a.extent(1), a.extent(3),
@@ -461,6 +465,8 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 7, iType> {
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_,
            const ExecSpace space = ExecSpace())
       : a(a_), b(b_) {
+    // MDRangePolicy is not supported for 7D views
+    // Iterate separately over extent(2)
     Kokkos::parallel_for("Kokkos::ViewCopy-7D",
                          policy_type(space, {0, 0, 0, 0, 0, 0},
                                      {a.extent(0), a.extent(1), a.extent(3),
@@ -494,6 +500,8 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 8, iType> {
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_,
            const ExecSpace space = ExecSpace())
       : a(a_), b(b_) {
+    // MDRangePolicy is not supported for 8D views
+    // Iterate separately over extent(2) and extent(4)
     Kokkos::parallel_for("Kokkos::ViewCopy-8D",
                          policy_type(space, {0, 0, 0, 0, 0, 0},
                                      {a.extent(0), a.extent(1), a.extent(3),

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -223,8 +223,8 @@ struct ViewFill<ViewType, Layout, ExecSpace, 7, iType> {
       : a(a_), val(val_) {
     Kokkos::parallel_for("Kokkos::ViewFill-7D",
                          policy_type(space, {0, 0, 0, 0, 0, 0},
-                                     {a.extent(0), a.extent(1), a.extent(2),
-                                      a.extent(3), a.extent(5), a.extent(6)}),
+                                     {a.extent(0), a.extent(1), a.extent(3),
+                                      a.extent(4), a.extent(5), a.extent(6)}),
                          *this);
   }
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -236,6 +236,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       ViewAPI_e
       ViewCopy_a
       ViewCopy_b
+      ViewCopy_c
       ViewCtorDimMatch
       ViewEmptyRuntimeUnmanaged
       ViewHooks
@@ -353,6 +354,7 @@ foreach(PairDeviceSpace HIP-HostPinned;HIP-Managed;Cuda-HostPinned;Cuda-UVM;SYCL
       ViewAPI_e
       ViewCopy_a
       ViewCopy_b
+      ViewCopy_c
       ViewMapping_a
       ViewMapping_b
       ViewMapping_subview

--- a/core/unit_test/Makefile
+++ b/core/unit_test/Makefile
@@ -62,7 +62,7 @@ else
    STACK_TRACE_TERMINATE_FILTER :=
 endif
 
-TESTS = AtomicOperations_int AtomicOperations_unsignedint AtomicOperations_longint AtomicOperations_unsignedlongint AtomicOperations_longlongint AtomicOperations_double AtomicOperations_float AtomicOperations_complexdouble AtomicOperations_complexfloat AtomicViews Atomics BlockSizeDeduction Concepts Complex Crs DeepCopyAlignment FunctorAnalysis Init LocalDeepCopy MDRange_a MDRange_b MDRange_c MDRange_d MDRange_e MDRange_f Other ParallelScanRangePolicy RangePolicy RangePolicyRequire Reductions Reducers_a Reducers_b Reducers_c Reducers_d Reducers_e Reductions_DeviceView SharedAlloc TeamBasic TeamReductionScan TeamScratch TeamTeamSize TeamVectorRange UniqueToken ViewAPI_a ViewAPI_b ViewAPI_c ViewAPI_d ViewAPI_e ViewCopy_a ViewCopy_b ViewLayoutStrideAssignment ViewMapping_a ViewMapping_b ViewMapping_subview ViewOfClass WorkGraph View_64bit ViewResize
+TESTS = AtomicOperations_int AtomicOperations_unsignedint AtomicOperations_longint AtomicOperations_unsignedlongint AtomicOperations_longlongint AtomicOperations_double AtomicOperations_float AtomicOperations_complexdouble AtomicOperations_complexfloat AtomicViews Atomics BlockSizeDeduction Concepts Complex Crs DeepCopyAlignment FunctorAnalysis Init LocalDeepCopy MDRange_a MDRange_b MDRange_c MDRange_d MDRange_e MDRange_f Other ParallelScanRangePolicy RangePolicy RangePolicyRequire Reductions Reducers_a Reducers_b Reducers_c Reducers_d Reducers_e Reductions_DeviceView SharedAlloc TeamBasic TeamReductionScan TeamScratch TeamTeamSize TeamVectorRange UniqueToken ViewAPI_a ViewAPI_b ViewAPI_c ViewAPI_d ViewAPI_e ViewCopy_a ViewCopy_b ViewCopy_c ViewLayoutStrideAssignment ViewMapping_a ViewMapping_b ViewMapping_subview ViewOfClass WorkGraph View_64bit ViewResize
 
 tmp := $(foreach device, $(KOKKOS_DEVICELIST), \
   tmp2 := $(foreach test, $(TESTS), \
@@ -73,7 +73,7 @@ tmp := $(foreach device, $(KOKKOS_DEVICELIST), \
   ) \
 )
 
-GPU_SPACE_TESTS = SharedAlloc ViewAPI_a ViewAPI_b ViewAPI_c ViewAPI_d ViewAPI_e ViewCopy_a ViewCopy_b ViewMapping_a ViewMapping_b ViewMapping_subview
+GPU_SPACE_TESTS = SharedAlloc ViewAPI_a ViewAPI_b ViewAPI_c ViewAPI_d ViewAPI_e ViewCopy_a ViewCopy_b ViewCopy_c ViewMapping_a ViewMapping_b ViewMapping_subview
 
 SUBVIEW_TESTS = SubView_a SubView_b SubView_c01 SubView_c02 SubView_c03 SubView_c04 SubView_c05 SubView_c06 SubView_c07 SubView_c08 SubView_c09 SubView_c10 SubView_c11 SubView_c12 SubView_c13
 
@@ -110,14 +110,14 @@ ifeq ($(KOKKOS_INTERNAL_USE_CUDA), 1)
     OBJ_CUDA += TestCuda_Init.o
     OBJ_CUDA += TestCuda_SharedAlloc.o TestCudaUVM_SharedAlloc.o TestCudaHostPinned_SharedAlloc.o
     OBJ_CUDA += TestCuda_RangePolicy.o TestCuda_RangePolicyRequire.o
-    OBJ_CUDA += TestCuda_ViewAPI_a.o TestCuda_ViewAPI_b.o TestCuda_ViewAPI_c.o TestCuda_ViewAPI_d.o TestCuda_ViewAPI_e.o TestCuda_ViewCopy_a.o TestCuda_ViewCopy_b.o
+    OBJ_CUDA += TestCuda_ViewAPI_a.o TestCuda_ViewAPI_b.o TestCuda_ViewAPI_c.o TestCuda_ViewAPI_d.o TestCuda_ViewAPI_e.o TestCuda_ViewCopy_a.o TestCuda_ViewCopy_b.o TestCuda_ViewCopy_c.o
     OBJ_CUDA += TestCuda_DeepCopyAlignment.o
     OBJ_CUDA += TestCuda_ViewMapping_a.o TestCuda_ViewMapping_b.o TestCuda_ViewMapping_subview.o TestCuda_ViewResize.o TestCuda_ViewLayoutStrideAssignment.o
     OBJ_CUDA += TestCudaUVM_ViewAPI_a.o TestCudaUVM_ViewAPI_b.o TestCudaUVM_ViewAPI_c.o TestCudaUVM_ViewAPI_d.o TestCudaUVM_ViewAPI_e.o
-    OBJ_CUDA += TestCudaUVM_ViewCopy_a.o TestCudaUVM_ViewCopy_b.o
+    OBJ_CUDA += TestCudaUVM_ViewCopy_a.o TestCudaUVM_ViewCopy_b.o TestCudaUVM_ViewCopy_c.o
     OBJ_CUDA += TestCudaUVM_ViewMapping_a.o TestCudaUVM_ViewMapping_b.o TestCudaUVM_ViewMapping_subview.o
     OBJ_CUDA += TestCudaHostPinned_ViewAPI_a.o TestCudaHostPinned_ViewAPI_b.o TestCudaHostPinned_ViewAPI_c.o TestCudaHostPinned_ViewAPI_d.o TestCudaHostPinned_ViewAPI_e.o
-    OBJ_CUDA += TestCudaHostPinned_ViewCopy_a.o TestCudaHostPinned_ViewCopy_b.o
+    OBJ_CUDA += TestCudaHostPinned_ViewCopy_a.o TestCudaHostPinned_ViewCopy_b.o TestCudaHostPinned_ViewCopy_c.o
     OBJ_CUDA += TestCudaHostPinned_ViewMapping_a.o TestCudaHostPinned_ViewMapping_b.o TestCudaHostPinned_ViewMapping_subview.o
     OBJ_CUDA += TestCuda_View_64bit.o
     OBJ_CUDA += TestCuda_ViewOfClass.o
@@ -162,7 +162,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_THREADS), 1)
     OBJ_THREADS += TestThreads_RangePolicy.o TestThreads_RangePolicyRequire.o
     OBJ_THREADS += TestThreads_View_64bit.o
     OBJ_THREADS += TestThreads_ViewAPI_a.o TestThreads_ViewAPI_b.o TestThreads_ViewAPI_c.o TestThreads_ViewAPI_d.o TestThreads_ViewAPI_e.o
-    OBJ_THREADS += TestThreads_ViewCopy_a.o TestThreads_ViewCopy_b.o
+    OBJ_THREADS += TestThreads_ViewCopy_a.o TestThreads_ViewCopy_b.o TestThreads_ViewCopy_c.o
     OBJ_THREADS += TestThreads_DeepCopyAlignment.o
     OBJ_THREADS += TestThreads_ViewMapping_a.o TestThreads_ViewMapping_b.o TestThreads_ViewMapping_subview.o TestThreads_ViewResize.o TestThreads_ViewLayoutStrideAssignment.o
     OBJ_THREADS += TestThreads_ViewOfClass.o
@@ -198,7 +198,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_OPENMP), 1)
     OBJ_OPENMP += TestOpenMP_RangePolicy.o TestOpenMP_RangePolicyRequire.o
     OBJ_OPENMP += TestOpenMP_View_64bit.o
     OBJ_OPENMP += TestOpenMP_ViewAPI_a.o TestOpenMP_ViewAPI_b.o TestOpenMP_ViewAPI_c.o TestOpenMP_ViewAPI_d.o TestOpenMP_ViewAPI_e.o
-    OBJ_OPENMP += TestOpenMP_DeepCopyAlignment.o TestOpenMP_ViewCopy_a.o TestOpenMP_ViewCopy_b.o
+    OBJ_OPENMP += TestOpenMP_DeepCopyAlignment.o TestOpenMP_ViewCopy_a.o TestOpenMP_ViewCopy_b.o TestOpenMP_ViewCopy_c.o
     OBJ_OPENMP += TestOpenMP_ViewMapping_a.o TestOpenMP_ViewMapping_b.o TestOpenMP_ViewMapping_subview.o TestOpenMP_ViewResize.o TestOpenMP_ViewLayoutStrideAssignment.o
     OBJ_OPENMP += TestOpenMP_ViewOfClass.o
     OBJ_OPENMP += TestOpenMP_SubView_a.o TestOpenMP_SubView_b.o
@@ -237,7 +237,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_OPENMPTARGET), 1)
     #OBJ_OPENMPTARGET += TestOpenMPTarget_SharedAlloc.o
     OBJ_OPENMPTARGET += TestOpenMPTarget_RangePolicy.o
     OBJ_OPENMPTARGET += TestOpenMPTarget_ViewAPI_a.o TestOpenMPTarget_ViewAPI_b.o TestOpenMPTarget_ViewAPI_c.o TestOpenMPTarget_ViewAPI_d.o  #Some commented out code
-    #OBJ_OPENMPTARGET += TestOpenMPTarget_ViewAPI_e.o TestOpenMPTarget_ViewCopy_a.o TestOpenMPTarget_ViewCopy_b.o
+    #OBJ_OPENMPTARGET += TestOpenMPTarget_ViewAPI_e.o TestOpenMPTarget_ViewCopy_a.o TestOpenMPTarget_ViewCopy_b.o TestOpenMPTarget_ViewCopy_c.o
     OBJ_OPENMPTARGET += TestOpenMPTarget_DeepCopyAlignment.o
     OBJ_OPENMPTARGET += TestOpenMPTarget_ViewMapping_a.o
     OBJ_OPENMPTARGET += TestOpenMPTarget_ViewMapping_b.o
@@ -292,7 +292,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_HIP), 1)
 	OBJ_HIP += TestHIP_Memory_Requirements.o
         OBJ_HIP += TestHIP_ParallelScanRangePolicy.o
 	OBJ_HIP += TestHIPHostPinned_ViewAPI_a.o TestHIPHostPinned_ViewAPI_b.o TestHIPHostPinned_ViewAPI_c.o TestHIPHostPinned_ViewAPI_d.o TestHIPHostPinned_ViewAPI_e.o
-	OBJ_HIP += TestHIPHostPinned_ViewCopy_a.o TestHIPHostPinned_ViewCopy_b.o
+	OBJ_HIP += TestHIPHostPinned_ViewCopy_a.o TestHIPHostPinned_ViewCopy_b.o TestHIPHostPinned_ViewCopy_c.o
 	OBJ_HIP += TestHIPHostPinned_ViewMapping_a.o TestHIPHostPinned_ViewMapping_b.o TestHIPHostPinned_ViewMapping_subview.o
 
 	TARGETS += KokkosCore_UnitTest_HIP
@@ -307,7 +307,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_HPX), 1)
 	OBJ_HPX += TestHPX_RangePolicy.o TestHPX_RangePolicyRequire.o
 	OBJ_HPX += TestHPX_View_64bit.o
 	OBJ_HPX += TestHPX_ViewAPI_a.o TestHPX_ViewAPI_b.o TestHPX_ViewAPI_c.o TestHPX_ViewAPI_d.o TestHPX_ViewAPI_e.o
-	OBJ_HPX += TestHPX_ViewCopy_a.o TestHPX_ViewCopy_b.o
+	OBJ_HPX += TestHPX_ViewCopy_a.o TestHPX_ViewCopy_b.o TestHPX_ViewCopy_c.o
 	OBJ_HPX += TestHPX_ViewMapping_a.o TestHPX_ViewMapping_b.o TestHPX_ViewMapping_subview.o TestHPX_ViewResize.o
 	OBJ_HPX += TestHPX_ViewOfClass.o
 	OBJ_HPX += TestHPX_SubView_a.o TestHPX_SubView_b.o
@@ -347,7 +347,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_SERIAL), 1)
     OBJ_SERIAL += TestSerial_RangePolicy.o TestSerial_RangePolicyRequire.o
     OBJ_SERIAL += TestSerial_View_64bit.o
     OBJ_SERIAL += TestSerial_ViewAPI_a.o TestSerial_ViewAPI_b.o TestSerial_ViewAPI_c.o TestSerial_ViewAPI_d.o TestSerial_ViewAPI_e.o
-    OBJ_SERIAL += TestSerial_DeepCopyAlignment.o TestSerial_ViewCopy_a.o TestSerial_ViewCopy_b.o
+    OBJ_SERIAL += TestSerial_DeepCopyAlignment.o TestSerial_ViewCopy_a.o TestSerial_ViewCopy_b.o TestSerial_ViewCopy_c.o
     OBJ_SERIAL += TestSerial_ViewMapping_a.o TestSerial_ViewMapping_b.o TestSerial_ViewMapping_subview.o TestSerial_ViewResize.o TestSerial_ViewLayoutStrideAssignment.o
     OBJ_SERIAL += TestSerial_ViewOfClass.o
     OBJ_SERIAL += TestSerial_SubView_a.o TestSerial_SubView_b.o

--- a/core/unit_test/TestViewCopy_c.hpp
+++ b/core/unit_test/TestViewCopy_c.hpp
@@ -237,12 +237,11 @@ template <class ExecSpace, class ViewType>
 bool view_fill_test(const ExecSpace& space, ViewType& a, int magic) {
   Kokkos::deep_copy(space, a, magic);
 #if defined(KOKKOS_ENABLE_OPENMPTARGET)
-  if constexpr (std::is_same_v<TEST_EXECSPACE::execution_space,
-                               Kokkos::Experimental::OpenMPTarget>) {
-    return true;
-  }
-#endif  // KOKKOS_ENABLE_OPENMPTARGET
+  // FIXME_OPENMPTARGET Does not work with Land reducer
+  return true;
+#else   // KOKKOS_ENABLE_OPENMPTARGET
   return check_magic_value(space, a, magic);
+#endif  // KOKKOS_ENABLE_OPENMPTARGET
 }
 
 template <class Layout, class Space>

--- a/core/unit_test/TestViewCopy_c.hpp
+++ b/core/unit_test/TestViewCopy_c.hpp
@@ -1,0 +1,435 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+
+namespace {
+// Do not rely on deep_copy(0) as we want to test it!
+template <class ViewType, class ExecSpace>
+void reset_view(const ExecSpace& space, ViewType& a, int magic) {
+  auto policy = Kokkos::RangePolicy<ExecSpace>(space, 0, a.span());
+
+  assert(a.span_is_contiguous());
+
+  Kokkos::parallel_for(
+      "TestViewCopy::ResetView", policy,
+      KOKKOS_LAMBDA(int i) { a.data()[i] = magic; });
+}
+
+template <class ViewType, class ExecSpace>
+size_t compute_overall_sum(const ExecSpace& space, ViewType& a) {
+  auto policy = Kokkos::RangePolicy<ExecSpace>(space, 0, a.span());
+
+  assert(a.span_is_contiguous());
+
+  typename ViewType::value_type sum = 0;
+  Kokkos::parallel_reduce(
+      "TestViewCopy::ComputeSum", policy,
+      KOKKOS_LAMBDA(int i, int& lcl_sum) { lcl_sum += a.data()[i]; }, sum);
+
+  return static_cast<size_t>(sum);
+}
+
+template <typename ExecSpace, typename DT, typename... DP>
+bool check_magic_value(
+    const ExecSpace& space, const Kokkos::View<DT, DP...>& a, int magic,
+    std::enable_if_t<Kokkos::ViewTraits<DT, DP...>::rank == 0>* = nullptr) {
+  auto policy = Kokkos::RangePolicy<ExecSpace>(space, 0, 1);
+
+  bool all_elements_are_set;  // Uninitialized, set by parallel_reduce
+
+  Kokkos::parallel_reduce(
+      "TestViewCopy::CheckMagicValueRank0", policy,
+      KOKKOS_LAMBDA(int, bool& local_check) { local_check &= (a() == magic); },
+      Kokkos::LAnd<bool>(all_elements_are_set));
+
+  return all_elements_are_set;
+}
+
+template <typename ExecSpace, typename DT, typename... DP>
+bool check_magic_value(
+    const ExecSpace& space, const Kokkos::View<DT, DP...>& a, int magic,
+    std::enable_if_t<Kokkos::ViewTraits<DT, DP...>::rank == 1>* = nullptr) {
+  auto policy = Kokkos::RangePolicy<ExecSpace>(space, 0, a.extent(0));
+
+  bool all_elements_are_set;  // Uninitialized, set by parallel_reduce
+
+  Kokkos::parallel_reduce(
+      "TestViewCopy::CheckMagicValueRank1", policy,
+      KOKKOS_LAMBDA(int i, bool& local_check) {
+        local_check &= (a(i) == magic);
+      },
+      Kokkos::LAnd<bool>(all_elements_are_set));
+
+  return all_elements_are_set;
+}
+
+template <typename ExecSpace, typename DT, typename... DP>
+bool check_magic_value(
+    const ExecSpace& space, const Kokkos::View<DT, DP...>& a, int magic,
+    std::enable_if_t<Kokkos::ViewTraits<DT, DP...>::rank == 2>* = nullptr) {
+  auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<2>, ExecSpace>(
+      space, {0, 0}, {a.extent(0), a.extent(1)});
+
+  bool all_elements_are_set;  // Uninitialized, set by parallel_reduce
+
+  Kokkos::parallel_reduce(
+      "TestViewCopy::CheckMagicValueRank2", policy,
+      KOKKOS_LAMBDA(int i0, int i1, bool& local_check) {
+        local_check &= (a(i0, i1) == magic);
+      },
+      Kokkos::LAnd<bool>(all_elements_are_set));
+
+  return all_elements_are_set;
+}
+
+template <typename ExecSpace, typename DT, typename... DP>
+bool check_magic_value(
+    const ExecSpace& space, const Kokkos::View<DT, DP...>& a, int magic,
+    std::enable_if_t<Kokkos::ViewTraits<DT, DP...>::rank == 3>* = nullptr) {
+  auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<3>, ExecSpace>(
+      space, {0, 0, 0}, {a.extent(0), a.extent(1), a.extent(2)});
+
+  bool all_elements_are_set;  // Uninitialized, set by parallel_reduce
+
+  Kokkos::parallel_reduce(
+      "TestViewCopy::CheckMagicValueRank3", policy,
+      KOKKOS_LAMBDA(int i0, int i1, int i2, bool& local_check) {
+        local_check &= (a(i0, i1, i2) == magic);
+      },
+      Kokkos::LAnd<bool>(all_elements_are_set));
+
+  return all_elements_are_set;
+}
+
+template <typename ExecSpace, typename DT, typename... DP>
+bool check_magic_value(
+    const ExecSpace& space, const Kokkos::View<DT, DP...>& a, int magic,
+    std::enable_if_t<Kokkos::ViewTraits<DT, DP...>::rank == 4>* = nullptr) {
+  auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<4>, ExecSpace>(
+      space, {0, 0, 0, 0},
+      {a.extent(0), a.extent(1), a.extent(2), a.extent(3)});
+
+  bool all_elements_are_set;  // Uninitialized, set by parallel_reduce
+
+  Kokkos::parallel_reduce(
+      "TestViewCopy::CheckMagicValueRank4", policy,
+      KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, bool& local_check) {
+        local_check &= (a(i0, i1, i2, i3) == magic);
+      },
+      Kokkos::LAnd<bool>(all_elements_are_set));
+
+  return all_elements_are_set;
+}
+
+template <typename ExecSpace, typename DT, typename... DP>
+bool check_magic_value(
+    const ExecSpace& space, const Kokkos::View<DT, DP...>& a, int magic,
+    std::enable_if_t<Kokkos::ViewTraits<DT, DP...>::rank == 5>* = nullptr) {
+  auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<5>, ExecSpace>(
+      space, {0, 0, 0, 0, 0},
+      {a.extent(0), a.extent(1), a.extent(2), a.extent(3), a.extent(4)});
+
+  bool all_elements_are_set;  // Uninitialized, set by parallel_reduce
+
+  Kokkos::parallel_reduce(
+      "TestViewCopy::CheckMagicValueRank5", policy,
+      KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, bool& local_check) {
+        local_check &= (a(i0, i1, i2, i3, i4) == magic);
+      },
+      Kokkos::LAnd<bool>(all_elements_are_set));
+
+  return all_elements_are_set;
+}
+
+template <typename ExecSpace, typename DT, typename... DP>
+bool check_magic_value(
+    const ExecSpace& space, const Kokkos::View<DT, DP...>& a, int magic,
+    std::enable_if_t<Kokkos::ViewTraits<DT, DP...>::rank == 6>* = nullptr) {
+  auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<6>, ExecSpace>(
+      space, {0, 0, 0, 0, 0, 0},
+      {a.extent(0), a.extent(1), a.extent(2), a.extent(3), a.extent(4),
+       a.extent(5)});
+
+  bool all_elements_are_set;  // Uninitialized, set by parallel_reduce
+
+  Kokkos::parallel_reduce(
+      "TestViewCopy::CheckMagicValueRank6", policy,
+      KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, int i5,
+                    bool& local_check) {
+        local_check &= (a(i0, i1, i2, i3, i4, i5) == magic);
+      },
+      Kokkos::LAnd<bool>(all_elements_are_set));
+
+  return all_elements_are_set;
+}
+
+template <typename ExecSpace, typename DT, typename... DP>
+bool check_magic_value(
+    const ExecSpace& space, const Kokkos::View<DT, DP...>& a, int magic,
+    std::enable_if_t<Kokkos::ViewTraits<DT, DP...>::rank == 7>* = nullptr) {
+  auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<6>, ExecSpace>(
+      space, {0, 0, 0, 0, 0, 0},
+      {a.extent(0), a.extent(1), a.extent(2), a.extent(3), a.extent(4),
+       a.extent(5)});
+
+  bool all_elements_are_set = true;
+
+  for (size_t outer = 0; outer < a.extent(6); ++outer) {
+    bool all_local_elements_are_set;  // Uninitialized, set by parallel_reduce
+    Kokkos::parallel_reduce(
+        "TestViewCopy::CheckMagicValueRank7", policy,
+        KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, int i5,
+                      bool& local_check) {
+          local_check &= (a(i0, i1, i2, i3, i4, i5, outer) == magic);
+        },
+        Kokkos::LAnd<bool>(all_local_elements_are_set));
+
+    all_elements_are_set = all_elements_are_set && all_local_elements_are_set;
+  }
+  return all_elements_are_set;
+}
+
+template <typename ExecSpace, typename DT, typename... DP>
+bool check_magic_value(
+    const ExecSpace& space, const Kokkos::View<DT, DP...>& a, int magic,
+    std::enable_if_t<Kokkos::ViewTraits<DT, DP...>::rank == 8>* = nullptr) {
+  auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<6>, ExecSpace>(
+      space, {0, 0, 0, 0, 0, 0},
+      {a.extent(0), a.extent(1), a.extent(2), a.extent(3), a.extent(4),
+       a.extent(5)});
+
+  bool all_elements_are_set = true;
+
+  for (size_t outer = 0; outer < a.extent(7); ++outer) {
+    for (size_t inner = 0; inner < a.extent(6); ++inner) {
+      bool all_local_elements_are_set;  // Uninitialized, set by parallel_reduce
+      Kokkos::parallel_reduce(
+          "TestViewCopy::CheckMagicValueRank8", policy,
+          KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, int i5,
+                        bool& local_check) {
+            local_check &= (a(i0, i1, i2, i3, i4, i5, inner, outer) == magic);
+          },
+          Kokkos::LAnd<bool>(all_local_elements_are_set));
+
+      all_elements_are_set = all_elements_are_set && all_local_elements_are_set;
+    }
+  }
+  return all_elements_are_set;
+}
+
+template <class ExecSpace, class ViewType>
+bool view_fill_test(const ExecSpace& space, ViewType& a, int magic) {
+  Kokkos::deep_copy(space, a, magic);
+#if defined(KOKKOS_ENABLE_OPENMPTARGET)
+  if constexpr (std::is_same_v<TEST_EXECSPACE::execution_space,
+                               Kokkos::Experimental::OpenMPTarget>) {
+    return true;
+  }
+#endif  // KOKKOS_ENABLE_OPENMPTARGET
+  return check_magic_value(space, a, magic);
+}
+
+template <class Layout, class Space>
+void run_test() {
+  int magic = 19;
+
+  using ViewType = Kokkos::View<int********, Layout, Space>;
+  // Create views with different lengths for each dimension
+  // We want to test if all loops are over the correct dimensions
+  // We use prime numbers to make sure that the strides are different
+  ViewType a_decreasing("a", 23, 19, 17, 13, 11, 7, 5, 3);
+  // We also test with increasing strides to catch more "out-of-bounds" errors
+  // within subviews.
+  ViewType a_increasing("a", 3, 5, 7, 11, 13, 17, 19, 23);
+
+  using exec_space = typename Space::execution_space;
+  auto space       = exec_space();
+
+  // Use subviews in the tests to have cases with different ranks and
+  // non-contiguous memory
+  // Tests have two parts:
+  // 1. Fill the subview with a magic value and check that all elements are set
+  // 2. Check if only the subview is set by summing all elements in the view and
+  // comparing to the subview size times the magic value
+
+  // Rank 0
+  {
+    auto sub_dec = Kokkos::subview(a_decreasing, 0, 0, 0, 0, 0, 0, 0, 0);
+    EXPECT_TRUE(view_fill_test(space, sub_dec, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_decreasing),
+              static_cast<size_t>(magic));
+
+    auto sub_inc = Kokkos::subview(a_increasing, 0, 0, 0, 0, 0, 0, 0, 0);
+    EXPECT_TRUE(view_fill_test(space, sub_inc, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_increasing),
+              static_cast<size_t>(magic));
+  }
+  reset_view(space, a_decreasing, 0);
+  reset_view(space, a_increasing, 0);
+
+  // Rank 1
+  {
+    auto sub_dec =
+        Kokkos::subview(a_decreasing, Kokkos::ALL, 0, 0, 0, 0, 0, 0, 0);
+    EXPECT_TRUE(view_fill_test(space, sub_dec, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_decreasing), sub_dec.size() * magic);
+
+    auto sub_inc =
+        Kokkos::subview(a_increasing, Kokkos::ALL, 0, 0, 0, 0, 0, 0, 0);
+    EXPECT_TRUE(view_fill_test(space, sub_inc, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_increasing), sub_inc.size() * magic);
+  }
+  reset_view(space, a_decreasing, 0);
+  reset_view(space, a_increasing, 0);
+
+  // Rank 2
+  {
+    auto sub_dec = Kokkos::subview(a_decreasing, Kokkos::ALL, Kokkos::ALL, 0, 0,
+                                   0, 0, 0, 0);
+    EXPECT_TRUE(view_fill_test(space, sub_dec, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_decreasing), sub_dec.size() * magic);
+
+    auto sub_inc = Kokkos::subview(a_increasing, Kokkos::ALL, Kokkos::ALL, 0, 0,
+                                   0, 0, 0, 0);
+    EXPECT_TRUE(view_fill_test(space, sub_inc, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_increasing), sub_inc.size() * magic);
+  }
+  reset_view(space, a_decreasing, 0);
+  reset_view(space, a_increasing, 0);
+  space.fence();
+
+  // Rank 3
+  {
+    auto sub_dec = Kokkos::subview(a_decreasing, Kokkos::ALL, Kokkos::ALL,
+                                   Kokkos::ALL, 0, 0, 0, 0, 0);
+    EXPECT_TRUE(view_fill_test(space, sub_dec, magic));
+    EXPECT_EQ(
+        compute_overall_sum(space, a_decreasing),
+        sub_dec.extent(0) * sub_dec.extent(1) * sub_dec.extent(2) * magic);
+
+    auto sub_inc = Kokkos::subview(a_increasing, Kokkos::ALL, Kokkos::ALL,
+                                   Kokkos::ALL, 0, 0, 0, 0, 0);
+    EXPECT_TRUE(view_fill_test(space, sub_inc, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_increasing), sub_inc.size() * magic);
+  }
+  reset_view(space, a_decreasing, 0);
+  reset_view(space, a_increasing, 0);
+  space.fence();
+
+  // Rank 4
+  {
+    auto sub_dec = Kokkos::subview(a_decreasing, Kokkos::ALL, Kokkos::ALL,
+                                   Kokkos::ALL, Kokkos::ALL, 0, 0, 0, 0);
+    EXPECT_TRUE(view_fill_test(space, sub_dec, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_decreasing),
+              sub_dec.extent(0) * sub_dec.extent(1) * sub_dec.extent(2) *
+                  sub_dec.extent(3) * magic);
+
+    auto sub_inc = Kokkos::subview(a_increasing, Kokkos::ALL, Kokkos::ALL,
+                                   Kokkos::ALL, Kokkos::ALL, 0, 0, 0, 0);
+    EXPECT_TRUE(view_fill_test(space, sub_inc, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_increasing), sub_inc.size() * magic);
+  }
+  reset_view(space, a_decreasing, 0);
+  reset_view(space, a_increasing, 0);
+  space.fence();
+
+  // Rank 5
+  {
+    auto sub_dec =
+        Kokkos::subview(a_decreasing, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
+                        Kokkos::ALL, Kokkos::ALL, 0, 0, 0);
+    EXPECT_TRUE(view_fill_test(space, sub_dec, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_decreasing), sub_dec.size() * magic);
+
+    auto sub_inc =
+        Kokkos::subview(a_increasing, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
+                        Kokkos::ALL, Kokkos::ALL, 0, 0, 0);
+    EXPECT_TRUE(view_fill_test(space, sub_inc, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_increasing), sub_inc.size() * magic);
+  }
+  reset_view(space, a_decreasing, 0);
+  reset_view(space, a_increasing, 0);
+  space.fence();
+
+  // Rank 6
+  {
+    auto sub_dec =
+        Kokkos::subview(a_decreasing, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
+                        Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, 0, 0);
+    EXPECT_TRUE(view_fill_test(space, sub_dec, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_decreasing), sub_dec.size() * magic);
+
+    auto sub_inc =
+        Kokkos::subview(a_increasing, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
+                        Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, 0, 0);
+    EXPECT_TRUE(view_fill_test(space, sub_inc, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_increasing), sub_inc.size() * magic);
+  }
+  reset_view(space, a_decreasing, 0);
+  reset_view(space, a_increasing, 0);
+  space.fence();
+
+  // Rank 7
+  {
+    auto sub_dec =
+        Kokkos::subview(a_decreasing, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
+                        Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, 0);
+    EXPECT_TRUE(view_fill_test(space, sub_dec, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_decreasing), sub_dec.size() * magic);
+
+    auto sub_inc =
+        Kokkos::subview(a_increasing, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
+                        Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, 0);
+    EXPECT_TRUE(view_fill_test(space, sub_inc, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_increasing), sub_inc.size() * magic);
+  }
+  reset_view(space, a_decreasing, 0);
+  reset_view(space, a_increasing, 0);
+  space.fence();
+
+  // Rank 8
+  {
+    auto sub_dec = Kokkos::subview(
+        a_decreasing, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
+        Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, std::make_pair(0, 2));
+    EXPECT_TRUE(view_fill_test(space, sub_dec, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_decreasing), sub_dec.size() * magic);
+
+    auto sub_inc = Kokkos::subview(
+        a_increasing, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
+        Kokkos::ALL, Kokkos::ALL, Kokkos::ALL, std::make_pair(0, 2));
+    EXPECT_TRUE(view_fill_test(space, sub_inc, magic));
+    EXPECT_EQ(compute_overall_sum(space, a_increasing), sub_inc.size() * magic);
+  }
+}
+
+TEST(TEST_CATEGORY, view_fill_tests_layout_right) {
+  using Space  = TEST_EXECSPACE;
+  using Layout = Kokkos::LayoutRight;
+  run_test<Layout, Space>();
+}
+
+TEST(TEST_CATEGORY, view_fill_tests_layout_left) {
+  using Space  = TEST_EXECSPACE;
+  using Layout = Kokkos::LayoutLeft;
+  run_test<Layout, Space>();
+}
+
+}  // namespace


### PR DESCRIPTION
While working on #6783 , I found a typo in loop indices in `ViewFill` for 7 dimensional views, where MDRange arguments where not compatible with the corresponding `operator()`. 

`extend(2)` was used twice while `extend(4)` was skipped.

I adopted the same view decomposition (6 MDRange + 1) as `ViewCopy`.
