### PR TITLE
Improve `Impl::is_zero_byte()`

### DIFF
--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2529,11 +2529,9 @@ struct ViewDataHandle<
 namespace Kokkos {
 namespace Impl {
 
-inline static constexpr std::byte all_zeroes[256] = {};
-
 template <typename T>
 bool is_zero_byte(const T& x) {
-  if (sizeof(T) > sizeof(all_zeroes)) return false;  // out of luck
+  constexpr std::byte all_zeroes[sizeof(T)] = {};
   return std::memcmp(&x, all_zeroes, sizeof(T)) == 0;
 }
 


### PR DESCRIPTION
Follow up on #7014
Simplify the logic, do not copy the value and use `memcmp`,  trust that the standard library implementers know what they are doing.
I assumed that no one will stuff elements of size exceeding 256 bytes in views.  It just means that the `ZeroMemset` code path would not be exerted if that happens, code correctness would not be affected.