### PR TITLE
Avoid unused variable warning in TestRangePolicyCTAD.cpp

### DIFF
--- a/core/unit_test/TestRangePolicyCTAD.cpp
+++ b/core/unit_test/TestRangePolicyCTAD.cpp
@@ -84,7 +84,7 @@ struct TestRangePolicyCTAD {
 };  // TestRangePolicyCTAD struct
 
 // To eliminate maybe_unused warning on some compilers
-const Kokkos::DefaultExecutionSpace des =
+[[maybe_unused]] const Kokkos::DefaultExecutionSpace des =
     TestRangePolicyCTAD::ImplicitlyConvertibleToDefaultExecutionSpace();
 
 }  // namespace


### PR DESCRIPTION
Fixes
```/var/jenkins/workspace/Kokkos_PR-6847/core/unit_test/TestRangePolicyCTAD.cpp:87:37: error: unused variable 'des' [-Werror,-Wunused-const-variable]
const Kokkos::DefaultExecutionSpace des =
                                    ^
1 error generated.
make[2]: *** [core/unit_test/CMakeFiles/Kokkos_CoreTestCompileOnly.dir/build.make:160: core/unit_test/CMakeFiles/Kokkos_CoreTestCompileOnly.dir/TestRangePolicyCTAD.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1943: core/unit_test/CMakeFiles/Kokkos_CoreTestCompileOnly.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```
introduced in #6803.