### PR TITLE
(Rebase) Partial fix to compile time issues w/nvcc + Kokkos_ENABLE_DEBUG_BOUNDS_CHECK

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_abort.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_abort.hpp
@@ -28,7 +28,7 @@ extern "C" {
 /*  Cuda runtime function, declared in <crt/device_runtime.h>
  *  Requires capability 2.x or better.
  */
-extern __device__ void __assertfail(const void *message, const void *file,
+__device__ [[noreturn]] void __assertfail(const void *message, const void *file,
                                     unsigned int line, const void *function,
                                     size_t charsize);
 }
@@ -38,25 +38,11 @@ namespace Impl {
 
 // required to workaround failures in random number generator unit tests with
 // pre-volta architectures
-#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-__device__ inline void cuda_abort(const char *const message) {
-#else
-[[noreturn]] __device__ inline void cuda_abort(const char *const message) {
-#endif
+__device__ __noinline__ [[noreturn]] static  void cuda_abort(const char *const message) {
   const char empty[] = "";
 
   __assertfail((const void *)message, (const void *)empty, (unsigned int)0,
                (const void *)empty, sizeof(char));
-
-  // This loop is never executed. It's intended to suppress warnings that the
-  // function returns, even though it does not. This is necessary because
-  // __assertfail is not marked as [[noreturn]], even though it does not return.
-  //  Disable with KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK to workaround failures
-  //  in random number generator unit tests with pre-volta architectures
-#if !defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-  while (true)
-    ;
-#endif
 }
 
 }  // namespace Impl


### PR DESCRIPTION
Rebase of #6596

For reference when configured with:

```
  CMAKE_BUILD_TYPE="Debug"
  CMAKE_COMPILE_WARNING_AS_ERROR="ON"
  CMAKE_CXX_COMPILER="kokkos/bin/nvcc_wrapper"
  CMAKE_CXX_STANDARD="17"
  CMAKE_EXE_LINKER_FLAGS="-rdynamic"
  CMAKE_EXPORT_COMPILE_COMMANDS="ON"
  CMAKE_INSTALL_PREFIX:PATH="..."
  CMAKE_POSITION_INDEPENDENT_CODE="ON"
  CMAKE_VERBOSE_MAKEFILE:BOOL="OFF"
  CUDAToolkit_BIN_DIR=".../spack-env/view/gcc-12.2.0/cuda/11.6.0/bin"
  CUDAToolkit_ROOT=".../spack-env/view/gcc-12.2.0/cuda/11.6.0"
  Kokkos_ENABLE_CUDA="ON"
  Kokkos_ENABLE_CUDA_CONSTEXPR="OFF"
  Kokkos_ENABLE_CUDA_LAMBDA="ON"
  Kokkos_ENABLE_DEBUG="ON"
  Kokkos_ENABLE_DEBUG_BOUNDS_CHECK="ON"
  Kokkos_ENABLE_DEPRECATED_CODE_3:BOOL="OFF"
  Kokkos_ENABLE_DEPRECATED_CODE_4:BOOL="OFF"
  Kokkos_ENABLE_OPENMP:BOOL="OFF"
  Kokkos_ENABLE_SERIAL:BOOL="ON"
  Kokkos_ENABLE_TESTS="ON"
```

This (rebased) PR builds in 20 mins. Current develop takes _insert waiting for develop to build time here_.