### PR TITLE
Add tests to `ScopeGuard`

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -989,6 +989,13 @@ KOKKOS_ADD_EXECUTABLE_AND_TEST(
     UnitTest_PushFinalizeHook.cpp
 )
 
+KOKKOS_ADD_EXECUTABLE_AND_TEST(
+  CoreUnitTest_ScopeGuard
+  SOURCES
+    UnitTestMain.cpp
+    UnitTest_ScopeGuard.cpp
+)
+
 # This test is intended for development and debugging by putting code
 # into TestDefaultDeviceDevelop.cpp. By default its empty.
 KOKKOS_ADD_EXECUTABLE_AND_TEST(

--- a/core/unit_test/UnitTest_ScopeGuard.cpp
+++ b/core/unit_test/UnitTest_ScopeGuard.cpp
@@ -147,4 +147,8 @@ TEST_F(scope_guard_DeathTest, destroy_after_finalize) {
 static_assert(!std::is_copy_assignable<Kokkos::ScopeGuard>());
 static_assert(!std::is_copy_constructible<Kokkos::ScopeGuard>());
 
+// Test scope guard is not movable.
+static_assert(!std::is_move_assignable<Kokkos::ScopeGuard>());
+static_assert(!std::is_move_constructible<Kokkos::ScopeGuard>());
+
 }  // namespace

--- a/core/unit_test/UnitTest_ScopeGuard.cpp
+++ b/core/unit_test/UnitTest_ScopeGuard.cpp
@@ -1,0 +1,95 @@
+#include <cstdlib>
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+
+namespace Test {
+
+/**
+ * Test to create a scope guard normally.
+ */
+TEST(scope_guard, create) {
+  ASSERT_FALSE(Kokkos::is_initialized());
+  ASSERT_FALSE(Kokkos::is_finalized());
+
+  // run it in a different process so side effects are not kept
+  EXPECT_EXIT(
+      {
+        {
+          Kokkos::ScopeGuard guard{};
+
+          ASSERT_TRUE(Kokkos::is_initialized());
+          ASSERT_FALSE(Kokkos::is_finalized());
+        }
+
+        ASSERT_FALSE(Kokkos::is_initialized());
+        ASSERT_TRUE(Kokkos::is_finalized());
+
+        std::exit(EXIT_SUCCESS);
+      },
+      testing::ExitedWithCode(0), "");
+
+  ASSERT_FALSE(Kokkos::is_initialized());
+  ASSERT_FALSE(Kokkos::is_finalized());
+}
+
+/**
+ * Test to create another scope guard when one has been created.
+ */
+TEST(scope_guard, create_while_initialize) {
+  ASSERT_FALSE(Kokkos::is_initialized());
+  ASSERT_FALSE(Kokkos::is_finalized());
+
+  EXPECT_DEATH(
+      {
+        Kokkos::ScopeGuard guard1{};
+
+        // create a second scope guard while there is one already existing
+        Kokkos::ScopeGuard guard2{};
+      },
+      "Creating a ScopeGuard while Kokkos is initialized");
+
+  ASSERT_FALSE(Kokkos::is_initialized());
+  ASSERT_FALSE(Kokkos::is_finalized());
+}
+
+/**
+ * Test to create another scope guard when one has been destroyed.
+ */
+TEST(scope_guard, create_after_finalize) {
+  ASSERT_FALSE(Kokkos::is_initialized());
+  ASSERT_FALSE(Kokkos::is_finalized());
+
+  EXPECT_DEATH(
+      {
+        { Kokkos::ScopeGuard guard1{}; }
+
+        // create a second scope guard while the first one has been destroyed
+        // already
+        Kokkos::ScopeGuard guard2{};
+      },
+      "Creating a ScopeGuard after Kokkos was finalized");
+
+  ASSERT_FALSE(Kokkos::is_initialized());
+  ASSERT_FALSE(Kokkos::is_finalized());
+}
+
+/**
+ * Test to destroy a scope guard when finalization has been done manually.
+ */
+TEST(scope_guard, destroy_after_finalize) {
+  ASSERT_FALSE(Kokkos::is_initialized());
+  ASSERT_FALSE(Kokkos::is_finalized());
+
+  EXPECT_DEATH(
+      {
+        // create a scope guard and finalize it manually
+        Kokkos::ScopeGuard guard{};
+        Kokkos::finalize();
+      },
+      "Destroying a ScopeGuard after Kokkos was finalized");
+
+  ASSERT_FALSE(Kokkos::is_initialized());
+  ASSERT_FALSE(Kokkos::is_finalized());
+}
+
+}  // namespace Test

--- a/core/unit_test/UnitTest_ScopeGuard.cpp
+++ b/core/unit_test/UnitTest_ScopeGuard.cpp
@@ -95,6 +95,21 @@ TEST_F(scope_guard_DeathTest, create_while_initialize) {
 }
 
 /**
+ * Test to create a scope guard when initialization has been done manually.
+ */
+TEST_F(scope_guard_DeathTest, create_after_initialize) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_DEATH(
+      {
+        Kokkos::initialize();
+
+        // create a scope guard after manual initialization
+        Kokkos::ScopeGuard guard{};
+      },
+      "Creating a ScopeGuard while Kokkos is initialized");
+}
+
+/**
  * Test to create another scope guard when one has been destroyed.
  */
 TEST_F(scope_guard_DeathTest, create_after_finalize) {

--- a/core/unit_test/UnitTest_ScopeGuard.cpp
+++ b/core/unit_test/UnitTest_ScopeGuard.cpp
@@ -1,3 +1,19 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.3
+//       Copyright (2024) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
 #include <cstdlib>
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>

--- a/core/unit_test/UnitTest_ScopeGuard.cpp
+++ b/core/unit_test/UnitTest_ScopeGuard.cpp
@@ -80,16 +80,6 @@ TEST_F(scope_guard, create_argument) {
 }
 
 /**
- * Test scope guard is not copyable.
- */
-TEST_F(scope_guard, not_copyable) {
-  static_assert(!std::is_copy_assignable<Kokkos::ScopeGuard>());
-  static_assert(!std::is_copy_constructible<Kokkos::ScopeGuard>());
-
-  SUCCEED();
-}
-
-/**
  * Test to create another scope guard when one has been created.
  */
 TEST_F(scope_guard_DeathTest, create_while_initialize) {
@@ -130,5 +120,13 @@ TEST_F(scope_guard_DeathTest, destroy_after_finalize) {
       },
       "Destroying a ScopeGuard after Kokkos was finalized");
 }
