### PR TITLE
Fixup for disabling deprecation warnings with NVC++

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -563,7 +563,12 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 #endif
 
 // clang-format off
-#if defined(__EDG__)
+#if defined(__NVCOMPILER)
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH() \
+    _Pragma("diag_suppress 1216")
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP() \
+    _Pragma("diag_default 1216")
+#elif defined(__EDG__)
   #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH() \
     _Pragma("warning push")                              \
     _Pragma("warning disable 1478")


### PR DESCRIPTION
Fixup for #6999

Deprecation warnings are still showing in the OpenACC CI build
```
"/var/jenkins/workspace/Kokkos_PR-7017/core/unit_test/TestArrayOps.hpp", line 136: warning: class "Kokkos::Array<int, 18446744073709551615UL, Kokkos::Impl::KokkosArrayContiguous>" was declared deprecated [deprecated_entity]
    using A =
          ^
"/var/jenkins/workspace/Kokkos_PR-7017/core/src/Kokkos_Array.hpp", line 217: note: because of a "deprecated" attribute
  struct KOKKOS_DEPRECATED
         ^

Remark: individual warnings can be suppressed with "--diag_suppress <warning-name>"

"/var/jenkins/workspace/Kokkos_PR-7017/core/unit_test/TestArrayOps.hpp", line 197: warning: class "Kokkos::Array<int, 18446744073709551615UL, Kokkos::Impl::KokkosArrayContiguous>" was declared deprecated [deprecated_entity]
    using A =
          ^
"/var/jenkins/workspace/Kokkos_PR-7017/core/src/Kokkos_Array.hpp", line 217: note: because of a "deprecated" attribute
  struct KOKKOS_DEPRECATED
         ^

"/var/jenkins/workspace/Kokkos_PR-7017/core/unit_test/TestArrayOps.hpp", line 274: warning: class "Kokkos::Array<int, 18446744073709551615UL, Kokkos::Impl::KokkosArrayStrided>" was declared deprecated [deprecated_entity]
    using A = Kokkos::Array<int, KOKKOS_INVALID_INDEX, Kokkos::Array<>::strided>;
          ^
"/var/jenkins/workspace/Kokkos_PR-7017/core/src/Kokkos_Array.hpp", line 286: note: because of a "deprecated" attribute
  struct KOKKOS_DEPRECATED
         ^

"/var/jenkins/workspace/Kokkos_PR-7017/core/unit_test/TestArrayOps.hpp", line 338: warning: class "Kokkos::Array<int, 18446744073709551615UL, Kokkos::Impl::KokkosArrayStrided>" was declared deprecated [deprecated_entity]
    using A  = Kokkos::Array<int, KOKKOS_INVALID_INDEX, Kokkos::Array<>::strided>;
          ^
"/var/jenkins/workspace/Kokkos_PR-7017/core/src/Kokkos_Array.hpp", line 286: note: because of a "deprecated" attribute
  struct KOKKOS_DEPRECATED
         ^

```

The generic EDG warning disable did not work so we handle NVC++ separately and use diagnostic pragmas.

In case anyone wants to try something else https://godbolt.org/z/nxWbPMT95