### PR TITLE
Fix support for `Kokkos::Array` of const-qualified element type

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -134,8 +134,9 @@ struct Array {
   }
 
  private:
+  template <class U = T>
   friend KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-      Impl::is_swappable<T>::value>
+      Impl::is_swappable<U>::value>
   kokkos_swap(Array<T, N>& a,
               Array<T, N>& b) noexcept(Impl::is_nothrow_swappable_v<T>) {
     for (std::size_t i = 0; i < N; ++i) {

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -137,8 +137,13 @@ struct Array {
   template <class U = T>
   friend KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
       Impl::is_swappable<U>::value>
-  kokkos_swap(Array<T, N>& a,
-              Array<T, N>& b) noexcept(Impl::is_nothrow_swappable_v<T>) {
+  kokkos_swap(
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+      Array<T, N, Proxy>& a, Array<T, N, Proxy>& b
+#else
+      Array<T, N>& a, Array<T, N>& b
+#endif
+      ) noexcept(Impl::is_nothrow_swappable_v<T>) {
     for (std::size_t i = 0; i < N; ++i) {
       kokkos_swap(a[i], b[i]);
     }

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -137,13 +137,8 @@ struct Array {
   template <class U = T>
   friend KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
       Impl::is_swappable<U>::value>
-  kokkos_swap(
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-      Array<T, N, Proxy>& a, Array<T, N, Proxy>& b
-#else
-      Array<T, N>& a, Array<T, N>& b
-#endif
-      ) noexcept(Impl::is_nothrow_swappable_v<T>) {
+  kokkos_swap(Array<T, N>& a,
+              Array<T, N>& b) noexcept(Impl::is_nothrow_swappable_v<T>) {
     for (std::size_t i = 0; i < N; ++i) {
       kokkos_swap(a[i], b[i]);
     }

--- a/core/src/Kokkos_Swap.hpp
+++ b/core/src/Kokkos_Swap.hpp
@@ -37,26 +37,6 @@ kokkos_swap(T& a, T& b) noexcept(std::is_nothrow_move_constructible_v<T>&&
 
 namespace Impl {
 
-// Workaround for the definition of is_nothrow_swappable_v
-#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1140)
-template <class T>
-struct is_swappable {
-  template <class U>
-  static decltype(kokkos_swap(std::declval<T&>(), std::declval<T&>()))
-  test_swap(int) noexcept(noexcept(kokkos_swap(std::declval<T&>(),
-                                               std::declval<T&>())));
-  struct Nope {};  // test_swap must return a complete type for the definition
-                   // of nothrow below
-  template <class U>
-  static Nope test_swap(long);
-  static constexpr bool value =
-      !std::is_same_v<decltype(test_swap<T>(0)), Nope>;
-  static constexpr bool nothrow = noexcept(test_swap<T>(0));
-};
-
-template <class T>
-inline constexpr bool is_nothrow_swappable_v = is_swappable<T>::nothrow;
-#else
 template <class T>
 struct is_swappable {
   template <class U>
@@ -69,6 +49,13 @@ struct is_swappable {
       !std::is_same_v<decltype(test_swap<T>(0)), Nope>;
 };
 
+#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1140)
+template <class T>
+inline constexpr bool is_nothrow_swappable_v =
+    is_swappable<T>::value&& noexcept(
+        kokkos_swap(std::declval<std::remove_const_t<T>&>(),
+                    std::declval<std::remove_const_t<T>&>()));
+#else
 template <class T>
 inline constexpr bool is_nothrow_swappable_v =
     noexcept(kokkos_swap(std::declval<T&>(), std::declval<T&>()));

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -120,6 +120,13 @@ static_assert(test_array_aggregate_initialization());
   }
 }
 
+constexpr bool test_array_const_qualified_element_type() {
+  Kokkos::Array<int const, 1> a{255};
+  return a[0] == 255;
+}
+
+static_assert(test_array_const_qualified_element_type());
+
 // User-defined type providing a sepcialization of kokkos_swap
 struct MyInt {
   int i;


### PR DESCRIPTION
Fix #6960 
Poorly-crafted constraint on the `kokkos_swap` hidden friend in #6943 inadvertently broke use of Kokkos arrays of const-qualified element type.

In the process had to come up with a workaround in the definition of the `Impl::is_nothrow_swappable_v` variable template for NVCC pre 11.4