### PR TITLE
Allow functors as reducers for nested team parallel reduce

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -184,24 +184,37 @@ class CudaTeamMember {
    *    ( 1 == blockDim.z )
    */
   template <typename ReducerType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<ReducerType>::value>
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer_v<ReducerType>>
   team_reduce(ReducerType const& reducer) const noexcept {
     team_reduce(reducer, reducer.reference());
   }
 
   template <typename ReducerType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<ReducerType>::value>
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer_v<ReducerType>>
   team_reduce(ReducerType const& reducer,
               typename ReducerType::value_type& value) const noexcept {
     (void)reducer;
     (void)value;
+
+    KOKKOS_IF_ON_DEVICE((
+        typename Impl::FunctorAnalysis<
+            Impl::FunctorPatternInterface::REDUCE, TeamPolicy<Cuda>,
+            ReducerType, typename ReducerType::value_type>::Reducer
+            wrapped_reducer(reducer);
+
+        impl_team_reduce(wrapped_reducer, value); reducer.reference() = value;))
+  }
+
+  template <typename WrappedReducerType>
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer_v<WrappedReducerType>>
+  impl_team_reduce(
+      WrappedReducerType const& wrapped_reducer,
+      typename WrappedReducerType::value_type& value) const noexcept {
+    (void)wrapped_reducer;
+    (void)value;
+
     KOKKOS_IF_ON_DEVICE(
-        (typename Impl::FunctorAnalysis<
-             Impl::FunctorPatternInterface::REDUCE, TeamPolicy<Cuda>,
-             ReducerType, typename ReducerType::value_type>::Reducer
-             wrapped_reducer(reducer);
-         cuda_intra_block_reduction(value, wrapped_reducer, blockDim.y);
-         reducer.reference() = value;))
+        (cuda_intra_block_reduction(value, wrapped_reducer, blockDim.y);))
   }
 
   //--------------------------------------------------------------------------
@@ -260,23 +273,42 @@ class CudaTeamMember {
   //----------------------------------------
 
   template <typename ReducerType>
-  KOKKOS_INLINE_FUNCTION static std::enable_if_t<is_reducer<ReducerType>::value>
+  KOKKOS_INLINE_FUNCTION static std::enable_if_t<is_reducer_v<ReducerType>>
   vector_reduce(ReducerType const& reducer) {
     vector_reduce(reducer, reducer.reference());
   }
 
   template <typename ReducerType>
-  KOKKOS_INLINE_FUNCTION static std::enable_if_t<is_reducer<ReducerType>::value>
+  KOKKOS_INLINE_FUNCTION static std::enable_if_t<is_reducer_v<ReducerType>>
   vector_reduce(ReducerType const& reducer,
                 typename ReducerType::value_type& value) {
     (void)reducer;
     (void)value;
+
+    KOKKOS_IF_ON_DEVICE(
+        (typename Impl::FunctorAnalysis<
+             Impl::FunctorPatternInterface::REDUCE, TeamPolicy<Cuda>,
+             ReducerType, typename ReducerType::value_type>::Reducer
+             wrapped_reducer(reducer);
+
+         impl_vector_reduce(wrapped_reducer, value);
+         reducer.reference() = value;))
+  }
+
+  template <typename WrappedReducerType>
+  KOKKOS_INLINE_FUNCTION static std::enable_if_t<
+      is_reducer_v<WrappedReducerType>>
+  impl_vector_reduce(WrappedReducerType const& wrapped_reducer,
+                     typename WrappedReducerType::value_type& value) {
+    (void)wrapped_reducer;
+    (void)value;
+
     KOKKOS_IF_ON_DEVICE(
         (if (blockDim.x == 1) return;
 
          // Intra vector lane shuffle reduction:
-         typename ReducerType::value_type tmp(value);
-         typename ReducerType::value_type tmp2 = tmp;
+         typename WrappedReducerType::value_type tmp(value);
+         typename WrappedReducerType::value_type tmp2 = tmp;
 
          unsigned mask =
              blockDim.x == 32
@@ -287,7 +319,7 @@ class CudaTeamMember {
          for (int i = blockDim.x; (i >>= 1);) {
            Impl::in_place_shfl_down(tmp2, tmp, i, blockDim.x, mask);
            if ((int)threadIdx.x < i) {
-             reducer.join(tmp, tmp2);
+             wrapped_reducer.join(&tmp, &tmp2);
            }
          }
 
@@ -297,7 +329,7 @@ class CudaTeamMember {
          // and thus different threads could have different results.
 
          Impl::in_place_shfl(tmp2, tmp, 0, blockDim.x, mask);
-         value = tmp2; reducer.reference() = tmp2;))
+         value = tmp2;))
   }
 
   //----------------------------------------
@@ -487,14 +519,21 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
                     iType, Impl::CudaTeamMember>& loop_boundaries,
                 const Closure& closure, const ReducerType& reducer) {
   KOKKOS_IF_ON_DEVICE(
-      (typename ReducerType::value_type value;
+      (using value_type            = typename ReducerType::value_type;
+       using functor_analysis_type = typename Impl::FunctorAnalysis<
+           Impl::FunctorPatternInterface::REDUCE,
+           TeamPolicy<typename Impl::CudaTeamMember::execution_space>,
+           ReducerType, value_type>;
+       using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
-       reducer.init(value);
+       wrapped_reducer_type wrapped_reducer(reducer); value_type value{};
+       wrapped_reducer.init(&value);
 
        for (iType i = loop_boundaries.start + threadIdx.y;
             i < loop_boundaries.end; i += blockDim.y) { closure(i, value); }
 
-       loop_boundaries.member.team_reduce(reducer, value);))
+       loop_boundaries.member.impl_team_reduce(wrapped_reducer, value);
+       wrapped_reducer.final(&value); reducer.reference() = value;))
   // Avoid bogus warning about reducer value being uninitialized with combined
   // reducers
   KOKKOS_IF_ON_HOST(((void)loop_boundaries; (void)closure;
@@ -518,16 +557,25 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
   (void)loop_boundaries;
   (void)closure;
   (void)result;
-  KOKKOS_IF_ON_DEVICE(
-      (ValueType val; Kokkos::Sum<ValueType> reducer(val);
 
-       reducer.init(reducer.reference());
+  KOKKOS_IF_ON_DEVICE(
+      (using functor_analysis_type = typename Impl::FunctorAnalysis<
+           Impl::FunctorPatternInterface::REDUCE,
+           TeamPolicy<typename Impl::CudaTeamMember::execution_space>, Closure,
+           ValueType>;
+       using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+       using value_type           = typename wrapped_reducer_type::value_type;
+
+       wrapped_reducer_type wrapped_reducer(closure); value_type value{};
+       wrapped_reducer.init(&value);
 
        for (iType i = loop_boundaries.start + threadIdx.y;
-            i < loop_boundaries.end; i += blockDim.y) { closure(i, val); }
+            i < loop_boundaries.end; i += blockDim.y) { closure(i, value); }
 
-       loop_boundaries.member.team_reduce(reducer, val);
-       result = reducer.reference();))
+       loop_boundaries.member.impl_team_reduce(wrapped_reducer, value);
+       wrapped_reducer.final(&value); result = value;
+
+       ))
 }
 
 template <typename iType, class Closure>
