### PR TITLE
Fix C-style cast warnings with clang-tidy

### DIFF
--- a/core/src/Serial/Kokkos_Serial_Task.hpp
+++ b/core/src/Serial/Kokkos_Serial_Task.hpp
@@ -121,7 +121,7 @@ class TaskQueueSpecializationConstrained<
     using task_base_type = TaskBase;
     using queue_type     = typename scheduler_type::queue_type;
 
-    task_base_type* const end = (task_base_type*)task_base_type::EndTag;
+    auto* const end = reinterpret_cast<task_base_type*>(task_base_type::EndTag);
 
     execution_space serial_execution_space;
     auto& data = serial_execution_space.impl_internal_space_instance()
@@ -157,7 +157,7 @@ class TaskQueueSpecializationConstrained<
     using task_base_type = TaskBase;
     using queue_type     = typename scheduler_type::queue_type;
 
-    task_base_type* const end = (task_base_type*)task_base_type::EndTag;
+    auto* const end = reinterpret_cast<task_base_type*>(task_base_type::EndTag);
 
     execution_space serial_execution_space;
 


### PR DESCRIPTION
Running `clang-tidy` locally with our current settings, I still see some complaints about C-style casts.