### PR TITLE
Deprecate trailing `Proxy` template argument in `Kokkos::Array`

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -80,7 +80,11 @@ struct ArrayBoundsCheck<Integral, false> {
 /**\brief  Derived from the C++17 'std::array'.
  *         Dropping the iterator interface.
  */
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class T = void, size_t N = KOKKOS_INVALID_INDEX, class Proxy = void>
+#else
+template <class T, size_t N>
+#endif
 struct Array {
  public:
   /**
@@ -131,8 +135,13 @@ struct Array {
   }
 };
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class T, class Proxy>
 struct Array<T, 0, Proxy> {
+#else
+template <class T>
+struct Array<T, 0> {
+#endif
  public:
   using reference       = T&;
   using const_reference = std::add_const_t<T>&;
@@ -178,14 +187,15 @@ struct Array<T, 0, Proxy> {
   // Array & operator = ( Array && ) = default ;
 };
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <>
-struct Array<void, KOKKOS_INVALID_INDEX, void> {
+struct KOKKOS_DEPRECATED Array<void, KOKKOS_INVALID_INDEX, void> {
   struct contiguous {};
   struct strided {};
 };
 
 template <class T>
-struct Array<T, KOKKOS_INVALID_INDEX, Array<>::contiguous> {
+struct KOKKOS_DEPRECATED Array<T, KOKKOS_INVALID_INDEX, Array<>::contiguous> {
  private:
   T* m_elem;
   size_t m_size;
@@ -253,7 +263,7 @@ struct Array<T, KOKKOS_INVALID_INDEX, Array<>::contiguous> {
 };
 
 template <class T>
-struct Array<T, KOKKOS_INVALID_INDEX, Array<>::strided> {
+struct KOKKOS_DEPRECATED Array<T, KOKKOS_INVALID_INDEX, Array<>::strided> {
  private:
   T* m_elem;
   size_t m_size;
@@ -320,6 +330,7 @@ struct Array<T, KOKKOS_INVALID_INDEX, Array<>::strided> {
                                          size_type arg_stride)
       : m_elem(arg_ptr), m_size(arg_size), m_stride(arg_stride) {}
 };
+#endif
 
 template <typename T, typename... Us>
 Array(T, Us...)->Array<T, 1 + sizeof...(Us)>;

--- a/core/unit_test/TestArrayOps.hpp
+++ b/core/unit_test/TestArrayOps.hpp
@@ -111,6 +111,7 @@ TEST(TEST_CATEGORY, array_zero_data_nullptr) {
   ASSERT_EQ(ce.data(), nullptr);
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 TEST(TEST_CATEGORY, array_contiguous_capacity) {
   using A =
       Kokkos::Array<int, KOKKOS_INVALID_INDEX, Kokkos::Array<>::contiguous>;
@@ -389,5 +390,6 @@ TEST(TEST_CATEGORY, array_strided_assignment) {
   ASSERT_EQ(e.max_size(), std::size(ee) / eStride);
   ASSERT_EQ(e[0], ee[0]);
 }
+#endif
 
 }  // namespace


### PR DESCRIPTION
Following up on #6906 and deprecating the `Proxy` template argument in `Kokkos::Array<T, N, Proxy>`.

Rational:
* Further alignment with `std::array<T, N>`, `Kokkos::Array` is provided as a drop-in replacement for the facility provided by the standard library.  One caveat is we still spell it differently with that leading uppercase A...
* This rather obscure facility was solely there to support the view specialization that we removed in #6906.  We deprecate it instead of removing to be safe (I could not find any use when searching through Trilinos).  Doing so will reduce the code complexity and make it trivial to document `Kokkoss::Array` as we can just refer to the standard library documentation (we never bothered documenting it).