### PR TITLE
Structured binding support for Kokkos::complex

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -38,8 +38,10 @@ template <size_t I, typename ComplexForwardingRef>
 KOKKOS_FUNCTION constexpr auto&& complex_get(
     ComplexForwardingRef&& z) noexcept {
   static_assert(I < 2);
-  if constexpr (I == 0) return static_cast<ComplexForwardingRef&&>(z).re_;
-  if constexpr (I == 1) return static_cast<ComplexForwardingRef&&>(z).im_;
+  if constexpr (I == 0)
+    return static_cast<ComplexForwardingRef&&>(z).re_;
+  else
+    return static_cast<ComplexForwardingRef&&>(z).im_;
 }
 }  // namespace Impl
 

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -442,7 +442,8 @@ class
 
 }  // namespace Kokkos
 
-// Tuple protocol for complex based on https://wg21.link/p2819r2
+// Tuple protocol for complex based on https://wg21.link/p2819r2 (voted into
+// the C++26 working draft on 2023-11)
 template <typename RealType>
 struct std::tuple_size<Kokkos::complex<RealType>>
     : std::integral_constant<size_t, 2> {};

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -301,24 +301,24 @@ class
 
   template <size_t I>
   KOKKOS_FUNCTION friend constexpr RealType& get(complex& z) noexcept {
-    return get_ref<I>(z);
+    return complex::get_ref<I>(z);
   }
 
   template <size_t I>
   KOKKOS_FUNCTION friend constexpr RealType&& get(complex&& z) noexcept {
-    return get_ref<I>(std::move(z));
+    return complex::get_ref<I>(std::move(z));
   }
 
   template <size_t I>
   KOKKOS_FUNCTION friend constexpr const RealType& get(
       const complex& z) noexcept {
-    return get_ref<I>(z);
+    return complex::get_ref<I>(z);
   }
 
   template <size_t I>
   KOKKOS_FUNCTION friend constexpr const RealType&& get(
       const complex&& z) noexcept {
-    return get_ref<I>(std::move(z));
+    return complex::get_ref<I>(std::move(z));
   }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -39,9 +39,9 @@ KOKKOS_FUNCTION constexpr auto&& complex_get(
     ComplexForwardingRef&& z) noexcept {
   static_assert(I < 2);
   if constexpr (I == 0)
-    return static_cast<ComplexForwardingRef&&>(z).re_;
+    return std::forward<ComplexForwardingRef>(z).re_;
   else
-    return static_cast<ComplexForwardingRef&&>(z).im_;
+    return std::forward<ComplexForwardingRef>(z).im_;
 }
 }  // namespace Impl
 

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -603,7 +603,6 @@ TEST(TEST_CATEGORY, complex_structured_bindings) {
   ASSERT_EQ(li, z0.real());
   ASSERT_EQ(l.real(), z0.imag());
   ASSERT_EQ(l.imag(), z0.real());
-
 }
 
 }  // namespace Test

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -544,70 +544,6 @@ TEST(TEST_CATEGORY, complex_operations_arithmetic_types_overloads) {
                               Kokkos::complex<long double>>::value));
 }
 
