### PR TITLE
Do not return a copy of the input functor for `Kokkos::Experimental::for_each`

### DIFF
--- a/algorithms/src/std_algorithms/Kokkos_ForEach.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ForEach.hpp
@@ -29,49 +29,46 @@ namespace Experimental {
 template <
     class ExecutionSpace, class IteratorType, class UnaryFunctorType,
     std::enable_if_t<Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
-UnaryFunctorType for_each(const std::string& label, const ExecutionSpace& ex,
-                          IteratorType first, IteratorType last,
-                          UnaryFunctorType functor) {
-  return Impl::for_each_exespace_impl(label, ex, first, last,
-                                      std::move(functor));
+void for_each(const std::string& label, const ExecutionSpace& ex,
+              IteratorType first, IteratorType last, UnaryFunctorType functor) {
+  Impl::for_each_exespace_impl(label, ex, first, last, std::move(functor));
 }
 
 template <
     class ExecutionSpace, class IteratorType, class UnaryFunctorType,
     std::enable_if_t<Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
-UnaryFunctorType for_each(const ExecutionSpace& ex, IteratorType first,
-                          IteratorType last, UnaryFunctorType functor) {
-  return Impl::for_each_exespace_impl("Kokkos::for_each_iterator_api_default",
-                                      ex, first, last, std::move(functor));
+void for_each(const ExecutionSpace& ex, IteratorType first, IteratorType last,
+              UnaryFunctorType functor) {
+  Impl::for_each_exespace_impl("Kokkos::for_each_iterator_api_default", ex,
+                               first, last, std::move(functor));
 }
 
 template <
     class ExecutionSpace, class DataType, class... Properties,
     class UnaryFunctorType,
     std::enable_if_t<Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
-UnaryFunctorType for_each(const std::string& label, const ExecutionSpace& ex,
-                          const ::Kokkos::View<DataType, Properties...>& v,
-                          UnaryFunctorType functor) {
+void for_each(const std::string& label, const ExecutionSpace& ex,
+              const ::Kokkos::View<DataType, Properties...>& v,
+              UnaryFunctorType functor) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(v);
 
   namespace KE = ::Kokkos::Experimental;
-  return Impl::for_each_exespace_impl(label, ex, KE::begin(v), KE::end(v),
-                                      std::move(functor));
+  Impl::for_each_exespace_impl(label, ex, KE::begin(v), KE::end(v),
+                               std::move(functor));
 }
 
 template <
     class ExecutionSpace, class DataType, class... Properties,
     class UnaryFunctorType,
     std::enable_if_t<Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
-UnaryFunctorType for_each(const ExecutionSpace& ex,
-                          const ::Kokkos::View<DataType, Properties...>& v,
-                          UnaryFunctorType functor) {
+void for_each(const ExecutionSpace& ex,
+              const ::Kokkos::View<DataType, Properties...>& v,
+              UnaryFunctorType functor) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(v);
 
   namespace KE = ::Kokkos::Experimental;
-  return Impl::for_each_exespace_impl("Kokkos::for_each_view_api_default", ex,
-                                      KE::begin(v), KE::end(v),
-                                      std::move(functor));
+  Impl::for_each_exespace_impl("Kokkos::for_each_view_api_default", ex,
+                               KE::begin(v), KE::end(v), std::move(functor));
 }
 
 //
@@ -82,24 +79,23 @@ UnaryFunctorType for_each(const ExecutionSpace& ex,
 
 template <class TeamHandleType, class IteratorType, class UnaryFunctorType,
           std::enable_if_t<Kokkos::is_team_handle_v<TeamHandleType>, int> = 0>
-KOKKOS_FUNCTION UnaryFunctorType for_each(const TeamHandleType& teamHandle,
-                                          IteratorType first, IteratorType last,
-                                          UnaryFunctorType functor) {
-  return Impl::for_each_team_impl(teamHandle, first, last, std::move(functor));
+KOKKOS_FUNCTION void for_each(const TeamHandleType& teamHandle,
+                              IteratorType first, IteratorType last,
+                              UnaryFunctorType functor) {
+  Impl::for_each_team_impl(teamHandle, first, last, std::move(functor));
 }
 
 template <class TeamHandleType, class DataType, class... Properties,
           class UnaryFunctorType,
           std::enable_if_t<Kokkos::is_team_handle_v<TeamHandleType>, int> = 0>
-KOKKOS_FUNCTION UnaryFunctorType
-for_each(const TeamHandleType& teamHandle,
-         const ::Kokkos::View<DataType, Properties...>& v,
-         UnaryFunctorType functor) {
+KOKKOS_FUNCTION void for_each(const TeamHandleType& teamHandle,
+                              const ::Kokkos::View<DataType, Properties...>& v,
+                              UnaryFunctorType functor) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(v);
 
   namespace KE = ::Kokkos::Experimental;
-  return Impl::for_each_team_impl(teamHandle, KE::begin(v), KE::end(v),
-                                  std::move(functor));
+  Impl::for_each_team_impl(teamHandle, KE::begin(v), KE::end(v),
+                           std::move(functor));
 }
 
 }  // namespace Experimental

--- a/algorithms/src/std_algorithms/impl/Kokkos_ForEachForEachN.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ForEachForEachN.hpp
@@ -42,10 +42,9 @@ struct StdForEachFunctor {
 };
 
 template <class HandleType, class IteratorType, class UnaryFunctorType>
-UnaryFunctorType for_each_exespace_impl(const std::string& label,
-                                        const HandleType& handle,
-                                        IteratorType first, IteratorType last,
-                                        UnaryFunctorType functor) {
+void for_each_exespace_impl(const std::string& label, const HandleType& handle,
+                            IteratorType first, IteratorType last,
+                            UnaryFunctorType functor) {
   // checks
   Impl::static_assert_random_access_and_accessible(handle, first);
   Impl::expect_valid_range(first, last);
@@ -56,8 +55,6 @@ UnaryFunctorType for_each_exespace_impl(const std::string& label,
       label, RangePolicy<HandleType>(handle, 0, num_elements),
       StdForEachFunctor<IteratorType, UnaryFunctorType>(first, functor));
   handle.fence("Kokkos::for_each: fence after operation");
-
-  return functor;
 }
 
 template <class ExecutionSpace, class IteratorType, class SizeType,
@@ -75,7 +72,7 @@ IteratorType for_each_n_exespace_impl(const std::string& label,
   }
 
   for_each_exespace_impl(label, ex, first, last, std::move(functor));
-  // no neeed to fence since for_each_exespace_impl fences already
+  // no need to fence since for_each_exespace_impl fences already
 
   return last;
 }
@@ -84,9 +81,9 @@ IteratorType for_each_n_exespace_impl(const std::string& label,
 // team impl
 //
 template <class TeamHandleType, class IteratorType, class UnaryFunctorType>
-KOKKOS_FUNCTION UnaryFunctorType
-for_each_team_impl(const TeamHandleType& teamHandle, IteratorType first,
-                   IteratorType last, UnaryFunctorType functor) {
+KOKKOS_FUNCTION void for_each_team_impl(const TeamHandleType& teamHandle,
+                                        IteratorType first, IteratorType last,
+                                        UnaryFunctorType functor) {
   // checks
   Impl::static_assert_random_access_and_accessible(teamHandle, first);
   Impl::expect_valid_range(first, last);
@@ -96,7 +93,6 @@ for_each_team_impl(const TeamHandleType& teamHandle, IteratorType first,
       TeamThreadRange(teamHandle, 0, num_elements),
       StdForEachFunctor<IteratorType, UnaryFunctorType>(first, functor));
   teamHandle.team_barrier();
-  return functor;
 }
 
 template <class TeamHandleType, class IteratorType, class SizeType,
@@ -113,7 +109,7 @@ for_each_n_team_impl(const TeamHandleType& teamHandle, IteratorType first,
   }
 
   for_each_team_impl(teamHandle, first, last, std::move(functor));
-  // no neeed to fence since for_each_team_impl fences already
+  // no need to fence since for_each_team_impl fences already
 
   return last;
 }


### PR DESCRIPTION
If I understand correctly, the Kokkos algorithms match the standard algorithms with an execution policy. From https://eel.is/c++draft/alg.foreach#10, the `for_each` version taking an execution policy should not return a copy of the input functor.

The PR makes all `Kokkos::Experimental::for_each` versions return `void`. Should `Kokkos::Serial` be a special case ?