### PR TITLE
Add thread-safety tests

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -427,6 +427,7 @@ if(Kokkos_ENABLE_OPENACC)
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_complexdouble.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_complexfloat.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_Crs.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ExecSpaceThreadSafety.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_JoinBackwardCompatibility.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_LocalDeepCopy.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_Other.cpp

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -638,6 +638,8 @@ IF(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
 endif()
 
 if(Kokkos_ENABLE_SERIAL)
+  list(REMOVE_ITEM Serial_SOURCES1
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_ExecSpaceThreadSafety.cpp)
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     CoreUnitTest_Serial1
     SOURCES
@@ -668,6 +670,9 @@ if(Kokkos_ENABLE_THREADS)
 endif()
 
 if (Kokkos_ENABLE_OPENMP)
+  list(REMOVE_ITEM OpenMP_SOURCES
+    ${CMAKE_CURRENT_BINARY_DIR}/openmp/TestOpenMP_ExecSpaceThreadSafety.cpp)
+
   set(OpenMP_EXTRA_SOURCES
     openmp/TestOpenMP_Task.cpp
   )

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -148,6 +148,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         Crs
         DeepCopyAlignment
         ExecSpacePartitioning
+        ExecSpaceThreadSafety
         ExecutionSpace
         FunctorAnalysis
         HostSharedPtr

--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -33,8 +33,8 @@ void run_threaded_test(const Lambda1 l1, const Lambda2 l2) {
 #elif !defined(KOKKOS_ENABLE_THREADS) && !defined(KOKKOS_ENABLE_HPX)
 template <class Lambda1, class Lambda2>
 void run_threaded_test(const Lambda1 l1, const Lambda2 l2) {
-  std::thread t1(std::move(l1));
-  std::thread t2(std::move(l2));
+  std::thread t1(l1);
+  std::thread t2(l2);
   t1.join();
   t2.join();
 }

--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -98,11 +98,6 @@ void run_exec_space_thread_safety_range() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_range) {
-// FIXME_OPENACC
-#ifdef KOKKOS_ENABLE_OPENACC
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP() << "skipping since test is known to fail for OpenACC";
-#endif
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP() << "skipping since test is known to fail for OpenMPTarget";
@@ -166,11 +161,6 @@ void run_exec_space_thread_safety_mdrange() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange) {
-// FIXME_OPENACC
-#ifdef KOKKOS_ENABLE_OPENACC
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP() << "skipping since test is known to fail for OpenACC";
-#endif
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP() << "skipping since test is known to fail for OpenMPTarget";
@@ -232,11 +222,6 @@ void run_exec_space_thread_safety_team_policy() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy) {
-// FIXME_OPENACC
-#ifdef KOKKOS_ENABLE_OPENACC
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP() << "skipping since test is known to fail for OpenACC";
-#endif
 // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
@@ -302,11 +287,6 @@ void run_exec_space_thread_safety_range_reduce() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_range_reduce) {
-// FIXME_OPENACC
-#ifdef KOKKOS_ENABLE_OPENACC
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP() << "skipping since test is known to fail for OpenACC";
-#endif
   run_exec_space_thread_safety_range_reduce();
 }
 
@@ -370,11 +350,6 @@ void run_exec_space_thread_safety_mdrange_reduce() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange_reduce) {
-// FIXME_OPENACC
-#ifdef KOKKOS_ENABLE_OPENACC
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP() << "skipping since test is known to fail for OpenACC";
-#endif
 // FIXME_INTEL
 #ifdef KOKKOS_COMPILER_INTEL
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::OpenMP>)
@@ -444,11 +419,6 @@ void run_exec_space_thread_safety_team_policy_reduce() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy_reduce) {
-// FIXME_OPENACC
-#ifdef KOKKOS_ENABLE_OPENACC
-  GTEST_SKIP() << "skipping since test is known to fail when compiling with "
-                  "the OpenACC backend";
-#endif
 // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)

--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -14,18 +14,10 @@
 //
 //@HEADER
 
-#include <cstdio>
-#include <sstream>
-#include <iostream>
+#include <Kokkos_Core.hpp>
 #include <thread>
 
-#include <Kokkos_Core.hpp>
-
-namespace Test {
-
-#include <Kokkos_Core.hpp>
-#include <iostream>
-#include <thread>
+namespace {
 
 #ifdef KOKKOS_ENABLE_OPENMP
 template <class Lambda1, class Lambda2>
@@ -534,4 +526,4 @@ TEST(TEST_CATEGORY, exec_space_thread_safety_range_scan) {
   run_exec_space_thread_safety_range_scan();
 }
 
-}  // namespace Test
+}  // namespace

--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -1,0 +1,537 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <cstdio>
+#include <sstream>
+#include <iostream>
+#include <thread>
+
+#include <Kokkos_Core.hpp>
+
+namespace Test {
+
+#include <Kokkos_Core.hpp>
+#include <iostream>
+#include <thread>
+
+#ifdef KOKKOS_ENABLE_OPENMP
+template <class Lambda1, class Lambda2>
+void run_threaded_test(const Lambda1 l1, const Lambda2 l2) {
+#pragma omp parallel num_threads(2)
+  {
+    if (omp_get_thread_num() == 0) l1();
+    if (omp_get_thread_num() == 1) l2();
+  }
+}
+// We cannot run the multithreaded test when threads or HPX is enabled because
+// we cannot launch a thread from inside another thread
+#elif !defined(KOKKOS_ENABLE_THREADS) && !defined(KOKKOS_ENABLE_HPX)
+template <class Lambda1, class Lambda2>
+void run_threaded_test(const Lambda1 l1, const Lambda2 l2) {
+  std::thread t1(std::move(l1));
+  std::thread t2(std::move(l2));
+  t1.join();
+  t2.join();
+}
+#else
+template <class Lambda1, class Lambda2>
+void run_threaded_test(const Lambda1 l1, const Lambda2 l2) {
+  l1();
+  l2();
+}
+#endif
+
+void run_exec_space_thread_safety_range() {
+  constexpr int N = 1000;
+  constexpr int M = 1000;
+
+  Kokkos::View<int *, TEST_EXECSPACE> view("view", N);
+  Kokkos::View<Kokkos::pair<int, int>, TEST_EXECSPACE> error_index(
+      "error_index");
+
+  run_threaded_test(
+      [=]() {
+        TEST_EXECSPACE exec;
+        for (int j = 0; j < M; ++j) {
+          Kokkos::parallel_for(
+              "bar", Kokkos::RangePolicy<TEST_EXECSPACE>(exec, 0, N),
+              KOKKOS_LAMBDA(int i) {
+                if (i < N - 1 &&
+                    (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
+                  Kokkos::atomic_store(error_index.data(),
+                                       Kokkos::pair{j + 1, i});
+                ++view(i);
+              });
+        }
+        exec.fence();
+      },
+      [=]() {
+        TEST_EXECSPACE exec;
+        for (int j = 0; j < M; ++j) {
+          Kokkos::parallel_for(
+              "foo", Kokkos::RangePolicy<TEST_EXECSPACE>(exec, 0, N),
+              KOKKOS_LAMBDA(int i) {
+                if (i < N - 1 &&
+                    (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
+                     view(N - 1 - i)) > 1)
+                  Kokkos::atomic_store(error_index.data(),
+                                       Kokkos::pair{j + 1, N - 1 - i});
+                ++view(N - 1 - i);
+              });
+        }
+        exec.fence();
+      });
+
+  auto host_error_index =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, error_index);
+  auto [iteration, element] = Kokkos::pair<int, int>(host_error_index());
+  ASSERT_EQ(iteration, 0) << " failing at " << iteration << ", " << element;
+  auto host_view =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, view);
+  for (int i = 0; i < N; ++i)
+    ASSERT_EQ(host_view(i), 2 * M) << " failing at " << i;
+}
+
+TEST(TEST_CATEGORY, exec_space_thread_safety_range) {
+// FIXME_OPENACC
+#ifdef KOKKOS_ENABLE_OPENACC
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+    GTEST_SKIP() << "skipping since test is known to fail for OpenACC";
+#endif
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
+    GTEST_SKIP() << "skipping since test is known to fail for OpenMPTarget";
+#endif
+  run_exec_space_thread_safety_range();
+}
+
+void run_exec_space_thread_safety_mdrange() {
+  constexpr int N = 1000;
+  constexpr int M = 1000;
+
+  Kokkos::View<int *, TEST_EXECSPACE> view("view", N);
+  Kokkos::View<Kokkos::pair<int, int>, TEST_EXECSPACE> error_index(
+      "error_index");
+
+  run_threaded_test(
+      [=]() {
+        TEST_EXECSPACE exec;
+        for (int j = 0; j < M; ++j) {
+          Kokkos::parallel_for(
+              "bar",
+              Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
+                  exec, {0, 0}, {N, 1}),
+              KOKKOS_LAMBDA(int i, int) {
+                if (i < N - 1 &&
+                    (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
+                  Kokkos::atomic_store(error_index.data(),
+                                       Kokkos::pair{j + 1, i});
+                ++view(i);
+              });
+        }
+        exec.fence();
+      },
+      [=]() {
+        TEST_EXECSPACE exec;
+        for (int j = 0; j < M; ++j) {
+          Kokkos::parallel_for(
+              "foo",
+              Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
+                  exec, {0, 0}, {N, 1}),
+              KOKKOS_LAMBDA(int i, int) {
+                if (i < N - 1 &&
+                    (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
+                     view(N - 1 - i)) > 1)
+                  Kokkos::atomic_store(error_index.data(),
+                                       Kokkos::pair{j + 1, N - 1 - i});
+                ++view(N - 1 - i);
+              });
+        }
+        exec.fence();
+      });
+
+  auto host_error_index =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, error_index);
+  auto [iteration, element] = Kokkos::pair<int, int>(host_error_index());
+  ASSERT_EQ(iteration, 0) << " failing at " << iteration << ", " << element;
+  auto host_view =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, view);
+  for (int i = 0; i < N; ++i)
+    ASSERT_EQ(host_view(i), 2 * M) << " failing at " << i;
+}
+
+TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange) {
+// FIXME_OPENACC
+#ifdef KOKKOS_ENABLE_OPENACC
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+    GTEST_SKIP() << "skipping since test is known to fail for OpenACC";
+#endif
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
+    GTEST_SKIP() << "skipping since test is known to fail for OpenMPTarget";
+#endif
+  run_exec_space_thread_safety_mdrange();
+}
+
+void run_exec_space_thread_safety_team_policy() {
+  constexpr int N = 1000;
+  constexpr int M = 1000;
+
+  Kokkos::View<int *, TEST_EXECSPACE> view("view", N);
+  Kokkos::View<int, TEST_EXECSPACE> error_index("error_index");
+
+  run_threaded_test(
+      [=]() {
+        TEST_EXECSPACE exec;
+        for (int j = 0; j < M; ++j) {
+          Kokkos::parallel_for(
+              "bar", Kokkos::TeamPolicy<TEST_EXECSPACE>(exec, N, 1, 1),
+              KOKKOS_LAMBDA(
+                  const Kokkos::TeamPolicy<TEST_EXECSPACE>::member_type
+                      &team_member) {
+                int i = team_member.league_rank();
+                if (i < N - 1 &&
+                    (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
+                  Kokkos::atomic_store(error_index.data(), 1);
+                ++view(i);
+              });
+        }
+        exec.fence();
+      },
+      [=]() {
+        TEST_EXECSPACE exec;
+        for (int j = 0; j < M; ++j) {
+          Kokkos::parallel_for(
+              "foo", Kokkos::TeamPolicy<TEST_EXECSPACE>(exec, N, 1, 1),
+              KOKKOS_LAMBDA(
+                  const Kokkos::TeamPolicy<TEST_EXECSPACE>::member_type
+                      &team_member) {
+                int i = team_member.league_rank();
+                if (i < N - 1 &&
+                    (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
+                     view(N - 1 - i)) > 1)
+                  Kokkos::atomic_store(error_index.data(), 1);
+                ++view(N - 1 - i);
+              });
+        }
+        exec.fence();
+      });
+
+  auto host_error_index =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, error_index);
+  ASSERT_EQ(host_error_index(), 0);
+  auto host_view =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, view);
+  for (int i = 0; i < N; ++i)
+    ASSERT_EQ(host_view(i), 2 * M) << " failing at " << i;
+}
+
+TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy) {
+// FIXME_OPENACC
+#ifdef KOKKOS_ENABLE_OPENACC
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+    GTEST_SKIP() << "skipping since test is known to fail for OpenACC";
+#endif
+// FIXME_OPENMPTARGET
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
+    GTEST_SKIP() << "skipping for OpenMPTarget since the test is designed to "
+                    "run with vector_length=1";
+#endif
+  run_exec_space_thread_safety_team_policy();
+}
+
+void run_exec_space_thread_safety_range_reduce() {
+  constexpr int N = 1000;
+  constexpr int M = 1000;
+
+  Kokkos::View<int *, TEST_EXECSPACE> view("view", N);
+  Kokkos::View<Kokkos::pair<int, int>, TEST_EXECSPACE> error_index(
+      "error_index");
+
+  run_threaded_test(
+      [=]() {
+        int dummy;
+        TEST_EXECSPACE exec;
+        for (int j = 0; j < M; ++j) {
+          Kokkos::parallel_reduce(
+              "bar", Kokkos::RangePolicy<TEST_EXECSPACE>(exec, 0, N),
+              KOKKOS_LAMBDA(int i, int &) {
+                if (i < N - 1 &&
+                    (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
+                  Kokkos::atomic_store(error_index.data(),
+                                       Kokkos::pair{j + 1, i});
+                ++view(i);
+              },
+              dummy);
+        }
+        exec.fence();
+      },
+      [=]() {
+        int dummy;
+        TEST_EXECSPACE exec;
+        for (int j = 0; j < M; ++j) {
+          Kokkos::parallel_reduce(
+              "foo", Kokkos::RangePolicy<TEST_EXECSPACE>(exec, 0, N),
+              KOKKOS_LAMBDA(int i, int &) {
+                if (i < N - 1 &&
+                    (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
+                     view(N - 1 - i)) > 1)
+                  Kokkos::atomic_store(error_index.data(),
+                                       Kokkos::pair{j + 1, N - 1 - i});
+                ++view(N - 1 - i);
+              },
+              dummy);
+        }
+        exec.fence();
+      });
+
+  auto host_error_index =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, error_index);
+  auto [iteration, element] = Kokkos::pair<int, int>(host_error_index());
+  ASSERT_EQ(iteration, 0) << " failing at " << iteration << ", " << element;
+  auto host_view =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, view);
+  for (int i = 0; i < N; ++i)
+    ASSERT_EQ(host_view(i), 2 * M) << " failing at " << i;
+}
+
+TEST(TEST_CATEGORY, exec_space_thread_safety_range_reduce) {
+// FIXME_OPENACC
+#ifdef KOKKOS_ENABLE_OPENACC
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+    GTEST_SKIP() << "skipping since test is known to fail for OpenACC";
+#endif
+  run_exec_space_thread_safety_range_reduce();
+}
+
+void run_exec_space_thread_safety_mdrange_reduce() {
+  constexpr int N = 1000;
+  constexpr int M = 1000;
+
+  Kokkos::View<int *, TEST_EXECSPACE> view("view", N);
+  Kokkos::View<Kokkos::pair<int, int>, TEST_EXECSPACE> error_index(
+      "error_index");
+
+  run_threaded_test(
+      [=]() {
+        int dummy;
+        TEST_EXECSPACE exec;
+        for (int j = 0; j < M; ++j) {
+          Kokkos::parallel_reduce(
+              "bar",
+              Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
+                  exec, {0, 0}, {N, 1}),
+              KOKKOS_LAMBDA(int i, int, int &) {
+                if (i < N - 1 &&
+                    (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
+                  Kokkos::atomic_store(error_index.data(),
+                                       Kokkos::pair{j + 1, i});
+                ++view(i);
+              },
+              dummy);
+        }
+        exec.fence();
+      },
+      [=]() {
+        int dummy;
+        TEST_EXECSPACE exec;
+        for (int j = 0; j < M; ++j) {
+          Kokkos::parallel_reduce(
+              "foo",
+              Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
+                  exec, {0, 0}, {N, 1}),
+              KOKKOS_LAMBDA(int i, int, int &) {
+                if (i < N - 1 &&
+                    (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
+                     view(N - 1 - i)) > 1)
+                  Kokkos::atomic_store(error_index.data(),
+                                       Kokkos::pair{j + 1, N - 1 - i});
+                ++view(N - 1 - i);
+              },
+              dummy);
+        }
+        exec.fence();
+      });
+
+  auto host_error_index =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, error_index);
+  auto [iteration, element] = Kokkos::pair<int, int>(host_error_index());
+  ASSERT_EQ(iteration, 0) << " failing at " << iteration << ", " << element;
+  auto host_view =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, view);
+  for (int i = 0; i < N; ++i)
+    ASSERT_EQ(host_view(i), 2 * M) << " failing at " << i;
+}
+
+TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange_reduce) {
+// FIXME_OPENACC
+#ifdef KOKKOS_ENABLE_OPENACC
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+    GTEST_SKIP() << "skipping since test is known to fail for OpenACC";
+#endif
+// FIXME_INTEL
+#ifdef KOKKOS_COMPILER_INTEL
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::OpenMP>)
+    GTEST_SKIP() << "skipping since test is known to fail for OpenMP using the "
+                    "legacy Intel compiler";
+#endif
+  run_exec_space_thread_safety_mdrange_reduce();
+}
+
+void run_exec_space_thread_safety_team_policy_reduce() {
+  constexpr int N = 1000;
+  constexpr int M = 1000;
+
+  Kokkos::View<int *, TEST_EXECSPACE> view("view", N);
+  Kokkos::View<int, TEST_EXECSPACE> error_index("error_index");
+
+  run_threaded_test(
+      [=]() {
+        int dummy;
+        TEST_EXECSPACE exec;
+        for (int j = 0; j < M; ++j) {
+          Kokkos::parallel_reduce(
+              "bar", Kokkos::TeamPolicy<TEST_EXECSPACE>(exec, N, 1, 1),
+              KOKKOS_LAMBDA(
+                  const Kokkos::TeamPolicy<TEST_EXECSPACE>::member_type
+                      &team_member,
+                  int &) {
+                int i = team_member.league_rank();
+                if (i < N - 1 &&
+                    (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
+                  Kokkos::atomic_store(error_index.data(), 1);
+                ++view(i);
+              },
+              dummy);
+        }
+        exec.fence();
+      },
+      [=]() {
+        int dummy;
+        TEST_EXECSPACE exec;
+        for (int j = 0; j < M; ++j) {
+          Kokkos::parallel_reduce(
+              "foo", Kokkos::TeamPolicy<TEST_EXECSPACE>(exec, N, 1, 1),
+              KOKKOS_LAMBDA(
+                  const Kokkos::TeamPolicy<TEST_EXECSPACE>::member_type
+                      &team_member,
+                  int &) {
+                int i = team_member.league_rank();
+                if (i < N - 1 &&
+                    (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
+                     view(N - 1 - i)) > 1)
+                  Kokkos::atomic_store(error_index.data(), 1);
+                ++view(N - 1 - i);
+              },
+              dummy);
+        }
+        exec.fence();
+      });
+
+  auto host_error_index =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, error_index);
+  ASSERT_EQ(host_error_index(), 0);
+  auto host_view =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, view);
+  for (int i = 0; i < N; ++i)
+    ASSERT_EQ(host_view(i), 2 * M) << " failing at " << i;
+}
+
+TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy_reduce) {
+// FIXME_OPENACC
+#ifdef KOKKOS_ENABLE_OPENACC
+  GTEST_SKIP() << "skipping since test is known to fail when compiling with "
+                  "the OpenACC backend";
+#endif
+// FIXME_OPENMPTARGET
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
+    GTEST_SKIP() << "skipping for OpenMPTarget since the test is designed to "
+                    "run with vector_length=1";
+#endif
+    // FIXME_SYCL
+#if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
+    GTEST_SKIP() << "skipping since test is know to fail with SYCL+Cuda";
+#endif
+  run_exec_space_thread_safety_team_policy_reduce();
+}
+
+void run_exec_space_thread_safety_range_scan() {
+  constexpr int N = 1000;
+  constexpr int M = 1000;
+
+  Kokkos::View<int *, TEST_EXECSPACE> view("view", N);
+  Kokkos::View<Kokkos::pair<int, int>, TEST_EXECSPACE> error_index(
+      "error_index");
+
+  run_threaded_test(
+      [=]() {
+        int dummy;
+        TEST_EXECSPACE exec;
+        for (int j = 0; j < M; ++j) {
+          Kokkos::parallel_scan(
+              "bar", Kokkos::RangePolicy<TEST_EXECSPACE>(exec, 0, N),
+              KOKKOS_LAMBDA(const int i, int &, const bool final) {
+                if (final) {
+                  if (i < N - 1 && (Kokkos::atomic_load(view.data() + (i + 1)) -
+                                    view(i)) > 1)
+                    Kokkos::atomic_store(error_index.data(),
+                                         Kokkos::pair{j + 1, i});
+                  ++view(i);
+                }
+              },
+              dummy);
+        }
+        exec.fence();
+      },
+      [=]() {
+        int dummy;
+        TEST_EXECSPACE exec;
+        for (int j = 0; j < M; ++j) {
+          Kokkos::parallel_scan(
+              "foo", Kokkos::RangePolicy<TEST_EXECSPACE>(exec, 0, N),
+              KOKKOS_LAMBDA(const int i, int &, const bool final) {
+                if (final) {
+                  if (i < N - 1 &&
+                      (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
+                       view(N - 1 - i)) > 1)
+                    Kokkos::atomic_store(error_index.data(),
+                                         Kokkos::pair{j + 1, N - 1 - i});
+                  ++view(N - 1 - i);
+                }
+              },
+              dummy);
+        }
+        exec.fence();
+      });
+
+  auto host_error_index =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, error_index);
+  auto [iteration, element] = Kokkos::pair<int, int>(host_error_index());
+  ASSERT_EQ(iteration, 0) << " failing at " << iteration << ", " << element;
+  auto host_view =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, view);
+  for (int i = 0; i < N; ++i)
+    ASSERT_EQ(host_view(i), 2 * M) << " failing at " << i;
+}
+
+TEST(TEST_CATEGORY, exec_space_thread_safety_range_scan) {
+  run_exec_space_thread_safety_range_scan();
+}
+
+}  // namespace Test

