### PR TITLE
Improve message on view out of bounds access and always abort

### DIFF
--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -124,15 +124,7 @@ KOKKOS_INLINE_FUNCTION void offsetview_verify_operator_bounds(
                                              args...);
          Kokkos::Impl::throw_runtime_exception(std::string(buffer));))
 
-    KOKKOS_IF_ON_DEVICE((
-        /* Check #1: is there a SharedAllocationRecord?
-          (we won't use it, but if it is not there then there isn't
-           a corresponding SharedAllocationHeader containing a label).
-          This check should cover the case of Views that don't
-          have the Unmanaged trait but were initialized by pointer. */
-        if (tracker.has_record()) {
-          Kokkos::abort("OffsetView bounds error");  // FIXME
-        } else { Kokkos::abort("OffsetView bounds error"); }))
+    KOKKOS_IF_ON_DEVICE((Kokkos::abort("OffsetView bounds error");))
   }
 }
 

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -124,7 +124,8 @@ KOKKOS_INLINE_FUNCTION void offsetview_verify_operator_bounds(
                                              args...);
          Kokkos::Impl::throw_runtime_exception(std::string(buffer));))
 
-    KOKKOS_IF_ON_DEVICE((Kokkos::abort("OffsetView bounds error");))
+    KOKKOS_IF_ON_DEVICE(
+        (Kokkos::abort("OffsetView bounds error"); (void)tracker;))
   }
 }
 

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -131,7 +131,7 @@ KOKKOS_INLINE_FUNCTION void offsetview_verify_operator_bounds(
           This check should cover the case of Views that don't
           have the Unmanaged trait but were initialized by pointer. */
         if (tracker.has_record()) {
-          Kokkos::Impl::operator_bounds_error_on_device(map);
+          Kokkos::abort("OffsetView bounds error");  // FIXME
         } else { Kokkos::abort("OffsetView bounds error"); }))
   }
 }

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -685,9 +685,8 @@ class View : public ViewTraits<DataType, Properties...> {
                                            traits::dimension::rank_dynamic>
       rank_dynamic = {};
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  enum {
-    Rank KOKKOS_DEPRECATED_WITH_COMMENT("Use rank instead.") = map_type::Rank
-  };
+  enum {Rank KOKKOS_DEPRECATED_WITH_COMMENT("Use rank instead.") =
+            map_type::Rank};
 #endif
 
   template <typename iType>
@@ -827,6 +826,8 @@ class View : public ViewTraits<DataType, Properties...> {
       std::is_void<typename traits::specialize>::value &&
       (is_layout_left || is_layout_right || is_layout_stride);
 
+#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+
 #define KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(...)                               \
   Kokkos::Impl::runtime_check_memory_access_violation<                      \
       typename traits::memory_space>(                                       \
@@ -834,6 +835,16 @@ class View : public ViewTraits<DataType, Properties...> {
       __VA_ARGS__);                                                         \
   Kokkos::Impl::view_verify_operator_bounds<typename traits::memory_space>( \
       __VA_ARGS__);
+
+#else
+
+#define KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(...)                            \
+  Kokkos::Impl::runtime_check_memory_access_violation<                   \
+      typename traits::memory_space>(                                    \
+      "Kokkos::View ERROR: attempt to access inaccessible memory space", \
+      __VA_ARGS__);
+
+#endif
 
   template <typename... Is>
   static KOKKOS_FUNCTION void check_access_member_function_valid_args(Is...) {

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -685,8 +685,9 @@ class View : public ViewTraits<DataType, Properties...> {
                                            traits::dimension::rank_dynamic>
       rank_dynamic = {};
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  enum {Rank KOKKOS_DEPRECATED_WITH_COMMENT("Use rank instead.") =
-            map_type::Rank};
+  enum {
+    Rank KOKKOS_DEPRECATED_WITH_COMMENT("Use rank instead.") = map_type::Rank
+  };
 #endif
 
   template <typename iType>
@@ -826,8 +827,6 @@ class View : public ViewTraits<DataType, Properties...> {
       std::is_void<typename traits::specialize>::value &&
       (is_layout_left || is_layout_right || is_layout_stride);
 
-#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-
 #define KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(...)                               \
   Kokkos::Impl::runtime_check_memory_access_violation<                      \
       typename traits::memory_space>(                                       \
@@ -835,16 +834,6 @@ class View : public ViewTraits<DataType, Properties...> {
       __VA_ARGS__);                                                         \
   Kokkos::Impl::view_verify_operator_bounds<typename traits::memory_space>( \
       __VA_ARGS__);
-
-#else
-
-#define KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(...)                            \
-  Kokkos::Impl::runtime_check_memory_access_violation<                   \
-      typename traits::memory_space>(                                    \
-      "Kokkos::View ERROR: attempt to access inaccessible memory space", \
-      __VA_ARGS__);
-
-#endif
 
   template <typename... Is>
   static KOKKOS_FUNCTION void check_access_member_function_valid_args(Is...) {

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3541,7 +3541,7 @@ template <class Map, class... Indices, std::size_t... Enumerate>
 KOKKOS_FUNCTION bool within_range(Map const& map,
                                   std::index_sequence<Enumerate...>,
                                   Indices... indices) {
-  return (... && ((std::size_t)indices < map.extent(Enumerate)));
+  return (((std::size_t)indices < map.extent(Enumerate)) && ...);
 }
 
 template <class... Indices>

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3545,7 +3545,7 @@ KOKKOS_FUNCTION bool check_bounds(Map const& map,
 }
 
 template <class... Indices>
-KOKKOS_FUNCTION constexpr char* append_formated_multidimensional_index(
+KOKKOS_FUNCTION constexpr char* append_formatted_multidimensional_index(
     char* dest, Indices... indices) {
   char* d = dest;
   Kokkos::Impl::strcat(d, "[");
@@ -3565,7 +3565,7 @@ KOKKOS_FUNCTION constexpr char* append_formated_multidimensional_index(
 template <class Map, class... Indices, std::size_t... Enumerate>
 KOKKOS_FUNCTION void print_extents(char* dest, Map const& map,
                                    std::index_sequence<Enumerate...>) {
-  (void)append_formated_multidimensional_index(dest, map.extent(Enumerate)...);
+  (void)append_formatted_multidimensional_index(dest, map.extent(Enumerate)...);
 }
 
 template <class T>
@@ -3616,7 +3616,7 @@ KOKKOS_INLINE_FUNCTION void view_verify_operator_bounds(
       }
     }();)
     Kokkos::Impl::strcat(err, "\") with indices ");
-    Kokkos::Impl::append_formated_multidimensional_index(err, args...);
+    Kokkos::Impl::append_formatted_multidimensional_index(err, args...);
     Kokkos::Impl::strcat(err, " but extents ");
     Kokkos::Impl::print_extents(err, map,
                                 std::make_index_sequence<sizeof...(Args)>());

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3548,24 +3548,24 @@ template <class... Indices>
 KOKKOS_FUNCTION constexpr char* append_formatted_multidimensional_index(
     char* dest, Indices... indices) {
   char* d = dest;
-  Kokkos::Impl::strcat(d, "[");
+  strcat(d, "[");
   (
       [&] {
-        d += Kokkos::Impl::strlen(d);
-        (void)Kokkos::Impl::to_chars_i(d,
-                                       d + 20,  // 20 digits ought to be enough
-                                       indices);
-        Kokkos::Impl::strcat(d, ",");
+        d += strlen(d);
+        to_chars_i(d,
+                   d + 20,  // 20 digits ought to be enough
+                   indices);
+        strcat(d, ",");
       }(),
       ...);
-  d[Kokkos::Impl::strlen(d) - 1] = ']';  // overwrite trailing comma
+  d[strlen(d) - 1] = ']';  // overwrite trailing comma
   return dest;
 }
 
 template <class Map, class... Indices, std::size_t... Enumerate>
 KOKKOS_FUNCTION void print_extents(char* dest, Map const& map,
                                    std::index_sequence<Enumerate...>) {
-  (void)append_formatted_multidimensional_index(dest, map.extent(Enumerate)...);
+  append_formatted_multidimensional_index(dest, map.extent(Enumerate)...);
 }
 
 template <class T>
@@ -3578,15 +3578,14 @@ KOKKOS_INLINE_FUNCTION void view_verify_operator_bounds(
   if (!check_bounds(map, std::make_index_sequence<sizeof...(Args)>(),
                     args...)) {
     char err[256] = "";
-    Kokkos::Impl::strcat(err, "Kokkos::View ERROR: out of bounds access");
-    Kokkos::Impl::strcat(err, " label=(\"");
+    strcat(err, "Kokkos::View ERROR: out of bounds access");
+    strcat(err, " label=(\"");
     KOKKOS_IF_ON_HOST([&] {
       if (tracker.m_tracker.has_record()) {
-        Kokkos::Impl::strncat(
-            err, tracker.m_tracker.template get_label<void>().c_str(), 128);
+        strncat(err, tracker.m_tracker.template get_label<void>().c_str(), 128);
         return;
       }
-      Kokkos::Impl::strcat(err, "**UNMANAGED**");
+      strcat(err, "**UNMANAGED**");
     }();)
     KOKKOS_IF_ON_DEVICE([&] {
       // Check #1: is there a SharedAllocationRecord?  (we won't use it, but
@@ -3595,7 +3594,7 @@ KOKKOS_INLINE_FUNCTION void view_verify_operator_bounds(
       // the case of Views that don't have the Unmanaged trait but were
       // initialized by pointer.
       if (!tracker.m_tracker.has_record()) {
-        Kokkos::Impl::strcat(err, "**UNMANAGED**");
+        strcat(err, "**UNMANAGED**");
         return;
       }
       // Check #2: does the ViewMapping have the printable_label_typedef
@@ -3609,17 +3608,16 @@ KOKKOS_INLINE_FUNCTION void view_verify_operator_bounds(
               SharedAllocationHeader::get_header(
                   static_cast<void const*>(map.data()));
           char const* const label = header->label();
-          Kokkos::Impl::strcat(err, label);
+          strcat(err, label);
           return;
         }
-        Kokkos::Impl::strcat(err, "**UNAVAILABLE**");
+        strcat(err, "**UNAVAILABLE**");
       }
     }();)
-    Kokkos::Impl::strcat(err, "\") with indices ");
-    Kokkos::Impl::append_formatted_multidimensional_index(err, args...);
-    Kokkos::Impl::strcat(err, " but extents ");
-    Kokkos::Impl::print_extents(err, map,
-                                std::make_index_sequence<sizeof...(Args)>());
+    strcat(err, "\") with indices ");
+    append_formatted_multidimensional_index(err, args...);
+    strcat(err, " but extents ");
+    print_extents(err, map, std::make_index_sequence<sizeof...(Args)>());
     Kokkos::abort(err);
   }
 }

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3630,7 +3630,7 @@ KOKKOS_INLINE_FUNCTION void view_verify_operator_bounds(
          int n = snprintf(buffer, LEN, "View bounds error of view %s (",
                           label.c_str());
          view_error_operator_bounds<0>(buffer + n, LEN - n, map, args...);
-         Kokkos::Impl::throw_runtime_exception(std::string(buffer));))
+         Kokkos::abort(buffer);))
 
     KOKKOS_IF_ON_DEVICE((
         /* Check #1: is there a SharedAllocationRecord?

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3612,7 +3612,7 @@ KOKKOS_INLINE_FUNCTION void view_verify_operator_bounds(
           Kokkos::Impl::strcat(err, label);
           return;
         }
-        Kokkos::Impl::strcat(err, "**UNMANAGED**");
+        Kokkos::Impl::strcat(err, "**UNAVAILABLE**");
       }
     }();)
     Kokkos::Impl::strcat(err, "\") with indices ");

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3580,13 +3580,11 @@ KOKKOS_INLINE_FUNCTION void view_verify_operator_bounds(
     char err[256] = "";
     strcat(err, "Kokkos::View ERROR: out of bounds access");
     strcat(err, " label=(\"");
-    KOKKOS_IF_ON_HOST([&] {
-      if (tracker.m_tracker.has_record()) {
-        strncat(err, tracker.m_tracker.template get_label<void>().c_str(), 128);
-        return;
-      }
-      strcat(err, "**UNMANAGED**");
-    }();)
+    KOKKOS_IF_ON_HOST(
+        if (tracker.m_tracker.has_record()) {
+          strncat(err, tracker.m_tracker.template get_label<void>().c_str(),
+                  128);
+        } else { strcat(err, "**UNMANAGED**"); })
     KOKKOS_IF_ON_DEVICE([&] {
       // Check #1: is there a SharedAllocationRecord?  (we won't use it, but
       // if its not there then there isn't a corresponding

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3537,110 +3537,90 @@ class ViewMapping<
 namespace Kokkos {
 namespace Impl {
 
-template <unsigned, class MapType>
-KOKKOS_INLINE_FUNCTION bool view_verify_operator_bounds(const MapType&) {
-  return true;
+template <class Map, class... Indices, std::size_t... Enumerate>
+KOKKOS_FUNCTION bool check_bounds(Map const& map,
+                                  std::index_sequence<Enumerate...>,
+                                  Indices... indices) {
+  return (... && ((std::size_t)indices < map.extent(Enumerate)));
 }
 
-template <unsigned R, class MapType, class iType, class... Args>
-KOKKOS_INLINE_FUNCTION bool view_verify_operator_bounds(const MapType& map,
-                                                        const iType& i,
-                                                        Args... args) {
-  return (size_t(i) < map.extent(R)) &&
-         view_verify_operator_bounds<R + 1>(map, args...);
+template <class... Indices>
+KOKKOS_FUNCTION constexpr char* append_formated_multidimensional_index(
+    char* dest, Indices... indices) {
+  char* d = dest;
+  Kokkos::Impl::strcat(d, "[");
+  (
+      [&] {
+        d += Kokkos::Impl::strlen(d);
+        (void)Kokkos::Impl::to_chars_i(d,
+                                       d + 20,  // 20 digits ought to be enough
+                                       indices);
+        Kokkos::Impl::strcat(d, ",");
+      }(),
+      ...);
+  d[Kokkos::Impl::strlen(d) - 1] = ']';  // overwrite trailing comma
+  return dest;
 }
 
-template <unsigned, class MapType>
-inline void view_error_operator_bounds(char*, int, const MapType&) {}
-
-template <unsigned R, class MapType, class iType, class... Args>
-inline void view_error_operator_bounds(char* buf, int len, const MapType& map,
-                                       const iType& i, Args... args) {
-  const int n = snprintf(
-      buf, len, " %ld < %ld %c", static_cast<unsigned long>(i),
-      static_cast<unsigned long>(map.extent(R)), (sizeof...(Args) ? ',' : ')'));
-  view_error_operator_bounds<R + 1>(buf + n, len - n, map, args...);
+template <class Map, class... Indices, std::size_t... Enumerate>
+KOKKOS_FUNCTION void print_extents(char* dest, Map const& map,
+                                   std::index_sequence<Enumerate...>) {
+  (void)append_formated_multidimensional_index(dest, map.extent(Enumerate)...);
 }
 
-/* Check #3: is the View managed as determined by the MemoryTraits? */
-template <class MapType, bool is_managed = (MapType::is_managed != 0)>
-struct OperatorBoundsErrorOnDevice;
-
-template <class MapType>
-struct OperatorBoundsErrorOnDevice<MapType, false> {
-  KOKKOS_INLINE_FUNCTION
-  static void run(MapType const&) { Kokkos::abort("View bounds error"); }
-};
-
-template <class MapType>
-struct OperatorBoundsErrorOnDevice<MapType, true> {
-  KOKKOS_INLINE_FUNCTION
-  static void run(MapType const& map) {
-    SharedAllocationHeader const* const header =
-        SharedAllocationHeader::get_header(
-            static_cast<void const*>(map.data()));
-    char const* const label = header->label();
-    enum { LEN = 128 };
-    char msg[LEN];
-    char const* const first_part = "View bounds error of view ";
-    char* p                      = msg;
-    char* const end              = msg + LEN - 1;
-    for (char const* p2 = first_part; (*p2 != '\0') && (p < end); ++p, ++p2) {
-      *p = *p2;
-    }
-    for (char const* p2 = label; (*p2 != '\0') && (p < end); ++p, ++p2) {
-      *p = *p2;
-    }
-    *p = '\0';
-    Kokkos::abort(msg);
-  }
-};
-
-/* Check #2: does the ViewMapping have the printable_label_typedef defined?
-   See above that only the non-specialized standard-layout ViewMapping has
-   this defined by default.
-   The existence of this alias indicates the existence of MapType::is_managed
- */
 template <class T>
 using printable_label_typedef_t = typename T::printable_label_typedef;
-
-template <class Map>
-KOKKOS_FUNCTION
-    std::enable_if_t<!is_detected<printable_label_typedef_t, Map>::value>
-    operator_bounds_error_on_device(Map const&) {
-  Kokkos::abort("View bounds error");
-}
-
-template <class Map>
-KOKKOS_FUNCTION
-    std::enable_if_t<is_detected<printable_label_typedef_t, Map>::value>
-    operator_bounds_error_on_device(Map const& map) {
-  OperatorBoundsErrorOnDevice<Map>::run(map);
-}
 
 template <class MemorySpace, class ViewType, class MapType, class... Args>
 KOKKOS_INLINE_FUNCTION void view_verify_operator_bounds(
     Kokkos::Impl::ViewTracker<ViewType> const& tracker, const MapType& map,
     Args... args) {
-  if (!view_verify_operator_bounds<0>(map, args...)) {
-    KOKKOS_IF_ON_HOST(
-        (enum {LEN = 1024}; char buffer[LEN];
-         const std::string label =
-             tracker.m_tracker.template get_label<MemorySpace>();
-         int n = snprintf(buffer, LEN, "View bounds error of view %s (",
-                          label.c_str());
-         view_error_operator_bounds<0>(buffer + n, LEN - n, map, args...);
-         Kokkos::abort(buffer);))
-
-    KOKKOS_IF_ON_DEVICE((
-        /* Check #1: is there a SharedAllocationRecord?
-           (we won't use it, but if its not there then there isn't
-            a corresponding SharedAllocationHeader containing a label).
-           This check should cover the case of Views that don't
-           have the Unmanaged trait but were initialized by pointer. */
-        if (tracker.m_tracker.has_record()) {
-          operator_bounds_error_on_device(map);
-        } else { Kokkos::abort("View bounds error"); }))
+  if (!check_bounds(map, std::make_index_sequence<sizeof...(Args)>(),
+                    args...)) {
+    char err[256] = "";
+    Kokkos::Impl::strcat(err, "Kokkos::View ERROR: out of bounds access");
+    Kokkos::Impl::strcat(err, " label=(\"");
+    KOKKOS_IF_ON_HOST([&] {
+      if (tracker.m_tracker.has_record()) {
+        Kokkos::Impl::strncat(
+            err, tracker.m_tracker.template get_label<void>().c_str(), 128);
+        return;
+      }
+      Kokkos::Impl::strcat(err, "**UNMANAGED**");
+    }();)
+    KOKKOS_IF_ON_DEVICE([&] {
+      // Check #1: is there a SharedAllocationRecord?  (we won't use it, but
+      // if its not there then there isn't a corresponding
+      // SharedAllocationHeader containing a label).  This check should cover
+      // the case of Views that don't have the Unmanaged trait but were
+      // initialized by pointer.
+      if (!tracker.m_tracker.has_record()) {
+        Kokkos::Impl::strcat(err, "**UNMANAGED**");
+        return;
+      }
+      // Check #2: does the ViewMapping have the printable_label_typedef
+      // defined? See above that only the non-specialized standard-layout
+      // ViewMapping has this defined by default. The existence of this
+      // alias indicates the existence of MapType::is_managed
+      if constexpr (is_detected_v<printable_label_typedef_t, MapType>) {
+        // Check #3: is the View managed as determined by the MemoryTraits?
+        if constexpr (MapType::is_managed != 0) {
+          SharedAllocationHeader const* const header =
+              SharedAllocationHeader::get_header(
+                  static_cast<void const*>(map.data()));
+          char const* const label = header->label();
+          Kokkos::Impl::strcat(err, label);
+          return;
+        }
+        Kokkos::Impl::strcat(err, "**UNMANAGED**");
+      }
+    }();)
+    Kokkos::Impl::strcat(err, "\") with indices ");
+    Kokkos::Impl::append_formated_multidimensional_index(err, args...);
+    Kokkos::Impl::strcat(err, " but extents ");
+    Kokkos::Impl::print_extents(err, map,
+                                std::make_index_sequence<sizeof...(Args)>());
+    Kokkos::abort(err);
   }
 }
 

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2737,7 +2737,6 @@ class ViewMapping<
       : m_impl_handle(arg_handle), m_impl_offset(arg_offset) {}
 
  public:
-  using printable_label_typedef = void;
   enum { is_managed = Traits::is_managed };
 
   //----------------------------------------
@@ -3568,9 +3567,6 @@ KOKKOS_FUNCTION void print_extents(char* dest, Map const& map,
   (void)append_formated_multidimensional_index(dest, map.extent(Enumerate)...);
 }
 
-template <class T>
-using printable_label_typedef_t = typename T::printable_label_typedef;
-
 template <class MemorySpace, class ViewType, class MapType, class... Args>
 KOKKOS_INLINE_FUNCTION void view_verify_operator_bounds(
     Kokkos::Impl::ViewTracker<ViewType> const& tracker, const MapType& map,
@@ -3580,41 +3576,14 @@ KOKKOS_INLINE_FUNCTION void view_verify_operator_bounds(
     char err[256] = "";
     Kokkos::Impl::strcat(err, "Kokkos::View ERROR: out of bounds access");
     Kokkos::Impl::strcat(err, " label=(\"");
-    KOKKOS_IF_ON_HOST([&] {
-      if (tracker.m_tracker.has_record()) {
-        Kokkos::Impl::strncat(
-            err, tracker.m_tracker.template get_label<void>().c_str(), 128);
-        return;
-      }
+    if (tracker.m_tracker.has_record()) {
+      KOKKOS_IF_ON_HOST(
+          Kokkos::Impl::strncat(
+              err, tracker.m_tracker.template get_label<void>().c_str(), 128);)
+      KOKKOS_IF_ON_DEVICE(Kokkos::Impl::strcat(err, "**UNAVAILABLE**");)
+    } else {
       Kokkos::Impl::strcat(err, "**UNMANAGED**");
-    }();)
-    KOKKOS_IF_ON_DEVICE([&] {
-      // Check #1: is there a SharedAllocationRecord?  (we won't use it, but
-      // if its not there then there isn't a corresponding
-      // SharedAllocationHeader containing a label).  This check should cover
-      // the case of Views that don't have the Unmanaged trait but were
-      // initialized by pointer.
-      if (!tracker.m_tracker.has_record()) {
-        Kokkos::Impl::strcat(err, "**UNMANAGED**");
-        return;
-      }
-      // Check #2: does the ViewMapping have the printable_label_typedef
-      // defined? See above that only the non-specialized standard-layout
-      // ViewMapping has this defined by default. The existence of this
-      // alias indicates the existence of MapType::is_managed
-      if constexpr (is_detected_v<printable_label_typedef_t, MapType>) {
-        // Check #3: is the View managed as determined by the MemoryTraits?
-        if constexpr (MapType::is_managed != 0) {
-          SharedAllocationHeader const* const header =
-              SharedAllocationHeader::get_header(
-                  static_cast<void const*>(map.data()));
-          char const* const label = header->label();
-          Kokkos::Impl::strcat(err, label);
-          return;
-        }
-        Kokkos::Impl::strcat(err, "**UNMANAGED**");
-      }
-    }();)
+    }
     Kokkos::Impl::strcat(err, "\") with indices ");
     Kokkos::Impl::append_formated_multidimensional_index(err, args...);
     Kokkos::Impl::strcat(err, " but extents ");

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3538,7 +3538,7 @@ namespace Kokkos {
 namespace Impl {
 
 template <class Map, class... Indices, std::size_t... Enumerate>
-KOKKOS_FUNCTION bool check_bounds(Map const& map,
+KOKKOS_FUNCTION bool within_range(Map const& map,
                                   std::index_sequence<Enumerate...>,
                                   Indices... indices) {
   return (... && ((std::size_t)indices < map.extent(Enumerate)));
@@ -3575,7 +3575,7 @@ template <class MemorySpace, class ViewType, class MapType, class... Args>
 KOKKOS_INLINE_FUNCTION void view_verify_operator_bounds(
     Kokkos::Impl::ViewTracker<ViewType> const& tracker, const MapType& map,
     Args... args) {
-  if (!check_bounds(map, std::make_index_sequence<sizeof...(Args)>(),
+  if (!within_range(map, std::make_index_sequence<sizeof...(Args)>(),
                     args...)) {
     char err[256] = "";
     strcat(err, "Kokkos::View ERROR: out of bounds access");

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -245,6 +245,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       ViewMapping_subview
       ViewMemoryAccessViolation
       ViewOfClass
+      ViewOutOfBoundsAccess
       ViewResize
       WorkGraph
       WithoutInitializing

--- a/core/unit_test/TestViewOutOfBoundsAccess.hpp
+++ b/core/unit_test/TestViewOutOfBoundsAccess.hpp
@@ -108,16 +108,21 @@ void test_view_out_of_bounds_access() {
   using V6 = Kokkos::View<int******,   ExecutionSpace>;
   using V7 = Kokkos::View<int*******,  ExecutionSpace>;
   using V8 = Kokkos::View<int********, ExecutionSpace>;
+  constexpr bool is_device =
+      std::is_same_v<ExecutionSpace, Kokkos::DefaultExecutionSpace> &&
+      std::is_same_v<Kokkos::DefaultExecutionSpace,
+                     Kokkos::DefaultHostExecutionSpace>;
   std::string const prefix = "Kokkos::View ERROR: out of bounds access";
-  std::string const lbl = "my_label";
-  TestViewOutOfBoundAccess(make_view<V1>(lbl), exec_space, prefix + ".*" + lbl);
-  TestViewOutOfBoundAccess(make_view<V2>(lbl), exec_space, prefix + ".*" + lbl);
-  TestViewOutOfBoundAccess(make_view<V3>(lbl), exec_space, prefix + ".*" + lbl);
-  TestViewOutOfBoundAccess(make_view<V4>(lbl), exec_space, prefix + ".*" + lbl);
-  TestViewOutOfBoundAccess(make_view<V5>(lbl), exec_space, prefix + ".*" + lbl);
-  TestViewOutOfBoundAccess(make_view<V6>(lbl), exec_space, prefix + ".*" + lbl);
-  TestViewOutOfBoundAccess(make_view<V7>(lbl), exec_space, prefix + ".*" + lbl);
-  TestViewOutOfBoundAccess(make_view<V8>(lbl), exec_space, prefix + ".*" + lbl);
+  std::string const lbl    = "my_label";
+  std::string const sry    = "UNAVAILABLE";
+  TestViewOutOfBoundAccess(make_view<V1>(lbl), exec_space, prefix + ".*" + (is_device ? sry : lbl));
+  TestViewOutOfBoundAccess(make_view<V2>(lbl), exec_space, prefix + ".*" + (is_device ? sry : lbl));
+  TestViewOutOfBoundAccess(make_view<V3>(lbl), exec_space, prefix + ".*" + (is_device ? sry : lbl));
+  TestViewOutOfBoundAccess(make_view<V4>(lbl), exec_space, prefix + ".*" + (is_device ? sry : lbl));
+  TestViewOutOfBoundAccess(make_view<V5>(lbl), exec_space, prefix + ".*" + (is_device ? sry : lbl));
+  TestViewOutOfBoundAccess(make_view<V6>(lbl), exec_space, prefix + ".*" + (is_device ? sry : lbl));
+  TestViewOutOfBoundAccess(make_view<V7>(lbl), exec_space, prefix + ".*" + (is_device ? sry : lbl));
+  TestViewOutOfBoundAccess(make_view<V8>(lbl), exec_space, prefix + ".*" + (is_device ? sry : lbl));
   int* const ptr = nullptr;
   TestViewOutOfBoundAccess(make_view<V1>(ptr), exec_space, prefix + ".*UNMANAGED");
   TestViewOutOfBoundAccess(make_view<V2>(ptr), exec_space, prefix + ".*UNMANAGED");

--- a/core/unit_test/TestViewOutOfBoundsAccess.hpp
+++ b/core/unit_test/TestViewOutOfBoundsAccess.hpp
@@ -1,0 +1,148 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+#include <sstream>
+
+#include <gtest/gtest.h>
+
+template <class View, class ExecutionSpace>
+struct TestViewOutOfBoundAccess {
+  View v;
+  static constexpr auto rank = View::rank;
+
+  template <std::size_t... Is>
+  KOKKOS_FUNCTION decltype(auto) bad_access(std::index_sequence<Is...>) const {
+    return v((Is * 1 + Is == 0 ? v.extent(Is) + 3 : 0)...);
+  }
+
+  KOKKOS_FUNCTION void operator()(int) const {
+    ++bad_access(std::make_index_sequence<rank>{});
+  }
+
+  template <std::size_t... Is>
+  std::string get_details(std::index_sequence<Is...>) {
+    std::stringstream ss;
+    ss << "with indices \\[";
+    ((ss << (Is == 0 ? v.extent(Is) + 3 : 0)
+         << (Is == View::rank() - 1 ? "\\]" : ",")),
+     ...);
+    ss << " but extents \\[";
+    ((ss << v.extent(Is) << (Is == View::rank() - 1 ? "\\]" : ",")), ...);
+    return ss.str();
+  }
+
+  auto get_details() {
+    return get_details(std::make_index_sequence<View::rank()>());
+  }
+
+  TestViewOutOfBoundAccess(View w, ExecutionSpace const& s, std::string matcher)
+      : v(std::move(w)) {
+    constexpr bool view_accessible_from_execution_space =
+        Kokkos::SpaceAccessibility<
+            /*AccessSpace=*/ExecutionSpace,
+            /*MemorySpace=*/typename View::memory_space>::accessible;
+    EXPECT_TRUE(view_accessible_from_execution_space);
+
+    matcher += ".*" + get_details();
+
+    EXPECT_DEATH(
+        {
+          Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(s, 0, 1),
+                               *this);
+          Kokkos::fence();
+        },
+        matcher);
+  }
+};
+
+template <class View, class LblOrPtr, std::size_t... Is>
+auto make_view_impl(LblOrPtr x, std::index_sequence<Is...>) {
+  return View(x, (Is + 1)...);
+}
+
+template <class View, class LblOrPtr>
+auto make_view(LblOrPtr x) {
+  return make_view_impl<View>(std::move(x),
+                              std::make_index_sequence<View::rank>());
+}
+
+template <class ExecutionSpace>
+void test_view_out_of_bounds_access() {
+  ExecutionSpace const exec_space{};
+  // clang-format off
+  using V1 = Kokkos::View<int*,        ExecutionSpace>;
+  using V2 = Kokkos::View<int**,       ExecutionSpace>;
+  using V3 = Kokkos::View<int***,      ExecutionSpace>;
+  using V4 = Kokkos::View<int****,     ExecutionSpace>;
+  using V5 = Kokkos::View<int*****,    ExecutionSpace>;
+  using V6 = Kokkos::View<int******,   ExecutionSpace>;
+  using V7 = Kokkos::View<int*******,  ExecutionSpace>;
+  using V8 = Kokkos::View<int********, ExecutionSpace>;
+  std::string const prefix = "Kokkos::View ERROR: out of bounds access";
+  std::string const lbl = "my_label";
+  TestViewOutOfBoundAccess(make_view<V1>(lbl), exec_space, prefix + ".*" + lbl);
+  TestViewOutOfBoundAccess(make_view<V2>(lbl), exec_space, prefix + ".*" + lbl);
+  TestViewOutOfBoundAccess(make_view<V3>(lbl), exec_space, prefix + ".*" + lbl);
+  TestViewOutOfBoundAccess(make_view<V4>(lbl), exec_space, prefix + ".*" + lbl);
+  TestViewOutOfBoundAccess(make_view<V5>(lbl), exec_space, prefix + ".*" + lbl);
+  TestViewOutOfBoundAccess(make_view<V6>(lbl), exec_space, prefix + ".*" + lbl);
+  TestViewOutOfBoundAccess(make_view<V7>(lbl), exec_space, prefix + ".*" + lbl);
+  TestViewOutOfBoundAccess(make_view<V8>(lbl), exec_space, prefix + ".*" + lbl);
+  int* const ptr = nullptr;
+  TestViewOutOfBoundAccess(make_view<V1>(ptr), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V2>(ptr), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V3>(ptr), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V4>(ptr), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V5>(ptr), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V6>(ptr), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V7>(ptr), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V8>(ptr), exec_space, prefix + ".*UNMANAGED");
+  // clang-format on
+}
+
+TEST(TEST_CATEGORY_DEATH, view_out_of_bounds_access) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  using ExecutionSpace = TEST_EXECSPACE;
+
+  if (false && Kokkos::SpaceAccessibility<
+                   /*AccessSpace=*/ExecutionSpace,
+                   /*MemorySpace=*/Kokkos::HostSpace>::accessible) {
+    GTEST_SKIP() << "skipping since no memory access violation would occur";
+  }
+
+#if defined(KOKKOS_ENABLE_SYCL) && defined(NDEBUG)  // FIXME_SYCL
+  if (std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>) {
+    GTEST_SKIP() << "skipping SYCL device-side abort does not work when NDEBUG "
+                    "is defined";
+  }
+#endif
+#if defined(KOKKOS_ENABLE_OPENMPTARGET)  // FIXME_OPENMPTARGET
+  if (std::is_same_v<ExecutionSpace, Kokkos::Experimental::OpenMPTarget>) {
+    GTEST_SKIP() << "skipping because OpenMPTarget backend is currently not "
+                    "able to abort from the device";
+  }
+#endif
+#if defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC
+  if (std::is_same<ExecutionSpace, Kokkos::Experimental::OpenACC>::value) {
+    GTEST_SKIP() << "skipping because OpenACC backend is currently not "
+                    "able to abort from the device";
+  }
+#endif
+
+  test_view_out_of_bounds_access<ExecutionSpace>();
+}

--- a/core/unit_test/TestViewOutOfBoundsAccess.hpp
+++ b/core/unit_test/TestViewOutOfBoundsAccess.hpp
@@ -35,6 +35,8 @@ TEST(TEST_CATEGORY, append_formated_multidimensional_index) {
   }
 }
 
+#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
+
 template <class View, class ExecutionSpace>
 struct TestViewOutOfBoundAccess {
   View v;
@@ -162,5 +164,7 @@ TEST(TEST_CATEGORY_DEATH, view_out_of_bounds_access) {
 
   test_view_out_of_bounds_access<ExecutionSpace>();
 }
+
+#endif
 
 }  // namespace

--- a/core/unit_test/TestViewOutOfBoundsAccess.hpp
+++ b/core/unit_test/TestViewOutOfBoundsAccess.hpp
@@ -33,6 +33,11 @@ TEST(TEST_CATEGORY, append_formatted_multidimensional_index) {
     append_formatted_multidimensional_index(buffer, 1, 2, 3);
     EXPECT_STREQ(buffer, "I was here[1,2,3]");
   }
+  {
+    char buffer[64] = "with mixed integer types ";
+    append_formatted_multidimensional_index(buffer, 1u, -2);
+    EXPECT_STREQ(buffer, "with mixed integer types [1,-2]");
+  }
 }
 
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK

--- a/core/unit_test/TestViewOutOfBoundsAccess.hpp
+++ b/core/unit_test/TestViewOutOfBoundsAccess.hpp
@@ -21,16 +21,16 @@
 
 namespace {
 
-TEST(TEST_CATEGORY, append_formated_multidimensional_index) {
-  using Kokkos::Impl::append_formated_multidimensional_index;
+TEST(TEST_CATEGORY, append_formatted_multidimensional_index) {
+  using Kokkos::Impl::append_formatted_multidimensional_index;
   {
     char buffer[64] = "my prefix ";
-    append_formated_multidimensional_index(buffer, 1);
+    append_formatted_multidimensional_index(buffer, 1);
     EXPECT_STREQ(buffer, "my prefix [1]");
   }
   {
     char buffer[64] = "I was here";
-    append_formated_multidimensional_index(buffer, 1, 2, 3);
+    append_formatted_multidimensional_index(buffer, 1, 2, 3);
     EXPECT_STREQ(buffer, "I was here[1,2,3]");
   }
 }

--- a/core/unit_test/TestViewOutOfBoundsAccess.hpp
+++ b/core/unit_test/TestViewOutOfBoundsAccess.hpp
@@ -19,6 +19,22 @@
 
 #include <gtest/gtest.h>
 
+namespace {
+
+TEST(TEST_CATEGORY, append_formated_multidimensional_index) {
+  using Kokkos::Impl::append_formated_multidimensional_index;
+  {
+    char buffer[64] = "my prefix ";
+    append_formated_multidimensional_index(buffer, 1);
+    EXPECT_STREQ(buffer, "my prefix [1]");
+  }
+  {
+    char buffer[64] = "I was here";
+    append_formated_multidimensional_index(buffer, 1, 2, 3);
+    EXPECT_STREQ(buffer, "I was here[1,2,3]");
+  }
+}
+
 template <class View, class ExecutionSpace>
 struct TestViewOutOfBoundAccess {
   View v;
@@ -146,3 +162,5 @@ TEST(TEST_CATEGORY_DEATH, view_out_of_bounds_access) {
 
   test_view_out_of_bounds_access<ExecutionSpace>();
 }
+
+}  // namespace

--- a/core/unit_test/TestViewOutOfBoundsAccess.hpp
+++ b/core/unit_test/TestViewOutOfBoundsAccess.hpp
@@ -108,21 +108,16 @@ void test_view_out_of_bounds_access() {
   using V6 = Kokkos::View<int******,   ExecutionSpace>;
   using V7 = Kokkos::View<int*******,  ExecutionSpace>;
   using V8 = Kokkos::View<int********, ExecutionSpace>;
-  constexpr bool is_device =
-      std::is_same_v<ExecutionSpace, Kokkos::DefaultExecutionSpace> &&
-      std::is_same_v<Kokkos::DefaultExecutionSpace,
-                     Kokkos::DefaultHostExecutionSpace>;
   std::string const prefix = "Kokkos::View ERROR: out of bounds access";
-  std::string const lbl    = "my_label";
-  std::string const sry    = "UNAVAILABLE";
-  TestViewOutOfBoundAccess(make_view<V1>(lbl), exec_space, prefix + ".*" + (is_device ? sry : lbl));
-  TestViewOutOfBoundAccess(make_view<V2>(lbl), exec_space, prefix + ".*" + (is_device ? sry : lbl));
-  TestViewOutOfBoundAccess(make_view<V3>(lbl), exec_space, prefix + ".*" + (is_device ? sry : lbl));
-  TestViewOutOfBoundAccess(make_view<V4>(lbl), exec_space, prefix + ".*" + (is_device ? sry : lbl));
-  TestViewOutOfBoundAccess(make_view<V5>(lbl), exec_space, prefix + ".*" + (is_device ? sry : lbl));
-  TestViewOutOfBoundAccess(make_view<V6>(lbl), exec_space, prefix + ".*" + (is_device ? sry : lbl));
-  TestViewOutOfBoundAccess(make_view<V7>(lbl), exec_space, prefix + ".*" + (is_device ? sry : lbl));
-  TestViewOutOfBoundAccess(make_view<V8>(lbl), exec_space, prefix + ".*" + (is_device ? sry : lbl));
+  std::string const lbl = "my_label";
+  TestViewOutOfBoundAccess(make_view<V1>(lbl), exec_space, prefix + ".*" + lbl);
+  TestViewOutOfBoundAccess(make_view<V2>(lbl), exec_space, prefix + ".*" + lbl);
+  TestViewOutOfBoundAccess(make_view<V3>(lbl), exec_space, prefix + ".*" + lbl);
+  TestViewOutOfBoundAccess(make_view<V4>(lbl), exec_space, prefix + ".*" + lbl);
+  TestViewOutOfBoundAccess(make_view<V5>(lbl), exec_space, prefix + ".*" + lbl);
+  TestViewOutOfBoundAccess(make_view<V6>(lbl), exec_space, prefix + ".*" + lbl);
+  TestViewOutOfBoundAccess(make_view<V7>(lbl), exec_space, prefix + ".*" + lbl);
+  TestViewOutOfBoundAccess(make_view<V8>(lbl), exec_space, prefix + ".*" + lbl);
   int* const ptr = nullptr;
   TestViewOutOfBoundAccess(make_view<V1>(ptr), exec_space, prefix + ".*UNMANAGED");
   TestViewOutOfBoundAccess(make_view<V2>(ptr), exec_space, prefix + ".*UNMANAGED");


### PR DESCRIPTION
Fix #6851 

* Always call abort when out-of-bounds access is detected.  (We were throwing a runtime exception when it occurred on the host side.)
* Improve the error message

Before this PR
```
View bounds error of view my_label ( 10 < 1 , 0 < 2 )
```
changed to
```
Kokkos::View ERROR: out of bounds access (label="mylabel") with indices [10,0] but extents [1,2]
```

TLDR; Stan's wishes are my command