### PR TITLE
Avoid detecting unwanted fences in the parallel_scan_no_fence test

### DIFF
--- a/core/unit_test/tools/TestEventCorrectness.hpp
+++ b/core/unit_test/tools/TestEventCorrectness.hpp
@@ -409,14 +409,19 @@ TEST(kokkosp, parallel_scan_no_fence) {
         << "skipping since the OpenMPTarget backend has unexpected fences";
 #endif
 
+  // Execute the parallel_scan first without looking for fence events.
+  // Depending on the backend implementation and the order of tests,
+  // it might be that the first call to parallel_scan is reallocating scratch
+  // memory which implies a fence when deallocating. We are not interested in
+  // detecting this event.
+  TestScanFunctor tf;
+  Kokkos::parallel_scan("dogs", Kokkos::RangePolicy<>(0, 1), tf);
+
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels(),
                      Config::EnableFences());
   auto success = validate_absence(
-      [=]() {
-        TestScanFunctor tf;
-        Kokkos::parallel_scan("dogs", Kokkos::RangePolicy<>(0, 1), tf);
-      },
+      [=]() { Kokkos::parallel_scan("dogs", Kokkos::RangePolicy<>(0, 1), tf); },
       [=](BeginFenceEvent begin_event) {
         if (begin_event.name.find("Debug Only Check for Execution Error") !=
                 std::string::npos ||
@@ -450,13 +455,20 @@ TEST(kokkosp, parallel_scan_no_fence_view) {
         << "skipping since the OpenMPTarget backend has unexpected fences";
 #endif
 
+  // Execute the parallel_scan first without looking for fence events.
+  // Depending on the backend implementation and the order of tests,
+  // it might be that the first call to parallel_scan is reallocating scratch
+  // memory which implies a fence when deallocating. We are not interested in
+  // detecting this event.
+  TestScanFunctor tf;
+  Kokkos::View<typename TestScanFunctor::value_type> v("scan_result");
+  Kokkos::parallel_scan("dogs", Kokkos::RangePolicy<>(0, 1), tf, v);
+
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels(),
                      Config::EnableFences());
-  Kokkos::View<typename TestScanFunctor::value_type> v("scan_result");
   auto success = validate_absence(
       [=]() {
-        TestScanFunctor tf;
         Kokkos::parallel_scan("dogs", Kokkos::RangePolicy<>(0, 1), tf, v);
       },
       [=](BeginFenceEvent begin_event) {


### PR DESCRIPTION
Fixes #6794. Alternative to #6836.
The problem was that we are reallocating scratch memory if the previous allocation wasn't large enough and that implies a fence when deallocating. Thus, it depends on the order of tests run if we encounter the test failure in #6794 or not.
#6836 just ignores all deallocation fences but it should be enough to just run the `parallel_scan` twice and only look at the events for the second call that should already have the scratch memory set to an appropriate size.

@ajpowelsnl @ndellingwood Can you please test if this pull request would also fix the failure on your end? 