-TEST(TEST_CATEGORY, complex_structured_bindings_ORIG) {
-  using Z = Kokkos::complex<double>;
-
-  // tuple_size
-  static_assert(std::is_same_v<std::tuple_size<Z>::type,
-                               std::integral_constant<size_t, 2>>);
-
-  // tuple_element
-  static_assert(std::is_same_v<std::tuple_element_t<0, Z>, Z::value_type>);
-  static_assert(std::is_same_v<std::tuple_element_t<1, Z>, Z::value_type>);
-
-  Z z(2., 3.);
-
-  // get lvalue
-  Z &l = z;
-  static_assert(std::is_same_v<decltype(Kokkos::get<0>(l)), Z::value_type &>);
-  static_assert(std::is_same_v<decltype(Kokkos::get<1>(l)), Z::value_type &>);
-  auto &[lr, li] = l;
-  ASSERT_EQ(lr, l.real());
-  ASSERT_EQ(li, l.imag());
-
-  // get const lvalue
-  Z const &c = z;
-  static_assert(
-      std::is_same_v<decltype(Kokkos::get<0>(c)), Z::value_type const &>);
-  static_assert(
-      std::is_same_v<decltype(Kokkos::get<1>(c)), Z::value_type const &>);
-  auto &[cr, ci] = c;
-  ASSERT_EQ(cr, c.real());
-  ASSERT_EQ(ci, c.imag());
-
-  // get rvalue
-  static_assert(
-      std::is_same_v<decltype(Kokkos::get<0>(Z(5., 7.))), Z::value_type &&>);
-  static_assert(
-      std::is_same_v<decltype(Kokkos::get<1>(Z(5., 7.))), Z::value_type &&>);
-
-  auto &&[rr, ri] = Z(5., 7.);
-  ASSERT_EQ(rr, 5.);
-  ASSERT_EQ(ri, 7.);
-
-  // get const rvalue
-  auto rc = []() -> Z const && {
-    static const Z zz(11., 13.);
-    return std::move(zz);
-  };
-  static_assert(
-      std::is_same_v<decltype(Kokkos::get<0>(rc())), Z::value_type const &&>);
-  static_assert(
-      std::is_same_v<decltype(Kokkos::get<1>(rc())), Z::value_type const &&>);
-
-  auto &&[crr, cri] = rc();
-  ASSERT_EQ(crr, rc().real());
-  ASSERT_EQ(cri, rc().imag());
-
-  // swap real and imaginary
-  const Z z0 = l;
-  std::swap(lr, li);
-  ASSERT_EQ(lr, z0.imag());
-  ASSERT_EQ(li, z0.real());
-  ASSERT_EQ(l.real(), z0.imag());
-  ASSERT_EQ(l.imag(), z0.real());
-}
-
 template <class ExecSpace>
 struct TestComplexStructuredBindings {
   using exec_space       = ExecSpace;
@@ -630,7 +566,7 @@ struct TestComplexStructuredBindings {
   host_view_type h_results;
 
   void testit() {
-    d_results = device_view_type("DeviceComplexStructuredBindings", 10);
+    d_results = device_view_type("TestComplexStructuredBindings", 6);
     h_results = Kokkos::create_mirror_view(d_results);
 
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0, 1), *this);

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -15,7 +15,6 @@
 //@HEADER
 
 #include <Kokkos_Core.hpp>
-#include <cstdio>
 #include <sstream>
 
 // Suppress "'long double' is treated as 'double' in device code"
@@ -543,6 +542,68 @@ TEST(TEST_CATEGORY, complex_operations_arithmetic_types_overloads) {
                               Kokkos::complex<double>>::value));
   static_assert((std::is_same<decltype(Kokkos::conj(4.l)),
                               Kokkos::complex<long double>>::value));
