### PR TITLE
HPCBIND: Prevent hwloc-ls from opening graphic windows unintentionally

### DIFF
--- a/bin/hpcbind
+++ b/bin/hpcbind
@@ -635,7 +635,9 @@ if [[ ${HPCBIND_TEE} -eq 0 || ${HPCBIND_VERBOSE} -eq 0 ]]; then
 
   if [[ ${HPCBIND_HAS_HWLOC} -eq 1 ]]; then
     echo "[BINDINGS]" >> ${HPCBIND_LOG}
-    hwloc-ls --restrict "${HPCBIND_HWLOC_CPUSET}" >> ${HPCBIND_LOG}
+    if [[ ${HPCBIND_LSTOPO} -eq 1 && ! -z ${DISPLAY} ]]; then
+      hwloc-ls --restrict "${HPCBIND_HWLOC_CPUSET}" >> ${HPCBIND_LOG}
+    fi
   else
     echo "Unable to show bindings, hwloc not available." >> ${HPCBIND_LOG}
   fi
@@ -660,7 +662,9 @@ else
 
   if [[ ${HPCBIND_HAS_HWLOC} -eq 1 ]]; then
     echo "[BINDINGS]" > >(tee -a ${HPCBIND_LOG})
-    hwloc-ls --restrict "${HPCBIND_HWLOC_CPUSET}" --no-io --no-bridges > >(tee -a ${HPCBIND_LOG})
+    if [[ ${HPCBIND_LSTOPO} -eq 1 && ! -z ${DISPLAY} ]]; then
+      hwloc-ls --restrict "${HPCBIND_HWLOC_CPUSET}" --no-io --no-bridges > >(tee -a ${HPCBIND_LOG})
+    fi
   else
     echo "Unable to show bindings, hwloc not available." > >(tee -a ${HPCBIND_LOG})
   fi


### PR DESCRIPTION
I noticed that `hpcbind` unconditionally opens two lstopo X windows when a display is present. The command I ran to trigger this behavior was

`hpcbind --distribute=2 --distribute-partition=1 -v`

in combination with hwloc version 2.7.0 on ubuntu 22.04 lts.

This PR changes this behavior to only open these windows when the `--lstopo` flag is passed at the command line.