--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -69,11 +69,11 @@ void run_exec_space_thread_safety_range() {
                 // check that values in the View don't differ by more than one
                 // which would indicate that the other kernel has written to it
                 // while this one is running.
-                if (i < N - 1 &&
-                    (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
+                if (i < N - 1 && (Kokkos::atomic_load(&view(i + 1)) -
+                                  Kokkos::atomic_load(&view(i))) > 1)
                   Kokkos::atomic_store(error_index.data(),
                                        Kokkos::pair{j + 1, i});
-                ++view(i);
+                Kokkos::atomic_inc(&view(i));
               });
         }
         exec.fence();
@@ -87,12 +87,11 @@ void run_exec_space_thread_safety_range() {
                 // check that values in the View don't differ by more than one
                 // which would indicate that the other kernel has written to it
                 // while this one is running.
-                if (i < N - 1 &&
-                    (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
-                     view(N - 1 - i)) > 1)
+                if (i < N - 1 && (Kokkos::atomic_load(&view(N - 2 - i)) -
+                                  Kokkos::atomic_load(&view(N - 1 - i))) > 1)
                   Kokkos::atomic_store(error_index.data(),
                                        Kokkos::pair{j + 1, N - 1 - i});
-                ++view(N - 1 - i);
+                Kokkos::atomic_inc(&view(N - i - 1));
               });
         }
         exec.fence();
