### PR TITLE
Fix deprecation warnings with GCC for `pair<T1,void>` comparison operators

### DIFF
--- a/core/src/Kokkos_Pair.hpp
+++ b/core/src/Kokkos_Pair.hpp
@@ -450,37 +450,37 @@ struct KOKKOS_DEPRECATED pair<T1, void> {
 //
 
 template <class T1>
-KOKKOS_FORCEINLINE_FUNCTION constexpr bool operator==(
+KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION constexpr bool operator==(
     const pair<T1, void>& lhs, const pair<T1, void>& rhs) {
   return lhs.first == rhs.first;
 }
 
 template <class T1>
-KOKKOS_FORCEINLINE_FUNCTION constexpr bool operator!=(
+KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION constexpr bool operator!=(
     const pair<T1, void>& lhs, const pair<T1, void>& rhs) {
   return !(lhs == rhs);
 }
 
 template <class T1>
-KOKKOS_FORCEINLINE_FUNCTION constexpr bool operator<(
+KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION constexpr bool operator<(
     const pair<T1, void>& lhs, const pair<T1, void>& rhs) {
   return lhs.first < rhs.first;
 }
 
 template <class T1>
-KOKKOS_FORCEINLINE_FUNCTION constexpr bool operator<=(
+KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION constexpr bool operator<=(
     const pair<T1, void>& lhs, const pair<T1, void>& rhs) {
   return !(rhs < lhs);
 }
 
 template <class T1>
-KOKKOS_FORCEINLINE_FUNCTION constexpr bool operator>(
+KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION constexpr bool operator>(
     const pair<T1, void>& lhs, const pair<T1, void>& rhs) {
   return rhs < lhs;
 }
 
 template <class T1>
-KOKKOS_FORCEINLINE_FUNCTION constexpr bool operator>=(
+KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION constexpr bool operator>=(
     const pair<T1, void>& lhs, const pair<T1, void>& rhs) {
   return !(lhs < rhs);
 }


### PR DESCRIPTION
Fixup for  #6947

GCC emits deprecation warnings in the definition of comparison operators for the deprecated specialization `Kokkos::pair<T1, void>`.  The fix is simple: add the `[[deprecated]]` attribute for all of these comparison operators.

The issue was spotted in the ArborX nightlies and is also present in our nighties on ORNL Jenkins, we just didn't notice.
@ndellingwood did the SNL nighty builds not catch this issue?!!

Reproducer [here](https://godbolt.org/z/4sfEjoWbG) does not seem to be sensitive to the GCC version.