+
+/**
+ * Static tests
+ */
+
+// Test scope guard is not copyable.
+static_assert(!std::is_copy_assignable<Kokkos::ScopeGuard>());
+static_assert(!std::is_copy_constructible<Kokkos::ScopeGuard>());
 
 }  // namespace

--- a/core/unit_test/UnitTest_ScopeGuard.cpp
+++ b/core/unit_test/UnitTest_ScopeGuard.cpp
@@ -37,7 +37,7 @@ class AssertEnvironmentTest : public ::testing::Test {
   }
 };
 
-using scope_guard = AssertEnvironmentTest;
+using scope_guard           = AssertEnvironmentTest;
 using scope_guard_DeathTest = AssertEnvironmentTest;
 
 /**

--- a/core/unit_test/UnitTest_ScopeGuard.cpp
+++ b/core/unit_test/UnitTest_ScopeGuard.cpp
@@ -18,6 +18,8 @@
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
 
+namespace {
+
 /**
  * Fixture that checks Kokkos is neither initialized nor finalized before and
  * after the test.
@@ -35,9 +37,8 @@ class AssertEnvironmentTest : public ::testing::Test {
   }
 };
 
-namespace Test {
-
 using scope_guard = AssertEnvironmentTest;
+using scope_guard_DeathTest = AssertEnvironmentTest;
 
 /**
  * Test to create a scope guard normally.
@@ -81,15 +82,17 @@ TEST_F(scope_guard, create_argument) {
 /**
  * Test scope guard is not copyable.
  */