@@ -136,11 +135,11 @@ void run_exec_space_thread_safety_mdrange() {
                 // check that values in the View don't differ by more than one
                 // which would indicate that the other kernel has written to it
                 // while this one is running.
-                if (i < N - 1 &&
-                    (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
+                if (i < N - 1 && (Kokkos::atomic_load(&view(i + 1)) -
+                                  Kokkos::atomic_load(&view(i))) > 1)
                   Kokkos::atomic_store(error_index.data(),
                                        Kokkos::pair{j + 1, i});
-                ++view(i);
+                Kokkos::atomic_inc(&view(i));
               });
         }
         exec.fence();
@@ -156,12 +155,11 @@ void run_exec_space_thread_safety_mdrange() {
                 // check that values in the View don't differ by more than one
                 // which would indicate that the other kernel has written to it
                 // while this one is running.
-                if (i < N - 1 &&
-                    (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
-                     view(N - 1 - i)) > 1)
+                if (i < N - 1 && (Kokkos::atomic_load(&view(N - 2 - i)) -
+                                  Kokkos::atomic_load(&view(N - 1 - i))) > 1)
                   Kokkos::atomic_store(error_index.data(),
                                        Kokkos::pair{j + 1, N - 1 - i});
-                ++view(N - 1 - i);
+                Kokkos::atomic_inc(&view(N - i - 1));
               });
         }
         exec.fence();
