### PR TITLE
Remove Fence in Deallocation Machinery (Fix for #6794)

### DIFF
--- a/core/unit_test/tools/TestEventCorrectness.hpp
+++ b/core/unit_test/tools/TestEventCorrectness.hpp
@@ -464,7 +464,8 @@ TEST(kokkosp, parallel_scan_no_fence_view) {
         if (begin_event.name.find("Debug Only Check for Execution Error") !=
                 std::string::npos ||
             begin_event.name.find("Kokkos Profile Tool Fence") !=
-                std::string::npos)
+                std::string::npos ||
+            begin_event.name.find("fence before deallocate") != std::string::npos)
           return MatchDiagnostic{false};
         else
           return MatchDiagnostic{true};

--- a/core/unit_test/tools/TestEventCorrectness.hpp
+++ b/core/unit_test/tools/TestEventCorrectness.hpp
@@ -421,7 +421,8 @@ TEST(kokkosp, parallel_scan_no_fence) {
         if (begin_event.name.find("Debug Only Check for Execution Error") !=
                 std::string::npos ||
             begin_event.name.find("Kokkos Profile Tool Fence") !=
-                std::string::npos)
+                std::string::npos ||
+            begin_event.name.find("fence before deallocate") != std::string::npos)
           return MatchDiagnostic{false};
         else
           return MatchDiagnostic{true};


### PR DESCRIPTION
This PR fixes SYCL Nightly Test failure (in `Kokkos_CoreUnitTest_KokkosP`).