### PR TITLE
Serial: Use the provided execution space instance in TeamPolicy

### DIFF
--- a/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
@@ -37,6 +37,8 @@ class TeamPolicyInternal<Kokkos::Serial, Properties...>
   int m_league_size;
   int m_chunk_size;
 
+  Kokkos::Serial m_space;
+
  public:
   //! Tag this class as a kokkos execution policy
   using execution_policy = TeamPolicyInternal;
@@ -46,10 +48,7 @@ class TeamPolicyInternal<Kokkos::Serial, Properties...>
   //! Execution space of this execution policy:
   using execution_space = Kokkos::Serial;
 
-  const typename traits::execution_space& space() const {
-    static typename traits::execution_space m_space;
-    return m_space;
-  }
+  const typename traits::execution_space& space() const { return m_space; }
 
   template <class ExecSpace, class... OtherProperties>
   friend class TeamPolicyInternal;
@@ -116,12 +115,13 @@ class TeamPolicyInternal<Kokkos::Serial, Properties...>
     return (level == 0 ? 1024 * 32 : 20 * 1024 * 1024);
   }
   /** \brief  Specify league size, request team size */
-  TeamPolicyInternal(const execution_space&, int league_size_request,
+  TeamPolicyInternal(const execution_space& space, int league_size_request,
                      int team_size_request, int /* vector_length_request */ = 1)
       : m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_league_size(league_size_request),
-        m_chunk_size(32) {
+        m_chunk_size(32),
+        m_space(space) {
     if (team_size_request > 1)
       Kokkos::abort("Kokkos::abort: Requested Team Size is too large!");
   }

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -35,7 +35,7 @@ void check_space_member_for_policies(const ExecSpace& exec) {
   Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>> mdrange_policy(exec, {0, 0},
                                                                    {1, 1});
   ASSERT_EQ(mdrange_policy.space(), exec);
-  Kokkos::TeamPolicy<ExecSpace> team_policy(exec, 1, 1);
+  Kokkos::TeamPolicy<ExecSpace> team_policy(exec, 1, Kokkos::AUTO);
   ASSERT_EQ(team_policy.space(), exec);
 }
 

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -29,6 +29,17 @@ struct SumFunctor {
 };
 
 template <class ExecSpace>
+void check_space_member_for_policies(const ExecSpace& exec) {
+  Kokkos::RangePolicy<ExecSpace> range_policy(exec, 0, 1);
+  ASSERT_EQ(range_policy.space(), exec);
+  Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>> mdrange_policy(exec, {0, 0},
+                                                                   {1, 1});
+  ASSERT_EQ(mdrange_policy.space(), exec);
+  Kokkos::TeamPolicy<ExecSpace> team_policy(exec, 1, 1);
+  ASSERT_EQ(team_policy.space(), exec);
+}
+
+template <class ExecSpace>
 void check_distinctive([[maybe_unused]] ExecSpace exec1,
                        [[maybe_unused]] ExecSpace exec2) {
 #ifdef KOKKOS_ENABLE_SERIAL
@@ -89,6 +100,9 @@ void run_threaded_test(const Lambda1 l1, const Lambda2 l2) {
 
 void test_partitioning(std::vector<TEST_EXECSPACE>& instances) {
   check_distinctive(instances[0], instances[1]);
+  check_space_member_for_policies(instances[0]);
+  check_space_member_for_policies(instances[1]);
+
   int sum1, sum2;
   int N = 3910;
   run_threaded_test(


### PR DESCRIPTION
https://kokkosteam.slack.com/archives/C5BGU5NDQ/p1713386069368429 noticed serialization of `TeamPolicy` kernels from different `Serial` execution space instances. The culprit was that `TeamPolicy` returned the default executions pace instance instead of the one provided in the constructor.