@@ -205,10 +203,10 @@ void run_exec_space_thread_safety_team_policy() {
                 // check that values in the View don't differ by more than one
                 // which would indicate that the other kernel has written to it
                 // while this one is running.
-                if (i < N - 1 &&
-                    (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
+                if (i < N - 1 && (Kokkos::atomic_load(&view(i + 1)) -
+                                  Kokkos::atomic_load(&view(i))) > 1)
                   Kokkos::atomic_store(error_index.data(), 1);
-                ++view(i);
+                Kokkos::atomic_inc(&view(i));
               });
         }
         exec.fence();
@@ -225,11 +223,10 @@ void run_exec_space_thread_safety_team_policy() {
                 // check that values in the View don't differ by more than one
                 // which would indicate that the other kernel has written to it
                 // while this one is running.
-                if (i < N - 1 &&
-                    (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
-                     view(N - 1 - i)) > 1)
+                if (i < N - 1 && (Kokkos::atomic_load(&view(N - 2 - i)) -
+                                  Kokkos::atomic_load(&view(N - 1 - i))) > 1)
                   Kokkos::atomic_store(error_index.data(), 1);
-                ++view(N - 1 - i);
+                Kokkos::atomic_inc(&view(N - i - 1));
               });
         }
         exec.fence();
@@ -273,11 +270,11 @@ void run_exec_space_thread_safety_range_reduce() {
                 // check that values in the View don't differ by more than one
                 // which would indicate that the other kernel has written to it
                 // while this one is running.
-                if (i < N - 1 &&
-                    (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
+                if (i < N - 1 && (Kokkos::atomic_load(&view(i + 1)) -
+                                  Kokkos::atomic_load(&view(i))) > 1)
                   Kokkos::atomic_store(error_index.data(),
                                        Kokkos::pair{j + 1, i});
-                ++view(i);
+                Kokkos::atomic_inc(&view(i));
               },
               dummy);
         }
