### PR TITLE
Create mirror view of the keys on the host in `sort_by_key` fallback implementation

### DIFF
--- a/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
@@ -166,7 +166,8 @@ void sort_by_key_via_sort(
       KOKKOS_LAMBDA(int i) { permute(i) = i; });
 
   auto keys_in_comparator = Kokkos::create_mirror_view(
-      Kokkos::view_alloc(Kokkos::HostSpace{}, Kokkos::WithoutInitializing),
+      Kokkos::view_alloc(Kokkos::HostSpace{}, Kokkos::WithoutInitializing,
+                         exec),
       keys);
   Kokkos::deep_copy(exec, keys_in_comparator, keys);
 

--- a/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
@@ -166,8 +166,7 @@ void sort_by_key_via_sort(
       KOKKOS_LAMBDA(int i) { permute(i) = i; });
 
   auto keys_in_comparator = Kokkos::create_mirror_view(
-      Kokkos::view_alloc(Kokkos::HostSpace{}, Kokkos::WithoutInitializing,
-                         exec),
+      Kokkos::view_alloc(Kokkos::HostSpace{}, Kokkos::WithoutInitializing),
       keys);
   Kokkos::deep_copy(exec, keys_in_comparator, keys);
 

--- a/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
@@ -165,15 +165,10 @@ void sort_by_key_via_sort(
       Kokkos::RangePolicy<ExecutionSpace>(exec, 0, n),
       KOKKOS_LAMBDA(int i) { permute(i) = i; });
 
-// FIXME OPENMPTARGET The sort happens on the host so we have to copy keys there
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
   auto keys_in_comparator = Kokkos::create_mirror_view(
       Kokkos::view_alloc(Kokkos::HostSpace{}, Kokkos::WithoutInitializing),
       keys);
   Kokkos::deep_copy(exec, keys_in_comparator, keys);
-#else
-  auto keys_in_comparator = keys;
-#endif
 
   static_assert(sizeof...(MaybeComparator) <= 1);
   if constexpr (sizeof...(MaybeComparator) == 0) {


### PR DESCRIPTION
Fix #6848 
Creating a mirror view and deep copying was guarded for OpenMPTarget but it really should be done unconditionally.
It will be a no-op if the keys are accessible from the host.