### PR TITLE
CTAD TeamPolicy (v3)

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -714,6 +714,58 @@ class TeamPolicy
   }
 };
 
+// Execution space not provided deduces to TeamPolicy<>
+
+TeamPolicy()->TeamPolicy<>;
+
+TeamPolicy(int, int)->TeamPolicy<>;
+TeamPolicy(int, int, int)->TeamPolicy<>;
+TeamPolicy(int, Kokkos::AUTO_t const&)->TeamPolicy<>;
+TeamPolicy(int, Kokkos::AUTO_t const&, int)->TeamPolicy<>;
+TeamPolicy(int, Kokkos::AUTO_t const&, Kokkos::AUTO_t const&)->TeamPolicy<>;
+TeamPolicy(int, int, Kokkos::AUTO_t const&)->TeamPolicy<>;
+
+// DefaultExecutionSpace deduces to TeamPolicy<>
+
+TeamPolicy(DefaultExecutionSpace const&, int, int)->TeamPolicy<>;
+TeamPolicy(DefaultExecutionSpace const&, int, int, int)->TeamPolicy<>;
+TeamPolicy(DefaultExecutionSpace const&, int, Kokkos::AUTO_t const&)
+    ->TeamPolicy<>;
+TeamPolicy(DefaultExecutionSpace const&, int, Kokkos::AUTO_t const&, int)
+    ->TeamPolicy<>;
+TeamPolicy(DefaultExecutionSpace const&, int, Kokkos::AUTO_t const&,
+           Kokkos::AUTO_t const&)
+    ->TeamPolicy<>;
+TeamPolicy(DefaultExecutionSpace const&, int, int, Kokkos::AUTO_t const&)
+    ->TeamPolicy<>;
+
+// ES != DefaultExecutionSpace deduces to TeamPolicy<ES>
+
+template <typename ES,
+          typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
+TeamPolicy(ES const&, int, int)->TeamPolicy<ES>;
+
+template <typename ES,
+          typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
+TeamPolicy(ES const&, int, int, int)->TeamPolicy<ES>;
+
+template <typename ES,
+          typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
+TeamPolicy(ES const&, int, Kokkos::AUTO_t const&)->TeamPolicy<ES>;
+
+template <typename ES,
+          typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
+TeamPolicy(ES const&, int, Kokkos::AUTO_t const&, int)->TeamPolicy<ES>;
+
+template <typename ES,
+          typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
+TeamPolicy(ES const&, int, Kokkos::AUTO_t const&, Kokkos::AUTO_t const&)
+    ->TeamPolicy<ES>;
+
+template <typename ES,
+          typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
+TeamPolicy(ES const&, int, int, Kokkos::AUTO_t const&)->TeamPolicy<ES>;
+
 namespace Impl {
 
 template <typename iType, class TeamMemberType>

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -93,6 +93,7 @@ SET(COMPILE_ONLY_SOURCES
   TestViewTypeTraits.cpp
   TestTypeList.cpp
   TestMDRangePolicyCTAD.cpp
+  TestTeamPolicyCTAD.cpp
   view/TestExtentsDatatypeConversion.cpp
 )
 

--- a/core/unit_test/TestTeamPolicyCTAD.cpp
+++ b/core/unit_test/TestTeamPolicyCTAD.cpp
@@ -1,0 +1,135 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+namespace {
+
+struct TestTeamPolicyCTAD {
+  template <typename... Ts>
+  static void maybe_unused(Ts&&...) {}
+
+  struct SomeExecutionSpace {
+    using execution_space = SomeExecutionSpace;
+    using size_type       = size_t;
+  };
+  static_assert(Kokkos::is_execution_space_v<SomeExecutionSpace>);
+
+  struct ImplicitlyConvertibleToDefaultExecutionSpace {
+    [[maybe_unused]] operator Kokkos::DefaultExecutionSpace() const {
+      return Kokkos::DefaultExecutionSpace();
+    }
+  };
+  static_assert(!Kokkos::is_execution_space_v<
+                ImplicitlyConvertibleToDefaultExecutionSpace>);
+
+  [[maybe_unused]] static inline Kokkos::DefaultExecutionSpace des;
+  [[maybe_unused]] static inline ImplicitlyConvertibleToDefaultExecutionSpace
+      notEs;
+  [[maybe_unused]] static inline SomeExecutionSpace ses;
+
+  [[maybe_unused]] static inline int i;
+
+  // Workaround for nvc++ (CUDA-11.7-NVHPC) ignoring [[maybe_unused]] on
+  // ImplicitlyConvertibleToDefaultExecutionSpace::operator
+  // Kokkos::DefaultExecutionSpace() const
+  [[maybe_unused]] static inline Kokkos::DefaultExecutionSpace notEsToDes =
+      notEs;
+
+  // Workaround for HIP-ROCm-5.2 warning about was declared but never referenced
+  TestTeamPolicyCTAD() { maybe_unused(des, notEs, ses, i, notEsToDes); }
+
+  // Default construction deduces to TeamPolicy<>
+  static_assert(
+      std::is_same_v<Kokkos::TeamPolicy<>, decltype(Kokkos::TeamPolicy{})>);
+
+  // Execution space not provided deduces to TeamPolicy<>
+
+  static_assert(
+      std::is_same_v<Kokkos::TeamPolicy<>, decltype(Kokkos::TeamPolicy(i, i))>);
+  static_assert(std::is_same_v<Kokkos::TeamPolicy<>,
+                               decltype(Kokkos::TeamPolicy(i, i, i))>);
+  static_assert(std::is_same_v<Kokkos::TeamPolicy<>,
+                               decltype(Kokkos::TeamPolicy(i, Kokkos::AUTO))>);
+  static_assert(
+      std::is_same_v<Kokkos::TeamPolicy<>,
+                     decltype(Kokkos::TeamPolicy(i, Kokkos::AUTO, i))>);
+  static_assert(std::is_same_v<Kokkos::TeamPolicy<>,
+                               decltype(Kokkos::TeamPolicy(i, Kokkos::AUTO,
+                                                           Kokkos::AUTO))>);
+  static_assert(
+      std::is_same_v<Kokkos::TeamPolicy<>,
+                     decltype(Kokkos::TeamPolicy(i, i, Kokkos::AUTO))>);
+
+  // DefaultExecutionSpace deduces to TeamPolicy<>
+
+  static_assert(std::is_same_v<Kokkos::TeamPolicy<>,
+                               decltype(Kokkos::TeamPolicy(des, i, i))>);
+  static_assert(std::is_same_v<Kokkos::TeamPolicy<>,
+                               decltype(Kokkos::TeamPolicy(des, i, i, i))>);
+  static_assert(
+      std::is_same_v<Kokkos::TeamPolicy<>,
+                     decltype(Kokkos::TeamPolicy(des, i, Kokkos::AUTO))>);
+  static_assert(
+      std::is_same_v<Kokkos::TeamPolicy<>,
+                     decltype(Kokkos::TeamPolicy(des, i, Kokkos::AUTO, i))>);
+  static_assert(std::is_same_v<Kokkos::TeamPolicy<>,
+                               decltype(Kokkos::TeamPolicy(des, i, Kokkos::AUTO,
+                                                           Kokkos::AUTO))>);
+  static_assert(
+      std::is_same_v<Kokkos::TeamPolicy<>,
+                     decltype(Kokkos::TeamPolicy(des, i, i, Kokkos::AUTO))>);
+
+  // Convertible to DefaultExecutionSpace deduces to TeamPolicy<>
+
+  static_assert(std::is_same_v<Kokkos::TeamPolicy<>,
+                               decltype(Kokkos::TeamPolicy(notEs, i, i))>);
+  static_assert(std::is_same_v<Kokkos::TeamPolicy<>,
+                               decltype(Kokkos::TeamPolicy(notEs, i, i, i))>);
+  static_assert(
+      std::is_same_v<Kokkos::TeamPolicy<>,
+                     decltype(Kokkos::TeamPolicy(notEs, i, Kokkos::AUTO))>);
+  static_assert(
+      std::is_same_v<Kokkos::TeamPolicy<>,
+                     decltype(Kokkos::TeamPolicy(notEs, i, Kokkos::AUTO, i))>);
+  static_assert(std::is_same_v<Kokkos::TeamPolicy<>,
+                               decltype(Kokkos::TeamPolicy(
+                                   notEs, i, Kokkos::AUTO, Kokkos::AUTO))>);
+  static_assert(
+      std::is_same_v<Kokkos::TeamPolicy<>,
+                     decltype(Kokkos::TeamPolicy(notEs, i, i, Kokkos::AUTO))>);
+
+  // SES != DefaultExecutionSpace deduces to TeamPolicy<SES>
+
+  static_assert(std::is_same_v<Kokkos::TeamPolicy<SomeExecutionSpace>,
+                               decltype(Kokkos::TeamPolicy(ses, i, i))>);
+  static_assert(std::is_same_v<Kokkos::TeamPolicy<SomeExecutionSpace>,
+                               decltype(Kokkos::TeamPolicy(ses, i, i, i))>);
+  static_assert(
+      std::is_same_v<Kokkos::TeamPolicy<SomeExecutionSpace>,
+                     decltype(Kokkos::TeamPolicy(ses, i, Kokkos::AUTO))>);
+  static_assert(
+      std::is_same_v<Kokkos::TeamPolicy<SomeExecutionSpace>,
+                     decltype(Kokkos::TeamPolicy(ses, i, Kokkos::AUTO, i))>);
+  static_assert(std::is_same_v<Kokkos::TeamPolicy<SomeExecutionSpace>,
+                               decltype(Kokkos::TeamPolicy(ses, i, Kokkos::AUTO,
+                                                           Kokkos::AUTO))>);
+  static_assert(
+      std::is_same_v<Kokkos::TeamPolicy<SomeExecutionSpace>,
+                     decltype(Kokkos::TeamPolicy(ses, i, i, Kokkos::AUTO))>);
+};
+
+}  // namespace


### PR DESCRIPTION
Starting with the deduction guides & test cases from ctad-teampolicy-v3
This compiles under llvm12, llvm18, gcc11 and gcc14.