### PR TITLE
Fix undefined behavior in is_zero_byte

### DIFF
--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -20,6 +20,8 @@
 #include <type_traits>
 #include <initializer_list>
 
+#include <Kokkos_Array.hpp>            // is_zero_byte
+#include <Kokkos_BitManipulation.hpp>  // is_zero_byte
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_DetectionIdiom.hpp>
 #include <Kokkos_Pair.hpp>
@@ -2439,9 +2441,10 @@ inline bool is_zero_byte(const T& t) {
               sizeof(T) % sizeof(int) == 0, int,
               std::conditional_t<sizeof(T) % sizeof(short int) == 0, short int,
                                  char>>>>;
-  const auto* const ptr = reinterpret_cast<const comparison_type*>(&t);
+  auto bit_values = Kokkos::bit_cast<
+      Kokkos::Array<comparison_type, sizeof(T) / sizeof(comparison_type)>>(t);
   for (std::size_t i = 0; i < sizeof(T) / sizeof(comparison_type); ++i)
-    if (ptr[i] != 0) return false;
+    if (bit_values[i] != 0) return false;
   return true;
 }
 

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -20,8 +20,8 @@
 #include <type_traits>
 #include <initializer_list>
 
-#include <Kokkos_Array.hpp>            // is_zero_byte
-#include <Kokkos_BitManipulation.hpp>  // is_zero_byte
+#include <Kokkos_Array.hpp>
+#include <Kokkos_BitManipulation.hpp>
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_DetectionIdiom.hpp>
 #include <Kokkos_Pair.hpp>


### PR DESCRIPTION
```C++
#include <Kokkos_Core.hpp>
 
int main(int argc, char* argv[]) {
  Kokkos::ScopeGuard scope_guard;
  Kokkos::View<long double, Kokkos::OpenMP> dummy("C");
}
```
would fail with `icpx` and `-fp-model=precise -O2 -g -DNDEBUG -fiopenmp` due to the type punning approach used in `is_zero_byte`. This also manifests in the test suite with `openmp.numeric_traits_infinity` segfaulting.

Using `bitcast` (which requires using Kokkos::Array in turn) instead fixes the issue. An alternative is to always use `char` as a comparison type but I went for minimal modifications.