### PR TITLE
 SYCL: Fix deprecation in custom parallel_for RangePolicy implementation 

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Range.hpp
@@ -43,8 +43,8 @@ template <typename FunctorWrapper, typename Policy>
 struct FunctorWrapperRangePolicyParallelForCustom {
   using WorkTag = typename Policy::work_tag;
 
-  void operator()(sycl::item<1> item) const {
-    const typename Policy::index_type id = item.get_linear_id();
+  void operator()(sycl::nd_item<1> item) const {
+    const typename Policy::index_type id = item.get_global_linear_id();
     if (id < m_work_size) {
       const auto shifted_id = id + m_begin;
       if constexpr (std::is_void_v<WorkTag>)


### PR DESCRIPTION
Extracted from #6828 From https://github.com/intel/llvm/pull/11067: 

> According to the SYCL 2020 specification:
> > The function object that represents the SYCL kernel function must take one of: 1) a single SYCL nd_item parameter, 2) a single generic parameter (template parameter or auto) that will be treated as an nd_item parameter, 3) any other type converted from SYCL nd_item, representing the currently executing work-item within the range specified by the nd_range parameter.
>
> However, the current implementation allows also sycl::item and any argument types convertible from a sycl::item. This commit addresses this discrepancy by disallowing anything other than sycl::nd_item and all types convertible from sycl::nd_item in this kind of parallel_for. Since this may break existing code, this new restriction is guarded by the SYCL2020_CONFORMANT_APIS preprocessor macro.

The pull request fixes using this deprecated behavior that is turned into an error in the https://github.com/intel/llvm repository.