### PR TITLE
Fix linking with rocthrust (alternative to #6871)

### DIFF
--- a/cmake/Modules/FindTPLROCTHRUST.cmake
+++ b/cmake/Modules/FindTPLROCTHRUST.cmake
@@ -8,7 +8,7 @@
 # the values are not cached, FIND_PACKAGE(rocthrust) will overwrite them.
 SET(AMDGPU_TARGETS "" CACHE STRING "AMD GPU targets to compile for")
 SET(GPU_TARGETS "" CACHE STRING "GPU targets to compile for")
-FIND_PACKAGE(rocthrust REQUIRED)
+FIND_PACKAGE(ROCTHRUST REQUIRED)
 KOKKOS_CREATE_IMPORTED_TPL(ROCTHRUST INTERFACE LINK_LIBRARIES roc::rocthrust)
 
 # Export ROCTHRUST as a Kokkos dependency


### PR DESCRIPTION
Alternative to https://github.com/kokkos/kokkos/pull/6871 The other PR is closer to what we should do in CMake while this one is the Kokkos/Tribits way to do it. My issue with the other PR is that we do not export the TPL that we create but instead we export the underlying library. Admittedly, our own TPL is just a shell around rocThrust but I still prefer not mixing the two ways of dealing with TPLs. One difference for the user is that in https://github.com/kokkos/kokkos/pull/6871, the user should set the rocThrust directory using `rocthrust_DIR` while in this PR, it should be done using `ROCTHRUST_DIR`.

For the rocprim issue, this looks like a problem with how rocThrust deals with its dependencies. Given that it only affects user that install their own version of rocThrust and that it can be fixed using `CMAKE_PREFIX_PATH`, I propose to not add `FIND_PACKAGE(rocprim)/KOKKOS_EXPORT_CMAKE_TPL(rocprim)` and just complain to AMD that they don't expose their dependencies properly.