@@ -293,12 +290,11 @@ void run_exec_space_thread_safety_range_reduce() {
                 // check that values in the View don't differ by more than one
                 // which would indicate that the other kernel has written to it
                 // while this one is running.
-                if (i < N - 1 &&
-                    (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
-                     view(N - 1 - i)) > 1)
+                if (i < N - 1 && (Kokkos::atomic_load(&view(N - 2 - i)) -
+                                  Kokkos::atomic_load(&view(N - 1 - i))) > 1)
                   Kokkos::atomic_store(error_index.data(),
                                        Kokkos::pair{j + 1, N - 1 - i});
-                ++view(N - 1 - i);
+                Kokkos::atomic_inc(&view(N - i - 1));
               },
               dummy);
         }
@@ -340,11 +336,11 @@ void run_exec_space_thread_safety_mdrange_reduce() {
                 // check that values in the View don't differ by more than one
                 // which would indicate that the other kernel has written to it
                 // while this one is running.
-                if (i < N - 1 &&
-                    (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
+                if (i < N - 1 && (Kokkos::atomic_load(&view(i + 1)) -
+                                  Kokkos::atomic_load(&view(i))) > 1)
                   Kokkos::atomic_store(error_index.data(),
                                        Kokkos::pair{j + 1, i});
-                ++view(i);
+                Kokkos::atomic_inc(&view(i));
               },
               dummy);
         }
