### PR TITLE
OpenMPTarget: Fix compiling Graph tests

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -383,7 +383,6 @@ endforeach()
 # Disable non-compiling tests based on clang version.
 if(Kokkos_ENABLE_OPENMPTARGET)
   list(REMOVE_ITEM OpenMPTarget_SOURCES
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Graph.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Other.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamCombinedReducers.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamReductionScan.cpp

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -130,7 +130,12 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), launch_six) {
         Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>{{0, 0}, {1, 1}},
         count_functor{count, bugs, 0, 6});
     //----------------------------------------
-    ready.then_parallel_for(Kokkos::TeamPolicy<TEST_EXECSPACE>{1, 1},
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+    int team_size = 32;
+#else
+    int team_size = 1;
+#endif
+    ready.then_parallel_for(Kokkos::TeamPolicy<TEST_EXECSPACE>{1, team_size},
                             count_functor{count, bugs, 0, 6});
     //----------------------------------------
     ready.then_parallel_for(2, count_functor{count, bugs, 0, 6});


### PR DESCRIPTION
Moving the locks into `execute` fixes the issue and makes the relevant classes copyable. We only mess with scratch memory in `execute` and not in the constructor anyway. For consistency, I changed all classes even those that are not yet tested with Graphs.