### PR TITLE
Don't use Fedora development version in GitHub CI

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -20,7 +20,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        distro: ['fedora:latest', 'fedora:rawhide', 'ubuntu:latest']
+        distro: ['fedora:latest', 'ubuntu:latest']
         cxx: ['g++', 'clang++']
         cxx_extra_flags: ['']
         cmake_build_type: ['Release', 'Debug']


### PR DESCRIPTION
Our GitHub CI started failing with linking errors like
```
/usr/bin/ld: /usr/bin/../lib/gcc/x86_64-redhat-linux/14/../../../../lib64/libFortran_main.a(Fortran_main.c.o): in function `main':
(.text.startup.main+0x0): multiple definition of `main'; CMakeFiles/example.dir/cmake_example.cpp.o:cmake_example.cpp:(.text+0x0): first defined here
/usr/bin/ld: /usr/bin/../lib/gcc/x86_64-redhat-linux/14/../../../../lib64/libFortran_main.a(Fortran_main.c.o): in function `main':
(.text.startup.main+0xb): undefined reference to `_QQEnvironmentDefaults'
```
a couple days ago. and this is not the first time the fedora rawhide build has caused problems. Note that this is not a stable but a development version. This pull request suggests removing testing with this development version and only considering stable OSs.