### PR TITLE
Do not require OpenMP support for languages other than CXX

### DIFF
--- a/cmake/kokkos_tpls.cmake
+++ b/cmake/kokkos_tpls.cmake
@@ -103,13 +103,13 @@ if (Kokkos_ENABLE_IMPL_MDSPAN AND Kokkos_ENABLE_MDSPAN_EXTERNAL)
 endif()
 
 IF (Kokkos_ENABLE_OPENMP)
-  find_package(OpenMP REQUIRED)
+  find_package(OpenMP REQUIRED COMPONENTS CXX)
   # FIXME_TRILINOS Trilinos doesn't allow for Kokkos to use find_dependency
   # so we just append the flags here instead of linking with the OpenMP target.
   IF(KOKKOS_HAS_TRILINOS)
     COMPILER_SPECIFIC_FLAGS(DEFAULT ${OpenMP_CXX_FLAGS})
   ELSE()
-    KOKKOS_EXPORT_CMAKE_TPL(OpenMP REQUIRED)
+    KOKKOS_EXPORT_CMAKE_TPL(OpenMP REQUIRED COMPONENTS CXX)
   ENDIF()
 ENDIF()
 


### PR DESCRIPTION
This change was prompted by a discussion on Slack https://kokkosteam.slack.com/archives/C5BGU5NDQ/p1714063365919929

Specify CXX component when searching for OpenMP so that OpenMP support is not required for other languages with CMake.

One caveat with that change is that finding the OpenMP dependency downstream now requires a CMake minimum version of 3.10

The CMake module documentation can be found at https://cmake.org/cmake/help/latest/module/FindOpenMP.html