### PR TITLE
Remove variadic range policy constructor

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -150,11 +150,12 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
       : m_space(work_space),
         m_begin(work_begin),
         m_end(work_end),
-        m_granularity(chunk_size.value),
-        m_granularity_mask(m_granularity - 1) {
+        m_granularity(0),
+        m_granularity_mask(0) {
     check_conversion_safety(work_begin);
     check_conversion_safety(work_end);
     check_bounds_validity();
+    set_chunk_size(chunk_size.value);
   }
 
   /** \brief  Total range */
@@ -168,10 +169,13 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
                     chunk_size) {}
 
  public:
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use set_chunk_size instead")
   inline void set(ChunkSize chunksize) {
     m_granularity      = chunksize.value;
     m_granularity_mask = m_granularity - 1;
   }
+#endif
 
  public:
   /** \brief return chunk_size */

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -144,9 +144,9 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
             std::enable_if_t<(std::is_convertible_v<IndexType1, member_type> &&
                               std::is_convertible_v<IndexType2, member_type>),
                              bool> = false>
-  inline RangePolicy(const typename traits::execution_space& work_space,
-                     const IndexType1 work_begin, const IndexType2 work_end,
-                     const ChunkSize chunk_size)
+  RangePolicy(const typename traits::execution_space& work_space,
+              const IndexType1 work_begin, const IndexType2 work_end,
+              const ChunkSize chunk_size)
       : m_space(work_space),
         m_begin(work_begin),
         m_end(work_end),
@@ -163,8 +163,8 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
             std::enable_if_t<(std::is_convertible_v<IndexType1, member_type> &&
                               std::is_convertible_v<IndexType2, member_type>),
                              bool> = false>
-  inline RangePolicy(const IndexType1 work_begin, const IndexType2 work_end,
-                     const ChunkSize chunk_size)
+  RangePolicy(const IndexType1 work_begin, const IndexType2 work_end,
+              const ChunkSize chunk_size)
       : RangePolicy(typename traits::execution_space(), work_begin, work_end,
                     chunk_size) {}
 


### PR DESCRIPTION
To be added after #6841.

This removes the `RangePolicy` variadic constructor (in favor of two non-variadic constructors) and associated `set` functions, as the only extra parameter was `ChunkSize`.

`ChunkSize` is now pass-by-value in `set` as well to be consistent, as it only wraps an `int`.

In the member initializer for the constructor that takes `ChunkSize`, `m_granularity_mask` is assigned from `m_granularity - 1` instead of `chunk_size.value - 1` to reduced the likelihood of type mismatch (they should be the same value).