### PR TITLE
SYCL: Fix multi-GPU support and add test

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -171,21 +171,22 @@ sycl::device_ptr<void> SYCLInternal::resize_team_scratch_space(
   // Multiple ParallelFor/Reduce Teams can call this function at the same time
   // and invalidate the m_team_scratch_ptr. We use a pool to avoid any race
   // condition.
-  if (m_team_scratch_current_size[scratch_pool_id] == 0) {
+  auto mem_space = Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue);
+  if (m_team_scratch_current_size[scratch_pool_id] == 0 && bytes > 0) {
     m_team_scratch_current_size[scratch_pool_id] = bytes;
-    m_team_scratch_ptr[scratch_pool_id] =
-        Kokkos::kokkos_malloc<Experimental::SYCLDeviceUSMSpace>(
-            "Kokkos::Experimental::SYCLDeviceUSMSpace::TeamScratchMemory",
-            m_team_scratch_current_size[scratch_pool_id]);
+    m_team_scratch_ptr[scratch_pool_id]          = mem_space.allocate(
+        "Kokkos::Experimental::SYCL::InternalTeamScratchMemory",
+        m_team_scratch_current_size[scratch_pool_id]);
   }
   if ((bytes > m_team_scratch_current_size[scratch_pool_id]) ||
       ((bytes < m_team_scratch_current_size[scratch_pool_id]) &&
        (force_shrink))) {
+    mem_space.deallocate(m_team_scratch_ptr[scratch_pool_id],
+                         m_team_scratch_current_size[scratch_pool_id]);
     m_team_scratch_current_size[scratch_pool_id] = bytes;
-    m_team_scratch_ptr[scratch_pool_id] =
-        Kokkos::kokkos_realloc<Experimental::SYCLDeviceUSMSpace>(
-            m_team_scratch_ptr[scratch_pool_id],
-            m_team_scratch_current_size[scratch_pool_id]);
+    m_team_scratch_ptr[scratch_pool_id]          = mem_space.allocate(
+        "Kokkos::Experimental::SYCL::InternalTeamScratchMemory",
+        m_team_scratch_current_size[scratch_pool_id]);
   }
   return m_team_scratch_ptr[scratch_pool_id];
 }
@@ -234,8 +235,8 @@ void SYCLInternal::finalize() {
 
   for (int i = 0; i < m_n_team_scratch; ++i) {
     if (m_team_scratch_current_size[i] > 0) {
-      Kokkos::kokkos_free<Kokkos::Experimental::SYCLDeviceUSMSpace>(
-          m_team_scratch_ptr[i]);
+      device_mem_space.deallocate(m_team_scratch_ptr[i],
+                                  m_team_scratch_current_size[i]);
       m_team_scratch_current_size[i] = 0;
       m_team_scratch_ptr[i]          = nullptr;
     }

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -902,14 +902,20 @@ if(Kokkos_ENABLE_SYCL)
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     CoreUnitTest_SYCLInterOpInit_Context
     SOURCES
-    UnitTestMainInit.cpp
+      UnitTestMainInit.cpp
       sycl/TestSYCL_InterOp_Init_Context.cpp
   )
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     CoreUnitTest_SYCLInterOpStreams
     SOURCES
-      UnitTestMain.cpp
+     UnitTestMain.cpp
      sycl/TestSYCL_InterOp_Streams.cpp
+  )
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+      CoreUnitTest_SYCLInterOpStreamsMultiGPU
+    SOURCES
+      UnitTestMainInit.cpp
+      sycl/TestSYCL_InterOp_StreamsMultiGPU.cpp
   )
 endif()
 