@@ -362,12 +358,11 @@ void run_exec_space_thread_safety_mdrange_reduce() {
                 // check that values in the View don't differ by more than one
                 // which would indicate that the other kernel has written to it
                 // while this one is running.
-                if (i < N - 1 &&
-                    (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
-                     view(N - 1 - i)) > 1)
+                if (i < N - 1 && (Kokkos::atomic_load(&view(N - 2 - i)) -
+                                  Kokkos::atomic_load(&view(N - 1 - i))) > 1)
                   Kokkos::atomic_store(error_index.data(),
                                        Kokkos::pair{j + 1, N - 1 - i});
-                ++view(N - 1 - i);
+                Kokkos::atomic_inc(&view(N - i - 1));
               },
               dummy);
         }
@@ -416,10 +411,10 @@ void run_exec_space_thread_safety_team_policy_reduce() {
                 // check that values in the View don't differ by more than one
                 // which would indicate that the other kernel has written to it
                 // while this one is running.
-                if (i < N - 1 &&
-                    (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
+                if (i < N - 1 && (Kokkos::atomic_load(&view(i + 1)) -
+                                  Kokkos::atomic_load(&view(i))) > 1)
                   Kokkos::atomic_store(error_index.data(), 1);
-                ++view(i);
+                Kokkos::atomic_inc(&view(i));
               },
               dummy);
         }
