### PR TITLE
Validate environment variables "KOKKOS_..."

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -34,6 +34,7 @@
 #include <cstdlib>
 #include <stack>
 #include <functional>
+#include <unordered_set>
 #include <list>
 #include <cerrno>
 #include <random>
@@ -42,6 +43,14 @@
 #include <unistd.h>
 #else
 #include <windows.h>
+#endif
+
+// environ is included in the C runtime on posix platforms.
+// It contains a null-terminated list of existing environment variables.
+// This is used below in validate_prefixed_env_vars().
+#if not(defined(WIN) && (_MSC_VER >= 1900))
+// This declaration needs to be in the global namespace.
+extern char** environ;
 #endif
 
 //----------------------------------------------------------------------------
@@ -485,6 +494,56 @@ std::string version_string_from_int(int version_number) {
   return str_builder.str();
 }
 
+// For each currently set environment variable prefixed with "KOKKOS_" (case
+// insensitive), make sure that:
+// - the variable's name is recognized
+// - the variable's name is in all-caps
+// Print a warning for each variable that is unrecognized or not all-caps.
+void validate_prefixed_env_vars() {
+  std::unordered_set<std::string> validPrefixedVars = {
+      "KOKKOS_VISIBLE_DEVICES",     "KOKKOS_NUM_THREADS",
+      "KOKKOS_DEVICE_ID",           "KOKKOS_DISABLE_WARNINGS",
+      "KOKKOS_PRINT_CONFIGURATION", "KOKKOS_TUNE_INTERNALS",
+      "KOKKOS_MAP_DEVICE_ID_BY",    "KOKKOS_PROFILE_LIBRARY",
+      "KOKKOS_TOOLS_LIBS",          "KOKKOS_TOOLS_ARGS",
+      "KOKKOS_TOOLS_TIMER_JSON",    "KOKKOS_PROFILE_EXPORT_JSON",
+      "KOKKOS_TOOLS_GLOBALFENCES",  "KOKKOS_VARIORUM_FUNC_TYPE"};
+  char** env;
+#if defined(_WIN32) && (_MSC_VER >= 1900)
+  env = *__p__environ();
+#else
+  env = environ;  // declared at the top of this file as extern char **environ;
+#endif
+  std::string prefix = "KOKKOS_";
+  for (; *env; ++env) {
+    std::string name = *env;
+    // name now is in the format "KEY=VALUE", but we just want to check KEY.
+    // Split at the "=".
+    size_t endOfKey = name.find("=");
+    if (endOfKey == std::string::npos) continue;
+    name                 = name.substr(0, endOfKey);
+    std::string nameCaps = name;
+    for (char& c : nameCaps) c = std::toupper(c);
+    if (nameCaps.length() < prefix.length()) continue;
+    if (nameCaps.substr(0, prefix.length()) != prefix) continue;
+    // name is a variable prefixed with "KOKKOS_" (or a case insensitive version
+    // of it) If name is both unrecognized and not all caps, just print the
+    // first warning (for unrecognized).
+    if (validPrefixedVars.find(nameCaps) == validPrefixedVars.end()) {
+      std::cerr << "Warning: environment variable \"" << name << "\"\n";
+      std::cerr << "is prefixed like a variable that controls Kokkos,\n";
+      std::cerr << "but is not in the list of valid\n";
+      std::cerr << "Kokkos environment variables.\n" << std::endl;
+    } else if (name != nameCaps) {
+      std::cerr << "Warning: environment variable \"" << name << "\" is\n";
+      std::cerr << "not in all-caps, but is otherwise one of the valid\n";
+      std::cerr << "environment variables used by Kokkos. If you intended\n";
+      std::cerr << "to set \"" << nameCaps << "\", this variable\n";
+      std::cerr << "will not have the same effect.\n" << std::endl;
+    }
+  }
+}
+
 void pre_initialize_internal(const Kokkos::InitializationSettings& settings) {
   if (settings.has_disable_warnings() && settings.get_disable_warnings())
     g_show_warnings = false;
@@ -779,6 +838,7 @@ void initialize_internal(const Kokkos::InitializationSettings& settings) {
   // these callbacks are not called inside the backend initialization, before
   // the tool initialization happened.
   Kokkos::Tools::Experimental::pause_tools();
+  validate_prefixed_env_vars();
   pre_initialize_internal(settings);
   initialize_backends(settings);
   Kokkos::Tools::Experimental::resume_tools();


### PR DESCRIPTION
For any environment variables prefixed with ``KOKKOS_`` (case insensitive), check that it is one of the recognized variables that kokkos or kokkos-tools uses. Give a warning if it's unrecognized, or if it's recognized but not in the correct case (all-caps).

This is based off work @cwpearson did for Tpetra in https://github.com/trilinos/Trilinos/pull/12722.

Example usage:
```
export KOKKOS_NOT_A_VALID_VAR=123
export KOKKOS_device_id=0
./example 10
```
prints:
```
Warning: environment variable "KOKKOS_device_id" is
not in all-caps, but is otherwise one of the valid
environment variables used by Kokkos. If you intended
to set "KOKKOS_DEVICE_ID", this variable
will not have the same effect.

Warning: environment variable "KOKKOS_NOT_A_VALID_VAR"
is prefixed like a variable that controls Kokkos,
but is not in the list of valid
Kokkos environment variables.
...
```