### PR TITLE
Suppress deprecated warnings via pragma push/pop in the tests

### DIFF
--- a/containers/unit_tests/TestVector.hpp
+++ b/containers/unit_tests/TestVector.hpp
@@ -21,6 +21,8 @@
 #include <iostream>
 #include <cstdlib>
 #include <cstdio>
+#include <Kokkos_Macros.hpp>
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
 #include <Kokkos_Vector.hpp>
 
 namespace Test {

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -562,6 +562,28 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 #define KOKKOS_IMPL_WARNING(desc) KOKKOS_IMPL_DO_PRAGMA(message(#desc))
 #endif
 
+// clang-format off
+#if defined(__EDG__)
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH() \
+    _Pragma("push")                                      \
+    _Pragma("diag_suppress 1223")
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP() \
+    _Pragma("pop")
+#elif defined(__GNUC__) || defined(__clang__)
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH() \
+    _Pragma("GCC diagnostic push")                       \
+    _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP() \
+    _Pragma("GCC diagnostic pop")
+#elif defined(_MSC_VER)
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH() \
+    _Pragma("warning(push)")                             \
+    _Pragma("warning(disable: 4996)")
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP() \
+    _Pragma("warning(pop)")
+#endif
+// clang-format on
+
 #define KOKKOS_ATTRIBUTE_NODISCARD [[nodiscard]]
 
 #if (defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG) ||        \

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -565,10 +565,10 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 // clang-format off
 #if defined(__EDG__)
   #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH() \
-    _Pragma("push")                                      \
-    _Pragma("diag_suppress 1223")
+    _Pragma("warning push")                              \
+    _Pragma("warning disable 1478")
   #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP() \
-    _Pragma("pop")
+    _Pragma("warning pop")
 #elif defined(__GNUC__) || defined(__clang__)
   #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH() \
     _Pragma("GCC diagnostic push")                       \
@@ -581,6 +581,9 @@ static constexpr bool kokkos_omp_on_host() { return false; }
     _Pragma("warning(disable: 4996)")
   #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP() \
     _Pragma("warning(pop)")
+#else
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 #endif
 // clang-format on
 

--- a/core/unit_test/TestArrayOps.hpp
+++ b/core/unit_test/TestArrayOps.hpp
@@ -112,6 +112,7 @@ TEST(TEST_CATEGORY, array_zero_data_nullptr) {
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
 TEST(TEST_CATEGORY, array_contiguous_capacity) {
   using A =
       Kokkos::Array<int, KOKKOS_INVALID_INDEX, Kokkos::Array<>::contiguous>;
@@ -390,6 +391,7 @@ TEST(TEST_CATEGORY, array_strided_assignment) {
   ASSERT_EQ(e.max_size(), std::size(ee) / eStride);
   ASSERT_EQ(e[0], ee[0]);
 }
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 #endif
 
 }  // namespace

--- a/core/unit_test/incremental/Test01_execspace.hpp
+++ b/core/unit_test/incremental/Test01_execspace.hpp
@@ -63,7 +63,9 @@ struct TestIncrExecSpace {
     ASSERT_GT(concurrency, 0);
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
     int in_parallel = ExecSpace::in_parallel();
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
     ASSERT_FALSE(in_parallel);
 #endif
 

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -81,7 +81,9 @@ class absolutes {
   auto on_host(T const& a) const {
     if constexpr (std::is_signed_v<typename T::value_type>) {
 #if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
+      KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
       return Kokkos::Experimental::abs(a);
+      KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 #else
       return Kokkos::abs(a);
 #endif


### PR DESCRIPTION
Introduce `KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_{PUSH,POP}` macros to suppress diagnostics when appropriate and fix all the warnings I could see in our tests.

Just in case we need to rework the suppressions macros https://godbolt.org/z/Pjd7hYba9