### PR TITLE
Update GitHub actions ot use Node 20

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -4,7 +4,7 @@ jobs:
   formatting-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run clang-format style check.
       uses: DoozyX/clang-format-lint-action@v0.16.2
       with:

--- a/.github/workflows/continuous-integration-workflow-32bit.yml
+++ b/.github/workflows/continuous-integration-workflow-32bit.yml
@@ -21,7 +21,7 @@ jobs:
       image: ghcr.io/kokkos/ci-containers/ubuntu:latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: install_multilib
         run: sudo apt-get update && sudo apt-get install -y gcc-multilib g++-multilib gfortran-multilib
       - name: Configure Kokkos

--- a/.github/workflows/continuous-integration-workflow-hpx.yml
+++ b/.github/workflows/continuous-integration-workflow-hpx.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: kokkos
       - name: setup hpx dependencies
@@ -33,12 +33,12 @@ jobs:
             libboost-all-dev \
             ninja-build
       - name: checkout hpx
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: STELLAR-GROUP/hpx
           ref: v1.9.0
           path: hpx
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id:   cache-hpx
         with:
           path:         ./hpx/install

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -67,7 +67,7 @@ jobs:
       image: ghcr.io/kokkos/ci-containers/${{ matrix.distro }}
     steps:
       - name: Checkout desul
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: desul/desul
           ref: 477da9c8f40f8db369c28dd3f93a67e376d8511b
@@ -82,8 +82,8 @@ jobs:
           cmake -DDESUL_ENABLE_TESTS=OFF -DCMAKE_INSTALL_PREFIX=/usr/desul-install ..
           sudo cmake --build . --target install --parallel 2
       - name: Checkout code
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
+        uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/ccache
           key: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.cmake_build_type }}-${{ matrix.openmp }}-${{ github.ref }}-${{ github.sha }}

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -31,7 +31,7 @@ jobs:
             cmake_build_type: "Release"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: configure
         run:
           cmake -B build .

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -23,8 +23,8 @@ jobs:
       BUILD_ID: ${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.backend }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
+        uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/ccache
           key: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.backend }}-${{ github.ref }}-${{ github.sha }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: windows-2022
 
     steps:
-    - uses: Jimver/cuda-toolkit@v0.2.11
+    - uses: Jimver/cuda-toolkit@v0.2.14
       id: cuda-toolkit
       with:
         cuda: '12.1.0'


### PR DESCRIPTION
Fixes the warning caused by using Node 16 instead of Node 20, see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.