### PR TITLE
Remove redundant RangePolicy constructor

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -119,24 +119,6 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
             std::enable_if_t<(std::is_convertible_v<IndexType1, member_type> &&
                               std::is_convertible_v<IndexType2, member_type>),
                              bool> = false>
-  inline RangePolicy(const typename traits::execution_space& work_space,
-                     const IndexType1 work_begin, const IndexType2 work_end)
-      : m_space(work_space),
-        m_begin(work_begin),
-        m_end(work_end),
-        m_granularity(0),
-        m_granularity_mask(0) {
-    check_conversion_safety(work_begin);
-    check_conversion_safety(work_end);
-    check_bounds_validity();
-    set_auto_chunk_size();
-  }
-
-  /** \brief  Total range */
-  template <typename IndexType1, typename IndexType2,
-            std::enable_if_t<(std::is_convertible_v<IndexType1, member_type> &&
-                              std::is_convertible_v<IndexType2, member_type>),
-                             bool> = false>
   inline RangePolicy(const IndexType1 work_begin, const IndexType2 work_end)
       : RangePolicy(typename traits::execution_space(), work_begin, work_end) {}
 

--- a/core/unit_test/TestRangePolicyCTAD.cpp
+++ b/core/unit_test/TestRangePolicyCTAD.cpp
@@ -69,7 +69,10 @@ struct TestRangePolicyCTAD {
 
   // RangePolicy(execution_space, index_type, index_type)
 
-  // none (ambiguous deduction for template arguments)
+  KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, des, i64, i64);
+  KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, des, i32, i32);
+  KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, nes, i64, i64);
+  KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, nes, i32, i32);
 
   // RangePolicy(execution_space, index_type, index_type, Args...)
 

--- a/core/unit_test/TestRangePolicyCTAD.cpp
+++ b/core/unit_test/TestRangePolicyCTAD.cpp
@@ -17,6 +17,8 @@
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Core_fwd.hpp"
 
+#if !defined(KOKKOS_COMPILER_NVCC) || KOKKOS_COMPILER_NVCC >= 1120
+
 namespace {
 
 template <class... Args>
@@ -54,7 +56,6 @@ struct TestRangePolicyCTAD {
 
   // RangePolicy(index_type, index_type)
 
-#if !defined(KOKKOS_COMPILER_NVCC) || KOKKOS_COMPILER_NVCC >= 1120
   KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, i64, i64);
   KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, i64, i32);
   KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, i32, i64);
@@ -80,7 +81,6 @@ struct TestRangePolicyCTAD {
   KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, des, i32, i32, cs);
   KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, nes, i64, i64, cs);
   KOKKOS_TEST_RANGE_POLICY(Kokkos::RangePolicy<>, nes, i32, i32, cs);
-#endif
 };  // TestRangePolicyCTAD struct
 
 // To eliminate maybe_unused warning on some compilers
@@ -88,3 +88,5 @@ const Kokkos::DefaultExecutionSpace des =
     TestRangePolicyCTAD::ImplicitlyConvertibleToDefaultExecutionSpace();
 
 }  // namespace
+
+#endif


### PR DESCRIPTION
Following the discussion in https://kokkosteam.slack.com/archives/C5BGU5NDQ/p1708708198675449, there are two possible constructors for
```
Kokkos::RangePolicy        policy(ExecutionSpace(), 0, N);
```
which only differ by a trailing variadic template argument, which is why some compilers have trouble with CTAD in this case. Since the variadic template argument can be empty, we don't actually need the constructor without the variadic template argument.