@@ -439,11 +434,10 @@ void run_exec_space_thread_safety_team_policy_reduce() {
                 // check that values in the View don't differ by more than one
                 // which would indicate that the other kernel has written to it
                 // while this one is running.
-                if (i < N - 1 &&
-                    (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
-                     view(N - 1 - i)) > 1)
+                if (i < N - 1 && (Kokkos::atomic_load(&view(N - 2 - i)) -
+                                  Kokkos::atomic_load(&view(N - 1 - i))) > 1)
                   Kokkos::atomic_store(error_index.data(), 1);
-                ++view(N - 1 - i);
+                Kokkos::atomic_inc(&view(N - i - 1));
               },
               dummy);
         }
@@ -494,11 +488,11 @@ void run_exec_space_thread_safety_range_scan() {
                   // check that values in the View don't differ by more than one
                   // which would indicate that the other kernel has written to
                   // it while this one is running.
-                  if (i < N - 1 && (Kokkos::atomic_load(view.data() + (i + 1)) -
-                                    view(i)) > 1)
+                  if (i < N - 1 && (Kokkos::atomic_load(&view(i + 1)) -
+                                    Kokkos::atomic_load(&view(i))) > 1)
                     Kokkos::atomic_store(error_index.data(),
                                          Kokkos::pair{j + 1, i});
-                  ++view(i);
+                  Kokkos::atomic_inc(&view(i));
                 }
               },
               dummy);
@@ -516,12 +510,11 @@ void run_exec_space_thread_safety_range_scan() {
                   // check that values in the View don't differ by more than one
                   // which would indicate that the other kernel has written to
                   // it while this one is running.
-                  if (i < N - 1 &&
-                      (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
-                       view(N - 1 - i)) > 1)
+                  if (i < N - 1 && (Kokkos::atomic_load(&view(N - 2 - i)) -
+                                    Kokkos::atomic_load(&view(N - 1 - i))) > 1)
                     Kokkos::atomic_store(error_index.data(),
                                          Kokkos::pair{j + 1, N - 1 - i});
-                  ++view(N - 1 - i);
+                  Kokkos::atomic_inc(&view(N - i - 1));
                 }
               },
               dummy);

--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -46,6 +46,11 @@ void run_threaded_test(const Lambda1 l1, const Lambda2 l2) {
 }
 #endif
 