-void static_test_not_copyable() {
+TEST_F(scope_guard, not_copyable) {
   static_assert(!std::is_copy_assignable<Kokkos::ScopeGuard>());
   static_assert(!std::is_copy_constructible<Kokkos::ScopeGuard>());
+
+  SUCCEED();
 }
 
 /**
  * Test to create another scope guard when one has been created.
  */
-TEST_F(scope_guard, create_while_initialize) {
+TEST_F(scope_guard_DeathTest, create_while_initialize) {
   EXPECT_DEATH(
       {
         Kokkos::ScopeGuard guard1{};
@@ -103,7 +106,7 @@ TEST_F(scope_guard, create_while_initialize) {
 /**
  * Test to create another scope guard when one has been destroyed.
  */
-TEST_F(scope_guard, create_after_finalize) {
+TEST_F(scope_guard_DeathTest, create_after_finalize) {
   EXPECT_DEATH(
       {
         { Kokkos::ScopeGuard guard1{}; }
@@ -118,7 +121,7 @@ TEST_F(scope_guard, create_after_finalize) {
 /**
  * Test to destroy a scope guard when finalization has been done manually.
  */
-TEST_F(scope_guard, destroy_after_finalize) {
+TEST_F(scope_guard_DeathTest, destroy_after_finalize) {
   EXPECT_DEATH(
       {
         // create a scope guard and finalize it manually
@@ -128,4 +131,4 @@ TEST_F(scope_guard, destroy_after_finalize) {
       "Destroying a ScopeGuard after Kokkos was finalized");
 }
 
-}  // namespace Test
+}  // namespace

--- a/core/unit_test/UnitTest_ScopeGuard.cpp
+++ b/core/unit_test/UnitTest_ScopeGuard.cpp
@@ -59,7 +59,7 @@ TEST_F(scope_guard, create) {
 
         std::exit(EXIT_SUCCESS);
       },
-      testing::ExitedWithCode(0), "");
+      testing::ExitedWithCode(EXIT_SUCCESS), "");
 }
 
 /**
@@ -76,7 +76,7 @@ TEST_F(scope_guard, create_argument) {
 
         std::exit(EXIT_SUCCESS);
       },
-      testing::ExitedWithCode(0), "");
+      testing::ExitedWithCode(EXIT_SUCCESS), "");
 }
 
 /**

--- a/core/unit_test/UnitTest_ScopeGuard.cpp
+++ b/core/unit_test/UnitTest_ScopeGuard.cpp
@@ -83,6 +83,7 @@ TEST_F(scope_guard, create_argument) {
  * Test to create another scope guard when one has been created.
  */
 TEST_F(scope_guard_DeathTest, create_while_initialize) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(
       {
         Kokkos::ScopeGuard guard1{};
@@ -97,6 +98,7 @@ TEST_F(scope_guard_DeathTest, create_while_initialize) {
  * Test to create another scope guard when one has been destroyed.
  */
 TEST_F(scope_guard_DeathTest, create_after_finalize) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(
       {
         { Kokkos::ScopeGuard guard1{}; }
@@ -112,6 +114,7 @@ TEST_F(scope_guard_DeathTest, create_after_finalize) {
  * Test to destroy a scope guard when finalization has been done manually.
  */
 TEST_F(scope_guard_DeathTest, destroy_after_finalize) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(
       {
         // create a scope guard and finalize it manually

--- a/core/unit_test/UnitTest_ScopeGuard.cpp
+++ b/core/unit_test/UnitTest_ScopeGuard.cpp
@@ -79,6 +79,14 @@ TEST_F(scope_guard, create_argument) {
 }
 
 /**
+ * Test scope guard is not copyable.
+ */
+void static_test_not_copyable() {
+  static_assert(!std::is_copy_assignable<Kokkos::ScopeGuard>());
+  static_assert(!std::is_copy_constructible<Kokkos::ScopeGuard>());
+}
+
+/**
  * Test to create another scope guard when one has been created.
  */
 TEST_F(scope_guard, create_while_initialize) {

--- a/core/unit_test/UnitTest_ScopeGuard.cpp
+++ b/core/unit_test/UnitTest_ScopeGuard.cpp
@@ -49,12 +49,12 @@ TEST_F(scope_guard, create) {
         {
           Kokkos::ScopeGuard guard{};
 
-          ASSERT_TRUE(Kokkos::is_initialized());
-          ASSERT_FALSE(Kokkos::is_finalized());
+          if (!Kokkos::is_initialized()) std::exit(EXIT_FAILURE);
+          if (Kokkos::is_finalized()) std::exit(EXIT_FAILURE);
         }
 
-        ASSERT_FALSE(Kokkos::is_initialized());
-        ASSERT_TRUE(Kokkos::is_finalized());
+        if (Kokkos::is_initialized()) std::exit(EXIT_FAILURE);
+        if (!Kokkos::is_finalized()) std::exit(EXIT_FAILURE);
 
         std::exit(EXIT_SUCCESS);
       },

--- a/core/unit_test/UnitTest_ScopeGuard.cpp
+++ b/core/unit_test/UnitTest_ScopeGuard.cpp
@@ -62,6 +62,23 @@ TEST_F(scope_guard, create) {
 }
 
 /**
+ * Test to create a scope guard with an argument.
+ */
+TEST_F(scope_guard, create_argument) {
+  // run it in a different process so side effects are not kept
+  EXPECT_EXIT(
+      {
+        {
+          Kokkos::InitializationSettings settings{};
+          Kokkos::ScopeGuard guard{settings};
+        }
+
+        std::exit(EXIT_SUCCESS);
+      },
+      testing::ExitedWithCode(0), "");
+}
+
+/**
  * Test to create another scope guard when one has been created.
  */
 TEST_F(scope_guard, create_while_initialize) {

--- a/core/unit_test/UnitTest_ScopeGuard.cpp
+++ b/core/unit_test/UnitTest_ScopeGuard.cpp
@@ -1,8 +1,8 @@
 //@HEADER
 // ************************************************************************
 //
-//                        Kokkos v. 4.3
-//       Copyright (2024) National Technology & Engineering
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
 //               Solutions of Sandia, LLC (NTESS).
 //
 // Under the terms of Contract DE-NA0003525 with NTESS,

--- a/core/unit_test/UnitTest_ScopeGuard.cpp
+++ b/core/unit_test/UnitTest_ScopeGuard.cpp
@@ -37,13 +37,13 @@ class AssertEnvironmentTest : public ::testing::Test {
   }
 };
 
-using scope_guard           = AssertEnvironmentTest;
 using scope_guard_DeathTest = AssertEnvironmentTest;
 
 /**
  * Test to create a scope guard normally.
  */
-TEST_F(scope_guard, create) {
+TEST_F(scope_guard_DeathTest, create) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   // run it in a different process so side effects are not kept
   EXPECT_EXIT(
       {
@@ -65,7 +65,8 @@ TEST_F(scope_guard, create) {
 /**
  * Test to create a scope guard with an argument.
  */
-TEST_F(scope_guard, create_argument) {
+TEST_F(scope_guard_DeathTest, create_argument) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   // run it in a different process so side effects are not kept
   EXPECT_EXIT(
       {


### PR DESCRIPTION
This PR aims to test the `Kokkos::ScopeGuard` class, that was untested.

No new features nor modifications were added to the core source code. A new test file `core/unit_test/UnitTest_ScopeGuard.cpp` was created and tests the scope guard on various configurations. Especially, faulty situations were tested, e.g. when creating two scope guards.