### PR TITLE
kokkos: add IWYU pragmas to mark private and exported headers

### DIFF
--- a/algorithms/src/Kokkos_NestedSort.hpp
+++ b/algorithms/src/Kokkos_NestedSort.hpp
@@ -21,7 +21,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_NESTED_SORT
 #endif
 
-#include "sorting/Kokkos_NestedSortPublicAPI.hpp"
+#include "sorting/Kokkos_NestedSortPublicAPI.hpp" // IWYU pragma: export
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_NESTED_SORT
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE

--- a/algorithms/src/Kokkos_NestedSort.hpp
+++ b/algorithms/src/Kokkos_NestedSort.hpp
@@ -21,7 +21,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_NESTED_SORT
 #endif
 
-#include "sorting/Kokkos_NestedSortPublicAPI.hpp" // IWYU pragma: export
+#include "sorting/Kokkos_NestedSortPublicAPI.hpp"  // IWYU pragma: export
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_NESTED_SORT
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -21,10 +21,10 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_SORT
 #endif
 
-#include "sorting/Kokkos_BinSortPublicAPI.hpp" // IWYU pragma: export
-#include "sorting/Kokkos_SortPublicAPI.hpp" // IWYU pragma: export
-#include "sorting/Kokkos_SortByKeyPublicAPI.hpp" // IWYU pragma: export
-#include "sorting/Kokkos_NestedSortPublicAPI.hpp" // IWYU pragma: export
+#include "sorting/Kokkos_BinSortPublicAPI.hpp"     // IWYU pragma: export
+#include "sorting/Kokkos_SortPublicAPI.hpp"        // IWYU pragma: export
+#include "sorting/Kokkos_SortByKeyPublicAPI.hpp"   // IWYU pragma: export
+#include "sorting/Kokkos_NestedSortPublicAPI.hpp"  // IWYU pragma: export
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_SORT
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -21,10 +21,10 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_SORT
 #endif
 
-#include "sorting/Kokkos_BinSortPublicAPI.hpp"
-#include "sorting/Kokkos_SortPublicAPI.hpp"
-#include "sorting/Kokkos_SortByKeyPublicAPI.hpp"
-#include "sorting/Kokkos_NestedSortPublicAPI.hpp"
+#include "sorting/Kokkos_BinSortPublicAPI.hpp" // IWYU pragma: export
+#include "sorting/Kokkos_SortPublicAPI.hpp" // IWYU pragma: export
+#include "sorting/Kokkos_SortByKeyPublicAPI.hpp" // IWYU pragma: export
+#include "sorting/Kokkos_NestedSortPublicAPI.hpp" // IWYU pragma: export
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_SORT
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE

--- a/algorithms/src/Kokkos_StdAlgorithms.hpp
+++ b/algorithms/src/Kokkos_StdAlgorithms.hpp
@@ -24,91 +24,91 @@
 /// \file Kokkos_StdAlgorithms.hpp
 /// \brief Kokkos counterparts for Standard C++ Library algorithms
 
-#include "std_algorithms/impl/Kokkos_Constraints.hpp"
-#include "std_algorithms/impl/Kokkos_RandomAccessIterator.hpp"
-#include "std_algorithms/Kokkos_BeginEnd.hpp"
+#include "std_algorithms/impl/Kokkos_Constraints.hpp" // IWYU pragma: export
+#include "std_algorithms/impl/Kokkos_RandomAccessIterator.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_BeginEnd.hpp" // IWYU pragma: export
 
 // distance
-#include "std_algorithms/Kokkos_Distance.hpp"
+#include "std_algorithms/Kokkos_Distance.hpp" // IWYU pragma: export
 
 // note that we categorize below the headers
 // following the std classification.
 
 // modifying ops
-#include "std_algorithms/Kokkos_IterSwap.hpp"
+#include "std_algorithms/Kokkos_IterSwap.hpp" // IWYU pragma: export
 
 // non-modifying sequence
-#include "std_algorithms/Kokkos_AdjacentFind.hpp"
-#include "std_algorithms/Kokkos_Count.hpp"
-#include "std_algorithms/Kokkos_CountIf.hpp"
-#include "std_algorithms/Kokkos_AllOf.hpp"
-#include "std_algorithms/Kokkos_AnyOf.hpp"
-#include "std_algorithms/Kokkos_NoneOf.hpp"
-#include "std_algorithms/Kokkos_Equal.hpp"
-#include "std_algorithms/Kokkos_Find.hpp"
-#include "std_algorithms/Kokkos_FindIf.hpp"
-#include "std_algorithms/Kokkos_FindIfNot.hpp"
-#include "std_algorithms/Kokkos_FindEnd.hpp"
-#include "std_algorithms/Kokkos_FindFirstOf.hpp"
-#include "std_algorithms/Kokkos_ForEach.hpp"
-#include "std_algorithms/Kokkos_ForEachN.hpp"
-#include "std_algorithms/Kokkos_LexicographicalCompare.hpp"
-#include "std_algorithms/Kokkos_Mismatch.hpp"
-#include "std_algorithms/Kokkos_Search.hpp"
-#include "std_algorithms/Kokkos_SearchN.hpp"
+#include "std_algorithms/Kokkos_AdjacentFind.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Count.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_CountIf.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_AllOf.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_AnyOf.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_NoneOf.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Equal.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Find.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_FindIf.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_FindIfNot.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_FindEnd.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_FindFirstOf.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_ForEach.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_ForEachN.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_LexicographicalCompare.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Mismatch.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Search.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_SearchN.hpp" // IWYU pragma: export
 
 // modifying sequence
-#include "std_algorithms/Kokkos_Fill.hpp"
-#include "std_algorithms/Kokkos_FillN.hpp"
-#include "std_algorithms/Kokkos_Replace.hpp"
-#include "std_algorithms/Kokkos_ReplaceIf.hpp"
-#include "std_algorithms/Kokkos_ReplaceCopyIf.hpp"
-#include "std_algorithms/Kokkos_ReplaceCopy.hpp"
-#include "std_algorithms/Kokkos_Copy.hpp"
-#include "std_algorithms/Kokkos_CopyN.hpp"
-#include "std_algorithms/Kokkos_CopyBackward.hpp"
-#include "std_algorithms/Kokkos_CopyIf.hpp"
-#include "std_algorithms/Kokkos_Transform.hpp"
-#include "std_algorithms/Kokkos_Generate.hpp"
-#include "std_algorithms/Kokkos_GenerateN.hpp"
-#include "std_algorithms/Kokkos_Reverse.hpp"
-#include "std_algorithms/Kokkos_ReverseCopy.hpp"
-#include "std_algorithms/Kokkos_Move.hpp"
-#include "std_algorithms/Kokkos_MoveBackward.hpp"
-#include "std_algorithms/Kokkos_SwapRanges.hpp"
-#include "std_algorithms/Kokkos_Unique.hpp"
-#include "std_algorithms/Kokkos_UniqueCopy.hpp"
-#include "std_algorithms/Kokkos_Rotate.hpp"
-#include "std_algorithms/Kokkos_RotateCopy.hpp"
-#include "std_algorithms/Kokkos_Remove.hpp"
-#include "std_algorithms/Kokkos_RemoveIf.hpp"
-#include "std_algorithms/Kokkos_RemoveCopy.hpp"
-#include "std_algorithms/Kokkos_RemoveCopyIf.hpp"
-#include "std_algorithms/Kokkos_ShiftLeft.hpp"
-#include "std_algorithms/Kokkos_ShiftRight.hpp"
+#include "std_algorithms/Kokkos_Fill.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_FillN.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Replace.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_ReplaceIf.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_ReplaceCopyIf.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_ReplaceCopy.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Copy.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_CopyN.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_CopyBackward.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_CopyIf.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Transform.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Generate.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_GenerateN.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Reverse.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_ReverseCopy.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Move.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_MoveBackward.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_SwapRanges.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Unique.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_UniqueCopy.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Rotate.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_RotateCopy.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Remove.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_RemoveIf.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_RemoveCopy.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_RemoveCopyIf.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_ShiftLeft.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_ShiftRight.hpp" // IWYU pragma: export
 
 // sorting
-#include "std_algorithms/Kokkos_IsSortedUntil.hpp"
-#include "std_algorithms/Kokkos_IsSorted.hpp"
+#include "std_algorithms/Kokkos_IsSortedUntil.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_IsSorted.hpp" // IWYU pragma: export
 
 // min/max element
-#include "std_algorithms/Kokkos_MinElement.hpp"
-#include "std_algorithms/Kokkos_MaxElement.hpp"
-#include "std_algorithms/Kokkos_MinMaxElement.hpp"
+#include "std_algorithms/Kokkos_MinElement.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_MaxElement.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_MinMaxElement.hpp" // IWYU pragma: export
 
 // partitioning
-#include "std_algorithms/Kokkos_IsPartitioned.hpp"
-#include "std_algorithms/Kokkos_PartitionCopy.hpp"
-#include "std_algorithms/Kokkos_PartitionPoint.hpp"
+#include "std_algorithms/Kokkos_IsPartitioned.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_PartitionCopy.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_PartitionPoint.hpp" // IWYU pragma: export
 
 // numeric
-#include "std_algorithms/Kokkos_AdjacentDifference.hpp"
-#include "std_algorithms/Kokkos_Reduce.hpp"
-#include "std_algorithms/Kokkos_TransformReduce.hpp"
-#include "std_algorithms/Kokkos_ExclusiveScan.hpp"
-#include "std_algorithms/Kokkos_TransformExclusiveScan.hpp"
-#include "std_algorithms/Kokkos_InclusiveScan.hpp"
-#include "std_algorithms/Kokkos_TransformInclusiveScan.hpp"
+#include "std_algorithms/Kokkos_AdjacentDifference.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Reduce.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_TransformReduce.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_ExclusiveScan.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_TransformExclusiveScan.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_InclusiveScan.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_TransformInclusiveScan.hpp" // IWYU pragma: export
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_STD_ALGORITHMS
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE

--- a/algorithms/src/Kokkos_StdAlgorithms.hpp
+++ b/algorithms/src/Kokkos_StdAlgorithms.hpp
@@ -24,91 +24,91 @@
 /// \file Kokkos_StdAlgorithms.hpp
 /// \brief Kokkos counterparts for Standard C++ Library algorithms
 
-#include "std_algorithms/impl/Kokkos_Constraints.hpp" // IWYU pragma: export
-#include "std_algorithms/impl/Kokkos_RandomAccessIterator.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_BeginEnd.hpp" // IWYU pragma: export
+#include "std_algorithms/impl/Kokkos_Constraints.hpp"  // IWYU pragma: export
+#include "std_algorithms/impl/Kokkos_RandomAccessIterator.hpp"  // IWYU pragma: export
+#include "std_algorithms/Kokkos_BeginEnd.hpp"  // IWYU pragma: export
 
 // distance
-#include "std_algorithms/Kokkos_Distance.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Distance.hpp"  // IWYU pragma: export
 
 // note that we categorize below the headers
 // following the std classification.
 
 // modifying ops
-#include "std_algorithms/Kokkos_IterSwap.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_IterSwap.hpp"  // IWYU pragma: export
 
 // non-modifying sequence
-#include "std_algorithms/Kokkos_AdjacentFind.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_Count.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_CountIf.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_AllOf.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_AnyOf.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_NoneOf.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_Equal.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_Find.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_FindIf.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_FindIfNot.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_FindEnd.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_FindFirstOf.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_ForEach.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_ForEachN.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_LexicographicalCompare.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_Mismatch.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_Search.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_SearchN.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_AdjacentFind.hpp"  // IWYU pragma: export
+#include "std_algorithms/Kokkos_Count.hpp"         // IWYU pragma: export
+#include "std_algorithms/Kokkos_CountIf.hpp"       // IWYU pragma: export
+#include "std_algorithms/Kokkos_AllOf.hpp"         // IWYU pragma: export
+#include "std_algorithms/Kokkos_AnyOf.hpp"         // IWYU pragma: export
+#include "std_algorithms/Kokkos_NoneOf.hpp"        // IWYU pragma: export
+#include "std_algorithms/Kokkos_Equal.hpp"         // IWYU pragma: export
+#include "std_algorithms/Kokkos_Find.hpp"          // IWYU pragma: export
+#include "std_algorithms/Kokkos_FindIf.hpp"        // IWYU pragma: export
+#include "std_algorithms/Kokkos_FindIfNot.hpp"     // IWYU pragma: export
+#include "std_algorithms/Kokkos_FindEnd.hpp"       // IWYU pragma: export
+#include "std_algorithms/Kokkos_FindFirstOf.hpp"   // IWYU pragma: export
+#include "std_algorithms/Kokkos_ForEach.hpp"       // IWYU pragma: export
+#include "std_algorithms/Kokkos_ForEachN.hpp"      // IWYU pragma: export
+#include "std_algorithms/Kokkos_LexicographicalCompare.hpp"  // IWYU pragma: export
+#include "std_algorithms/Kokkos_Mismatch.hpp"  // IWYU pragma: export
+#include "std_algorithms/Kokkos_Search.hpp"    // IWYU pragma: export
+#include "std_algorithms/Kokkos_SearchN.hpp"   // IWYU pragma: export
 
 // modifying sequence
-#include "std_algorithms/Kokkos_Fill.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_FillN.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_Replace.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_ReplaceIf.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_ReplaceCopyIf.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_ReplaceCopy.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_Copy.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_CopyN.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_CopyBackward.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_CopyIf.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_Transform.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_Generate.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_GenerateN.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_Reverse.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_ReverseCopy.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_Move.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_MoveBackward.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_SwapRanges.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_Unique.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_UniqueCopy.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_Rotate.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_RotateCopy.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_Remove.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_RemoveIf.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_RemoveCopy.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_RemoveCopyIf.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_ShiftLeft.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_ShiftRight.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_Fill.hpp"           // IWYU pragma: export
+#include "std_algorithms/Kokkos_FillN.hpp"          // IWYU pragma: export
+#include "std_algorithms/Kokkos_Replace.hpp"        // IWYU pragma: export
+#include "std_algorithms/Kokkos_ReplaceIf.hpp"      // IWYU pragma: export
+#include "std_algorithms/Kokkos_ReplaceCopyIf.hpp"  // IWYU pragma: export
+#include "std_algorithms/Kokkos_ReplaceCopy.hpp"    // IWYU pragma: export
+#include "std_algorithms/Kokkos_Copy.hpp"           // IWYU pragma: export
+#include "std_algorithms/Kokkos_CopyN.hpp"          // IWYU pragma: export
+#include "std_algorithms/Kokkos_CopyBackward.hpp"   // IWYU pragma: export
+#include "std_algorithms/Kokkos_CopyIf.hpp"         // IWYU pragma: export
+#include "std_algorithms/Kokkos_Transform.hpp"      // IWYU pragma: export
+#include "std_algorithms/Kokkos_Generate.hpp"       // IWYU pragma: export
+#include "std_algorithms/Kokkos_GenerateN.hpp"      // IWYU pragma: export
+#include "std_algorithms/Kokkos_Reverse.hpp"        // IWYU pragma: export
+#include "std_algorithms/Kokkos_ReverseCopy.hpp"    // IWYU pragma: export
+#include "std_algorithms/Kokkos_Move.hpp"           // IWYU pragma: export
+#include "std_algorithms/Kokkos_MoveBackward.hpp"   // IWYU pragma: export
+#include "std_algorithms/Kokkos_SwapRanges.hpp"     // IWYU pragma: export
+#include "std_algorithms/Kokkos_Unique.hpp"         // IWYU pragma: export
+#include "std_algorithms/Kokkos_UniqueCopy.hpp"     // IWYU pragma: export
+#include "std_algorithms/Kokkos_Rotate.hpp"         // IWYU pragma: export
+#include "std_algorithms/Kokkos_RotateCopy.hpp"     // IWYU pragma: export
+#include "std_algorithms/Kokkos_Remove.hpp"         // IWYU pragma: export
+#include "std_algorithms/Kokkos_RemoveIf.hpp"       // IWYU pragma: export
+#include "std_algorithms/Kokkos_RemoveCopy.hpp"     // IWYU pragma: export
+#include "std_algorithms/Kokkos_RemoveCopyIf.hpp"   // IWYU pragma: export
+#include "std_algorithms/Kokkos_ShiftLeft.hpp"      // IWYU pragma: export
+#include "std_algorithms/Kokkos_ShiftRight.hpp"     // IWYU pragma: export
 
 // sorting
-#include "std_algorithms/Kokkos_IsSortedUntil.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_IsSorted.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_IsSortedUntil.hpp"  // IWYU pragma: export
+#include "std_algorithms/Kokkos_IsSorted.hpp"       // IWYU pragma: export
 
 // min/max element
-#include "std_algorithms/Kokkos_MinElement.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_MaxElement.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_MinMaxElement.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_MinElement.hpp"     // IWYU pragma: export
+#include "std_algorithms/Kokkos_MaxElement.hpp"     // IWYU pragma: export
+#include "std_algorithms/Kokkos_MinMaxElement.hpp"  // IWYU pragma: export
 
 // partitioning
-#include "std_algorithms/Kokkos_IsPartitioned.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_PartitionCopy.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_PartitionPoint.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_IsPartitioned.hpp"   // IWYU pragma: export
+#include "std_algorithms/Kokkos_PartitionCopy.hpp"   // IWYU pragma: export
+#include "std_algorithms/Kokkos_PartitionPoint.hpp"  // IWYU pragma: export
 
 // numeric
-#include "std_algorithms/Kokkos_AdjacentDifference.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_Reduce.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_TransformReduce.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_ExclusiveScan.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_TransformExclusiveScan.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_InclusiveScan.hpp" // IWYU pragma: export
-#include "std_algorithms/Kokkos_TransformInclusiveScan.hpp" // IWYU pragma: export
+#include "std_algorithms/Kokkos_AdjacentDifference.hpp"  // IWYU pragma: export
+#include "std_algorithms/Kokkos_Reduce.hpp"              // IWYU pragma: export
+#include "std_algorithms/Kokkos_TransformReduce.hpp"     // IWYU pragma: export
+#include "std_algorithms/Kokkos_ExclusiveScan.hpp"       // IWYU pragma: export
+#include "std_algorithms/Kokkos_TransformExclusiveScan.hpp"  // IWYU pragma: export
+#include "std_algorithms/Kokkos_InclusiveScan.hpp"  // IWYU pragma: export
+#include "std_algorithms/Kokkos_TransformInclusiveScan.hpp"  // IWYU pragma: export
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_STD_ALGORITHMS
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_SORT_PUBLIC_API_HPP_
 #define KOKKOS_SORT_PUBLIC_API_HPP_
 
-// IWYU pragma: private; include <Kokkos_Sort.hpp>
+// IWYU pragma: private, include "Kokkos_Sort.hpp"
 #include "./impl/Kokkos_SortImpl.hpp"
 #include <std_algorithms/Kokkos_BeginEnd.hpp>
 #include <Kokkos_Core.hpp>

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_SORT_PUBLIC_API_HPP_
 #define KOKKOS_SORT_PUBLIC_API_HPP_
 
+// IWYU pragma: private; include <Kokkos_Sort.hpp>
 #include "./impl/Kokkos_SortImpl.hpp"
 #include <std_algorithms/Kokkos_BeginEnd.hpp>
 #include <Kokkos_Core.hpp>

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_SORT_FREE_FUNCS_IMPL_HPP_
 #define KOKKOS_SORT_FREE_FUNCS_IMPL_HPP_
 
