### PR TITLE
Replace deprecated sycl::device_ptr/sycl::host_ptr

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -166,7 +166,7 @@ int SYCLInternal::acquire_team_scratch_space() {
   return current_team_scratch;
 }
 
-sycl::device_ptr<void> SYCLInternal::resize_team_scratch_space(
+sycl::ext::intel::device_ptr<void> SYCLInternal::resize_team_scratch_space(
     int scratch_pool_id, std::int64_t bytes, bool force_shrink) {
   // Multiple ParallelFor/Reduce Teams can call this function at the same time
   // and invalidate the m_team_scratch_ptr. We use a pool to avoid any race
@@ -251,7 +251,8 @@ void SYCLInternal::finalize() {
   m_queue.reset();
 }
 
-sycl::device_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {
+sycl::ext::intel::device_ptr<void> SYCLInternal::scratch_space(
+    const std::size_t size) {
   if (verify_is_initialized("scratch_space") &&
       m_scratchSpaceCount < scratch_count(size)) {
     auto mem_space = Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue);
@@ -271,7 +272,8 @@ sycl::device_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {
   return m_scratchSpace;
 }
 
-sycl::host_ptr<void> SYCLInternal::scratch_host(const std::size_t size) {
+sycl::ext::intel::host_ptr<void> SYCLInternal::scratch_host(
+    const std::size_t size) {
   if (verify_is_initialized("scratch_unified") &&
       m_scratchHostCount < scratch_count(size)) {
     auto mem_space = Kokkos::Experimental::SYCLHostUSMSpace(*m_queue);
@@ -291,7 +293,8 @@ sycl::host_ptr<void> SYCLInternal::scratch_host(const std::size_t size) {
   return m_scratchHost;
 }
 
-sycl::device_ptr<void> SYCLInternal::scratch_flags(const std::size_t size) {
+sycl::ext::intel::device_ptr<void> SYCLInternal::scratch_flags(
+    const std::size_t size) {
   if (verify_is_initialized("scratch_flags") &&
       m_scratchFlagsCount < scratch_count(size)) {
     auto mem_space = Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue);

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -166,8 +166,9 @@ int SYCLInternal::acquire_team_scratch_space() {
   return current_team_scratch;
 }
 
-sycl::ext::intel::device_ptr<void> SYCLInternal::resize_team_scratch_space(
-    int scratch_pool_id, std::int64_t bytes, bool force_shrink) {
+Kokkos::Impl::SYCLTypes::device_ptr<void>
+SYCLInternal::resize_team_scratch_space(int scratch_pool_id, std::int64_t bytes,
+                                        bool force_shrink) {
   // Multiple ParallelFor/Reduce Teams can call this function at the same time
   // and invalidate the m_team_scratch_ptr. We use a pool to avoid any race
   // condition.
@@ -251,7 +252,7 @@ void SYCLInternal::finalize() {
   m_queue.reset();
 }
 
-sycl::ext::intel::device_ptr<void> SYCLInternal::scratch_space(
+Kokkos::Impl::SYCLTypes::device_ptr<void> SYCLInternal::scratch_space(
     const std::size_t size) {
   if (verify_is_initialized("scratch_space") &&
       m_scratchSpaceCount < scratch_count(size)) {
@@ -272,7 +273,7 @@ sycl::ext::intel::device_ptr<void> SYCLInternal::scratch_space(
   return m_scratchSpace;
 }
 
-sycl::ext::intel::host_ptr<void> SYCLInternal::scratch_host(
+Kokkos::Impl::SYCLTypes::host_ptr<void> SYCLInternal::scratch_host(
     const std::size_t size) {
   if (verify_is_initialized("scratch_unified") &&
       m_scratchHostCount < scratch_count(size)) {
@@ -293,7 +294,7 @@ sycl::ext::intel::host_ptr<void> SYCLInternal::scratch_host(
   return m_scratchHost;
 }
 
-sycl::ext::intel::device_ptr<void> SYCLInternal::scratch_flags(
+Kokkos::Impl::SYCLTypes::device_ptr<void> SYCLInternal::scratch_flags(
     const std::size_t size) {
   if (verify_is_initialized("scratch_flags") &&
       m_scratchFlagsCount < scratch_count(size)) {

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -166,9 +166,8 @@ int SYCLInternal::acquire_team_scratch_space() {
   return current_team_scratch;
 }
 
-Kokkos::Impl::SYCLTypes::device_ptr<void>
-SYCLInternal::resize_team_scratch_space(int scratch_pool_id, std::int64_t bytes,
-                                        bool force_shrink) {
+Kokkos::Impl::sycl_device_ptr<void> SYCLInternal::resize_team_scratch_space(
+    int scratch_pool_id, std::int64_t bytes, bool force_shrink) {
   // Multiple ParallelFor/Reduce Teams can call this function at the same time
   // and invalidate the m_team_scratch_ptr. We use a pool to avoid any race
   // condition.
@@ -252,7 +251,7 @@ void SYCLInternal::finalize() {
   m_queue.reset();
 }
 
-Kokkos::Impl::SYCLTypes::device_ptr<void> SYCLInternal::scratch_space(
+Kokkos::Impl::sycl_device_ptr<void> SYCLInternal::scratch_space(
     const std::size_t size) {
   if (verify_is_initialized("scratch_space") &&
       m_scratchSpaceCount < scratch_count(size)) {
@@ -273,7 +272,7 @@ Kokkos::Impl::SYCLTypes::device_ptr<void> SYCLInternal::scratch_space(
   return m_scratchSpace;
 }
 
-Kokkos::Impl::SYCLTypes::host_ptr<void> SYCLInternal::scratch_host(
+Kokkos::Impl::sycl_host_ptr<void> SYCLInternal::scratch_host(
     const std::size_t size) {
   if (verify_is_initialized("scratch_unified") &&
       m_scratchHostCount < scratch_count(size)) {
@@ -294,7 +293,7 @@ Kokkos::Impl::SYCLTypes::host_ptr<void> SYCLInternal::scratch_host(
   return m_scratchHost;
 }
 
-Kokkos::Impl::SYCLTypes::device_ptr<void> SYCLInternal::scratch_flags(
+Kokkos::Impl::sycl_device_ptr<void> SYCLInternal::scratch_flags(
     const std::size_t size) {
   if (verify_is_initialized("scratch_flags") &&
       m_scratchFlagsCount < scratch_count(size)) {

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -43,13 +43,11 @@ class SYCLInternal {
   SYCLInternal& operator=(SYCLInternal&&) = delete;
   SYCLInternal(SYCLInternal&&)            = delete;
 
-  Kokkos::Impl::SYCLTypes::device_ptr<void> scratch_space(
-      const std::size_t size);
-  Kokkos::Impl::SYCLTypes::device_ptr<void> scratch_flags(
-      const std::size_t size);
-  Kokkos::Impl::SYCLTypes::host_ptr<void> scratch_host(const std::size_t size);
+  Kokkos::Impl::sycl_device_ptr<void> scratch_space(const std::size_t size);
+  Kokkos::Impl::sycl_device_ptr<void> scratch_flags(const std::size_t size);
+  Kokkos::Impl::sycl_host_ptr<void> scratch_host(const std::size_t size);
   int acquire_team_scratch_space();
-  Kokkos::Impl::SYCLTypes::device_ptr<void> resize_team_scratch_space(
+  Kokkos::Impl::sycl_device_ptr<void> resize_team_scratch_space(
       int scratch_pool_id, std::int64_t bytes, bool force_shrink = false);
   void register_team_scratch_event(int scratch_pool_id, sycl::event event);
 
@@ -60,19 +58,19 @@ class SYCLInternal {
   uint32_t m_maxConcurrency   = 0;
   uint64_t m_maxShmemPerBlock = 0;
 
-  std::size_t m_scratchSpaceCount                               = 0;
-  Kokkos::Impl::SYCLTypes::device_ptr<size_type> m_scratchSpace = nullptr;
-  std::size_t m_scratchHostCount                                = 0;
-  Kokkos::Impl::SYCLTypes::host_ptr<size_type> m_scratchHost    = nullptr;
-  std::size_t m_scratchFlagsCount                               = 0;
-  Kokkos::Impl::SYCLTypes::device_ptr<size_type> m_scratchFlags = nullptr;
+  std::size_t m_scratchSpaceCount                         = 0;
+  Kokkos::Impl::sycl_device_ptr<size_type> m_scratchSpace = nullptr;
+  std::size_t m_scratchHostCount                          = 0;
+  Kokkos::Impl::sycl_host_ptr<size_type> m_scratchHost    = nullptr;
+  std::size_t m_scratchFlagsCount                         = 0;
+  Kokkos::Impl::sycl_device_ptr<size_type> m_scratchFlags = nullptr;
   // mutex to access shared memory
   mutable std::mutex m_mutexScratchSpace;
 
   // Team Scratch Level 1 Space
   static constexpr int m_n_team_scratch                         = 10;
   mutable int64_t m_team_scratch_current_size[m_n_team_scratch] = {};
-  mutable Kokkos::Impl::SYCLTypes::device_ptr<void>
+  mutable Kokkos::Impl::sycl_device_ptr<void>
       m_team_scratch_ptr[m_n_team_scratch]                   = {};
   mutable int m_current_team_scratch                         = 0;
   mutable sycl::event m_team_scratch_event[m_n_team_scratch] = {};

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -43,13 +43,12 @@ class SYCLInternal {
   SYCLInternal& operator=(SYCLInternal&&) = delete;
   SYCLInternal(SYCLInternal&&)            = delete;
 
-  sycl::device_ptr<void> scratch_space(const std::size_t size);
-  sycl::device_ptr<void> scratch_flags(const std::size_t size);
-  sycl::host_ptr<void> scratch_host(const std::size_t size);
+  sycl::ext::intel::device_ptr<void> scratch_space(const std::size_t size);
+  sycl::ext::intel::device_ptr<void> scratch_flags(const std::size_t size);
+  sycl::ext::intel::host_ptr<void> scratch_host(const std::size_t size);
   int acquire_team_scratch_space();
-  sycl::device_ptr<void> resize_team_scratch_space(int scratch_pool_id,
-                                                   std::int64_t bytes,
-                                                   bool force_shrink = false);
+  sycl::ext::intel::device_ptr<void> resize_team_scratch_space(
+      int scratch_pool_id, std::int64_t bytes, bool force_shrink = false);
   void register_team_scratch_event(int scratch_pool_id, sycl::event event);
 
   uint32_t impl_get_instance_id() const;
@@ -59,21 +58,22 @@ class SYCLInternal {
   uint32_t m_maxConcurrency   = 0;
   uint64_t m_maxShmemPerBlock = 0;
 
-  std::size_t m_scratchSpaceCount            = 0;
-  sycl::device_ptr<size_type> m_scratchSpace = nullptr;
-  std::size_t m_scratchHostCount             = 0;
-  sycl::host_ptr<size_type> m_scratchHost    = nullptr;
-  std::size_t m_scratchFlagsCount            = 0;
-  sycl::device_ptr<size_type> m_scratchFlags = nullptr;
+  std::size_t m_scratchSpaceCount                        = 0;
+  sycl::ext::intel::device_ptr<size_type> m_scratchSpace = nullptr;
+  std::size_t m_scratchHostCount                         = 0;
+  sycl::ext::intel::host_ptr<size_type> m_scratchHost    = nullptr;
+  std::size_t m_scratchFlagsCount                        = 0;
+  sycl::ext::intel::device_ptr<size_type> m_scratchFlags = nullptr;
   // mutex to access shared memory
   mutable std::mutex m_mutexScratchSpace;
 
   // Team Scratch Level 1 Space
-  static constexpr int m_n_team_scratch                               = 10;
-  mutable int64_t m_team_scratch_current_size[m_n_team_scratch]       = {};
-  mutable sycl::device_ptr<void> m_team_scratch_ptr[m_n_team_scratch] = {};
-  mutable int m_current_team_scratch                                  = 0;
-  mutable sycl::event m_team_scratch_event[m_n_team_scratch]          = {};
+  static constexpr int m_n_team_scratch                         = 10;
+  mutable int64_t m_team_scratch_current_size[m_n_team_scratch] = {};
+  mutable sycl::ext::intel::device_ptr<void>
+      m_team_scratch_ptr[m_n_team_scratch]                   = {};
+  mutable int m_current_team_scratch                         = 0;
+  mutable sycl::event m_team_scratch_event[m_n_team_scratch] = {};
   mutable std::mutex m_team_scratch_mutex;
 
   uint32_t m_instance_id = Kokkos::Tools::Experimental::Impl::idForInstance<

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -43,11 +43,13 @@ class SYCLInternal {
   SYCLInternal& operator=(SYCLInternal&&) = delete;
   SYCLInternal(SYCLInternal&&)            = delete;
 
-  sycl::ext::intel::device_ptr<void> scratch_space(const std::size_t size);
-  sycl::ext::intel::device_ptr<void> scratch_flags(const std::size_t size);
-  sycl::ext::intel::host_ptr<void> scratch_host(const std::size_t size);
+  Kokkos::Impl::SYCLTypes::device_ptr<void> scratch_space(
+      const std::size_t size);
+  Kokkos::Impl::SYCLTypes::device_ptr<void> scratch_flags(
+      const std::size_t size);
+  Kokkos::Impl::SYCLTypes::host_ptr<void> scratch_host(const std::size_t size);
   int acquire_team_scratch_space();
-  sycl::ext::intel::device_ptr<void> resize_team_scratch_space(
+  Kokkos::Impl::SYCLTypes::device_ptr<void> resize_team_scratch_space(
       int scratch_pool_id, std::int64_t bytes, bool force_shrink = false);
   void register_team_scratch_event(int scratch_pool_id, sycl::event event);
 
@@ -58,19 +60,19 @@ class SYCLInternal {
   uint32_t m_maxConcurrency   = 0;
   uint64_t m_maxShmemPerBlock = 0;
 
-  std::size_t m_scratchSpaceCount                        = 0;
-  sycl::ext::intel::device_ptr<size_type> m_scratchSpace = nullptr;
-  std::size_t m_scratchHostCount                         = 0;
-  sycl::ext::intel::host_ptr<size_type> m_scratchHost    = nullptr;
-  std::size_t m_scratchFlagsCount                        = 0;
-  sycl::ext::intel::device_ptr<size_type> m_scratchFlags = nullptr;
+  std::size_t m_scratchSpaceCount                               = 0;
+  Kokkos::Impl::SYCLTypes::device_ptr<size_type> m_scratchSpace = nullptr;
+  std::size_t m_scratchHostCount                                = 0;
+  Kokkos::Impl::SYCLTypes::host_ptr<size_type> m_scratchHost    = nullptr;
+  std::size_t m_scratchFlagsCount                               = 0;
+  Kokkos::Impl::SYCLTypes::device_ptr<size_type> m_scratchFlags = nullptr;
   // mutex to access shared memory
   mutable std::mutex m_mutexScratchSpace;
 
   // Team Scratch Level 1 Space
   static constexpr int m_n_team_scratch                         = 10;
   mutable int64_t m_team_scratch_current_size[m_n_team_scratch] = {};
-  mutable sycl::ext::intel::device_ptr<void>
+  mutable Kokkos::Impl::SYCLTypes::device_ptr<void>
       m_team_scratch_ptr[m_n_team_scratch]                   = {};
   mutable int m_current_team_scratch                         = 0;
   mutable sycl::event m_team_scratch_event[m_n_team_scratch] = {};

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
@@ -44,7 +44,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   size_type const m_vector_size;
   int m_shmem_begin;
   int m_shmem_size;
-  Kokkos::Impl::SYCLTypes::device_ptr<char> m_global_scratch_ptr;
+  sycl_device_ptr<char> m_global_scratch_ptr;
   size_t m_scratch_size[2];
   // Only let one ParallelFor instance at a time use the team scratch memory.
   // The constructor acquires the mutex which is released in the destructor.
@@ -72,8 +72,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
       // Avoid capturing *this since it might not be trivially copyable
       const auto shmem_begin       = m_shmem_begin;
       const size_t scratch_size[2] = {m_scratch_size[0], m_scratch_size[1]};
-      Kokkos::Impl::SYCLTypes::device_ptr<char> const global_scratch_ptr =
-          m_global_scratch_ptr;
+      sycl_device_ptr<char> const global_scratch_ptr = m_global_scratch_ptr;
 
       auto lambda = [=](sycl::nd_item<2> item) {
         const member_type team_member(
@@ -165,10 +164,9 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     auto& space       = *m_policy.space().impl_internal_space_instance();
     m_scratch_pool_id = space.acquire_team_scratch_space();
     m_global_scratch_ptr =
-        static_cast<Kokkos::Impl::SYCLTypes::device_ptr<char>>(
-            space.resize_team_scratch_space(
-                m_scratch_pool_id,
-                static_cast<ptrdiff_t>(m_scratch_size[1]) * m_league_size));
+        static_cast<sycl_device_ptr<char>>(space.resize_team_scratch_space(
+            m_scratch_pool_id,
+            static_cast<ptrdiff_t>(m_scratch_size[1]) * m_league_size));
 
     if (static_cast<int>(space.m_maxShmemPerBlock) <
         m_shmem_size - m_shmem_begin) {

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
@@ -44,7 +44,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   size_type const m_vector_size;
   int m_shmem_begin;
   int m_shmem_size;
-  sycl::device_ptr<char> m_global_scratch_ptr;
+  sycl::ext::intel::device_ptr<char> m_global_scratch_ptr;
   size_t m_scratch_size[2];
   // Only let one ParallelFor instance at a time use the team scratch memory.
   // The constructor acquires the mutex which is released in the destructor.
@@ -72,7 +72,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
       // Avoid capturing *this since it might not be trivially copyable
       const auto shmem_begin       = m_shmem_begin;
       const size_t scratch_size[2] = {m_scratch_size[0], m_scratch_size[1]};
-      sycl::device_ptr<char> const global_scratch_ptr = m_global_scratch_ptr;
+      sycl::ext::intel::device_ptr<char> const global_scratch_ptr =
+          m_global_scratch_ptr;
 
       auto lambda = [=](sycl::nd_item<2> item) {
         const member_type team_member(
@@ -161,10 +162,10 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
     // Functor's reduce memory, team scan memory, and team shared memory depend
     // upon team size.
-    auto& space       = *m_policy.space().impl_internal_space_instance();
-    m_scratch_pool_id = space.acquire_team_scratch_space();
-    m_global_scratch_ptr =
-        static_cast<sycl::device_ptr<char>>(space.resize_team_scratch_space(
+    auto& space          = *m_policy.space().impl_internal_space_instance();
+    m_scratch_pool_id    = space.acquire_team_scratch_space();
+    m_global_scratch_ptr = static_cast<sycl::ext::intel::device_ptr<char>>(
+        space.resize_team_scratch_space(
             m_scratch_pool_id,
             static_cast<ptrdiff_t>(m_scratch_size[1]) * m_league_size));
 

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
@@ -94,10 +94,10 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     const typename Policy::index_type n_tiles = m_policy.m_num_tiles;
     const unsigned int value_count =
         m_functor_reducer.get_reducer().value_count();
-    Kokkos::Impl::SYCLTypes::device_ptr<value_type> results_ptr;
+    sycl_device_ptr<value_type> results_ptr;
     auto host_result_ptr =
         (m_result_ptr && !m_result_ptr_device_accessible)
-            ? static_cast<Kokkos::Impl::SYCLTypes::host_ptr<value_type>>(
+            ? static_cast<sycl_host_ptr<value_type>>(
                   instance.scratch_host(sizeof(value_type) * value_count))
             : nullptr;
 
@@ -114,9 +114,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
 #else
         (void)memcpy_event;
 #endif
-        results_ptr =
-            static_cast<Kokkos::Impl::SYCLTypes::device_ptr<value_type>>(
-                instance.scratch_space(sizeof(value_type) * value_count));
+        results_ptr = static_cast<sycl_device_ptr<value_type>>(
+            instance.scratch_space(sizeof(value_type) * value_count));
         auto device_accessible_result_ptr =
             m_result_ptr_device_accessible
                 ? static_cast<sycl::global_ptr<value_type>>(m_result_ptr)
@@ -156,17 +155,14 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         n_wgroups = (n_tiles + values_per_thread - 1) / values_per_thread;
       }
 
-      results_ptr =
-          static_cast<Kokkos::Impl::SYCLTypes::device_ptr<value_type>>(
-              instance.scratch_space(sizeof(value_type) * value_count *
-                                     n_wgroups));
+      results_ptr = static_cast<sycl_device_ptr<value_type>>(
+          instance.scratch_space(sizeof(value_type) * value_count * n_wgroups));
       auto device_accessible_result_ptr =
           m_result_ptr_device_accessible
               ? static_cast<sycl::global_ptr<value_type>>(m_result_ptr)
               : static_cast<sycl::global_ptr<value_type>>(host_result_ptr);
-      auto scratch_flags =
-          static_cast<Kokkos::Impl::SYCLTypes::device_ptr<unsigned int>>(
-              instance.scratch_flags(sizeof(unsigned int)));
+      auto scratch_flags = static_cast<sycl_device_ptr<unsigned int>>(
+          instance.scratch_flags(sizeof(unsigned int)));
 
       auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {
         sycl::local_accessor<value_type> local_mem(

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
@@ -94,10 +94,10 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     const typename Policy::index_type n_tiles = m_policy.m_num_tiles;
     const unsigned int value_count =
         m_functor_reducer.get_reducer().value_count();
-    sycl::device_ptr<value_type> results_ptr;
+    sycl::ext::intel::device_ptr<value_type> results_ptr;
     auto host_result_ptr =
         (m_result_ptr && !m_result_ptr_device_accessible)
-            ? static_cast<sycl::host_ptr<value_type>>(
+            ? static_cast<sycl::ext::intel::host_ptr<value_type>>(
                   instance.scratch_host(sizeof(value_type) * value_count))
             : nullptr;
 
@@ -114,7 +114,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
 #else
         (void)memcpy_event;
 #endif
-        results_ptr = static_cast<sycl::device_ptr<value_type>>(
+        results_ptr = static_cast<sycl::ext::intel::device_ptr<value_type>>(
             instance.scratch_space(sizeof(value_type) * value_count));
         auto device_accessible_result_ptr =
             m_result_ptr_device_accessible
@@ -155,14 +155,15 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         n_wgroups = (n_tiles + values_per_thread - 1) / values_per_thread;
       }
 
-      results_ptr = static_cast<sycl::device_ptr<value_type>>(
+      results_ptr = static_cast<sycl::ext::intel::device_ptr<value_type>>(
           instance.scratch_space(sizeof(value_type) * value_count * n_wgroups));
       auto device_accessible_result_ptr =
           m_result_ptr_device_accessible
               ? static_cast<sycl::global_ptr<value_type>>(m_result_ptr)
               : static_cast<sycl::global_ptr<value_type>>(host_result_ptr);
-      auto scratch_flags = static_cast<sycl::device_ptr<unsigned int>>(
-          instance.scratch_flags(sizeof(unsigned int)));
+      auto scratch_flags =
+          static_cast<sycl::ext::intel::device_ptr<unsigned int>>(
+              instance.scratch_flags(sizeof(unsigned int)));
 
       auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {
         sycl::local_accessor<value_type> local_mem(

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
@@ -94,10 +94,10 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     const typename Policy::index_type n_tiles = m_policy.m_num_tiles;
     const unsigned int value_count =
         m_functor_reducer.get_reducer().value_count();
-    sycl::ext::intel::device_ptr<value_type> results_ptr;
+    Kokkos::Impl::SYCLTypes::device_ptr<value_type> results_ptr;
     auto host_result_ptr =
         (m_result_ptr && !m_result_ptr_device_accessible)
-            ? static_cast<sycl::ext::intel::host_ptr<value_type>>(
+            ? static_cast<Kokkos::Impl::SYCLTypes::host_ptr<value_type>>(
                   instance.scratch_host(sizeof(value_type) * value_count))
             : nullptr;
 
@@ -114,8 +114,9 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
 #else
         (void)memcpy_event;
 #endif
-        results_ptr = static_cast<sycl::ext::intel::device_ptr<value_type>>(
-            instance.scratch_space(sizeof(value_type) * value_count));
+        results_ptr =
+            static_cast<Kokkos::Impl::SYCLTypes::device_ptr<value_type>>(
+                instance.scratch_space(sizeof(value_type) * value_count));
         auto device_accessible_result_ptr =
             m_result_ptr_device_accessible
                 ? static_cast<sycl::global_ptr<value_type>>(m_result_ptr)
@@ -155,14 +156,16 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         n_wgroups = (n_tiles + values_per_thread - 1) / values_per_thread;
       }
 
-      results_ptr = static_cast<sycl::ext::intel::device_ptr<value_type>>(
-          instance.scratch_space(sizeof(value_type) * value_count * n_wgroups));
+      results_ptr =
+          static_cast<Kokkos::Impl::SYCLTypes::device_ptr<value_type>>(
+              instance.scratch_space(sizeof(value_type) * value_count *
+                                     n_wgroups));
       auto device_accessible_result_ptr =
           m_result_ptr_device_accessible
               ? static_cast<sycl::global_ptr<value_type>>(m_result_ptr)
               : static_cast<sycl::global_ptr<value_type>>(host_result_ptr);
       auto scratch_flags =
-          static_cast<sycl::ext::intel::device_ptr<unsigned int>>(
+          static_cast<Kokkos::Impl::SYCLTypes::device_ptr<unsigned int>>(
               instance.scratch_flags(sizeof(unsigned int)));
 
       auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
@@ -69,10 +69,10 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     std::size_t size = policy.end() - policy.begin();
     const unsigned int value_count =
         m_functor_reducer.get_reducer().value_count();
-    Kokkos::Impl::SYCLTypes::device_ptr<value_type> results_ptr = nullptr;
+    sycl_device_ptr<value_type> results_ptr = nullptr;
     auto host_result_ptr =
         (m_result_ptr && !m_result_ptr_device_accessible)
-            ? static_cast<Kokkos::Impl::SYCLTypes::host_ptr<value_type>>(
+            ? static_cast<sycl_host_ptr<value_type>>(
                   instance.scratch_host(sizeof(value_type) * value_count))
             : nullptr;
     auto device_accessible_result_ptr =
@@ -88,9 +88,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     // working with the global scratch memory but don't copy back to
     // m_result_ptr yet.
     if (size <= 1) {
-      results_ptr =
-          static_cast<Kokkos::Impl::SYCLTypes::device_ptr<value_type>>(
-              instance.scratch_space(sizeof(value_type) * value_count));
+      results_ptr = static_cast<sycl_device_ptr<value_type>>(
+          instance.scratch_space(sizeof(value_type) * value_count));
 
       auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {
         const auto begin = policy.begin();
@@ -126,15 +125,13 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
       // workgroups separately, write the workgroup results back to global
       // memory and recurse until only one workgroup does the reduction and thus
       // gets the final value.
-      auto scratch_flags =
-          static_cast<Kokkos::Impl::SYCLTypes::device_ptr<unsigned int>>(
-              instance.scratch_flags(sizeof(unsigned int)));
+      auto scratch_flags = static_cast<sycl_device_ptr<unsigned int>>(
+          instance.scratch_flags(sizeof(unsigned int)));
 
       auto reduction_lambda_factory =
           [&](sycl::local_accessor<value_type> local_mem,
               sycl::local_accessor<unsigned int> num_teams_done,
-              Kokkos::Impl::SYCLTypes::device_ptr<value_type> results_ptr,
-              int values_per_thread) {
+              sycl_device_ptr<value_type> results_ptr, int values_per_thread) {
             const auto begin = policy.begin();
 
             auto lambda = [=](sycl::nd_item<1> item) {
@@ -305,9 +302,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         }
 
         results_ptr =
-            static_cast<Kokkos::Impl::SYCLTypes::device_ptr<value_type>>(
-                instance.scratch_space(sizeof(value_type) * value_count *
-                                       n_wgroups));
+            static_cast<sycl_device_ptr<value_type>>(instance.scratch_space(
+                sizeof(value_type) * value_count * n_wgroups));
 
         sycl::local_accessor<value_type> local_mem(
             sycl::range<1>(wgroup_size) * value_count, cgh);

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
@@ -69,10 +69,10 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     std::size_t size = policy.end() - policy.begin();
     const unsigned int value_count =
         m_functor_reducer.get_reducer().value_count();
-    sycl::ext::intel::device_ptr<value_type> results_ptr = nullptr;
+    Kokkos::Impl::SYCLTypes::device_ptr<value_type> results_ptr = nullptr;
     auto host_result_ptr =
         (m_result_ptr && !m_result_ptr_device_accessible)
-            ? static_cast<sycl::ext::intel::host_ptr<value_type>>(
+            ? static_cast<Kokkos::Impl::SYCLTypes::host_ptr<value_type>>(
                   instance.scratch_host(sizeof(value_type) * value_count))
             : nullptr;
     auto device_accessible_result_ptr =
@@ -88,8 +88,9 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     // working with the global scratch memory but don't copy back to
     // m_result_ptr yet.
     if (size <= 1) {
-      results_ptr = static_cast<sycl::ext::intel::device_ptr<value_type>>(
-          instance.scratch_space(sizeof(value_type) * value_count));
+      results_ptr =
+          static_cast<Kokkos::Impl::SYCLTypes::device_ptr<value_type>>(
+              instance.scratch_space(sizeof(value_type) * value_count));
 
       auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {
         const auto begin = policy.begin();
@@ -126,13 +127,13 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
       // memory and recurse until only one workgroup does the reduction and thus
       // gets the final value.
       auto scratch_flags =
-          static_cast<sycl::ext::intel::device_ptr<unsigned int>>(
+          static_cast<Kokkos::Impl::SYCLTypes::device_ptr<unsigned int>>(
               instance.scratch_flags(sizeof(unsigned int)));
 
       auto reduction_lambda_factory =
           [&](sycl::local_accessor<value_type> local_mem,
               sycl::local_accessor<unsigned int> num_teams_done,
-              sycl::ext::intel::device_ptr<value_type> results_ptr,
+              Kokkos::Impl::SYCLTypes::device_ptr<value_type> results_ptr,
               int values_per_thread) {
             const auto begin = policy.begin();
 
@@ -303,9 +304,10 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                       wgroup_size;
         }
 
-        results_ptr = static_cast<sycl::ext::intel::device_ptr<value_type>>(
-            instance.scratch_space(sizeof(value_type) * value_count *
-                                   n_wgroups));
+        results_ptr =
+            static_cast<Kokkos::Impl::SYCLTypes::device_ptr<value_type>>(
+                instance.scratch_space(sizeof(value_type) * value_count *
+                                       n_wgroups));
 
         sycl::local_accessor<value_type> local_mem(
             sycl::range<1>(wgroup_size) * value_count, cgh);

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
@@ -69,10 +69,10 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     std::size_t size = policy.end() - policy.begin();
     const unsigned int value_count =
         m_functor_reducer.get_reducer().value_count();
-    sycl::device_ptr<value_type> results_ptr = nullptr;
+    sycl::ext::intel::device_ptr<value_type> results_ptr = nullptr;
     auto host_result_ptr =
         (m_result_ptr && !m_result_ptr_device_accessible)
-            ? static_cast<sycl::host_ptr<value_type>>(
+            ? static_cast<sycl::ext::intel::host_ptr<value_type>>(
                   instance.scratch_host(sizeof(value_type) * value_count))
             : nullptr;
     auto device_accessible_result_ptr =
@@ -88,7 +88,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     // working with the global scratch memory but don't copy back to
     // m_result_ptr yet.
     if (size <= 1) {
-      results_ptr = static_cast<sycl::device_ptr<value_type>>(
+      results_ptr = static_cast<sycl::ext::intel::device_ptr<value_type>>(
           instance.scratch_space(sizeof(value_type) * value_count));
 
       auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {
@@ -125,13 +125,15 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
       // workgroups separately, write the workgroup results back to global
       // memory and recurse until only one workgroup does the reduction and thus
       // gets the final value.
-      auto scratch_flags = static_cast<sycl::device_ptr<unsigned int>>(
-          instance.scratch_flags(sizeof(unsigned int)));
+      auto scratch_flags =
+          static_cast<sycl::ext::intel::device_ptr<unsigned int>>(
+              instance.scratch_flags(sizeof(unsigned int)));
 
       auto reduction_lambda_factory =
           [&](sycl::local_accessor<value_type> local_mem,
               sycl::local_accessor<unsigned int> num_teams_done,
-              sycl::device_ptr<value_type> results_ptr, int values_per_thread) {
+              sycl::ext::intel::device_ptr<value_type> results_ptr,
+              int values_per_thread) {
             const auto begin = policy.begin();
 
             auto lambda = [=](sycl::nd_item<1> item) {
@@ -301,9 +303,9 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                       wgroup_size;
         }
 
-        results_ptr =
-            static_cast<sycl::device_ptr<value_type>>(instance.scratch_space(
-                sizeof(value_type) * value_count * n_wgroups));
+        results_ptr = static_cast<sycl::ext::intel::device_ptr<value_type>>(
+            instance.scratch_space(sizeof(value_type) * value_count *
+                                   n_wgroups));
 
         sycl::local_accessor<value_type> local_mem(
             sycl::range<1>(wgroup_size) * value_count, cgh);

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -54,7 +54,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
   const bool m_result_ptr_device_accessible;
   size_type m_shmem_begin;
   size_type m_shmem_size;
-  Kokkos::Impl::SYCLTypes::device_ptr<char> m_global_scratch_ptr;
+  sycl_device_ptr<char> m_global_scratch_ptr;
   size_t m_scratch_size[2];
   const size_type m_league_size;
   int m_team_size;
@@ -82,7 +82,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     value_type* results_ptr = nullptr;
     auto host_result_ptr =
         (m_result_ptr && !m_result_ptr_device_accessible)
-            ? static_cast<Kokkos::Impl::SYCLTypes::host_ptr<value_type>>(
+            ? static_cast<sycl_host_ptr<value_type>>(
                   instance.scratch_host(sizeof(value_type) * value_count))
             : nullptr;
 
@@ -95,9 +95,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     // m_result_ptr yet.
     if (size <= 1) {
       results_ptr =
-          static_cast<Kokkos::Impl::SYCLTypes::device_ptr<value_type>>(
-              instance.scratch_space(sizeof(value_type) *
-                                     std::max(value_count, 1u)));
+          static_cast<sycl_device_ptr<value_type>>(instance.scratch_space(
+              sizeof(value_type) * std::max(value_count, 1u)));
       auto device_accessible_result_ptr =
           m_result_ptr_device_accessible
               ? static_cast<sycl::global_ptr<value_type>>(m_result_ptr)
@@ -114,8 +113,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         // Avoid capturing *this since it might not be trivially copyable
         const auto shmem_begin       = m_shmem_begin;
         const size_t scratch_size[2] = {m_scratch_size[0], m_scratch_size[1]};
-        Kokkos::Impl::SYCLTypes::device_ptr<char> const global_scratch_ptr =
-            m_global_scratch_ptr;
+        sycl_device_ptr<char> const global_scratch_ptr = m_global_scratch_ptr;
 
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
         cgh.depends_on(memcpy_event);
@@ -158,9 +156,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
       // workgroup results back to global memory and recurse until only one
       // workgroup does the reduction and thus gets the final value.
       auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {
-        auto scratch_flags =
-            static_cast<Kokkos::Impl::SYCLTypes::device_ptr<unsigned int>>(
-                instance.scratch_flags(sizeof(unsigned int)));
+        auto scratch_flags = static_cast<sycl_device_ptr<unsigned int>>(
+            instance.scratch_flags(sizeof(unsigned int)));
 
         // FIXME_SYCL accessors seem to need a size greater than zero at least
         // for host queues
@@ -173,13 +170,12 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         const auto shmem_begin       = m_shmem_begin;
         const auto league_size       = m_league_size;
         const size_t scratch_size[2] = {m_scratch_size[0], m_scratch_size[1]};
-        Kokkos::Impl::SYCLTypes::device_ptr<char> const global_scratch_ptr =
-            m_global_scratch_ptr;
+        sycl_device_ptr<char> const global_scratch_ptr = m_global_scratch_ptr;
         sycl::local_accessor<unsigned int> num_teams_done(1, cgh);
 
         auto team_reduction_factory =
             [&](sycl::local_accessor<value_type, 1> local_mem,
-                Kokkos::Impl::SYCLTypes::device_ptr<value_type> results_ptr) {
+                sycl_device_ptr<value_type> results_ptr) {
               auto device_accessible_result_ptr =
                   m_result_ptr_device_accessible
                       ? static_cast<sycl::global_ptr<value_type>>(m_result_ptr)
@@ -335,9 +331,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         const auto init_size =
             std::max<std::size_t>((size + wgroup_size - 1) / wgroup_size, 1);
         results_ptr =
-            static_cast<Kokkos::Impl::SYCLTypes::device_ptr<value_type>>(
-                instance.scratch_space(sizeof(value_type) *
-                                       std::max(value_count, 1u) * init_size));
+            static_cast<sycl_device_ptr<value_type>>(instance.scratch_space(
+                sizeof(value_type) * std::max(value_count, 1u) * init_size));
 
         size_t max_work_groups =
             2 *
@@ -433,10 +428,9 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     auto& space       = *m_policy.space().impl_internal_space_instance();
     m_scratch_pool_id = space.acquire_team_scratch_space();
     m_global_scratch_ptr =
-        static_cast<Kokkos::Impl::SYCLTypes::device_ptr<char>>(
-            space.resize_team_scratch_space(
-                m_scratch_pool_id,
-                static_cast<ptrdiff_t>(m_scratch_size[1]) * m_league_size));
+        static_cast<sycl_device_ptr<char>>(space.resize_team_scratch_space(
+            m_scratch_pool_id,
+            static_cast<ptrdiff_t>(m_scratch_size[1]) * m_league_size));
 
     if (static_cast<int>(space.m_maxShmemPerBlock) <
         m_shmem_size - m_shmem_begin) {

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -54,7 +54,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
   const bool m_result_ptr_device_accessible;
   size_type m_shmem_begin;
   size_type m_shmem_size;
-  sycl::ext::intel::device_ptr<char> m_global_scratch_ptr;
+  Kokkos::Impl::SYCLTypes::device_ptr<char> m_global_scratch_ptr;
   size_t m_scratch_size[2];
   const size_type m_league_size;
   int m_team_size;
@@ -82,7 +82,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     value_type* results_ptr = nullptr;
     auto host_result_ptr =
         (m_result_ptr && !m_result_ptr_device_accessible)
-            ? static_cast<sycl::ext::intel::host_ptr<value_type>>(
+            ? static_cast<Kokkos::Impl::SYCLTypes::host_ptr<value_type>>(
                   instance.scratch_host(sizeof(value_type) * value_count))
             : nullptr;
 
@@ -94,9 +94,10 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     // working with the global scratch memory but don't copy back to
     // m_result_ptr yet.
     if (size <= 1) {
-      results_ptr = static_cast<sycl::ext::intel::device_ptr<value_type>>(
-          instance.scratch_space(sizeof(value_type) *
-                                 std::max(value_count, 1u)));
+      results_ptr =
+          static_cast<Kokkos::Impl::SYCLTypes::device_ptr<value_type>>(
+              instance.scratch_space(sizeof(value_type) *
+                                     std::max(value_count, 1u)));
       auto device_accessible_result_ptr =
           m_result_ptr_device_accessible
               ? static_cast<sycl::global_ptr<value_type>>(m_result_ptr)
@@ -113,7 +114,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         // Avoid capturing *this since it might not be trivially copyable
         const auto shmem_begin       = m_shmem_begin;
         const size_t scratch_size[2] = {m_scratch_size[0], m_scratch_size[1]};
-        sycl::ext::intel::device_ptr<char> const global_scratch_ptr =
+        Kokkos::Impl::SYCLTypes::device_ptr<char> const global_scratch_ptr =
             m_global_scratch_ptr;
 
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
@@ -158,7 +159,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
       // workgroup does the reduction and thus gets the final value.
       auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {
         auto scratch_flags =
-            static_cast<sycl::ext::intel::device_ptr<unsigned int>>(
+            static_cast<Kokkos::Impl::SYCLTypes::device_ptr<unsigned int>>(
                 instance.scratch_flags(sizeof(unsigned int)));
 
         // FIXME_SYCL accessors seem to need a size greater than zero at least
@@ -172,13 +173,13 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         const auto shmem_begin       = m_shmem_begin;
         const auto league_size       = m_league_size;
         const size_t scratch_size[2] = {m_scratch_size[0], m_scratch_size[1]};
-        sycl::ext::intel::device_ptr<char> const global_scratch_ptr =
+        Kokkos::Impl::SYCLTypes::device_ptr<char> const global_scratch_ptr =
             m_global_scratch_ptr;
         sycl::local_accessor<unsigned int> num_teams_done(1, cgh);
 
         auto team_reduction_factory =
             [&](sycl::local_accessor<value_type, 1> local_mem,
-                sycl::ext::intel::device_ptr<value_type> results_ptr) {
+                Kokkos::Impl::SYCLTypes::device_ptr<value_type> results_ptr) {
               auto device_accessible_result_ptr =
                   m_result_ptr_device_accessible
                       ? static_cast<sycl::global_ptr<value_type>>(m_result_ptr)
@@ -333,9 +334,10 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
 
         const auto init_size =
             std::max<std::size_t>((size + wgroup_size - 1) / wgroup_size, 1);
-        results_ptr = static_cast<sycl::ext::intel::device_ptr<value_type>>(
-            instance.scratch_space(sizeof(value_type) *
-                                   std::max(value_count, 1u) * init_size));
+        results_ptr =
+            static_cast<Kokkos::Impl::SYCLTypes::device_ptr<value_type>>(
+                instance.scratch_space(sizeof(value_type) *
+                                       std::max(value_count, 1u) * init_size));
 
         size_t max_work_groups =
             2 *
@@ -428,12 +430,13 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
 
     // Functor's reduce memory, team scan memory, and team shared memory depend
     // upon team size.
-    auto& space          = *m_policy.space().impl_internal_space_instance();
-    m_scratch_pool_id    = space.acquire_team_scratch_space();
-    m_global_scratch_ptr = static_cast<sycl::ext::intel::device_ptr<char>>(
-        space.resize_team_scratch_space(
-            m_scratch_pool_id,
-            static_cast<ptrdiff_t>(m_scratch_size[1]) * m_league_size));
+    auto& space       = *m_policy.space().impl_internal_space_instance();
+    m_scratch_pool_id = space.acquire_team_scratch_space();
+    m_global_scratch_ptr =
+        static_cast<Kokkos::Impl::SYCLTypes::device_ptr<char>>(
+            space.resize_team_scratch_space(
+                m_scratch_pool_id,
+                static_cast<ptrdiff_t>(m_scratch_size[1]) * m_league_size));
 
     if (static_cast<int>(space.m_maxShmemPerBlock) <
         m_shmem_size - m_shmem_begin) {

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -54,7 +54,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
   const bool m_result_ptr_device_accessible;
   size_type m_shmem_begin;
   size_type m_shmem_size;
-  sycl::device_ptr<char> m_global_scratch_ptr;
+  sycl::ext::intel::device_ptr<char> m_global_scratch_ptr;
   size_t m_scratch_size[2];
   const size_type m_league_size;
   int m_team_size;
@@ -82,7 +82,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     value_type* results_ptr = nullptr;
     auto host_result_ptr =
         (m_result_ptr && !m_result_ptr_device_accessible)
-            ? static_cast<sycl::host_ptr<value_type>>(
+            ? static_cast<sycl::ext::intel::host_ptr<value_type>>(
                   instance.scratch_host(sizeof(value_type) * value_count))
             : nullptr;
 
@@ -94,9 +94,9 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     // working with the global scratch memory but don't copy back to
     // m_result_ptr yet.
     if (size <= 1) {
-      results_ptr =
-          static_cast<sycl::device_ptr<value_type>>(instance.scratch_space(
-              sizeof(value_type) * std::max(value_count, 1u)));
+      results_ptr = static_cast<sycl::ext::intel::device_ptr<value_type>>(
+          instance.scratch_space(sizeof(value_type) *
+                                 std::max(value_count, 1u)));
       auto device_accessible_result_ptr =
           m_result_ptr_device_accessible
               ? static_cast<sycl::global_ptr<value_type>>(m_result_ptr)
@@ -113,7 +113,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         // Avoid capturing *this since it might not be trivially copyable
         const auto shmem_begin       = m_shmem_begin;
         const size_t scratch_size[2] = {m_scratch_size[0], m_scratch_size[1]};
-        sycl::device_ptr<char> const global_scratch_ptr = m_global_scratch_ptr;
+        sycl::ext::intel::device_ptr<char> const global_scratch_ptr =
+            m_global_scratch_ptr;
 
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
         cgh.depends_on(memcpy_event);
@@ -156,8 +157,9 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
       // workgroup results back to global memory and recurse until only one
       // workgroup does the reduction and thus gets the final value.
       auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {
-        auto scratch_flags = static_cast<sycl::device_ptr<unsigned int>>(
-            instance.scratch_flags(sizeof(unsigned int)));
+        auto scratch_flags =
+            static_cast<sycl::ext::intel::device_ptr<unsigned int>>(
+                instance.scratch_flags(sizeof(unsigned int)));
 
         // FIXME_SYCL accessors seem to need a size greater than zero at least
         // for host queues
@@ -170,12 +172,13 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         const auto shmem_begin       = m_shmem_begin;
         const auto league_size       = m_league_size;
         const size_t scratch_size[2] = {m_scratch_size[0], m_scratch_size[1]};
-        sycl::device_ptr<char> const global_scratch_ptr = m_global_scratch_ptr;
+        sycl::ext::intel::device_ptr<char> const global_scratch_ptr =
+            m_global_scratch_ptr;
         sycl::local_accessor<unsigned int> num_teams_done(1, cgh);
 
         auto team_reduction_factory =
             [&](sycl::local_accessor<value_type, 1> local_mem,
-                sycl::device_ptr<value_type> results_ptr) {
+                sycl::ext::intel::device_ptr<value_type> results_ptr) {
               auto device_accessible_result_ptr =
                   m_result_ptr_device_accessible
                       ? static_cast<sycl::global_ptr<value_type>>(m_result_ptr)
@@ -330,9 +333,9 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
 
         const auto init_size =
             std::max<std::size_t>((size + wgroup_size - 1) / wgroup_size, 1);
-        results_ptr =
-            static_cast<sycl::device_ptr<value_type>>(instance.scratch_space(
-                sizeof(value_type) * std::max(value_count, 1u) * init_size));
+        results_ptr = static_cast<sycl::ext::intel::device_ptr<value_type>>(
+            instance.scratch_space(sizeof(value_type) *
+                                   std::max(value_count, 1u) * init_size));
 
         size_t max_work_groups =
             2 *
@@ -425,10 +428,10 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
 
     // Functor's reduce memory, team scan memory, and team shared memory depend
     // upon team size.
-    auto& space       = *m_policy.space().impl_internal_space_instance();
-    m_scratch_pool_id = space.acquire_team_scratch_space();
-    m_global_scratch_ptr =
-        static_cast<sycl::device_ptr<char>>(space.resize_team_scratch_space(
+    auto& space          = *m_policy.space().impl_internal_space_instance();
+    m_scratch_pool_id    = space.acquire_team_scratch_space();
+    m_global_scratch_ptr = static_cast<sycl::ext::intel::device_ptr<char>>(
+        space.resize_team_scratch_space(
             m_scratch_pool_id,
             static_cast<ptrdiff_t>(m_scratch_size[1]) * m_league_size));
 

--- a/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
@@ -146,7 +146,7 @@ class ParallelScanSYCLBase {
   const CombinedFunctorReducer<FunctorType, typename Analysis::Reducer>
       m_functor_reducer;
   const Policy m_policy;
-  Kokkos::Impl::SYCLTypes::host_ptr<value_type> m_scratch_host = nullptr;
+  sycl_host_ptr<value_type> m_scratch_host = nullptr;
   pointer_type m_result_ptr;
   const bool m_result_ptr_device_accessible;
 
@@ -166,96 +166,93 @@ class ParallelScanSYCLBase {
 
     const auto size = m_policy.end() - m_policy.begin();
 
-    auto scratch_flags =
-        static_cast<Kokkos::Impl::SYCLTypes::device_ptr<unsigned int>>(
-            instance.scratch_flags(sizeof(unsigned int)));
+    auto scratch_flags = static_cast<sycl_device_ptr<unsigned int>>(
+        instance.scratch_flags(sizeof(unsigned int)));
 
     const auto begin = m_policy.begin();
 
     // Initialize global memory
-    auto scan_lambda_factory =
-        [&](sycl::local_accessor<value_type> local_mem,
-            sycl::local_accessor<unsigned int> num_teams_done,
-            Kokkos::Impl::SYCLTypes::device_ptr<value_type> global_mem_,
-            Kokkos::Impl::SYCLTypes::device_ptr<value_type> group_results_) {
-          auto lambda = [=](sycl::nd_item<1> item) {
-            auto global_mem    = global_mem_;
-            auto group_results = group_results_;
+    auto scan_lambda_factory = [&](sycl::local_accessor<value_type> local_mem,
+                                   sycl::local_accessor<unsigned int>
+                                       num_teams_done,
+                                   sycl_device_ptr<value_type> global_mem_,
+                                   sycl_device_ptr<value_type> group_results_) {
+      auto lambda = [=](sycl::nd_item<1> item) {
+        auto global_mem    = global_mem_;
+        auto group_results = group_results_;
 
-            const CombinedFunctorReducer<
-                FunctorType, typename Analysis::Reducer>& functor_reducer =
-                functor_wrapper.get_functor();
-            const FunctorType& functor = functor_reducer.get_functor();
-            const typename Analysis::Reducer& reducer =
-                functor_reducer.get_reducer();
+        const CombinedFunctorReducer<FunctorType, typename Analysis::Reducer>&
+            functor_reducer        = functor_wrapper.get_functor();
+        const FunctorType& functor = functor_reducer.get_functor();
+        const typename Analysis::Reducer& reducer =
+            functor_reducer.get_reducer();
 
-            const auto n_wgroups  = item.get_group_range()[0];
-            const int wgroup_size = item.get_local_range()[0];
+        const auto n_wgroups  = item.get_group_range()[0];
+        const int wgroup_size = item.get_local_range()[0];
 
-            const int local_id         = item.get_local_linear_id();
-            const index_type global_id = item.get_global_linear_id();
+        const int local_id         = item.get_local_linear_id();
+        const index_type global_id = item.get_global_linear_id();
 
-            // Initialize local memory
-            value_type local_value;
-            reducer.init(&local_value);
-            if (global_id < size) {
-              if constexpr (std::is_void<WorkTag>::value)
-                functor(global_id + begin, local_value, false);
-              else
-                functor(WorkTag(), global_id + begin, local_value, false);
+        // Initialize local memory
+        value_type local_value;
+        reducer.init(&local_value);
+        if (global_id < size) {
+          if constexpr (std::is_void<WorkTag>::value)
+            functor(global_id + begin, local_value, false);
+          else
+            functor(WorkTag(), global_id + begin, local_value, false);
+        }
+
+        workgroup_scan<>(item, reducer, local_mem, local_value, wgroup_size);
+
+        // Write results to global memory
+        if (global_id < size) global_mem[global_id] = local_value;
+
+        if (local_id == wgroup_size - 1) {
+          group_results[item.get_group_linear_id()] =
+              local_mem[item.get_sub_group().get_group_range()[0] - 1];
+
+          sycl::atomic_ref<unsigned, sycl::memory_order::acq_rel,
+                           sycl::memory_scope::device,
+                           sycl::access::address_space::global_space>
+              scratch_flags_ref(*scratch_flags);
+          num_teams_done[0] = ++scratch_flags_ref;
+        }
+        item.barrier(sycl::access::fence_space::global_space);
+        if (num_teams_done[0] == n_wgroups) {
+          if (local_id == 0) *scratch_flags = 0;
+          value_type total;
+          reducer.init(&total);
+
+          for (unsigned int offset = 0; offset < n_wgroups;
+               offset += wgroup_size) {
+            index_type id = local_id + offset;
+            if (id < static_cast<index_type>(n_wgroups))
+              local_value = group_results[id];
+            else
+              reducer.init(&local_value);
+            workgroup_scan<>(
+                item, reducer, local_mem, local_value,
+                std::min<index_type>(n_wgroups - offset, wgroup_size));
+            if (id < static_cast<index_type>(n_wgroups)) {
+              reducer.join(&local_value, &total);
+              group_results[id] = local_value;
             }
-
-            workgroup_scan<>(item, reducer, local_mem, local_value,
-                             wgroup_size);
-
-            // Write results to global memory
-            if (global_id < size) global_mem[global_id] = local_value;
-
-            if (local_id == wgroup_size - 1) {
-              group_results[item.get_group_linear_id()] =
-                  local_mem[item.get_sub_group().get_group_range()[0] - 1];
-
-              sycl::atomic_ref<unsigned, sycl::memory_order::acq_rel,
-                               sycl::memory_scope::device,
-                               sycl::access::address_space::global_space>
-                  scratch_flags_ref(*scratch_flags);
-              num_teams_done[0] = ++scratch_flags_ref;
-            }
-            item.barrier(sycl::access::fence_space::global_space);
-            if (num_teams_done[0] == n_wgroups) {
-              if (local_id == 0) *scratch_flags = 0;
-              value_type total;
-              reducer.init(&total);
-
-              for (unsigned int offset = 0; offset < n_wgroups;
-                   offset += wgroup_size) {
-                index_type id = local_id + offset;
-                if (id < static_cast<index_type>(n_wgroups))
-                  local_value = group_results[id];
-                else
-                  reducer.init(&local_value);
-                workgroup_scan<>(
-                    item, reducer, local_mem, local_value,
-                    std::min<index_type>(n_wgroups - offset, wgroup_size));
-                if (id < static_cast<index_type>(n_wgroups)) {
-                  reducer.join(&local_value, &total);
-                  group_results[id] = local_value;
-                }
-                reducer.join(
-                    &total,
-                    &local_mem[item.get_sub_group().get_group_range()[0] - 1]);
-                if (offset + wgroup_size < n_wgroups)
-                  item.barrier(sycl::access::fence_space::global_space);
-              }
-            }
-          };
-          return lambda;
-        };
+            reducer.join(
+                &total,
+                &local_mem[item.get_sub_group().get_group_range()[0] - 1]);
+            if (offset + wgroup_size < n_wgroups)
+              item.barrier(sycl::access::fence_space::global_space);
+          }
+        }
+      };
+      return lambda;
+    };
 
     size_t wgroup_size;
     size_t n_wgroups;
-    Kokkos::Impl::SYCLTypes::device_ptr<value_type> global_mem;
-    Kokkos::Impl::SYCLTypes::device_ptr<value_type> group_results;
+    sycl_device_ptr<value_type> global_mem;
+    sycl_device_ptr<value_type> group_results;
 
     desul::ensure_sycl_lock_arrays_on_device(q);
 
@@ -289,12 +286,11 @@ class ParallelScanSYCLBase {
       // that will contain the sum of the previous workgroups totals.
       // FIXME_SYCL consider only storing one value per block and recreate
       // initial results in the end before doing the final pass
-      global_mem = static_cast<Kokkos::Impl::SYCLTypes::device_ptr<value_type>>(
-          instance.scratch_space(n_wgroups * (wgroup_size + 1) *
-                                 sizeof(value_type)));
-      m_scratch_host =
-          static_cast<Kokkos::Impl::SYCLTypes::host_ptr<value_type>>(
-              instance.scratch_host(sizeof(value_type)));
+      global_mem =
+          static_cast<sycl_device_ptr<value_type>>(instance.scratch_space(
+              n_wgroups * (wgroup_size + 1) * sizeof(value_type)));
+      m_scratch_host = static_cast<sycl_host_ptr<value_type>>(
+          instance.scratch_host(sizeof(value_type)));
 
       group_results = global_mem + n_wgroups * wgroup_size;
 

--- a/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
@@ -146,7 +146,7 @@ class ParallelScanSYCLBase {
   const CombinedFunctorReducer<FunctorType, typename Analysis::Reducer>
       m_functor_reducer;
   const Policy m_policy;
-  sycl::host_ptr<value_type> m_scratch_host = nullptr;
+  sycl::ext::intel::host_ptr<value_type> m_scratch_host = nullptr;
   pointer_type m_result_ptr;
   const bool m_result_ptr_device_accessible;
 
@@ -166,8 +166,9 @@ class ParallelScanSYCLBase {
 
     const auto size = m_policy.end() - m_policy.begin();
 
-    auto scratch_flags = static_cast<sycl::device_ptr<unsigned int>>(
-        instance.scratch_flags(sizeof(unsigned int)));
+    auto scratch_flags =
+        static_cast<sycl::ext::intel::device_ptr<unsigned int>>(
+            instance.scratch_flags(sizeof(unsigned int)));
 
     const auto begin = m_policy.begin();
 
@@ -175,8 +176,8 @@ class ParallelScanSYCLBase {
     auto scan_lambda_factory =
         [&](sycl::local_accessor<value_type> local_mem,
             sycl::local_accessor<unsigned int> num_teams_done,
-            sycl::device_ptr<value_type> global_mem_,
-            sycl::device_ptr<value_type> group_results_) {
+            sycl::ext::intel::device_ptr<value_type> global_mem_,
+            sycl::ext::intel::device_ptr<value_type> group_results_) {
           auto lambda = [=](sycl::nd_item<1> item) {
             auto global_mem    = global_mem_;
             auto group_results = group_results_;
@@ -253,8 +254,8 @@ class ParallelScanSYCLBase {
 
     size_t wgroup_size;
     size_t n_wgroups;
-    sycl::device_ptr<value_type> global_mem;
-    sycl::device_ptr<value_type> group_results;
+    sycl::ext::intel::device_ptr<value_type> global_mem;
+    sycl::ext::intel::device_ptr<value_type> group_results;
 
     desul::ensure_sycl_lock_arrays_on_device(q);
 
@@ -288,10 +289,10 @@ class ParallelScanSYCLBase {
       // that will contain the sum of the previous workgroups totals.
       // FIXME_SYCL consider only storing one value per block and recreate
       // initial results in the end before doing the final pass
-      global_mem =
-          static_cast<sycl::device_ptr<value_type>>(instance.scratch_space(
-              n_wgroups * (wgroup_size + 1) * sizeof(value_type)));
-      m_scratch_host = static_cast<sycl::host_ptr<value_type>>(
+      global_mem = static_cast<sycl::ext::intel::device_ptr<value_type>>(
+          instance.scratch_space(n_wgroups * (wgroup_size + 1) *
+                                 sizeof(value_type)));
+      m_scratch_host = static_cast<sycl::ext::intel::host_ptr<value_type>>(
           instance.scratch_host(sizeof(value_type)));
 
       group_results = global_mem + n_wgroups * wgroup_size;

--- a/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
@@ -146,7 +146,7 @@ class ParallelScanSYCLBase {
   const CombinedFunctorReducer<FunctorType, typename Analysis::Reducer>
       m_functor_reducer;
   const Policy m_policy;
-  sycl::ext::intel::host_ptr<value_type> m_scratch_host = nullptr;
+  Kokkos::Impl::SYCLTypes::host_ptr<value_type> m_scratch_host = nullptr;
   pointer_type m_result_ptr;
   const bool m_result_ptr_device_accessible;
 
@@ -167,7 +167,7 @@ class ParallelScanSYCLBase {
     const auto size = m_policy.end() - m_policy.begin();
 
     auto scratch_flags =
-        static_cast<sycl::ext::intel::device_ptr<unsigned int>>(
+        static_cast<Kokkos::Impl::SYCLTypes::device_ptr<unsigned int>>(
             instance.scratch_flags(sizeof(unsigned int)));
 
     const auto begin = m_policy.begin();
@@ -176,8 +176,8 @@ class ParallelScanSYCLBase {
     auto scan_lambda_factory =
         [&](sycl::local_accessor<value_type> local_mem,
             sycl::local_accessor<unsigned int> num_teams_done,
-            sycl::ext::intel::device_ptr<value_type> global_mem_,
-            sycl::ext::intel::device_ptr<value_type> group_results_) {
+            Kokkos::Impl::SYCLTypes::device_ptr<value_type> global_mem_,
+            Kokkos::Impl::SYCLTypes::device_ptr<value_type> group_results_) {
           auto lambda = [=](sycl::nd_item<1> item) {
             auto global_mem    = global_mem_;
             auto group_results = group_results_;
@@ -254,8 +254,8 @@ class ParallelScanSYCLBase {
 
     size_t wgroup_size;
     size_t n_wgroups;
-    sycl::ext::intel::device_ptr<value_type> global_mem;
-    sycl::ext::intel::device_ptr<value_type> group_results;
+    Kokkos::Impl::SYCLTypes::device_ptr<value_type> global_mem;
+    Kokkos::Impl::SYCLTypes::device_ptr<value_type> group_results;
 
     desul::ensure_sycl_lock_arrays_on_device(q);
 
@@ -289,11 +289,12 @@ class ParallelScanSYCLBase {
       // that will contain the sum of the previous workgroups totals.
       // FIXME_SYCL consider only storing one value per block and recreate
       // initial results in the end before doing the final pass
-      global_mem = static_cast<sycl::ext::intel::device_ptr<value_type>>(
+      global_mem = static_cast<Kokkos::Impl::SYCLTypes::device_ptr<value_type>>(
           instance.scratch_space(n_wgroups * (wgroup_size + 1) *
                                  sizeof(value_type)));
-      m_scratch_host = static_cast<sycl::ext::intel::host_ptr<value_type>>(
-          instance.scratch_host(sizeof(value_type)));
+      m_scratch_host =
+          static_cast<Kokkos::Impl::SYCLTypes::host_ptr<value_type>>(
+              instance.scratch_host(sizeof(value_type)));
 
       group_results = global_mem + n_wgroups * wgroup_size;
 

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -339,7 +339,7 @@ class SYCLTeamMember {
   KOKKOS_INLINE_FUNCTION
   SYCLTeamMember(sycl::local_ptr<void> shared, const std::size_t shared_begin,
                  const std::size_t shared_size,
-                 sycl::device_ptr<void> scratch_level_1_ptr,
+                 sycl::ext::intel::device_ptr<void> scratch_level_1_ptr,
                  const std::size_t scratch_level_1_size,
                  const sycl::nd_item<2> item, const int arg_league_rank,
                  const int arg_league_size)

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -339,7 +339,7 @@ class SYCLTeamMember {
   KOKKOS_INLINE_FUNCTION
   SYCLTeamMember(sycl::local_ptr<void> shared, const std::size_t shared_begin,
                  const std::size_t shared_size,
-                 Kokkos::Impl::SYCLTypes::device_ptr<void> scratch_level_1_ptr,
+                 sycl_device_ptr<void> scratch_level_1_ptr,
                  const std::size_t scratch_level_1_size,
                  const sycl::nd_item<2> item, const int arg_league_rank,
                  const int arg_league_size)

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -339,7 +339,7 @@ class SYCLTeamMember {
   KOKKOS_INLINE_FUNCTION
   SYCLTeamMember(sycl::local_ptr<void> shared, const std::size_t shared_begin,
                  const std::size_t shared_size,
-                 sycl::ext::intel::device_ptr<void> scratch_level_1_ptr,
+                 Kokkos::Impl::SYCLTypes::device_ptr<void> scratch_level_1_ptr,
                  const std::size_t scratch_level_1_size,
                  const sycl::nd_item<2> item, const int arg_league_rank,
                  const int arg_league_size)

--- a/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
@@ -28,7 +28,7 @@ inline constexpr bool use_shuffle_based_algorithm =
 template <typename ValueType, typename ReducerType, int dim>
 std::enable_if_t<!use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(
     sycl::nd_item<dim>& item, sycl::local_accessor<ValueType> local_mem,
-    sycl::device_ptr<ValueType> results_ptr,
+    sycl::ext::intel::device_ptr<ValueType> results_ptr,
     sycl::global_ptr<ValueType> device_accessible_result_ptr,
     const unsigned int value_count_, const ReducerType& final_reducer,
     bool final, unsigned int max_size) {
@@ -100,7 +100,7 @@ std::enable_if_t<!use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(
 template <typename ValueType, typename ReducerType, int dim>
 std::enable_if_t<use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(
     sycl::nd_item<dim>& item, sycl::local_accessor<ValueType> local_mem,
-    ValueType local_value, sycl::device_ptr<ValueType> results_ptr,
+    ValueType local_value, sycl::ext::intel::device_ptr<ValueType> results_ptr,
     sycl::global_ptr<ValueType> device_accessible_result_ptr,
     const ReducerType& final_reducer, bool final, unsigned int max_size) {
   const auto local_id = item.get_local_linear_id();

--- a/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
@@ -28,7 +28,7 @@ inline constexpr bool use_shuffle_based_algorithm =
 template <typename ValueType, typename ReducerType, int dim>
 std::enable_if_t<!use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(
     sycl::nd_item<dim>& item, sycl::local_accessor<ValueType> local_mem,
-    Kokkos::Impl::SYCLTypes::device_ptr<ValueType> results_ptr,
+    sycl_device_ptr<ValueType> results_ptr,
     sycl::global_ptr<ValueType> device_accessible_result_ptr,
     const unsigned int value_count_, const ReducerType& final_reducer,
     bool final, unsigned int max_size) {
@@ -100,8 +100,7 @@ std::enable_if_t<!use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(
 template <typename ValueType, typename ReducerType, int dim>
 std::enable_if_t<use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(
     sycl::nd_item<dim>& item, sycl::local_accessor<ValueType> local_mem,
-    ValueType local_value,
-    Kokkos::Impl::SYCLTypes::device_ptr<ValueType> results_ptr,
+    ValueType local_value, sycl_device_ptr<ValueType> results_ptr,
     sycl::global_ptr<ValueType> device_accessible_result_ptr,
     const ReducerType& final_reducer, bool final, unsigned int max_size) {
   const auto local_id = item.get_local_linear_id();

--- a/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
@@ -28,7 +28,7 @@ inline constexpr bool use_shuffle_based_algorithm =
 template <typename ValueType, typename ReducerType, int dim>
 std::enable_if_t<!use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(
     sycl::nd_item<dim>& item, sycl::local_accessor<ValueType> local_mem,
-    sycl::ext::intel::device_ptr<ValueType> results_ptr,
+    Kokkos::Impl::SYCLTypes::device_ptr<ValueType> results_ptr,
     sycl::global_ptr<ValueType> device_accessible_result_ptr,
     const unsigned int value_count_, const ReducerType& final_reducer,
     bool final, unsigned int max_size) {
@@ -100,7 +100,8 @@ std::enable_if_t<!use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(
 template <typename ValueType, typename ReducerType, int dim>
 std::enable_if_t<use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(
     sycl::nd_item<dim>& item, sycl::local_accessor<ValueType> local_mem,
-    ValueType local_value, sycl::ext::intel::device_ptr<ValueType> results_ptr,
+    ValueType local_value,
+    Kokkos::Impl::SYCLTypes::device_ptr<ValueType> results_ptr,
     sycl::global_ptr<ValueType> device_accessible_result_ptr,
     const ReducerType& final_reducer, bool final, unsigned int max_size) {
   const auto local_id = item.get_local_linear_id();

--- a/core/src/setup/Kokkos_Setup_SYCL.hpp
+++ b/core/src/setup/Kokkos_Setup_SYCL.hpp
@@ -45,4 +45,21 @@
 #define KOKKOS_IMPL_SYCL_GET_MULTI_PTR(accessor) accessor.get_pointer()
 #endif
 
+// FIXME_SYCL Use type directly once it has stabilized in SYCL.
+namespace Kokkos::Impl::SYCLTypes {
+#ifndef SYCL_EXT_INTEL_USM_ADDRESS_SPACES
+#error SYCL_EXT_INTEL_USM_ADDRESS_SPACES undefined!
+#elif SYCL_EXT_INTEL_USM_ADDRESS_SPACES >= 2
+template <typename T>
+using device_ptr = sycl::ext::intel::device_ptr<T>;
+template <typename T>
+using host_ptr = sycl::ext::intel::host_ptr<T>;
+#else
+template <typename T>
+using device_ptr = sycl::device_ptr<T>;
+template <typename T>
+using host_ptr = sycl::host_ptr<T>;
+#endif
+}  // namespace Kokkos::Impl::SYCLTypes
+
 #endif

--- a/core/src/setup/Kokkos_Setup_SYCL.hpp
+++ b/core/src/setup/Kokkos_Setup_SYCL.hpp
@@ -46,20 +46,20 @@
 #endif
 
 // FIXME_SYCL Use type directly once it has stabilized in SYCL.
-namespace Kokkos::Impl::SYCLTypes {
+namespace Kokkos::Impl {
 #ifndef SYCL_EXT_INTEL_USM_ADDRESS_SPACES
 #error SYCL_EXT_INTEL_USM_ADDRESS_SPACES undefined!
 #elif SYCL_EXT_INTEL_USM_ADDRESS_SPACES >= 2
 template <typename T>
-using device_ptr = sycl::ext::intel::device_ptr<T>;
+using sycl_device_ptr = sycl::ext::intel::device_ptr<T>;
 template <typename T>
-using host_ptr = sycl::ext::intel::host_ptr<T>;
+using sycl_host_ptr = sycl::ext::intel::host_ptr<T>;
 #else
 template <typename T>
-using device_ptr = sycl::device_ptr<T>;
+using sycl_device_ptr = sycl::device_ptr<T>;
 template <typename T>
-using host_ptr = sycl::host_ptr<T>;
+using sycl_host_ptr = sycl::host_ptr<T>;
 #endif
-}  // namespace Kokkos::Impl::SYCLTypes
+}  // namespace Kokkos::Impl
 
 #endif


### PR DESCRIPTION
See https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_intel_usm_address_spaces.asciidoc#feature-test-macro. `sycl::ext::intel::device_ptr/host_ptr` was introduced in https://github.com/intel/llvm/pull/7680 and `sycl::device_ptr/host_ptr` was removed in https://github.com/intel/llvm/pull/13240.
This pull request introduces aliases in `Kokkos::Impl::SYCLTypes` based on the level of feature support.