### PR TITLE
Fix unmanaged View construction with Kokkos::Array extent

### DIFF
--- a/core/src/impl/Kokkos_ViewArray.hpp
+++ b/core/src/impl/Kokkos_ViewArray.hpp
@@ -322,6 +322,11 @@ class ViewMapping<Traits, Kokkos::Array<>> {
         m_impl_offset(std::integral_constant<unsigned, 0>(), args...),
         m_stride(m_impl_offset.span()) {}
 
+  template <class... P, class... Args>
+  KOKKOS_INLINE_FUNCTION ViewMapping(
+      Kokkos::Impl::ViewCtorProp<P...> const &arg_prop, Args... args)
+      : ViewMapping(Impl::get_property<Impl::PointerTag>(arg_prop), args...) {}
+
   //----------------------------------------
 
   template <class... P>


### PR DESCRIPTION
Fixes #6883. The failing example requires calling `ViewMapping` with `ViewCtorProp` and we were missing that overload in `ViewArray`. The corresponding overload in `ViewMapping.hpp` also only extracts the pointer from the `ViewCtorProp` object.
To me, it was surprising that
```
Kokkos::View<Kokkos::Array<double, 32> **, DeviceType>::pointer_type;
```
is
```
double*
```
and not
```
Kokkos::Array<double, 32>*
```
but the fix and the test would work either way.