### PR TITLE
Move `Kokkos::Array` tests to a more suitable place

### DIFF
--- a/core/unit_test/TestAggregate.hpp
+++ b/core/unit_test/TestAggregate.hpp
@@ -63,42 +63,6 @@ void TestViewAggregate() {
   ASSERT_EQ(y.extent(0), 4u);
   ASSERT_EQ(y.extent(1), 5u);
   ASSERT_EQ(y.extent(2), 32u);
-
-  // Initialize arrays from brace-init-list as for std::array.
-  //
-  // Comment: Clang will issue the following warning if we don't use double
-  //          braces here (one for initializing the Kokkos::Array and one for
-  //          initializing the sub-aggreagate C-array data member),
-  //
-  //            warning: suggest braces around initialization of subobject
-  //
-  //          but single brace syntax would be valid as well.
-  Kokkos::Array<float, 2> aggregate_initialization_syntax_1 = {{1.41, 3.14}};
-  ASSERT_FLOAT_EQ(aggregate_initialization_syntax_1[0], 1.41);
-  ASSERT_FLOAT_EQ(aggregate_initialization_syntax_1[1], 3.14);
-
-  Kokkos::Array<int, 3> aggregate_initialization_syntax_2{
-      {0, 1, 2}};  // since C++11
-  for (int i = 0; i < 3; ++i) {
-    ASSERT_EQ(aggregate_initialization_syntax_2[i], i);
-  }
-
-  // Note that this is a valid initialization.
-  Kokkos::Array<double, 3> initialized_with_one_argument_missing = {{255, 255}};
-  for (int i = 0; i < 2; ++i) {
-    ASSERT_DOUBLE_EQ(initialized_with_one_argument_missing[i], 255);
-  }
-  // But the following line would not compile
-  //  Kokkos::Array< double, 3 > initialized_with_too_many{ { 1, 2, 3, 4 } };
-
-  // The code below must compile for zero-sized arrays.
-  using T = float;
-
-  constexpr int N = 0;
-  Kokkos::Array<T, N> a;
-  for (int i = 0; i < N; ++i) {
-    a[i] = T();
-  }
 }
 
 TEST(TEST_CATEGORY, view_aggregate) { TestViewAggregate<TEST_EXECSPACE>(); }

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -103,7 +103,13 @@ KOKKOS_FUNCTION constexpr bool test_array_aggregate_initialization() {
 
 static_assert(test_array_aggregate_initialization());
 
-KOKKOS_FUNCTION constexpr bool test_array_zero_sized() {
+// A few compilers, such as GCC 8.4, were erroring out when the function below
+// appeared in a constant expression because
+// Kokkos::Array<T, 0, Proxy>::operator[] is non-constexpr.  The issue
+// disappears with GCC 9.1 (https://godbolt.org/z/TG4TEef1b).  As a workaround,
+// the static_assert was dropped and the [[maybe_unused]] is used as an attempt
+// to silent warnings that the function is never used.
+[[maybe_unused]] KOKKOS_FUNCTION void test_array_zero_sized() {
   using T = float;
 
   // The code below must compile for zero-sized arrays.
@@ -112,9 +118,6 @@ KOKKOS_FUNCTION constexpr bool test_array_zero_sized() {
   for (int i = 0; i < N; ++i) {
     a[i] = T();
   }
-  return true;
 }
-
-static_assert(test_array_zero_sized());
 
 }  // namespace

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -73,4 +73,48 @@ KOKKOS_FUNCTION constexpr bool test_array_ctad() {
 static_assert(test_array_ctad());
 #endif
 
+KOKKOS_FUNCTION constexpr bool test_array_aggregate_initialization() {
+  // Initialize arrays from brace-init-list as for std::array.
+
+  Kokkos::Array<float, 2> aggregate_initialization_syntax_1 = {1.41f, 3.14f};
+  if ((aggregate_initialization_syntax_1[0] != 1.41f) ||
+      (aggregate_initialization_syntax_1[1] != 3.14f))
+    return false;
+
+  Kokkos::Array<int, 3> aggregate_initialization_syntax_2{
+      {0, 1, 2}};  // since C++11
+  if ((aggregate_initialization_syntax_2[0] != 0) ||
+      (aggregate_initialization_syntax_2[1] != 1) ||
+      (aggregate_initialization_syntax_2[2] != 2))
+    return false;
+
+  // Note that this is a valid initialization.
+  Kokkos::Array<double, 3> initialized_with_one_argument_missing = {{255, 255}};
+  if ((initialized_with_one_argument_missing[0] != 255) ||
+      (initialized_with_one_argument_missing[1] != 255) ||
+      (initialized_with_one_argument_missing[2] != 0))
+    return false;
+
+  // But the following line would not compile
+  //  Kokkos::Array< double, 3 > initialized_with_too_many{ { 1, 2, 3, 4 } };
+
+  return true;
+}
+
+static_assert(test_array_aggregate_initialization());
+
+KOKKOS_FUNCTION constexpr bool test_array_zero_sized() {
+  using T = float;
+
+  // The code below must compile for zero-sized arrays.
+  constexpr int N = 0;
+  Kokkos::Array<T, N> a;
+  for (int i = 0; i < N; ++i) {
+    a[i] = T();
+  }
+  return true;
+}
+
+static_assert(test_array_zero_sized());
+
 }  // namespace


### PR DESCRIPTION
Motivation: new place is a better fit and upcoming changes to view of Kokkos arrays where the remaining tests in that file would be removed

The `Kokkos::Array` tests are move from runtime `view_aggregate` test to `TestArray.cpp` that currently had CTAD compile-only tests.  I split the tests into "aggregate initialization" and "zero-sized array code that must compile" and refactored to get the assertions checked at compile time.  I did not really want to refactor further and actually run code on the device.  I think that is good enough, the tests are easier to find and fairly readable.

These tests were introduced in 2017 and placed here for lack of a better place.