--- a/core/unit_test/TestMultiGPU.hpp
+++ b/core/unit_test/TestMultiGPU.hpp
@@ -1,0 +1,184 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Test_InterOp_Streams.hpp>
+
+namespace {
+
+void test_policies(TEST_EXECSPACE exec0, Kokkos::View<int *, TEST_EXECSPACE> v0,
+                   TEST_EXECSPACE exec, Kokkos::View<int *, TEST_EXECSPACE> v) {
+  using MemorySpace = typename TEST_EXECSPACE::memory_space;
+
+  exec.fence();
+  exec0.fence();
+
+  Kokkos::deep_copy(exec, v, 5);
+  Kokkos::deep_copy(exec0, v0, 5);
+
+  Kokkos::deep_copy(v, v0);
+
+  int sum;
+  int sum0;
+
+  Kokkos::parallel_for("Test::Range_0",
+                       Kokkos::RangePolicy<TEST_EXECSPACE>(exec0, 0, 100),
+                       Test::FunctorRange<MemorySpace>(v0));
+  Kokkos::parallel_for("Test::Range",
+                       Kokkos::RangePolicy<TEST_EXECSPACE>(exec, 0, 100),
+                       Test::FunctorRange<MemorySpace>(v));
+  exec.fence();
+  exec0.fence();
+  Kokkos::parallel_reduce(
+      "Test::RangeReduce_0",
+      Kokkos::RangePolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 2>>(exec0,
+                                                                        0, 100),
+      Test::FunctorRangeReduce<MemorySpace>(v0), sum0);
+  Kokkos::parallel_reduce(
+      "Test::RangeReduce",
+      Kokkos::RangePolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 2>>(exec, 0,
+                                                                        100),
+      Test::FunctorRangeReduce<MemorySpace>(v), sum);
+  ASSERT_EQ(600, sum0);
+  ASSERT_EQ(600, sum);
+
+  Kokkos::parallel_for("Test::MDRange_0",
+                       Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
+                           exec0, {0, 0}, {10, 10}),
+                       Test::FunctorMDRange<MemorySpace>(v0));
+  Kokkos::parallel_for("Test::MDRange",
+                       Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
+                           exec, {0, 0}, {10, 10}),
+                       Test::FunctorMDRange<MemorySpace>(v));
+  Kokkos::parallel_reduce("Test::MDRangeReduce_0",
+                          Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>,
+                                                Kokkos::LaunchBounds<128, 2>>(
+                              exec0, {0, 0}, {10, 10}),
+                          Test::FunctorMDRangeReduce<MemorySpace>(v0), sum0);
+  Kokkos::parallel_reduce("Test::MDRangeReduce",
+                          Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>,
+                                                Kokkos::LaunchBounds<128, 2>>(
+                              exec, {0, 0}, {10, 10}),
+                          Test::FunctorMDRangeReduce<MemorySpace>(v), sum);
+  ASSERT_EQ(700, sum0);
+  ASSERT_EQ(700, sum);
+
+  Kokkos::parallel_for("Test::Team_0",
+                       Kokkos::TeamPolicy<TEST_EXECSPACE>(exec0, 10, 10),
+                       Test::FunctorTeam<MemorySpace, TEST_EXECSPACE>(v0));
+  Kokkos::parallel_for("Test::Team",
+                       Kokkos::TeamPolicy<TEST_EXECSPACE>(exec, 10, 10),
+                       Test::FunctorTeam<MemorySpace, TEST_EXECSPACE>(v));
+  Kokkos::parallel_reduce(
+      "Test::Team_0",
+      Kokkos::TeamPolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 2>>(exec0,
+                                                                       10, 10),
+      Test::FunctorTeamReduce<MemorySpace, TEST_EXECSPACE>(v0), sum0);
+  Kokkos::parallel_reduce(
+      "Test::Team",
+      Kokkos::TeamPolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 2>>(exec, 10,
+                                                                       10),
+      Test::FunctorTeamReduce<MemorySpace, TEST_EXECSPACE>(v), sum);
+  ASSERT_EQ(800, sum0);
+  ASSERT_EQ(800, sum);
+}
+
+struct ScratchFunctor {
+  int scratch_size;
+  int R;
+
+  ScratchFunctor(int scratch_size_, int R_)
+      : scratch_size(scratch_size_), R(R_) {}
+
+  KOKKOS_FUNCTION
+  void operator()(const Kokkos::TeamPolicy<TEST_EXECSPACE>::member_type &team,
+                  int &error_accum) const {
+    Kokkos::View<int *, TEST_EXECSPACE::scratch_memory_space> scratch_mem(
+        team.team_scratch(1), scratch_size);
+
+    // Initialize scratch memory
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 0, scratch_size),
+                         [&](int i) { scratch_mem(i) = 0; });
+    team.team_barrier();
+
+    // Increment each entry in scratch memory R times
+    for (int r = 0; r < R; ++r) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 0, scratch_size),
+                           [&](int i) { scratch_mem(i) += 1; });
+    }
+    team.team_barrier();
+
+    // Check that each scratch entry has been incremented exactly R times
+    int team_error_accum;
+    auto R_loc = R;  // avoid implicit capture of this
+    Kokkos::parallel_reduce(
+        Kokkos::TeamVectorRange(team, 0, scratch_size),
+        [&](int i, int &tsum) {
+          if (scratch_mem(i) != R_loc) {
+            tsum += 1;
+          }
+        },
+        team_error_accum);
+    Kokkos::single(Kokkos::PerTeam(team),
+                   [&]() { error_accum += team_error_accum; });
+  }
+};
+
+void test_scratch(TEST_EXECSPACE exec0, TEST_EXECSPACE exec1) {
+  constexpr int N            = 10;
+  constexpr int R            = 1000;
+  constexpr int scratch_size = 100;
+  using ScratchType = Kokkos::View<int *, TEST_EXECSPACE::scratch_memory_space>;
+
+  // Test allocating and using scratch space
+  ScratchFunctor f(scratch_size, R);
+
+  auto policy0 =
+      Kokkos::TeamPolicy<TEST_EXECSPACE>(exec0, N, 10)
+          .set_scratch_size(
+              1, Kokkos::PerTeam(ScratchType::shmem_size(scratch_size)));
+  auto policy1 =
+      Kokkos::TeamPolicy<TEST_EXECSPACE>(exec1, N, 10)
+          .set_scratch_size(
+              1, Kokkos::PerTeam(ScratchType::shmem_size(scratch_size)));
+
+  int error0, error1;
+
+  Kokkos::parallel_reduce("test_scratch_device_0", policy0, f, error0);
+  Kokkos::parallel_reduce("test_scratch_device_1", policy1, f, error1);
+  ASSERT_EQ(error0, 0);
+  ASSERT_EQ(error1, 0);
+
+  // Request larger scratch size to trigger a realloc and test
+  const auto new_scratch_size = scratch_size + 10;
+  ScratchFunctor f_more_scratch(new_scratch_size, R);
+
+  auto policy0_more_scratch =
+      Kokkos::TeamPolicy<TEST_EXECSPACE>(exec0, N, 10)
+          .set_scratch_size(
+              1, Kokkos::PerTeam(ScratchType::shmem_size(new_scratch_size)));
+  auto policy1_more_scratch =
+      Kokkos::TeamPolicy<TEST_EXECSPACE>(exec1, N, 10)
+          .set_scratch_size(
+              1, Kokkos::PerTeam(ScratchType::shmem_size(new_scratch_size)));
+
+  Kokkos::parallel_reduce("test_realloc_scratch_device_0", policy0_more_scratch,
+                          f_more_scratch, error0);
+  Kokkos::parallel_reduce("test_realloc_scratch_device_1", policy1_more_scratch,
+                          f_more_scratch, error1);
+  ASSERT_EQ(error0, 0);
+  ASSERT_EQ(error1, 0);
+}
+}  // namespace

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #include <TestCuda_Category.hpp>
-#include <Test_InterOp_Streams.hpp>
+#include <TestMultiGPU.hpp>
 
 namespace {
 
@@ -57,79 +57,6 @@ std::array<TEST_EXECSPACE, 2> get_execution_spaces(
   return {exec0, exec1};
 }
 
-// Test Interoperability with Cuda Streams
-void test_policies(TEST_EXECSPACE exec0, Kokkos::View<int *, TEST_EXECSPACE> v0,
-                   TEST_EXECSPACE exec, Kokkos::View<int *, TEST_EXECSPACE> v) {
-  using MemorySpace = typename TEST_EXECSPACE::memory_space;
-
-  Kokkos::deep_copy(exec, v, 5);
-  Kokkos::deep_copy(exec0, v0, 5);
-
-  Kokkos::deep_copy(v, v0);
-
-  int sum;
-  int sum0;
-
-  Kokkos::parallel_for("Test::cuda::raw_cuda_stream::Range_0",
-                       Kokkos::RangePolicy<TEST_EXECSPACE>(exec0, 0, 100),
-                       Test::FunctorRange<MemorySpace>(v0));
-  Kokkos::parallel_for("Test::cuda::raw_cuda_stream::Range",
-                       Kokkos::RangePolicy<TEST_EXECSPACE>(exec, 0, 100),
-                       Test::FunctorRange<MemorySpace>(v));
-  Kokkos::parallel_reduce(
-      "Test::cuda::raw_cuda_stream::RangeReduce_0",
-      Kokkos::RangePolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 2>>(exec0,
-                                                                        0, 100),
-      Test::FunctorRangeReduce<MemorySpace>(v0), sum0);
-  Kokkos::parallel_reduce(
-      "Test::cuda::raw_cuda_stream::RangeReduce",
-      Kokkos::RangePolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 2>>(exec, 0,
-                                                                        100),
-      Test::FunctorRangeReduce<MemorySpace>(v), sum);
-  ASSERT_EQ(600, sum0);
-  ASSERT_EQ(600, sum);
-
-  Kokkos::parallel_for("Test::cuda::raw_cuda_stream::MDRange_0",
-                       Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
-                           exec0, {0, 0}, {10, 10}),
-                       Test::FunctorMDRange<MemorySpace>(v0));
-  Kokkos::parallel_for("Test::cuda::raw_cuda_stream::MDRange",
-                       Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
-                           exec, {0, 0}, {10, 10}),
-                       Test::FunctorMDRange<MemorySpace>(v));
-  Kokkos::parallel_reduce("Test::cuda::raw_cuda_stream::MDRangeReduce_0",
-                          Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>,
-                                                Kokkos::LaunchBounds<128, 2>>(
-                              exec0, {0, 0}, {10, 10}),
-                          Test::FunctorMDRangeReduce<MemorySpace>(v0), sum0);
-  Kokkos::parallel_reduce("Test::cuda::raw_cuda_stream::MDRangeReduce",
-                          Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>,
-                                                Kokkos::LaunchBounds<128, 2>>(
-                              exec, {0, 0}, {10, 10}),
-                          Test::FunctorMDRangeReduce<MemorySpace>(v), sum);
-  ASSERT_EQ(700, sum0);
-  ASSERT_EQ(700, sum);
-
-  Kokkos::parallel_for("Test::cuda::raw_cuda_stream::Team_0",
-                       Kokkos::TeamPolicy<TEST_EXECSPACE>(exec0, 10, 10),
-                       Test::FunctorTeam<MemorySpace, TEST_EXECSPACE>(v0));
-  Kokkos::parallel_for("Test::cuda::raw_cuda_stream::Team",
-                       Kokkos::TeamPolicy<TEST_EXECSPACE>(exec, 10, 10),
-                       Test::FunctorTeam<MemorySpace, TEST_EXECSPACE>(v));
-  Kokkos::parallel_reduce(
-      "Test::cuda::raw_cuda_stream::Team_0",
-      Kokkos::TeamPolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 2>>(exec0,
-                                                                       10, 10),
-      Test::FunctorTeamReduce<MemorySpace, TEST_EXECSPACE>(v0), sum0);
-  Kokkos::parallel_reduce(
-      "Test::cuda::raw_cuda_stream::Team",
-      Kokkos::TeamPolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 2>>(exec, 10,
-                                                                       10),
-      Test::FunctorTeamReduce<MemorySpace, TEST_EXECSPACE>(v), sum);
-  ASSERT_EQ(800, sum0);
-  ASSERT_EQ(800, sum);
-}
-
 TEST(cuda_multi_gpu, managed_views) {
   StreamsAndDevices streams_and_devices;
   {
@@ -167,93 +94,6 @@ TEST(cuda_multi_gpu, unmanaged_views) {
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(p0));
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(p));
   }
