### PR TITLE
Scratch space fix for MultiGPU

### DIFF
--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -196,10 +196,11 @@ struct ScratchFunctor {
 
     // Check that each scratch entry has been incremented exactly R times
     int team_error_accum;
+    auto R_loc = R;  // avoid implicit capture of this
     Kokkos::parallel_reduce(
         Kokkos::TeamVectorRange(team, 0, scratch_size),
         [&](int i, int &tsum) {
-          if (scratch_mem(i) != R) {
+          if (scratch_mem(i) != R_loc) {
             tsum += 1;
           }
         },

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -237,7 +237,7 @@ void test_scratch(TEST_EXECSPACE exec0, TEST_EXECSPACE exec1) {
   ASSERT_EQ(error0, 0);
   ASSERT_EQ(error1, 0);
 
-  // Request larget scratch size to trigger a realloc and test
+  // Request largest scratch size to trigger a realloc and test
   const auto new_scratch_size = scratch_size + 10;
   ScratchFunctor f0_more_scratch(exec0, new_scratch_size, R);
   ScratchFunctor f1_more_scratch(exec1, new_scratch_size, R);


### PR DESCRIPTION
For cuda, use `CudaSpace::(de)allocate()` functions instead of `Kokkos::kokkos_malloc`, `Kokkos::kokkos_free`, and `Kokkos::realloc` to avoid using `Kokkos_SharedAlloc.hpp` classes, which allocate only on default execution space.