+// IWYU pragma: private
 #include "../Kokkos_BinOpsPublicAPI.hpp"
 #include "../Kokkos_BinSortPublicAPI.hpp"
 #include <std_algorithms/Kokkos_BeginEnd.hpp>

--- a/algorithms/src/std_algorithms/Kokkos_AdjacentDifference.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_AdjacentDifference.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ADJACENT_DIFFERENCE_HPP
 #define KOKKOS_STD_ALGORITHMS_ADJACENT_DIFFERENCE_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_AdjacentDifference.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_AdjacentDifference.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_AdjacentDifference.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ADJACENT_DIFFERENCE_HPP
 #define KOKKOS_STD_ALGORITHMS_ADJACENT_DIFFERENCE_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_AdjacentDifference.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_AdjacentFind.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_AdjacentFind.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ADJACENT_FIND_HPP
 #define KOKKOS_STD_ALGORITHMS_ADJACENT_FIND_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_AdjacentFind.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_AdjacentFind.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_AdjacentFind.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ADJACENT_FIND_HPP
 #define KOKKOS_STD_ALGORITHMS_ADJACENT_FIND_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_AdjacentFind.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_AllOf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_AllOf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ALL_OF_HPP
 #define KOKKOS_STD_ALGORITHMS_ALL_OF_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_AllOfAnyOfNoneOf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_AllOf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_AllOf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ALL_OF_HPP
 #define KOKKOS_STD_ALGORITHMS_ALL_OF_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_AllOfAnyOfNoneOf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_AnyOf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_AnyOf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ANY_OF_HPP
 #define KOKKOS_STD_ALGORITHMS_ANY_OF_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_AllOfAnyOfNoneOf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_AnyOf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_AnyOf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ANY_OF_HPP
 #define KOKKOS_STD_ALGORITHMS_ANY_OF_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_AllOfAnyOfNoneOf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_BeginEnd.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_BeginEnd.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_BEGIN_END_HPP
 #define KOKKOS_BEGIN_END_HPP
 
+// IWYU pragma: private
 #include <Kokkos_View.hpp>
 #include "impl/Kokkos_RandomAccessIterator.hpp"
 #include "impl/Kokkos_Constraints.hpp"

--- a/algorithms/src/std_algorithms/Kokkos_Copy.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Copy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COPY_HPP
 #define KOKKOS_STD_ALGORITHMS_COPY_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_CopyCopyN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Copy.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Copy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COPY_HPP
 #define KOKKOS_STD_ALGORITHMS_COPY_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_CopyCopyN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_CopyBackward.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_CopyBackward.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COPY_BACKWARD_HPP
 #define KOKKOS_STD_ALGORITHMS_COPY_BACKWARD_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_CopyBackward.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_CopyBackward.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_CopyBackward.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COPY_BACKWARD_HPP
 #define KOKKOS_STD_ALGORITHMS_COPY_BACKWARD_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_CopyBackward.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_CopyIf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_CopyIf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COPY_IF_HPP
 #define KOKKOS_STD_ALGORITHMS_COPY_IF_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_CopyIf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_CopyIf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_CopyIf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COPY_IF_HPP
 #define KOKKOS_STD_ALGORITHMS_COPY_IF_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_CopyIf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_CopyN.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_CopyN.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COPY_N_HPP
 #define KOKKOS_STD_ALGORITHMS_COPY_N_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_CopyCopyN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_CopyN.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_CopyN.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COPY_N_HPP
 #define KOKKOS_STD_ALGORITHMS_COPY_N_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_CopyCopyN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Count.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Count.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COUNT_HPP
 #define KOKKOS_STD_ALGORITHMS_COUNT_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_CountCountIf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Count.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Count.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COUNT_HPP
 #define KOKKOS_STD_ALGORITHMS_COUNT_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_CountCountIf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_CountIf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_CountIf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COUNT_IF_HPP
 #define KOKKOS_STD_ALGORITHMS_COUNT_IF_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_CountCountIf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_CountIf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_CountIf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COUNT_IF_HPP
 #define KOKKOS_STD_ALGORITHMS_COUNT_IF_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_CountCountIf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Distance.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Distance.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_DISTANCE_HPP
 #define KOKKOS_STD_ALGORITHMS_DISTANCE_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_Constraints.hpp"
 #include "impl/Kokkos_RandomAccessIterator.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Distance.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Distance.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_DISTANCE_HPP
 #define KOKKOS_STD_ALGORITHMS_DISTANCE_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_Constraints.hpp"
 #include "impl/Kokkos_RandomAccessIterator.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Equal.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Equal.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_EQUAL_HPP
 #define KOKKOS_STD_ALGORITHMS_EQUAL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_Equal.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Equal.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Equal.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_EQUAL_HPP
 #define KOKKOS_STD_ALGORITHMS_EQUAL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_Equal.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ExclusiveScan.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_EXCLUSIVE_SCAN_HPP
 #define KOKKOS_STD_ALGORITHMS_EXCLUSIVE_SCAN_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_ExclusiveScan.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ExclusiveScan.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_EXCLUSIVE_SCAN_HPP
 #define KOKKOS_STD_ALGORITHMS_EXCLUSIVE_SCAN_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_ExclusiveScan.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Fill.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Fill.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FILL_HPP
 #define KOKKOS_STD_ALGORITHMS_FILL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_FillFillN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Fill.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Fill.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FILL_HPP
 #define KOKKOS_STD_ALGORITHMS_FILL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_FillFillN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_FillN.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_FillN.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FILL_N_HPP
 #define KOKKOS_STD_ALGORITHMS_FILL_N_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_FillFillN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_FillN.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_FillN.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FILL_N_HPP
 #define KOKKOS_STD_ALGORITHMS_FILL_N_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_FillFillN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Find.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Find.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FIND_HPP
 #define KOKKOS_STD_ALGORITHMS_FIND_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_FindIfOrNot.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Find.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Find.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FIND_HPP
 #define KOKKOS_STD_ALGORITHMS_FIND_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_FindIfOrNot.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_FindEnd.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_FindEnd.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FIND_END_HPP
 #define KOKKOS_STD_ALGORITHMS_FIND_END_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_FindEnd.hpp"
 #include "Kokkos_Equal.hpp"
 #include "Kokkos_BeginEnd.hpp"

--- a/algorithms/src/std_algorithms/Kokkos_FindEnd.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_FindEnd.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FIND_END_HPP
 #define KOKKOS_STD_ALGORITHMS_FIND_END_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_FindEnd.hpp"
 #include "Kokkos_Equal.hpp"
 #include "Kokkos_BeginEnd.hpp"

--- a/algorithms/src/std_algorithms/Kokkos_FindFirstOf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_FindFirstOf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FIND_FIRST_OF_HPP
 #define KOKKOS_STD_ALGORITHMS_FIND_FIRST_OF_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_FindFirstOf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_FindFirstOf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_FindFirstOf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FIND_FIRST_OF_HPP
 #define KOKKOS_STD_ALGORITHMS_FIND_FIRST_OF_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_FindFirstOf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_FindIf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_FindIf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FIND_IF_HPP
 #define KOKKOS_STD_ALGORITHMS_FIND_IF_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_FindIfOrNot.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_FindIf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_FindIf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FIND_IF_HPP
 #define KOKKOS_STD_ALGORITHMS_FIND_IF_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_FindIfOrNot.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_FindIfNot.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_FindIfNot.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FIND_IF_NOT_HPP
 #define KOKKOS_STD_ALGORITHMS_FIND_IF_NOT_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_FindIfOrNot.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_FindIfNot.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_FindIfNot.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FIND_IF_NOT_HPP
 #define KOKKOS_STD_ALGORITHMS_FIND_IF_NOT_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_FindIfOrNot.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ForEach.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ForEach.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FOR_EACH_HPP
 #define KOKKOS_STD_ALGORITHMS_FOR_EACH_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_ForEachForEachN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ForEach.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ForEach.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FOR_EACH_HPP
 #define KOKKOS_STD_ALGORITHMS_FOR_EACH_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_ForEachForEachN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ForEachN.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ForEachN.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FOR_EACH_N_HPP
 #define KOKKOS_STD_ALGORITHMS_FOR_EACH_N_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_ForEachForEachN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ForEachN.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ForEachN.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FOR_EACH_N_HPP
 #define KOKKOS_STD_ALGORITHMS_FOR_EACH_N_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_ForEachForEachN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Generate.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Generate.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_GENERATE_HPP
 #define KOKKOS_STD_ALGORITHMS_GENERATE_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_GenerateGenerateN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Generate.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Generate.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_GENERATE_HPP
 #define KOKKOS_STD_ALGORITHMS_GENERATE_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_GenerateGenerateN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_GenerateN.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_GenerateN.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_GENERATE_N_HPP
 #define KOKKOS_STD_ALGORITHMS_GENERATE_N_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_GenerateGenerateN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_GenerateN.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_GenerateN.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_GENERATE_N_HPP
 #define KOKKOS_STD_ALGORITHMS_GENERATE_N_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_GenerateGenerateN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_InclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_InclusiveScan.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_INCLUSIVE_SCAN_HPP
 #define KOKKOS_STD_ALGORITHMS_INCLUSIVE_SCAN_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_InclusiveScan.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_InclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_InclusiveScan.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_INCLUSIVE_SCAN_HPP
 #define KOKKOS_STD_ALGORITHMS_INCLUSIVE_SCAN_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_InclusiveScan.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_IsPartitioned.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_IsPartitioned.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_IS_PARTITIONED_HPP
 #define KOKKOS_STD_ALGORITHMS_IS_PARTITIONED_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_IsPartitioned.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_IsPartitioned.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_IsPartitioned.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_IS_PARTITIONED_HPP
 #define KOKKOS_STD_ALGORITHMS_IS_PARTITIONED_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_IsPartitioned.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_IsSorted.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_IsSorted.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_IS_SORTED_HPP
 #define KOKKOS_STD_ALGORITHMS_IS_SORTED_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_IsSorted.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_IsSorted.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_IsSorted.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_IS_SORTED_HPP
 #define KOKKOS_STD_ALGORITHMS_IS_SORTED_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_IsSorted.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_IsSortedUntil.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_IsSortedUntil.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_IS_SORTED_UNTIL_HPP
 #define KOKKOS_STD_ALGORITHMS_IS_SORTED_UNTIL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_IsSortedUntil.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_IsSortedUntil.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_IsSortedUntil.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_IS_SORTED_UNTIL_HPP
 #define KOKKOS_STD_ALGORITHMS_IS_SORTED_UNTIL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_IsSortedUntil.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_IterSwap.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_IterSwap.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ITER_SWAP_HPP
 #define KOKKOS_STD_ALGORITHMS_ITER_SWAP_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "impl/Kokkos_Constraints.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_IterSwap.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_IterSwap.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ITER_SWAP_HPP
 #define KOKKOS_STD_ALGORITHMS_ITER_SWAP_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "impl/Kokkos_Constraints.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_LexicographicalCompare.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_LexicographicalCompare.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_LEXICOGRAPHICAL_COMPARE_HPP
 #define KOKKOS_STD_ALGORITHMS_LEXICOGRAPHICAL_COMPARE_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_LexicographicalCompare.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_LexicographicalCompare.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_LexicographicalCompare.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_LEXICOGRAPHICAL_COMPARE_HPP
 #define KOKKOS_STD_ALGORITHMS_LEXICOGRAPHICAL_COMPARE_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_LexicographicalCompare.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_MaxElement.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_MaxElement.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MAX_ELEMENT_HPP
 #define KOKKOS_STD_ALGORITHMS_MAX_ELEMENT_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_MinMaxMinmaxElement.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_MaxElement.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_MaxElement.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MAX_ELEMENT_HPP
 #define KOKKOS_STD_ALGORITHMS_MAX_ELEMENT_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_MinMaxMinmaxElement.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_MinElement.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_MinElement.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MIN_ELEMENT_HPP
 #define KOKKOS_STD_ALGORITHMS_MIN_ELEMENT_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_MinMaxMinmaxElement.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_MinElement.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_MinElement.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MIN_ELEMENT_HPP
 #define KOKKOS_STD_ALGORITHMS_MIN_ELEMENT_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_MinMaxMinmaxElement.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_MinMaxElement.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_MinMaxElement.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MINMAX_ELEMENT_HPP
 #define KOKKOS_STD_ALGORITHMS_MINMAX_ELEMENT_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_MinMaxMinmaxElement.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_MinMaxElement.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_MinMaxElement.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MINMAX_ELEMENT_HPP
 #define KOKKOS_STD_ALGORITHMS_MINMAX_ELEMENT_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_MinMaxMinmaxElement.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Mismatch.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Mismatch.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MISMATCH_HPP
 #define KOKKOS_STD_ALGORITHMS_MISMATCH_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_Mismatch.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Mismatch.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Mismatch.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MISMATCH_HPP
 #define KOKKOS_STD_ALGORITHMS_MISMATCH_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_Mismatch.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Move.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Move.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MOVE_HPP
 #define KOKKOS_STD_ALGORITHMS_MOVE_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_Move.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Move.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Move.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MOVE_HPP
 #define KOKKOS_STD_ALGORITHMS_MOVE_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_Move.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_MoveBackward.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_MoveBackward.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MOVE_BACKWARD_HPP
 #define KOKKOS_STD_ALGORITHMS_MOVE_BACKWARD_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_MoveBackward.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_MoveBackward.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_MoveBackward.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MOVE_BACKWARD_HPP
 #define KOKKOS_STD_ALGORITHMS_MOVE_BACKWARD_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_MoveBackward.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_NoneOf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_NoneOf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_NONE_OF_HPP
 #define KOKKOS_STD_ALGORITHMS_NONE_OF_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_AllOfAnyOfNoneOf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_NoneOf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_NoneOf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_NONE_OF_HPP
 #define KOKKOS_STD_ALGORITHMS_NONE_OF_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_AllOfAnyOfNoneOf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_PartitionCopy.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_PartitionCopy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_PARTITION_COPY_HPP
 #define KOKKOS_STD_ALGORITHMS_PARTITION_COPY_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_PartitionCopy.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_PartitionCopy.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_PartitionCopy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_PARTITION_COPY_HPP
 #define KOKKOS_STD_ALGORITHMS_PARTITION_COPY_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_PartitionCopy.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_PartitionPoint.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_PartitionPoint.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_PARTITION_POINT_HPP
 #define KOKKOS_STD_ALGORITHMS_PARTITION_POINT_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_PartitionPoint.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_PartitionPoint.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_PartitionPoint.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_PARTITION_POINT_HPP
 #define KOKKOS_STD_ALGORITHMS_PARTITION_POINT_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_PartitionPoint.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Reduce.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Reduce.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REDUCE_HPP
 #define KOKKOS_STD_ALGORITHMS_REDUCE_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_Reduce.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Reduce.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Reduce.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REDUCE_HPP
 #define KOKKOS_STD_ALGORITHMS_REDUCE_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_Reduce.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Remove.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Remove.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REMOVE_HPP
 #define KOKKOS_STD_ALGORITHMS_REMOVE_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_RemoveAllVariants.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Remove.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Remove.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REMOVE_HPP
 #define KOKKOS_STD_ALGORITHMS_REMOVE_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_RemoveAllVariants.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_RemoveCopy.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_RemoveCopy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REMOVE_COPY_HPP
 #define KOKKOS_STD_ALGORITHMS_REMOVE_COPY_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_RemoveAllVariants.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_RemoveCopy.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_RemoveCopy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REMOVE_COPY_HPP
 #define KOKKOS_STD_ALGORITHMS_REMOVE_COPY_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_RemoveAllVariants.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_RemoveCopyIf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_RemoveCopyIf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REMOVE_COPY_IF_HPP
 #define KOKKOS_STD_ALGORITHMS_REMOVE_COPY_IF_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_RemoveAllVariants.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_RemoveCopyIf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_RemoveCopyIf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REMOVE_COPY_IF_HPP
 #define KOKKOS_STD_ALGORITHMS_REMOVE_COPY_IF_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_RemoveAllVariants.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_RemoveIf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_RemoveIf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REMOVE_IF_HPP
 #define KOKKOS_STD_ALGORITHMS_REMOVE_IF_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_RemoveAllVariants.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_RemoveIf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_RemoveIf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REMOVE_IF_HPP
 #define KOKKOS_STD_ALGORITHMS_REMOVE_IF_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_RemoveAllVariants.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Replace.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Replace.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REPLACE_HPP
 #define KOKKOS_STD_ALGORITHMS_REPLACE_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_Replace.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Replace.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Replace.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REPLACE_HPP
 #define KOKKOS_STD_ALGORITHMS_REPLACE_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_Replace.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ReplaceCopy.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ReplaceCopy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REPLACE_COPY_HPP
 #define KOKKOS_STD_ALGORITHMS_REPLACE_COPY_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_ReplaceCopy.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ReplaceCopy.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ReplaceCopy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REPLACE_COPY_HPP
 #define KOKKOS_STD_ALGORITHMS_REPLACE_COPY_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_ReplaceCopy.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ReplaceCopyIf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ReplaceCopyIf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REPLACE_COPY_IF_HPP
 #define KOKKOS_STD_ALGORITHMS_REPLACE_COPY_IF_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_ReplaceCopyIf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ReplaceCopyIf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ReplaceCopyIf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REPLACE_COPY_IF_HPP
 #define KOKKOS_STD_ALGORITHMS_REPLACE_COPY_IF_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_ReplaceCopyIf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ReplaceIf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ReplaceIf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REPLACE_IF_HPP
 #define KOKKOS_STD_ALGORITHMS_REPLACE_IF_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_ReplaceIf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ReplaceIf.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ReplaceIf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REPLACE_IF_HPP
 #define KOKKOS_STD_ALGORITHMS_REPLACE_IF_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_ReplaceIf.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Reverse.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Reverse.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REVERSE_HPP
 #define KOKKOS_STD_ALGORITHMS_REVERSE_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_Reverse.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Reverse.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Reverse.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REVERSE_HPP
 #define KOKKOS_STD_ALGORITHMS_REVERSE_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_Reverse.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ReverseCopy.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ReverseCopy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REVERSE_COPY_HPP
 #define KOKKOS_STD_ALGORITHMS_REVERSE_COPY_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_ReverseCopy.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ReverseCopy.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ReverseCopy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REVERSE_COPY_HPP
 #define KOKKOS_STD_ALGORITHMS_REVERSE_COPY_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_ReverseCopy.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Rotate.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Rotate.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ROTATE_HPP
 #define KOKKOS_STD_ALGORITHMS_ROTATE_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_Rotate.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Rotate.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Rotate.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ROTATE_HPP
 #define KOKKOS_STD_ALGORITHMS_ROTATE_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_Rotate.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_RotateCopy.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_RotateCopy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ROTATE_COPY_HPP
 #define KOKKOS_STD_ALGORITHMS_ROTATE_COPY_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_RotateCopy.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_RotateCopy.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_RotateCopy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ROTATE_COPY_HPP
 #define KOKKOS_STD_ALGORITHMS_ROTATE_COPY_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_RotateCopy.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Search.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Search.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SEARCH_HPP
 #define KOKKOS_STD_ALGORITHMS_SEARCH_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_Search.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Search.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Search.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SEARCH_HPP
 #define KOKKOS_STD_ALGORITHMS_SEARCH_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_Search.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_SearchN.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_SearchN.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SEARCH_N_HPP
 #define KOKKOS_STD_ALGORITHMS_SEARCH_N_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_SearchN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_SearchN.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_SearchN.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SEARCH_N_HPP
 #define KOKKOS_STD_ALGORITHMS_SEARCH_N_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_SearchN.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ShiftLeft.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ShiftLeft.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SHIFT_LEFT_HPP
 #define KOKKOS_STD_ALGORITHMS_SHIFT_LEFT_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_ShiftLeft.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ShiftLeft.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ShiftLeft.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SHIFT_LEFT_HPP
 #define KOKKOS_STD_ALGORITHMS_SHIFT_LEFT_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_ShiftLeft.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ShiftRight.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ShiftRight.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SHIFT_RIGHT_HPP
 #define KOKKOS_STD_ALGORITHMS_SHIFT_RIGHT_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_ShiftRight.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_ShiftRight.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ShiftRight.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SHIFT_RIGHT_HPP
 #define KOKKOS_STD_ALGORITHMS_SHIFT_RIGHT_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_ShiftRight.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_SwapRanges.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_SwapRanges.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SWAP_RANGES_HPP
 #define KOKKOS_STD_ALGORITHMS_SWAP_RANGES_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_SwapRanges.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_SwapRanges.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_SwapRanges.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SWAP_RANGES_HPP
 #define KOKKOS_STD_ALGORITHMS_SWAP_RANGES_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_SwapRanges.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Transform.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Transform.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_TRANSFORM_HPP
 #define KOKKOS_STD_ALGORITHMS_TRANSFORM_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_Transform.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Transform.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Transform.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_TRANSFORM_HPP
 #define KOKKOS_STD_ALGORITHMS_TRANSFORM_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_Transform.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_TransformExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_TransformExclusiveScan.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_TRASFORM_EXCLUSIVE_SCAN_HPP
 #define KOKKOS_STD_ALGORITHMS_TRASFORM_EXCLUSIVE_SCAN_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_TransformExclusiveScan.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_TransformExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_TransformExclusiveScan.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_TRASFORM_EXCLUSIVE_SCAN_HPP
 #define KOKKOS_STD_ALGORITHMS_TRASFORM_EXCLUSIVE_SCAN_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_TransformExclusiveScan.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_TransformInclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_TransformInclusiveScan.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_TRANSFORM_INCLUSIVE_SCAN_HPP
 #define KOKKOS_STD_ALGORITHMS_TRANSFORM_INCLUSIVE_SCAN_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_TransformInclusiveScan.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_TransformInclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_TransformInclusiveScan.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_TRANSFORM_INCLUSIVE_SCAN_HPP
 #define KOKKOS_STD_ALGORITHMS_TRANSFORM_INCLUSIVE_SCAN_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_TransformInclusiveScan.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_TransformReduce.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_TransformReduce.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_TRANSFORM_REDUCE_HPP
 #define KOKKOS_STD_ALGORITHMS_TRANSFORM_REDUCE_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_TransformReduce.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_TransformReduce.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_TransformReduce.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_TRANSFORM_REDUCE_HPP
 #define KOKKOS_STD_ALGORITHMS_TRANSFORM_REDUCE_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_TransformReduce.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Unique.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Unique.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_UNIQUE_HPP
 #define KOKKOS_STD_ALGORITHMS_UNIQUE_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_Unique.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_Unique.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Unique.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_UNIQUE_HPP
 #define KOKKOS_STD_ALGORITHMS_UNIQUE_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_Unique.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_UniqueCopy.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_UniqueCopy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_UNIQUE_COPY_HPP
 #define KOKKOS_STD_ALGORITHMS_UNIQUE_COPY_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "impl/Kokkos_UniqueCopy.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/Kokkos_UniqueCopy.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_UniqueCopy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_UNIQUE_COPY_HPP
 #define KOKKOS_STD_ALGORITHMS_UNIQUE_COPY_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "impl/Kokkos_UniqueCopy.hpp"
 #include "Kokkos_BeginEnd.hpp"
 

