### PR TITLE
Add ExecSpace constructor from MemSpace

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1096,7 +1096,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
         prop_copy,
         Impl::DynRankDimTraits<typename traits::specialize>::
             template createLayout<traits, P...>(arg_prop, arg_layout),
-        Impl::ViewCtorProp<P...>::has_execution_space);
+        Impl::ViewCtorProp<P...>::has_execution_space,
+        Impl::ViewCtorProp<P...>::has_memory_space);
 
     // Setup and initialization complete, start tracking
     m_track.assign_allocated_record_to_uninitialized(record);

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1189,7 +1189,8 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
 
     Kokkos::Impl::SharedAllocationRecord<>* record = m_map.allocate_shared(
         prop_copy, arg_layout,
-        Kokkos::Impl::ViewCtorProp<P...>::has_execution_space);
+        Kokkos::Impl::ViewCtorProp<P...>::has_execution_space,
+        Kokkos::Impl::ViewCtorProp<P...>::has_memory_space);
 
     // Setup and initialization complete, start tracking
     m_track.assign_allocated_record_to_uninitialized(record);

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -171,6 +171,11 @@ class Cuda {
 
   KOKKOS_DEPRECATED Cuda(cudaStream_t stream, bool manage_stream);
 
+  template <class MemSpace>
+  Cuda(const MemSpace& mem_space,
+       std::enable_if_t<Kokkos::is_memory_space<MemSpace>::value>* = nullptr)
+      : Cuda(mem_space.get_stream()) {}
+
   //--------------------------------------------------------------------------
   //! Free any resources being consumed by the device.
   static void impl_finalize();

--- a/core/src/Cuda/Kokkos_CudaSpace.hpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.hpp
@@ -118,6 +118,8 @@ class CudaSpace {
   /**\brief Return Name of the MemorySpace */
   static constexpr const char* name() { return m_name; }
 
+  cudaStream_t get_stream() const { return m_stream; }
+
  private:
   int m_device;
   cudaStream_t m_stream;
@@ -213,6 +215,8 @@ class CudaUVMSpace {
     return CudaUVMSpace(device_id, stream);
   }
 
+  cudaStream_t get_stream() const { return m_stream; }
+
  private:
   int m_device;
   cudaStream_t m_stream;
@@ -298,6 +302,8 @@ class CudaHostPinnedSpace {
  public:
   /**\brief Return Name of the MemorySpace */
   static constexpr const char* name() { return m_name; }
+
+  cudaStream_t get_stream() const { return m_stream; }
 
  private:
   int m_device;

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -52,6 +52,11 @@ class HIP {
       Impl::ManageStream manage_stream = Impl::ManageStream::no);
   KOKKOS_DEPRECATED HIP(hipStream_t stream, bool manage_stream);
 
+  template <class MemSpace>
+  HIP(const MemSpace&,
+      std::enable_if_t<Kokkos::is_memory_space<MemSpace>::value>* = nullptr)
+      : HIP() {}
+
   //@}
   //------------------------------------
   //! \name Functions that all Kokkos devices must implement.

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1485,9 +1485,9 @@ class View : public ViewTraits<DataType, Properties...> {
           i2, i3, i4, i5, i6, i7, alloc_name.c_str());
     }
 #endif
-
     Kokkos::Impl::SharedAllocationRecord<>* record = m_map.allocate_shared(
-        prop_copy, arg_layout, Impl::ViewCtorProp<P...>::has_execution_space);
+        prop_copy, arg_layout, Impl::ViewCtorProp<P...>::has_execution_space,
+        Impl::ViewCtorProp<P...>::has_memory_space);
 
     // Setup and initialization complete, start tracking
     m_track.m_tracker.assign_allocated_record_to_uninitialized(record);

--- a/core/src/OpenACC/Kokkos_OpenACC.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC.hpp
@@ -73,6 +73,11 @@ class OpenACC {
 
   OpenACC();
 
+  template <class MemSpace>
+  OpenACC(const MemSpace&,
+          std::enable_if_t<Kokkos::is_memory_space<MemSpace>::value>* = nullptr)
+      : OpenACC() {}
+
   explicit OpenACC(int async_arg);
 
   static void impl_initialize(InitializationSettings const& settings);

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -69,6 +69,11 @@ class OpenMP {
 
   OpenMP(int pool_size);
 
+  template <class MemSpace>
+  OpenMP(const MemSpace&,
+         std::enable_if_t<Kokkos::is_memory_space<MemSpace>::value>* = nullptr)
+      : OpenMP() {}
+
   /// \brief Print configuration information to the given output stream.
   void print_configuration(std::ostream& os, bool verbose = false) const;
 

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget.hpp
@@ -102,6 +102,13 @@ class OpenMPTarget {
   }
 
   OpenMPTarget();
+
+  template <class MemSpace>
+  OpenMPTarget(
+      const MemSpace&,
+      std::enable_if_t<Kokkos::is_memory_space<MemSpace>::value>* = nullptr)
+      : OpenMPTarget() {}
+
   uint32_t impl_instance_id() const noexcept;
 
  private:

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -65,6 +65,11 @@ class SYCL {
   SYCL();
   explicit SYCL(const sycl::queue&);
 
+  template <class MemSpace>
+  SYCL(const MemSpace&,
+       std::enable_if_t<Kokkos::is_memory_space<MemSpace>::value>* = nullptr)
+      : SYCL() {}
+
   uint32_t impl_instance_id() const noexcept {
     return m_space_instance->impl_get_instance_id();
   }

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -115,6 +115,11 @@ class Serial {
 
   Serial(NewInstance);
 
+  template <class MemSpace>
+  Serial(const MemSpace&,
+         std::enable_if_t<Kokkos::is_memory_space<MemSpace>::value>* = nullptr)
+      : Serial() {}
+
   /// \brief True if and only if this method is being called in a
   ///   thread-parallel function.
   ///

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -57,6 +57,13 @@ class Threads {
 
   using scratch_memory_space = ScratchMemorySpace<Threads>;
 
+  Threads() = default;
+
+  template <class MemSpace>
+  Threads(const MemSpace&,
+          std::enable_if_t<Kokkos::is_memory_space<MemSpace>::value>* = nullptr)
+      : Threads() {}
+
   //@}
   /*------------------------------------------------------------------------*/
   //! \name Static functions that all Kokkos devices must implement.

--- a/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
@@ -81,7 +81,7 @@ HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::
 
   fill_host_accessible_header_info(this, header, label);
 
-  typename MemorySpace::execution_space exec;
+  typename MemorySpace::execution_space exec(space);
   Kokkos::Impl::DeepCopy<MemorySpace, HostSpace>(
       exec, SharedAllocationRecord<void, void>::m_alloc_ptr, &header,
       sizeof(SharedAllocationHeader));

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -105,4 +105,26 @@ TEST(cuda_multi_gpu, scratch_space) {
     test_scratch(execs[0], execs[1]);
   }
 }
+
+TEST(cuda_muti_gpu, mem_space_view_construct) {
+  using ViewType = Kokkos::View<int *, TEST_EXECSPACE>;
+
+  StreamsAndDevices streams_and_devices;
+  {
+    std::array<TEST_EXECSPACE, 2> execs =
+        get_execution_spaces(streams_and_devices);
+
+    std::array<TEST_EXECSPACE::memory_space, 2> memspaces = {
+        TEST_EXECSPACE::memory_space::impl_create(execs[0].cuda_device(),
+                                                  execs[0].cuda_stream()),
+        TEST_EXECSPACE::memory_space::impl_create(execs[1].cuda_device(),
+                                                  execs[1].cuda_stream())};
+
+    std::array<ViewType, 2> views = {
+        ViewType(Kokkos::view_alloc("v0", memspaces[0]), 100),
+        ViewType(Kokkos::view_alloc("v", memspaces[1]), 100)};
+
+    test_policies(execs[0], views[0], execs[1], views[1]);
+  }
+}
 }  // namespace


### PR DESCRIPTION
This is the least evasive solution I thought of for the following problem.

### Problem: ###
Constructing a view from a cuda memory space defined on a non-default device does not allocate memory correctly:
```
Kokkos::View v(Kokkos::view_alloc(..., mem_space), N); // Allocation will be on default dev
                                                       // even if mem_space is not
```

The problem exists because inside `Kokkos_ViewMapping.hpp` and `Kokkos_SharedAlloc_tmpi.hpp`, default execution spaces are created and passed to `ZeroMemset` and `Impl::DeepCopy`, respectively.

This is a relatively common tripping point for multi-gpu, namely, code **not** in `core/src/Cuda` which work by creating default constructed exec/mem spaces which are obviously not on correct device (e.g. `kokkos_malloc()`, which poses similar problem for multi-gpu as mentioned in #6918).

### Solution: ###
Give each backend a constructor for execution space which takes in a memory space. Every other backend just default constructs, but it allows cuda to extract the correct stream.

### Notes: ###
- Leaving this as Draft since more tests would be needed. Didn't want to write them if people do not like this solution.
- Other solutions I considered...
  - Things like `ZeroMemset` and `DeepCopy` could have an overload that takes a memory space, then Cuda could internally extract the stream and create an execution space.
  - Memory spaces could contain a fall-back execution space instance that it points too instead of using a default constructed execution space.