### PR TITLE
Change the default execution behavior of the parallel_for(team-policy) constructs in the OpenACC backend

### DIFF
--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp
@@ -44,10 +44,12 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     auto team_size     = m_policy.team_size();
     auto vector_length = m_policy.impl_vector_length();
 
+    int const async_arg = m_policy.space().acc_async_queue();
+
     auto const a_functor(m_functor);
 
 #pragma acc parallel loop gang vector num_gangs(league_size) \
-    vector_length(team_size* vector_length) copyin(a_functor)
+    vector_length(team_size* vector_length) copyin(a_functor) async(async_arg)
     for (int i = 0; i < league_size * team_size * vector_length; i++) {
       int league_id = i / (team_size * vector_length);
       typename Policy::member_type team(league_id, league_size, team_size,
@@ -145,10 +147,12 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     auto team_size     = m_policy.team_size();
     auto vector_length = m_policy.impl_vector_length();
 
+    int const async_arg = m_policy.space().acc_async_queue();
+
     auto const a_functor(m_functor);
 
 #pragma acc parallel loop gang num_gangs(league_size) num_workers(team_size) \
-    vector_length(vector_length) copyin(a_functor)
+    vector_length(vector_length) copyin(a_functor) async(async_arg)
     for (int i = 0; i < league_size; i++) {
       int league_id = i;
       typename Policy::member_type team(league_id, league_size, team_size,

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -427,7 +427,6 @@ if(Kokkos_ENABLE_OPENACC)
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_complexdouble.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_complexfloat.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_Crs.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ExecSpaceThreadSafety.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_JoinBackwardCompatibility.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_LocalDeepCopy.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_Other.cpp


### PR DESCRIPTION
This PR changes the default execution behavior of the parallel_for(team-policy) constructs in the OpenACC backend.
(This PR handles a missing case not covered by the previous PR #6772)
The update in this PR fixes the OpenACC backend error in the thread safety test in PR #6938.