### PR TITLE
SYCL: Don't use shuffles for top-level reductions

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
@@ -21,9 +21,11 @@
 
 namespace Kokkos::Impl::SYCLReduction {
 
+// FIXME_SYCL It appears that using shuffles is slower than going through local
+// memory.
 template <class ReducerType>
-inline constexpr bool use_shuffle_based_algorithm =
-    std::is_reference_v<typename ReducerType::reference_type>;
+inline constexpr bool use_shuffle_based_algorithm = false;
+// std::is_reference_v<typename ReducerType::reference_type>;
 
 template <typename ValueType, typename ReducerType, int dim>
 std::enable_if_t<!use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(


### PR DESCRIPTION
Partly reverts #6750. It turns out that using `shuffles` using more generic types such as in
```C++
Kokkos::parallel_reduce("kk_wup", N, KOKKOS_LAMBDA(int i, double& lsum1, double& lsum2) {
                      lsum1 += x_data_[i]*y_data_[i];
                      lsum2 += x_data_[i]*y_data_[i];},
                      result1, result2);
```
is much slower. Given that #6750 brought shuffle reductions only on par with local memory reductions, it makes sense to always use the latter for now. I have a slight preference for keeping the code for shuffle reductions (like we do for Cuda and HIP).
