### PR TITLE
Fix fallback implementation for sort_by_key

### DIFF
--- a/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
@@ -116,7 +116,7 @@ void sort_by_key_cudathrust(
 }
 #endif
 
-#if defined(KOKKOS_ENABLE_SYCL)
+#if defined(KOKKOS_ENABLE_ONEDPL)
 template <class Layout>
 struct sort_on_device<Kokkos::Experimental::SYCL, Layout>
     : std::bool_constant<std::is_same_v<Layout, Kokkos::LayoutLeft> ||

--- a/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
@@ -89,9 +89,11 @@ static_assert_is_admissible_to_kokkos_sort_by_key(const ViewType& /* view */) {
 
 // For the fallback implementation for sort_by_key using Kokkos::sort, we need
 // to consider if Kokkos::sort defers to the fallback implementation that copies
-// the array to the host and uses std::sort. This decision is made in
-// impl/Kokkos_SortImpl.hpp and this type trait decides at runtime when it is
-// safe to assume that Kokkos::sort doesn't manually copy to the host.
+// the array to the host and uses std::sort, see
+// copy_to_host_run_stdsort_copy_back() in impl/Kokkos_SortImpl.hpp. If
+// sort_on_device_v is true, we assume that std::sort doesn't copy data.
+// Otherwise, we manually copy all data to the host and provide Kokkos::sort
+// with a host execution space.
 template <class ExecutionSpace, class Layout>
 inline constexpr bool sort_on_device_v = false;
 

--- a/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
@@ -87,9 +87,11 @@ static_assert_is_admissible_to_kokkos_sort_by_key(const ViewType& /* view */) {
                 "LayoutRight, LayoutLeft or LayoutStride.");
 }
 
-// For the fallback sort_by_key implementation we might need to execute
-// Kokkos::sort on the host. This type trait determines at compile-time where we
-// want to execute.
+// For the fallback implementation for sort_by_key using Kokkos::sort, we need
+// to consider if Kokkos::sort defers to the fallback implementation that copies
+// the array to the host and uses std::sort. This decision is made in
+// impl/Kokkos_SortImpl.hpp and this type trait decides at runtime when it is
+// safe to assume that Kokkos::sort doesn't manually copy to the host.
 template <class ExecutionSpace, class Layout>
 inline constexpr bool sort_on_device_v = false;
 

--- a/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
@@ -91,14 +91,11 @@ static_assert_is_admissible_to_kokkos_sort_by_key(const ViewType& /* view */) {
 // Kokkos::sort on the host. This type trait determines at compile-time where we
 // want to execute.
 template <class ExecutionSpace, class Layout>
-struct sort_on_device : std::false_type {};
-
-template <class T, class Layout>
-inline constexpr bool sort_on_device_v = sort_on_device<T, Layout>::value;
+inline constexpr bool sort_on_device_v = false;
 
 #if defined(KOKKOS_ENABLE_CUDA)
 template <class Layout>
-struct sort_on_device<Kokkos::Cuda, Layout> : std::true_type {};
+inline constexpr bool sort_on_device_v<Kokkos::Cuda, Layout> = true;
 
 template <class KeysDataType, class... KeysProperties, class ValuesDataType,
           class... ValuesProperties, class... MaybeComparator>
@@ -118,9 +115,9 @@ void sort_by_key_cudathrust(
 
 #if defined(KOKKOS_ENABLE_ONEDPL)
 template <class Layout>
-struct sort_on_device<Kokkos::Experimental::SYCL, Layout>
-    : std::bool_constant<std::is_same_v<Layout, Kokkos::LayoutLeft> ||
-                         std::is_same_v<Layout, Kokkos::LayoutRight>> {};
+inline constexpr bool sort_on_device_v<Kokkos::Experimental::SYCL, Layout> =
+    std::is_same_v<Layout, Kokkos::LayoutLeft> ||
+    std::is_same_v<Layout, Kokkos::LayoutRight>;
 
 #ifdef KOKKOS_ONEDPL_HAS_SORT_BY_KEY
 template <class KeysDataType, class... KeysProperties, class ValuesDataType,


### PR DESCRIPTION
Alternative to #6849. For the fallback implementation of `sort_by_key` using  `Kokkos::sort`, we need to know in advance if the sort executes on the same device or the host so we can copy the keys used in the comparator accordingly.
This pull request makes this decision explicitly and we only call `sort` on the device in cases where we are sure that it doesn't execute in the host. Note that this disregards runtime decisions like when using `SYCL` with `LayoutStride` and we just play it safe by executing on the host in this case. Making it a compile-time decision might improve compile-time and avoids dealing with SYCL device-copyable issues in both branches.