### PR TITLE
Fix fedora CI builds with flang-new

### DIFF
--- a/example/build_cmake_installed/CMakeLists.txt
+++ b/example/build_cmake_installed/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(Kokkos REQUIRED)
 add_executable(example cmake_example.cpp foo.f)
 if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
   set_target_properties(example PROPERTIES LINKER_LANGUAGE Fortran)
+  target_link_options(example PRIVATE -fno-fortran-main)
 endif()
 
 # This is the only thing required to set up compiler/linker flags


### PR DESCRIPTION
This fixes the fedora CI builds that started failing this week. Linking with `-fno-fortran-main`, prevents creating a main function from the `Fortran` code.
```bash
/usr/bin/ld: /usr/bin/../lib/gcc/x86_64-redhat-linux/14/../../../../lib64/libFortran_main.a(Fortran_main.c.o): in function `main':
(.text.startup.main+0x0): multiple definition of `main'; CMakeFiles/example.dir/cmake_example.cpp.o:cmake_example.cpp:(.text+0x0): first defined here
/usr/bin/ld: /usr/bin/../lib/gcc/x86_64-redhat-linux/14/../../../../lib64/libFortran_main.a(Fortran_main.c.o): in function `main':
(.text.startup.main+0xb): undefined reference to `_QQEnvironmentDefaults'
/usr/bin/ld: (.text.startup.main+0x18): undefined reference to `_QQmain'
flang-new: error: linker command failed with exit code 1 (use -v to see invocation)
```