### PR TITLE
Workaround icpc warnings

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1958,6 +1958,9 @@ inline auto create_mirror(const DynRankView<T, P...>& src,
     return dst_type(prop_copy,
                     Impl::reconstructLayout(src.layout(), src.rank()));
   }
+#if defined KOKKOS_COMPILER_INTEL
+  __builtin_unreachable();
+#endif
 }
 
 }  // namespace Impl
@@ -2055,6 +2058,9 @@ inline auto create_mirror_view(
       return Kokkos::Impl::create_mirror(src, arg_prop);
     }
   }
+#if defined KOKKOS_COMPILER_INTEL
+  __builtin_unreachable();
+#endif
 }
 
 }  // namespace Impl

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -621,6 +621,9 @@ inline auto create_mirror(const Kokkos::Experimental::DynamicView<T, P...>& src,
 
     return ret;
   }
+#if defined KOKKOS_COMPILER_INTEL
+  __builtin_unreachable();
+#endif
 }
 
 }  // namespace Impl
@@ -697,6 +700,9 @@ inline auto create_mirror_view(
       return Kokkos::Impl::create_mirror(src, arg_prop);
     }
   }
+#if defined KOKKOS_COMPILER_INTEL
+  __builtin_unreachable();
+#endif
 }
 
 }  // namespace Impl

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1864,6 +1864,9 @@ inline auto create_mirror(const Kokkos::Experimental::OffsetView<T, P...>& src,
     return typename Kokkos::Experimental::OffsetView<T, P...>::HostMirror(
         Kokkos::create_mirror(arg_prop, src.view()), src.begins());
   }
+#if defined KOKKOS_COMPILER_INTEL
+  __builtin_unreachable();
+#endif
 }
 
 }  // namespace Impl
@@ -1940,6 +1943,9 @@ inline auto create_mirror_view(
       return Kokkos::Impl::create_mirror(src, arg_prop);
     }
   }
+#if defined KOKKOS_COMPILER_INTEL
+  __builtin_unreachable();
+#endif
 }
 
 }  // namespace Impl

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3495,6 +3495,9 @@ inline auto create_mirror(const Kokkos::View<T, P...>& src,
     using dst_type = typename View<T, P...>::HostMirror;
     return dst_type(prop_copy, src.layout());
   }
+#if defined KOKKOS_COMPILER_INTEL
+  __builtin_unreachable();
+#endif
 }
 }  // namespace Impl
 
@@ -3583,6 +3586,9 @@ inline auto create_mirror_view(
       return Kokkos::Impl::create_mirror(src, arg_prop);
     }
   }
+#if defined KOKKOS_COMPILER_INTEL
+  __builtin_unreachable();
+#endif
 }
 }  // namespace Impl
 


### PR DESCRIPTION
Workaround "missing return statement at end of non-void function" warnings triggering -Werror with intel classic compilers Address issue #7031