### PR TITLE
Tailor Existing Kokkos "build_cmake_installed" Example for Quick Start 

### DIFF
--- a/example/build_cmake_installed/CMakeLists.txt
+++ b/example/build_cmake_installed/CMakeLists.txt
@@ -1,21 +1,9 @@
-# Kokkos minimally requires 3.16 right now,
-# but your project can set it higher
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
-# Projects can safely mix languages - must have C++ support
-# Kokkos flags will only apply to C++ files
-project(Example CXX Fortran)
+project(KokkosCMakeExample CXX)
 
-# Look for an installed Kokkos
 find_package(Kokkos REQUIRED)
 
-add_executable(example cmake_example.cpp foo.f)
-if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
-  set_target_properties(example PROPERTIES LINKER_LANGUAGE Fortran)
-endif()
+add_executable(cmake_example cmake_example.cpp)
 
-# This is the only thing required to set up compiler/linker flags
-target_link_libraries(example Kokkos::kokkos)
-
-enable_testing()
-add_test(NAME KokkosInTree_Verify COMMAND example 10)
+target_link_libraries(cmake_example PRIVATE Kokkos::kokkos)

--- a/example/build_cmake_installed/cmake_example.cpp
+++ b/example/build_cmake_installed/cmake_example.cpp
@@ -61,7 +61,6 @@ int main(int argc, char* argv[]) {
   count_time = timer.seconds();
   printf("Sequential: %ld    %10.6f\n", seq_count, count_time);
 
-
   Kokkos::finalize();
 
   return (count == seq_count) ? 0 : -1;

--- a/example/build_cmake_installed/cmake_example.cpp
+++ b/example/build_cmake_installed/cmake_example.cpp
@@ -19,8 +19,6 @@
 #include <cstdio>
 #include <iostream>
 
-extern "C" void print_fortran_();
-
 struct CountFunctor {
   KOKKOS_FUNCTION void operator()(const long i, long& lcount) const {
     lcount += (i % 2) == 0;
@@ -63,7 +61,6 @@ int main(int argc, char* argv[]) {
   count_time = timer.seconds();
   printf("Sequential: %ld    %10.6f\n", seq_count, count_time);
 
-  print_fortran_();
 
   Kokkos::finalize();
 

--- a/example/build_cmake_installed/foo.f
+++ b/example/build_cmake_installed/foo.f
@@ -1,4 +1,0 @@
-        FUNCTION print_fortran()
-          PRINT *, 'Hello World from Fortran'
-          RETURN
-        END


### PR DESCRIPTION
This PR proposes updates to the "build_cmake_installed" example to integrate with the Quick Start (documentation).

In the future, we would like to change the "build_cmake_installed" directory name to "quick_start_example", or suchlike.

Here are the steps for the updated example:


- Configure / build / install Kokkos (nota bene:  Kokkos build recipe will be the modern CMake version in the "Quick Start"; it is necessary to turn CMake extensions off in the Kokkos build to avoid the `find_package` warning in the example)
```
cmake \
-DKokkos_ENABLE_CUDA=ON \
-DKokkos_ARCH_VOLTA70=ON \
-DKokkos_ENABLE_SERIAL=ON \
-DCMAKE_EXTENSIONS=OFF \
-DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
-DCMAKE_BUILD_TYPE=Release ..
```

- Configure example

```
cmake -B <build-dir-name> -S . -DKokkos_ROOT=<kokkos-installation>
```
- Build example

```
cmake --build <build-dir-name>
```

- Run example
```
cd  <build-dir-name>
$ ./cmake_example 
Device Execution Space:
  KOKKOS_ENABLE_CUDA: yes
Cuda Options:
  KOKKOS_ENABLE_CUDA_LAMBDA: yes
  KOKKOS_ENABLE_CUDA_LDG_INTRINSIC: yes
  KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE: no
  KOKKOS_ENABLE_CUDA_UVM: no
  KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA: yes
  KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC: yes

Cuda Runtime Configuration:
macro  KOKKOS_ENABLE_CUDA      : defined
macro  CUDA_VERSION          = 12000 = version 12.0
Kokkos::Cuda[ 0 ] Tesla V100-PCIE-16GB capability 7.0, Total Global Memory: 15.77 G, Shared Memory per Block: 48 K : Selected
Kokkos::Cuda[ 1 ] Tesla V100-PCIE-16GB capability 7.0, Total Global Memory: 15.77 G, Shared Memory per Block: 48 K
Usage: ./cmake_example [<kokkos_options>] <size>
```