@@ -548,16 +596,27 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
 parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
                     iType, Impl::CudaTeamMember>& loop_boundaries,
                 const Closure& closure, const ReducerType& reducer) {
-  KOKKOS_IF_ON_DEVICE((typename ReducerType::value_type value;
-                       reducer.init(value);
+  KOKKOS_IF_ON_DEVICE(
+      (using value_type            = typename ReducerType::value_type;
+       using functor_analysis_type = typename Impl::FunctorAnalysis<
+           Impl::FunctorPatternInterface::REDUCE,
+           TeamPolicy<typename Impl::CudaTeamMember::execution_space>,
+           ReducerType, value_type>;
+       using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
-                       for (iType i = loop_boundaries.start +
-                                      threadIdx.y * blockDim.x + threadIdx.x;
-                            i < loop_boundaries.end;
-                            i += blockDim.y * blockDim.x) { closure(i, value); }
+       wrapped_reducer_type wrapped_reducer(reducer); value_type value{};
+       wrapped_reducer.init(&value);
 
-                       loop_boundaries.member.vector_reduce(reducer, value);
-                       loop_boundaries.member.team_reduce(reducer, value);))
+       for (iType i =
+                loop_boundaries.start + threadIdx.y * blockDim.x + threadIdx.x;
+            i < loop_boundaries.end;
+            i += blockDim.y * blockDim.x) { closure(i, value); }
+
+       loop_boundaries.member.impl_vector_reduce(wrapped_reducer, value);
+       loop_boundaries.member.impl_team_reduce(wrapped_reducer, value);
+
+       wrapped_reducer.final(&value); reducer.reference() = value;))
+
   // Avoid bogus warning about reducer value being uninitialized with combined
   // reducers
   KOKKOS_IF_ON_HOST(((void)loop_boundaries; (void)closure;
@@ -573,18 +632,27 @@ parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
   (void)loop_boundaries;
   (void)closure;
   (void)result;
-  KOKKOS_IF_ON_DEVICE((ValueType val; Kokkos::Sum<ValueType> reducer(val);
 
-                       reducer.init(reducer.reference());
+  KOKKOS_IF_ON_DEVICE(
+      (using functor_analysis_type = typename Impl::FunctorAnalysis<
+           Impl::FunctorPatternInterface::REDUCE,
+           TeamPolicy<typename Impl::CudaTeamMember::execution_space>, Closure,
+           ValueType>;
+       using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+       using value_type           = typename wrapped_reducer_type::value_type;
 
-                       for (iType i = loop_boundaries.start +
-                                      threadIdx.y * blockDim.x + threadIdx.x;
-                            i < loop_boundaries.end;
-                            i += blockDim.y * blockDim.x) { closure(i, val); }
+       wrapped_reducer_type wrapped_reducer(closure); value_type value{};
+       wrapped_reducer.init(&value);
 
-                       loop_boundaries.member.vector_reduce(reducer);
-                       loop_boundaries.member.team_reduce(reducer);
-                       result = reducer.reference();))
+       for (iType i =
+                loop_boundaries.start + threadIdx.y * blockDim.x + threadIdx.x;
+            i < loop_boundaries.end;
+            i += blockDim.y * blockDim.x) { closure(i, value); }
+
+       loop_boundaries.member.impl_vector_reduce(wrapped_reducer, value);
+       loop_boundaries.member.impl_team_reduce(wrapped_reducer, value);
+
+       wrapped_reducer.final(&value); result = value;))
 }
 
 //----------------------------------------------------------------------------
@@ -632,13 +700,22 @@ parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
                 Closure const& closure, ReducerType const& reducer) {
   KOKKOS_IF_ON_DEVICE((
 
-      reducer.init(reducer.reference());
+      using value_type            = typename ReducerType::value_type;
+      using functor_analysis_type = typename Impl::FunctorAnalysis<
+          Impl::FunctorPatternInterface::REDUCE,
+          TeamPolicy<typename Impl::CudaTeamMember::execution_space>,
+          ReducerType, value_type>;
+      using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+
+      wrapped_reducer_type wrapped_reducer(reducer); value_type value{};
+      wrapped_reducer.init(&value);
 
       for (iType i = loop_boundaries.start + threadIdx.x;
-           i < loop_boundaries.end;
-           i += blockDim.x) { closure(i, reducer.reference()); }
+           i < loop_boundaries.end; i += blockDim.x) { closure(i, value); }
 
-      Impl::CudaTeamMember::vector_reduce(reducer);
+      Impl::CudaTeamMember::impl_vector_reduce(wrapped_reducer, value);
+
+      wrapped_reducer.final(&value); reducer.reference() = value;
 
       ))
   // Avoid bogus warning about reducer value being uninitialized with combined
@@ -667,15 +744,26 @@ parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
   (void)loop_boundaries;
   (void)closure;
   (void)result;
-  KOKKOS_IF_ON_DEVICE(
-      (result = ValueType();
 
-       for (iType i = loop_boundaries.start + threadIdx.x;
-            i < loop_boundaries.end; i += blockDim.x) { closure(i, result); }
+  KOKKOS_IF_ON_DEVICE((
 
-       Impl::CudaTeamMember::vector_reduce(Kokkos::Sum<ValueType>(result));
+      using functor_analysis_type = typename Impl::FunctorAnalysis<
+          Impl::FunctorPatternInterface::REDUCE,
+          TeamPolicy<typename Impl::CudaTeamMember::execution_space>, Closure,
+          ValueType>;
+      using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+      using value_type           = typename wrapped_reducer_type::value_type;
 
-       ))
+      wrapped_reducer_type wrapped_reducer(closure); value_type value{};
+      wrapped_reducer.init(&value);
+
+      for (iType i = loop_boundaries.start + threadIdx.x;
+           i < loop_boundaries.end; i += blockDim.x) { closure(i, value); }
+
+      Impl::CudaTeamMember::impl_vector_reduce(wrapped_reducer, value);
+      wrapped_reducer.final(&value); result = value;
+
+      ))
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -526,7 +526,7 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
            ReducerType, value_type>;
        using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
-       wrapped_reducer_type wrapped_reducer(reducer); value_type value{};
+       wrapped_reducer_type wrapped_reducer(reducer); value_type value;
        wrapped_reducer.init(&value);
 
        for (iType i = loop_boundaries.start + threadIdx.y;
@@ -604,7 +604,7 @@ parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
            ReducerType, value_type>;
        using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
-       wrapped_reducer_type wrapped_reducer(reducer); value_type value{};
+       wrapped_reducer_type wrapped_reducer(reducer); value_type value;
        wrapped_reducer.init(&value);
 
        for (iType i =
@@ -641,7 +641,7 @@ parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
        using wrapped_reducer_type = typename functor_analysis_type::Reducer;
        using value_type           = typename wrapped_reducer_type::value_type;
 
-       wrapped_reducer_type wrapped_reducer(closure); value_type value{};
+       wrapped_reducer_type wrapped_reducer(closure); value_type value;
        wrapped_reducer.init(&value);
 
        for (iType i =
@@ -707,7 +707,7 @@ parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
           ReducerType, value_type>;
       using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
-      wrapped_reducer_type wrapped_reducer(reducer); value_type value{};
+      wrapped_reducer_type wrapped_reducer(reducer); value_type value;
       wrapped_reducer.init(&value);
 
       for (iType i = loop_boundaries.start + threadIdx.x;
@@ -754,7 +754,7 @@ parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
       using wrapped_reducer_type = typename functor_analysis_type::Reducer;
       using value_type           = typename wrapped_reducer_type::value_type;
 
-      wrapped_reducer_type wrapped_reducer(closure); value_type value{};
+      wrapped_reducer_type wrapped_reducer(closure); value_type value;
       wrapped_reducer.init(&value);
 
       for (iType i = loop_boundaries.start + threadIdx.x;

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -289,11 +289,11 @@ class HIPTeamMember {
 #endif
   }
 
-  template <typename WrapperReducerType>
+  template <typename WrappedReducerType>
   KOKKOS_INLINE_FUNCTION static std::enable_if_t<
-      is_reducer<WrapperReducerType>::value>
-  impl_vector_reduce(WrapperReducerType const& wrapped_reducer,
-                     typename WrapperReducerType::value_type& value) {
+      is_reducer<WrappedReducerType>::value>
+  impl_vector_reduce(WrappedReducerType const& wrapped_reducer,
+                     typename WrappedReducerType::value_type& value) {
 #ifdef __HIP_DEVICE_COMPILE__
     if (blockDim.x == 1) return;
 

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -519,7 +519,7 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
   using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
   wrapped_reducer_type wrapped_reducer(reducer);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start + threadIdx.y; i < loop_boundaries.end;
@@ -559,7 +559,7 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
        using wrapped_reducer_type = typename functor_analysis_type::Reducer;
        using value_type           = typename wrapped_reducer_type::value_type;
 
-       wrapped_reducer_type wrapped_reducer(closure); value_type value{};
+       wrapped_reducer_type wrapped_reducer(closure); value_type value;
        wrapped_reducer.init(&value);
 
        for (iType i = loop_boundaries.start + threadIdx.y;
@@ -671,7 +671,7 @@ parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
   using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
   wrapped_reducer_type wrapped_reducer(reducer);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start + threadIdx.y * blockDim.x + threadIdx.x;
@@ -703,7 +703,7 @@ parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
        using wrapped_reducer_type = typename functor_analysis_type::Reducer;
        using value_type           = typename wrapped_reducer_type::value_type;
 
-       wrapped_reducer_type wrapped_reducer(closure); value_type value{};
+       wrapped_reducer_type wrapped_reducer(closure); value_type value;
        wrapped_reducer.init(&value);
 
        for (iType i =
@@ -769,7 +769,7 @@ parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
   using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
   wrapped_reducer_type wrapped_reducer(reducer);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start + threadIdx.x; i < loop_boundaries.end;
@@ -812,7 +812,7 @@ parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
        using wrapped_reducer_type = typename functor_analysis_type::Reducer;
        using value_type           = typename wrapped_reducer_type::value_type;
 
-       wrapped_reducer_type wrapped_reducer(closure); value_type value{};
+       wrapped_reducer_type wrapped_reducer(closure); value_type value;
        wrapped_reducer.init(&value);
 
        for (iType i = loop_boundaries.start + threadIdx.x;

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -183,10 +183,23 @@ class HIPTeamMember {
     typename Kokkos::Impl::FunctorAnalysis<
         FunctorPatternInterface::REDUCE, TeamPolicy<HIP>, ReducerType,
         typename ReducerType::value_type>::Reducer wrapped_reducer(reducer);
-    hip_intra_block_shuffle_reduction(value, wrapped_reducer, blockDim.y);
+    impl_team_reduce(wrapped_reducer, value);
     reducer.reference() = value;
 #else
     (void)reducer;
+    (void)value;
+#endif
+  }
+
+  template <typename WrappedReducerType>
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<WrappedReducerType>::value>
+  impl_team_reduce(
+      WrappedReducerType const& wrapped_reducer,
+      typename WrappedReducerType::value_type& value) const noexcept {
+#ifdef __HIP_DEVICE_COMPILE__
+    hip_intra_block_shuffle_reduction(value, wrapped_reducer, blockDim.y);
+#else
+    (void)wrapped_reducer;
     (void)value;
 #endif
   }
@@ -262,16 +275,36 @@ class HIPTeamMember {
   vector_reduce(ReducerType const& reducer,
                 typename ReducerType::value_type& value) {
 #ifdef __HIP_DEVICE_COMPILE__
+    using value_type = typename ReducerType::value_type;
+    using wrapped_reducer_type =
+        typename Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
+                                       TeamPolicy<HIP>, ReducerType,
+                                       value_type>::Reducer;
+
+    impl_vector_reduce(wrapped_reducer_type(reducer), value);
+    reducer.reference() = value;
+#else
+    (void)reducer;
+    (void)value;
+#endif
+  }
+
+  template <typename WrapperReducerType>
+  KOKKOS_INLINE_FUNCTION static std::enable_if_t<
+      is_reducer<WrapperReducerType>::value>
+  impl_vector_reduce(WrapperReducerType const& wrapped_reducer,
+                     typename WrapperReducerType::value_type& value) {
+#ifdef __HIP_DEVICE_COMPILE__
     if (blockDim.x == 1) return;
 
     // Intra vector lane shuffle reduction:
-    typename ReducerType::value_type tmp(value);
-    typename ReducerType::value_type tmp2 = tmp;
+    typename WrappedReducerType::value_type tmp(value);
+    typename WrappedReducerType::value_type tmp2 = tmp;
 
     for (int i = blockDim.x; (i >>= 1);) {
       in_place_shfl_down(tmp2, tmp, i, blockDim.x);
       if (static_cast<int>(threadIdx.x) < i) {
-        reducer.join(tmp, tmp2);
+        wrapped_reducer.join(&tmp, &tmp2);
       }
     }
 
@@ -281,10 +314,9 @@ class HIPTeamMember {
     // and thus different threads could have different results.
 
     in_place_shfl(tmp2, tmp, 0, blockDim.x);
-    value               = tmp2;
-    reducer.reference() = tmp2;
+    value = tmp2;
 #else
-    (void)reducer;
+    (void)wrapped_reducer;
     (void)value;
 #endif
   }
@@ -479,15 +511,26 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
                     iType, Impl::HIPTeamMember>& loop_boundaries,
                 const Closure& closure, const ReducerType& reducer) {
 #ifdef __HIP_DEVICE_COMPILE__
-  typename ReducerType::value_type value;
-  reducer.init(value);
+  using value_type            = typename ReducerType::value_type;
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::HIPTeamMember::execution_space>, ReducerType,
+      value_type>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+
+  wrapped_reducer_type wrapped_reducer(reducer);
+  value_type value{};
+  wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start + threadIdx.y; i < loop_boundaries.end;
        i += blockDim.y) {
     closure(i, value);
   }
 
-  loop_boundaries.member.team_reduce(reducer, value);
+  loop_boundaries.member.impl_team_reduce(wrapped_reducer, value);
+
+  wrapped_reducer.final(&value);
+  reducer.reference() = value;
 #else
   (void)loop_boundaries;
   (void)closure;
@@ -508,24 +551,24 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer<ValueType>::value>
 parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
                     iType, Impl::HIPTeamMember>& loop_boundaries,
                 const Closure& closure, ValueType& result) {
-#ifdef __HIP_DEVICE_COMPILE__
-  ValueType val;
-  Kokkos::Sum<ValueType> reducer(val);
+  KOKKOS_IF_ON_DEVICE(
+      (using functor_analysis_type = typename Impl::FunctorAnalysis<
+           Impl::FunctorPatternInterface::REDUCE,
+           TeamPolicy<typename Impl::HIPTeamMember::execution_space>, Closure,
+           ValueType>;
+       using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+       using value_type           = typename wrapped_reducer_type::value_type;
 
-  reducer.init(reducer.reference());
+       wrapped_reducer_type wrapped_reducer(closure); value_type value{};
+       wrapped_reducer.init(&value);
 
-  for (iType i = loop_boundaries.start + threadIdx.y; i < loop_boundaries.end;
-       i += blockDim.y) {
-    closure(i, val);
-  }
+       for (iType i = loop_boundaries.start + threadIdx.y;
+            i < loop_boundaries.end; i += blockDim.y) { closure(i, value); }
 
-  loop_boundaries.member.team_reduce(reducer, val);
-  result = reducer.reference();
-#else
-  (void)loop_boundaries;
-  (void)closure;
-  (void)result;
-#endif
+       loop_boundaries.member.impl_team_reduce(wrapped_reducer, value);
+
+       wrapped_reducer.final(&value); result = value;))
+  KOKKOS_IF_ON_HOST(((void)loop_boundaries; (void)closure; (void)result;))
 }
 
 /** \brief  Inter-thread parallel exclusive prefix sum.
@@ -620,16 +663,26 @@ parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
                     iType, Impl::HIPTeamMember>& loop_boundaries,
                 const Closure& closure, const ReducerType& reducer) {
 #ifdef __HIP_DEVICE_COMPILE__
-  typename ReducerType::value_type value;
-  reducer.init(value);
+  using value_type            = typename ReducerType::value_type;
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::HIPTeamMember::execution_space>, ReducerType,
+      value_type>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+
+  wrapped_reducer_type wrapped_reducer(reducer);
+  value_type value{};
+  wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start + threadIdx.y * blockDim.x + threadIdx.x;
        i < loop_boundaries.end; i += blockDim.y * blockDim.x) {
     closure(i, value);
   }
 
-  loop_boundaries.member.vector_reduce(reducer, value);
-  loop_boundaries.member.team_reduce(reducer, value);
+  loop_boundaries.member.impl_vector_reduce(wrapped_reducer, value);
+  loop_boundaries.member.impl_team_reduce(wrapped_reducer, value);
+  wrapped_reducer.final(&value);
+  reducer.reference() = value;
 #else
   (void)loop_boundaries;
   (void)closure;
@@ -642,25 +695,27 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer<ValueType>::value>
 parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
                     iType, Impl::HIPTeamMember>& loop_boundaries,
                 const Closure& closure, ValueType& result) {
-#ifdef __HIP_DEVICE_COMPILE__
-  ValueType val;
-  Kokkos::Sum<ValueType> reducer(val);
+  KOKKOS_IF_ON_DEVICE(
+      (using functor_analysis_type = typename Impl::FunctorAnalysis<
+           Impl::FunctorPatternInterface::REDUCE,
+           TeamPolicy<typename Impl::HIPTeamMember::execution_space>, Closure,
+           ValueType>;
+       using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+       using value_type           = typename wrapped_reducer_type::value_type;
 
-  reducer.init(reducer.reference());
+       wrapped_reducer_type wrapped_reducer(closure); value_type value{};
+       wrapped_reducer.init(&value);
 
-  for (iType i = loop_boundaries.start + threadIdx.y * blockDim.x + threadIdx.x;
-       i < loop_boundaries.end; i += blockDim.y * blockDim.x) {
-    closure(i, val);
-  }
+       for (iType i =
+                loop_boundaries.start + threadIdx.y * blockDim.x + threadIdx.x;
+            i < loop_boundaries.end;
+            i += blockDim.y * blockDim.x) { closure(i, value); }
 
-  loop_boundaries.member.vector_reduce(reducer);
-  loop_boundaries.member.team_reduce(reducer);
-  result = reducer.reference();
-#else
-  (void)loop_boundaries;
-  (void)closure;
-  (void)result;
-#endif
+       loop_boundaries.member.impl_vector_reduce(wrapped_reducer, value);
+       loop_boundaries.member.impl_team_reduce(wrapped_reducer, value);
+       wrapped_reducer.final(&value); result = value;))
+
+  KOKKOS_IF_ON_HOST(((void)loop_boundaries; (void)closure; (void)result;))
 }
 
 //----------------------------------------------------------------------------
@@ -706,14 +761,26 @@ parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
                     iType, Impl::HIPTeamMember> const& loop_boundaries,
                 Closure const& closure, ReducerType const& reducer) {
 #ifdef __HIP_DEVICE_COMPILE__
-  reducer.init(reducer.reference());
+  using value_type            = typename ReducerType::value_type;
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::HIPTeamMember::execution_space>, ReducerType,
+      value_type>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+
+  wrapped_reducer_type wrapped_reducer(reducer);
+  value_type value{};
+  wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start + threadIdx.x; i < loop_boundaries.end;
        i += blockDim.x) {
-    closure(i, reducer.reference());
+    closure(i, value);
   }
 
-  Impl::HIPTeamMember::vector_reduce(reducer);
+  Impl::HIPTeamMember::impl_vector_reduce(wrapped_reducer, value);
+
+  wrapped_reducer.final(&value);
+  reducer.reference() = value;
 #else
   (void)loop_boundaries;
   (void)closure;
@@ -737,20 +804,24 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<!is_reducer<ValueType>::value>
 parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
                     iType, Impl::HIPTeamMember> const& loop_boundaries,
                 Closure const& closure, ValueType& result) {
-#ifdef __HIP_DEVICE_COMPILE__
-  result = ValueType();
+  KOKKOS_IF_ON_DEVICE(
+      (using functor_analysis_type = typename Impl::FunctorAnalysis<
+           Impl::FunctorPatternInterface::REDUCE,
+           TeamPolicy<typename Impl::HIPTeamMember::execution_space>, Closure,
+           ValueType>;
+       using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+       using value_type           = typename wrapped_reducer_type::value_type;
 
-  for (iType i = loop_boundaries.start + threadIdx.x; i < loop_boundaries.end;
-       i += blockDim.x) {
-    closure(i, result);
-  }
+       wrapped_reducer_type wrapped_reducer(closure); value_type value{};
+       wrapped_reducer.init(&value);
 
-  Impl::HIPTeamMember::vector_reduce(Kokkos::Sum<ValueType>(result));
-#else
-  (void)loop_boundaries;
-  (void)closure;
-  (void)result;
-#endif
+       for (iType i = loop_boundaries.start + threadIdx.x;
+            i < loop_boundaries.end; i += blockDim.x) { closure(i, value); }
+
+       Impl::HIPTeamMember::impl_vector_reduce(wrapped_reducer, value);
+       wrapped_reducer.final(&value); result = value;))
+
+  KOKKOS_IF_ON_HOST(((void)loop_boundaries; (void)closure; (void)result;))
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -1786,11 +1786,24 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
     const Impl::TeamThreadRangeBoundariesStruct<iType, Impl::HPXTeamMember>
         &loop_boundaries,
     const Lambda &lambda, ValueType &result) {
-  result = ValueType();
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::HPXTeamMember::execution_space>, Lambda,
+      ValueType>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+  using value_type           = typename wrapped_reducer_type::value_type;
+
+  wrapped_reducer_type wrapped_reducer(lambda);
+  value_type value{};
+  wrapped_reducer.init(&value);
+
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
        i += loop_boundaries.increment) {
-    lambda(i, result);
+    lambda(i, value);
   }
+
+  wrapped_reducer.final(&value);
+  result = value;
 }
 
 /** \brief  Intra-thread vector parallel_for. Executes lambda(iType i) for each
@@ -1824,14 +1837,26 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
     const Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::HPXTeamMember>
         &loop_boundaries,
     const Lambda &lambda, ValueType &result) {
-  result = ValueType();
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::HPXTeamMember::execution_space>, Lambda,
+      ValueType>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+  using value_type           = typename wrapped_reducer_type::value_type;
+
+  wrapped_reducer_type wrapped_reducer(lambda);
+  value_type value{};
+  wrapped_reducer.init(&value);
+
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
 #pragma ivdep
 #endif
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
        i += loop_boundaries.increment) {
-    lambda(i, result);
+    lambda(i, value);
   }
+  wrapped_reducer.final(&value);
+  result = value;
 }
 
 template <typename iType, class Lambda, typename ReducerType,
@@ -1840,11 +1865,24 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
     const Impl::TeamThreadRangeBoundariesStruct<iType, Impl::HPXTeamMember>
         &loop_boundaries,
     const Lambda &lambda, const ReducerType &reducer) {
-  reducer.init(reducer.reference());
+  using value_type            = typename ReducerType::value_type;
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::HPXTeamMember::execution_space>, ReducerType,
+      value_type>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+
+  wrapped_reducer_type wrapped_reducer(reducer);
+  value_type value{};
+  wrapped_reducer.init(&value);
+
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
        i += loop_boundaries.increment) {
     lambda(i, reducer.reference());
   }
+
+  wrapped_reducer.final(&value);
+  reducer.reference() = value;
 }
 
 template <typename iType, class Lambda, typename ReducerType,
@@ -1853,14 +1891,27 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
     const Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::HPXTeamMember>
         &loop_boundaries,
     const Lambda &lambda, const ReducerType &reducer) {
-  reducer.init(reducer.reference());
+  using value_type            = typename ReducerType::value_type;
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::HPXTeamMember::execution_space>, ReducerType,
+      value_type>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+
+  wrapped_reducer_type wrapped_reducer(reducer);
+  value_type value{};
+  wrapped_reducer.init(&value);
+
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
 #pragma ivdep
 #endif
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
        i += loop_boundaries.increment) {
-    lambda(i, reducer.reference());
+    lambda(i, value);
   }
+
+  wrapped_reducer.final(&value);
+  reducer.reference() = value;
 }
 
 template <typename iType, class FunctorType, typename ValueType>

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -1794,7 +1794,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
   using value_type           = typename wrapped_reducer_type::value_type;
 
   wrapped_reducer_type wrapped_reducer(lambda);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
@@ -1845,7 +1845,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
   using value_type           = typename wrapped_reducer_type::value_type;
 
   wrapped_reducer_type wrapped_reducer(lambda);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
@@ -1873,7 +1873,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
   using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
   wrapped_reducer_type wrapped_reducer(reducer);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
@@ -1899,7 +1899,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
   using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
   wrapped_reducer_type wrapped_reducer(reducer);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -1878,7 +1878,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
 
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
        i += loop_boundaries.increment) {
-    lambda(i, reducer.reference());
+    lambda(i, value);
   }
 
   wrapped_reducer.final(&value);

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
@@ -163,13 +163,24 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer_v<ValueType>>
 parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
                     iType, Impl::OpenACCTeamMember>& loop_boundaries,
                 const Lambda& lambda, ValueType& result) {
-  ValueType tmp = ValueType();
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::OpenACCTeamMember::execution_space>, Lambda,
+      ValueType>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+  using value_type           = typename wrapped_reducer_type::value_type;
+
+  wrapped_reducer_type wrapped_reducer(lambda);
+  value_type tmp{};
+  wrapped_reducer.init(&tmp);
+
   iType j_start =
       loop_boundaries.team.team_rank() / loop_boundaries.team.vector_length();
   if (j_start == 0) {
 #pragma acc loop seq
     for (iType i = loop_boundaries.start; i < loop_boundaries.end; i++)
       lambda(i, tmp);
+    wrapped_reducer.final(&tmp);
     result = tmp;
   }
 }
@@ -180,15 +191,25 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer_v<ReducerType>>
 parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
                     iType, Impl::OpenACCTeamMember>& loop_boundaries,
                 const Lambda& lambda, const ReducerType& reducer) {
-  using ValueType = typename ReducerType::value_type;
-  ValueType tmp;
-  reducer.init(tmp);
+  using value_type            = typename ReducerType::value_type;
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::OpenACCTeamMember::execution_space>,
+      ReducerType, value_type>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+
+  wrapped_reducer_type wrapped_reducer(reducer);
+  value_type tmp{};
+  wrapped_reducer.init(&tmp);
+
   iType j_start =
       loop_boundaries.team.team_rank() / loop_boundaries.team.vector_length();
   if (j_start == 0) {
 #pragma acc loop seq
     for (iType i = loop_boundaries.start; i < loop_boundaries.end; i++)
       lambda(i, tmp);
+
+    wrapped_reducer.final(&tmp);
     reducer.reference() = tmp;
   }
 }
@@ -200,7 +221,17 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer_v<ValueType>>
 parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
                     iType, Impl::OpenACCTeamMember>& loop_boundaries,
                 const Lambda& lambda, ValueType& result) {
-  ValueType tmp = ValueType();
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::OpenACCTeamMember::execution_space>, Lambda,
+      ValueType>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+  using value_type           = typename wrapped_reducer_type::value_type;
+
+  wrapped_reducer_type wrapped_reducer(lambda);
+  value_type tmp{};
+  wrapped_reducer.init(&tmp);
+
   iType j_start =
       loop_boundaries.team.team_rank() % loop_boundaries.team.vector_length();
   if (j_start == 0) {
@@ -208,6 +239,7 @@ parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
     for (iType i = loop_boundaries.start; i < loop_boundaries.end; i++) {
       lambda(i, tmp);
     }
+    wrapped_reducer.final(&tmp);
     result = tmp;
   }
 }
@@ -218,9 +250,17 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer_v<ReducerType>>
 parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
                     iType, Impl::OpenACCTeamMember>& loop_boundaries,
                 const Lambda& lambda, const ReducerType& reducer) {
-  using ValueType = typename ReducerType::value_type;
-  ValueType tmp;
-  reducer.init(tmp);
+  using value_type            = typename ReducerType::value_type;
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::OpenACCTeamMember::execution_space>,
+      ReducerType, value_type>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+
+  wrapped_reducer_type wrapped_reducer(reducer);
+  value_type tmp{};
+  wrapped_reducer.init(&tmp);
+
   iType j_start =
       loop_boundaries.team.team_rank() % loop_boundaries.team.vector_length();
   if (j_start == 0) {
@@ -228,6 +268,8 @@ parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
     for (iType i = loop_boundaries.start; i < loop_boundaries.end; i++) {
       lambda(i, tmp);
     }
+
+    wrapped_reducer.final(&tmp);
     reducer.reference() = tmp;
   }
 }
@@ -239,7 +281,17 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
     const Impl::TeamVectorRangeBoundariesStruct<iType, Impl::OpenACCTeamMember>&
         loop_boundaries,
     const Lambda& lambda, ValueType& result) {
-  ValueType tmp = ValueType();
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::OpenACCTeamMember::execution_space>, Lambda,
+      ValueType>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+  using value_type           = typename wrapped_reducer_type::value_type;
+
+  wrapped_reducer_type wrapped_reducer(lambda);
+  value_type tmp{};
+  wrapped_reducer.init(&tmp);
+
   iType j_start =
       loop_boundaries.team.team_rank() % loop_boundaries.team.vector_length();
   if (j_start == 0) {
@@ -247,6 +299,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
     for (iType i = loop_boundaries.start; i < loop_boundaries.end; i++) {
       lambda(i, tmp);
     }
+    wrapped_reducer.final(&tmp);
     result = tmp;
   }
 }
@@ -273,10 +326,23 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer_v<ValueType>>
 parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
                     iType, Impl::OpenACCTeamMember>& loop_boundaries,
                 const Lambda& lambda, ValueType& result) {
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::OpenACCTeamMember::execution_space>, Lambda,
+      ValueType>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+  using value_type           = typename wrapped_reducer_type::value_type;
+
+  wrapped_reducer_type wrapped_reducer(lambda);
+  value_type tmp{};
+  wrapped_reducer.init(&tmp);
+
   ValueType tmp = ValueType();
 #pragma acc loop worker reduction(+ : tmp)
   for (iType i = loop_boundaries.start; i < loop_boundaries.end; i++)
     lambda(i, tmp);
+
+  wrapped_reducer.final(&tmp);
   result = tmp;
 }
 
@@ -314,11 +380,22 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer_v<ValueType>>
 parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
                     iType, Impl::OpenACCTeamMember>& loop_boundaries,
                 const Lambda& lambda, ValueType& result) {
-  ValueType tmp = ValueType();
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::OpenACCTeamMember::execution_space>, Lambda,
+      ValueType>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+  using value_type           = typename wrapped_reducer_type::value_type;
+
+  wrapped_reducer_type wrapped_reducer(lambda);
+  value_type tmp{};
+  wrapped_reducer.init(&tmp);
+
 #pragma acc loop vector reduction(+ : tmp)
   for (iType i = loop_boundaries.start; i < loop_boundaries.end; i++) {
     lambda(i, tmp);
   }
+  wrapped_reducer.final(&tmp);
   result = tmp;
 }
 
@@ -357,11 +434,23 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
     const Impl::TeamVectorRangeBoundariesStruct<iType, Impl::OpenACCTeamMember>&
         loop_boundaries,
     const Lambda& lambda, ValueType& result) {
-  ValueType tmp = ValueType();
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::OpenACCTeamMember::execution_space>, Lambda,
+      ValueType>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+  using value_type           = typename wrapped_reducer_type::value_type;
+
+  wrapped_reducer_type wrapped_reducer(lambda);
+  value_type tmp{};
+  wrapped_reducer.init(&tmp);
+
 #pragma acc loop vector reduction(+ : tmp)
   for (iType i = loop_boundaries.start; i < loop_boundaries.end; i++) {
     lambda(i, tmp);
   }
+
+  wrapped_reducer.final(&tmp);
   result = tmp;
 }
 

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
@@ -171,7 +171,7 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
   using value_type           = typename wrapped_reducer_type::value_type;
 
   wrapped_reducer_type wrapped_reducer(lambda);
-  value_type tmp{};
+  value_type tmp;
   wrapped_reducer.init(&tmp);
 
   iType j_start =
@@ -199,7 +199,7 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
   using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
   wrapped_reducer_type wrapped_reducer(reducer);
-  value_type tmp{};
+  value_type tmp;
   wrapped_reducer.init(&tmp);
 
   iType j_start =
@@ -229,7 +229,7 @@ parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
   using value_type           = typename wrapped_reducer_type::value_type;
 
   wrapped_reducer_type wrapped_reducer(lambda);
-  value_type tmp{};
+  value_type tmp;
   wrapped_reducer.init(&tmp);
 
   iType j_start =
@@ -258,7 +258,7 @@ parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
   using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
   wrapped_reducer_type wrapped_reducer(reducer);
-  value_type tmp{};
+  value_type tmp;
   wrapped_reducer.init(&tmp);
 
   iType j_start =
@@ -289,7 +289,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
   using value_type           = typename wrapped_reducer_type::value_type;
 
   wrapped_reducer_type wrapped_reducer(lambda);
-  value_type tmp{};
+  value_type tmp;
   wrapped_reducer.init(&tmp);
 
   iType j_start =
@@ -334,7 +334,7 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
   using value_type           = typename wrapped_reducer_type::value_type;
 
   wrapped_reducer_type wrapped_reducer(lambda);
-  value_type tmp{};
+  value_type tmp;
   wrapped_reducer.init(&tmp);
 
   ValueType tmp = ValueType();
@@ -388,7 +388,7 @@ parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
   using value_type           = typename wrapped_reducer_type::value_type;
 
   wrapped_reducer_type wrapped_reducer(lambda);
-  value_type tmp{};
+  value_type tmp;
   wrapped_reducer.init(&tmp);
 
 #pragma acc loop vector reduction(+ : tmp)
@@ -442,7 +442,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
   using value_type           = typename wrapped_reducer_type::value_type;
 
   wrapped_reducer_type wrapped_reducer(lambda);
-  value_type tmp{};
+  value_type tmp;
   wrapped_reducer.init(&tmp);
 
 #pragma acc loop vector reduction(+ : tmp)

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -563,7 +563,7 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
   using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
   wrapped_reducer_type wrapped_reducer(reducer);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start +
@@ -599,7 +599,7 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
   using value_type           = typename wrapped_reducer_type::value_type;
 
   wrapped_reducer_type wrapped_reducer(closure);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start +
@@ -707,7 +707,7 @@ parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
   using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
   wrapped_reducer_type wrapped_reducer(reducer);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   const iType tidx0 = loop_boundaries.member.item().get_local_id(0);
@@ -740,7 +740,7 @@ parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
   using value_type           = typename wrapped_reducer_type::value_type;
 
   wrapped_reducer_type wrapped_reducer(closure);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   const iType tidx0 = loop_boundaries.member.item().get_local_id(0);
@@ -815,7 +815,7 @@ parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
   using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
   wrapped_reducer_type wrapped_reducer(reducer);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   const iType tidx1   = loop_boundaries.member.item().get_local_id(1);
@@ -854,7 +854,7 @@ parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
   using value_type           = typename wrapped_reducer_type::value_type;
 
   wrapped_reducer_type wrapped_reducer(closure);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   const iType tidx1 = loop_boundaries.member.item().get_local_id(1);

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -126,6 +126,20 @@ class SYCLTeamMember {
   team_reduce(ReducerType const& reducer,
               typename ReducerType::value_type& value) const noexcept {
     using value_type = typename ReducerType::value_type;
+    using wrapped_reducer_type =
+        typename Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
+                                       TeamPolicy<SYCL>, ReducerType,
+                                       value_type>::Reducer;
+    impl_team_reduce(wrapped_reducer_type(reducer), value);
+    reducer.reference() = value;
+  }
+
+  template <typename WrapperReducerType>
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<WrapperReducerType>::value>
+  impl_team_reduce(
+      WrapperReducerType const& wrapper_reducer,
+      typename WrapperReducerType::value_type& value) const noexcept {
+    using value_type = WrapperReducerType::value_type;
 
     auto sg                       = m_item.get_sub_group();
     const auto sub_group_range    = sg.get_local_range()[0];
@@ -139,7 +153,7 @@ class SYCLTeamMember {
       if (vector_range * shift < sub_group_range) {
         const value_type tmp = Kokkos::Impl::SYCLReduction::shift_group_left(
             sg, value, vector_range * shift);
-        if (team_rank_ + shift < team_size_) reducer.join(value, tmp);
+        if (team_rank_ + shift < team_size_) wrapper_reducer.join(&value, &tmp);
       }
     };
     shuffle_combine(1);
@@ -153,14 +167,13 @@ class SYCLTeamMember {
          shift <<= 1) {
       auto tmp = Kokkos::Impl::SYCLReduction::shift_group_left(
           sg, value, vector_range * shift);
-      if (team_rank_ + shift < team_size_) reducer.join(value, tmp);
+      if (team_rank_ + shift < team_size_) wrapper_reducer.join(&value, &tmp);
     }
 #endif
     value = Kokkos::Impl::SYCLReduction::select_from_group(sg, value, 0);
 
     const int n_subgroups = sg.get_group_range()[0];
     if (n_subgroups == 1) {
-      reducer.reference() = value;
       return;
     }
 
@@ -187,16 +200,15 @@ class SYCLTeamMember {
     for (int start = step_width; start < n_subgroups; start += step_width) {
       if (id_in_sg == 0 && group_id >= start &&
           group_id < std::min(start + step_width, n_subgroups))
-        reducer.join(reduction_array[group_id - start], value);
+        wrapper_reducer.join(&reduction_array[group_id - start], &value);
       sycl::group_barrier(m_item.get_group());
     }
 
     // Do the final reduction for all threads redundantly
     value = reduction_array[0];
     for (int i = 1; i < std::min(step_width, n_subgroups); ++i)
-      reducer.join(value, reduction_array[i]);
+      wrapper_reducer.join(&value, &reduction_array[i]);
 
-    reducer.reference() = value;
     // Make sure that every thread is done using the reduction array.
     sycl::group_barrier(m_item.get_group());
   }
@@ -311,6 +323,19 @@ class SYCLTeamMember {
   KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<ReducerType>::value>
   vector_reduce(ReducerType const& reducer,
                 typename ReducerType::value_type& value) const {
+    using value_type = typename ReducerType::value_type;
+    using wrapped_reducer_type =
+        typename Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
+                                       TeamPolicy<SYCL>, ReducerType,
+                                       value_type>::Reducer;
+    impl_vector_reduce(wrapped_reducer_type(reducer), value);
+    reducer.reference() = value;
+  }
+
+  template <typename WrappedReducerType>
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<WrappedReducerType>::value>
+  impl_vector_reduce(WrapperReducerType const& wrapped_reducer,
+                     typename WrappedReducerType::value_type& value) const {
     const auto tidx1   = m_item.get_local_id(1);
     const auto grange1 = m_item.get_local_range(1);
 
@@ -319,13 +344,13 @@ class SYCLTeamMember {
     if (grange1 == 1) return;
 
     // Intra vector lane shuffle reduction:
-    typename ReducerType::value_type tmp(value);
-    typename ReducerType::value_type tmp2 = tmp;
+    typename WrappedReducerType::value_type tmp(value);
+    typename WrappedReducerType::value_type tmp2 = tmp;
 
     for (int i = grange1; (i >>= 1);) {
       tmp2 = Kokkos::Impl::SYCLReduction::shift_group_left(sg, tmp, i);
       if (static_cast<int>(tidx1) < i) {
-        reducer.join(tmp, tmp2);
+        wrapped_reducer.join(&tmp, &tmp2);
       }
     }
 
@@ -336,8 +361,7 @@ class SYCLTeamMember {
 
     tmp2 = Kokkos::Impl::SYCLReduction::select_from_group(
         sg, tmp, (sg.get_local_id() / grange1) * grange1);
-    value               = tmp2;
-    reducer.reference() = tmp2;
+    value = tmp2;
   }
 
   //----------------------------------------
@@ -531,8 +555,16 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
 parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
                     iType, Impl::SYCLTeamMember>& loop_boundaries,
                 const Closure& closure, const ReducerType& reducer) {
-  typename ReducerType::value_type value;
-  reducer.init(value);
+  using value_type            = typename ReducerType::value_type;
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::SYCLTeamMember::execution_space>, ReducerType,
+      value_type>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+
+  wrapped_reducer_type wrapped_reducer(reducer);
+  value_type value{};
+  wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start +
                  loop_boundaries.member.item().get_local_id(0);
@@ -541,7 +573,9 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
     closure(i, value);
   }
 
-  loop_boundaries.member.team_reduce(reducer, value);
+  loop_boundaries.member.impl_team_reduce(wrapped_reducer, value);
+  wrapped_reducer.final(&value);
+  reducer.reference() = value;
 }
 
 /** \brief  Inter-thread parallel_reduce assuming summation.
@@ -557,20 +591,28 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer<ValueType>::value>
 parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
                     iType, Impl::SYCLTeamMember>& loop_boundaries,
                 const Closure& closure, ValueType& result) {
-  ValueType val;
-  Kokkos::Sum<ValueType> reducer(val);
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::SYCLTeamMember::execution_space>, Closure,
+      ValueType>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+  using value_type           = typename wrapped_reducer_type::value_type;
 
-  reducer.init(reducer.reference());
+  wrapped_reducer_type wrapped_reducer(closure);
+  value_type value{};
+  wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start +
                  loop_boundaries.member.item().get_local_id(0);
        i < loop_boundaries.end;
        i += loop_boundaries.member.item().get_local_range(0)) {
-    closure(i, val);
+    closure(i, value);
   }
 
-  loop_boundaries.member.team_reduce(reducer, val);
-  result = reducer.reference();
+  loop_boundaries.member.impl_team_reduce(wrapped_reducer, value);
+
+  wrapped_reducer.final(&value);
+  result = value;
 }
 
 /** \brief  Inter-thread parallel exclusive prefix sum.
@@ -657,8 +699,16 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
 parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
                     iType, Impl::SYCLTeamMember>& loop_boundaries,
                 const Closure& closure, const ReducerType& reducer) {
-  typename ReducerType::value_type value;
-  reducer.init(value);
+  using value_type            = typename ReducerType::value_type;
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::SYCLTeamMember::execution_space>, ReducerType,
+      value_type>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+
+  wrapped_reducer_type wrapped_reducer(reducer);
+  value_type value{};
+  wrapped_reducer.init(&value);
 
   const iType tidx0 = loop_boundaries.member.item().get_local_id(0);
   const iType tidx1 = loop_boundaries.member.item().get_local_id(1);
@@ -670,8 +720,11 @@ parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
        i < loop_boundaries.end; i += grange0 * grange1)
     closure(i, value);
 
-  loop_boundaries.member.vector_reduce(reducer, value);
-  loop_boundaries.member.team_reduce(reducer, value);
+  loop_boundaries.member.impl_vector_reduce(wrapped_reducer, value);
+  loop_boundaries.member.impl_team_reduce(wrapped_reducer, value);
+
+  wrapped_reducer.final(&value);
+  reducer.reference() = value;
 }
 
 template <typename iType, class Closure, typename ValueType>
@@ -679,10 +732,16 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer<ValueType>::value>
 parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
                     iType, Impl::SYCLTeamMember>& loop_boundaries,
                 const Closure& closure, ValueType& result) {
-  ValueType val;
-  Kokkos::Sum<ValueType> reducer(val);
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::SYCLTeamMember::execution_space>, Closure,
+      ValueType>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+  using value_type           = typename wrapped_reducer_type::value_type;
 
-  reducer.init(reducer.reference());
+  wrapped_reducer_type wrapped_reducer(closure);
+  value_type value{};
+  wrapped_reducer.init(&value);
 
   const iType tidx0 = loop_boundaries.member.item().get_local_id(0);
   const iType tidx1 = loop_boundaries.member.item().get_local_id(1);
@@ -692,11 +751,13 @@ parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
 
   for (iType i = loop_boundaries.start + tidx0 * grange1 + tidx1;
        i < loop_boundaries.end; i += grange0 * grange1)
-    closure(i, val);
+    closure(i, value);
 
-  loop_boundaries.member.vector_reduce(reducer);
-  loop_boundaries.member.team_reduce(reducer);
-  result = reducer.reference();
+  loop_boundaries.member.impl_vector_reduce(wrapped_reducer, value);
+  loop_boundaries.member.impl_team_reduce(wrapped_reducer, value);
+
+  wrapped_reducer.final(&value);
+  result = value;
 }
 
 //----------------------------------------------------------------------------
@@ -746,16 +807,27 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<ReducerType>::value>
 parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
                     iType, Impl::SYCLTeamMember> const& loop_boundaries,
                 Closure const& closure, ReducerType const& reducer) {
-  reducer.init(reducer.reference());
+  using value_type            = typename ReducerType::value_type;
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::SYCLTeamMember::execution_space>, ReducerType,
+      value_type>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+
+  wrapped_reducer_type wrapped_reducer(reducer);
+  value_type value{};
+  wrapped_reducer.init(&value);
 
   const iType tidx1   = loop_boundaries.member.item().get_local_id(1);
   const iType grange1 = loop_boundaries.member.item().get_local_range(1);
 
   for (iType i = loop_boundaries.start + tidx1; i < loop_boundaries.end;
        i += grange1)
-    closure(i, reducer.reference());
+    closure(i, value);
 
-  loop_boundaries.member.vector_reduce(reducer);
+  loop_boundaries.member.impl_vector_reduce(wrapped_reducer, value);
+  wrapped_reducer.final(&value);
+  reducer.reference() = value;
 }
 
 /** \brief  Intra-thread vector parallel_reduce.
@@ -774,16 +846,27 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<!is_reducer<ValueType>::value>
 parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
                     iType, Impl::SYCLTeamMember> const& loop_boundaries,
                 Closure const& closure, ValueType& result) {
-  result = ValueType();
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::SYCLTeamMember::execution_space>, Closure,
+      ValueType>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+  using value_type           = typename wrapped_reducer_type::value_type;
+
+  wrapped_reducer_type wrapped_reducer(closure);
+  value_type value{};
+  wrapped_reducer.init(&value);
 
   const iType tidx1 = loop_boundaries.member.item().get_local_id(1);
   const int grange1 = loop_boundaries.member.item().get_local_range(1);
 
   for (iType i = loop_boundaries.start + tidx1; i < loop_boundaries.end;
        i += grange1)
-    closure(i, result);
+    closure(i, value);
 
-  loop_boundaries.member.vector_reduce(Kokkos::Sum<ValueType>(result));
+  loop_boundaries.member.impl_vector_reduce(wrapped_reducer, value);
+  wrapped_reducer.final(&value);
+  result = value;
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -215,52 +215,65 @@ class ThreadsExecTeamMember {
   }
 
   template <typename ReducerType>
-  KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
-      team_reduce(const ReducerType& reducer,
-                  const typename ReducerType::value_type contribution) const {
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<ReducerType>::value>
+  team_reduce(const ReducerType& reducer,
+              typename ReducerType::value_type& contribution) const {
     KOKKOS_IF_ON_DEVICE(((void)reducer; (void)contribution;))
 
-    KOKKOS_IF_ON_HOST((
-        using value_type = typename ReducerType::value_type;
-        // Make sure there is enough scratch space:
-        using type = std::conditional_t<sizeof(value_type) < TEAM_REDUCE_SIZE,
-                                        value_type, void>;
+    KOKKOS_IF_ON_HOST(
+        (using value_type           = typename ReducerType::value_type;
+         using wrapped_reducer_type = typename Impl::FunctorAnalysis<
+             Impl::FunctorPatternInterface::REDUCE, TeamPolicy<Threads>,
+             ReducerType, value_type>::Reducer;
+         impl_team_reduce(wrapped_reducer_type(reducer), contribution);
+         reducer.reference() = contribution;))
+  }
 
-        type* const local_value = ((type*)m_instance->scratch_memory());
+  template <typename WrappedReducerType>
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<WrappedReducerType>::value>
+  impl_team_reduce(
+      const WrappedReducerType& wrapped_reducer,
+      typename WrappedReducerType::value_type& contribution) const {
+    using value_type = typename WrappedReducerType::value_type;
+    // Make sure there is enough scratch space:
+    using type = std::conditional_t<sizeof(value_type) < TEAM_REDUCE_SIZE,
+                                    value_type, void>;
 
-        // Set this thread's contribution
-        if (team_rank() != team_size() - 1) { *local_value = contribution; }
+    type* const local_value = ((type*)m_instance->scratch_memory());
 
-        // Fence to make sure the base team member has access:
-        memory_fence();
+    // Set this thread's contribution
+    if (team_rank() != team_size() - 1) {
+      *local_value = contribution;
+    }
 
-        if (team_fan_in()) {
-          // The last thread to synchronize returns true, all other threads
-          // wait for team_fan_out()
-          type* const team_value = ((type*)m_team_base[0]->scratch_memory());
+    // Fence to make sure the base team member has access:
+    memory_fence();
 
-          *team_value = contribution;
-          // Join to the team value:
-          for (int i = 1; i < m_team_size; ++i) {
-            reducer.join(*team_value,
-                         *((type*)m_team_base[i]->scratch_memory()));
-          }
+    if (team_fan_in()) {
+      // The last thread to synchronize returns true, all other threads
+      // wait for team_fan_out()
+      type* const team_value = ((type*)m_team_base[0]->scratch_memory());
 
-          // Team base thread may "lap" member threads so copy out to their
-          // local value.
-          for (int i = 1; i < m_team_size; ++i) {
-            *((type*)m_team_base[i]->scratch_memory()) = *team_value;
-          }
+      *team_value = contribution;
+      // Join to the team value:
+      for (int i = 1; i < m_team_size; ++i) {
+        wrapped_reducer.join(team_value,
+                             ((type*)m_team_base[i]->scratch_memory()));
+      }
 
-          // Fence to make sure all team members have access
-          memory_fence();
-        }
+      // Team base thread may "lap" member threads so copy out to their
+      // local value.
+      for (int i = 1; i < m_team_size; ++i) {
+        *((type*)m_team_base[i]->scratch_memory()) = *team_value;
+      }
 
-        team_fan_out();
+      // Fence to make sure all team members have access
+      memory_fence();
+    }
 
-        // Value was changed by the team base
-        reducer.reference() = *local_value;))
+    team_fan_out();
+
+    contribution = *local_value;
   }
 
   /** \brief  Intra-team exclusive prefix sum with team_rank() ordering
@@ -887,19 +900,25 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer<ValueType>::value>
 parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
                     iType, Impl::ThreadsExecTeamMember>& loop_boundaries,
                 const Lambda& lambda, ValueType& result) {
-  ValueType intermediate;
-  Sum<ValueType> sum(intermediate);
-  sum.init(intermediate);
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::ThreadsExecTeamMember::execution_space>, Lambda,
+      ValueType>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+  using value_type           = typename wrapped_reducer_type::value_type;
+
+  wrapped_reducer_type wrapped_reducer(lambda);
+  value_type value{};
+  wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
        i += loop_boundaries.increment) {
-    ValueType tmp = ValueType();
-    lambda(i, tmp);
-    intermediate += tmp;
+    lambda(i, value);
   }
 
-  loop_boundaries.thread.team_reduce(sum, intermediate);
-  result = sum.reference();
+  loop_boundaries.thread.impl_team_reduce(wrapped_reducer, value);
+  wrapped_reducer.final(&value);
+  result = value;
 }
 
 template <typename iType, class Lambda, typename ReducerType>
@@ -907,15 +926,25 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
 parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
                     iType, Impl::ThreadsExecTeamMember>& loop_boundaries,
                 const Lambda& lambda, const ReducerType& reducer) {
-  typename ReducerType::value_type value;
-  reducer.init(value);
+  using value_type            = typename ReducerType::value_type;
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::ThreadsExecTeamMember::execution_space>,
+      ReducerType, value_type>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+
+  wrapped_reducer_type wrapped_reducer(reducer);
+  value_type value{};
+  wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
        i += loop_boundaries.increment) {
     lambda(i, value);
   }
 
-  loop_boundaries.thread.team_reduce(reducer, value);
+  loop_boundaries.thread.impl_team_reduce(wrapped_reducer, value);
+  wrapped_reducer.final(&value);
+  reducer.reference() = value;
 }
 
 }  // namespace Kokkos
@@ -950,11 +979,24 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer<ValueType>::value>
 parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
                     iType, Impl::ThreadsExecTeamMember>& loop_boundaries,
                 const Lambda& lambda, ValueType& result) {
-  result = ValueType();
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::ThreadsExecTeamMember::execution_space>, Lambda,
+      ValueType>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+  using value_type           = typename wrapped_reducer_type::value_type;
+
+  wrapped_reducer_type wrapped_reducer(lambda);
+  value_type value{};
+  wrapped_reducer.init(&value);
+
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
        i += loop_boundaries.increment) {
-    lambda(i, result);
+    lambda(i, value);
   }
+
+  wrapped_reducer.final(&value);
+  result = value;
 }
 
 template <typename iType, class Lambda, typename ReducerType>
@@ -962,11 +1004,24 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
 parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
                     iType, Impl::ThreadsExecTeamMember>& loop_boundaries,
                 const Lambda& lambda, const ReducerType& reducer) {
-  reducer.init(reducer.reference());
+  using value_type            = typename ReducerType::value_type;
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<typename Impl::ThreadsExecTeamMember::execution_space>,
+      ReducerType, value_type>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+
+  wrapped_reducer_type wrapped_reducer(reducer);
+  value_type value{};
+  wrapped_reducer.init(&value);
+
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
        i += loop_boundaries.increment) {
-    lambda(i, reducer.reference());
+    lambda(i, value);
   }
+
+  wrapped_reducer.final(&value);
+  reducer.reference() = value;
 }
 
 /** \brief  Inter-thread parallel exclusive prefix sum. Executes

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -908,7 +908,7 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
   using value_type           = typename wrapped_reducer_type::value_type;
 
   wrapped_reducer_type wrapped_reducer(lambda);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
@@ -934,7 +934,7 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
   using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
   wrapped_reducer_type wrapped_reducer(reducer);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
@@ -987,7 +987,7 @@ parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
   using value_type           = typename wrapped_reducer_type::value_type;
 
   wrapped_reducer_type wrapped_reducer(lambda);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
@@ -1012,7 +1012,7 @@ parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
   using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
   wrapped_reducer_type wrapped_reducer(reducer);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -550,18 +550,34 @@ class HostThreadTeamMember {
   // team_reduce( Max(result) );
 
   template <typename ReducerType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<ReducerType>::value>
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer_v<ReducerType>>
   team_reduce(ReducerType const& reducer) const noexcept {
     team_reduce(reducer, reducer.reference());
   }
 
   template <typename ReducerType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<ReducerType>::value>
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer_v<ReducerType>>
   team_reduce(ReducerType const& reducer,
               typename ReducerType::value_type contribution) const noexcept {
+    using value_type           = typename ReducerType::value_type;
+    using wrapped_reducer_type = typename Impl::FunctorAnalysis<
+        Impl::FunctorPatternInterface::REDUCE,
+        TeamPolicy<Kokkos::DefaultHostExecutionSpace>, ReducerType,
+        value_type>::Reducer;
+
+    impl_team_reduce(wrapped_reducer_type(reducer), contribution);
+    reducer.reference() = contribution;
+  }
+
+  template <typename WrappedReducerType>
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer_v<WrappedReducerType>>
+  impl_team_reduce(
+      WrappedReducerType const& reducer,
+      typename WrappedReducerType::value_type& contribution) const {
     KOKKOS_IF_ON_HOST((
+
         if (1 < m_data.m_team_size) {
-          using value_type = typename ReducerType::value_type;
+          using value_type = typename WrappedReducerType::value_type;
 
           if (0 != m_data.m_team_rank) {
             // Non-root copies to their local buffer:
@@ -583,22 +599,22 @@ class HostThreadTeamMember {
               value_type* const src =
                   (value_type*)m_data.team_member(i)->team_reduce_local();
 
-              reducer.join(contribution, *src);
+              reducer.join(&contribution, src);
             }
 
             // Copy result to root member's buffer:
             // reducer.copy( (value_type*) m_data.team_reduce() , reducer.data()
             // );
             *((value_type*)m_data.team_reduce()) = contribution;
-            reducer.reference()                  = contribution;
+
             m_data.team_rendezvous_release();
             // This thread released all other threads from 'team_rendezvous'
             // with a return value of 'false'
           } else {
             // Copy from root member's buffer:
-            reducer.reference() = *((value_type*)m_data.team_reduce());
+            contribution = *((value_type*)m_data.team_reduce());
           }
-        } else { reducer.reference() = contribution; }))
+        }))
 
     KOKKOS_IF_ON_DEVICE(((void)reducer; (void)contribution;
                          Kokkos::abort("HostThreadTeamMember team_reduce\n");))
@@ -781,15 +797,25 @@ KOKKOS_INLINE_FUNCTION
     parallel_reduce(Impl::TeamThreadRangeBoundariesStruct<iType, Member> const&
                         loop_boundaries,
                     Closure const& closure, Reducer const& reducer) {
-  typename Reducer::value_type value;
-  reducer.init(value);
+  using value_type            = typename Reducer::value_type;
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<Kokkos::DefaultHostExecutionSpace>, Reducer, value_type>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+
+  wrapped_reducer_type wrapped_reducer(reducer);
+  value_type value{};
+  wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
        i += loop_boundaries.increment) {
     closure(i, value);
   }
 
-  loop_boundaries.thread.team_reduce(reducer, value);
+  loop_boundaries.thread.impl_team_reduce(wrapped_reducer, value);
+
+  wrapped_reducer.final(&value);
+  reducer.reference() = value;
 }
 
 template <typename iType, typename Closure, typename ValueType, typename Member>
@@ -799,17 +825,24 @@ KOKKOS_INLINE_FUNCTION
     parallel_reduce(Impl::TeamThreadRangeBoundariesStruct<iType, Member> const&
                         loop_boundaries,
                     Closure const& closure, ValueType& result) {
-  ValueType val;
-  Sum<ValueType> reducer(val);
-  reducer.init(val);
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<Kokkos::DefaultHostExecutionSpace>, Closure, ValueType>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+  using value_type           = typename wrapped_reducer_type::value_type;
+
+  wrapped_reducer_type wrapped_reducer(closure);
+  value_type value{};
+  wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
        i += loop_boundaries.increment) {
-    closure(i, reducer.reference());
+    closure(i, value);
   }
 
-  loop_boundaries.thread.team_reduce(reducer);
-  result = reducer.reference();
+  loop_boundaries.thread.impl_team_reduce(wrapped_reducer, value);
+  wrapped_reducer.final(&value);
+  result = value;
 }
 
 /*template< typename iType, class Space
@@ -853,11 +886,23 @@ KOKKOS_INLINE_FUNCTION
     parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
                         iType, Member>& loop_boundaries,
                     const Lambda& lambda, ValueType& result) {
-  result = ValueType();
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<Kokkos::DefaultHostExecutionSpace>, Lambda, ValueType>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+  using value_type           = typename wrapped_reducer_type::value_type;
+
+  wrapped_reducer_type wrapped_reducer(lambda);
+  value_type value{};
+  wrapped_reducer.init(&value);
+
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
        i += loop_boundaries.increment) {
-    lambda(i, result);
+    lambda(i, value);
   }
+
+  wrapped_reducer.final(&value);
+  result = value;
 }
 
 template <typename iType, class Lambda, typename ReducerType, typename Member>
@@ -867,11 +912,23 @@ KOKKOS_INLINE_FUNCTION
     parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
                         iType, Member>& loop_boundaries,
                     const Lambda& lambda, const ReducerType& reducer) {
-  reducer.init(reducer.reference());
+  using value_type            = typename ReducerType::value_type;
+  using functor_analysis_type = typename Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE,
+      TeamPolicy<Kokkos::DefaultHostExecutionSpace>, ReducerType, value_type>;
+  using wrapped_reducer_type = typename functor_analysis_type::Reducer;
+
+  wrapped_reducer_type wrapped_reducer(reducer);
+  value_type value{};
+  wrapped_reducer.init(&value);
+
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
        i += loop_boundaries.increment) {
-    lambda(i, reducer.reference());
+    lambda(i, value);
   }
+
+  wrapped_reducer.final(&value);
+  reducer.reference() = value;
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -804,7 +804,7 @@ KOKKOS_INLINE_FUNCTION
   using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
   wrapped_reducer_type wrapped_reducer(reducer);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
@@ -832,7 +832,7 @@ KOKKOS_INLINE_FUNCTION
   using value_type           = typename wrapped_reducer_type::value_type;
 
   wrapped_reducer_type wrapped_reducer(closure);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
@@ -893,7 +893,7 @@ KOKKOS_INLINE_FUNCTION
   using value_type           = typename wrapped_reducer_type::value_type;
 
   wrapped_reducer_type wrapped_reducer(lambda);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
@@ -919,7 +919,7 @@ KOKKOS_INLINE_FUNCTION
   using wrapped_reducer_type = typename functor_analysis_type::Reducer;
 
   wrapped_reducer_type wrapped_reducer(reducer);
-  value_type value{};
+  value_type value;
   wrapped_reducer.init(&value);
 
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -1829,4 +1829,162 @@ struct TestRepeatedTeamReduce {
 
 }  // namespace Test
 
+namespace Test {
+
+struct SimpleTestValueType {
+  using ScalarType = int;
+
+  ScalarType value[2];
+};
+
+struct TestTeamReducerFunctor {
+  using value_type = SimpleTestValueType;
+
+  KOKKOS_INLINE_FUNCTION
+  void init(value_type &init) const {
+    init.value[0] = 1;
+    init.value[1] = 10;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void join(value_type &dst, value_type const &src) const {
+    dst.value[0] *= src.value[0];
+    dst.value[1] += src.value[1];
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void final(value_type &dst) const {
+    dst.value[0] /= -2;
+    dst.value[1] /= -2;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int i, value_type &update) const {
+    update.value[0] *= (i + 1);
+    update.value[1] *= (i + 2);
+  }
+};
+
+struct TestTeamReducer {
+  using reducer    = TestTeamReducer;
+  using value_type = SimpleTestValueType;
+
+  KOKKOS_INLINE_FUNCTION
+  TestTeamReducer(value_type &val) : local(val) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void init(value_type &init) const {
+    init.value[0] = 1;
+    init.value[1] = 10;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void join(value_type &dst, value_type const &src) const {
+    dst.value[0] *= src.value[0];
+    dst.value[1] += src.value[1];
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void final(value_type &dst) const {
+    dst.value[0] /= -2;
+    dst.value[1] /= -2;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  value_type &reference() const { return local; }
+
+  value_type &local;
+};
+
+namespace {
+
+template <typename ExecSpace>
+class TestTeamNestedReducerFunctor {
+ public:
+  using execution_space  = ExecSpace;
+  using team_policy_type = Kokkos::TeamPolicy<execution_space>;
+  using member_type      = typename team_policy_type::member_type;
+  using value_type       = SimpleTestValueType;
+  using functor_type     = TestTeamReducerFunctor;
+  using reducer_type     = TestTeamReducer;
+  using index_type       = int;
+
+  void run_test_team_thread() {
+    auto policy = KOKKOS_LAMBDA(member_type const &member, index_type count) {
+      return Kokkos::TeamThreadRange(member, count);
+    };
+    run_test_team_policies(policy);
+  };
+
+  void run_test_thread_vector() {
+    auto policy = KOKKOS_LAMBDA(member_type const &member, index_type count) {
+      return Kokkos::ThreadVectorRange(member, count);
+    };
+    run_test_team_policies(policy);
+  };
+
+  void run_test_team_vector() {
+    auto policy = KOKKOS_LAMBDA(member_type const &member, index_type count) {
+      return Kokkos::TeamVectorRange(member, count);
+    };
+    run_test_team_policies(policy);
+  };
+
+  template <typename Policy>
+  void run_test_team_policies(Policy &policy) {
+    constexpr index_type league_size = 3;
+    constexpr index_type test_count  = 8;
+
+    Kokkos::View<value_type[league_size], execution_space>
+        reducer_functor_result("reducer_functor_result");
+    Kokkos::View<value_type[league_size], execution_space> reducer_result(
+        "reducer_result");
+
+    Kokkos::parallel_for(
+        team_policy_type(league_size, Kokkos::AUTO),
+        KOKKOS_LAMBDA(member_type const &team) {
+          const int league = team.league_rank();
+
+          // Using a functor as reducer
+          value_type result1{};
+          Kokkos::parallel_reduce(policy(team, test_count), functor_type{},
+                                  result1);
+
+          // Using a reducer
+          value_type result2{};
+          reducer_type reducer(result2);
+          Kokkos::parallel_reduce(
+              policy(team, test_count),
+              [&](const int i, value_type &update) {
+                update.value[0] *= (i + 1);
+                update.value[1] *= (i + 2);
+              },
+              reducer);
+
+          Kokkos::single(Kokkos::PerTeam(team), [=]() {
+            reducer_functor_result(league).value[0] = result1.value[0];
+            reducer_functor_result(league).value[1] = result1.value[1];
+
+            reducer_result(league).value[0] = result2.value[0];
+            reducer_result(league).value[1] = result2.value[1];
+          });
+        });
+    Kokkos::fence();
+
+    auto test1 = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace{}, reducer_functor_result);
+    auto test2 = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace{}, reducer_result);
+
+    for (unsigned i = 0; i < test1.extent(0); ++i) {
+      EXPECT_EQ(test1(i).value[0], test2(i).value[0]);
+      EXPECT_EQ(test1(i).value[1], test2(i).value[1]);
+    }
+  }
+};
+
+}  // namespace
+
+}  // namespace Test
+
 /*--------------------------------------------------------------------------*/

--- a/core/unit_test/TestTeamReductionScan.hpp
+++ b/core/unit_test/TestTeamReductionScan.hpp
@@ -176,5 +176,18 @@ TEST(TEST_CATEGORY, repeated_team_reduce) {
   TestRepeatedTeamReduce<TEST_EXECSPACE>();
 }
 
+TEST(TEST_CATEGORY, nested_team_reduce_functor_as_reducer) {
+#ifdef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET: Not implemented
+  if (std::is_same<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>::value)
+    GTEST_SKIP() << "skipping since team_reduce for OpenMPTarget is not "
+                    "properly implemented";
+#endif
+  {
+    TestTeamNestedReducerFunctor<TEST_EXECSPACE>().run_test_team_thread();
+    TestTeamNestedReducerFunctor<TEST_EXECSPACE>().run_test_thread_vector();
+    TestTeamNestedReducerFunctor<TEST_EXECSPACE>().run_test_team_vector();
+  }
+}
+
 }  // namespace Test
 #endif


### PR DESCRIPTION
Resolves #6317.

This PR allows functors to be used as reducers in nested parallel reduction, specifically for `parallel_reduce` that takes in `TeamThreadRange`, `ThreadVectorRange` or `TeamVectorRange`.
This capability is already available for reductions with `Range/MDRange/Team` policies as noted in #6774.

Changes in this PR convert nested parallel reduces to use `FunctorAnalysis::Reducer` in order to avoid explicitly checking for the availability of `init` or `final` implementation in custom reducers.

Also, most of nested `parallel_reduce` weren't calling `final` even when it is available in a custom reducer. So that was addressed in this PR as well.