### PR TITLE
Also use is_nothrow_swappable workaround for Intel Classic Compilers

### DIFF
--- a/core/src/Kokkos_Swap.hpp
+++ b/core/src/Kokkos_Swap.hpp
@@ -49,7 +49,8 @@ struct is_swappable {
       !std::is_same_v<decltype(test_swap<T>(0)), Nope>;
 };
 
-#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1140)
+#if (defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1140)) || \
+    defined(KOKKOS_COMPILER_INTEL)
 template <class T>
 inline constexpr bool is_nothrow_swappable_v =
     is_swappable<T>::value&& noexcept(


### PR DESCRIPTION
Fixes #6960. Apparently, we need the same workaround for Intel compilers to avoid
```bash
<source>(61): error: no instance of overloaded function "Kokkos::kokkos_swap" matches the argument list
            argument types are: (const int, const int)
  inline constexpr bool is_nothrow_swappable_v = noexcept(kokkos_swap(std::declval<T&>(), std::declval<T&>()));
                                                          ^
<source>(69): note: this candidate was rejected because function is not visible
  kokkos_swap(T (&a)[N], T (&b)[N]) noexcept(Impl::is_nothrow_swappable_v<T>) {
  ^
<source>(19): note: this candidate was rejected because at least one template argument could not be deduced
  kokkos_swap(T& a, T& b) noexcept(std::is_nothrow_move_constructible_v<T>&&
  ^
          detected during:
            instantiation of "const bool Kokkos::Impl::is_nothrow_swappable_v [with T=const int]" at line 193
            instantiation of class "Kokkos::Array<T, N> [with T=const int, N=1UL]" at line 449

compilation aborted for <source> (code 2)
Compiler returned: 2
```
see https://godbolt.org/z/8rdbjYqs3.

@ndellingwood Can you please test that this resolves the build errors with `Intel` compilers indeed?