### PR TITLE
Fix wrong macro guards for deprecated `Kokkos::pair<T1,void>` specialization

### DIFF
--- a/core/src/Kokkos_Pair.hpp
+++ b/core/src/Kokkos_Pair.hpp
@@ -413,7 +413,7 @@ KOKKOS_FORCEINLINE_FUNCTION pair<T1&, T2&> tie(T1& x, T2& y) {
   return (pair<T1&, T2&>(x, y));
 }
 
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 //
 // Specialization of Kokkos::pair for a \c void second argument.  This
 // is not actually a "pair"; it only contains one element, the first.


### PR DESCRIPTION
Fixup for https://github.com/kokkos/kokkos/pull/6947#discussion_r1577008262

Reported on Slack.
Please investigate why this was not caught by the CI nor nightlies.