### PR TITLE
Adding converting constructor in Kokkos::RandomAccessIterator

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
@@ -162,6 +162,9 @@ class RandomAccessIterator< ::Kokkos::View<DataType, Args...> > {
  private:
   view_type m_view;
   ptrdiff_t m_current_index = 0;
+
+  template <class>
+  friend class RandomAccessIterator;
 };
 
 }  // namespace Impl

--- a/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
@@ -62,8 +62,10 @@ class RandomAccessIterator< ::Kokkos::View<DataType, Args...> > {
   template <
       class ViewType,
       std::enable_if_t<std::is_constructible_v<view_type, ViewType>, int> = 0>
-  KOKKOS_FUNCTION RandomAccessIterator(
-      const RandomAccessIterator<ViewType>& other)
+  KOKKOS_IMPL_CONDITIONAL_EXPLICIT(
+      (!std::is_convertible_v<ViewType, view_type>::value))
+  KOKKOS_FUNCTION
+      RandomAccessIterator(const RandomAccessIterator<ViewType>& other)
       : m_view(other.m_view), m_current_index(other.m_current_index) {}
 
   KOKKOS_FUNCTION

--- a/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
@@ -163,6 +163,7 @@ class RandomAccessIterator< ::Kokkos::View<DataType, Args...> > {
   view_type m_view;
   ptrdiff_t m_current_index = 0;
 
+  // Needed for the converting constructor accepting another iterator
   template <class>
   friend class RandomAccessIterator;
 };

--- a/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
@@ -59,13 +59,13 @@ class RandomAccessIterator< ::Kokkos::View<DataType, Args...> > {
                                                 ptrdiff_t current_index)
       : m_view(view), m_current_index(current_index) {}
 
-  template <
-      class ViewType,
-      std::enable_if_t<std::is_constructible_v<view_type, ViewType>, int> = 0>
+  template <class OtherViewType,
+            std::enable_if_t<std::is_constructible_v<view_type, OtherViewType>,
+                             int> = 0>
   KOKKOS_IMPL_CONDITIONAL_EXPLICIT(
-      (!std::is_convertible_v<ViewType, view_type>::value))
+      (!std::is_convertible_v<OtherViewType, view_type>::value))
   KOKKOS_FUNCTION
-      RandomAccessIterator(const RandomAccessIterator<ViewType>& other)
+      RandomAccessIterator(const RandomAccessIterator<OtherViewType>& other)
       : m_view(other.m_view), m_current_index(other.m_current_index) {}
 
   KOKKOS_FUNCTION

--- a/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
@@ -59,6 +59,13 @@ class RandomAccessIterator< ::Kokkos::View<DataType, Args...> > {
                                                 ptrdiff_t current_index)
       : m_view(view), m_current_index(current_index) {}
 
