### PR TITLE
Improve Kokkos Graphs

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -117,10 +117,7 @@ struct GraphImpl<Kokkos::Cuda> {
   //  requires NodeImplPtr is a shared_ptr to specialization of GraphNodeImpl
   //  Also requires that the kernel has the graph node tag in it's policy
   void add_node(std::shared_ptr<NodeImpl> const& arg_node_ptr) {
-    static_assert(
-        NodeImpl::kernel_type::Policy::is_graph_kernel::value,
-        "Something has gone horribly wrong, but it's too complicated to "
-        "explain here.  Buy Daisy a coffee and she'll explain it to you.");
+    static_assert(NodeImpl::kernel_type::Policy::is_graph_kernel::value);
     KOKKOS_EXPECTS(bool(arg_node_ptr));
     // The Kernel launch from the execute() method has been shimmed to insert
     // the node into the graph

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
@@ -50,6 +50,7 @@ class ParallelReduce<CombinedFunctorReducerType,
   using value_type     = typename ReducerType::value_type;
   using reference_type = typename ReducerType::reference_type;
   using functor_type   = FunctorType;
+  using reducer_type   = ReducerType;
   using size_type      = HIP::size_type;
 
   // Conditionally set word_size_type to int16_t or int8_t if value_type is

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
@@ -31,7 +31,7 @@ template <class CombinedFunctorReducerType, class... Properties>
 class ParallelReduce<CombinedFunctorReducerType,
                      Kokkos::TeamPolicy<Properties...>, HIP> {
  public:
-  using Policy      = TeamPolicyInternal<HIP, Properties...>;
+  using Policy      = TeamPolicy<Properties...>;
   using FunctorType = typename CombinedFunctorReducerType::functor_type;
   using ReducerType = typename CombinedFunctorReducerType::reducer_type;
 
@@ -46,6 +46,7 @@ class ParallelReduce<CombinedFunctorReducerType,
 
  public:
   using functor_type = FunctorType;
+  using reducer_type = ReducerType;
   using size_type    = HIP::size_type;
 
   // static int constexpr UseShflReduction = false;

--- a/core/src/impl/Kokkos_Default_Graph_Impl.hpp
+++ b/core/src/impl/Kokkos_Default_Graph_Impl.hpp
@@ -82,10 +82,7 @@ struct GraphImpl : private ExecutionSpaceInstanceStorage<ExecutionSpace> {
   template <class NodeImpl>
   //  requires NodeImplPtr is a shared_ptr to specialization of GraphNodeImpl
   void add_node(std::shared_ptr<NodeImpl> const& arg_node_ptr) {
-    static_assert(
-        NodeImpl::kernel_type::Policy::is_graph_kernel::value,
-        "Something has gone horribly wrong, but it's too complicated to "
-        "explain here.  Buy Daisy a coffee and she'll explain it to you.");
+    static_assert(NodeImpl::kernel_type::Policy::is_graph_kernel::value);
     // Since this is always called before any calls to add_predecessor involving
     // it, we can treat this node as a sink until we discover otherwise.
     arg_node_ptr->node_details_t::set_kernel(arg_node_ptr->get_kernel());

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -229,7 +229,8 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), zero_work_reduce) {
         root.then_parallel_reduce(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 0),
                                   no_op_functor, count)
 #if !defined(KOKKOS_ENABLE_SYCL)  // FIXME_SYCL
-#if !defined(KOKKOS_ENABLE_CUDA)  // FIXME_CUDA
+#if !defined(KOKKOS_ENABLE_CUDA) && \
+    !defined(KOKKOS_ENABLE_HIP)  // FIXME_CUDA FIXME_HIP
             .then_parallel_reduce(
                 Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>{{0, 0},
                                                                        {0, 0}},


### PR DESCRIPTION
Part of #6912. This pull request removes some strings from `static_assert`s that are not helpful anymore and expands the Kokkos::Graphs tests to cover all policies that the `Cuda` and `HIP` implementation support, i.e., everything except `parallel_scan`. This requires some fixes to `HIP` parallel constructs.