### PR TITLE
fix view constructor constraints

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -58,7 +58,6 @@ struct ViewDataAnalysis;
 template <class, class...>
 class ViewMapping {
  public:
-  enum : bool { is_assignable_data_type = false };
   enum : bool { is_assignable = false };
 };
 
@@ -1344,7 +1343,7 @@ class View : public ViewTraits<DataType, Properties...> {
       const View<RT, RP...>& rhs,
       std::enable_if_t<Kokkos::Impl::ViewMapping<
           traits, typename View<RT, RP...>::traits,
-          typename traits::specialize>::is_assignable_data_type>* = nullptr)
+          typename traits::specialize>::is_assignable>* = nullptr)
       : m_track(rhs), m_map() {
     using SrcTraits = typename View<RT, RP...>::traits;
     using Mapping   = Kokkos::Impl::ViewMapping<traits, SrcTraits,
@@ -1358,7 +1357,7 @@ class View : public ViewTraits<DataType, Properties...> {
   KOKKOS_INLINE_FUNCTION std::enable_if_t<
       Kokkos::Impl::ViewMapping<
           traits, typename View<RT, RP...>::traits,
-          typename traits::specialize>::is_assignable_data_type,
+          typename traits::specialize>::is_assignable,
       View>&
   operator=(const View<RT, RP...>& rhs) {
     using SrcTraits = typename View<RT, RP...>::traits;

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1348,22 +1348,18 @@ class View : public ViewTraits<DataType, Properties...> {
     using SrcTraits = typename View<RT, RP...>::traits;
     using Mapping   = Kokkos::Impl::ViewMapping<traits, SrcTraits,
                                               typename traits::specialize>;
-    static_assert(Mapping::is_assignable,
-                  "Incompatible View copy construction");
     Mapping::assign(m_map, rhs.m_map, rhs.m_track.m_tracker);
   }
 
   template <class RT, class... RP>
   KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      Kokkos::Impl::ViewMapping<
-          traits, typename View<RT, RP...>::traits,
-          typename traits::specialize>::is_assignable,
+      Kokkos::Impl::ViewMapping<traits, typename View<RT, RP...>::traits,
+                                typename traits::specialize>::is_assignable,
       View>&
   operator=(const View<RT, RP...>& rhs) {
     using SrcTraits = typename View<RT, RP...>::traits;
     using Mapping   = Kokkos::Impl::ViewMapping<traits, SrcTraits,
                                               typename traits::specialize>;
-    static_assert(Mapping::is_assignable, "Incompatible View copy assignment");
     Mapping::assign(m_map, rhs.m_map, rhs.m_track.m_tracker);
     m_track.assign(rhs);
     return *this;

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3115,10 +3115,6 @@ class ViewMapping<
 
  public:
   enum {
-    is_assignable_data_type =
-        is_assignable_value_type && is_assignable_dimension
-  };
-  enum {
     is_assignable = is_assignable_space && is_assignable_value_type &&
                     is_assignable_dimension && is_assignable_layout
   };
@@ -3236,10 +3232,6 @@ class ViewMapping<
   };
 
  public:
-  enum {
-    is_assignable_data_type =
-        is_assignable_value_type && is_assignable_dimension
-  };
   enum {
     is_assignable = is_assignable_space && is_assignable_value_type &&
                     is_assignable_dimension

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -94,6 +94,7 @@ SET(COMPILE_ONLY_SOURCES
   TestTypeList.cpp
   TestMDRangePolicyCTAD.cpp
   view/TestExtentsDatatypeConversion.cpp
+  view/TestViewConstructibilityTraits.cpp
 )
 
 #testing if windows.h and Kokkos_Core.hpp can be included

--- a/core/unit_test/view/TestViewConstructibilityTraits.cpp
+++ b/core/unit_test/view/TestViewConstructibilityTraits.cpp
@@ -1,0 +1,57 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+#include <type_traits>
+
+namespace {
+// Relevant documentation: https://kokkos.org/kokkos-core-wiki/API/core/view/view.html#assignment-rules
+// Not everything will be tested here as this is just testing the `std::is_constructible_v` trait
+
+// Differing rank not allowed
+static_assert(!std::is_constructible_v<Kokkos::View<double**>, Kokkos::View<double*>>);
+static_assert(!std::is_assignable_v<Kokkos::View<double**> &, Kokkos::View<double*>>);
+
+// Differing non const value type
+static_assert(!std::is_constructible_v<Kokkos::View<double*>, Kokkos::View<int*>>);
+static_assert(!std::is_assignable_v<Kokkos::View<double*> &, Kokkos::View<int*>>);
+
+// Don't construct away constness
+static_assert(!std::is_constructible_v<Kokkos::View<double*>, Kokkos::View<const double*>>);
+static_assert(!std::is_assignable_v<Kokkos::View<double*> &, Kokkos::View<const double*>>);
+
+// Construct to const is ok
+static_assert(std::is_constructible_v<Kokkos::View<const double*>, Kokkos::View<double*>>);
+static_assert(std::is_assignable_v<Kokkos::View<const double*> &, Kokkos::View<double*>>);
+
+// Differing static extents
+static_assert(!std::is_constructible_v<Kokkos::View<double[3]>, Kokkos::View<double[4]>>);
+static_assert(!std::is_assignable_v<Kokkos::View<double[3]> &, Kokkos::View<double[4]>>);
+
+// Differing layouts:
+// Single rank is OK
+static_assert(std::is_constructible_v<Kokkos::View<double[3], Kokkos::LayoutLeft>, Kokkos::View<double[3], Kokkos::LayoutRight>>);
+static_assert(std::is_constructible_v<Kokkos::View<double[3], Kokkos::LayoutRight>, Kokkos::View<double[3], Kokkos::LayoutLeft>>);
+static_assert(std::is_assignable_v<Kokkos::View<double[3], Kokkos::LayoutLeft> &, Kokkos::View<double[3], Kokkos::LayoutRight>>);
+static_assert(std::is_assignable_v<Kokkos::View<double[3], Kokkos::LayoutRight> &, Kokkos::View<double[3], Kokkos::LayoutLeft>>);
+
+// Rank > 1 not ok
+static_assert(!std::is_constructible_v<Kokkos::View<double[3][5], Kokkos::LayoutRight>, Kokkos::View<double[3][5], Kokkos::LayoutLeft>>);
+static_assert(!std::is_constructible_v<Kokkos::View<double[3][5], Kokkos::LayoutLeft>, Kokkos::View<double[3][5], Kokkos::LayoutRight>>);
+static_assert(!std::is_assignable_v<Kokkos::View<double[3][5], Kokkos::LayoutRight> &, Kokkos::View<double[3][5], Kokkos::LayoutLeft>>);
+static_assert(!std::is_assignable_v<Kokkos::View<double[3][5], Kokkos::LayoutLeft> &, Kokkos::View<double[3][5], Kokkos::LayoutRight>>);
+
+}  // namespace

--- a/core/unit_test/view/TestViewConstructibilityTraits.cpp
+++ b/core/unit_test/view/TestViewConstructibilityTraits.cpp
@@ -18,40 +18,68 @@
 #include <type_traits>
 
 namespace {
-// Relevant documentation: https://kokkos.org/kokkos-core-wiki/API/core/view/view.html#assignment-rules
-// Not everything will be tested here as this is just testing the `std::is_constructible_v` trait
+// Relevant documentation:
+// https://kokkos.org/kokkos-core-wiki/API/core/view/view.html#assignment-rules
+// Not everything will be tested here as this is just testing the
+// `std::is_constructible_v` trait
 
 // Differing rank not allowed
-static_assert(!std::is_constructible_v<Kokkos::View<double**>, Kokkos::View<double*>>);
-static_assert(!std::is_assignable_v<Kokkos::View<double**> &, Kokkos::View<double*>>);
+static_assert(
+    !std::is_constructible_v<Kokkos::View<double **>, Kokkos::View<double *>>);
+static_assert(
+    !std::is_assignable_v<Kokkos::View<double **> &, Kokkos::View<double *>>);
 
 // Differing non const value type
-static_assert(!std::is_constructible_v<Kokkos::View<double*>, Kokkos::View<int*>>);
-static_assert(!std::is_assignable_v<Kokkos::View<double*> &, Kokkos::View<int*>>);
+static_assert(
+    !std::is_constructible_v<Kokkos::View<double *>, Kokkos::View<int *>>);
+static_assert(
+    !std::is_assignable_v<Kokkos::View<double *> &, Kokkos::View<int *>>);
 
 // Don't construct away constness
-static_assert(!std::is_constructible_v<Kokkos::View<double*>, Kokkos::View<const double*>>);
-static_assert(!std::is_assignable_v<Kokkos::View<double*> &, Kokkos::View<const double*>>);
+static_assert(!std::is_constructible_v<Kokkos::View<double *>,
+                                       Kokkos::View<const double *>>);
+static_assert(!std::is_assignable_v<Kokkos::View<double *> &,
+                                    Kokkos::View<const double *>>);
 
 // Construct to const is ok
-static_assert(std::is_constructible_v<Kokkos::View<const double*>, Kokkos::View<double*>>);
-static_assert(std::is_assignable_v<Kokkos::View<const double*> &, Kokkos::View<double*>>);
+static_assert(std::is_constructible_v<Kokkos::View<const double *>,
+                                      Kokkos::View<double *>>);
+static_assert(std::is_assignable_v<Kokkos::View<const double *> &,
+                                   Kokkos::View<double *>>);
 
 // Differing static extents
-static_assert(!std::is_constructible_v<Kokkos::View<double[3]>, Kokkos::View<double[4]>>);
-static_assert(!std::is_assignable_v<Kokkos::View<double[3]> &, Kokkos::View<double[4]>>);
+static_assert(
+    !std::is_constructible_v<Kokkos::View<double[3]>, Kokkos::View<double[4]>>);
+static_assert(
+    !std::is_assignable_v<Kokkos::View<double[3]> &, Kokkos::View<double[4]>>);
 
 // Differing layouts:
 // Single rank is OK
-static_assert(std::is_constructible_v<Kokkos::View<double[3], Kokkos::LayoutLeft>, Kokkos::View<double[3], Kokkos::LayoutRight>>);
-static_assert(std::is_constructible_v<Kokkos::View<double[3], Kokkos::LayoutRight>, Kokkos::View<double[3], Kokkos::LayoutLeft>>);
-static_assert(std::is_assignable_v<Kokkos::View<double[3], Kokkos::LayoutLeft> &, Kokkos::View<double[3], Kokkos::LayoutRight>>);
-static_assert(std::is_assignable_v<Kokkos::View<double[3], Kokkos::LayoutRight> &, Kokkos::View<double[3], Kokkos::LayoutLeft>>);
+static_assert(
+    std::is_constructible_v<Kokkos::View<double[3], Kokkos::LayoutLeft>,
+                            Kokkos::View<double[3], Kokkos::LayoutRight>>);
+static_assert(
+    std::is_constructible_v<Kokkos::View<double[3], Kokkos::LayoutRight>,
+                            Kokkos::View<double[3], Kokkos::LayoutLeft>>);
+static_assert(
+    std::is_assignable_v<Kokkos::View<double[3], Kokkos::LayoutLeft> &,
+                         Kokkos::View<double[3], Kokkos::LayoutRight>>);
+static_assert(
+    std::is_assignable_v<Kokkos::View<double[3], Kokkos::LayoutRight> &,
+                         Kokkos::View<double[3], Kokkos::LayoutLeft>>);
 
 // Rank > 1 not ok
-static_assert(!std::is_constructible_v<Kokkos::View<double[3][5], Kokkos::LayoutRight>, Kokkos::View<double[3][5], Kokkos::LayoutLeft>>);
-static_assert(!std::is_constructible_v<Kokkos::View<double[3][5], Kokkos::LayoutLeft>, Kokkos::View<double[3][5], Kokkos::LayoutRight>>);
-static_assert(!std::is_assignable_v<Kokkos::View<double[3][5], Kokkos::LayoutRight> &, Kokkos::View<double[3][5], Kokkos::LayoutLeft>>);
-static_assert(!std::is_assignable_v<Kokkos::View<double[3][5], Kokkos::LayoutLeft> &, Kokkos::View<double[3][5], Kokkos::LayoutRight>>);
+static_assert(
+    !std::is_constructible_v<Kokkos::View<double[3][5], Kokkos::LayoutRight>,
+                             Kokkos::View<double[3][5], Kokkos::LayoutLeft>>);
+static_assert(
+    !std::is_constructible_v<Kokkos::View<double[3][5], Kokkos::LayoutLeft>,
+                             Kokkos::View<double[3][5], Kokkos::LayoutRight>>);
+static_assert(
+    !std::is_assignable_v<Kokkos::View<double[3][5], Kokkos::LayoutRight> &,
+                          Kokkos::View<double[3][5], Kokkos::LayoutLeft>>);
+static_assert(
+    !std::is_assignable_v<Kokkos::View<double[3][5], Kokkos::LayoutLeft> &,
+                          Kokkos::View<double[3][5], Kokkos::LayoutRight>>);
 
 }  // namespace


### PR DESCRIPTION
Note that this PR uses `is_assignable` on the mapping type for constraining the converting constructor and assignment for View., replacing `is_assignable_data_type`.

This is a breaking change; i.e. `std::is_constructible_v<Kokkos::View<double[3][5], Kokkos::LayoutRight>, Kokkos::View<double[3][5], Kokkos::LayoutLeft>>` was true before this change but is false now. However you couldn't _actually_ construct the view because we would static assert in the body of the function.

Finally, I removed `is_assignable_data_type`. It was not used anywhere else and was a strict subset of `is_assignable`.