### PR TITLE
Add functions for retrieving the default tile sizes in MDRangePolicy

### DIFF
--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -30,6 +30,7 @@ static_assert(false,
 #include <impl/KokkosExp_Host_IterateTile.hpp>
 #include <Kokkos_ExecPolicy.hpp>
 #include <type_traits>
+#include <cmath>
 
 namespace Kokkos {
 
@@ -326,7 +327,10 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   int tile_size_recommended(const int tile_rank) const {
     auto properties   = Impl::get_tile_size_properties(m_space);
     int last_rank     = (inner_direction == Iterate::Right) ? rank - 1 : 0;
-    int rec_tile_size = properties.default_tile_size;
+    int rec_tile_size = (std::pow(properties.default_tile_size, tile_rank + 1) <
+                         properties.max_total_tile_size)
+                            ? properties.default_tile_size
+                            : 1;
 
     if (tile_rank == last_rank) {
       rec_tile_size = tile_size_last_rank(

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -314,7 +314,38 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   }
   bool impl_tune_tile_size() const { return m_tune_tile_size; }
 
+  tile_type tile_size_recommended() const {
+    auto properties             = Impl::get_tile_size_properties(m_space);
+    tile_type default_tile_size = {};
+
+    for (std::size_t i = 0; i < default_tile_size.size(); ++i) {
+      default_tile_size[i] = properties.default_tile_size;
+    }
+
+    int last_rank = (inner_direction == Iterate::Right) ? rank - 1 : 0;
+    default_tile_size[last_rank] = tile_length_last_rank(
+        properties, m_upper[last_rank] - m_lower[last_rank]);
+    return default_tile_size;
+  }
+
+  int tile_length_max_recommended_per_rank(const int tile_rank) const {
+    auto properties = Impl::get_tile_size_properties(m_space);
+    return tile_length_last_rank(properties,
+                                 m_upper[tile_rank] - m_lower[tile_rank]);
+  }
+
+  int tile_size_max_total() const {
+    return Impl::get_tile_size_properties(m_space).max_total_tile_size;
+  }
+
  private:
+  int tile_length_last_rank(const Impl::TileSizeProperties properties,
+                            const index_type length) const {
+    return properties.default_largest_tile_size == 0
+               ? std::max<int>(length, 1)
+               : properties.default_largest_tile_size;
+  }
+
   void init_helper(Impl::TileSizeProperties properties) {
     m_prod_tile_dims = 1;
     int increment    = 1;
@@ -352,9 +383,7 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
             m_tile[i] = 1;
           }
         } else {
-          m_tile[i] = properties.default_largest_tile_size == 0
-                          ? std::max<int>(length, 1)
-                          : properties.default_largest_tile_size;
+          m_tile[i] = tile_length_last_rank(properties, length);
         }
       }
       m_tile_end[i] =

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -335,21 +335,6 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
     return rec_tile_size;
   }
 
-  tile_type largest_tile_size_recommended() const {
-    tile_type rec_largest_tile_sizes = {};
-
-    for (std::size_t i = 0; i < rec_largest_tile_sizes.size(); ++i) {
-      rec_largest_tile_sizes[i] = largest_tile_size_recommended(i);
-    }
-    return rec_largest_tile_sizes;
-  }
-
-  int largest_tile_size_recommended(const int tile_rank) const {
-    auto properties = Impl::get_tile_size_properties(m_space);
-    return tile_size_last_rank(properties,
-                               m_upper[tile_rank] - m_lower[tile_rank]);
-  }
-
   int max_total_tile_size() const {
     return Impl::get_tile_size_properties(m_space).max_total_tile_size;
   }

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -323,15 +323,15 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
     }
 
     int last_rank = (inner_direction == Iterate::Right) ? rank - 1 : 0;
-    default_tile_size[last_rank] = tile_length_last_rank(
+    default_tile_size[last_rank] = tile_size_last_rank(
         properties, m_upper[last_rank] - m_lower[last_rank]);
     return default_tile_size;
   }
 
