### PR TITLE
Add `kokkos_swap(Array<T, N>)` specialization

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -133,6 +133,17 @@ struct Array {
   KOKKOS_INLINE_FUNCTION constexpr const_pointer data() const {
     return &m_internal_implementation_private_member_data[0];
   }
+
+ private:
+  template <class U = T>
+  friend KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
+      Impl::is_swappable<T>::value>
+  kokkos_swap(Array<T, N>& a,
+              Array<T, N>& b) noexcept(Impl::is_nothrow_swappable_v<T>) {
+    for (std::size_t i = 0; i < N; ++i) {
+      kokkos_swap(a[i], b[i]);
+    }
+  }
 };
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -185,6 +196,10 @@ struct Array<T, 0> {
   // for default move constructor and move assignment operator.
   // Array( Array && ) = default ;
   // Array & operator = ( Array && ) = default ;
+
+ private:
+  friend KOKKOS_INLINE_FUNCTION constexpr void kokkos_swap(
+      Array<T, 0>&, Array<T, 0>&) noexcept(Impl::is_nothrow_swappable_v<T>) {}
 };
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -198,7 +198,7 @@ struct Array<T, 0> {
 
  private:
   friend KOKKOS_INLINE_FUNCTION constexpr void kokkos_swap(
-      Array<T, 0>&, Array<T, 0>&) noexcept(Impl::is_nothrow_swappable_v<T>) {}
+      Array<T, 0>&, Array<T, 0>&) noexcept {}
 };
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -135,7 +135,6 @@ struct Array {
   }
 
  private:
-  template <class U = T>
   friend KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
       Impl::is_swappable<T>::value>
   kokkos_swap(Array<T, N>& a,


### PR DESCRIPTION
Specializing the swap algorithm for Kokkos arrays was initially proposed in #6697 but we dropped it to focus on the Kokkos swap ADL ordeal. Somehow we overlooked a stray <Kokkos_Swap.hpp> header include in the Kokkos::Array header file.  This PR reintroduce a
`Kokkos::kokkos_swap(Kokkos::Array)` specialization, following closely what the standard library does for `std::swap(std::array)`.