+}
+
+TEST(TEST_CATEGORY, complex_structured_bindings) {
+  using Z = Kokkos::complex<double>;
+
+  // tuple_size
+  static_assert(std::is_same_v<std::tuple_size<Z>::type,
+                               std::integral_constant<size_t, 2>>);
+
+  // tuple_element
+  static_assert(std::is_same_v<std::tuple_element_t<0, Z>, Z::value_type>);
+  static_assert(std::is_same_v<std::tuple_element_t<1, Z>, Z::value_type>);
+
+  Z z(2., 3.);
+
+  // get lvalue
+  Z &l = z;
+  static_assert(std::is_same_v<decltype(Kokkos::get<0>(l)), Z::value_type &>);
+  static_assert(std::is_same_v<decltype(Kokkos::get<1>(l)), Z::value_type &>);
+  auto &[lr, li] = l;
+  ASSERT_EQ(lr, l.real());
+  ASSERT_EQ(li, l.imag());
+
+  // get const lvalue
+  Z const &c = z;
+  static_assert(
+      std::is_same_v<decltype(Kokkos::get<0>(c)), Z::value_type const &>);
+  static_assert(
+      std::is_same_v<decltype(Kokkos::get<1>(c)), Z::value_type const &>);
+  auto &[cr, ci] = c;
+  ASSERT_EQ(cr, c.real());
+  ASSERT_EQ(ci, c.imag());
+
+  // get rvalue
+  static_assert(
+      std::is_same_v<decltype(Kokkos::get<0>(Z(5., 7.))), Z::value_type &&>);
+  static_assert(
+      std::is_same_v<decltype(Kokkos::get<1>(Z(5., 7.))), Z::value_type &&>);
+
+  auto &&[rr, ri] = Z(5., 7.);
+  ASSERT_EQ(rr, 5.);
+  ASSERT_EQ(ri, 7.);
+
+  // get const rvalue
+  static_assert(std::is_same_v<decltype(Kokkos::get<0>(
+                                   const_cast<Z const &&>(Z(11., 13.)))),
+                               Z::value_type const &&>);
+  static_assert(std::is_same_v<decltype(Kokkos::get<1>(
+                                   const_cast<Z const &&>(Z(11., 13.)))),
+                               Z::value_type const &&>);
+  auto &&[crr, cri] = const_cast<Z const &&>(Z(11., 13.));
+  ASSERT_EQ(crr, 11.);
+  ASSERT_EQ(cri, 13.);
+
+  // swap real and imaginary
+  const Z z0 = l;
+  std::swap(lr, li);
+  ASSERT_EQ(lr, z0.imag());
+  ASSERT_EQ(li, z0.real());
+  ASSERT_EQ(l.real(), z0.imag());
+  ASSERT_EQ(l.imag(), z0.real());
+
 }
 
 }  // namespace Test

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -557,6 +557,9 @@ struct TestComplexStructuredBindings {
   using device_view_type = Kokkos::View<complex_type *, exec_space>;
   using host_view_type   = typename device_view_type::HostMirror;
 
+  device_view_type d_results;
+  host_view_type h_results;
+
   // tuple_size
   static_assert(std::is_same_v<std::tuple_size<complex_type>::type,
                                std::integral_constant<size_t, 2>>);
@@ -567,37 +570,41 @@ struct TestComplexStructuredBindings {
   static_assert(
       std::is_same_v<std::tuple_element_t<1, complex_type>, value_type>);
 
-  // get<...>(...) return reference types
-  inline static complex_type mm;
-  inline static const complex_type cc;
+  static void testgetreturnreferencetypes() {
+    complex_type m;
+    const complex_type c;
 
-  inline static complex_type &mml = mm;
-  static_assert(std::is_same_v<decltype(Kokkos::get<0>(mml)), value_type &>);
-  static_assert(std::is_same_v<decltype(Kokkos::get<1>(mml)), value_type &>);
+    // get lvalue
+    complex_type &ml = m;
+    static_assert(std::is_same_v<decltype(Kokkos::get<0>(ml)), value_type &>);
+    static_assert(std::is_same_v<decltype(Kokkos::get<1>(ml)), value_type &>);
 
-  inline static complex_type &&mmr = std::move(mm);
-  static_assert(
-      std::is_same_v<decltype(Kokkos::get<0>(std::move(mmr))), value_type &&>);
-  static_assert(
-      std::is_same_v<decltype(Kokkos::get<1>(std::move(mmr))), value_type &&>);
+    // get rvalue
+    complex_type &&mr = std::move(m);
+    static_assert(
+        std::is_same_v<decltype(Kokkos::get<0>(std::move(mr))), value_type &&>);
+    static_assert(
+        std::is_same_v<decltype(Kokkos::get<1>(std::move(mr))), value_type &&>);
 
-  inline static const complex_type &ccl = cc;
-  static_assert(
-      std::is_same_v<decltype(Kokkos::get<0>(ccl)), value_type const &>);
-  static_assert(
-      std::is_same_v<decltype(Kokkos::get<1>(ccl)), value_type const &>);
+    // get const lvalue
+    const complex_type &cl = c;
+    static_assert(
+        std::is_same_v<decltype(Kokkos::get<0>(cl)), value_type const &>);
+    static_assert(
+        std::is_same_v<decltype(Kokkos::get<1>(cl)), value_type const &>);
 
-  inline static complex_type const &&ccr = std::move(cc);
-  static_assert(std::is_same_v<decltype(Kokkos::get<0>(std::move(ccr))),
-                               value_type const &&>);
-  static_assert(std::is_same_v<decltype(Kokkos::get<1>(std::move(ccr))),
-                               value_type const &&>);
+    // get const rvalue
+    complex_type const &&cr = std::move(c);
+    static_assert(std::is_same_v<decltype(Kokkos::get<0>(std::move(cr))),
+                                 value_type const &&>);
+    static_assert(std::is_same_v<decltype(Kokkos::get<1>(std::move(cr))),
+                                 value_type const &&>);
 
-  device_view_type d_results;
-  host_view_type h_results;
+    maybe_unused(m, c, ml, mr, cl, cr);
+  }
 
   void testit() {
-    maybe_unused(mm, cc, mml, mmr, ccl, ccr);
+    testgetreturnreferencetypes();
 
     d_results = device_view_type("TestComplexStructuredBindings", 6);
     h_results = Kokkos::create_mirror_view(d_results);

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -586,15 +586,18 @@ TEST(TEST_CATEGORY, complex_structured_bindings) {
   ASSERT_EQ(ri, 7.);
 
   // get const rvalue
-  static_assert(std::is_same_v<decltype(Kokkos::get<0>(
-                                   const_cast<Z const &&>(Z(11., 13.)))),
-                               Z::value_type const &&>);
-  static_assert(std::is_same_v<decltype(Kokkos::get<1>(
-                                   const_cast<Z const &&>(Z(11., 13.)))),
-                               Z::value_type const &&>);
-  auto &&[crr, cri] = const_cast<Z const &&>(Z(11., 13.));
-  ASSERT_EQ(crr, 11.);
-  ASSERT_EQ(cri, 13.);
+  auto rc = []() -> Z const && {
+    static const Z zz(11., 13.);
+    return std::move(zz);
+  };
+  static_assert(
+      std::is_same_v<decltype(Kokkos::get<0>(rc())), Z::value_type const &&>);
+  static_assert(
+      std::is_same_v<decltype(Kokkos::get<1>(rc())), Z::value_type const &&>);
+
+  auto &&[crr, cri] = rc();
+  ASSERT_EQ(crr, rc().real());
+  ASSERT_EQ(cri, rc().imag());
 
   // swap real and imaginary
   const Z z0 = l;

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -574,26 +574,26 @@ struct TestComplexStructuredBindings {
     Kokkos::deep_copy(h_results, d_results);
 
     // get lvalue
-    ASSERT_FLOAT_EQ(d_results[0].real(), 2.);
-    ASSERT_FLOAT_EQ(d_results[0].imag(), 3.);
+    ASSERT_FLOAT_EQ(h_results[0].real(), 2.);
+    ASSERT_FLOAT_EQ(h_results[0].imag(), 3.);
 
     // get const lvalue
-    ASSERT_FLOAT_EQ(d_results[1].real(), 5.);
-    ASSERT_FLOAT_EQ(d_results[1].imag(), 7.);
+    ASSERT_FLOAT_EQ(h_results[1].real(), 5.);
+    ASSERT_FLOAT_EQ(h_results[1].imag(), 7.);
 
     // get rvalue
-    ASSERT_FLOAT_EQ(d_results[2].real(), 2.);
-    ASSERT_FLOAT_EQ(d_results[2].imag(), 3.);
+    ASSERT_FLOAT_EQ(h_results[2].real(), 2.);
+    ASSERT_FLOAT_EQ(h_results[2].imag(), 3.);
 
     // get const rvalue
-    ASSERT_FLOAT_EQ(d_results[3].real(), 5.);
-    ASSERT_FLOAT_EQ(d_results[3].imag(), 7.);
+    ASSERT_FLOAT_EQ(h_results[3].real(), 5.);
+    ASSERT_FLOAT_EQ(h_results[3].imag(), 7.);
 
     // swap real and imaginary
-    ASSERT_FLOAT_EQ(d_results[4].real(), 11.);
-    ASSERT_FLOAT_EQ(d_results[4].imag(), 13.);
-    ASSERT_FLOAT_EQ(d_results[5].real(), 13.);
-    ASSERT_FLOAT_EQ(d_results[5].imag(), 11.);
+    ASSERT_FLOAT_EQ(h_results[4].real(), 11.);
+    ASSERT_FLOAT_EQ(h_results[4].imag(), 13.);
+    ASSERT_FLOAT_EQ(h_results[5].real(), 13.);
+    ASSERT_FLOAT_EQ(h_results[5].imag(), 11.);
   }
 
   KOKKOS_FUNCTION

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -578,71 +578,80 @@ struct TestComplexStructuredBindings {
     ASSERT_FLOAT_EQ(d_results[0].imag(), 3.);
 
     // get const lvalue
-    ASSERT_FLOAT_EQ(d_results[1].real(), 2.);
-    ASSERT_FLOAT_EQ(d_results[1].imag(), 3.);
+    ASSERT_FLOAT_EQ(d_results[1].real(), 5.);
+    ASSERT_FLOAT_EQ(d_results[1].imag(), 7.);
 
     // get rvalue
-    ASSERT_FLOAT_EQ(d_results[2].real(), 5.);
-    ASSERT_FLOAT_EQ(d_results[2].imag(), 7.);
+    ASSERT_FLOAT_EQ(d_results[2].real(), 2.);
+    ASSERT_FLOAT_EQ(d_results[2].imag(), 3.);
 
     // get const rvalue
-    ASSERT_FLOAT_EQ(d_results[3].real(), 11.);
-    ASSERT_FLOAT_EQ(d_results[3].imag(), 13.);
+    ASSERT_FLOAT_EQ(d_results[3].real(), 5.);
+    ASSERT_FLOAT_EQ(d_results[3].imag(), 7.);
 
     // swap real and imaginary
-    ASSERT_FLOAT_EQ(d_results[4].real(), 2.);
-    ASSERT_FLOAT_EQ(d_results[4].imag(), 3.);
-    ASSERT_FLOAT_EQ(d_results[5].real(), 3.);
-    ASSERT_FLOAT_EQ(d_results[5].imag(), 2.);
+    ASSERT_FLOAT_EQ(d_results[4].real(), 11.);
+    ASSERT_FLOAT_EQ(d_results[4].imag(), 13.);
+    ASSERT_FLOAT_EQ(d_results[5].real(), 13.);
+    ASSERT_FLOAT_EQ(d_results[5].imag(), 11.);
   }
 
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_FUNCTION
   void operator()(int) const {
-    complex_type z(2., 3.);
+    complex_type m(2., 3.);
+    const complex_type c(5., 7.);
 
     // get lvalue
-    complex_type &l = z;
-    static_assert(std::is_same_v<decltype(Kokkos::get<0>(l)), value_type &>);
-    static_assert(std::is_same_v<decltype(Kokkos::get<1>(l)), value_type &>);
-    auto &[lr, li] = l;
-    d_results[0]   = complex_type(lr, li);
+    {
+      complex_type &ml = m;
+      static_assert(std::is_same_v<decltype(Kokkos::get<0>(ml)), value_type &>);
+      static_assert(std::is_same_v<decltype(Kokkos::get<1>(ml)), value_type &>);
+      auto &[mlr, mli] = ml;
+      d_results[0]     = complex_type(mlr, mli);
+    }
 
     // get const lvalue
-    complex_type const &c = z;
-    static_assert(
-        std::is_same_v<decltype(Kokkos::get<0>(c)), value_type const &>);
-    static_assert(
-        std::is_same_v<decltype(Kokkos::get<1>(c)), value_type const &>);
-    auto &[cr, ci] = c;
-    d_results[1]   = complex_type(cr, ci);
+    {
+      const complex_type &cl = c;
+      static_assert(
+          std::is_same_v<decltype(Kokkos::get<0>(cl)), value_type const &>);
+      static_assert(
+          std::is_same_v<decltype(Kokkos::get<1>(cl)), value_type const &>);
+      auto &[clr, cli] = cl;
+      d_results[1]     = complex_type(clr, cli);
+    }
 
     // get rvalue
-    static_assert(std::is_same_v<decltype(Kokkos::get<0>(complex_type(5., 7.))),
-                                 value_type &&>);
-    static_assert(std::is_same_v<decltype(Kokkos::get<1>(complex_type(5., 7.))),
-                                 value_type &&>);
-
-    auto &&[rr, ri] = complex_type(5., 7.);
-    d_results[2]    = complex_type(rr, ri);
+    {
+      complex_type &&mr = std::move(m);
+      static_assert(std::is_same_v<decltype(Kokkos::get<0>(std::move(mr))),
+                                   value_type &&>);
+      static_assert(std::is_same_v<decltype(Kokkos::get<1>(std::move(mr))),
+                                   value_type &&>);
+      auto &&[mrr, mri] = std::move(mr);
+      d_results[2]      = complex_type(mrr, mri);
+    }
 
     // get const rvalue
-    auto rc = []() -> complex_type const && {
-      static const complex_type zz(11., 13.);
-      return std::move(zz);
-    };
-    static_assert(
-        std::is_same_v<decltype(Kokkos::get<0>(rc())), value_type const &&>);
-    static_assert(
-        std::is_same_v<decltype(Kokkos::get<1>(rc())), value_type const &&>);
-
-    auto &&[crr, cri] = rc();
-    d_results[3]      = complex_type(crr, cri);
+    {
+      complex_type const &&cr = std::move(c);
+      static_assert(std::is_same_v<decltype(Kokkos::get<0>(std::move(cr))),
+                                   value_type const &&>);
+      static_assert(std::is_same_v<decltype(Kokkos::get<1>(std::move(cr))),
+                                   value_type const &&>);
+      auto &&[crr, cri] = std::move(cr);
+      d_results[3]      = complex_type(crr, cri);
+    }
 
     // swap real and imaginary
-    const complex_type l0 = l;
-    Kokkos::kokkos_swap(lr, li);
-    d_results[4] = l0;
-    d_results[5] = l;
+    {
+      complex_type z(11., 13.);
+      d_results[4] = z;
+
+      auto &[zr, zi] = z;
+      Kokkos::kokkos_swap(zr, zi);
+      d_results[5] = z;
+    }
   }
 };
 


### PR DESCRIPTION
Following the model in [P2819R2](https://wg21..link/P2819R2) (voted into C++26 on 2023-11), this adds structured binding support for Kokkos::complex.