-}
-
-struct ScratchFunctor {
-  int scratch_size;
-  int R;
-
-  ScratchFunctor(int scratch_size_, int R_)
-      : scratch_size(scratch_size_), R(R_) {}
-
-  KOKKOS_FUNCTION
-  void operator()(const Kokkos::TeamPolicy<Kokkos::Cuda>::member_type &team,
-                  int &error_accum) const {
-    Kokkos::View<int *, Kokkos::Cuda::scratch_memory_space> scratch_mem(
-        team.team_scratch(1), scratch_size);
-
-    // Initialize scratch memory
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 0, scratch_size),
-                         [&](int i) { scratch_mem(i) = 0; });
-    team.team_barrier();
-
-    // Increment each entry in scratch memory R times
-    for (int r = 0; r < R; ++r) {
-      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 0, scratch_size),
-                           [&](int i) { scratch_mem(i) += 1; });
-    }
-    team.team_barrier();
-
-    // Check that each scratch entry has been incremented exactly R times
-    int team_error_accum;
-    auto R_loc = R;  // avoid implicit capture of this
-    Kokkos::parallel_reduce(
-        Kokkos::TeamVectorRange(team, 0, scratch_size),
-        [&](int i, int &tsum) {
-          if (scratch_mem(i) != R_loc) {
-            tsum += 1;
-          }
-        },
-        team_error_accum);
-    Kokkos::single(Kokkos::PerTeam(team),
-                   [&]() { error_accum += team_error_accum; });
-  }
-};
-
-void test_scratch(TEST_EXECSPACE exec0, TEST_EXECSPACE exec1) {
-  constexpr int N            = 10;
-  constexpr int R            = 1000;
-  constexpr int scratch_size = 100;
-  using ScratchType = Kokkos::View<int *, Kokkos::Cuda::scratch_memory_space>;
-
-  // Test allocating and using scratch space
-  ScratchFunctor f(scratch_size, R);
-
-  auto policy0 =
-      Kokkos::TeamPolicy<Kokkos::Cuda>(exec0, N, 10)
-          .set_scratch_size(
-              1, Kokkos::PerTeam(ScratchType::shmem_size(scratch_size)));
-  auto policy1 =
-      Kokkos::TeamPolicy<Kokkos::Cuda>(exec1, N, 10)
-          .set_scratch_size(
-              1, Kokkos::PerTeam(ScratchType::shmem_size(scratch_size)));
-
-  int error0, error1;
-
-  Kokkos::parallel_reduce("test_scratch_device_0", policy0, f, error0);
-  Kokkos::parallel_reduce("test_scratch_device_1", policy1, f, error1);
-  ASSERT_EQ(error0, 0);
-  ASSERT_EQ(error1, 0);
-
-  // Request larger scratch size to trigger a realloc and test
-  const auto new_scratch_size = scratch_size + 10;
-  ScratchFunctor f_more_scratch(new_scratch_size, R);
-
-  auto policy0_more_scratch =
-      Kokkos::TeamPolicy<Kokkos::Cuda>(exec0, N, 10)
-          .set_scratch_size(
-              1, Kokkos::PerTeam(ScratchType::shmem_size(new_scratch_size)));
-  auto policy1_more_scratch =
-      Kokkos::TeamPolicy<Kokkos::Cuda>(exec1, N, 10)
-          .set_scratch_size(
-              1, Kokkos::PerTeam(ScratchType::shmem_size(new_scratch_size)));
-
-  Kokkos::parallel_reduce("test_realloc_scratch_device_0", policy0_more_scratch,
-                          f_more_scratch, error0);
-  Kokkos::parallel_reduce("test_realloc_scratch_device_1", policy1_more_scratch,
-                          f_more_scratch, error1);
-  ASSERT_EQ(error0, 0);
-  ASSERT_EQ(error1, 0);
 }
 
 TEST(cuda_multi_gpu, scratch_space) {

--- a/core/unit_test/sycl/TestSYCL_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_StreamsMultiGPU.cpp
@@ -22,25 +22,11 @@ namespace {
 std::array<TEST_EXECSPACE, 2> get_execution_spaces() {
   std::vector<sycl::device> gpu_devices =
       sycl::device::get_devices(sycl::info::device_type::gpu);
-  auto exception_handler = [](sycl::exception_list exceptions) {
-    bool asynchronous_error = false;
-    for (std::exception_ptr const &e : exceptions) {
-      try {
-        std::rethrow_exception(e);
-      } catch (sycl::exception const &e) {
-        std::cerr << e.what() << '\n';
-        asynchronous_error = true;
-      }
-    }
-    if (asynchronous_error)
-      Kokkos::Impl::throw_runtime_exception(
-          "There was an asynchronous SYCL error!\n");
-  };
 
-  TEST_EXECSPACE exec0(sycl::queue{gpu_devices.front(), exception_handler,
-                                   sycl::property::queue::in_order()});
-  TEST_EXECSPACE exec1(sycl::queue{gpu_devices.back(), exception_handler,
-                                   sycl::property::queue::in_order()});
+  TEST_EXECSPACE exec0(
+      sycl::queue{gpu_devices.front(), sycl::property::queue::in_order()});
+  TEST_EXECSPACE exec1(
+      sycl::queue{gpu_devices.back(), sycl::property::queue::in_order()});
 
   return {exec0, exec1};
 }

--- a/core/unit_test/sycl/TestSYCL_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_StreamsMultiGPU.cpp
@@ -1,0 +1,245 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <TestSYCL_Category.hpp>
+#include <Test_InterOp_Streams.hpp>
+
+namespace {
+
+std::array<TEST_EXECSPACE, 2> get_execution_spaces() {
+  std::vector<sycl::device> gpu_devices =
+      sycl::device::get_devices(sycl::info::device_type::gpu);
+  auto exception_handler = [](sycl::exception_list exceptions) {
+    bool asynchronous_error = false;
+    for (std::exception_ptr const &e : exceptions) {
+      try {
+        std::rethrow_exception(e);
+      } catch (sycl::exception const &e) {
+        std::cerr << e.what() << '\n';
+        asynchronous_error = true;
+      }
+    }
+    if (asynchronous_error)
+      Kokkos::Impl::throw_runtime_exception(
+          "There was an asynchronous SYCL error!\n");
+  };
+
+  TEST_EXECSPACE exec0(sycl::queue{gpu_devices.front(), exception_handler,
+                                   sycl::property::queue::in_order()});
+  TEST_EXECSPACE exec1(sycl::queue{gpu_devices.back(), exception_handler,
+                                   sycl::property::queue::in_order()});
+
+  return {exec0, exec1};
+}
+
+// Test Interoperability with SYCL Streams
+void test_policies(TEST_EXECSPACE exec0, Kokkos::View<int *, TEST_EXECSPACE> v0,
+                   TEST_EXECSPACE exec, Kokkos::View<int *, TEST_EXECSPACE> v) {
+  using MemorySpace = typename TEST_EXECSPACE::memory_space;
+
+  exec.fence();
+  exec0.fence();
+
+  Kokkos::deep_copy(exec, v, 5);
+  Kokkos::deep_copy(exec0, v0, 5);
+
+  Kokkos::deep_copy(v, v0);
+
+  int sum;
+  int sum0;
+
+  Kokkos::parallel_for("Test::sycl::raw_sycl_queue::Range_0",
+                       Kokkos::RangePolicy<TEST_EXECSPACE>(exec0, 0, 100),
+                       Test::FunctorRange<MemorySpace>(v0));
+  Kokkos::parallel_for("Test::sycl::raw_sycl_queue::Range",
+                       Kokkos::RangePolicy<TEST_EXECSPACE>(exec, 0, 100),
+                       Test::FunctorRange<MemorySpace>(v));
+  exec.fence();
+  exec0.fence();
+  Kokkos::parallel_reduce(
+      "Test::sycl::raw_sycl_queue::RangeReduce_0",
+      Kokkos::RangePolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 2>>(exec0,
+                                                                        0, 100),
+      Test::FunctorRangeReduce<MemorySpace>(v0), sum0);
+  Kokkos::parallel_reduce(
+      "Test::sycl::raw_sycl_queue::RangeReduce",
+      Kokkos::RangePolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 2>>(exec, 0,
+                                                                        100),
+      Test::FunctorRangeReduce<MemorySpace>(v), sum);
+  ASSERT_EQ(600, sum0);
+  ASSERT_EQ(600, sum);
+
+  Kokkos::parallel_for("Test::sycl::raw_sycl_queue::MDRange_0",
+                       Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
+                           exec0, {0, 0}, {10, 10}),
+                       Test::FunctorMDRange<MemorySpace>(v0));
+  Kokkos::parallel_for("Test::sycl::raw_sycl_queue::MDRange",
+                       Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
+                           exec, {0, 0}, {10, 10}),
+                       Test::FunctorMDRange<MemorySpace>(v));
+  Kokkos::parallel_reduce("Test::sycl::raw_sycl_queue::MDRangeReduce_0",
+                          Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>,
+                                                Kokkos::LaunchBounds<128, 2>>(
+                              exec0, {0, 0}, {10, 10}),
+                          Test::FunctorMDRangeReduce<MemorySpace>(v0), sum0);
+  Kokkos::parallel_reduce("Test::sycl::raw_sycl_queue::MDRangeReduce",
+                          Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>,
+                                                Kokkos::LaunchBounds<128, 2>>(
+                              exec, {0, 0}, {10, 10}),
+                          Test::FunctorMDRangeReduce<MemorySpace>(v), sum);
+  ASSERT_EQ(700, sum0);
+  ASSERT_EQ(700, sum);
+
+  Kokkos::parallel_for("Test::sycl::raw_sycl_queue::Team_0",
+                       Kokkos::TeamPolicy<TEST_EXECSPACE>(exec0, 10, 10),
+                       Test::FunctorTeam<MemorySpace, TEST_EXECSPACE>(v0));
+  Kokkos::parallel_for("Test::sycl::raw_sycl_queue::Team",
+                       Kokkos::TeamPolicy<TEST_EXECSPACE>(exec, 10, 10),
+                       Test::FunctorTeam<MemorySpace, TEST_EXECSPACE>(v));
+  Kokkos::parallel_reduce(
+      "Test::sycl::raw_sycl_queue::Team_0",
+      Kokkos::TeamPolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 2>>(exec0,
+                                                                       10, 10),
+      Test::FunctorTeamReduce<MemorySpace, TEST_EXECSPACE>(v0), sum0);
+  Kokkos::parallel_reduce(
+      "Test::sycl::raw_sycl_queue::Team",
+      Kokkos::TeamPolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 2>>(exec, 10,
+                                                                       10),
+      Test::FunctorTeamReduce<MemorySpace, TEST_EXECSPACE>(v), sum);
+  ASSERT_EQ(800, sum0);
+  ASSERT_EQ(800, sum);
+}
+
+TEST(sycl_multi_gpu, managed_views) {
+  std::array<TEST_EXECSPACE, 2> execs = get_execution_spaces();
+
+  Kokkos::View<int *, TEST_EXECSPACE> view0(Kokkos::view_alloc("v0", execs[0]),
+                                            100);
+  Kokkos::View<int *, TEST_EXECSPACE> view(Kokkos::view_alloc("v", execs[1]),
+                                           100);
+
+  test_policies(execs[0], view0, execs[1], view);
+}
+
+TEST(sycl_multi_gpu, unmanaged_views) {
+  std::array<TEST_EXECSPACE, 2> execs = get_execution_spaces();
+
+  int *p0 = sycl::malloc_device<int>(100, execs[0].sycl_queue());
+  Kokkos::View<int *, TEST_EXECSPACE> view0(p0, 100);
+
+  int *p1 = sycl::malloc_device<int>(100, execs[1].sycl_queue());
+  Kokkos::View<int *, TEST_EXECSPACE> view1(p1, 100);
+
+  test_policies(execs[0], view0, execs[1], view1);
+  sycl::free(p0, execs[0].sycl_queue());
+  sycl::free(p1, execs[1].sycl_queue());
+}
+
+struct ScratchFunctor {
+  int scratch_size;
+  int R;
+
+  ScratchFunctor(int scratch_size_, int R_)
+      : scratch_size(scratch_size_), R(R_) {}
+
+  KOKKOS_FUNCTION
+  void operator()(
+      const Kokkos::TeamPolicy<Kokkos::Experimental::SYCL>::member_type &team,
+      int &error_accum) const {
+    Kokkos::View<int *, Kokkos::Experimental::SYCL::scratch_memory_space>
+        scratch_mem(team.team_scratch(1), scratch_size);
+
+    // Initialize scratch memory
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 0, scratch_size),
+                         [&](int i) { scratch_mem(i) = 0; });
+    team.team_barrier();
+
+    // Increment each entry in scratch memory R times
+    for (int r = 0; r < R; ++r) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 0, scratch_size),
+                           [&](int i) { scratch_mem(i) += 1; });
+    }
+    team.team_barrier();
+
+    // Check that each scratch entry has been incremented exactly R times
+    int team_error_accum;
+    auto R_loc = R;  // avoid implicit capture of this
+    Kokkos::parallel_reduce(
+        Kokkos::TeamVectorRange(team, 0, scratch_size),
+        [&](int i, int &tsum) {
+          if (scratch_mem(i) != R_loc) {
+            tsum += 1;
+          }
+        },
+        team_error_accum);
+    Kokkos::single(Kokkos::PerTeam(team),
+                   [&]() { error_accum += team_error_accum; });
+  }
+};
+
+void test_scratch(TEST_EXECSPACE exec0, TEST_EXECSPACE exec1) {
+  constexpr int N            = 10;
+  constexpr int R            = 1000;
+  constexpr int scratch_size = 100;
+  using ScratchType =
+      Kokkos::View<int *, Kokkos::Experimental::SYCL::scratch_memory_space>;
+
+  // Test allocating and using scratch space
+  ScratchFunctor f(scratch_size, R);
+
+  auto policy0 =
+      Kokkos::TeamPolicy<Kokkos::Experimental::SYCL>(exec0, N, 10)
+          .set_scratch_size(
+              1, Kokkos::PerTeam(ScratchType::shmem_size(scratch_size)));
+  auto policy1 =
+      Kokkos::TeamPolicy<Kokkos::Experimental::SYCL>(exec1, N, 10)
+          .set_scratch_size(
+              1, Kokkos::PerTeam(ScratchType::shmem_size(scratch_size)));
+
+  int error0, error1;
+
+  Kokkos::parallel_reduce("test_scratch_device_0", policy0, f, error0);
+  Kokkos::parallel_reduce("test_scratch_device_1", policy1, f, error1);
+  ASSERT_EQ(error0, 0);
+  ASSERT_EQ(error1, 0);
+
+  // Request larger scratch size to trigger a realloc and test
+  const auto new_scratch_size = scratch_size + 10;
+  ScratchFunctor f_more_scratch(new_scratch_size, R);
+
+  auto policy0_more_scratch =
+      Kokkos::TeamPolicy<Kokkos::Experimental::SYCL>(exec0, N, 10)
+          .set_scratch_size(
+              1, Kokkos::PerTeam(ScratchType::shmem_size(new_scratch_size)));
+  auto policy1_more_scratch =
+      Kokkos::TeamPolicy<Kokkos::Experimental::SYCL>(exec1, N, 10)
+          .set_scratch_size(
+              1, Kokkos::PerTeam(ScratchType::shmem_size(new_scratch_size)));
+
+  Kokkos::parallel_reduce("test_realloc_scratch_device_0", policy0_more_scratch,
+                          f_more_scratch, error0);
+  Kokkos::parallel_reduce("test_realloc_scratch_device_1", policy1_more_scratch,
+                          f_more_scratch, error1);
+  ASSERT_EQ(error0, 0);
+  ASSERT_EQ(error1, 0);
+}
+
+TEST(sycl_multi_gpu, scratch_space) {
+  std::array<TEST_EXECSPACE, 2> execs = get_execution_spaces();
+
+  test_scratch(execs[0], execs[1]);
+}
+}  // namespace


### PR DESCRIPTION
This is analogous to https://github.com/kokkos/kokkos/pull/6866 and https://github.com/kokkos/kokkos/pull/6782 for `Cuda`. It's known to fail with `Intel GPUs` for some older compiler versions but works with the latest official release and on `polaris` with `A100`s.
The test added reuses and refactors the tests for CUDA multi-GPUs.