+// The idea for all of these tests is to access a View from kernels submitted by
+// two different threads to the same execution space instance. If the kernels
+// are executed concurrently, we expect to detect some indices in the View that
+// have unexpected values. We map the View element to work items in reversefor
+// for one of the threaads to try triggering problems better.
 void run_exec_space_thread_safety_range() {
   constexpr int N = 1000;
   constexpr int M = 1000;
@@ -61,6 +66,9 @@ void run_exec_space_thread_safety_range() {
           Kokkos::parallel_for(
               "bar", Kokkos::RangePolicy<TEST_EXECSPACE>(exec, 0, N),
               KOKKOS_LAMBDA(int i) {
+                // check that values in the View don't differ by more than one
+                // which would indicate that the other kernel has written to it
+                // while this one is running.
                 if (i < N - 1 &&
                     (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
                   Kokkos::atomic_store(error_index.data(),
@@ -76,6 +84,9 @@ void run_exec_space_thread_safety_range() {
           Kokkos::parallel_for(
               "foo", Kokkos::RangePolicy<TEST_EXECSPACE>(exec, 0, N),
               KOKKOS_LAMBDA(int i) {
+                // check that values in the View don't differ by more than one
+                // which would indicate that the other kernel has written to it
+                // while this one is running.
                 if (i < N - 1 &&
                     (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
                      view(N - 1 - i)) > 1)
@@ -122,6 +133,9 @@ void run_exec_space_thread_safety_mdrange() {
               Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
                   exec, {0, 0}, {N, 1}),
               KOKKOS_LAMBDA(int i, int) {
+                // check that values in the View don't differ by more than one
+                // which would indicate that the other kernel has written to it
+                // while this one is running.
                 if (i < N - 1 &&
                     (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
                   Kokkos::atomic_store(error_index.data(),
@@ -139,6 +153,9 @@ void run_exec_space_thread_safety_mdrange() {
               Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
                   exec, {0, 0}, {N, 1}),
               KOKKOS_LAMBDA(int i, int) {
+                // check that values in the View don't differ by more than one
+                // which would indicate that the other kernel has written to it
+                // while this one is running.
                 if (i < N - 1 &&
                     (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
                      view(N - 1 - i)) > 1)
@@ -185,6 +202,9 @@ void run_exec_space_thread_safety_team_policy() {
                   const Kokkos::TeamPolicy<TEST_EXECSPACE>::member_type
                       &team_member) {
                 int i = team_member.league_rank();
+                // check that values in the View don't differ by more than one
+                // which would indicate that the other kernel has written to it
+                // while this one is running.
                 if (i < N - 1 &&
                     (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
                   Kokkos::atomic_store(error_index.data(), 1);
@@ -202,6 +222,9 @@ void run_exec_space_thread_safety_team_policy() {
                   const Kokkos::TeamPolicy<TEST_EXECSPACE>::member_type
                       &team_member) {
                 int i = team_member.league_rank();
+                // check that values in the View don't differ by more than one
+                // which would indicate that the other kernel has written to it
+                // while this one is running.
                 if (i < N - 1 &&
                     (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
                      view(N - 1 - i)) > 1)
@@ -247,6 +270,9 @@ void run_exec_space_thread_safety_range_reduce() {
           Kokkos::parallel_reduce(
               "bar", Kokkos::RangePolicy<TEST_EXECSPACE>(exec, 0, N),
               KOKKOS_LAMBDA(int i, int &) {
+                // check that values in the View don't differ by more than one
+                // which would indicate that the other kernel has written to it
+                // while this one is running.
                 if (i < N - 1 &&
                     (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
                   Kokkos::atomic_store(error_index.data(),
@@ -264,6 +290,9 @@ void run_exec_space_thread_safety_range_reduce() {
           Kokkos::parallel_reduce(
               "foo", Kokkos::RangePolicy<TEST_EXECSPACE>(exec, 0, N),
               KOKKOS_LAMBDA(int i, int &) {
+                // check that values in the View don't differ by more than one
+                // which would indicate that the other kernel has written to it
+                // while this one is running.
                 if (i < N - 1 &&
                     (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
                      view(N - 1 - i)) > 1)
@@ -308,6 +337,9 @@ void run_exec_space_thread_safety_mdrange_reduce() {
               Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
                   exec, {0, 0}, {N, 1}),
               KOKKOS_LAMBDA(int i, int, int &) {
+                // check that values in the View don't differ by more than one
+                // which would indicate that the other kernel has written to it
+                // while this one is running.
                 if (i < N - 1 &&
                     (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
                   Kokkos::atomic_store(error_index.data(),
@@ -327,6 +359,9 @@ void run_exec_space_thread_safety_mdrange_reduce() {
               Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
                   exec, {0, 0}, {N, 1}),
               KOKKOS_LAMBDA(int i, int, int &) {
+                // check that values in the View don't differ by more than one
+                // which would indicate that the other kernel has written to it
+                // while this one is running.
                 if (i < N - 1 &&
                     (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
                      view(N - 1 - i)) > 1)
@@ -378,6 +413,9 @@ void run_exec_space_thread_safety_team_policy_reduce() {
                       &team_member,
                   int &) {
                 int i = team_member.league_rank();
+                // check that values in the View don't differ by more than one
+                // which would indicate that the other kernel has written to it
+                // while this one is running.
                 if (i < N - 1 &&
                     (Kokkos::atomic_load(view.data() + (i + 1)) - view(i)) > 1)
                   Kokkos::atomic_store(error_index.data(), 1);
@@ -398,6 +436,9 @@ void run_exec_space_thread_safety_team_policy_reduce() {
                       &team_member,
                   int &) {
                 int i = team_member.league_rank();
+                // check that values in the View don't differ by more than one
+                // which would indicate that the other kernel has written to it
+                // while this one is running.
                 if (i < N - 1 &&
                     (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
                      view(N - 1 - i)) > 1)
@@ -450,6 +491,9 @@ void run_exec_space_thread_safety_range_scan() {
               "bar", Kokkos::RangePolicy<TEST_EXECSPACE>(exec, 0, N),
               KOKKOS_LAMBDA(const int i, int &, const bool final) {
                 if (final) {
+                  // check that values in the View don't differ by more than one
+                  // which would indicate that the other kernel has written to
+                  // it while this one is running.
                   if (i < N - 1 && (Kokkos::atomic_load(view.data() + (i + 1)) -
                                     view(i)) > 1)
                     Kokkos::atomic_store(error_index.data(),
@@ -469,6 +513,9 @@ void run_exec_space_thread_safety_range_scan() {
               "foo", Kokkos::RangePolicy<TEST_EXECSPACE>(exec, 0, N),
               KOKKOS_LAMBDA(const int i, int &, const bool final) {
                 if (final) {
+                  // check that values in the View don't differ by more than one
+                  // which would indicate that the other kernel has written to
+                  // it while this one is running.
                   if (i < N - 1 &&
                       (Kokkos::atomic_load(view.data() + (N - 2 - i)) -
                        view(N - 1 - i)) > 1)


### PR DESCRIPTION
Part of https://github.com/kokkos/kokkos/pull/6151 that only adds the tests from there.
The tests check that kernels submitted to one execution space instance by multiple threads are not running concurrently.