-  int tile_length_max_recommended_per_rank(const int tile_rank) const {
+  int tile_size_max_recommended_per_rank(const int tile_rank) const {
     auto properties = Impl::get_tile_size_properties(m_space);
-    return tile_length_last_rank(properties,
-                                 m_upper[tile_rank] - m_lower[tile_rank]);
+    return tile_size_last_rank(properties,
+                               m_upper[tile_rank] - m_lower[tile_rank]);
   }
 
   int tile_size_max_total() const {
@@ -339,8 +339,8 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   }
 
  private:
-  int tile_length_last_rank(const Impl::TileSizeProperties properties,
-                            const index_type length) const {
+  int tile_size_last_rank(const Impl::TileSizeProperties properties,
+                          const index_type length) const {
     return properties.default_largest_tile_size == 0
                ? std::max<int>(length, 1)
                : properties.default_largest_tile_size;
@@ -383,7 +383,7 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
             m_tile[i] = 1;
           }
         } else {
-          m_tile[i] = tile_length_last_rank(properties, length);
+          m_tile[i] = tile_size_last_rank(properties, length);
         }
       }
       m_tile_end[i] =

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -315,26 +315,42 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   bool impl_tune_tile_size() const { return m_tune_tile_size; }
 
   tile_type tile_size_recommended() const {
-    auto properties             = Impl::get_tile_size_properties(m_space);
-    tile_type default_tile_size = {};
+    tile_type rec_tile_sizes = {};
 
-    for (std::size_t i = 0; i < default_tile_size.size(); ++i) {
-      default_tile_size[i] = properties.default_tile_size;
+    for (std::size_t i = 0; i < rec_tile_sizes.size(); ++i) {
+      rec_tile_sizes[i] = tile_size_recommended(i);
     }
-
-    int last_rank = (inner_direction == Iterate::Right) ? rank - 1 : 0;
-    default_tile_size[last_rank] = tile_size_last_rank(
-        properties, m_upper[last_rank] - m_lower[last_rank]);
-    return default_tile_size;
+    return rec_tile_sizes;
   }
 
-  int tile_size_max_recommended_per_rank(const int tile_rank) const {
+  int tile_size_recommended(const int tile_rank) const {
+    auto properties   = Impl::get_tile_size_properties(m_space);
+    int last_rank     = (inner_direction == Iterate::Right) ? rank - 1 : 0;
+    int rec_tile_size = properties.default_tile_size;
+
+    if (tile_rank == last_rank) {
+      rec_tile_size = tile_size_last_rank(
+          properties, m_upper[last_rank] - m_lower[last_rank]);
+    }
+    return rec_tile_size;
+  }
+
+  tile_type largest_tile_size_recommended() const {
+    tile_type rec_largest_tile_sizes = {};
+
+    for (std::size_t i = 0; i < rec_largest_tile_sizes.size(); ++i) {
+      rec_largest_tile_sizes[i] = largest_tile_size_recommended(i);
+    }
+    return rec_largest_tile_sizes;
+  }
+
+  int largest_tile_size_recommended(const int tile_rank) const {
     auto properties = Impl::get_tile_size_properties(m_space);
     return tile_size_last_rank(properties,
                                m_upper[tile_rank] - m_lower[tile_rank]);
   }
 
-  int tile_size_max_total() const {
+  int max_total_tile_size() const {
     return Impl::get_tile_size_properties(m_space).max_total_tile_size;
   }
 

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -151,6 +151,18 @@ TEST(TEST_CATEGORY, policy_get_tile_size) {
 
   {
     int dim_length = 100;
+    Policy policy_default({0, 0, 0}, {dim_length, dim_length, dim_length});
+
+    auto rec_tile_sizes      = policy_default.tile_size_recommended();
+    auto internal_tile_sizes = policy_default.m_tile;
+
+    for (std::size_t i = 0; i < rank; ++i) {
+      EXPECT_EQ(rec_tile_sizes[i], internal_tile_sizes[i])
+          << " incorrect recommended tile size returned for rank " << i;
+    }
+  }
+  {
+    int dim_length = 100;
     Policy policy({0, 0, 0}, {dim_length, dim_length, dim_length},
                   tile_type{{2, 4, 16}});
 

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -158,28 +158,25 @@ TEST(TEST_CATEGORY, policy_get_tile_size) {
               policy.tile_size_max_total());
 
     for (std::size_t i = 0; i < rank; ++i) {
-      if (i != last_rank) {
-        EXPECT_EQ(default_size_properties.default_tile_size, rec_tile_size[i]);
-      } else {
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
     defined(KOKKOS_ENABLE_SYCL)
+      EXPECT_EQ(default_size_properties.default_largest_tile_size,
+                policy.tile_size_max_recommended_per_rank(i));
+      if (i == last_rank) {
         if (default_size_properties.default_largest_tile_size == 0)
           EXPECT_EQ(100, rec_tile_size[i]);
         else
           EXPECT_EQ(default_size_properties.default_largest_tile_size,
                     rec_tile_size[i]);
+      }
 #else
-        EXPECT_EQ(policy.tile_length_max_recommended_per_rank(last_rank),
+      EXPECT_EQ(100, policy.tile_size_max_recommended_per_rank(i));
+      if (i == last_rank)
+        EXPECT_EQ(policy.tile_size_max_recommended_per_rank(last_rank),
                   rec_tile_size[i]);
 #endif
-      }
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
-    defined(KOKKOS_ENABLE_SYCL)
-      EXPECT_EQ(default_size_properties.default_largest_tile_size,
-                policy.tile_length_max_recommended_per_rank(i));
-#else
-      EXPECT_EQ(100, policy.tile_length_max_recommended_per_rank(i));
-#endif
+      else
+        EXPECT_EQ(default_size_properties.default_tile_size, rec_tile_size[i]);
     }
   }
 }

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -154,8 +154,7 @@ TEST(TEST_CATEGORY, policy_get_tile_size) {
     Policy policy({0, 0, 0}, {dim_length, dim_length, dim_length},
                   tile_type{{2, 4, 16}});
 
-    auto rec_tile_sizes         = policy.tile_size_recommended();
-    auto rec_largest_tile_sizes = policy.largest_tile_size_recommended();
+    auto rec_tile_sizes = policy.tile_size_recommended();
 
     EXPECT_EQ(default_size_properties.max_total_tile_size,
               policy.max_total_tile_size());
@@ -164,25 +163,14 @@ TEST(TEST_CATEGORY, policy_get_tile_size) {
     for (std::size_t i = 0; i < rank; ++i) {
       EXPECT_GT(rec_tile_sizes[i], 0)
           << " invalid default tile size for rank " << i;
-      EXPECT_LE(rec_tile_sizes[i], rec_largest_tile_sizes[i])
-          << " invalid default tile size for rank " << i;
 
       if (default_size_properties.default_largest_tile_size == 0) {
-        EXPECT_EQ(dim_length, rec_largest_tile_sizes[i])
-            << " incorrect recommended largest tile size returned for rank "
-            << i;
-
         auto expected_rec_tile_size =
             (i == last_rank) ? dim_length
                              : default_size_properties.default_tile_size;
         EXPECT_EQ(expected_rec_tile_size, rec_tile_sizes[i])
             << " incorrect recommended tile size returned for rank " << i;
       } else {
-        EXPECT_EQ(default_size_properties.default_largest_tile_size,
-                  rec_largest_tile_sizes[i])
-            << " incorrect recommended largest tile size returned for rank "
-            << i;
-
         auto expected_rec_tile_size =
             (i == last_rank) ? default_size_properties.default_largest_tile_size
                              : default_size_properties.default_tile_size;

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -158,25 +158,21 @@ TEST(TEST_CATEGORY, policy_get_tile_size) {
               policy.tile_size_max_total());
 
     for (std::size_t i = 0; i < rank; ++i) {
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
-    defined(KOKKOS_ENABLE_SYCL)
-      EXPECT_EQ(default_size_properties.default_largest_tile_size,
-                policy.tile_size_max_recommended_per_rank(i));
-      if (i == last_rank) {
-        if (default_size_properties.default_largest_tile_size == 0)
-          EXPECT_EQ(100, rec_tile_size[i]);
-        else
-          EXPECT_EQ(default_size_properties.default_largest_tile_size,
-                    rec_tile_size[i]);
+      if (default_size_properties.default_largest_tile_size == 0) {
+        EXPECT_EQ(100, policy.tile_size_max_recommended_per_rank(i));
+
+        auto expected_rec_tile_size =
+            (i == last_rank) ? 100 : default_size_properties.default_tile_size;
+        EXPECT_EQ(expected_rec_tile_size, rec_tile_size[i]);
+      } else {
+        EXPECT_EQ(default_size_properties.default_largest_tile_size,
+                  policy.tile_size_max_recommended_per_rank(i));
+
+        auto expected_rec_tile_size =
+            (i == last_rank) ? default_size_properties.default_largest_tile_size
+                             : default_size_properties.default_tile_size;
+        EXPECT_EQ(expected_rec_tile_size, rec_tile_size[i]);
       }
-#else
-      EXPECT_EQ(100, policy.tile_size_max_recommended_per_rank(i));
-      if (i == last_rank)
-        EXPECT_EQ(policy.tile_size_max_recommended_per_rank(last_rank),
-                  rec_tile_size[i]);
-#endif
-      else
-        EXPECT_EQ(default_size_properties.default_tile_size, rec_tile_size[i]);
     }
   }
 }


### PR DESCRIPTION
Resolves #6609

This PR adds query functions in MDRangePolicy to allow retrieving the default tile sizes that are used internally, if a custom tile size is not specified during the construction of the policy:
- `tile_type tile_size_recommended() const`
- `int tile_size_recommended(const int tile_rank) const`
- ~~`tile_type largest_tile_size_recommended() const`~~
- ~~`int largest_tile_size_recommended(const int tile_rank) const`~~
- `int max_total_tile_size() const`

The base setting of `TileSizeProperties` is in:
https://github.com/kokkos/kokkos/blob/e2689abc05d2b96890148cc26b4a05c4180b8541/core/src/KokkosExp_MDRangePolicy.hpp#L131-L147
And this setting is used to configure the tile size during the construction of the policy.

For `Cuda`, `HIP` and `SYCL`, the settings of `TileSizeProperties` are in `Kokkos_Cuda_MDRangePolicy.hpp`, `Kokkos_HIP_MDRangePolicy.hpp` and `Kokkos_SYCL_MDRangePolicy.hpp`, respectively.