### PR TITLE
Fix deprecated warning from `Kokkos::Array` specialization

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -188,7 +188,7 @@ struct Array<T, 0> {
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <>
-struct KOKKOS_DEPRECATED Array<void, KOKKOS_INVALID_INDEX, void> {
+struct Array<void, KOKKOS_INVALID_INDEX, void> {
   struct contiguous {};
   struct strided {};
 };

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -188,7 +188,7 @@ struct Array<T, 0> {
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <>
-struct Array<void, KOKKOS_INVALID_INDEX, void> {
+struct KOKKOS_DEPRECATED Array<void, KOKKOS_INVALID_INDEX, void> {
   struct contiguous {};
   struct strided {};
 };

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -187,14 +187,20 @@ struct Array<T, 0> {
 };
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+namespace Impl {
+struct KokkosArrayContiguous {};
+struct KokkosArrayStrided {};
+}  // namespace Impl
+
 template <>
 struct KOKKOS_DEPRECATED Array<void, KOKKOS_INVALID_INDEX, void> {
-  struct contiguous {};
-  struct strided {};
+  using contiguous = Impl::KokkosArrayContiguous;
+  using strided    = Impl::KokkosArrayStrided;
 };
 
 template <class T>
-struct KOKKOS_DEPRECATED Array<T, KOKKOS_INVALID_INDEX, Array<>::contiguous> {
+struct KOKKOS_DEPRECATED
+    Array<T, KOKKOS_INVALID_INDEX, Impl::KokkosArrayContiguous> {
  private:
   T* m_elem;
   size_t m_size;
@@ -262,7 +268,8 @@ struct KOKKOS_DEPRECATED Array<T, KOKKOS_INVALID_INDEX, Array<>::contiguous> {
 };
 
 template <class T>
-struct KOKKOS_DEPRECATED Array<T, KOKKOS_INVALID_INDEX, Array<>::strided> {
+struct KOKKOS_DEPRECATED
+    Array<T, KOKKOS_INVALID_INDEX, Impl::KokkosArrayStrided> {
  private:
   T* m_elem;
   size_t m_size;


### PR DESCRIPTION
Fixup for #6934 following a report downstream of warnings being raised in a GCC-13 plain vanilla build.

The warnings come from the template arguments in deprecated specialization `Kokkos::Array<>::{contiguous,strided}` which refer to `Kokkos::Array<>` that is marked as deprecated.

Minimal reproducer [here](https://godbolt.org/z/s18Txa5P6).  GCC9 eats it but GCC10 onwards raise a warning.

~~I propose the easy way out, that is we drop the `[[deprecated]]` attribute on `Kokkos::Array<>`.  Let me know if you have a better idea.~~
We make `Kokkos::Array<>::{contiguous,strided}` aliases to `Impl::` tag classes and directly refer to them in the specialization so that GCC does not warn.

Sample warning from ArborX nightlies for completeness:
```
In file included from /var/jenkins/workspace/ArborX_nightly/source-kokkos/core/src/KokkosExp_MDRangePolicy.hpp:29,
                 from /var/jenkins/workspace/ArborX_nightly/source-kokkos/core/src/Kokkos_Tuners.hpp:28,
                 from /var/jenkins/workspace/ArborX_nightly/source-kokkos/core/src/impl/Kokkos_Tools_Generic.hpp:26,
                 from /var/jenkins/workspace/ArborX_nightly/source-kokkos/core/src/Kokkos_Parallel.hpp:34,
                 from /var/jenkins/workspace/ArborX_nightly/source-kokkos/core/src/Kokkos_MemoryPool.hpp:26,
                 from /var/jenkins/workspace/ArborX_nightly/source-kokkos/core/src/Kokkos_TaskScheduler.hpp:34,
                 from /var/jenkins/workspace/ArborX_nightly/source-kokkos/core/src/Serial/Kokkos_Serial.hpp:37,
                 from /var/jenkins/workspace/ArborX_nightly/source-kokkos/core/src/decl/Kokkos_Declare_SERIAL.hpp:21,
                 from /var/jenkins/workspace/ArborX_nightly/build-kokkos/KokkosCore_Config_DeclareBackend.hpp:22,
                 from /var/jenkins/workspace/ArborX_nightly/source-kokkos/core/src/Kokkos_Core.hpp:45,
                 from /var/jenkins/workspace/ArborX_nightly/source-kokkos/core/src/impl/Kokkos_Core.cpp:21:
/var/jenkins/workspace/ArborX_nightly/source-kokkos/core/src/Kokkos_Array.hpp:197:66: warning: 'Array' is deprecated [-Wdeprecated-declarations]
  197 | struct KOKKOS_DEPRECATED Array<T, KOKKOS_INVALID_INDEX, Array<>::contiguous> {
      |                                                                  ^~~~~~~~~~
/var/jenkins/workspace/ArborX_nightly/source-kokkos/core/src/Kokkos_Array.hpp:191:26: note: declared here
  191 | struct KOKKOS_DEPRECATED Array<void, KOKKOS_INVALID_INDEX, void> {
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/var/jenkins/workspace/ArborX_nightly/source-kokkos/core/src/Kokkos_Array.hpp:265:66: warning: 'Array' is deprecated [-Wdeprecated-declarations]
  265 | struct KOKKOS_DEPRECATED Array<T, KOKKOS_INVALID_INDEX, Array<>::strided> {
      |                                                                  ^~~~~~~
/var/jenkins/workspace/ArborX_nightly/source-kokkos/core/src/Kokkos_Array.hpp:191:26: note: declared here
  191 | struct KOKKOS_DEPRECATED Array<void, KOKKOS_INVALID_INDEX, void> {
      |
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```