### PR TITLE
Fix unique_any_senders nvcc template deduction

### DIFF
--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -153,7 +153,7 @@ void HPX::impl_instance_fence_locked(const std::string &name) const {
         auto &s = impl_get_sender();
 
         hpx::this_thread::experimental::sync_wait(std::move(s));
-        s = hpx::execution::experimental::unique_any_sender(
+        s = hpx::execution::experimental::unique_any_sender<>(
             hpx::execution::experimental::just());
       });
 }
@@ -184,7 +184,7 @@ void HPX::impl_static_fence(const std::string &name) {
         }
 
         hpx::this_thread::experimental::sync_wait(std::move(s));
-        s = hpx::execution::experimental::unique_any_sender(
+        s = hpx::execution::experimental::unique_any_sender<>(
             hpx::execution::experimental::just());
       });
 }


### PR DESCRIPTION
Currently, it is not possible to compile the HPX execution space with nvcc!

The HPX PR STEllAR-GROUP/hpx#6492 addresses the HPX side of this problem. In turn, this PR adds the (minor) changes that are required within Kokkos itself (helping nvcc a bit with the template deduction).

Using both PRs together (with CUDA 12.3 and gcc/12.3.0) everything compiles and seems to work correctly!

Pinging @msimberg as he came up with the solution, I was merely the one reporting the issue and testing the fixes!