### PR TITLE
Cuda: Fix configuring with CMake 3.28.4

### DIFF
--- a/cmake/Modules/FindTPLCUDA.cmake
+++ b/cmake/Modules/FindTPLCUDA.cmake
@@ -7,8 +7,8 @@ IF (NOT CUDAToolkit_ROOT)
   ENDIF()
 ENDIF()
 
-# FIXME CMake 3.29.0 creates more targets than we export
-IF(CMAKE_VERSION VERSION_GREATER_EQUAL "3.17.0" AND CMAKE_VERSION VERSION_LESS "3.29.0")
+# FIXME CMake 3.28.4 creates more targets than we export
+IF(CMAKE_VERSION VERSION_GREATER_EQUAL "3.17.0" AND CMAKE_VERSION VERSION_LESS "3.28.4")
   find_package(CUDAToolkit)
 ELSE()
   include(${CMAKE_CURRENT_LIST_DIR}/CudaToolkit.cmake)

--- a/cmake/Modules/FindTPLCUDA.cmake
+++ b/cmake/Modules/FindTPLCUDA.cmake
@@ -7,7 +7,8 @@ IF (NOT CUDAToolkit_ROOT)
   ENDIF()
 ENDIF()
 
-IF(CMAKE_VERSION VERSION_GREATER_EQUAL "3.17.0")
+# FIXME CMake 3.29.0 creates more targets than we export
+IF(CMAKE_VERSION VERSION_GREATER_EQUAL "3.17.0" AND CMAKE_VERSION VERSION_LESS "3.29.0")
   find_package(CUDAToolkit)
 ELSE()
   include(${CMAKE_CURRENT_LIST_DIR}/CudaToolkit.cmake)


### PR DESCRIPTION
Fixes #6902. With `CMake 3.28.4`, we are getting
```bash
CMake Error at /app/kokkos-install/lib/cmake/Kokkos/KokkosConfig.cmake:41 (SET_TARGET_PROPERTIES):
  The link interface of target "CUDA::cudart" contains:

    CUDA::cudart_static_deps

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  CMakeLists.txt:10 (find_package)
```
when trying to link against `Kokkos::kokkos`. https://github.com/Kitware/CMake/commit/4a3cafec4ff195ec86ac60d693ec502b3fca58f2 to fix https://gitlab.kitware.com/cmake/cmake/-/issues/25665 seems responsible. Basically, `FindCUDAToolkit.cmake` now adds more dependencies to targets that we don't export. More precisely it's
```
  if(NOT TARGET CUDA::cudart_static_deps)
    add_library(CUDA::cudart_static_deps IMPORTED INTERFACE)
    if(UNIX AND (CMAKE_C_COMPILER OR CMAKE_CXX_COMPILER))
      find_package(Threads REQUIRED)
      target_link_libraries(CUDA::cudart_static_deps INTERFACE Threads::Threads ${CMAKE_DL_LIBS})
    endif()

    if(UNIX AND NOT APPLE AND NOT (CMAKE_SYSTEM_NAME STREQUAL "QNX"))
      # On Linux, you must link against librt when using the static cuda runtime.
      find_library(CUDAToolkit_rt_LIBRARY rt)
      mark_as_advanced(CUDAToolkit_rt_LIBRARY)
      if(NOT CUDAToolkit_rt_LIBRARY)
        message(WARNING "Could not find librt library, needed by CUDA::cudart_static")
      else()
        target_link_libraries(CUDA::cudart_static_deps INTERFACE ${CUDAToolkit_rt_LIBRARY})
      endif()
    endif()
  endif()
```
which means that we need to export `CUDA::cudart_static_deps`, and `Threads::Threads` as well (and refind `Threads`). This pull request suggests simply using our older bundled version of the file for now. Hopefully, we can clean this up when getting rid of `TriBITS` support.