### PR TITLE
OpenMPTarget: Update loop order in MDRange

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget.hpp
@@ -146,7 +146,8 @@ struct DeviceTypeTraits<::Kokkos::Experimental::OpenMPTarget> {
 /*--------------------------------------------------------------------------*/
 
 #include <OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp>
-#include <OpenMPTarget/Kokkos_OpenMPTarget_Parallel_MDRange.hpp>
+#include <OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_MDRange.hpp>
+#include <OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_MDRange.hpp>
 #include <OpenMPTarget/Kokkos_OpenMPTarget_Task.hpp>
 
 /*--------------------------------------------------------------------------*/

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_MDRangePolicy.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_MDRangePolicy.hpp
@@ -22,6 +22,10 @@
 namespace Kokkos {
 namespace Impl {
 
+using OpenMPTargetIterateLeft = std::integral_constant<Iterate, Iterate::Left>;
+using OpenMPTargetIterateRight =
+    std::integral_constant<Iterate, Iterate::Right>;
+
 template <typename Rank,
           ::Kokkos::Impl::TeamMDRangeThreadAndVector ThreadAndVector>
 struct ThreadAndVectorNestLevel<Rank, Kokkos::Experimental::OpenMPTarget,
@@ -30,4 +34,5 @@ struct ThreadAndVectorNestLevel<Rank, Kokkos::Experimental::OpenMPTarget,
 
 }  // namespace Impl
 }  // namespace Kokkos
+
 #endif

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_MDRange.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_MDRange.hpp
@@ -1,0 +1,385 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_OPENMPTARGET_PARALLELFOR_MDRANGE_HPP
+#define KOKKOS_OPENMPTARGET_PARALLELFOR_MDRANGE_HPP
+
+#include <omp.h>
+#include <Kokkos_Parallel.hpp>
+#include "Kokkos_OpenMPTarget_MDRangePolicy.hpp"
+#include <OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp>
+#include <OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp>
+
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+
+namespace Kokkos {
+namespace Impl {
+
+template <class FunctorType, class... Traits>
+class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
+                  Kokkos::Experimental::OpenMPTarget> {
+ private:
+  using Policy  = Kokkos::MDRangePolicy<Traits...>;
+  using WorkTag = typename Policy::work_tag;
+  using Member  = typename Policy::member_type;
+  using Index   = typename Policy::index_type;
+
+  const FunctorType m_functor;
+  const Policy m_policy;
+
+ public:
+  inline void execute() const {
+    OpenMPTargetExec::verify_is_process(
+        "Kokkos::Experimental::OpenMPTarget parallel_for");
+    OpenMPTargetExec::verify_initialized(
+        "Kokkos::Experimental::OpenMPTarget parallel_for");
+    FunctorType functor(m_functor);
+    Policy policy = m_policy;
+
+    typename Policy::point_type unused;
+    static_assert(1 < Policy::rank && Policy::rank < 7);
+    static_assert(Policy::inner_direction == Iterate::Left ||
+                  Policy::inner_direction == Iterate::Right);
+
+    execute_tile<Policy::rank>(
+        unused, functor, policy,
+        std::integral_constant<Iterate, Policy::inner_direction>());
+  }
+
+  template <int Rank>
+  inline std::enable_if_t<Rank == 2> execute_tile(
+      typename Policy::point_type offset, const FunctorType& functor,
+      const Policy& policy, OpenMPTargetIterateRight) const {
+    (void)offset;
+    const Index begin_0 = policy.m_lower[0];
+    const Index begin_1 = policy.m_lower[1];
+
+    const Index end_0 = policy.m_upper[0];
+    const Index end_1 = policy.m_upper[1];
+
+#pragma omp target teams distribute parallel for collapse(2) map(to : functor)
+    for (auto i0 = begin_0; i0 < end_0; ++i0)
+      for (auto i1 = begin_1; i1 < end_1; ++i1) {
+        if constexpr (std::is_void<typename Policy::work_tag>::value)
+          functor(i0, i1);
+        else
+          functor(typename Policy::work_tag(), i0, i1);
+      }
+  }
+
+  template <int Rank>
+  inline std::enable_if_t<Rank == 3> execute_tile(
+      typename Policy::point_type offset, const FunctorType& functor,
+      const Policy& policy, OpenMPTargetIterateRight) const {
+    (void)offset;
+    const Index begin_0 = policy.m_lower[0];
+    const Index begin_1 = policy.m_lower[1];
+    const Index begin_2 = policy.m_lower[2];
+
+    const Index end_0 = policy.m_upper[0];
+    const Index end_1 = policy.m_upper[1];
+    const Index end_2 = policy.m_upper[2];
+
+#pragma omp target teams distribute parallel for collapse(3) map(to : functor)
+    for (auto i0 = begin_0; i0 < end_0; ++i0) {
+      for (auto i1 = begin_1; i1 < end_1; ++i1) {
+        for (auto i2 = begin_2; i2 < end_2; ++i2) {
+          if constexpr (std::is_void<typename Policy::work_tag>::value)
+            functor(i0, i1, i2);
+          else
+            functor(typename Policy::work_tag(), i0, i1, i2);
+        }
+      }
+    }
+  }
+
+  template <int Rank>
+  inline std::enable_if_t<Rank == 4> execute_tile(
+      typename Policy::point_type offset, const FunctorType& functor,
+      const Policy& policy, OpenMPTargetIterateRight) const {
+    (void)offset;
+    const Index begin_0 = policy.m_lower[0];
+    const Index begin_1 = policy.m_lower[1];
+    const Index begin_2 = policy.m_lower[2];
+    const Index begin_3 = policy.m_lower[3];
+
+    const Index end_0 = policy.m_upper[0];
+    const Index end_1 = policy.m_upper[1];
+    const Index end_2 = policy.m_upper[2];
+    const Index end_3 = policy.m_upper[3];
+
+#pragma omp target teams distribute parallel for collapse(4) map(to : functor)
+    for (auto i0 = begin_0; i0 < end_0; ++i0) {
+      for (auto i1 = begin_1; i1 < end_1; ++i1) {
+        for (auto i2 = begin_2; i2 < end_2; ++i2) {
+          for (auto i3 = begin_3; i3 < end_3; ++i3) {
+            if constexpr (std::is_void<typename Policy::work_tag>::value)
+              functor(i0, i1, i2, i3);
+            else
+              functor(typename Policy::work_tag(), i0, i1, i2, i3);
+          }
+        }
+      }
+    }
+  }
+
+  template <int Rank>
+  inline std::enable_if_t<Rank == 5> execute_tile(
+      typename Policy::point_type offset, const FunctorType& functor,
+      const Policy& policy, OpenMPTargetIterateRight) const {
+    (void)offset;
+    const Index begin_0 = policy.m_lower[0];
+    const Index begin_1 = policy.m_lower[1];
+    const Index begin_2 = policy.m_lower[2];
+    const Index begin_3 = policy.m_lower[3];
+    const Index begin_4 = policy.m_lower[4];
+
+    const Index end_0 = policy.m_upper[0];
+    const Index end_1 = policy.m_upper[1];
+    const Index end_2 = policy.m_upper[2];
+    const Index end_3 = policy.m_upper[3];
+    const Index end_4 = policy.m_upper[4];
+
+#pragma omp target teams distribute parallel for collapse(5) map(to : functor)
+    for (auto i0 = begin_0; i0 < end_0; ++i0) {
+      for (auto i1 = begin_1; i1 < end_1; ++i1) {
+        for (auto i2 = begin_2; i2 < end_2; ++i2) {
+          for (auto i3 = begin_3; i3 < end_3; ++i3) {
+            for (auto i4 = begin_4; i4 < end_4; ++i4) {
+              if constexpr (std::is_same<typename Policy::work_tag,
+                                         void>::value)
+                functor(i0, i1, i2, i3, i4);
+              else
+                functor(typename Policy::work_tag(), i0, i1, i2, i3, i4);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  template <int Rank>
+  inline std::enable_if_t<Rank == 6> execute_tile(
+      typename Policy::point_type offset, const FunctorType& functor,
+      const Policy& policy, OpenMPTargetIterateRight) const {
+    (void)offset;
+    const Index begin_0 = policy.m_lower[0];
+    const Index begin_1 = policy.m_lower[1];
+    const Index begin_2 = policy.m_lower[2];
+    const Index begin_3 = policy.m_lower[3];
+    const Index begin_4 = policy.m_lower[4];
+    const Index begin_5 = policy.m_lower[5];
+
+    const Index end_0 = policy.m_upper[0];
+    const Index end_1 = policy.m_upper[1];
+    const Index end_2 = policy.m_upper[2];
+    const Index end_3 = policy.m_upper[3];
+    const Index end_4 = policy.m_upper[4];
+    const Index end_5 = policy.m_upper[5];
+
+#pragma omp target teams distribute parallel for collapse(6) map(to : functor)
+    for (auto i0 = begin_0; i0 < end_0; ++i0) {
+      for (auto i1 = begin_1; i1 < end_1; ++i1) {
+        for (auto i2 = begin_2; i2 < end_2; ++i2) {
+          for (auto i3 = begin_3; i3 < end_3; ++i3) {
+            for (auto i4 = begin_4; i4 < end_4; ++i4) {
+              for (auto i5 = begin_5; i5 < end_5; ++i5) {
+                {
+                  if constexpr (std::is_same<typename Policy::work_tag,
+                                             void>::value)
+                    functor(i0, i1, i2, i3, i4, i5);
+                  else
+                    functor(typename Policy::work_tag(), i0, i1, i2, i3, i4,
+                            i5);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  template <int Rank>
+  inline std::enable_if_t<Rank == 2> execute_tile(
+      typename Policy::point_type offset, const FunctorType& functor,
+      const Policy& policy, OpenMPTargetIterateLeft) const {
+    (void)offset;
+    const Index begin_0 = policy.m_lower[0];
+    const Index begin_1 = policy.m_lower[1];
+
+    const Index end_0 = policy.m_upper[0];
+    const Index end_1 = policy.m_upper[1];
+
+#pragma omp target teams distribute parallel for collapse(2) map(to : functor)
+    for (auto i1 = begin_1; i1 < end_1; ++i1)
+      for (auto i0 = begin_0; i0 < end_0; ++i0) {
+        if constexpr (std::is_void<typename Policy::work_tag>::value)
+          functor(i0, i1);
+        else
+          functor(typename Policy::work_tag(), i0, i1);
+      }
+  }
+
+  template <int Rank>
+  inline std::enable_if_t<Rank == 3> execute_tile(
+      typename Policy::point_type offset, const FunctorType& functor,
+      const Policy& policy, OpenMPTargetIterateLeft) const {
+    (void)offset;
+    const Index begin_0 = policy.m_lower[0];
+    const Index begin_1 = policy.m_lower[1];
+    const Index begin_2 = policy.m_lower[2];
+
+    const Index end_0 = policy.m_upper[0];
+    const Index end_1 = policy.m_upper[1];
+    const Index end_2 = policy.m_upper[2];
+
+#pragma omp target teams distribute parallel for collapse(3) map(to : functor)
+    for (auto i2 = begin_2; i2 < end_2; ++i2) {
+      for (auto i1 = begin_1; i1 < end_1; ++i1) {
+        for (auto i0 = begin_0; i0 < end_0; ++i0) {
+          if constexpr (std::is_void<typename Policy::work_tag>::value)
+            functor(i0, i1, i2);
+          else
+            functor(typename Policy::work_tag(), i0, i1, i2);
+        }
+      }
+    }
+  }
+
+  template <int Rank>
+  inline std::enable_if_t<Rank == 4> execute_tile(
+      typename Policy::point_type offset, const FunctorType& functor,
+      const Policy& policy, OpenMPTargetIterateLeft) const {
+    (void)offset;
+    const Index begin_0 = policy.m_lower[0];
+    const Index begin_1 = policy.m_lower[1];
+    const Index begin_2 = policy.m_lower[2];
+    const Index begin_3 = policy.m_lower[3];
+
+    const Index end_0 = policy.m_upper[0];
+    const Index end_1 = policy.m_upper[1];
+    const Index end_2 = policy.m_upper[2];
+    const Index end_3 = policy.m_upper[3];
+
+#pragma omp target teams distribute parallel for collapse(4) map(to : functor)
+    for (auto i3 = begin_3; i3 < end_3; ++i3) {
+      for (auto i2 = begin_2; i2 < end_2; ++i2) {
+        for (auto i1 = begin_1; i1 < end_1; ++i1) {
+          for (auto i0 = begin_0; i0 < end_0; ++i0) {
+            if constexpr (std::is_void<typename Policy::work_tag>::value)
+              functor(i0, i1, i2, i3);
+            else
+              functor(typename Policy::work_tag(), i0, i1, i2, i3);
+          }
+        }
+      }
+    }
+  }
+
+  template <int Rank>
+  inline std::enable_if_t<Rank == 5> execute_tile(
+      typename Policy::point_type offset, const FunctorType& functor,
+      const Policy& policy, OpenMPTargetIterateLeft) const {
+    (void)offset;
+    const Index begin_0 = policy.m_lower[0];
+    const Index begin_1 = policy.m_lower[1];
+    const Index begin_2 = policy.m_lower[2];
+    const Index begin_3 = policy.m_lower[3];
+    const Index begin_4 = policy.m_lower[4];
+
+    const Index end_0 = policy.m_upper[0];
+    const Index end_1 = policy.m_upper[1];
+    const Index end_2 = policy.m_upper[2];
+    const Index end_3 = policy.m_upper[3];
+    const Index end_4 = policy.m_upper[4];
+
+#pragma omp target teams distribute parallel for collapse(5) map(to : functor)
+    for (auto i4 = begin_4; i4 < end_4; ++i4) {
+      for (auto i3 = begin_3; i3 < end_3; ++i3) {
+        for (auto i2 = begin_2; i2 < end_2; ++i2) {
+          for (auto i1 = begin_1; i1 < end_1; ++i1) {
+            for (auto i0 = begin_0; i0 < end_0; ++i0) {
+              if constexpr (std::is_same<typename Policy::work_tag,
+                                         void>::value)
+                functor(i0, i1, i2, i3, i4);
+              else
+                functor(typename Policy::work_tag(), i0, i1, i2, i3, i4);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  template <int Rank>
+  inline std::enable_if_t<Rank == 6> execute_tile(
+      typename Policy::point_type offset, const FunctorType& functor,
+      const Policy& policy, OpenMPTargetIterateLeft) const {
+    (void)offset;
+    const Index begin_0 = policy.m_lower[0];
+    const Index begin_1 = policy.m_lower[1];
+    const Index begin_2 = policy.m_lower[2];
+    const Index begin_3 = policy.m_lower[3];
+    const Index begin_4 = policy.m_lower[4];
+    const Index begin_5 = policy.m_lower[5];
+
+    const Index end_0 = policy.m_upper[0];
+    const Index end_1 = policy.m_upper[1];
+    const Index end_2 = policy.m_upper[2];
+    const Index end_3 = policy.m_upper[3];
+    const Index end_4 = policy.m_upper[4];
+    const Index end_5 = policy.m_upper[5];
+
+#pragma omp target teams distribute parallel for collapse(6) map(to : functor)
+    for (auto i5 = begin_5; i5 < end_5; ++i5) {
+      for (auto i4 = begin_4; i4 < end_4; ++i4) {
+        for (auto i3 = begin_3; i3 < end_3; ++i3) {
+          for (auto i2 = begin_2; i2 < end_2; ++i2) {
+            for (auto i1 = begin_1; i1 < end_1; ++i1) {
+              for (auto i0 = begin_0; i0 < end_0; ++i0) {
+                {
+                  if constexpr (std::is_same<typename Policy::work_tag,
+                                             void>::value)
+                    functor(i0, i1, i2, i3, i4, i5);
+                  else
+                    functor(typename Policy::work_tag(), i0, i1, i2, i3, i4,
+                            i5);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  inline ParallelFor(const FunctorType& arg_functor, Policy arg_policy)
+      : m_functor(arg_functor), m_policy(arg_policy) {}
+  // TODO DZP: based on a conversation with Christian, we're using 256 as a
+  // heuristic here. We need something better once we can query these kinds of
+  // properties
+  template <typename Policy, typename Functor>
+  static int max_tile_size_product(const Policy&, const Functor&) {
+    return 256;
+  }
+};
+
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif /* KOKKOS_OPENMPTARGET_PARALLELFOR_MDRANGE_HPP */

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_MDRange.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_MDRange.hpp
@@ -20,8 +20,6 @@
 #include <omp.h>
 #include <Kokkos_Parallel.hpp>
 #include "Kokkos_OpenMPTarget_MDRangePolicy.hpp"
-#include <OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp>
-#include <OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_MDRange.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_MDRange.hpp
@@ -63,7 +63,8 @@ class ParallelReduce<CombinedFunctorReducerType,
  public:
   inline void execute() const {
     execute_tile<Policy::rank, typename ReducerType::value_type>(
-        m_functor_reducer.get_functor(), m_policy, m_result_ptr, std::integral_constant<Iterate, Policy::inner_direction>());
+        m_functor_reducer.get_functor(), m_policy, m_result_ptr,
+        std::integral_constant<Iterate, Policy::inner_direction>());
   }
 
   template <class ViewType>
@@ -78,9 +79,9 @@ class ParallelReduce<CombinedFunctorReducerType,
         m_scratch_memory_lock(OpenMPTargetExec::m_mutex_scratch_ptr) {}
 
   template <int Rank, class ValueType>
-  inline std::enable_if_t<Rank == 2> execute_tile(const FunctorType& functor,
-                                                  const Policy& policy,
-                                                  pointer_type ptr, OpenMPTargetIterateLeft) const {
+  inline std::enable_if_t<Rank == 2> execute_tile(
+      const FunctorType& functor, const Policy& policy, pointer_type ptr,
+      OpenMPTargetIterateLeft) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
 
@@ -127,9 +128,9 @@ reduction(+:result)
   }
 
   template <int Rank, class ValueType>
-  inline std::enable_if_t<Rank == 3> execute_tile(const FunctorType& functor,
-                                                  const Policy& policy,
-                                                  pointer_type ptr, OpenMPTargetIterateLeft) const {
+  inline std::enable_if_t<Rank == 3> execute_tile(
+      const FunctorType& functor, const Policy& policy, pointer_type ptr,
+      OpenMPTargetIterateLeft) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];
@@ -185,9 +186,9 @@ reduction(+:result)
   }
 
   template <int Rank, class ValueType>
-  inline std::enable_if_t<Rank == 4> execute_tile(const FunctorType& functor,
-                                                  const Policy& policy,
-                                                  pointer_type ptr, OpenMPTargetIterateLeft) const {
+  inline std::enable_if_t<Rank == 4> execute_tile(
+      const FunctorType& functor, const Policy& policy, pointer_type ptr,
+      OpenMPTargetIterateLeft) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[3];
@@ -248,9 +249,9 @@ reduction(+:result)
   }
 
   template <int Rank, class ValueType>
-  inline std::enable_if_t<Rank == 5> execute_tile(const FunctorType& functor,
-                                                  const Policy& policy,
-                                                  pointer_type ptr, OpenMPTargetIterateLeft) const {
+  inline std::enable_if_t<Rank == 5> execute_tile(
+      const FunctorType& functor, const Policy& policy, pointer_type ptr,
+      OpenMPTargetIterateLeft) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];
@@ -319,9 +320,9 @@ reduction(+:result)
   }
 
   template <int Rank, class ValueType>
-  inline std::enable_if_t<Rank == 6> execute_tile(const FunctorType& functor,
-                                                  const Policy& policy,
-                                                  pointer_type ptr, OpenMPTargetIterateLeft) const {
+  inline std::enable_if_t<Rank == 6> execute_tile(
+      const FunctorType& functor, const Policy& policy, pointer_type ptr,
+      OpenMPTargetIterateLeft) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];
@@ -396,9 +397,9 @@ reduction(+:result)
   }
 
   template <int Rank, class ValueType>
-  inline std::enable_if_t<Rank == 2> execute_tile(const FunctorType& functor,
-                                                  const Policy& policy,
-                                                  pointer_type ptr, OpenMPTargetIterateRight) const {
+  inline std::enable_if_t<Rank == 2> execute_tile(
+      const FunctorType& functor, const Policy& policy, pointer_type ptr,
+      OpenMPTargetIterateRight) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
 
@@ -419,8 +420,8 @@ reduction(+:result)
                                                                  : functor) \
     reduction(custom                                                        \
               : result)
-        for (auto i0 = begin_0; i0 < end_0; ++i0) {
-      for (auto i1 = begin_1; i1 < end_1; ++i1) {
+      for (auto i0 = begin_0; i0 < end_0; ++i0) {
+        for (auto i1 = begin_1; i1 < end_1; ++i1) {
           if constexpr (std::is_void<typename Policy::work_tag>::value)
             functor(i0, i1, result);
           else
@@ -430,8 +431,8 @@ reduction(+:result)
     } else {
 #pragma omp target teams distribute parallel for collapse(2) map(to : functor) \
 reduction(+:result)
-        for (auto i0 = begin_0; i0 < end_0; ++i0) {
-      for (auto i1 = begin_1; i1 < end_1; ++i1) {
+      for (auto i0 = begin_0; i0 < end_0; ++i0) {
+        for (auto i1 = begin_1; i1 < end_1; ++i1) {
           if constexpr (std::is_void<typename Policy::work_tag>::value)
             functor(i0, i1, result);
           else
@@ -445,9 +446,9 @@ reduction(+:result)
   }
 
   template <int Rank, class ValueType>
-  inline std::enable_if_t<Rank == 3> execute_tile(const FunctorType& functor,
-                                                  const Policy& policy,
-                                                  pointer_type ptr, OpenMPTargetIterateRight) const {
+  inline std::enable_if_t<Rank == 3> execute_tile(
+      const FunctorType& functor, const Policy& policy, pointer_type ptr,
+      OpenMPTargetIterateRight) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];
@@ -473,9 +474,9 @@ reduction(+:result)
                                                                  : functor) \
     reduction(custom                                                        \
               : result)
-          for (auto i0 = begin_0; i0 < end_0; ++i0) {
+      for (auto i0 = begin_0; i0 < end_0; ++i0) {
         for (auto i1 = begin_1; i1 < end_1; ++i1) {
-      for (auto i2 = begin_2; i2 < end_2; ++i2) {
+          for (auto i2 = begin_2; i2 < end_2; ++i2) {
             if constexpr (std::is_void<typename Policy::work_tag>::value)
               functor(i0, i1, i2, result);
             else
@@ -486,9 +487,9 @@ reduction(+:result)
     } else {
 #pragma omp target teams distribute parallel for collapse(3) map(to : functor) \
 reduction(+:result)
-          for (auto i0 = begin_0; i0 < end_0; ++i0) {
+      for (auto i0 = begin_0; i0 < end_0; ++i0) {
         for (auto i1 = begin_1; i1 < end_1; ++i1) {
-      for (auto i2 = begin_2; i2 < end_2; ++i2) {
+          for (auto i2 = begin_2; i2 < end_2; ++i2) {
             if constexpr (std::is_void<typename Policy::work_tag>::value)
               functor(i0, i1, i2, result);
             else
@@ -503,9 +504,9 @@ reduction(+:result)
   }
 
   template <int Rank, class ValueType>
-  inline std::enable_if_t<Rank == 4> execute_tile(const FunctorType& functor,
-                                                  const Policy& policy,
-                                                  pointer_type ptr, OpenMPTargetIterateRight) const {
+  inline std::enable_if_t<Rank == 4> execute_tile(
+      const FunctorType& functor, const Policy& policy, pointer_type ptr,
+      OpenMPTargetIterateRight) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[3];
@@ -530,10 +531,10 @@ reduction(+:result)
                                                                  : functor) \
     reduction(custom                                                        \
               : result)
-            for (auto i0 = begin_0; i0 < end_0; ++i0) {
-          for (auto i1 = begin_1; i1 < end_1; ++i1) {
-        for (auto i2 = begin_2; i2 < end_2; ++i2) {
-      for (auto i3 = begin_3; i3 < end_3; ++i3) {
+      for (auto i0 = begin_0; i0 < end_0; ++i0) {
+        for (auto i1 = begin_1; i1 < end_1; ++i1) {
+          for (auto i2 = begin_2; i2 < end_2; ++i2) {
+            for (auto i3 = begin_3; i3 < end_3; ++i3) {
               if constexpr (std::is_same<typename Policy::work_tag,
                                          void>::value)
                 functor(i0, i1, i2, i3, result);
@@ -546,10 +547,10 @@ reduction(+:result)
     } else {
 #pragma omp target teams distribute parallel for collapse(4) map(to : functor) \
 reduction(+:result)
-            for (auto i0 = begin_0; i0 < end_0; ++i0) {
-          for (auto i1 = begin_1; i1 < end_1; ++i1) {
-        for (auto i2 = begin_2; i2 < end_2; ++i2) {
-      for (auto i3 = begin_3; i3 < end_3; ++i3) {
+      for (auto i0 = begin_0; i0 < end_0; ++i0) {
+        for (auto i1 = begin_1; i1 < end_1; ++i1) {
+          for (auto i2 = begin_2; i2 < end_2; ++i2) {
+            for (auto i3 = begin_3; i3 < end_3; ++i3) {
               if constexpr (std::is_same<typename Policy::work_tag,
                                          void>::value)
                 functor(i0, i1, i2, i3, result);
@@ -566,9 +567,9 @@ reduction(+:result)
   }
 
   template <int Rank, class ValueType>
-  inline std::enable_if_t<Rank == 5> execute_tile(const FunctorType& functor,
-                                                  const Policy& policy,
-                                                  pointer_type ptr, OpenMPTargetIterateRight) const {
+  inline std::enable_if_t<Rank == 5> execute_tile(
+      const FunctorType& functor, const Policy& policy, pointer_type ptr,
+      OpenMPTargetIterateRight) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];
@@ -595,11 +596,11 @@ reduction(+:result)
                                                                  : functor) \
     reduction(custom                                                        \
               : result)
-              for (auto i0 = begin_0; i0 < end_0; ++i0) {
-            for (auto i1 = begin_1; i1 < end_1; ++i1) {
+      for (auto i0 = begin_0; i0 < end_0; ++i0) {
+        for (auto i1 = begin_1; i1 < end_1; ++i1) {
           for (auto i2 = begin_2; i2 < end_2; ++i2) {
-        for (auto i3 = begin_3; i3 < end_3; ++i3) {
-      for (auto i4 = begin_4; i4 < end_4; ++i4) {
+            for (auto i3 = begin_3; i3 < end_3; ++i3) {
+              for (auto i4 = begin_4; i4 < end_4; ++i4) {
                 if constexpr (std::is_same<typename Policy::work_tag,
                                            void>::value)
                   functor(i0, i1, i2, i3, i4, result);
@@ -614,11 +615,11 @@ reduction(+:result)
     } else {
 #pragma omp target teams distribute parallel for collapse(5) map(to : functor) \
 reduction(+:result)
-              for (auto i0 = begin_0; i0 < end_0; ++i0) {
-            for (auto i1 = begin_1; i1 < end_1; ++i1) {
+      for (auto i0 = begin_0; i0 < end_0; ++i0) {
+        for (auto i1 = begin_1; i1 < end_1; ++i1) {
           for (auto i2 = begin_2; i2 < end_2; ++i2) {
-        for (auto i3 = begin_3; i3 < end_3; ++i3) {
-      for (auto i4 = begin_4; i4 < end_4; ++i4) {
+            for (auto i3 = begin_3; i3 < end_3; ++i3) {
+              for (auto i4 = begin_4; i4 < end_4; ++i4) {
                 if constexpr (std::is_same<typename Policy::work_tag,
                                            void>::value)
                   functor(i0, i1, i2, i3, i4, result);
@@ -637,9 +638,9 @@ reduction(+:result)
   }
 
   template <int Rank, class ValueType>
-  inline std::enable_if_t<Rank == 6> execute_tile(const FunctorType& functor,
-                                                  const Policy& policy,
-                                                  pointer_type ptr, OpenMPTargetIterateRight) const {
+  inline std::enable_if_t<Rank == 6> execute_tile(
+      const FunctorType& functor, const Policy& policy, pointer_type ptr,
+      OpenMPTargetIterateRight) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];
@@ -668,12 +669,12 @@ reduction(+:result)
                                                                  : functor) \
     reduction(custom                                                        \
               : result)
-                for (auto i0 = begin_0; i0 < end_0; ++i0) {
-              for (auto i1 = begin_1; i1 < end_1; ++i1) {
-            for (auto i2 = begin_2; i2 < end_2; ++i2) {
-          for (auto i3 = begin_3; i3 < end_3; ++i3) {
-        for (auto i4 = begin_4; i4 < end_4; ++i4) {
-      for (auto i5 = begin_5; i5 < end_5; ++i5) {
+      for (auto i0 = begin_0; i0 < end_0; ++i0) {
+        for (auto i1 = begin_1; i1 < end_1; ++i1) {
+          for (auto i2 = begin_2; i2 < end_2; ++i2) {
+            for (auto i3 = begin_3; i3 < end_3; ++i3) {
+              for (auto i4 = begin_4; i4 < end_4; ++i4) {
+                for (auto i5 = begin_5; i5 < end_5; ++i5) {
                   if constexpr (std::is_same<typename Policy::work_tag,
                                              void>::value)
                     functor(i0, i1, i2, i3, i4, i5, result);
@@ -689,12 +690,12 @@ reduction(+:result)
     } else {
 #pragma omp target teams distribute parallel for collapse(6) map(to : functor) \
 reduction(+:result)
-                for (auto i0 = begin_0; i0 < end_0; ++i0) {
-              for (auto i1 = begin_1; i1 < end_1; ++i1) {
-            for (auto i2 = begin_2; i2 < end_2; ++i2) {
-          for (auto i3 = begin_3; i3 < end_3; ++i3) {
-        for (auto i4 = begin_4; i4 < end_4; ++i4) {
-      for (auto i5 = begin_5; i5 < end_5; ++i5) {
+      for (auto i0 = begin_0; i0 < end_0; ++i0) {
+        for (auto i1 = begin_1; i1 < end_1; ++i1) {
+          for (auto i2 = begin_2; i2 < end_2; ++i2) {
+            for (auto i3 = begin_3; i3 < end_3; ++i3) {
+              for (auto i4 = begin_4; i4 < end_4; ++i4) {
+                for (auto i5 = begin_5; i5 < end_5; ++i5) {
                   if constexpr (std::is_same<typename Policy::work_tag,
                                              void>::value)
                     functor(i0, i1, i2, i3, i4, i5, result);

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_MDRange.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_MDRange.hpp
@@ -20,7 +20,6 @@
 #include <omp.h>
 #include <Kokkos_Parallel.hpp>
 #include "Kokkos_OpenMPTarget_MDRangePolicy.hpp"
-#include <OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp>
 #include <OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp>
 
 //----------------------------------------------------------------------------

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_MDRange.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_MDRange.hpp
@@ -14,396 +14,14 @@
 //
 //@HEADER
 
-#ifndef KOKKOS_OPENMPTARGET_PARALLEL_MDRANGE_HPP
-#define KOKKOS_OPENMPTARGET_PARALLEL_MDRANGE_HPP
+#ifndef KOKKOS_OPENMPTARGET_PARALLELREDUCE_MDRANGE_HPP
+#define KOKKOS_OPENMPTARGET_PARALLELREDUCE_MDRANGE_HPP
 
 #include <omp.h>
 #include <Kokkos_Parallel.hpp>
+#include "Kokkos_OpenMPTarget_MDRangePolicy.hpp"
 #include <OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp>
 #include <OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp>
-
-// WORKAROUND OPENMPTARGET: sometimes tile sizes don't make it correctly,
-// this was tracked down to a bug in clang with regards of mapping structs
-// with arrays of long in it. Arrays of int might be fine though ...
-#define KOKKOS_IMPL_MDRANGE_USE_NO_TILES  // undef EOF
-
-//----------------------------------------------------------------------------
-//----------------------------------------------------------------------------
-
-namespace Kokkos {
-namespace Impl {
-
-template <class FunctorType, class... Traits>
-class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
-                  Kokkos::Experimental::OpenMPTarget> {
- private:
-  using Policy  = Kokkos::MDRangePolicy<Traits...>;
-  using WorkTag = typename Policy::work_tag;
-  using Member  = typename Policy::member_type;
-  using Index   = typename Policy::index_type;
-
-  const FunctorType m_functor;
-  const Policy m_policy;
-
- public:
-  inline void execute() const {
-    OpenMPTargetExec::verify_is_process(
-        "Kokkos::Experimental::OpenMPTarget parallel_for");
-    OpenMPTargetExec::verify_initialized(
-        "Kokkos::Experimental::OpenMPTarget parallel_for");
-    FunctorType functor(m_functor);
-    Policy policy = m_policy;
-
-#ifdef KOKKOS_IMPL_MDRANGE_USE_NO_TILES
-    typename Policy::point_type unused;
-
-    execute_tile<Policy::rank>(unused, functor, policy);
-#else
-    const int64_t begin = 0;
-    const int64_t end   = m_policy.m_num_tiles;
-
-#pragma omp target teams distribute map(to : functor) num_teams(end - begin)
-    {
-      for (ptrdiff_t tile_idx = begin; tile_idx < end; ++tile_idx) {
-
-#pragma omp parallel
-        {
-          typename Policy::point_type offset;
-          if (Policy::outer_direction == Policy::Left) {
-            for (int i = 0; i < Policy::rank; ++i) {
-              offset[i] = (tile_idx % policy.m_tile_end[i]) * policy.m_tile[i] +
-                          policy.m_lower[i];
-              tile_idx /= policy.m_tile_end[i];
-            }
-          } else {
-            for (int i = Policy::rank - 1; i >= 0; --i) {
-              offset[i] = (tile_idx % policy.m_tile_end[i]) * policy.m_tile[i] +
-                          policy.m_lower[i];
-              tile_idx /= policy.m_tile_end[i];
-            }
-          }
-          execute_tile<Policy::rank>(offset, functor, policy);
-        }
-      }
-    }
-#endif
-  }
-
-  template <int Rank>
-  inline std::enable_if_t<Rank == 2> execute_tile(
-      typename Policy::point_type offset, const FunctorType& functor,
-      const Policy& policy) const {
-#ifdef KOKKOS_IMPL_MDRANGE_USE_NO_TILES
-    (void)offset;
-    const Index begin_0 = policy.m_lower[0];
-    const Index begin_1 = policy.m_lower[1];
-
-    const Index end_0 = policy.m_upper[0];
-    const Index end_1 = policy.m_upper[1];
-
-#pragma omp target teams distribute parallel for collapse(2) map(to : functor)
-    for (auto i1 = begin_1; i1 < end_1; ++i1) {
-      for (auto i0 = begin_0; i0 < end_0; ++i0) {
-        if constexpr (std::is_void<typename Policy::work_tag>::value)
-          functor(i0, i1);
-        else
-          functor(typename Policy::work_tag(), i0, i1);
-      }
-    }
-#else
-    const ptrdiff_t begin_0 = offset[0];
-    ptrdiff_t end_0         = begin_0 + policy.m_tile[0];
-    end_0 = end_0 < policy.m_upper[0] ? end_0 : policy.m_upper[0];
-
-    const ptrdiff_t begin_1 = offset[1];
-    ptrdiff_t end_1         = begin_1 + policy.m_tile[1];
-    end_1 = end_1 < policy.m_upper[1] ? end_1 : policy.m_upper[1];
-
-#pragma omp for collapse(2)
-    for (ptrdiff_t i0 = begin_0; i0 < end_0; ++i0)
-      for (ptrdiff_t i1 = begin_1; i1 < end_1; ++i1) {
-        if constexpr (std::is_void<typename Policy::work_tag>::value)
-          functor(i0, i1);
-        else
-          functor(typename Policy::work_tag(), i0, i1);
-      }
-#endif
-  }
-
-  template <int Rank>
-  inline std::enable_if_t<Rank == 3> execute_tile(
-      typename Policy::point_type offset, const FunctorType& functor,
-      const Policy& policy) const {
-#ifdef KOKKOS_IMPL_MDRANGE_USE_NO_TILES
-    (void)offset;
-    const Index begin_0 = policy.m_lower[0];
-    const Index begin_1 = policy.m_lower[1];
-    const Index begin_2 = policy.m_lower[2];
-
-    const Index end_0 = policy.m_upper[0];
-    const Index end_1 = policy.m_upper[1];
-    const Index end_2 = policy.m_upper[2];
-
-#pragma omp target teams distribute parallel for collapse(3) map(to : functor)
-    for (auto i2 = begin_2; i2 < end_2; ++i2) {
-      for (auto i1 = begin_1; i1 < end_1; ++i1) {
-        for (auto i0 = begin_0; i0 < end_0; ++i0) {
-          if constexpr (std::is_void<typename Policy::work_tag>::value)
-            functor(i0, i1, i2);
-          else
-            functor(typename Policy::work_tag(), i0, i1, i2);
-        }
-      }
-    }
-#else
-    const ptrdiff_t begin_0 = offset[0];
-    ptrdiff_t end_0         = begin_0 + policy.m_tile[0];
-    end_0 = end_0 < policy.m_upper[0] ? end_0 : policy.m_upper[0];
-
-    const ptrdiff_t begin_1 = offset[1];
-    ptrdiff_t end_1         = begin_1 + policy.m_tile[1];
-    end_1 = end_1 < policy.m_upper[1] ? end_1 : policy.m_upper[1];
-
-    const ptrdiff_t begin_2 = offset[2];
-    ptrdiff_t end_2         = begin_2 + policy.m_tile[2];
-    end_2 = end_2 < policy.m_upper[2] ? end_2 : policy.m_upper[2];
-
-#pragma omp target teams distribute parallel for collapse(3) map(to : functor)
-    for (ptrdiff_t i0 = begin_0; i0 < end_0; ++i0)
-      for (ptrdiff_t i1 = begin_1; i1 < end_1; ++i1)
-        for (ptrdiff_t i2 = begin_2; i2 < end_2; ++i2) {
-          if constexpr (std::is_void<typename Policy::work_tag>::value)
-            functor(i0, i1, i2);
-          else
-            functor(typename Policy::work_tag(), i0, i1, i2);
-        }
-#endif
-  }
-
-  template <int Rank>
-  inline std::enable_if_t<Rank == 4> execute_tile(
-      typename Policy::point_type offset, const FunctorType& functor,
-      const Policy& policy) const {
-#ifdef KOKKOS_IMPL_MDRANGE_USE_NO_TILES
-    (void)offset;
-    const Index begin_0 = policy.m_lower[0];
-    const Index begin_1 = policy.m_lower[1];
-    const Index begin_2 = policy.m_lower[2];
-    const Index begin_3 = policy.m_lower[3];
-
-    const Index end_0 = policy.m_upper[0];
-    const Index end_1 = policy.m_upper[1];
-    const Index end_2 = policy.m_upper[2];
-    const Index end_3 = policy.m_upper[3];
-
-#pragma omp target teams distribute parallel for collapse(4) map(to : functor)
-    for (auto i3 = begin_3; i3 < end_3; ++i3) {
-      for (auto i2 = begin_2; i2 < end_2; ++i2) {
-        for (auto i1 = begin_1; i1 < end_1; ++i1) {
-          for (auto i0 = begin_0; i0 < end_0; ++i0) {
-            if constexpr (std::is_void<typename Policy::work_tag>::value)
-              functor(i0, i1, i2, i3);
-            else
-              functor(typename Policy::work_tag(), i0, i1, i2, i3);
-          }
-        }
-      }
-    }
-#else
-    const ptrdiff_t begin_0 = offset[0];
-    ptrdiff_t end_0         = begin_0 + policy.m_tile[0];
-    end_0 = end_0 < policy.m_upper[0] ? end_0 : policy.m_upper[0];
-
-    const ptrdiff_t begin_1 = offset[1];
-    ptrdiff_t end_1         = begin_1 + policy.m_tile[1];
-    end_1 = end_1 < policy.m_upper[1] ? end_1 : policy.m_upper[1];
-
-    const ptrdiff_t begin_2 = offset[2];
-    ptrdiff_t end_2         = begin_2 + policy.m_tile[2];
-    end_2 = end_2 < policy.m_upper[2] ? end_2 : policy.m_upper[2];
-
-    const ptrdiff_t begin_3 = offset[3];
-    ptrdiff_t end_3         = begin_3 + policy.m_tile[3];
-    end_3 = end_3 < policy.m_upper[3] ? end_3 : policy.m_upper[3];
-
-#pragma omp for collapse(4)
-    for (ptrdiff_t i0 = begin_0; i0 < end_0; ++i0)
-      for (ptrdiff_t i1 = begin_1; i1 < end_1; ++i1)
-        for (ptrdiff_t i2 = begin_2; i2 < end_2; ++i2)
-          for (ptrdiff_t i3 = begin_3; i3 < end_3; ++i3) {
-            if constexpr (std::is_void<typename Policy::work_tag>::value)
-              functor(i0, i1, i2, i3);
-            else
-              functor(typename Policy::work_tag(), i0, i1, i2, i3);
-          }
-#endif
-  }
-
-  template <int Rank>
-  inline std::enable_if_t<Rank == 5> execute_tile(
-      typename Policy::point_type offset, const FunctorType& functor,
-      const Policy& policy) const {
-#ifdef KOKKOS_IMPL_MDRANGE_USE_NO_TILES
-    (void)offset;
-    const Index begin_0 = policy.m_lower[0];
-    const Index begin_1 = policy.m_lower[1];
-    const Index begin_2 = policy.m_lower[2];
-    const Index begin_3 = policy.m_lower[3];
-    const Index begin_4 = policy.m_lower[4];
-
-    const Index end_0 = policy.m_upper[0];
-    const Index end_1 = policy.m_upper[1];
-    const Index end_2 = policy.m_upper[2];
-    const Index end_3 = policy.m_upper[3];
-    const Index end_4 = policy.m_upper[4];
-
-#pragma omp target teams distribute parallel for collapse(5) map(to : functor)
-    for (auto i4 = begin_4; i4 < end_4; ++i4) {
-      for (auto i3 = begin_3; i3 < end_3; ++i3) {
-        for (auto i2 = begin_2; i2 < end_2; ++i2) {
-          for (auto i1 = begin_1; i1 < end_1; ++i1) {
-            for (auto i0 = begin_0; i0 < end_0; ++i0) {
-              if constexpr (std::is_same<typename Policy::work_tag,
-                                         void>::value)
-                functor(i0, i1, i2, i3, i4);
-              else
-                functor(typename Policy::work_tag(), i0, i1, i2, i3, i4);
-            }
-          }
-        }
-      }
-    }
-#else
-    const ptrdiff_t begin_0 = offset[0];
-    ptrdiff_t end_0         = begin_0 + policy.m_tile[0];
-    end_0 = end_0 < policy.m_upper[0] ? end_0 : policy.m_upper[0];
-
-    const ptrdiff_t begin_1 = offset[1];
-    ptrdiff_t end_1         = begin_1 + policy.m_tile[1];
-    end_1 = end_1 < policy.m_upper[1] ? end_1 : policy.m_upper[1];
-
-    const ptrdiff_t begin_2 = offset[2];
-    ptrdiff_t end_2         = begin_2 + policy.m_tile[2];
-    end_2 = end_2 < policy.m_upper[2] ? end_2 : policy.m_upper[2];
-
-    const ptrdiff_t begin_3 = offset[3];
-    ptrdiff_t end_3         = begin_3 + policy.m_tile[3];
-    end_3 = end_3 < policy.m_upper[3] ? end_3 : policy.m_upper[3];
-
-    const ptrdiff_t begin_4 = offset[4];
-    ptrdiff_t end_4         = begin_4 + policy.m_tile[4];
-    end_4 = end_4 < policy.m_upper[4] ? end_4 : policy.m_upper[4];
-
-#pragma omp for collapse(5)
-    for (ptrdiff_t i0 = begin_0; i0 < end_0; ++i0)
-      for (ptrdiff_t i1 = begin_1; i1 < end_1; ++i1)
-        for (ptrdiff_t i2 = begin_2; i2 < end_2; ++i2)
-          for (ptrdiff_t i3 = begin_3; i3 < end_3; ++i3)
-            for (ptrdiff_t i4 = begin_4; i4 < end_4; ++i4) {
-              if constexpr (std::is_same<typename Policy::work_tag,
-                                         void>::value)
-                functor(i0, i1, i2, i3, i4);
-              else
-                functor(typename Policy::work_tag(), i0, i1, i2, i3, i4);
-            }
-#endif
-  }
-
-  template <int Rank>
-  inline std::enable_if_t<Rank == 6> execute_tile(
-      typename Policy::point_type offset, const FunctorType& functor,
-      const Policy& policy) const {
-#ifdef KOKKOS_IMPL_MDRANGE_USE_NO_TILES
-    (void)offset;
-    const Index begin_0 = policy.m_lower[0];
-    const Index begin_1 = policy.m_lower[1];
-    const Index begin_2 = policy.m_lower[2];
-    const Index begin_3 = policy.m_lower[3];
-    const Index begin_4 = policy.m_lower[4];
-    const Index begin_5 = policy.m_lower[5];
-
-    const Index end_0 = policy.m_upper[0];
-    const Index end_1 = policy.m_upper[1];
-    const Index end_2 = policy.m_upper[2];
-    const Index end_3 = policy.m_upper[3];
-    const Index end_4 = policy.m_upper[4];
-    const Index end_5 = policy.m_upper[5];
-
-#pragma omp target teams distribute parallel for collapse(6) map(to : functor)
-    for (auto i5 = begin_5; i5 < end_5; ++i5) {
-      for (auto i4 = begin_4; i4 < end_4; ++i4) {
-        for (auto i3 = begin_3; i3 < end_3; ++i3) {
-          for (auto i2 = begin_2; i2 < end_2; ++i2) {
-            for (auto i1 = begin_1; i1 < end_1; ++i1) {
-              for (auto i0 = begin_0; i0 < end_0; ++i0) {
-                {
-                  if constexpr (std::is_same<typename Policy::work_tag,
-                                             void>::value)
-                    functor(i0, i1, i2, i3, i4, i5);
-                  else
-                    functor(typename Policy::work_tag(), i0, i1, i2, i3, i4,
-                            i5);
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-#else
-    const ptrdiff_t begin_0 = offset[0];
-    ptrdiff_t end_0         = begin_0 + policy.m_tile[0];
-    end_0 = end_0 < policy.m_upper[0] ? end_0 : policy.m_upper[0];
-
-    const ptrdiff_t begin_1 = offset[1];
-    ptrdiff_t end_1         = begin_1 + policy.m_tile[1];
-    end_1 = end_1 < policy.m_upper[1] ? end_1 : policy.m_upper[1];
-
-    const ptrdiff_t begin_2 = offset[2];
-    ptrdiff_t end_2         = begin_2 + policy.m_tile[2];
-    end_2 = end_2 < policy.m_upper[2] ? end_2 : policy.m_upper[2];
-
-    const ptrdiff_t begin_3 = offset[3];
-    ptrdiff_t end_3         = begin_3 + policy.m_tile[3];
-    end_3 = end_3 < policy.m_upper[3] ? end_3 : policy.m_upper[3];
-
-    const ptrdiff_t begin_4 = offset[4];
-    ptrdiff_t end_4         = begin_4 + policy.m_tile[4];
-    end_4 = end_4 < policy.m_upper[4] ? end_4 : policy.m_upper[4];
-
-    const ptrdiff_t begin_5 = offset[5];
-    ptrdiff_t end_5         = begin_5 + policy.m_tile[5];
-    end_5 = end_5 < policy.m_upper[5] ? end_5 : policy.m_upper[5];
-
-#pragma omp for collapse(6)
-    for (ptrdiff_t i0 = begin_0; i0 < end_0; ++i0)
-      for (ptrdiff_t i1 = begin_1; i1 < end_1; ++i1)
-        for (ptrdiff_t i2 = begin_2; i2 < end_2; ++i2)
-          for (ptrdiff_t i3 = begin_3; i3 < end_3; ++i3)
-            for (ptrdiff_t i4 = begin_4; i4 < end_4; ++i4)
-              for (ptrdiff_t i5 = begin_5; i5 < end_5; ++i5) {
-                if constexpr (std::is_same<typename Policy::work_tag,
-                                           void>::value)
-                  functor(i0, i1, i2, i3, i4, i5);
-                else
-                  functor(typename Policy::work_tag(), i0, i1, i2, i3, i4, i5);
-              }
-#endif
-  }
-
-  inline ParallelFor(const FunctorType& arg_functor, Policy arg_policy)
-      : m_functor(arg_functor), m_policy(arg_policy) {}
-  // TODO DZP: based on a conversation with Christian, we're using 256 as a
-  // heuristic here. We need something better once we can query these kinds of
-  // properties
-  template <typename Policy, typename Functor>
-  static int max_tile_size_product(const Policy&, const Functor&) {
-    return 256;
-  }
-};
-
-}  // namespace Impl
-}  // namespace Kokkos
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -445,7 +63,7 @@ class ParallelReduce<CombinedFunctorReducerType,
  public:
   inline void execute() const {
     execute_tile<Policy::rank, typename ReducerType::value_type>(
-        m_functor_reducer.get_functor(), m_policy, m_result_ptr);
+        m_functor_reducer.get_functor(), m_policy, m_result_ptr, std::integral_constant<Iterate, Policy::inner_direction>());
   }
 
   template <class ViewType>
@@ -462,7 +80,7 @@ class ParallelReduce<CombinedFunctorReducerType,
   template <int Rank, class ValueType>
   inline std::enable_if_t<Rank == 2> execute_tile(const FunctorType& functor,
                                                   const Policy& policy,
-                                                  pointer_type ptr) const {
+                                                  pointer_type ptr, OpenMPTargetIterateLeft) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
 
@@ -511,7 +129,7 @@ reduction(+:result)
   template <int Rank, class ValueType>
   inline std::enable_if_t<Rank == 3> execute_tile(const FunctorType& functor,
                                                   const Policy& policy,
-                                                  pointer_type ptr) const {
+                                                  pointer_type ptr, OpenMPTargetIterateLeft) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];
@@ -569,7 +187,7 @@ reduction(+:result)
   template <int Rank, class ValueType>
   inline std::enable_if_t<Rank == 4> execute_tile(const FunctorType& functor,
                                                   const Policy& policy,
-                                                  pointer_type ptr) const {
+                                                  pointer_type ptr, OpenMPTargetIterateLeft) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[3];
@@ -632,7 +250,7 @@ reduction(+:result)
   template <int Rank, class ValueType>
   inline std::enable_if_t<Rank == 5> execute_tile(const FunctorType& functor,
                                                   const Policy& policy,
-                                                  pointer_type ptr) const {
+                                                  pointer_type ptr, OpenMPTargetIterateLeft) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];
@@ -703,7 +321,7 @@ reduction(+:result)
   template <int Rank, class ValueType>
   inline std::enable_if_t<Rank == 6> execute_tile(const FunctorType& functor,
                                                   const Policy& policy,
-                                                  pointer_type ptr) const {
+                                                  pointer_type ptr, OpenMPTargetIterateLeft) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];
@@ -777,6 +395,324 @@ reduction(+:result)
                                  m_result_ptr_on_device);
   }
 
+  template <int Rank, class ValueType>
+  inline std::enable_if_t<Rank == 2> execute_tile(const FunctorType& functor,
+                                                  const Policy& policy,
+                                                  pointer_type ptr, OpenMPTargetIterateRight) const {
+    const Index begin_0 = policy.m_lower[0];
+    const Index begin_1 = policy.m_lower[1];
+
+    const Index end_0 = policy.m_upper[0];
+    const Index end_1 = policy.m_upper[1];
+
+    ValueType result = ValueType();
+
+    // FIXME_OPENMPTARGET: Unable to separate directives and their companion
+    // loops which leads to code duplication for different reduction types.
+    if constexpr (UseReducer) {
+#pragma omp declare reduction(                                         \
+    custom:ValueType                                                   \
+    : OpenMPTargetReducerWrapper <ReducerType>::join(omp_out, omp_in)) \
+    initializer(OpenMPTargetReducerWrapper <ReducerType>::init(omp_priv))
+
+#pragma omp target teams distribute parallel for collapse(2) map(to         \
+                                                                 : functor) \
+    reduction(custom                                                        \
+              : result)
+        for (auto i0 = begin_0; i0 < end_0; ++i0) {
+      for (auto i1 = begin_1; i1 < end_1; ++i1) {
+          if constexpr (std::is_void<typename Policy::work_tag>::value)
+            functor(i0, i1, result);
+          else
+            functor(typename Policy::work_tag(), i0, i1, result);
+        }
+      }
+    } else {
+#pragma omp target teams distribute parallel for collapse(2) map(to : functor) \
+reduction(+:result)
+        for (auto i0 = begin_0; i0 < end_0; ++i0) {
+      for (auto i1 = begin_1; i1 < end_1; ++i1) {
+          if constexpr (std::is_void<typename Policy::work_tag>::value)
+            functor(i0, i1, result);
+          else
+            functor(typename Policy::work_tag(), i0, i1, result);
+        }
+      }
+    }
+
+    ParReduceCopy::memcpy_result(ptr, &result, sizeof(ValueType),
+                                 m_result_ptr_on_device);
+  }
+
+  template <int Rank, class ValueType>
+  inline std::enable_if_t<Rank == 3> execute_tile(const FunctorType& functor,
+                                                  const Policy& policy,
+                                                  pointer_type ptr, OpenMPTargetIterateRight) const {
+    const Index begin_0 = policy.m_lower[0];
+    const Index begin_1 = policy.m_lower[1];
+    const Index begin_2 = policy.m_lower[2];
+
+    const Index end_0 = policy.m_upper[0];
+    const Index end_1 = policy.m_upper[1];
+    const Index end_2 = policy.m_upper[2];
+
+    ValueType result = ValueType();
+
+    // FIXME_OPENMPTARGET: Unable to separate directives and their companion
+    // loops which leads to code duplication for different reduction types.
+    if constexpr (UseReducer) {
+#pragma omp declare reduction(                                                 \
+    custom:ValueType                                                           \
+    : OpenMPTargetReducerWrapper <typename ReducerType::functor_type>::join(   \
+        omp_out, omp_in))                                                      \
+    initializer(                                                               \
+        OpenMPTargetReducerWrapper <typename ReducerType::functor_type>::init( \
+            omp_priv))
+
+#pragma omp target teams distribute parallel for collapse(3) map(to         \
+                                                                 : functor) \
+    reduction(custom                                                        \
+              : result)
+          for (auto i0 = begin_0; i0 < end_0; ++i0) {
+        for (auto i1 = begin_1; i1 < end_1; ++i1) {
+      for (auto i2 = begin_2; i2 < end_2; ++i2) {
+            if constexpr (std::is_void<typename Policy::work_tag>::value)
+              functor(i0, i1, i2, result);
+            else
+              functor(typename Policy::work_tag(), i0, i1, i2, result);
+          }
+        }
+      }
+    } else {
+#pragma omp target teams distribute parallel for collapse(3) map(to : functor) \
+reduction(+:result)
+          for (auto i0 = begin_0; i0 < end_0; ++i0) {
+        for (auto i1 = begin_1; i1 < end_1; ++i1) {
+      for (auto i2 = begin_2; i2 < end_2; ++i2) {
+            if constexpr (std::is_void<typename Policy::work_tag>::value)
+              functor(i0, i1, i2, result);
+            else
+              functor(typename Policy::work_tag(), i0, i1, i2, result);
+          }
+        }
+      }
+    }
+
+    ParReduceCopy::memcpy_result(ptr, &result, sizeof(ValueType),
+                                 m_result_ptr_on_device);
+  }
+
+  template <int Rank, class ValueType>
+  inline std::enable_if_t<Rank == 4> execute_tile(const FunctorType& functor,
+                                                  const Policy& policy,
+                                                  pointer_type ptr, OpenMPTargetIterateRight) const {
+    const Index begin_0 = policy.m_lower[0];
+    const Index begin_1 = policy.m_lower[1];
+    const Index begin_2 = policy.m_lower[3];
+    const Index begin_3 = policy.m_lower[2];
+
+    const Index end_0 = policy.m_upper[0];
+    const Index end_1 = policy.m_upper[1];
+    const Index end_2 = policy.m_upper[2];
+    const Index end_3 = policy.m_upper[3];
+
+    ValueType result = ValueType();
+
+    // FIXME_OPENMPTARGET: Unable to separate directives and their companion
+    // loops which leads to code duplication for different reduction types.
+    if constexpr (UseReducer) {
+#pragma omp declare reduction(                                         \
+    custom:ValueType                                                   \
+    : OpenMPTargetReducerWrapper <ReducerType>::join(omp_out, omp_in)) \
+    initializer(OpenMPTargetReducerWrapper <ReducerType>::init(omp_priv))
+
+#pragma omp target teams distribute parallel for collapse(4) map(to         \
+                                                                 : functor) \
+    reduction(custom                                                        \
+              : result)
+            for (auto i0 = begin_0; i0 < end_0; ++i0) {
+          for (auto i1 = begin_1; i1 < end_1; ++i1) {
+        for (auto i2 = begin_2; i2 < end_2; ++i2) {
+      for (auto i3 = begin_3; i3 < end_3; ++i3) {
+              if constexpr (std::is_same<typename Policy::work_tag,
+                                         void>::value)
+                functor(i0, i1, i2, i3, result);
+              else
+                functor(typename Policy::work_tag(), i0, i1, i2, i3, result);
+            }
+          }
+        }
+      }
+    } else {
+#pragma omp target teams distribute parallel for collapse(4) map(to : functor) \
+reduction(+:result)
+            for (auto i0 = begin_0; i0 < end_0; ++i0) {
+          for (auto i1 = begin_1; i1 < end_1; ++i1) {
+        for (auto i2 = begin_2; i2 < end_2; ++i2) {
+      for (auto i3 = begin_3; i3 < end_3; ++i3) {
+              if constexpr (std::is_same<typename Policy::work_tag,
+                                         void>::value)
+                functor(i0, i1, i2, i3, result);
+              else
+                functor(typename Policy::work_tag(), i0, i1, i2, i3, result);
+            }
+          }
+        }
+      }
+    }
+
+    ParReduceCopy::memcpy_result(ptr, &result, sizeof(ValueType),
+                                 m_result_ptr_on_device);
+  }
+
+  template <int Rank, class ValueType>
+  inline std::enable_if_t<Rank == 5> execute_tile(const FunctorType& functor,
+                                                  const Policy& policy,
+                                                  pointer_type ptr, OpenMPTargetIterateRight) const {
+    const Index begin_0 = policy.m_lower[0];
+    const Index begin_1 = policy.m_lower[1];
+    const Index begin_2 = policy.m_lower[2];
+    const Index begin_3 = policy.m_lower[3];
+    const Index begin_4 = policy.m_lower[4];
+
+    const Index end_0 = policy.m_upper[0];
+    const Index end_1 = policy.m_upper[1];
+    const Index end_2 = policy.m_upper[2];
+    const Index end_3 = policy.m_upper[3];
+    const Index end_4 = policy.m_upper[4];
+
+    ValueType result = ValueType();
+
+    // FIXME_OPENMPTARGET: Unable to separate directives and their companion
+    // loops which leads to code duplication for different reduction types.
+    if constexpr (UseReducer) {
+#pragma omp declare reduction(                                         \
+    custom:ValueType                                                   \
+    : OpenMPTargetReducerWrapper <ReducerType>::join(omp_out, omp_in)) \
+    initializer(OpenMPTargetReducerWrapper <ReducerType>::init(omp_priv))
+
+#pragma omp target teams distribute parallel for collapse(5) map(to         \
+                                                                 : functor) \
+    reduction(custom                                                        \
+              : result)
+              for (auto i0 = begin_0; i0 < end_0; ++i0) {
+            for (auto i1 = begin_1; i1 < end_1; ++i1) {
+          for (auto i2 = begin_2; i2 < end_2; ++i2) {
+        for (auto i3 = begin_3; i3 < end_3; ++i3) {
+      for (auto i4 = begin_4; i4 < end_4; ++i4) {
+                if constexpr (std::is_same<typename Policy::work_tag,
+                                           void>::value)
+                  functor(i0, i1, i2, i3, i4, result);
+                else
+                  functor(typename Policy::work_tag(), i0, i1, i2, i3, i4,
+                          result);
+              }
+            }
+          }
+        }
+      }
+    } else {
+#pragma omp target teams distribute parallel for collapse(5) map(to : functor) \
+reduction(+:result)
+              for (auto i0 = begin_0; i0 < end_0; ++i0) {
+            for (auto i1 = begin_1; i1 < end_1; ++i1) {
+          for (auto i2 = begin_2; i2 < end_2; ++i2) {
+        for (auto i3 = begin_3; i3 < end_3; ++i3) {
+      for (auto i4 = begin_4; i4 < end_4; ++i4) {
+                if constexpr (std::is_same<typename Policy::work_tag,
+                                           void>::value)
+                  functor(i0, i1, i2, i3, i4, result);
+                else
+                  functor(typename Policy::work_tag(), i0, i1, i2, i3, i4,
+                          result);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    ParReduceCopy::memcpy_result(ptr, &result, sizeof(ValueType),
+                                 m_result_ptr_on_device);
+  }
+
+  template <int Rank, class ValueType>
+  inline std::enable_if_t<Rank == 6> execute_tile(const FunctorType& functor,
+                                                  const Policy& policy,
+                                                  pointer_type ptr, OpenMPTargetIterateRight) const {
+    const Index begin_0 = policy.m_lower[0];
+    const Index begin_1 = policy.m_lower[1];
+    const Index begin_2 = policy.m_lower[2];
+    const Index begin_3 = policy.m_lower[3];
+    const Index begin_4 = policy.m_lower[4];
+    const Index begin_5 = policy.m_lower[5];
+
+    const Index end_0 = policy.m_upper[0];
+    const Index end_1 = policy.m_upper[1];
+    const Index end_2 = policy.m_upper[2];
+    const Index end_3 = policy.m_upper[3];
+    const Index end_4 = policy.m_upper[4];
+    const Index end_5 = policy.m_upper[5];
+
+    ValueType result = ValueType();
+
+    // FIXME_OPENMPTARGET: Unable to separate directives and their companion
+    // loops which leads to code duplication for different reduction types.
+    if constexpr (UseReducer) {
+#pragma omp declare reduction(                                         \
+    custom:ValueType                                                   \
+    : OpenMPTargetReducerWrapper <ReducerType>::join(omp_out, omp_in)) \
+    initializer(OpenMPTargetReducerWrapper <ReducerType>::init(omp_priv))
+
+#pragma omp target teams distribute parallel for collapse(6) map(to         \
+                                                                 : functor) \
+    reduction(custom                                                        \
+              : result)
+                for (auto i0 = begin_0; i0 < end_0; ++i0) {
+              for (auto i1 = begin_1; i1 < end_1; ++i1) {
+            for (auto i2 = begin_2; i2 < end_2; ++i2) {
+          for (auto i3 = begin_3; i3 < end_3; ++i3) {
+        for (auto i4 = begin_4; i4 < end_4; ++i4) {
+      for (auto i5 = begin_5; i5 < end_5; ++i5) {
+                  if constexpr (std::is_same<typename Policy::work_tag,
+                                             void>::value)
+                    functor(i0, i1, i2, i3, i4, i5, result);
+                  else
+                    functor(typename Policy::work_tag(), i0, i1, i2, i3, i4, i5,
+                            result);
+                }
+              }
+            }
+          }
+        }
+      }
+    } else {
+#pragma omp target teams distribute parallel for collapse(6) map(to : functor) \
+reduction(+:result)
+                for (auto i0 = begin_0; i0 < end_0; ++i0) {
+              for (auto i1 = begin_1; i1 < end_1; ++i1) {
+            for (auto i2 = begin_2; i2 < end_2; ++i2) {
+          for (auto i3 = begin_3; i3 < end_3; ++i3) {
+        for (auto i4 = begin_4; i4 < end_4; ++i4) {
+      for (auto i5 = begin_5; i5 < end_5; ++i5) {
+                  if constexpr (std::is_same<typename Policy::work_tag,
+                                             void>::value)
+                    functor(i0, i1, i2, i3, i4, i5, result);
+                  else
+                    functor(typename Policy::work_tag(), i0, i1, i2, i3, i4, i5,
+                            result);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    ParReduceCopy::memcpy_result(ptr, &result, sizeof(ValueType),
+                                 m_result_ptr_on_device);
+  }
+
   template <typename Policy, typename Functor>
   static int max_tile_size_product(const Policy&, const Functor&) {
     return 256;
@@ -788,5 +724,4 @@ reduction(+:result)
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
-#undef KOKKOS_IMPL_MDRANGE_USE_NO_TILES
-#endif /* KOKKOS_OPENMPTARGET_PARALLEL_HPP */
+#endif /* KOKKOS_OPENMPTARGET_PARALLELREDUCE_MDRANGE_HPP */

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_MDRange.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_MDRange.hpp
@@ -102,8 +102,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     const Index end_1 = policy.m_upper[1];
 
 #pragma omp target teams distribute parallel for collapse(2) map(to : functor)
-    for (auto i0 = begin_0; i0 < end_0; ++i0) {
-      for (auto i1 = begin_1; i1 < end_1; ++i1) {
+    for (auto i1 = begin_1; i1 < end_1; ++i1) {
+      for (auto i0 = begin_0; i0 < end_0; ++i0) {
         if constexpr (std::is_void<typename Policy::work_tag>::value)
           functor(i0, i1);
         else
@@ -145,9 +145,9 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     const Index end_2 = policy.m_upper[2];
 
 #pragma omp target teams distribute parallel for collapse(3) map(to : functor)
-    for (auto i0 = begin_0; i0 < end_0; ++i0) {
+    for (auto i2 = begin_2; i2 < end_2; ++i2) {
       for (auto i1 = begin_1; i1 < end_1; ++i1) {
-        for (auto i2 = begin_2; i2 < end_2; ++i2) {
+        for (auto i0 = begin_0; i0 < end_0; ++i0) {
           if constexpr (std::is_void<typename Policy::work_tag>::value)
             functor(i0, i1, i2);
           else
@@ -168,7 +168,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     ptrdiff_t end_2         = begin_2 + policy.m_tile[2];
     end_2 = end_2 < policy.m_upper[2] ? end_2 : policy.m_upper[2];
 
-#pragma omp for collapse(3)
+#pragma omp target teams distribute parallel for collapse(3) map(to : functor)
     for (ptrdiff_t i0 = begin_0; i0 < end_0; ++i0)
       for (ptrdiff_t i1 = begin_1; i1 < end_1; ++i1)
         for (ptrdiff_t i2 = begin_2; i2 < end_2; ++i2) {
@@ -197,10 +197,10 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     const Index end_3 = policy.m_upper[3];
 
 #pragma omp target teams distribute parallel for collapse(4) map(to : functor)
-    for (auto i0 = begin_0; i0 < end_0; ++i0) {
-      for (auto i1 = begin_1; i1 < end_1; ++i1) {
-        for (auto i2 = begin_2; i2 < end_2; ++i2) {
-          for (auto i3 = begin_3; i3 < end_3; ++i3) {
+    for (auto i3 = begin_3; i3 < end_3; ++i3) {
+      for (auto i2 = begin_2; i2 < end_2; ++i2) {
+        for (auto i1 = begin_1; i1 < end_1; ++i1) {
+          for (auto i0 = begin_0; i0 < end_0; ++i0) {
             if constexpr (std::is_void<typename Policy::work_tag>::value)
               functor(i0, i1, i2, i3);
             else
@@ -258,11 +258,11 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     const Index end_4 = policy.m_upper[4];
 
 #pragma omp target teams distribute parallel for collapse(5) map(to : functor)
-    for (auto i0 = begin_0; i0 < end_0; ++i0) {
-      for (auto i1 = begin_1; i1 < end_1; ++i1) {
+    for (auto i4 = begin_4; i4 < end_4; ++i4) {
+      for (auto i3 = begin_3; i3 < end_3; ++i3) {
         for (auto i2 = begin_2; i2 < end_2; ++i2) {
-          for (auto i3 = begin_3; i3 < end_3; ++i3) {
-            for (auto i4 = begin_4; i4 < end_4; ++i4) {
+          for (auto i1 = begin_1; i1 < end_1; ++i1) {
+            for (auto i0 = begin_0; i0 < end_0; ++i0) {
               if constexpr (std::is_same<typename Policy::work_tag,
                                          void>::value)
                 functor(i0, i1, i2, i3, i4);
@@ -330,12 +330,12 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     const Index end_5 = policy.m_upper[5];
 
 #pragma omp target teams distribute parallel for collapse(6) map(to : functor)
-    for (auto i0 = begin_0; i0 < end_0; ++i0) {
-      for (auto i1 = begin_1; i1 < end_1; ++i1) {
-        for (auto i2 = begin_2; i2 < end_2; ++i2) {
-          for (auto i3 = begin_3; i3 < end_3; ++i3) {
-            for (auto i4 = begin_4; i4 < end_4; ++i4) {
-              for (auto i5 = begin_5; i5 < end_5; ++i5) {
+    for (auto i5 = begin_5; i5 < end_5; ++i5) {
+      for (auto i4 = begin_4; i4 < end_4; ++i4) {
+        for (auto i3 = begin_3; i3 < end_3; ++i3) {
+          for (auto i2 = begin_2; i2 < end_2; ++i2) {
+            for (auto i1 = begin_1; i1 < end_1; ++i1) {
+              for (auto i0 = begin_0; i0 < end_0; ++i0) {
                 {
                   if constexpr (std::is_same<typename Policy::work_tag,
                                              void>::value)
@@ -483,8 +483,8 @@ class ParallelReduce<CombinedFunctorReducerType,
                                                                  : functor) \
     reduction(custom                                                        \
               : result)
-      for (auto i0 = begin_0; i0 < end_0; ++i0) {
-        for (auto i1 = begin_1; i1 < end_1; ++i1) {
+      for (auto i1 = begin_1; i1 < end_1; ++i1) {
+        for (auto i0 = begin_0; i0 < end_0; ++i0) {
           if constexpr (std::is_void<typename Policy::work_tag>::value)
             functor(i0, i1, result);
           else
@@ -494,8 +494,8 @@ class ParallelReduce<CombinedFunctorReducerType,
     } else {
 #pragma omp target teams distribute parallel for collapse(2) map(to : functor) \
 reduction(+:result)
-      for (auto i0 = begin_0; i0 < end_0; ++i0) {
-        for (auto i1 = begin_1; i1 < end_1; ++i1) {
+      for (auto i1 = begin_1; i1 < end_1; ++i1) {
+        for (auto i0 = begin_0; i0 < end_0; ++i0) {
           if constexpr (std::is_void<typename Policy::work_tag>::value)
             functor(i0, i1, result);
           else
@@ -537,9 +537,9 @@ reduction(+:result)
                                                                  : functor) \
     reduction(custom                                                        \
               : result)
-      for (auto i0 = begin_0; i0 < end_0; ++i0) {
+      for (auto i2 = begin_2; i2 < end_2; ++i2) {
         for (auto i1 = begin_1; i1 < end_1; ++i1) {
-          for (auto i2 = begin_2; i2 < end_2; ++i2) {
+          for (auto i0 = begin_0; i0 < end_0; ++i0) {
             if constexpr (std::is_void<typename Policy::work_tag>::value)
               functor(i0, i1, i2, result);
             else
@@ -550,9 +550,9 @@ reduction(+:result)
     } else {
 #pragma omp target teams distribute parallel for collapse(3) map(to : functor) \
 reduction(+:result)
-      for (auto i0 = begin_0; i0 < end_0; ++i0) {
+      for (auto i2 = begin_2; i2 < end_2; ++i2) {
         for (auto i1 = begin_1; i1 < end_1; ++i1) {
-          for (auto i2 = begin_2; i2 < end_2; ++i2) {
+          for (auto i0 = begin_0; i0 < end_0; ++i0) {
             if constexpr (std::is_void<typename Policy::work_tag>::value)
               functor(i0, i1, i2, result);
             else
@@ -594,10 +594,10 @@ reduction(+:result)
                                                                  : functor) \
     reduction(custom                                                        \
               : result)
-      for (auto i0 = begin_0; i0 < end_0; ++i0) {
-        for (auto i1 = begin_1; i1 < end_1; ++i1) {
-          for (auto i2 = begin_2; i2 < end_2; ++i2) {
-            for (auto i3 = begin_3; i3 < end_3; ++i3) {
+      for (auto i3 = begin_3; i3 < end_3; ++i3) {
+        for (auto i2 = begin_2; i2 < end_2; ++i2) {
+          for (auto i1 = begin_1; i1 < end_1; ++i1) {
+            for (auto i0 = begin_0; i0 < end_0; ++i0) {
               if constexpr (std::is_same<typename Policy::work_tag,
                                          void>::value)
                 functor(i0, i1, i2, i3, result);
@@ -610,10 +610,10 @@ reduction(+:result)
     } else {
 #pragma omp target teams distribute parallel for collapse(4) map(to : functor) \
 reduction(+:result)
-      for (auto i0 = begin_0; i0 < end_0; ++i0) {
-        for (auto i1 = begin_1; i1 < end_1; ++i1) {
-          for (auto i2 = begin_2; i2 < end_2; ++i2) {
-            for (auto i3 = begin_3; i3 < end_3; ++i3) {
+      for (auto i3 = begin_3; i3 < end_3; ++i3) {
+        for (auto i2 = begin_2; i2 < end_2; ++i2) {
+          for (auto i1 = begin_1; i1 < end_1; ++i1) {
+            for (auto i0 = begin_0; i0 < end_0; ++i0) {
               if constexpr (std::is_same<typename Policy::work_tag,
                                          void>::value)
                 functor(i0, i1, i2, i3, result);
@@ -659,11 +659,11 @@ reduction(+:result)
                                                                  : functor) \
     reduction(custom                                                        \
               : result)
-      for (auto i0 = begin_0; i0 < end_0; ++i0) {
-        for (auto i1 = begin_1; i1 < end_1; ++i1) {
+      for (auto i4 = begin_4; i4 < end_4; ++i4) {
+        for (auto i3 = begin_3; i3 < end_3; ++i3) {
           for (auto i2 = begin_2; i2 < end_2; ++i2) {
-            for (auto i3 = begin_3; i3 < end_3; ++i3) {
-              for (auto i4 = begin_4; i4 < end_4; ++i4) {
+            for (auto i1 = begin_1; i1 < end_1; ++i1) {
+              for (auto i0 = begin_0; i0 < end_0; ++i0) {
                 if constexpr (std::is_same<typename Policy::work_tag,
                                            void>::value)
                   functor(i0, i1, i2, i3, i4, result);
@@ -678,11 +678,11 @@ reduction(+:result)
     } else {
 #pragma omp target teams distribute parallel for collapse(5) map(to : functor) \
 reduction(+:result)
-      for (auto i0 = begin_0; i0 < end_0; ++i0) {
-        for (auto i1 = begin_1; i1 < end_1; ++i1) {
+      for (auto i4 = begin_4; i4 < end_4; ++i4) {
+        for (auto i3 = begin_3; i3 < end_3; ++i3) {
           for (auto i2 = begin_2; i2 < end_2; ++i2) {
-            for (auto i3 = begin_3; i3 < end_3; ++i3) {
-              for (auto i4 = begin_4; i4 < end_4; ++i4) {
+            for (auto i1 = begin_1; i1 < end_1; ++i1) {
+              for (auto i0 = begin_0; i0 < end_0; ++i0) {
                 if constexpr (std::is_same<typename Policy::work_tag,
                                            void>::value)
                   functor(i0, i1, i2, i3, i4, result);
@@ -732,12 +732,12 @@ reduction(+:result)
                                                                  : functor) \
     reduction(custom                                                        \
               : result)
-      for (auto i0 = begin_0; i0 < end_0; ++i0) {
-        for (auto i1 = begin_1; i1 < end_1; ++i1) {
-          for (auto i2 = begin_2; i2 < end_2; ++i2) {
-            for (auto i3 = begin_3; i3 < end_3; ++i3) {
-              for (auto i4 = begin_4; i4 < end_4; ++i4) {
-                for (auto i5 = begin_5; i5 < end_5; ++i5) {
+      for (auto i5 = begin_5; i5 < end_5; ++i5) {
+        for (auto i4 = begin_4; i4 < end_4; ++i4) {
+          for (auto i3 = begin_3; i3 < end_3; ++i3) {
+            for (auto i2 = begin_2; i2 < end_2; ++i2) {
+              for (auto i1 = begin_1; i1 < end_1; ++i1) {
+                for (auto i0 = begin_0; i0 < end_0; ++i0) {
                   if constexpr (std::is_same<typename Policy::work_tag,
                                              void>::value)
                     functor(i0, i1, i2, i3, i4, i5, result);
@@ -753,12 +753,12 @@ reduction(+:result)
     } else {
 #pragma omp target teams distribute parallel for collapse(6) map(to : functor) \
 reduction(+:result)
-      for (auto i0 = begin_0; i0 < end_0; ++i0) {
-        for (auto i1 = begin_1; i1 < end_1; ++i1) {
-          for (auto i2 = begin_2; i2 < end_2; ++i2) {
-            for (auto i3 = begin_3; i3 < end_3; ++i3) {
-              for (auto i4 = begin_4; i4 < end_4; ++i4) {
-                for (auto i5 = begin_5; i5 < end_5; ++i5) {
+      for (auto i5 = begin_5; i5 < end_5; ++i5) {
+        for (auto i4 = begin_4; i4 < end_4; ++i4) {
+          for (auto i3 = begin_3; i3 < end_3; ++i3) {
+            for (auto i2 = begin_2; i2 < end_2; ++i2) {
+              for (auto i1 = begin_1; i1 < end_1; ++i1) {
+                for (auto i0 = begin_0; i0 < end_0; ++i0) {
                   if constexpr (std::is_same<typename Policy::work_tag,
                                              void>::value)
                     functor(i0, i1, i2, i3, i4, i5, result);


### PR DESCRIPTION
The PR updates the loop order to honor user requested loop ordering in the MDRange policy of the OpenMPTarget backend. 
It also deletes the unused (and not working) tiling implementation for now. 

FYI - Tiling implementation as-is gives wrong results in MDRange policy for the backend. Looking to fix it in a different PR later. 