### PR TITLE
Remove unnecessary `<limits>` header include in `<Kokkos_Array.hpp>`

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -29,7 +29,6 @@
 #include <type_traits>
 #include <algorithm>
 #include <utility>
-#include <limits>
 #include <cstddef>
 
 namespace Kokkos {


### PR DESCRIPTION
Reported in https://github.com/kokkos/kokkos/pull/6934#pullrequestreview-2001860702