### PR TITLE
Accommodate users that depend on a code that define silly macros

### DIFF
--- a/core/src/Kokkos_Tuners.hpp
+++ b/core/src/Kokkos_Tuners.hpp
@@ -256,13 +256,14 @@ auto get_point_helper(const PointType& in, const ArrayType& indices,
 template <typename PointType, typename ArrayType>
 struct GetPoint;
 
-template <typename PointType, size_t SZ>
-struct GetPoint<PointType,
-                std::array<Kokkos::Tools::Experimental::VariableValue, SZ>> {
+template <typename PointType, size_t ArraySize>
+struct GetPoint<
+    PointType,
+    std::array<Kokkos::Tools::Experimental::VariableValue, ArraySize>> {
   using index_set_type =
-      std::array<Kokkos::Tools::Experimental::VariableValue, SZ>;
+      std::array<Kokkos::Tools::Experimental::VariableValue, ArraySize>;
   static auto build(const PointType& in, const index_set_type& indices) {
-    return get_point_helper(in, indices, std::make_index_sequence<SZ>{});
+    return get_point_helper(in, indices, std::make_index_sequence<ArraySize>{});
   }
 };
 

--- a/core/src/Kokkos_Tuners.hpp
+++ b/core/src/Kokkos_Tuners.hpp
@@ -256,13 +256,13 @@ auto get_point_helper(const PointType& in, const ArrayType& indices,
 template <typename PointType, typename ArrayType>
 struct GetPoint;
 
-template <typename PointType, size_t X>
+template <typename PointType, size_t SZ>
 struct GetPoint<PointType,
-                std::array<Kokkos::Tools::Experimental::VariableValue, X>> {
+                std::array<Kokkos::Tools::Experimental::VariableValue, SZ>> {
   using index_set_type =
-      std::array<Kokkos::Tools::Experimental::VariableValue, X>;
+      std::array<Kokkos::Tools::Experimental::VariableValue, SZ>;
   static auto build(const PointType& in, const index_set_type& indices) {
-    return get_point_helper(in, indices, std::make_index_sequence<X>{});
+    return get_point_helper(in, indices, std::make_index_sequence<SZ>{});
   }
 };
 


### PR DESCRIPTION
Reported on Slack, user was getting when including some other dependency
```
<prefix>/include/Kokkos_Tuners.hpp(259): error: expected a "," or ">"
 template <typename PointType, size_t 0>
                    ^
```
It turns out that dependency defines macros such as "X", "Y", "Z", or even "DIM" which is really asking for trouble.  See here https://github.com/fluiddynsci/EngSketchPad/blob/1fe3fc4c68a759e0832c02f8d3c2bd8722f183a8/include/libCart3D/c3d_global.h#L24-L28

Since it does not take much change to accommodate that user, we avoid named parameters that collide with these silly macro defines.
We are not promising that we support it but this should help.