### PR TITLE
SYCL: Print submission command queue property

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -121,8 +121,14 @@ void SYCL::print_configuration(std::ostream& os, bool verbose) const {
     os << "Standard command queue enforced\n";
   else
 #endif
+  {
     os << "Immediate command lists and standard command queue allowed. "
           "SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS takes precedence.\n";
+    if (const char* environment_setting =
+            std::getenv("SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS"))
+      os << "SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS: "
+         << environment_setting << '\n';
+  }
 
   int counter       = 0;
   int active_device = Kokkos::device_id();

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -122,12 +122,13 @@ void SYCL::print_configuration(std::ostream& os, bool verbose) const {
   else
 #endif
   {
-    os << "Immediate command lists and standard command queue allowed. "
-          "SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS takes precedence.\n";
+    os << "Immediate command lists and standard command queue allowed.\n";
     if (const char* environment_setting =
             std::getenv("SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS"))
-      os << "SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS: "
-         << environment_setting << '\n';
+      os << "SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS="
+         << environment_setting << " takes precedence.\n";
+    else
+      os << "SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS not defined.\n";
   }
 
   int counter       = 0;

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -110,6 +110,19 @@ void SYCL::print_configuration(std::ostream& os, bool verbose) const {
 #else
   os << "macro  KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES : undefined\n";
 #endif
+#ifdef SYCL_EXT_INTEL_QUEUE_IMMEDIATE_COMMAND_LIST
+  if (sycl_queue()
+          .has_property<
+              sycl::ext::intel::property::queue::immediate_command_list>())
+    os << "Immediate command lists enforced\n";
+  else if (sycl_queue()
+               .has_property<sycl::ext::intel::property::queue::
+                                 no_immediate_command_list>())
+    os << "Standard command queue enforced\n";
+  else
+#endif
+    os << "Immediate command lists and standard command queue allowed. "
+          "SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS takes precedence.\n";
 
   int counter       = 0;
   int active_device = Kokkos::device_id();


### PR DESCRIPTION
Related to #6912 and #7003. Prior to https://github.com/intel/llvm/pull/12279 and https://github.com/oneapi-src/unified-runtime/pull/1218, the oneAPI implementation didn't support immediate command lists. 
There are different ways to make sure to use the standard command queue:
- constructing queues with the `sycl::ext::intel::property::queue::no_immediate_command_list` property (see https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_intel_queue_immediate_command_list.asciidoc)
- setting the `SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS` environment variable.

This pull request just detects if given queues have been constructed with either property. This should give enough information to diagnose potential problems with Graphs. The intended way to fix any related issues is to set `SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS`.