### PR TITLE
TestArray: add intel guard to to_array implicit conversion test

### DIFF
--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -176,8 +176,9 @@ constexpr bool test_to_array() {
   static_assert(std::is_same_v<decltype(a2), Kokkos::Array<int, 4>>);
   maybe_unused(a2);
 
-// gcc8 doesn't support the implicit conversion
-#if !defined(KOKKOS_COMPILER_GNU) || (KOKKOS_COMPILER_GNU >= 910)
+// gcc8 and icc do not support the implicit conversion
+#if !(defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 910)) && \
+    !(defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL < 2021))
   // deduces length with element type specified
   // implicit conversion happens
   [[maybe_unused]] auto a3 = Kokkos::to_array<long>({0, 1, 3});


### PR DESCRIPTION
resolve compilation errors with older intel/19.0.5 icpc compiler addresses issue #7038