### PR TITLE
Bump Google Benchmark version v1.{6.2 -> 7.1} in CMake FetchContent

### DIFF
--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -50,8 +50,8 @@ ELSE()
   FetchContent_Declare(
     googlebenchmark
     DOWNLOAD_EXTRACT_TIMESTAMP FALSE
-    URL https://github.com/google/benchmark/archive/refs/tags/v1.6.2.tar.gz
-    URL_HASH MD5=14d14849e075af116143a161bc3b927b
+    URL https://github.com/google/benchmark/archive/refs/tags/v1.7.1.tar.gz
+    URL_HASH MD5=0459a6c530df9851bee6504c3e37c2e7
   )
   FetchContent_MakeAvailable(googlebenchmark)
   list(POP_BACK CMAKE_MESSAGE_INDENT)


### PR DESCRIPTION
Fix #6853
Our configuration logs are polluted when configuring with `-DKokkos_ENABLE_BENCHMARKS=ON` and Google Benchmark is not found on the system.  Mark reported it in #6853 but this is not the first time users ask us about it.
I propose to bump the version we download from 1.6.2 to 1.7.1 because that is the first version that does not have the issue.
There is no 1.7.2 release and the current latest is 1.8.2

I chose to leave our minimum (v1.5.6) requirement alone.
https://github.com/kokkos/kokkos/blob/04a5334c699cb9b87293d27bc73090b3b7c13019/core/perf_test/CMakeLists.txt#L41