### PR TITLE
Update the unsafe implicit conversion error message in MDRangePolicy

### DIFF
--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -81,7 +81,7 @@ constexpr To checked_narrow_cast(From arg, std::size_t idx) {
       (is_different_signedness &&
        is_less_than_value_initialized_variable(arg) !=
            is_less_than_value_initialized_variable(ret))) {
-    std::string msg =
+    auto msg =
         "Kokkos::MDRangePolicy bound type error: an unsafe implicit conversion "
         "is performed on a bound (" +
         std::to_string(arg) + ") in dimension (" + std::to_string(idx) +

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -88,12 +88,15 @@ TEST(TEST_CATEGORY_DEATH, policy_bounds_unsafe_narrowing_conversions) {
   using Policy = Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>,
                                        Kokkos::IndexType<unsigned>>;
 
+  std::string msg =
+      "Kokkos::MDRangePolicy bound type error: an unsafe implicit conversion "
+      "is "
+      "performed on a bound (-1) in dimension (0), which may not preserve its "
+      "original value.\n";
+  std::string expected = std::regex_replace(msg, std::regex("\\(|\\)"), "\\$&");
+
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-  ASSERT_DEATH(
-      {
-        (void)Policy({-1, 0}, {2, 3});
-      },
-      "unsafe narrowing conversion");
+  ASSERT_DEATH({ (void)Policy({-1, 0}, {2, 3}); }, expected);
 }
 
 TEST(TEST_CATEGORY_DEATH, policy_invalid_bounds) {


### PR DESCRIPTION
Updated the error message in MDRangePolicy on unsafe implicit conversions to match the similar error message in RangePolicy. https://github.com/kokkos/kokkos/blob/04a5334c699cb9b87293d27bc73090b3b7c13019/core/src/Kokkos_ExecPolicy.hpp#L237-L248