### PR TITLE
Deprecate specialization of `Kokkos::pair` for a single element

### DIFF
--- a/core/src/Kokkos_Pair.hpp
+++ b/core/src/Kokkos_Pair.hpp
@@ -413,12 +413,13 @@ KOKKOS_FORCEINLINE_FUNCTION pair<T1&, T2&> tie(T1& x, T2& y) {
   return (pair<T1&, T2&>(x, y));
 }
 
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
 //
 // Specialization of Kokkos::pair for a \c void second argument.  This
 // is not actually a "pair"; it only contains one element, the first.
 //
 template <class T1>
-struct pair<T1, void> {
+struct KOKKOS_DEPRECATED pair<T1, void> {
   using first_type  = T1;
   using second_type = void;
 
@@ -483,6 +484,7 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr bool operator>=(
     const pair<T1, void>& lhs, const pair<T1, void>& rhs) {
   return !(lhs < rhs);
 }
+#endif
 
 namespace Impl {
 template <class T>


### PR DESCRIPTION
This specialization is not documented, does not follow the standard library, it is not tested and has no known usage in Trilinos. `Kokkos::pair`, as we generally describe it, was intended as a drop-in replacement for `std::pair`.  Hence, obscure departure from the standard implementation do not look like a good idea.
This PR suggest to deprecate that `T2=void` specialization for degenerate pair that only hold one element.