--- a/algorithms/src/std_algorithms/impl/Kokkos_AdjacentDifference.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_AdjacentDifference.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ADJACENT_DIFFERENCE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_ADJACENT_DIFFERENCE_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_AdjacentDifference.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_AdjacentDifference.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ADJACENT_DIFFERENCE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_ADJACENT_DIFFERENCE_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_AdjacentFind.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_AdjacentFind.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ADJACENT_FIND_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_ADJACENT_FIND_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_AdjacentFind.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_AdjacentFind.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ADJACENT_FIND_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_ADJACENT_FIND_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_AllOfAnyOfNoneOf.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_AllOfAnyOfNoneOf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ALL_OF_ANY_OF_NONE_OF_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_ALL_OF_ANY_OF_NONE_OF_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include "Kokkos_FindIfOrNot.hpp"
 
 namespace Kokkos {

--- a/algorithms/src/std_algorithms/impl/Kokkos_AllOfAnyOfNoneOf.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_AllOfAnyOfNoneOf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ALL_OF_ANY_OF_NONE_OF_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_ALL_OF_ANY_OF_NONE_OF_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include "Kokkos_FindIfOrNot.hpp"
 
 namespace Kokkos {

--- a/algorithms/src/std_algorithms/impl/Kokkos_Constraints.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Constraints.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_CONSTRAINTS_HPP_
 #define KOKKOS_STD_ALGORITHMS_CONSTRAINTS_HPP_
 
+// IWYU pragma: private
 #include <Kokkos_DetectionIdiom.hpp>
 #include <Kokkos_View.hpp>
 

--- a/algorithms/src/std_algorithms/impl/Kokkos_CopyBackward.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_CopyBackward.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COPY_BACKWARD_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_COPY_BACKWARD_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_CopyBackward.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_CopyBackward.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COPY_BACKWARD_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_COPY_BACKWARD_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_CopyCopyN.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_CopyCopyN.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COPY_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_COPY_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_CopyCopyN.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_CopyCopyN.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COPY_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_COPY_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_CopyIf.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_CopyIf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COPY_IF_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_COPY_IF_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_CopyIf.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_CopyIf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COPY_IF_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_COPY_IF_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_CountCountIf.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_CountCountIf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COUNT_IF_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_COUNT_IF_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_CountCountIf.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_CountCountIf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_COUNT_IF_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_COUNT_IF_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Equal.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Equal.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_EQUAL_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_EQUAL_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Equal.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Equal.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_EQUAL_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_EQUAL_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_ExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ExclusiveScan.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_EXCLUSIVE_SCAN_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_EXCLUSIVE_SCAN_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_ExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ExclusiveScan.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_EXCLUSIVE_SCAN_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_EXCLUSIVE_SCAN_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_FillFillN.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FillFillN.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FILL_AND_FILL_N_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_FILL_AND_FILL_N_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_FillFillN.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FillFillN.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FILL_AND_FILL_N_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_FILL_AND_FILL_N_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_FindEnd.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FindEnd.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FIND_END_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_FIND_END_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_FindEnd.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FindEnd.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FIND_END_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_FIND_END_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_FindFirstOf.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FindFirstOf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FIND_FIRST_OF_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_FIND_FIRST_OF_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_FindFirstOf.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FindFirstOf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FIND_FIRST_OF_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_FIND_FIRST_OF_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_FindIfOrNot.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FindIfOrNot.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FIND_IF_AND_FIND_IF_NOT_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_FIND_IF_AND_FIND_IF_NOT_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_FindIfOrNot.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FindIfOrNot.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FIND_IF_AND_FIND_IF_NOT_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_FIND_IF_AND_FIND_IF_NOT_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_ForEachForEachN.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ForEachForEachN.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FOR_EACH_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_FOR_EACH_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_ForEachForEachN.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ForEachForEachN.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_FOR_EACH_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_FOR_EACH_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_GenerateGenerateN.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_GenerateGenerateN.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_GENERATE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_GENERATE_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_GenerateGenerateN.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_GenerateGenerateN.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_GENERATE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_GENERATE_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_InclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_InclusiveScan.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_INCLUSIVE_SCAN_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_INCLUSIVE_SCAN_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_InclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_InclusiveScan.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_INCLUSIVE_SCAN_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_INCLUSIVE_SCAN_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_IsPartitioned.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_IsPartitioned.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_IS_PARTITIONED_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_IS_PARTITIONED_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_IsPartitioned.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_IsPartitioned.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_IS_PARTITIONED_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_IS_PARTITIONED_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_IsSorted.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_IsSorted.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_IS_SORTED_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_IS_SORTED_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_IsSorted.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_IsSorted.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_IS_SORTED_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_IS_SORTED_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_IsSortedUntil.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_IsSortedUntil.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_IS_SORTED_UNTIL_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_IS_SORTED_UNTIL_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_IsSortedUntil.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_IsSortedUntil.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_IS_SORTED_UNTIL_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_IS_SORTED_UNTIL_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_LexicographicalCompare.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_LexicographicalCompare.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_LEXICOGRAPHICAL_COMPARE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_LEXICOGRAPHICAL_COMPARE_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_LexicographicalCompare.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_LexicographicalCompare.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_LEXICOGRAPHICAL_COMPARE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_LEXICOGRAPHICAL_COMPARE_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_MinMaxMinmaxElement.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_MinMaxMinmaxElement.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MIN_MAX_MINMAX_ELEMENT_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_MIN_MAX_MINMAX_ELEMENT_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_MinMaxMinmaxElement.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_MinMaxMinmaxElement.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MIN_MAX_MINMAX_ELEMENT_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_MIN_MAX_MINMAX_ELEMENT_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Mismatch.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Mismatch.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MISMATCH_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_MISMATCH_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Mismatch.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Mismatch.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MISMATCH_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_MISMATCH_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Move.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Move.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MOVE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_MOVE_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Move.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Move.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MOVE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_MOVE_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_MoveBackward.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_MoveBackward.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MOVE_BACKWARD_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_MOVE_BACKWARD_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_MoveBackward.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_MoveBackward.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_MOVE_BACKWARD_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_MOVE_BACKWARD_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_PartitionCopy.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_PartitionCopy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_PARTITION_COPY_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_PARTITION_COPY_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_PartitionCopy.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_PartitionCopy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_PARTITION_COPY_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_PARTITION_COPY_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_PartitionPoint.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_PartitionPoint.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_PARTITION_POINT_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_PARTITION_POINT_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_PartitionPoint.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_PartitionPoint.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_PARTITION_POINT_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_PARTITION_POINT_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_RANDOM_ACCESS_ITERATOR_IMPL_HPP
 #define KOKKOS_RANDOM_ACCESS_ITERATOR_IMPL_HPP
 
+// IWYU pragma: private
 #include <iterator>
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_View.hpp>

--- a/algorithms/src/std_algorithms/impl/Kokkos_Reduce.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Reduce.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REDUCE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_REDUCE_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Reduce.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Reduce.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REDUCE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_REDUCE_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_RemoveAllVariants.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RemoveAllVariants.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REMOVE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_REMOVE_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_RemoveAllVariants.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RemoveAllVariants.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REMOVE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_REMOVE_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Replace.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Replace.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REPLACE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_REPLACE_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Replace.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Replace.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REPLACE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_REPLACE_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_ReplaceCopy.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ReplaceCopy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REPLACE_COPY_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_REPLACE_COPY_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_ReplaceCopy.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ReplaceCopy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REPLACE_COPY_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_REPLACE_COPY_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_ReplaceCopyIf.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ReplaceCopyIf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REPLACE_COPY_IF_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_REPLACE_COPY_IF_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_ReplaceCopyIf.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ReplaceCopyIf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REPLACE_COPY_IF_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_REPLACE_COPY_IF_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_ReplaceIf.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ReplaceIf.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REPLACE_IF_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_REPLACE_IF_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_ReplaceIf.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ReplaceIf.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REPLACE_IF_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_REPLACE_IF_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Reverse.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Reverse.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REVERSE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_REVERSE_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Reverse.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Reverse.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REVERSE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_REVERSE_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_ReverseCopy.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ReverseCopy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REVERSE_COPY_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_REVERSE_COPY_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_ReverseCopy.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ReverseCopy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_REVERSE_COPY_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_REVERSE_COPY_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Rotate.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Rotate.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ROTATE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_ROTATE_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Rotate.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Rotate.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ROTATE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_ROTATE_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_RotateCopy.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RotateCopy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ROTATE_COPY_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_ROTATE_COPY_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_RotateCopy.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RotateCopy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_ROTATE_COPY_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_ROTATE_COPY_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Search.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Search.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SEARCH_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_SEARCH_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Search.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Search.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SEARCH_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_SEARCH_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_SearchN.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_SearchN.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SEARCH_N_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_SEARCH_N_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_SearchN.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_SearchN.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SEARCH_N_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_SEARCH_N_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_ShiftLeft.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ShiftLeft.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SHIFT_LEFT_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_SHIFT_LEFT_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_ShiftLeft.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ShiftLeft.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SHIFT_LEFT_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_SHIFT_LEFT_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_ShiftRight.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ShiftRight.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SHIFT_RIGHT_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_SHIFT_RIGHT_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_ShiftRight.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ShiftRight.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SHIFT_RIGHT_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_SHIFT_RIGHT_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_SwapRanges.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_SwapRanges.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SWAP_RANGES_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_SWAP_RANGES_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_SwapRanges.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_SwapRanges.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_SWAP_RANGES_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_SWAP_RANGES_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Transform.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Transform.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_TRANSFORM_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_TRANSFORM_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Transform.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Transform.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_TRANSFORM_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_TRANSFORM_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_TransformExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_TransformExclusiveScan.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_TRANSFORM_EXCLUSIVE_SCAN_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_TRANSFORM_EXCLUSIVE_SCAN_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_TransformExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_TransformExclusiveScan.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_TRANSFORM_EXCLUSIVE_SCAN_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_TRANSFORM_EXCLUSIVE_SCAN_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_TransformInclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_TransformInclusiveScan.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_TRANSFORM_INCLUSIVE_SCAN_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_TRANSFORM_INCLUSIVE_SCAN_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_TransformInclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_TransformInclusiveScan.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_TRANSFORM_INCLUSIVE_SCAN_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_TRANSFORM_INCLUSIVE_SCAN_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_TransformReduce.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_TransformReduce.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_TRANSFORM_REDUCE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_TRANSFORM_REDUCE_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_TransformReduce.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_TransformReduce.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_TRANSFORM_REDUCE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_TRANSFORM_REDUCE_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Unique.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Unique.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_UNIQUE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_UNIQUE_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_Unique.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Unique.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_UNIQUE_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_UNIQUE_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_UniqueCopy.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_UniqueCopy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_UNIQUE_COPY_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_UNIQUE_COPY_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/algorithms/src/std_algorithms/impl/Kokkos_UniqueCopy.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_UniqueCopy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STD_ALGORITHMS_UNIQUE_COPY_IMPL_HPP
 #define KOKKOS_STD_ALGORITHMS_UNIQUE_COPY_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_StdAlgorithms.hpp>
+// IWYU pragma: private, include "Kokkos_StdAlgorithms.hpp"
 #include <Kokkos_Core.hpp>
 #include "Kokkos_Constraints.hpp"
 #include "Kokkos_HelperPredicates.hpp"

--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -24,7 +24,7 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Functional.hpp>
 
-#include <impl/Kokkos_Bitset_impl.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Bitset_impl.hpp>  // IWYU pragma: export
 
 namespace Kokkos {
 

--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -24,7 +24,7 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Functional.hpp>
 
-#include <impl/Kokkos_Bitset_impl.hpp>
+#include <impl/Kokkos_Bitset_impl.hpp> // IWYU pragma: export
 
 namespace Kokkos {
 

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -28,7 +28,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
-#include <impl/Kokkos_Error.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Error.hpp>  // IWYU pragma: export
 
 namespace Kokkos {
 

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -28,7 +28,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
-#include <impl/Kokkos_Error.hpp>
+#include <impl/Kokkos_Error.hpp> // IWYU pragma: export
 
 namespace Kokkos {
 

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -28,7 +28,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
-#include <impl/Kokkos_Error.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Error.hpp>  // IWYU pragma: export
 #include <type_traits>
 
 namespace Kokkos {

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -28,7 +28,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
-#include <impl/Kokkos_Error.hpp>
+#include <impl/Kokkos_Error.hpp> // IWYU pragma: export
 #include <type_traits>
 
 namespace Kokkos {

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -24,7 +24,7 @@
 #include <cstdio>
 
 #include <Kokkos_Core.hpp>
-#include <impl/Kokkos_Error.hpp>
+#include <impl/Kokkos_Error.hpp> // IWYU pragma: export
 
 namespace Kokkos {
 namespace Experimental {

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -24,7 +24,7 @@
 #include <cstdio>
 
 #include <Kokkos_Core.hpp>
-#include <impl/Kokkos_Error.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Error.hpp>  // IWYU pragma: export
 
 namespace Kokkos {
 namespace Experimental {

--- a/containers/src/Kokkos_ErrorReporter.hpp
+++ b/containers/src/Kokkos_ErrorReporter.hpp
@@ -23,7 +23,7 @@
 
 #include <vector>
 #include <Kokkos_Core.hpp>
-#include <Kokkos_View.hpp>
+#include <Kokkos_View.hpp> // IWYU pragma: export
 #include <Kokkos_DualView.hpp>
 
 namespace Kokkos {

--- a/containers/src/Kokkos_ErrorReporter.hpp
+++ b/containers/src/Kokkos_ErrorReporter.hpp
@@ -23,7 +23,7 @@
 
 #include <vector>
 #include <Kokkos_Core.hpp>
-#include <Kokkos_View.hpp> // IWYU pragma: export
+#include <Kokkos_View.hpp>  // IWYU pragma: export
 #include <Kokkos_DualView.hpp>
 
 namespace Kokkos {

--- a/containers/src/Kokkos_Functional.hpp
+++ b/containers/src/Kokkos_Functional.hpp
@@ -21,8 +21,8 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_FUNCTIONAL
 #endif
 
-#include <Kokkos_Macros.hpp>
-#include <impl/Kokkos_Functional_impl.hpp>
+#include <Kokkos_Macros.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Functional_impl.hpp> // IWYU pragma: export
 
 namespace Kokkos {
 

--- a/containers/src/Kokkos_Functional.hpp
+++ b/containers/src/Kokkos_Functional.hpp
@@ -21,8 +21,8 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_FUNCTIONAL
 #endif
 
-#include <Kokkos_Macros.hpp> // IWYU pragma: export
-#include <impl/Kokkos_Functional_impl.hpp> // IWYU pragma: export
+#include <Kokkos_Macros.hpp>                // IWYU pragma: export
+#include <impl/Kokkos_Functional_impl.hpp>  // IWYU pragma: export
 
 namespace Kokkos {
 

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -23,7 +23,7 @@
 
 #include <Kokkos_Core.hpp>
 
-#include <Kokkos_View.hpp> // IWYU pragma: export
+#include <Kokkos_View.hpp>  // IWYU pragma: export
 
 namespace Kokkos {
 

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -23,7 +23,7 @@
 
 #include <Kokkos_Core.hpp>
 
-#include <Kokkos_View.hpp>
+#include <Kokkos_View.hpp> // IWYU pragma: export
 
 namespace Kokkos {
 

--- a/containers/src/Kokkos_StaticCrsGraph.hpp
+++ b/containers/src/Kokkos_StaticCrsGraph.hpp
@@ -24,9 +24,9 @@
 #include <string>
 #include <vector>
 
-#include <Kokkos_View.hpp>
-#include <Kokkos_Parallel.hpp>
-#include <Kokkos_Parallel_Reduce.hpp>
+#include <Kokkos_View.hpp> // IWYU pragma: export
+#include <Kokkos_Parallel.hpp> // IWYU pragma: export
+#include <Kokkos_Parallel_Reduce.hpp> // IWYU pragma: export
 
 namespace Kokkos {
 
@@ -420,7 +420,7 @@ create_mirror(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-#include <impl/Kokkos_StaticCrsGraph_factory.hpp>
+#include <impl/Kokkos_StaticCrsGraph_factory.hpp> // IWYU pragma: export
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/containers/src/Kokkos_StaticCrsGraph.hpp
+++ b/containers/src/Kokkos_StaticCrsGraph.hpp
@@ -24,9 +24,9 @@
 #include <string>
 #include <vector>
 
-#include <Kokkos_View.hpp> // IWYU pragma: export
-#include <Kokkos_Parallel.hpp> // IWYU pragma: export
-#include <Kokkos_Parallel_Reduce.hpp> // IWYU pragma: export
+#include <Kokkos_View.hpp>             // IWYU pragma: export
+#include <Kokkos_Parallel.hpp>         // IWYU pragma: export
+#include <Kokkos_Parallel_Reduce.hpp>  // IWYU pragma: export
 
 namespace Kokkos {
 
@@ -420,7 +420,7 @@ create_mirror(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-#include <impl/Kokkos_StaticCrsGraph_factory.hpp> // IWYU pragma: export
+#include <impl/Kokkos_StaticCrsGraph_factory.hpp>  // IWYU pragma: export
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -32,9 +32,9 @@
 
 #include <Kokkos_Bitset.hpp>
 
-#include <impl/Kokkos_Traits.hpp> // IWYU pragma: export
-#include <impl/Kokkos_UnorderedMap_impl.hpp> // IWYU pragma: export
-#include <impl/Kokkos_ViewCtor.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Traits.hpp>             // IWYU pragma: export
+#include <impl/Kokkos_UnorderedMap_impl.hpp>  // IWYU pragma: export
+#include <impl/Kokkos_ViewCtor.hpp>           // IWYU pragma: export
 
 #include <cstdint>
 

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -32,9 +32,9 @@
 
 #include <Kokkos_Bitset.hpp>
 
-#include <impl/Kokkos_Traits.hpp>
-#include <impl/Kokkos_UnorderedMap_impl.hpp>
-#include <impl/Kokkos_ViewCtor.hpp>
+#include <impl/Kokkos_Traits.hpp> // IWYU pragma: export
+#include <impl/Kokkos_UnorderedMap_impl.hpp> // IWYU pragma: export
+#include <impl/Kokkos_ViewCtor.hpp> // IWYU pragma: export
 
 #include <cstdint>
 

--- a/containers/src/Kokkos_Vector.hpp
+++ b/containers/src/Kokkos_Vector.hpp
@@ -21,7 +21,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_VECTOR
 #endif
 
-#include <Kokkos_Macros.hpp> // IWYU pragma: export
+#include <Kokkos_Macros.hpp>  // IWYU pragma: export
 
 #if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
 #if defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)

--- a/containers/src/Kokkos_Vector.hpp
+++ b/containers/src/Kokkos_Vector.hpp
@@ -21,7 +21,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_VECTOR
 #endif
 
-#include <Kokkos_Macros.hpp>
+#include <Kokkos_Macros.hpp> // IWYU pragma: export
 
 #if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
 #if defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Cuda/Kokkos_CudaSpace.hpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Cuda/Kokkos_CudaSpace.hpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_KOKKOS_CUDA_GRAPHNODEKERNEL_IMPL_HPP
 #define KOKKOS_KOKKOS_CUDA_GRAPHNODEKERNEL_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_KOKKOS_CUDA_GRAPHNODEKERNEL_IMPL_HPP
 #define KOKKOS_KOKKOS_CUDA_GRAPHNODEKERNEL_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/core/src/Cuda/Kokkos_Cuda_GraphNode_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNode_Impl.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_KOKKOS_CUDA_GRAPHNODE_IMPL_HPP
 #define KOKKOS_KOKKOS_CUDA_GRAPHNODE_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_Graph.hpp>
+// IWYU pragma: private, include "Kokkos_Graph.hpp"
 #include <Kokkos_Macros.hpp>
 
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/core/src/Cuda/Kokkos_Cuda_GraphNode_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNode_Impl.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_KOKKOS_CUDA_GRAPHNODE_IMPL_HPP
 #define KOKKOS_KOKKOS_CUDA_GRAPHNODE_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_Graph.hpp>
 #include <Kokkos_Macros.hpp>
 
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_KOKKOS_CUDA_GRAPH_IMPL_HPP
 #define KOKKOS_KOKKOS_CUDA_GRAPH_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_Graph.hpp>
+// IWYU pragma: private, include "Kokkos_Graph.hpp"
 #include <Kokkos_Macros.hpp>
 
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_KOKKOS_CUDA_GRAPH_IMPL_HPP
 #define KOKKOS_KOKKOS_CUDA_GRAPH_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_Graph.hpp>
 #include <Kokkos_Macros.hpp>
 
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_CUDA_INSTANCE_HPP_
 #define KOKKOS_CUDA_INSTANCE_HPP_
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <vector>
 #include <impl/Kokkos_Tools.hpp>
 #include <atomic>

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_CUDA_INSTANCE_HPP_
 #define KOKKOS_CUDA_INSTANCE_HPP_
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <vector>
 #include <impl/Kokkos_Tools.hpp>
 #include <atomic>

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_CUDAEXEC_HPP
 #define KOKKOS_CUDAEXEC_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_CUDA
 

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_CUDAEXEC_HPP
 #define KOKKOS_CUDAEXEC_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_CUDA
 

--- a/core/src/Cuda/Kokkos_Cuda_MDRangePolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_MDRangePolicy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_CUDA_MDRANGEPOLICY_HPP_
 #define KOKKOS_CUDA_MDRANGEPOLICY_HPP_
 
+// IWYU pragma: private
 #include <KokkosExp_MDRangePolicy.hpp>
 
 namespace Kokkos {

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_CUDA_PARALLEL_MD_RANGE_HPP
 #define KOKKOS_CUDA_PARALLEL_MD_RANGE_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_CUDA)
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_CUDA_PARALLEL_RANGE_HPP
 #define KOKKOS_CUDA_PARALLEL_RANGE_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_CUDA)
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_CUDA_PARALLEL_TEAM_HPP
 #define KOKKOS_CUDA_PARALLEL_TEAM_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_CUDA)
 

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_CUDA_REDUCESCAN_HPP
 #define KOKKOS_CUDA_REDUCESCAN_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_CUDA)
 

--- a/core/src/Cuda/Kokkos_Cuda_Task.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Task.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_IMPL_CUDA_TASK_HPP
 #define KOKKOS_IMPL_CUDA_TASK_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_CUDA_TEAM_HPP
 #define KOKKOS_CUDA_TEAM_HPP
 
+// IWYU pragma: private
 #include <algorithm>
 
 #include <Kokkos_Macros.hpp>

--- a/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_CUDA_UNIQUE_TOKEN_HPP
 #define KOKKOS_CUDA_UNIQUE_TOKEN_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_CUDA
 

--- a/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_CUDA_WORKGRAPHPOLICY_HPP
 #define KOKKOS_CUDA_WORKGRAPHPOLICY_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Cuda/Kokkos_Cuda.hpp>
 #include <Cuda/Kokkos_Cuda_KernelLaunch.hpp>
 

--- a/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_CUDA_WORKGRAPHPOLICY_HPP
 #define KOKKOS_CUDA_WORKGRAPHPOLICY_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Cuda/Kokkos_Cuda.hpp>
 #include <Cuda/Kokkos_Cuda_KernelLaunch.hpp>
 

--- a/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
@@ -16,6 +16,7 @@
 #ifndef KOKKOS_CUDA_ZEROMEMSET_HPP
 #define KOKKOS_CUDA_ZEROMEMSET_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 #include <Cuda/Kokkos_Cuda.hpp>
 #include <impl/Kokkos_ZeroMemset_fwd.hpp>

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_HPP
 #define KOKKOS_HIP_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Core_fwd.hpp>
 
 #include <Kokkos_Layout.hpp>

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_HIP_HPP
 #define KOKKOS_HIP_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Core_fwd.hpp>
 
 #include <Kokkos_Layout.hpp>

--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_BLOCKSIZE_DEDUCTION_HPP
 #define KOKKOS_HIP_BLOCKSIZE_DEDUCTION_HPP
 
+// IWYU pragma: private
 #include <functional>
 #include <Kokkos_Macros.hpp>
 

--- a/core/src/HIP/Kokkos_HIP_DeepCopy.hpp
+++ b/core/src/HIP/Kokkos_HIP_DeepCopy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_DEEP_COPY_HPP
 #define KOKKOS_HIP_DEEP_COPY_HPP
 
+// IWYU pragma: private
 #include <HIP/Kokkos_HIP_Space.hpp>
 #include <HIP/Kokkos_HIP_Error.hpp>  // HIP_SAFE_CALL
 

--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_HIP_GRAPHNODEKERNEL_HPP
 #define KOKKOS_HIP_GRAPHNODEKERNEL_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Graph_fwd.hpp>
 
 #include <impl/Kokkos_GraphImpl.hpp>

--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_GRAPHNODEKERNEL_HPP
 #define KOKKOS_HIP_GRAPHNODEKERNEL_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Graph_fwd.hpp>
 
 #include <impl/Kokkos_GraphImpl.hpp>

--- a/core/src/HIP/Kokkos_HIP_GraphNode_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNode_Impl.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_GRAPHNODE_IMPL_HPP
 #define KOKKOS_HIP_GRAPHNODE_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Graph_fwd.hpp>
 
 #include <impl/Kokkos_GraphImpl.hpp>

--- a/core/src/HIP/Kokkos_HIP_GraphNode_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNode_Impl.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_HIP_GRAPHNODE_IMPL_HPP
 #define KOKKOS_HIP_GRAPHNODE_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Graph_fwd.hpp>
 
 #include <impl/Kokkos_GraphImpl.hpp>

--- a/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_HIP_GRAPH_IMPL_HPP
 #define KOKKOS_HIP_GRAPH_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_Graph.hpp>
+// IWYU pragma: private, include "Kokkos_Graph.hpp"
 #include <Kokkos_Macros.hpp>
 
 #include <Kokkos_Graph_fwd.hpp>

--- a/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_GRAPH_IMPL_HPP
 #define KOKKOS_HIP_GRAPH_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_Graph.hpp>
 #include <Kokkos_Macros.hpp>
 
 #include <Kokkos_Graph_fwd.hpp>

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -19,6 +19,7 @@
 #ifndef KOKKOS_HIP_INSTANCE_HPP
 #define KOKKOS_HIP_INSTANCE_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <HIP/Kokkos_HIP_Space.hpp>
 #include <HIP/Kokkos_HIP_Error.hpp>
 

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -19,7 +19,7 @@
 #ifndef KOKKOS_HIP_INSTANCE_HPP
 #define KOKKOS_HIP_INSTANCE_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <HIP/Kokkos_HIP_Space.hpp>
 #include <HIP/Kokkos_HIP_Error.hpp>
 

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_KERNEL_LAUNCH_HPP
 #define KOKKOS_HIP_KERNEL_LAUNCH_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 
 #if defined(__HIPCC__)

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_HIP_KERNEL_LAUNCH_HPP
 #define KOKKOS_HIP_KERNEL_LAUNCH_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 
 #if defined(__HIPCC__)

--- a/core/src/HIP/Kokkos_HIP_MDRangePolicy.hpp
+++ b/core/src/HIP/Kokkos_HIP_MDRangePolicy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_MDRANGEPOLICY_HPP_
 #define KOKKOS_HIP_MDRANGEPOLICY_HPP_
 
+// IWYU pragma: private
 #include <KokkosExp_MDRangePolicy.hpp>
 
 namespace Kokkos {

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_PARALLEL_FOR_MDRANGE_HPP
 #define KOKKOS_HIP_PARALLEL_FOR_MDRANGE_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Parallel.hpp>
 
 #include <HIP/Kokkos_HIP_BlockSize_Deduction.hpp>

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_PARALLEL_FOR_RANGE_HPP
 #define KOKKOS_HIP_PARALLEL_FOR_RANGE_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Parallel.hpp>
 
 #include <HIP/Kokkos_HIP_BlockSize_Deduction.hpp>

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_PARALLEL_FOR_TEAM_HPP
 #define KOKKOS_HIP_PARALLEL_FOR_TEAM_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Parallel.hpp>
 
 #include <HIP/Kokkos_HIP_KernelLaunch.hpp>

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_PARALLEL_REDUCE_MDRANGE_HPP
 #define KOKKOS_HIP_PARALLEL_REDUCE_MDRANGE_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Parallel.hpp>
 
 #include <HIP/Kokkos_HIP_BlockSize_Deduction.hpp>

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_Range.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_PARALLEL_REDUCE_RANGE_HPP
 #define KOKKOS_HIP_PARALLEL_REDUCE_RANGE_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Parallel.hpp>
 
 #include <HIP/Kokkos_HIP_BlockSize_Deduction.hpp>

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_PARALLEL_REDUCE_TEAM_HPP
 #define KOKKOS_HIP_PARALLEL_REDUCE_TEAM_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Parallel.hpp>
 
 #include <HIP/Kokkos_HIP_KernelLaunch.hpp>

--- a/core/src/HIP/Kokkos_HIP_ParallelScan_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelScan_Range.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_PARALLEL_SCAN_RANGE_HPP
 #define KOKKOS_HIP_PARALLEL_SCAN_RANGE_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Parallel.hpp>
 
 #include <HIP/Kokkos_HIP_BlockSize_Deduction.hpp>

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_REDUCESCAN_HPP
 #define KOKKOS_HIP_REDUCESCAN_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 
 #if defined(__HIPCC__)

--- a/core/src/HIP/Kokkos_HIP_SharedAllocationRecord.hpp
+++ b/core/src/HIP/Kokkos_HIP_SharedAllocationRecord.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_SHARED_ALLOCATION_RECORD_HPP
 #define KOKKOS_HIP_SHARED_ALLOCATION_RECORD_HPP
 
+// IWYU pragma: private
 #include <HIP/Kokkos_HIP_Space.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>
 

--- a/core/src/HIP/Kokkos_HIP_Space.hpp
+++ b/core/src/HIP/Kokkos_HIP_Space.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIPSPACE_HPP
 #define KOKKOS_HIPSPACE_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Core_fwd.hpp>
 
 #include <iosfwd>

--- a/core/src/HIP/Kokkos_HIP_Space.hpp
+++ b/core/src/HIP/Kokkos_HIP_Space.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_HIPSPACE_HPP
 #define KOKKOS_HIPSPACE_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Core_fwd.hpp>
 
 #include <iosfwd>

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_TEAM_HPP
 #define KOKKOS_HIP_TEAM_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 
 #if defined(__HIPCC__)

--- a/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
+++ b/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_UNIQUE_TOKEN_HPP
 #define KOKKOS_HIP_UNIQUE_TOKEN_HPP
 
+// IWYU pragma: private
 #include <HIP/Kokkos_HIP_Space.hpp>
 #include <Kokkos_UniqueToken.hpp>
 

--- a/core/src/HIP/Kokkos_HIP_WorkGraphPolicy.hpp
+++ b/core/src/HIP/Kokkos_HIP_WorkGraphPolicy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_HIP_WORKGRAPHPOLICY_HPP
 #define KOKKOS_HIP_WORKGRAPHPOLICY_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <HIP/Kokkos_HIP.hpp>
 #include <HIP/Kokkos_HIP_Instance.hpp>
 #include <HIP/Kokkos_HIP_KernelLaunch.hpp>

--- a/core/src/HIP/Kokkos_HIP_WorkGraphPolicy.hpp
+++ b/core/src/HIP/Kokkos_HIP_WorkGraphPolicy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_WORKGRAPHPOLICY_HPP
 #define KOKKOS_HIP_WORKGRAPHPOLICY_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <HIP/Kokkos_HIP.hpp>
 #include <HIP/Kokkos_HIP_Instance.hpp>
 #include <HIP/Kokkos_HIP_KernelLaunch.hpp>

--- a/core/src/HIP/Kokkos_HIP_ZeroMemset.hpp
+++ b/core/src/HIP/Kokkos_HIP_ZeroMemset.hpp
@@ -16,6 +16,7 @@
 #ifndef KOKKOS_HIP_ZEROMEMSET_HPP
 #define KOKKOS_HIP_ZEROMEMSET_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 #include <HIP/Kokkos_HIP.hpp>
 #include <impl/Kokkos_ZeroMemset_fwd.hpp>

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/HPX/Kokkos_HPX_MDRangePolicy.hpp
+++ b/core/src/HPX/Kokkos_HPX_MDRangePolicy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HPX_MDRANGEPOLICY_HPP_
 #define KOKKOS_HPX_MDRANGEPOLICY_HPP_
 
+// IWYU pragma: private
 #include <KokkosExp_MDRangePolicy.hpp>
 
 namespace Kokkos {

--- a/core/src/HPX/Kokkos_HPX_Task.hpp
+++ b/core/src/HPX/Kokkos_HPX_Task.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HPX_TASK_HPP
 #define KOKKOS_HPX_TASK_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_HPX) && defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/HPX/Kokkos_HPX_Task.hpp
+++ b/core/src/HPX/Kokkos_HPX_Task.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_HPX_TASK_HPP
 #define KOKKOS_HPX_TASK_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_HPX) && defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/HPX/Kokkos_HPX_WorkGraphPolicy.hpp
+++ b/core/src/HPX/Kokkos_HPX_WorkGraphPolicy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_HPX_WORKGRAPHPOLICY_HPP
 #define KOKKOS_HPX_WORKGRAPHPOLICY_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <HPX/Kokkos_HPX.hpp>
 
 #include <hpx/execution.hpp>

--- a/core/src/HPX/Kokkos_HPX_WorkGraphPolicy.hpp
+++ b/core/src/HPX/Kokkos_HPX_WorkGraphPolicy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HPX_WORKGRAPHPOLICY_HPP
 #define KOKKOS_HPX_WORKGRAPHPOLICY_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <HPX/Kokkos_HPX.hpp>
 
 #include <hpx/execution.hpp>

--- a/core/src/KokkosExp_InterOp.hpp
+++ b/core/src/KokkosExp_InterOp.hpp
@@ -22,10 +22,10 @@
 #endif
 
 #include <Kokkos_Core_fwd.hpp>
-#include <Kokkos_Layout.hpp> // IWYU pragma: export
-#include <Kokkos_MemoryTraits.hpp> // IWYU pragma: export
-#include <Kokkos_View.hpp> // IWYU pragma: export
-#include <impl/Kokkos_Utilities.hpp> // IWYU pragma: export
+#include <Kokkos_Layout.hpp>          // IWYU pragma: export
+#include <Kokkos_MemoryTraits.hpp>    // IWYU pragma: export
+#include <Kokkos_View.hpp>            // IWYU pragma: export
+#include <impl/Kokkos_Utilities.hpp>  // IWYU pragma: export
 #include <type_traits>
 
 namespace Kokkos {

--- a/core/src/KokkosExp_InterOp.hpp
+++ b/core/src/KokkosExp_InterOp.hpp
@@ -22,10 +22,10 @@
 #endif
 
 #include <Kokkos_Core_fwd.hpp>
-#include <Kokkos_Layout.hpp>
-#include <Kokkos_MemoryTraits.hpp>
-#include <Kokkos_View.hpp>
-#include <impl/Kokkos_Utilities.hpp>
+#include <Kokkos_Layout.hpp> // IWYU pragma: export
+#include <Kokkos_MemoryTraits.hpp> // IWYU pragma: export
+#include <Kokkos_View.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Utilities.hpp> // IWYU pragma: export
 #include <type_traits>
 
 namespace Kokkos {

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_AcquireUniqueTokenImpl.hpp
+++ b/core/src/Kokkos_AcquireUniqueTokenImpl.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_AcquireUniqueTokenImpl.hpp
+++ b/core/src/Kokkos_AcquireUniqueTokenImpl.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_AnonymousSpace.hpp
+++ b/core/src/Kokkos_AnonymousSpace.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_AnonymousSpace.hpp
+++ b/core/src/Kokkos_AnonymousSpace.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -21,10 +21,10 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_ARRAY
 #endif
 
-#include <Kokkos_Macros.hpp>
-#include <Kokkos_Swap.hpp>
-#include <impl/Kokkos_Error.hpp>
-#include <impl/Kokkos_StringManipulation.hpp>
+#include <Kokkos_Macros.hpp> // IWYU pragma: export
+#include <Kokkos_Swap.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Error.hpp> // IWYU pragma: export
+#include <impl/Kokkos_StringManipulation.hpp> // IWYU pragma: export
 
 #include <type_traits>
 #include <algorithm>

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -21,10 +21,10 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_ARRAY
 #endif
 
-#include <Kokkos_Macros.hpp> // IWYU pragma: export
-#include <Kokkos_Swap.hpp> // IWYU pragma: export
-#include <impl/Kokkos_Error.hpp> // IWYU pragma: export
-#include <impl/Kokkos_StringManipulation.hpp> // IWYU pragma: export
+#include <Kokkos_Macros.hpp>                   // IWYU pragma: export
+#include <Kokkos_Swap.hpp>                     // IWYU pragma: export
+#include <impl/Kokkos_Error.hpp>               // IWYU pragma: export
+#include <impl/Kokkos_StringManipulation.hpp>  // IWYU pragma: export
 
 #include <type_traits>
 #include <algorithm>

--- a/core/src/Kokkos_Atomic.hpp
+++ b/core/src/Kokkos_Atomic.hpp
@@ -44,10 +44,10 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_ATOMIC
 #endif
 
-#include <Kokkos_Macros.hpp> // IWYU pragma: export
+#include <Kokkos_Macros.hpp>  // IWYU pragma: export
 
-#include <Kokkos_Atomics_Desul_Wrapper.hpp> // IWYU pragma: export
-#include <Kokkos_Atomics_Desul_Volatile_Wrapper.hpp> // IWYU pragma: export
+#include <Kokkos_Atomics_Desul_Wrapper.hpp>           // IWYU pragma: export
+#include <Kokkos_Atomics_Desul_Volatile_Wrapper.hpp>  // IWYU pragma: export
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_ATOMIC
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE

--- a/core/src/Kokkos_Atomic.hpp
+++ b/core/src/Kokkos_Atomic.hpp
@@ -44,10 +44,10 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_ATOMIC
 #endif
 
-#include <Kokkos_Macros.hpp>
+#include <Kokkos_Macros.hpp> // IWYU pragma: export
 
-#include <Kokkos_Atomics_Desul_Wrapper.hpp>
-#include <Kokkos_Atomics_Desul_Volatile_Wrapper.hpp>
+#include <Kokkos_Atomics_Desul_Wrapper.hpp> // IWYU pragma: export
+#include <Kokkos_Atomics_Desul_Volatile_Wrapper.hpp> // IWYU pragma: export
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_ATOMIC
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE

--- a/core/src/Kokkos_Atomics_Desul_Config.hpp
+++ b/core/src/Kokkos_Atomics_Desul_Config.hpp
@@ -14,6 +14,7 @@
 //
 //@HEADER
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Atomic.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Atomics_Desul_Config.hpp
+++ b/core/src/Kokkos_Atomics_Desul_Config.hpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Atomic.hpp>
+// IWYU pragma: private, include "Kokkos_Atomic.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Atomics_Desul_Volatile_Wrapper.hpp
+++ b/core/src/Kokkos_Atomics_Desul_Volatile_Wrapper.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Atomic.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Atomics_Desul_Volatile_Wrapper.hpp
+++ b/core/src/Kokkos_Atomics_Desul_Volatile_Wrapper.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Atomic.hpp>
+// IWYU pragma: private, include "Kokkos_Atomic.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Atomics_Desul_Wrapper.hpp
+++ b/core/src/Kokkos_Atomics_Desul_Wrapper.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Atomic.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Atomics_Desul_Wrapper.hpp
+++ b/core/src/Kokkos_Atomics_Desul_Wrapper.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Atomic.hpp>
+// IWYU pragma: private, include "Kokkos_Atomic.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -24,7 +24,7 @@
 #include <Kokkos_MathematicalFunctions.hpp>
 #include <Kokkos_NumericTraits.hpp>
 #include <Kokkos_ReductionIdentity.hpp>
-#include <impl/Kokkos_Error.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Error.hpp>  // IWYU pragma: export
 #include <complex>
 #include <type_traits>
 #include <iosfwd>

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -24,7 +24,7 @@
 #include <Kokkos_MathematicalFunctions.hpp>
 #include <Kokkos_NumericTraits.hpp>
 #include <Kokkos_ReductionIdentity.hpp>
-#include <impl/Kokkos_Error.hpp>
+#include <impl/Kokkos_Error.hpp> // IWYU pragma: export
 #include <complex>
 #include <type_traits>
 #include <iosfwd>

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -45,29 +45,29 @@
 #include <KokkosCore_Config_DeclareBackend.hpp>
 
 #include <Kokkos_Half.hpp>
-#include <Kokkos_AnonymousSpace.hpp> // IWYU pragma: export
+#include <Kokkos_AnonymousSpace.hpp>  // IWYU pragma: export
 #include <Kokkos_Pair.hpp>
-#include <Kokkos_Clamp.hpp> // IWYU pragma: export
-#include <Kokkos_MinMax.hpp> // IWYU pragma: export
+#include <Kokkos_Clamp.hpp>   // IWYU pragma: export
+#include <Kokkos_MinMax.hpp>  // IWYU pragma: export
 #include <Kokkos_MathematicalConstants.hpp>
 #include <Kokkos_MathematicalFunctions.hpp>
 #include <Kokkos_MathematicalSpecialFunctions.hpp>
 #include <Kokkos_NumericTraits.hpp>
-#include <Kokkos_BitManipulation.hpp> // IWYU pragma: export
-#include <Kokkos_Swap.hpp> // IWYU pragma: export
-#include <Kokkos_MemoryPool.hpp> // IWYU pragma: export
+#include <Kokkos_BitManipulation.hpp>  // IWYU pragma: export
+#include <Kokkos_Swap.hpp>             // IWYU pragma: export
+#include <Kokkos_MemoryPool.hpp>       // IWYU pragma: export
 #include <Kokkos_Array.hpp>
-#include <Kokkos_View.hpp> // IWYU pragma: export
-#include <Kokkos_Vectorization.hpp> // IWYU pragma: export
+#include <Kokkos_View.hpp>           // IWYU pragma: export
+#include <Kokkos_Vectorization.hpp>  // IWYU pragma: export
 #include <Kokkos_Atomic.hpp>
-#include <Kokkos_hwloc.hpp> // IWYU pragma: export
+#include <Kokkos_hwloc.hpp>  // IWYU pragma: export
 #include <Kokkos_Timer.hpp>
-#include <Kokkos_Tuners.hpp> // IWYU pragma: export
-#include <Kokkos_TaskScheduler.hpp> // IWYU pragma: export
+#include <Kokkos_Tuners.hpp>         // IWYU pragma: export
+#include <Kokkos_TaskScheduler.hpp>  // IWYU pragma: export
 #include <Kokkos_Complex.hpp>
-#include <Kokkos_CopyViews.hpp> // IWYU pragma: export
-#include <impl/Kokkos_TeamMDPolicy.hpp> // IWYU pragma: export
-#include <impl/Kokkos_InitializationSettings.hpp> // IWYU pragma: export
+#include <Kokkos_CopyViews.hpp>                    // IWYU pragma: export
+#include <impl/Kokkos_TeamMDPolicy.hpp>            // IWYU pragma: export
+#include <impl/Kokkos_InitializationSettings.hpp>  // IWYU pragma: export
 #include <functional>
 #include <iosfwd>
 #include <memory>
@@ -291,16 +291,16 @@ std::vector<ExecSpace> partition_space(ExecSpace const& space,
 }  // namespace Experimental
 }  // namespace Kokkos
 
-#include <Kokkos_Crs.hpp> // IWYU pragma: export
-#include <Kokkos_WorkGraphPolicy.hpp> // IWYU pragma: export
+#include <Kokkos_Crs.hpp>              // IWYU pragma: export
+#include <Kokkos_WorkGraphPolicy.hpp>  // IWYU pragma: export
 // Including this in Kokkos_Parallel_Reduce.hpp led to a circular dependency
 // because Kokkos::Sum is used in Kokkos_Combined_Reducer.hpp and the default.
 // The real answer is to finally break up Kokkos_Parallel_Reduce.hpp into
 // smaller parts...
-#include <impl/Kokkos_Combined_Reducer.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Combined_Reducer.hpp>  // IWYU pragma: export
 // Yet another workaround to deal with circular dependency issues because the
 // implementation of the RAII wrapper is using Kokkos::single.
-#include <Kokkos_AcquireUniqueTokenImpl.hpp> // IWYU pragma: export
+#include <Kokkos_AcquireUniqueTokenImpl.hpp>  // IWYU pragma: export
 
 //----------------------------------------------------------------------------
 // Redefinition of the macros min and max if we pushed them at entry of

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -45,29 +45,29 @@
 #include <KokkosCore_Config_DeclareBackend.hpp>
 
 #include <Kokkos_Half.hpp>
-#include <Kokkos_AnonymousSpace.hpp>
+#include <Kokkos_AnonymousSpace.hpp> // IWYU pragma: export
 #include <Kokkos_Pair.hpp>
-#include <Kokkos_Clamp.hpp>
-#include <Kokkos_MinMax.hpp>
+#include <Kokkos_Clamp.hpp> // IWYU pragma: export
+#include <Kokkos_MinMax.hpp> // IWYU pragma: export
 #include <Kokkos_MathematicalConstants.hpp>
 #include <Kokkos_MathematicalFunctions.hpp>
 #include <Kokkos_MathematicalSpecialFunctions.hpp>
 #include <Kokkos_NumericTraits.hpp>
-#include <Kokkos_BitManipulation.hpp>
-#include <Kokkos_Swap.hpp>
-#include <Kokkos_MemoryPool.hpp>
+#include <Kokkos_BitManipulation.hpp> // IWYU pragma: export
+#include <Kokkos_Swap.hpp> // IWYU pragma: export
+#include <Kokkos_MemoryPool.hpp> // IWYU pragma: export
 #include <Kokkos_Array.hpp>
-#include <Kokkos_View.hpp>
-#include <Kokkos_Vectorization.hpp>
+#include <Kokkos_View.hpp> // IWYU pragma: export
+#include <Kokkos_Vectorization.hpp> // IWYU pragma: export
 #include <Kokkos_Atomic.hpp>
-#include <Kokkos_hwloc.hpp>
+#include <Kokkos_hwloc.hpp> // IWYU pragma: export
 #include <Kokkos_Timer.hpp>
-#include <Kokkos_Tuners.hpp>
-#include <Kokkos_TaskScheduler.hpp>
+#include <Kokkos_Tuners.hpp> // IWYU pragma: export
+#include <Kokkos_TaskScheduler.hpp> // IWYU pragma: export
 #include <Kokkos_Complex.hpp>
-#include <Kokkos_CopyViews.hpp>
-#include <impl/Kokkos_TeamMDPolicy.hpp>
-#include <impl/Kokkos_InitializationSettings.hpp>
+#include <Kokkos_CopyViews.hpp> // IWYU pragma: export
+#include <impl/Kokkos_TeamMDPolicy.hpp> // IWYU pragma: export
+#include <impl/Kokkos_InitializationSettings.hpp> // IWYU pragma: export
 #include <functional>
 #include <iosfwd>
 #include <memory>
@@ -291,16 +291,16 @@ std::vector<ExecSpace> partition_space(ExecSpace const& space,
 }  // namespace Experimental
 }  // namespace Kokkos
 
-#include <Kokkos_Crs.hpp>
-#include <Kokkos_WorkGraphPolicy.hpp>
+#include <Kokkos_Crs.hpp> // IWYU pragma: export
+#include <Kokkos_WorkGraphPolicy.hpp> // IWYU pragma: export
 // Including this in Kokkos_Parallel_Reduce.hpp led to a circular dependency
 // because Kokkos::Sum is used in Kokkos_Combined_Reducer.hpp and the default.
 // The real answer is to finally break up Kokkos_Parallel_Reduce.hpp into
 // smaller parts...
-#include <impl/Kokkos_Combined_Reducer.hpp>
+#include <impl/Kokkos_Combined_Reducer.hpp> // IWYU pragma: export
 // Yet another workaround to deal with circular dependency issues because the
 // implementation of the RAII wrapper is using Kokkos::single.
-#include <Kokkos_AcquireUniqueTokenImpl.hpp>
+#include <Kokkos_AcquireUniqueTokenImpl.hpp> // IWYU pragma: export
 
 //----------------------------------------------------------------------------
 // Redefinition of the macros min and max if we pushed them at entry of

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -25,10 +25,10 @@
 // Kokkos_Macros.hpp does introspection on configuration options
 // and compiler environment then sets a collection of #define macros.
 
-#include <Kokkos_Macros.hpp>
-#include <Kokkos_Printf.hpp>
-#include <impl/Kokkos_Error.hpp>
-#include <impl/Kokkos_Utilities.hpp>
+#include <Kokkos_Macros.hpp> // IWYU pragma: export
+#include <Kokkos_Printf.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Error.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Utilities.hpp> // IWYU pragma: export
 
 //----------------------------------------------------------------------------
 // Have assumed a 64-bit build (8-byte pointers) throughout the code base.

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -25,10 +25,10 @@
 // Kokkos_Macros.hpp does introspection on configuration options
 // and compiler environment then sets a collection of #define macros.
 
-#include <Kokkos_Macros.hpp> // IWYU pragma: export
-#include <Kokkos_Printf.hpp> // IWYU pragma: export
-#include <impl/Kokkos_Error.hpp> // IWYU pragma: export
-#include <impl/Kokkos_Utilities.hpp> // IWYU pragma: export
+#include <Kokkos_Macros.hpp>          // IWYU pragma: export
+#include <Kokkos_Printf.hpp>          // IWYU pragma: export
+#include <impl/Kokkos_Error.hpp>      // IWYU pragma: export
+#include <impl/Kokkos_Utilities.hpp>  // IWYU pragma: export
 
 //----------------------------------------------------------------------------
 // Have assumed a 64-bit build (8-byte pointers) throughout the code base.

--- a/core/src/Kokkos_Crs.hpp
+++ b/core/src/Kokkos_Crs.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Crs.hpp
+++ b/core/src/Kokkos_Crs.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Extents.hpp
+++ b/core/src/Kokkos_Extents.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Extents.hpp
+++ b/core/src/Kokkos_Extents.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Future.hpp
+++ b/core/src/Kokkos_Future.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Future.hpp
+++ b/core/src/Kokkos_Future.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -21,14 +21,14 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_GRAPH
 #endif
 
-#include <Kokkos_Macros.hpp>
+#include <Kokkos_Macros.hpp> // IWYU pragma: export
 #include <impl/Kokkos_Error.hpp>  // KOKKOS_EXPECTS
 
 #include <Kokkos_Graph_fwd.hpp>
-#include <impl/Kokkos_GraphImpl_fwd.hpp>
+#include <impl/Kokkos_GraphImpl_fwd.hpp> // IWYU pragma: export
 
 // GraphAccess needs to be defined, not just declared
-#include <impl/Kokkos_GraphImpl.hpp>
+#include <impl/Kokkos_GraphImpl.hpp> // IWYU pragma: export
 
 #include <functional>
 #include <memory>
@@ -156,15 +156,15 @@ Graph<ExecutionSpace> create_graph(Closure&& arg_closure) {
 
 // Even though these things are separable, include them here for now so that
 // the user only needs to include Kokkos_Graph.hpp to get the whole facility.
-#include <Kokkos_GraphNode.hpp>
+#include <Kokkos_GraphNode.hpp> // IWYU pragma: export
 
-#include <impl/Kokkos_GraphNodeImpl.hpp>
-#include <impl/Kokkos_Default_Graph_Impl.hpp>
-#include <Cuda/Kokkos_Cuda_Graph_Impl.hpp>
+#include <impl/Kokkos_GraphNodeImpl.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Default_Graph_Impl.hpp> // IWYU pragma: export
+#include <Cuda/Kokkos_Cuda_Graph_Impl.hpp> // IWYU pragma: export
 #if defined(KOKKOS_ENABLE_HIP)
 // The implementation of hipGraph in ROCm 5.2 is bugged, so we cannot use it.
 #if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 2))
-#include <HIP/Kokkos_HIP_Graph_Impl.hpp>
+#include <HIP/Kokkos_HIP_Graph_Impl.hpp> // IWYU pragma: export
 #endif
 #endif
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_GRAPH

--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -21,14 +21,14 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_GRAPH
 #endif
 
-#include <Kokkos_Macros.hpp> // IWYU pragma: export
+#include <Kokkos_Macros.hpp>      // IWYU pragma: export
 #include <impl/Kokkos_Error.hpp>  // KOKKOS_EXPECTS
 
 #include <Kokkos_Graph_fwd.hpp>
-#include <impl/Kokkos_GraphImpl_fwd.hpp> // IWYU pragma: export
+#include <impl/Kokkos_GraphImpl_fwd.hpp>  // IWYU pragma: export
 
 // GraphAccess needs to be defined, not just declared
-#include <impl/Kokkos_GraphImpl.hpp> // IWYU pragma: export
+#include <impl/Kokkos_GraphImpl.hpp>  // IWYU pragma: export
 
 #include <functional>
 #include <memory>
@@ -156,15 +156,15 @@ Graph<ExecutionSpace> create_graph(Closure&& arg_closure) {
 
 // Even though these things are separable, include them here for now so that
 // the user only needs to include Kokkos_Graph.hpp to get the whole facility.
-#include <Kokkos_GraphNode.hpp> // IWYU pragma: export
+#include <Kokkos_GraphNode.hpp>  // IWYU pragma: export
 
-#include <impl/Kokkos_GraphNodeImpl.hpp> // IWYU pragma: export
-#include <impl/Kokkos_Default_Graph_Impl.hpp> // IWYU pragma: export
-#include <Cuda/Kokkos_Cuda_Graph_Impl.hpp> // IWYU pragma: export
+#include <impl/Kokkos_GraphNodeImpl.hpp>       // IWYU pragma: export
+#include <impl/Kokkos_Default_Graph_Impl.hpp>  // IWYU pragma: export
+#include <Cuda/Kokkos_Cuda_Graph_Impl.hpp>     // IWYU pragma: export
 #if defined(KOKKOS_ENABLE_HIP)
 // The implementation of hipGraph in ROCm 5.2 is bugged, so we cannot use it.
 #if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 2))
-#include <HIP/Kokkos_HIP_Graph_Impl.hpp> // IWYU pragma: export
+#include <HIP/Kokkos_HIP_Graph_Impl.hpp>  // IWYU pragma: export
 #endif
 #endif
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_GRAPH

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Graph.hpp>
+// IWYU pragma: private, include "Kokkos_Graph.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Graph.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Graph_fwd.hpp
+++ b/core/src/Kokkos_Graph_fwd.hpp
@@ -21,7 +21,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_GRAPH_FWD
 #endif
 
-#include <Kokkos_Macros.hpp>
+#include <Kokkos_Macros.hpp> // IWYU pragma: export
 
 namespace Kokkos {
 namespace Experimental {

--- a/core/src/Kokkos_Graph_fwd.hpp
+++ b/core/src/Kokkos_Graph_fwd.hpp
@@ -21,7 +21,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_GRAPH_FWD
 #endif
 
-#include <Kokkos_Macros.hpp> // IWYU pragma: export
+#include <Kokkos_Macros.hpp>  // IWYU pragma: export
 
 namespace Kokkos {
 namespace Experimental {

--- a/core/src/Kokkos_Half.hpp
+++ b/core/src/Kokkos_Half.hpp
@@ -21,9 +21,9 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_HALF
 #endif
 
-#include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
-#include <impl/Kokkos_Half_NumericTraits.hpp>
-#include <impl/Kokkos_Half_MathematicalFunctions.hpp>
+#include <impl/Kokkos_Half_FloatingPointWrapper.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Half_NumericTraits.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Half_MathematicalFunctions.hpp> // IWYU pragma: export
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_HALF
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE

--- a/core/src/Kokkos_Half.hpp
+++ b/core/src/Kokkos_Half.hpp
@@ -21,9 +21,9 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_HALF
 #endif
 
-#include <impl/Kokkos_Half_FloatingPointWrapper.hpp> // IWYU pragma: export
-#include <impl/Kokkos_Half_NumericTraits.hpp> // IWYU pragma: export
-#include <impl/Kokkos_Half_MathematicalFunctions.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Half_FloatingPointWrapper.hpp>   // IWYU pragma: export
+#include <impl/Kokkos_Half_NumericTraits.hpp>          // IWYU pragma: export
+#include <impl/Kokkos_Half_MathematicalFunctions.hpp>  // IWYU pragma: export
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_HALF
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -18,7 +18,7 @@
 /// \brief Declaration of various \c MemoryLayout options.
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -18,6 +18,7 @@
 /// \brief Declaration of various \c MemoryLayout options.
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_MathematicalConstants.hpp
+++ b/core/src/Kokkos_MathematicalConstants.hpp
@@ -20,7 +20,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_MATHCONSTANTS
 #endif
 
-#include <Kokkos_Macros.hpp>
+#include <Kokkos_Macros.hpp> // IWYU pragma: export
 #include <type_traits>
 
 namespace Kokkos::numbers {

--- a/core/src/Kokkos_MathematicalConstants.hpp
+++ b/core/src/Kokkos_MathematicalConstants.hpp
@@ -20,7 +20,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_MATHCONSTANTS
 #endif
 
-#include <Kokkos_Macros.hpp> // IWYU pragma: export
+#include <Kokkos_Macros.hpp>  // IWYU pragma: export
 #include <type_traits>
 
 namespace Kokkos::numbers {

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -21,7 +21,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_MATHFUNCTIONS
 #endif
 
-#include <Kokkos_Macros.hpp> // IWYU pragma: export
+#include <Kokkos_Macros.hpp>  // IWYU pragma: export
 #include <cmath>
 #include <cstdlib>
 #include <type_traits>

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -21,7 +21,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_MATHFUNCTIONS
 #endif
 
-#include <Kokkos_Macros.hpp>
+#include <Kokkos_Macros.hpp> // IWYU pragma: export
 #include <cmath>
 #include <cstdlib>
 #include <type_traits>

--- a/core/src/Kokkos_MathematicalSpecialFunctions.hpp
+++ b/core/src/Kokkos_MathematicalSpecialFunctions.hpp
@@ -21,7 +21,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_MATHSPECFUNCTIONS
 #endif
 
-#include <Kokkos_Macros.hpp>
+#include <Kokkos_Macros.hpp> // IWYU pragma: export
 #include <cmath>
 #include <algorithm>
 #include <type_traits>

--- a/core/src/Kokkos_MathematicalSpecialFunctions.hpp
+++ b/core/src/Kokkos_MathematicalSpecialFunctions.hpp
@@ -21,7 +21,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_MATHSPECFUNCTIONS
 #endif
 
-#include <Kokkos_Macros.hpp> // IWYU pragma: export
+#include <Kokkos_Macros.hpp>  // IWYU pragma: export
 #include <cmath>
 #include <algorithm>
 #include <type_traits>

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_MemoryTraits.hpp
+++ b/core/src/Kokkos_MemoryTraits.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_MemoryTraits.hpp
+++ b/core/src/Kokkos_MemoryTraits.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -21,7 +21,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_NUMERIC_TRAITS
 #endif
 
-#include <Kokkos_Macros.hpp> // IWYU pragma: export
+#include <Kokkos_Macros.hpp>  // IWYU pragma: export
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 #include <Kokkos_ReductionIdentity.hpp>
 #endif

--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -21,7 +21,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_NUMERIC_TRAITS
 #endif
 
-#include <Kokkos_Macros.hpp>
+#include <Kokkos_Macros.hpp> // IWYU pragma: export
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 #include <Kokkos_ReductionIdentity.hpp>
 #endif

--- a/core/src/Kokkos_Pair.hpp
+++ b/core/src/Kokkos_Pair.hpp
@@ -27,8 +27,8 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_PAIR
 #endif
 
-#include <Kokkos_Macros.hpp> // IWYU pragma: export
-#include <Kokkos_Swap.hpp> // IWYU pragma: export
+#include <Kokkos_Macros.hpp>  // IWYU pragma: export
+#include <Kokkos_Swap.hpp>    // IWYU pragma: export
 #include <utility>
 
 namespace Kokkos {

--- a/core/src/Kokkos_Pair.hpp
+++ b/core/src/Kokkos_Pair.hpp
@@ -27,8 +27,8 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_PAIR
 #endif
 
-#include <Kokkos_Macros.hpp>
-#include <Kokkos_Swap.hpp>
+#include <Kokkos_Macros.hpp> // IWYU pragma: export
+#include <Kokkos_Swap.hpp> // IWYU pragma: export
 #include <utility>
 
 namespace Kokkos {

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -18,7 +18,7 @@
 /// \brief Declaration of parallel operators
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -18,6 +18,7 @@
 /// \brief Declaration of parallel operators
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_PointerOwnership.hpp
+++ b/core/src/Kokkos_PointerOwnership.hpp
@@ -17,7 +17,7 @@
 // Experimental unified task-data parallel manycore LDRD
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_PointerOwnership.hpp
+++ b/core/src/Kokkos_PointerOwnership.hpp
@@ -17,6 +17,7 @@
 // Experimental unified task-data parallel manycore LDRD
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Profiling_ProfileSection.hpp
+++ b/core/src/Kokkos_Profiling_ProfileSection.hpp
@@ -21,8 +21,8 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_PROFILING_PROFILESECTION
 #endif
 
-#include <Kokkos_Macros.hpp>
-#include <impl/Kokkos_Profiling.hpp>
+#include <Kokkos_Macros.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Profiling.hpp> // IWYU pragma: export
 
 #include <string>
 

--- a/core/src/Kokkos_Profiling_ProfileSection.hpp
+++ b/core/src/Kokkos_Profiling_ProfileSection.hpp
@@ -21,8 +21,8 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_PROFILING_PROFILESECTION
 #endif
 
-#include <Kokkos_Macros.hpp> // IWYU pragma: export
-#include <impl/Kokkos_Profiling.hpp> // IWYU pragma: export
+#include <Kokkos_Macros.hpp>          // IWYU pragma: export
+#include <impl/Kokkos_Profiling.hpp>  // IWYU pragma: export
 
 #include <string>
 

--- a/core/src/Kokkos_Profiling_ScopedRegion.hpp
+++ b/core/src/Kokkos_Profiling_ScopedRegion.hpp
@@ -21,8 +21,8 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_PROFILING_SCOPEDREGION
 #endif
 
-#include <Kokkos_Macros.hpp>
-#include <impl/Kokkos_Profiling.hpp>
+#include <Kokkos_Macros.hpp> // IWYU pragma: export
+#include <impl/Kokkos_Profiling.hpp> // IWYU pragma: export
 
 #include <string>
 

--- a/core/src/Kokkos_Profiling_ScopedRegion.hpp
+++ b/core/src/Kokkos_Profiling_ScopedRegion.hpp
@@ -21,8 +21,8 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_PROFILING_SCOPEDREGION
 #endif
 
-#include <Kokkos_Macros.hpp> // IWYU pragma: export
-#include <impl/Kokkos_Profiling.hpp> // IWYU pragma: export
+#include <Kokkos_Macros.hpp>          // IWYU pragma: export
+#include <impl/Kokkos_Profiling.hpp>  // IWYU pragma: export
 
 #include <string>
 

--- a/core/src/Kokkos_Rank.hpp
+++ b/core/src/Kokkos_Rank.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Rank.hpp
+++ b/core/src/Kokkos_Rank.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_ReductionIdentity.hpp
+++ b/core/src/Kokkos_ReductionIdentity.hpp
@@ -21,7 +21,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_REDUCTION_IDENTITY
 #endif
 
-#include <Kokkos_Macros.hpp> // IWYU pragma: export
+#include <Kokkos_Macros.hpp>  // IWYU pragma: export
 #include <cfloat>
 #include <climits>
 

--- a/core/src/Kokkos_ReductionIdentity.hpp
+++ b/core/src/Kokkos_ReductionIdentity.hpp
@@ -21,7 +21,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_REDUCTION_IDENTITY
 #endif
 
-#include <Kokkos_Macros.hpp>
+#include <Kokkos_Macros.hpp> // IWYU pragma: export
 #include <cfloat>
 #include <climits>
 

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_TaskScheduler.hpp
+++ b/core/src/Kokkos_TaskScheduler.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_TaskScheduler.hpp
+++ b/core/src/Kokkos_TaskScheduler.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_TaskScheduler_fwd.hpp
+++ b/core/src/Kokkos_TaskScheduler_fwd.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_TaskScheduler_fwd.hpp
+++ b/core/src/Kokkos_TaskScheduler_fwd.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Timer.hpp
+++ b/core/src/Kokkos_Timer.hpp
@@ -21,7 +21,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_TIMER
 #endif
 
-#include <Kokkos_Macros.hpp> // IWYU pragma: export
+#include <Kokkos_Macros.hpp>  // IWYU pragma: export
 // gcc 10.3.0 with CUDA doesn't support std::chrono,
 // see https://github.com/kokkos/kokkos/issues/4334
 #if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU == 1030) && \

--- a/core/src/Kokkos_Timer.hpp
+++ b/core/src/Kokkos_Timer.hpp
@@ -21,7 +21,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_TIMER
 #endif
 
-#include <Kokkos_Macros.hpp>
+#include <Kokkos_Macros.hpp> // IWYU pragma: export
 // gcc 10.3.0 with CUDA doesn't support std::chrono,
 // see https://github.com/kokkos/kokkos/issues/4334
 #if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU == 1030) && \

--- a/core/src/Kokkos_Tuners.hpp
+++ b/core/src/Kokkos_Tuners.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Tuners.hpp
+++ b/core/src/Kokkos_Tuners.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_UniqueToken.hpp
+++ b/core/src/Kokkos_UniqueToken.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_UniqueToken.hpp
+++ b/core/src/Kokkos_UniqueToken.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Vectorization.hpp
+++ b/core/src/Kokkos_Vectorization.hpp
@@ -17,6 +17,7 @@
 /// \file Kokkos_Vectorization.hpp
 /// \brief Declaration and definition of Kokkos::Vectorization interface.
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_Vectorization.hpp
+++ b/core/src/Kokkos_Vectorization.hpp
@@ -17,7 +17,7 @@
 /// \file Kokkos_Vectorization.hpp
 /// \brief Declaration and definition of Kokkos::Vectorization interface.
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_WorkGraphPolicy.hpp
+++ b/core/src/Kokkos_WorkGraphPolicy.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_WorkGraphPolicy.hpp
+++ b/core/src/Kokkos_WorkGraphPolicy.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_hwloc.hpp
+++ b/core/src/Kokkos_hwloc.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Kokkos_hwloc.hpp
+++ b/core/src/Kokkos_hwloc.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/OpenACC/Kokkos_OpenACC.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/OpenACC/Kokkos_OpenACC_DeepCopy.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_DeepCopy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENACC_DEEP_COPY_HPP
 #define KOKKOS_OPENACC_DEEP_COPY_HPP
 
+// IWYU pragma: private
 #include <OpenACC/Kokkos_OpenACC.hpp>
 #include <OpenACC/Kokkos_OpenACCSpace.hpp>
 

--- a/core/src/OpenACC/Kokkos_OpenACC_MDRangePolicy.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_MDRangePolicy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENACC_MDRANGE_POLICY_HPP_
 #define KOKKOS_OPENACC_MDRANGE_POLICY_HPP_
 
+// IWYU pragma: private
 #include <KokkosExp_MDRangePolicy.hpp>
 
 template <>

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_MDRange.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_MDRange.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENACC_PARALLEL_FOR_MDRANGE_HPP
 #define KOKKOS_OPENACC_PARALLEL_FOR_MDRANGE_HPP
 
+// IWYU pragma: private
 #include <OpenACC/Kokkos_OpenACC.hpp>
 #include <OpenACC/Kokkos_OpenACC_FunctorAdapter.hpp>
 #include <OpenACC/Kokkos_OpenACC_MDRangePolicy.hpp>

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Range.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Range.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENACC_PARALLEL_FOR_RANGE_HPP
 #define KOKKOS_OPENACC_PARALLEL_FOR_RANGE_HPP
 
+// IWYU pragma: private
 #include <OpenACC/Kokkos_OpenACC.hpp>
 #include <OpenACC/Kokkos_OpenACC_FunctorAdapter.hpp>
 #include <OpenACC/Kokkos_OpenACC_ScheduleType.hpp>

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENACC_PARALLEL_FOR_TEAM_HPP
 #define KOKKOS_OPENACC_PARALLEL_FOR_TEAM_HPP
 
+// IWYU pragma: private
 #include <OpenACC/Kokkos_OpenACC_Team.hpp>
 #include <OpenACC/Kokkos_OpenACC_FunctorAdapter.hpp>
 

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENACC_PARALLEL_REDUCE_MDRANGE_HPP
 #define KOKKOS_OPENACC_PARALLEL_REDUCE_MDRANGE_HPP
 
+// IWYU pragma: private
 #include <OpenACC/Kokkos_OpenACC.hpp>
 #include <OpenACC/Kokkos_OpenACC_Macros.hpp>
 #include <OpenACC/Kokkos_OpenACC_FunctorAdapter.hpp>

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENACC_PARALLEL_REDUCE_RANGE_HPP
 #define KOKKOS_OPENACC_PARALLEL_REDUCE_RANGE_HPP
 
+// IWYU pragma: private
 #include <OpenACC/Kokkos_OpenACC.hpp>
 #include <OpenACC/Kokkos_OpenACC_Macros.hpp>
 #include <OpenACC/Kokkos_OpenACC_FunctorAdapter.hpp>

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENACC_PARALLEL_REDUCE_TEAM_HPP
 #define KOKKOS_OPENACC_PARALLEL_REDUCE_TEAM_HPP
 
+// IWYU pragma: private
 #include <OpenACC/Kokkos_OpenACC_Team.hpp>
 #include <OpenACC/Kokkos_OpenACC_FunctorAdapter.hpp>
 #include <OpenACC/Kokkos_OpenACC_Macros.hpp>

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelScan_Range.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelScan_Range.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENACC_PARALLEL_SCAN_RANGE_HPP
 #define KOKKOS_OPENACC_PARALLEL_SCAN_RANGE_HPP
 
+// IWYU pragma: private
 #include <OpenACC/Kokkos_OpenACC.hpp>
 #include <OpenACC/Kokkos_OpenACC_FunctorAdapter.hpp>
 #include <OpenACC/Kokkos_OpenACC_Macros.hpp>

--- a/core/src/OpenACC/Kokkos_OpenACC_ScheduleType.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ScheduleType.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENACC_SCHEDULE_TYPE_HPP
 #define KOKKOS_OPENACC_SCHEDULE_TYPE_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Concepts.hpp>
 #include <type_traits>
 

--- a/core/src/OpenACC/Kokkos_OpenACC_SharedAllocationRecord.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_SharedAllocationRecord.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENACC_SHARED_ALLOCATION_RECORD_HPP
 #define KOKKOS_OPENACC_SHARED_ALLOCATION_RECORD_HPP
 
+// IWYU pragma: private
 #include <OpenACC/Kokkos_OpenACCSpace.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>
 

--- a/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENACC_TEAM_HPP
 #define KOKKOS_OPENACC_TEAM_HPP
 
+// IWYU pragma: private
 #include <openacc.h>
 #include <impl/Kokkos_Traits.hpp>
 #include <OpenACC/Kokkos_OpenACC.hpp>

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_OPENMP_INSTANCE_HPP
 #define KOKKOS_OPENMP_INSTANCE_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if !defined(_OPENMP) && !defined(__CUDA_ARCH__) && \
     !defined(__HIP_DEVICE_COMPILE__) && !defined(__SYCL_DEVICE_ONLY__)

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMP_INSTANCE_HPP
 #define KOKKOS_OPENMP_INSTANCE_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if !defined(_OPENMP) && !defined(__CUDA_ARCH__) && \
     !defined(__HIP_DEVICE_COMPILE__) && !defined(__SYCL_DEVICE_ONLY__)

--- a/core/src/OpenMP/Kokkos_OpenMP_MDRangePolicy.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_MDRangePolicy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMP_MDRANGEPOLICY_HPP_
 #define KOKKOS_OPENMP_MDRANGEPOLICY_HPP_
 
+// IWYU pragma: private
 #include <KokkosExp_MDRangePolicy.hpp>
 
 namespace Kokkos {

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel_For.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel_For.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMP_PARALLEL_FOR_HPP
 #define KOKKOS_OPENMP_PARALLEL_FOR_HPP
 
+// IWYU pragma: private
 #include <omp.h>
 #include <OpenMP/Kokkos_OpenMP_Instance.hpp>
 #include <KokkosExp_MDRangePolicy.hpp>

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel_Reduce.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel_Reduce.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMP_PARALLEL_REDUCE_HPP
 #define KOKKOS_OPENMP_PARALLEL_REDUCE_HPP
 
+// IWYU pragma: private
 #include <omp.h>
 #include <OpenMP/Kokkos_OpenMP_Instance.hpp>
 #include <KokkosExp_MDRangePolicy.hpp>

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel_Scan.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel_Scan.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMP_PARALLEL_SCAN_HPP
 #define KOKKOS_OPENMP_PARALLEL_SCAN_HPP
 
+// IWYU pragma: private
 #include <omp.h>
 #include <OpenMP/Kokkos_OpenMP_Instance.hpp>
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_IMPL_OPENMP_TASK_HPP
 #define KOKKOS_IMPL_OPENMP_TASK_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_OPENMP) && defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_IMPL_OPENMP_TASK_HPP
 #define KOKKOS_IMPL_OPENMP_TASK_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_OPENMP) && defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMP_TEAM_HPP
 #define KOKKOS_OPENMP_TEAM_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_OPENMP)
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_OPENMP_TEAM_HPP
 #define KOKKOS_OPENMP_TEAM_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_OPENMP)
 

--- a/core/src/OpenMP/Kokkos_OpenMP_UniqueToken.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_UniqueToken.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMP_UNIQUE_TOKEN_HPP
 #define KOKKOS_OPENMP_UNIQUE_TOKEN_HPP
 
+// IWYU pragma: private
 #include <Kokkos_UniqueToken.hpp>
 
 namespace Kokkos::Experimental {

--- a/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMP_WORKGRAPHPOLICY_HPP
 #define KOKKOS_OPENMP_WORKGRAPHPOLICY_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <OpenMP/Kokkos_OpenMP.hpp>
 
 namespace Kokkos {

--- a/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_OPENMP_WORKGRAPHPOLICY_HPP
 #define KOKKOS_OPENMP_WORKGRAPHPOLICY_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <OpenMP/Kokkos_OpenMP.hpp>
 
 namespace Kokkos {

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_MDRangePolicy.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_MDRangePolicy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMPTARGET_MDRANGEPOLICY_HPP_
 #define KOKKOS_OPENMPTARGET_MDRANGEPOLICY_HPP_
 
+// IWYU pragma: private
 #include <KokkosExp_MDRangePolicy.hpp>
 
 namespace Kokkos {

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMPTARGET_PARALLEL_HPP
 #define KOKKOS_OPENMPTARGET_PARALLEL_HPP
 
+// IWYU pragma: private
 #include <omp.h>
 #include <sstream>
 #include <Kokkos_Parallel.hpp>

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_Range.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_Range.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMPTARGET_PARALLEL_FOR_RANGE_HPP
 #define KOKKOS_OPENMPTARGET_PARALLEL_FOR_RANGE_HPP
 
+// IWYU pragma: private
 #include <omp.h>
 #include <sstream>
 #include <Kokkos_Parallel.hpp>

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_Team.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMPTARGET_PARALLEL_FOR_TEAM_HPP
 #define KOKKOS_OPENMPTARGET_PARALLEL_FOR_TEAM_HPP
 
+// IWYU pragma: private
 #include <omp.h>
 #include <sstream>
 #include <OpenMPTarget/Kokkos_OpenMPTarget_Macros.hpp>

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Range.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Range.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMPTARGET_PARALLELREDUCE_RANGE_HPP
 #define KOKKOS_OPENMPTARGET_PARALLELREDUCE_RANGE_HPP
 
+// IWYU pragma: private
 #include <omp.h>
 #include <sstream>
 #include <Kokkos_Parallel.hpp>

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Team.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMPTARGET_PARALLELREDUCE_TEAM_HPP
 #define KOKKOS_OPENMPTARGET_PARALLELREDUCE_TEAM_HPP
 
+// IWYU pragma: private
 #include <omp.h>
 #include <sstream>
 #include <Kokkos_Parallel.hpp>

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Range.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Range.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMPTARGET_PARALLELSCAN_RANGE_HPP
 #define KOKKOS_OPENMPTARGET_PARALLELSCAN_RANGE_HPP
 
+// IWYU pragma: private
 #include <omp.h>
 #include <sstream>
 #include <Kokkos_Parallel.hpp>

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Team.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMPTARGET_PARALLELSCAN_TEAM_HPP
 #define KOKKOS_OPENMPTARGET_PARALLELSCAN_TEAM_HPP
 
+// IWYU pragma: private
 #include <omp.h>
 #include <sstream>
 #include <Kokkos_Parallel.hpp>

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMPTARGET_PARALLEL_COMMON_HPP
 #define KOKKOS_OPENMPTARGET_PARALLEL_COMMON_HPP
 
+// IWYU pragma: private
 #include <omp.h>
 #include <sstream>
 #include <Kokkos_Parallel.hpp>

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_MDRange.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_MDRange.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMPTARGET_PARALLEL_MDRANGE_HPP
 #define KOKKOS_OPENMPTARGET_PARALLEL_MDRANGE_HPP
 
+// IWYU pragma: private
 #include <omp.h>
 #include <Kokkos_Parallel.hpp>
 #include <OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp>

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_UniqueToken.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_UniqueToken.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_OPENMPTARGET_UNIQUE_TOKEN_HPP
 #define KOKKOS_OPENMPTARGET_UNIQUE_TOKEN_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
 

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/SYCL/Kokkos_SYCL_DeepCopy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_DeepCopy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_SYCLDEEPCOPY_HPP
 #define KOKKOS_SYCLDEEPCOPY_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Core_fwd.hpp>
 #include <SYCL/Kokkos_SYCL.hpp>
 

--- a/core/src/SYCL/Kokkos_SYCL_MDRangePolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_MDRangePolicy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_SYCL_MDRANGEPOLICY_HPP_
 #define KOKKOS_SYCL_MDRANGEPOLICY_HPP_
 
+// IWYU pragma: private
 #include <KokkosExp_MDRangePolicy.hpp>
 
 namespace Kokkos {

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_SYCL_PARALLEL_FOR_TEAM_HPP
 #define KOKKOS_SYCL_PARALLEL_FOR_TEAM_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Parallel.hpp>
 
 #include <SYCL/Kokkos_SYCL_Team.hpp>

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_SYCL_PARALLEL_REDUCE_MDRANGE_HPP
 #define KOKKOS_SYCL_PARALLEL_REDUCE_MDRANGE_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 
 #include <Kokkos_Parallel_Reduce.hpp>

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_SYCL_PARALLEL_REDUCE_RANGE_HPP
 #define KOKKOS_SYCL_PARALLEL_REDUCE_RANGE_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 
 #include <Kokkos_BitManipulation.hpp>

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_SYCL_PARALLEL_REDUCE_TEAM_HPP
 #define KOKKOS_SYCL_PARALLEL_REDUCE_TEAM_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Parallel.hpp>
 
 #include <SYCL/Kokkos_SYCL_Team.hpp>

--- a/core/src/SYCL/Kokkos_SYCL_Space.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_SYCL_UNIQUE_TOKEN_HPP
 #define KOKKOS_SYCL_UNIQUE_TOKEN_HPP
 
+// IWYU pragma: private
 #include <impl/Kokkos_ConcurrentBitset.hpp>
 #include <SYCL/Kokkos_SYCL_Space.hpp>
 #include <Kokkos_UniqueToken.hpp>

--- a/core/src/SYCL/Kokkos_SYCL_ZeroMemset.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ZeroMemset.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_SYCL_ZEROMEMSET_HPP
 #define KOKKOS_SYCL_ZEROMEMSET_HPP
 
+// IWYU pragma: private
 #include <impl/Kokkos_ZeroMemset_fwd.hpp>
 #include <SYCL/Kokkos_SYCL.hpp>
 

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -18,6 +18,7 @@
 /// \brief Declaration and definition of Kokkos::Serial device.
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Graph.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -18,7 +18,7 @@
 /// \brief Declaration and definition of Kokkos::Serial device.
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Graph.hpp>
+// IWYU pragma: private, include "Kokkos_Graph.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Serial/Kokkos_Serial_MDRangePolicy.hpp
+++ b/core/src/Serial/Kokkos_Serial_MDRangePolicy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_SERIAL_MDRANGEPOLICY_HPP_
 #define KOKKOS_SERIAL_MDRANGEPOLICY_HPP_
 
+// IWYU pragma: private
 #include <KokkosExp_MDRangePolicy.hpp>
 
 namespace Kokkos {

--- a/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_SERIAL_PARALLEL_MDRANGE_HPP
 #define KOKKOS_SERIAL_PARALLEL_MDRANGE_HPP
 
-// IWYU pragma: private; include <Kokkos_Graph.hpp>
+// IWYU pragma: private, include "Kokkos_Graph.hpp"
 #include <Kokkos_Parallel.hpp>
 #include <KokkosExp_MDRangePolicy.hpp>
 

--- a/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_SERIAL_PARALLEL_MDRANGE_HPP
 #define KOKKOS_SERIAL_PARALLEL_MDRANGE_HPP
 
+// IWYU pragma: private; include <Kokkos_Graph.hpp>
 #include <Kokkos_Parallel.hpp>
 #include <KokkosExp_MDRangePolicy.hpp>
 

--- a/core/src/Serial/Kokkos_Serial_Parallel_Range.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Range.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_SERIAL_PARALLEL_RANGE_HPP
 #define KOKKOS_SERIAL_PARALLEL_RANGE_HPP
 
+// IWYU pragma: private; include <Kokkos_Graph.hpp>
 #include <Kokkos_Parallel.hpp>
 
 namespace Kokkos {

--- a/core/src/Serial/Kokkos_Serial_Parallel_Range.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Range.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_SERIAL_PARALLEL_RANGE_HPP
 #define KOKKOS_SERIAL_PARALLEL_RANGE_HPP
 
-// IWYU pragma: private; include <Kokkos_Graph.hpp>
+// IWYU pragma: private, include "Kokkos_Graph.hpp"
 #include <Kokkos_Parallel.hpp>
 
 namespace Kokkos {

--- a/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_SERIAL_PARALLEL_TEAM_HPP
 #define KOKKOS_SERIAL_PARALLEL_TEAM_HPP
 
-// IWYU pragma: private; include <Kokkos_Graph.hpp>
+// IWYU pragma: private, include "Kokkos_Graph.hpp"
 #include <Kokkos_Parallel.hpp>
 
 namespace Kokkos {

--- a/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_SERIAL_PARALLEL_TEAM_HPP
 #define KOKKOS_SERIAL_PARALLEL_TEAM_HPP
 
+// IWYU pragma: private; include <Kokkos_Graph.hpp>
 #include <Kokkos_Parallel.hpp>
 
 namespace Kokkos {

--- a/core/src/Serial/Kokkos_Serial_Task.hpp
+++ b/core/src/Serial/Kokkos_Serial_Task.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_IMPL_SERIAL_TASK_HPP
 #define KOKKOS_IMPL_SERIAL_TASK_HPP
 
-// IWYU pragma: private; include <Kokkos_Graph.hpp>
+// IWYU pragma: private, include "Kokkos_Graph.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/Serial/Kokkos_Serial_Task.hpp
+++ b/core/src/Serial/Kokkos_Serial_Task.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_IMPL_SERIAL_TASK_HPP
 #define KOKKOS_IMPL_SERIAL_TASK_HPP
 
+// IWYU pragma: private; include <Kokkos_Graph.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/Serial/Kokkos_Serial_UniqueToken.hpp
+++ b/core/src/Serial/Kokkos_Serial_UniqueToken.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_SERIAL_UNIQUE_TOKEN_HPP
 #define KOKKOS_SERIAL_UNIQUE_TOKEN_HPP
 
-// IWYU pragma: private; include <Kokkos_Graph.hpp>
+// IWYU pragma: private, include "Kokkos_Graph.hpp"
 #include <Kokkos_UniqueToken.hpp>
 
 namespace Kokkos {

--- a/core/src/Serial/Kokkos_Serial_UniqueToken.hpp
+++ b/core/src/Serial/Kokkos_Serial_UniqueToken.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_SERIAL_UNIQUE_TOKEN_HPP
 #define KOKKOS_SERIAL_UNIQUE_TOKEN_HPP
 
+// IWYU pragma: private; include <Kokkos_Graph.hpp>
 #include <Kokkos_UniqueToken.hpp>
 
 namespace Kokkos {

--- a/core/src/Serial/Kokkos_Serial_ZeroMemset.hpp
+++ b/core/src/Serial/Kokkos_Serial_ZeroMemset.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_SERIAL_ZEROMEMSET_HPP
 #define KOKKOS_SERIAL_ZEROMEMSET_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 #include <impl/Kokkos_ZeroMemset_fwd.hpp>
 #include <Serial/Kokkos_Serial.hpp>

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/Threads/Kokkos_Threads_Instance.hpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_THREADS_INSTANCE_HPP
 #define KOKKOS_THREADS_INSTANCE_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 
 #include <cstdio>

--- a/core/src/Threads/Kokkos_Threads_Instance.hpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_THREADS_INSTANCE_HPP
 #define KOKKOS_THREADS_INSTANCE_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 
 #include <cstdio>

--- a/core/src/Threads/Kokkos_Threads_MDRangePolicy.hpp
+++ b/core/src/Threads/Kokkos_Threads_MDRangePolicy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_THREADS_MDRANGEPOLICY_HPP_
 #define KOKKOS_THREADS_MDRANGEPOLICY_HPP_
 
+// IWYU pragma: private
 #include <KokkosExp_MDRangePolicy.hpp>
 
 namespace Kokkos {

--- a/core/src/Threads/Kokkos_Threads_ParallelFor_MDRange.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelFor_MDRange.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_THREADS_PARALLEL_FOR_MDRANGE_HPP
 #define KOKKOS_THREADS_PARALLEL_FOR_MDRANGE_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Parallel.hpp>
 
 #include <KokkosExp_MDRangePolicy.hpp>

--- a/core/src/Threads/Kokkos_Threads_ParallelFor_Range.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelFor_Range.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_THREADS_PARALLEL_FOR_RANGE_HPP
 #define KOKKOS_THREADS_PARALLEL_FOR_RANGE_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Parallel.hpp>
 
 namespace Kokkos {

--- a/core/src/Threads/Kokkos_Threads_ParallelFor_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelFor_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_THREADS_PARALLEL_FOR_TEAM_HPP
 #define KOKKOS_THREADS_PARALLEL_FOR_TEAM_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Parallel.hpp>
 
 namespace Kokkos {

--- a/core/src/Threads/Kokkos_Threads_ParallelReduce_MDRange.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelReduce_MDRange.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_THREADS_PARALLEL_REDUCE_MDRANGE_HPP
 #define KOKKOS_THREADS_PARALLEL_REDUCE_MDRANGE_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Parallel.hpp>
 
 #include <KokkosExp_MDRangePolicy.hpp>

--- a/core/src/Threads/Kokkos_Threads_ParallelReduce_Range.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelReduce_Range.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_THREADS_PARALLEL_REDUCE_RANGE_HPP
 #define KOKKOS_THREADS_PARALLEL_REDUCE_RANGE_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Parallel.hpp>
 
 namespace Kokkos {

--- a/core/src/Threads/Kokkos_Threads_ParallelReduce_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelReduce_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_THREADS_PARALLEL_REDUCE_TEAM_HPP
 #define KOKKOS_THREADS_PARALLEL_REDUCE_TEAM_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Parallel.hpp>
 
 namespace Kokkos {

--- a/core/src/Threads/Kokkos_Threads_ParallelScan_Range.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelScan_Range.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_THREADS_PARALLEL_SCAN_RANGE_HPP
 #define KOKKOS_THREADS_PARALLEL_SCAN_RANGE_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Parallel.hpp>
 
 namespace Kokkos {

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_THREADSTEAM_HPP
 #define KOKKOS_THREADSTEAM_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Macros.hpp>
 
 #include <cstdio>

--- a/core/src/Threads/Kokkos_Threads_UniqueToken.hpp
+++ b/core/src/Threads/Kokkos_Threads_UniqueToken.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_THREADS_UNIQUETOKEN_HPP
 #define KOKKOS_THREADS_UNIQUETOKEN_HPP
 
+// IWYU pragma: private
 #include <Kokkos_UniqueToken.hpp>
 
 namespace Kokkos {

--- a/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
+++ b/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_THREADS_WORKGRAPHPOLICY_HPP
 #define KOKKOS_THREADS_WORKGRAPHPOLICY_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Core_fwd.hpp>
 #include <Threads/Kokkos_Threads_Instance.hpp>
 

--- a/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
+++ b/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_THREADS_WORKGRAPHPOLICY_HPP
 #define KOKKOS_THREADS_WORKGRAPHPOLICY_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Core_fwd.hpp>
 #include <Threads/Kokkos_Threads_Instance.hpp>
 

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Extents.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Extents.hpp
@@ -22,7 +22,7 @@ static_assert(false,
 #ifndef KOKKOS_EXPERIMENTAL_MDSPAN_EXTENTS_HPP
 #define KOKKOS_EXPERIMENTAL_MDSPAN_EXTENTS_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include "Kokkos_MDSpan_Header.hpp"
 
 namespace Kokkos::Impl {

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Extents.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Extents.hpp
@@ -22,6 +22,7 @@ static_assert(false,
 #ifndef KOKKOS_EXPERIMENTAL_MDSPAN_EXTENTS_HPP
 #define KOKKOS_EXPERIMENTAL_MDSPAN_EXTENTS_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include "Kokkos_MDSpan_Header.hpp"
 
 namespace Kokkos::Impl {

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Header.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Header.hpp
@@ -24,6 +24,7 @@ static_assert(false,
 
 // Look for the right mdspan
 #if __cplusplus >= 202002L
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <version>
 #endif
 

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Header.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Header.hpp
@@ -24,7 +24,7 @@ static_assert(false,
 
 // Look for the right mdspan
 #if __cplusplus >= 202002L
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <version>
 #endif
 

--- a/core/src/decl/Kokkos_Declare_CUDA.hpp
+++ b/core/src/decl/Kokkos_Declare_CUDA.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_DECLARE_CUDA_HPP
 
 #if defined(KOKKOS_ENABLE_CUDA)
+// IWYU pragma: private
 #include <Cuda/Kokkos_Cuda.hpp>
 #include <Cuda/Kokkos_Cuda_Half_Impl_Type.hpp>
 #include <Cuda/Kokkos_Cuda_Half_Conversion.hpp>

--- a/core/src/decl/Kokkos_Declare_HIP.hpp
+++ b/core/src/decl/Kokkos_Declare_HIP.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_DECLARE_HIP_HPP
 
 #if defined(KOKKOS_ENABLE_HIP)
+// IWYU pragma: private
 #include <HIP/Kokkos_HIP.hpp>
 #include <HIP/Kokkos_HIP_Space.hpp>
 #include <HIP/Kokkos_HIP_DeepCopy.hpp>

--- a/core/src/decl/Kokkos_Declare_HPX.hpp
+++ b/core/src/decl/Kokkos_Declare_HPX.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_DECLARE_HPX_HPP
 
 #if defined(KOKKOS_ENABLE_HPX)
+// IWYU pragma: private
 #include <HPX/Kokkos_HPX.hpp>
 #include <HPX/Kokkos_HPX_MDRangePolicy.hpp>
 #endif

--- a/core/src/decl/Kokkos_Declare_OPENACC.hpp
+++ b/core/src/decl/Kokkos_Declare_OPENACC.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_DECLARE_OPENACC_HPP
 
 #if defined(KOKKOS_ENABLE_OPENACC)
+// IWYU pragma: private
 #include <OpenACC/Kokkos_OpenACC.hpp>
 #include <OpenACC/Kokkos_OpenACCSpace.hpp>
 #include <OpenACC/Kokkos_OpenACC_DeepCopy.hpp>

--- a/core/src/decl/Kokkos_Declare_OPENMP.hpp
+++ b/core/src/decl/Kokkos_Declare_OPENMP.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_DECLARE_OPENMP_HPP
 
 #if defined(KOKKOS_ENABLE_OPENMP)
+// IWYU pragma: private
 #include <OpenMP/Kokkos_OpenMP.hpp>
 #include <OpenMP/Kokkos_OpenMP_MDRangePolicy.hpp>
 #include <OpenMP/Kokkos_OpenMP_UniqueToken.hpp>

--- a/core/src/decl/Kokkos_Declare_OPENMPTARGET.hpp
+++ b/core/src/decl/Kokkos_Declare_OPENMPTARGET.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_DECLARE_OPENMPTARGET_HPP
 
 #if defined(KOKKOS_ENABLE_OPENMPTARGET)
+// IWYU pragma: private
 #include <OpenMPTarget/Kokkos_OpenMPTarget.hpp>
 #include <OpenMPTarget/Kokkos_OpenMPTargetSpace.hpp>
 #include <OpenMPTarget/Kokkos_OpenMPTarget_Reducer.hpp>

--- a/core/src/decl/Kokkos_Declare_SERIAL.hpp
+++ b/core/src/decl/Kokkos_Declare_SERIAL.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_DECLARE_SERIAL_HPP
 
 #if defined(KOKKOS_ENABLE_SERIAL)
+// IWYU pragma: private
 #include <Serial/Kokkos_Serial.hpp>
 #include <Serial/Kokkos_Serial_MDRangePolicy.hpp>
 #include <Serial/Kokkos_Serial_ZeroMemset.hpp>

--- a/core/src/decl/Kokkos_Declare_SYCL.hpp
+++ b/core/src/decl/Kokkos_Declare_SYCL.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_DECLARE_SYCL_HPP
 
 #if defined(KOKKOS_ENABLE_SYCL)
+// IWYU pragma: private
 #include <SYCL/Kokkos_SYCL.hpp>
 #include <SYCL/Kokkos_SYCL_Half_Impl_Type.hpp>
 #include <SYCL/Kokkos_SYCL_Half_Conversion.hpp>

--- a/core/src/decl/Kokkos_Declare_THREADS.hpp
+++ b/core/src/decl/Kokkos_Declare_THREADS.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_DECLARE_THREADS_HPP
 
 #if defined(KOKKOS_ENABLE_THREADS)
+// IWYU pragma: private
 #include <Threads/Kokkos_Threads.hpp>
 #include <Threads/Kokkos_Threads_Instance.hpp>
 #include <Threads/Kokkos_Threads_MDRangePolicy.hpp>

--- a/core/src/impl/KokkosExp_ViewMapping.hpp
+++ b/core/src/impl/KokkosExp_ViewMapping.hpp
@@ -16,4 +16,5 @@
 
 // Deprecated file for backward compatibility
 
+// IWYU pragma: private
 #include <impl/Kokkos_ViewMapping.hpp>

--- a/core/src/impl/Kokkos_ChaseLev.hpp
+++ b/core/src/impl/Kokkos_ChaseLev.hpp
@@ -19,6 +19,7 @@
 #ifndef KOKKOS_IMPL_LOCKFREEDEQUE_HPP
 #define KOKKOS_IMPL_LOCKFREEDEQUE_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_TASKDAG
 

--- a/core/src/impl/Kokkos_ChaseLev.hpp
+++ b/core/src/impl/Kokkos_ChaseLev.hpp
@@ -19,7 +19,7 @@
 #ifndef KOKKOS_IMPL_LOCKFREEDEQUE_HPP
 #define KOKKOS_IMPL_LOCKFREEDEQUE_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_TASKDAG
 

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_COMBINED_REDUCER_HPP
 #define KOKKOS_COMBINED_REDUCER_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Core_fwd.hpp>
 

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_COMBINED_REDUCER_HPP
 #define KOKKOS_COMBINED_REDUCER_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Core_fwd.hpp>
 

--- a/core/src/impl/Kokkos_Default_GraphNodeKernel.hpp
+++ b/core/src/impl/Kokkos_Default_GraphNodeKernel.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_KOKKOS_HOST_GRAPHNODEKERNEL_HPP
 #define KOKKOS_KOKKOS_HOST_GRAPHNODEKERNEL_HPP
 
-// IWYU pragma: private; include <Kokkos_Graph.hpp>
+// IWYU pragma: private, include "Kokkos_Graph.hpp"
 #include <Kokkos_Macros.hpp>
 
 #include <impl/Kokkos_Default_Graph_fwd.hpp>

--- a/core/src/impl/Kokkos_Default_GraphNodeKernel.hpp
+++ b/core/src/impl/Kokkos_Default_GraphNodeKernel.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_KOKKOS_HOST_GRAPHNODEKERNEL_HPP
 #define KOKKOS_KOKKOS_HOST_GRAPHNODEKERNEL_HPP
 
+// IWYU pragma: private; include <Kokkos_Graph.hpp>
 #include <Kokkos_Macros.hpp>
 
 #include <impl/Kokkos_Default_Graph_fwd.hpp>

--- a/core/src/impl/Kokkos_Default_Graph_Impl.hpp
+++ b/core/src/impl/Kokkos_Default_Graph_Impl.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HOST_GRAPH_IMPL_HPP
 #define KOKKOS_HOST_GRAPH_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_Graph.hpp>
 #include <Kokkos_ExecPolicy.hpp>
 #include <Kokkos_Graph.hpp>
 

--- a/core/src/impl/Kokkos_Default_Graph_Impl.hpp
+++ b/core/src/impl/Kokkos_Default_Graph_Impl.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_HOST_GRAPH_IMPL_HPP
 #define KOKKOS_HOST_GRAPH_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_Graph.hpp>
+// IWYU pragma: private, include "Kokkos_Graph.hpp"
 #include <Kokkos_ExecPolicy.hpp>
 #include <Kokkos_Graph.hpp>
 

--- a/core/src/impl/Kokkos_ExecSpaceManager.hpp
+++ b/core/src/impl/Kokkos_ExecSpaceManager.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_EXEC_SPACE_MANAGER_HPP
 #define KOKKOS_EXEC_SPACE_MANAGER_HPP
 
+// IWYU pragma: private
 #include <impl/Kokkos_InitializationSettings.hpp>
 #include <Kokkos_DetectionIdiom.hpp>
 #include <Kokkos_Concepts.hpp>

--- a/core/src/impl/Kokkos_FixedBufferMemoryPool.hpp
+++ b/core/src/impl/Kokkos_FixedBufferMemoryPool.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_IMPL_KOKKOS_FIXEDBUFFERMEMORYPOOL_HPP
 #define KOKKOS_IMPL_KOKKOS_FIXEDBUFFERMEMORYPOOL_HPP
 
+// IWYU pragma: private
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_Atomic.hpp>
 

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_IMPL_KOKKOS_GRAPHIMPL_HPP
 #define KOKKOS_IMPL_KOKKOS_GRAPHIMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 
 #include <Kokkos_Core_fwd.hpp>

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_IMPL_KOKKOS_GRAPHIMPL_HPP
 #define KOKKOS_IMPL_KOKKOS_GRAPHIMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 
 #include <Kokkos_Core_fwd.hpp>

--- a/core/src/impl/Kokkos_GraphNodeImpl.hpp
+++ b/core/src/impl/Kokkos_GraphNodeImpl.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_IMPL_GRAPHNODEIMPL_HPP
 #define KOKKOS_IMPL_GRAPHNODEIMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_Graph.hpp>
+// IWYU pragma: private, include "Kokkos_Graph.hpp"
 #include <Kokkos_Macros.hpp>
 
 #include <Kokkos_Core_fwd.hpp>

--- a/core/src/impl/Kokkos_GraphNodeImpl.hpp
+++ b/core/src/impl/Kokkos_GraphNodeImpl.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_IMPL_GRAPHNODEIMPL_HPP
 #define KOKKOS_IMPL_GRAPHNODEIMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_Graph.hpp>
 #include <Kokkos_Macros.hpp>
 
 #include <Kokkos_Core_fwd.hpp>

--- a/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
+++ b/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HOSTSPACE_ZEROMEMSET_HPP
 #define KOKKOS_HOSTSPACE_ZEROMEMSET_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_HostSpace.hpp>
 #include <impl/Kokkos_ZeroMemset_fwd.hpp>

--- a/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
+++ b/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_HOSTSPACE_ZEROMEMSET_HPP
 #define KOKKOS_HOSTSPACE_ZEROMEMSET_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_HostSpace.hpp>
 #include <impl/Kokkos_ZeroMemset_fwd.hpp>

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_IMPL_HOSTTHREADTEAM_HPP
 #define KOKKOS_IMPL_HOSTTHREADTEAM_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_Pair.hpp>
 #include <Kokkos_Atomic.hpp>

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_IMPL_HOSTTHREADTEAM_HPP
 #define KOKKOS_IMPL_HOSTTHREADTEAM_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_Pair.hpp>
 #include <Kokkos_Atomic.hpp>

--- a/core/src/impl/Kokkos_LIFO.hpp
+++ b/core/src/impl/Kokkos_LIFO.hpp
@@ -19,6 +19,7 @@
 #ifndef KOKKOS_IMPL_LIFO_HPP
 #define KOKKOS_IMPL_LIFO_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_TASKDAG
 

--- a/core/src/impl/Kokkos_LIFO.hpp
+++ b/core/src/impl/Kokkos_LIFO.hpp
@@ -19,7 +19,7 @@
 #ifndef KOKKOS_IMPL_LIFO_HPP
 #define KOKKOS_IMPL_LIFO_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_TASKDAG
 

--- a/core/src/impl/Kokkos_LinkedListNode.hpp
+++ b/core/src/impl/Kokkos_LinkedListNode.hpp
@@ -19,6 +19,7 @@
 #ifndef KOKKOS_IMPL_LINKEDLISTNODE_HPP
 #define KOKKOS_IMPL_LINKEDLISTNODE_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_TASKDAG
 

--- a/core/src/impl/Kokkos_LinkedListNode.hpp
+++ b/core/src/impl/Kokkos_LinkedListNode.hpp
@@ -19,7 +19,7 @@
 #ifndef KOKKOS_IMPL_LINKEDLISTNODE_HPP
 #define KOKKOS_IMPL_LINKEDLISTNODE_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_TASKDAG
 

--- a/core/src/impl/Kokkos_MultipleTaskQueue.hpp
+++ b/core/src/impl/Kokkos_MultipleTaskQueue.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_IMPL_MULTIPLETASKQUEUE_HPP
 #define KOKKOS_IMPL_MULTIPLETASKQUEUE_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_MultipleTaskQueue.hpp
+++ b/core/src/impl/Kokkos_MultipleTaskQueue.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_IMPL_MULTIPLETASKQUEUE_HPP
 #define KOKKOS_IMPL_MULTIPLETASKQUEUE_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_OptionalRef.hpp
+++ b/core/src/impl/Kokkos_OptionalRef.hpp
@@ -19,6 +19,7 @@
 #ifndef KOKKOS_IMPL_OPTIONALREF_HPP
 #define KOKKOS_IMPL_OPTIONALREF_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 
 #include <Kokkos_Core_fwd.hpp>

--- a/core/src/impl/Kokkos_OptionalRef.hpp
+++ b/core/src/impl/Kokkos_OptionalRef.hpp
@@ -19,7 +19,7 @@
 #ifndef KOKKOS_IMPL_OPTIONALREF_HPP
 #define KOKKOS_IMPL_OPTIONALREF_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 
 #include <Kokkos_Core_fwd.hpp>

--- a/core/src/impl/Kokkos_SimpleTaskScheduler.hpp
+++ b/core/src/impl/Kokkos_SimpleTaskScheduler.hpp
@@ -19,7 +19,7 @@
 
 //----------------------------------------------------------------------------
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_SimpleTaskScheduler.hpp
+++ b/core/src/impl/Kokkos_SimpleTaskScheduler.hpp
@@ -19,6 +19,7 @@
 
 //----------------------------------------------------------------------------
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_SingleTaskQueue.hpp
+++ b/core/src/impl/Kokkos_SingleTaskQueue.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_IMPL_SINGLETASKQUEUE_HPP
 #define KOKKOS_IMPL_SINGLETASKQUEUE_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_SingleTaskQueue.hpp
+++ b/core/src/impl/Kokkos_SingleTaskQueue.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_IMPL_SINGLETASKQUEUE_HPP
 #define KOKKOS_IMPL_SINGLETASKQUEUE_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskBase.hpp
+++ b/core/src/impl/Kokkos_TaskBase.hpp
@@ -19,7 +19,7 @@
 #ifndef KOKKOS_IMPL_TASKBASE_HPP
 #define KOKKOS_IMPL_TASKBASE_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskBase.hpp
+++ b/core/src/impl/Kokkos_TaskBase.hpp
@@ -19,6 +19,7 @@
 #ifndef KOKKOS_IMPL_TASKBASE_HPP
 #define KOKKOS_IMPL_TASKBASE_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskNode.hpp
+++ b/core/src/impl/Kokkos_TaskNode.hpp
@@ -19,7 +19,7 @@
 #ifndef KOKKOS_IMPL_TASKNODE_HPP
 #define KOKKOS_IMPL_TASKNODE_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskNode.hpp
+++ b/core/src/impl/Kokkos_TaskNode.hpp
@@ -19,6 +19,7 @@
 #ifndef KOKKOS_IMPL_TASKNODE_HPP
 #define KOKKOS_IMPL_TASKNODE_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskPolicyData.hpp
+++ b/core/src/impl/Kokkos_TaskPolicyData.hpp
@@ -19,7 +19,7 @@
 
 //----------------------------------------------------------------------------
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskPolicyData.hpp
+++ b/core/src/impl/Kokkos_TaskPolicyData.hpp
@@ -19,6 +19,7 @@
 
 //----------------------------------------------------------------------------
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskQueue.hpp
+++ b/core/src/impl/Kokkos_TaskQueue.hpp
@@ -19,7 +19,7 @@
 #ifndef KOKKOS_IMPL_TASKQUEUE_HPP
 #define KOKKOS_IMPL_TASKQUEUE_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskQueue.hpp
+++ b/core/src/impl/Kokkos_TaskQueue.hpp
@@ -19,6 +19,7 @@
 #ifndef KOKKOS_IMPL_TASKQUEUE_HPP
 #define KOKKOS_IMPL_TASKQUEUE_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskQueueCommon.hpp
+++ b/core/src/impl/Kokkos_TaskQueueCommon.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_IMPL_TASKQUEUECOMMON_HPP
 #define KOKKOS_IMPL_TASKQUEUECOMMON_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskQueueCommon.hpp
+++ b/core/src/impl/Kokkos_TaskQueueCommon.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_IMPL_TASKQUEUECOMMON_HPP
 #define KOKKOS_IMPL_TASKQUEUECOMMON_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskQueueMemoryManager.hpp
+++ b/core/src/impl/Kokkos_TaskQueueMemoryManager.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_IMPL_TASKQUEUEMEMORYMANAGER_HPP
 #define KOKKOS_IMPL_TASKQUEUEMEMORYMANAGER_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskQueueMemoryManager.hpp
+++ b/core/src/impl/Kokkos_TaskQueueMemoryManager.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_IMPL_TASKQUEUEMEMORYMANAGER_HPP
 #define KOKKOS_IMPL_TASKQUEUEMEMORYMANAGER_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskQueueMultiple.hpp
+++ b/core/src/impl/Kokkos_TaskQueueMultiple.hpp
@@ -19,6 +19,7 @@
 #ifndef KOKKOS_IMPL_TASKQUEUEMULTIPLE_HPP
 #define KOKKOS_IMPL_TASKQUEUEMULTIPLE_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskQueueMultiple.hpp
+++ b/core/src/impl/Kokkos_TaskQueueMultiple.hpp
@@ -19,7 +19,7 @@
 #ifndef KOKKOS_IMPL_TASKQUEUEMULTIPLE_HPP
 #define KOKKOS_IMPL_TASKQUEUEMULTIPLE_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskQueueMultiple_impl.hpp
+++ b/core/src/impl/Kokkos_TaskQueueMultiple_impl.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_IMPL_TASKQUEUEMULTIPLE_IMPL_HPP
 #define KOKKOS_IMPL_TASKQUEUEMULTIPLE_IMPL_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskQueueMultiple_impl.hpp
+++ b/core/src/impl/Kokkos_TaskQueueMultiple_impl.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_IMPL_TASKQUEUEMULTIPLE_IMPL_HPP
 #define KOKKOS_IMPL_TASKQUEUEMULTIPLE_IMPL_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskResult.hpp
+++ b/core/src/impl/Kokkos_TaskResult.hpp
@@ -19,7 +19,7 @@
 #ifndef KOKKOS_IMPL_TASKRESULT_HPP
 #define KOKKOS_IMPL_TASKRESULT_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskResult.hpp
+++ b/core/src/impl/Kokkos_TaskResult.hpp
@@ -19,6 +19,7 @@
 #ifndef KOKKOS_IMPL_TASKRESULT_HPP
 #define KOKKOS_IMPL_TASKRESULT_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskTeamMember.hpp
+++ b/core/src/impl/Kokkos_TaskTeamMember.hpp
@@ -19,7 +19,7 @@
 
 //----------------------------------------------------------------------------
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TaskTeamMember.hpp
+++ b/core/src/impl/Kokkos_TaskTeamMember.hpp
@@ -19,6 +19,7 @@
 
 //----------------------------------------------------------------------------
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/impl/Kokkos_TeamMDPolicy.hpp
+++ b/core/src/impl/Kokkos_TeamMDPolicy.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/impl/Kokkos_TeamMDPolicy.hpp
+++ b/core/src/impl/Kokkos_TeamMDPolicy.hpp
@@ -15,7 +15,7 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");

--- a/core/src/impl/Kokkos_Tools_Generic.hpp
+++ b/core/src/impl/Kokkos_Tools_Generic.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_IMPL_KOKKOS_TOOLS_GENERIC_HPP
 #define KOKKOS_IMPL_KOKKOS_TOOLS_GENERIC_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <impl/Kokkos_Profiling.hpp>
 #include <impl/Kokkos_FunctorAnalysis.hpp>
 

--- a/core/src/impl/Kokkos_Tools_Generic.hpp
+++ b/core/src/impl/Kokkos_Tools_Generic.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_IMPL_KOKKOS_TOOLS_GENERIC_HPP
 #define KOKKOS_IMPL_KOKKOS_TOOLS_GENERIC_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <impl/Kokkos_Profiling.hpp>
 #include <impl/Kokkos_FunctorAnalysis.hpp>
 

--- a/core/src/impl/Kokkos_ViewDataAnalysis.hpp
+++ b/core/src/impl/Kokkos_ViewDataAnalysis.hpp
@@ -22,6 +22,7 @@ static_assert(false,
 #ifndef KOKKOS_VIEW_DATA_ANALYSIS_HPP
 #define KOKKOS_VIEW_DATA_ANALYSIS_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <Kokkos_Macros.hpp>
 
 namespace Kokkos::Impl {

--- a/core/src/impl/Kokkos_ViewDataAnalysis.hpp
+++ b/core/src/impl/Kokkos_ViewDataAnalysis.hpp
@@ -22,7 +22,7 @@ static_assert(false,
 #ifndef KOKKOS_VIEW_DATA_ANALYSIS_HPP
 #define KOKKOS_VIEW_DATA_ANALYSIS_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <Kokkos_Macros.hpp>
 
 namespace Kokkos::Impl {

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_EXPERIMENTAL_VIEW_MAPPING_HPP
 #define KOKKOS_EXPERIMENTAL_VIEW_MAPPING_HPP
 
+// IWYU pragma: private; include <Kokkos_Core.hpp>
 #include <type_traits>
 #include <initializer_list>
 

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_EXPERIMENTAL_VIEW_MAPPING_HPP
 #define KOKKOS_EXPERIMENTAL_VIEW_MAPPING_HPP
 
-// IWYU pragma: private; include <Kokkos_Core.hpp>
+// IWYU pragma: private, include "Kokkos_Core.hpp"
 #include <type_traits>
 #include <initializer_list>
 


### PR DESCRIPTION
This MR is an initial stab at the feature request outlined in https://github.com/kokkos/kokkos/issues/6933 to support IWYU pragmas. The basic approach taken here was to build up a dependency graph based on header includes, and propagate "privateness" to files that include private files without the `KOKKOS_IMPL_PUBLIC_INCLUDE` guard. If there is a single parent header file that is public (or the file is reachable by `Kokkos_Core.hpp`), suggest that as alternative in the `private` pragma.

There were a fair number of files that couldn't be resolved as public or private in this way so they were left untouched.

@dalg24 can you loop in relevant reviews here? and do you have any ideas for testing?