### PR TITLE
SYCL: Avoid deprecated floating-point number abs overloads

### DIFF
--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -278,7 +278,7 @@ KOKKOS_INLINE_FUNCTION long long abs(long long n) {
 }
 KOKKOS_INLINE_FUNCTION float abs(float x) {
 #ifdef KOKKOS_ENABLE_SYCL
-  return sycl::fabs(x);
+  return sycl::fabs(x);  // sycl::abs is only provided for integral types
 #else
   using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::abs;
   return abs(x);
@@ -286,7 +286,7 @@ KOKKOS_INLINE_FUNCTION float abs(float x) {
 }
 KOKKOS_INLINE_FUNCTION double abs(double x) {
 #ifdef KOKKOS_ENABLE_SYCL
-  return sycl::fabs(x);
+  return sycl::fabs(x);  // sycl::abs is only provided for integral types
 #else
   using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::abs;
   return abs(x);

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -277,12 +277,20 @@ KOKKOS_INLINE_FUNCTION long long abs(long long n) {
 #endif
 }
 KOKKOS_INLINE_FUNCTION float abs(float x) {
+#ifdef KOKKOS_ENABLE_SYCL
+  return sycl::fabs(x);
+#else
   using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::abs;
   return abs(x);
+#endif
 }
 KOKKOS_INLINE_FUNCTION double abs(double x) {
+#ifdef KOKKOS_ENABLE_SYCL
+  return sycl::fabs(x);
+#else
   using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::abs;
   return abs(x);
+#endif
 }
 inline long double abs(long double x) {
   using std::abs;


### PR DESCRIPTION
The floating-point number overloads for `sycl::abs` were deprecated in https://github.com/intel/llvm/pull/11774, see https://github.com/steffenlarsen/llvm/blob/4497895152baca8212549e645d1d7c5c9ce96988/sycl/include/sycl/builtins_legacy_scalar.hpp#L468-L474.