+  template <
+      class ViewType,
+      std::enable_if_t<std::is_convertible_v<ViewType, view_type>, int> = 0>
+  KOKKOS_FUNCTION RandomAccessIterator(
+      const RandomAccessIterator<ViewType>& other)
+      : m_view(other.m_view), m_current_index(other.m_current_index) {}
+
   KOKKOS_FUNCTION
   iterator_type& operator++() {
     ++m_current_index;

--- a/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
@@ -61,7 +61,7 @@ class RandomAccessIterator< ::Kokkos::View<DataType, Args...> > {
 
   template <
       class ViewType,
-      std::enable_if_t<std::is_convertible_v<ViewType, view_type>, int> = 0>
+      std::enable_if_t<std::is_constructible_v<view_type, ViewType>, int> = 0>
   KOKKOS_FUNCTION RandomAccessIterator(
       const RandomAccessIterator<ViewType>& other)
       : m_view(other.m_view), m_current_index(other.m_current_index) {}

--- a/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
@@ -62,9 +62,8 @@ class RandomAccessIterator< ::Kokkos::View<DataType, Args...> > {
   template <class OtherViewType,
             std::enable_if_t<std::is_constructible_v<view_type, OtherViewType>,
                              int> = 0>
-  KOKKOS_IMPL_CONDITIONAL_EXPLICIT(
-      (!std::is_convertible_v<OtherViewType, view_type>::value))
-  KOKKOS_FUNCTION
+  KOKKOS_FUNCTION KOKKOS_IMPL_CONDITIONAL_EXPLICIT(
+      !std::is_convertible_v<OtherViewType, view_type>)
       RandomAccessIterator(const RandomAccessIterator<OtherViewType>& other)
       : m_view(other.m_view), m_current_index(other.m_current_index) {}
 

--- a/algorithms/unit_tests/TestRandomAccessIterator.cpp
+++ b/algorithms/unit_tests/TestRandomAccessIterator.cpp
@@ -50,58 +50,38 @@ TEST_F(random_access_iterator_test, constructiblity) {
   auto first_d  = KE::begin(m_dynamic_view);
   auto cfirst_d = KE::cbegin(m_dynamic_view);
 
-  bool first_d2cfirst_d =
-      std::is_constructible_v<decltype(cfirst_d), decltype(first_d)>;
-  bool cfirst_d2first_d =
-      std::is_constructible_v<decltype(first_d), decltype(cfirst_d)>;
+  static_assert(std::is_constructible_v<decltype(cfirst_d), decltype(first_d)>);
+  static_assert(
+      !std::is_constructible_v<decltype(first_d), decltype(cfirst_d)>);
   [[maybe_unused]] decltype(cfirst_d) tmp_cfirst_d(first_d);
-
-  ASSERT_TRUE(first_d2cfirst_d);
-  ASSERT_FALSE(cfirst_d2first_d);
 
   auto first_s  = KE::begin(m_static_view);
   auto cfirst_s = KE::cbegin(m_static_view);
 
-  bool first_s2cfirst_s =
-      std::is_constructible_v<decltype(cfirst_s), decltype(first_s)>;
-  bool cfirst_s2first_s =
-      std::is_constructible_v<decltype(first_s), decltype(cfirst_s)>;
+  static_assert(std::is_constructible_v<decltype(cfirst_s), decltype(first_s)>);
+  static_assert(
+      !std::is_constructible_v<decltype(first_s), decltype(cfirst_s)>);
   [[maybe_unused]] decltype(cfirst_s) tmp_cfirst_s(first_s);
-
-  ASSERT_TRUE(first_s2cfirst_s);
-  ASSERT_FALSE(cfirst_s2first_s);
 
   auto first_st  = KE::begin(m_strided_view);
   auto cfirst_st = KE::cbegin(m_strided_view);
 
-  bool first_st2cfirst_st =
-      std::is_constructible_v<decltype(cfirst_st), decltype(first_st)>;
-  bool cfirst_st2first_st =
-      std::is_constructible_v<decltype(first_st), decltype(cfirst_st)>;
+  static_assert(
+      std::is_constructible_v<decltype(cfirst_st), decltype(first_st)>);
+  static_assert(
+      !std::is_constructible_v<decltype(first_st), decltype(cfirst_st)>);
   [[maybe_unused]] decltype(cfirst_st) tmp_cfirst_st(first_st);
 
-  ASSERT_TRUE(first_st2cfirst_st);
-  ASSERT_FALSE(cfirst_st2first_st);
-
-  bool first_d2first_s =
-      std::is_constructible_v<decltype(first_s), decltype(first_d)>;
-  bool first_d2first_st =
-      std::is_constructible_v<decltype(first_st), decltype(first_d)>;
-  bool first_s2first_d =
-      std::is_constructible_v<decltype(first_d), decltype(first_s)>;
-  bool first_s2first_st =
-      std::is_constructible_v<decltype(first_st), decltype(first_s)>;
-  bool first_st2first_d =
-      std::is_constructible_v<decltype(first_d), decltype(first_st)>;
-  bool first_st2first_s =
-      std::is_constructible_v<decltype(first_s), decltype(first_st)>;
-
-  ASSERT_TRUE(first_d2first_s);
-  ASSERT_TRUE(first_d2first_st);
-  ASSERT_TRUE(first_s2first_d);
-  ASSERT_TRUE(first_s2first_st);
-  ASSERT_TRUE(first_st2first_d);
-  ASSERT_TRUE(first_st2first_s);
+  // [FIXME] Better to have tests for the explicit specifier with an expression.
+  // As soon as View converting constructors are re-implemented with a
+  // conditional explicit, we may add those tests.
+  static_assert(std::is_constructible_v<decltype(first_s), decltype(first_d)>);
+  static_assert(std::is_constructible_v<decltype(first_st), decltype(first_d)>);
+  static_assert(std::is_constructible_v<decltype(first_d), decltype(first_s)>);
+  static_assert(std::is_constructible_v<decltype(first_st), decltype(first_s)>);
+  static_assert(std::is_constructible_v<decltype(first_d), decltype(first_st)>);
+  static_assert(std::is_constructible_v<decltype(first_s), decltype(first_st)>);
+  EXPECT_TRUE(true);
 }
 
 template <class IteratorType, class ValueType>

--- a/algorithms/unit_tests/TestRandomAccessIterator.cpp
+++ b/algorithms/unit_tests/TestRandomAccessIterator.cpp
@@ -46,6 +46,58 @@ TEST_F(random_access_iterator_test, constructor) {
   EXPECT_TRUE(true);
 }
 
+TEST_F(random_access_iterator_test, constructiblity) {
+  auto first_d  = KE::begin(m_dynamic_view);
+  auto cfirst_d = KE::cbegin(m_dynamic_view);
+
+  bool cfirst2first_d =
+      std::is_constructible_v<decltype(cfirst_d), decltype(first_d)>;
+  bool first2cfirst_d =
+      std::is_constructible_v<decltype(first_d), decltype(cfirst_d)>;
+  ASSERT_TRUE(cfirst2first_d);
+  ASSERT_FALSE(first2cfirst_d);
+
+  auto first_s  = KE::begin(m_static_view);
+  auto cfirst_s = KE::cbegin(m_static_view);
+
+  bool cfirst2first_s =
+      std::is_constructible_v<decltype(cfirst_s), decltype(first_s)>;
+  bool first2cfirst_s =
+      std::is_constructible_v<decltype(first_s), decltype(cfirst_s)>;
+  ASSERT_TRUE(cfirst2first_s);
+  ASSERT_FALSE(first2cfirst_s);
+
+  auto first_st  = KE::begin(m_strided_view);
+  auto cfirst_st = KE::cbegin(m_strided_view);
+
+  bool cfirst2first_st =
+      std::is_constructible_v<decltype(cfirst_st), decltype(first_st)>;
+  bool first2cfirst_st =
+      std::is_constructible_v<decltype(first_st), decltype(cfirst_st)>;
+  ASSERT_TRUE(cfirst2first_st);
+  ASSERT_FALSE(first2cfirst_st);
+
+  bool first_d2first_s =
+      std::is_constructible_v<decltype(first_d), decltype(first_s)>;
+  bool first_d2first_st =
+      std::is_constructible_v<decltype(first_d), decltype(first_st)>;
+  bool first_s2first_d =
+      std::is_constructible_v<decltype(first_s), decltype(first_d)>;
+  bool first_s2first_st =
+      std::is_constructible_v<decltype(first_s), decltype(first_st)>;
+  bool first_st2first_d =
+      std::is_constructible_v<decltype(first_st), decltype(first_d)>;
+  bool first_st2first_s =
+      std::is_constructible_v<decltype(first_st), decltype(first_s)>;
+
+  ASSERT_TRUE(first_d2first_s);
+  ASSERT_TRUE(first_d2first_st);
+  ASSERT_TRUE(first_s2first_d);
+  ASSERT_TRUE(first_s2first_st);
+  ASSERT_TRUE(first_st2first_d);
+  ASSERT_TRUE(first_st2first_s);
+}
+
 template <class IteratorType, class ValueType>
 void test_random_access_it_verify(IteratorType it, ValueType gold_value) {
   using view_t = Kokkos::View<typename IteratorType::value_type>;

--- a/algorithms/unit_tests/TestRandomAccessIterator.cpp
+++ b/algorithms/unit_tests/TestRandomAccessIterator.cpp
@@ -50,45 +50,51 @@ TEST_F(random_access_iterator_test, constructiblity) {
   auto first_d  = KE::begin(m_dynamic_view);
   auto cfirst_d = KE::cbegin(m_dynamic_view);
 
-  bool cfirst2first_d =
+  bool first_d2cfirst_d =
       std::is_constructible_v<decltype(cfirst_d), decltype(first_d)>;
-  bool first2cfirst_d =
+  bool cfirst_d2first_d =
       std::is_constructible_v<decltype(first_d), decltype(cfirst_d)>;
-  ASSERT_TRUE(cfirst2first_d);
-  ASSERT_FALSE(first2cfirst_d);
+  [[maybe_unused]] decltype(cfirst_d) tmp_cfirst_d(first_d);
+
+  ASSERT_TRUE(first_d2cfirst_d);
+  ASSERT_FALSE(cfirst_d2first_d);
 
   auto first_s  = KE::begin(m_static_view);
   auto cfirst_s = KE::cbegin(m_static_view);
 
-  bool cfirst2first_s =
+  bool first_s2cfirst_s =
       std::is_constructible_v<decltype(cfirst_s), decltype(first_s)>;
-  bool first2cfirst_s =
+  bool cfirst_s2first_s =
       std::is_constructible_v<decltype(first_s), decltype(cfirst_s)>;
-  ASSERT_TRUE(cfirst2first_s);
-  ASSERT_FALSE(first2cfirst_s);
+  [[maybe_unused]] decltype(cfirst_s) tmp_cfirst_s(first_s);
+
+  ASSERT_TRUE(first_s2cfirst_s);
+  ASSERT_FALSE(cfirst_s2first_s);
 
   auto first_st  = KE::begin(m_strided_view);
   auto cfirst_st = KE::cbegin(m_strided_view);
 
-  bool cfirst2first_st =
+  bool first_st2cfirst_st =
       std::is_constructible_v<decltype(cfirst_st), decltype(first_st)>;
-  bool first2cfirst_st =
+  bool cfirst_st2first_st =
       std::is_constructible_v<decltype(first_st), decltype(cfirst_st)>;
-  ASSERT_TRUE(cfirst2first_st);
-  ASSERT_FALSE(first2cfirst_st);
+  [[maybe_unused]] decltype(cfirst_st) tmp_cfirst_st(first_st);
+
+  ASSERT_TRUE(first_st2cfirst_st);
+  ASSERT_FALSE(cfirst_st2first_st);
 
   bool first_d2first_s =
-      std::is_constructible_v<decltype(first_d), decltype(first_s)>;
-  bool first_d2first_st =
-      std::is_constructible_v<decltype(first_d), decltype(first_st)>;
-  bool first_s2first_d =
       std::is_constructible_v<decltype(first_s), decltype(first_d)>;
-  bool first_s2first_st =
-      std::is_constructible_v<decltype(first_s), decltype(first_st)>;
-  bool first_st2first_d =
+  bool first_d2first_st =
       std::is_constructible_v<decltype(first_st), decltype(first_d)>;
-  bool first_st2first_s =
+  bool first_s2first_d =
+      std::is_constructible_v<decltype(first_d), decltype(first_s)>;
+  bool first_s2first_st =
       std::is_constructible_v<decltype(first_st), decltype(first_s)>;
+  bool first_st2first_d =
+      std::is_constructible_v<decltype(first_d), decltype(first_st)>;
+  bool first_st2first_s =
+      std::is_constructible_v<decltype(first_s), decltype(first_st)>;
 
   ASSERT_TRUE(first_d2first_s);
   ASSERT_TRUE(first_d2first_st);

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -564,12 +564,6 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 
 #define KOKKOS_ATTRIBUTE_NODISCARD [[nodiscard]]
 
-#ifdef KOKKOS_ENABLE_CXX20
-#define KOKKOS_IMPL_CONDITIONAL_EXPLICIT(...) explicit(__VA_ARGS__)
-#else
-#define KOKKOS_IMPL_CONDITIONAL_EXPLICIT(...)
-#endif
-
 #if (defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG) ||        \
      defined(KOKKOS_COMPILER_INTEL) || defined(KOKKOS_COMPILER_INTEL_LLVM) || \
      defined(KOKKOS_COMPILER_NVHPC)) &&                                       \

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -564,6 +564,12 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 
 #define KOKKOS_ATTRIBUTE_NODISCARD [[nodiscard]]
 
+#ifdef KOKKOS_ENABLE_CXX20
+#define KOKKOS_IMPL_CONDITIONAL_EXPLICIT(...) explicit(__VA_ARGS__)
+#else
+#define KOKKOS_IMPL_CONDITIONAL_EXPLICIT(...)
+#endif
+
 #if (defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG) ||        \
      defined(KOKKOS_COMPILER_INTEL) || defined(KOKKOS_COMPILER_INTEL_LLVM) || \
      defined(KOKKOS_COMPILER_NVHPC)) &&                                       \


### PR DESCRIPTION
This PR aims at adding a missing converting constructor in `Kokkos::RandomAccessIterator`.
Convertibility of iterators is based on the convertibility of underlying views.

It now allows to construct ~~a non-const iterator from a const iterator but disallows to construct a const iterator from a non-const iterator~~ a const iterator from a non-const iterator but disallows to construct a non-const iterator from a const iterator

```C++
auto it  = KE::begin(view_from)
auto cit = KE::cbegin(view_from)
bool it2cit = std::is_constructible_v<decltype(cit), decltype(it)>; // True
bool cit2it = std::is_constructible_v<decltype(it), decltype(cit)>; // False
```
