### PR TITLE
Avoid using "#if not defined"

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsTeamExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamExclusiveScan.cpp
@@ -85,7 +85,7 @@ struct TestFunctorA {
         break;
       }
 
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
 
       case 2: {
         auto it = KE::exclusive_scan(
@@ -213,7 +213,7 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
         break;
       }
 
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
       case 2:
       case 3: {
         auto it = exclusive_scan(KE::cbegin(rowFrom), KE::cend(rowFrom),
@@ -242,7 +242,7 @@ template <class LayoutTag, class ValueType, class InPlaceOrVoid = void>
 void run_all_scenarios() {
   for (int numTeams : teamSizesToTest) {
     for (const auto& numCols : {0, 1, 2, 13, 101, 1444, 8153}) {
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
       for (int apiId : {0, 1, 2, 3}) {
 #else
       for (int apiId : {0, 1}) {

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamIsSorted.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamIsSorted.cpp
@@ -52,7 +52,7 @@ struct TestFunctorA {
       Kokkos::single(Kokkos::PerTeam(member),
                      [=, *this]() { m_returnsView(myRowIndex) = result; });
     }
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
     else if (m_apiPick == 2) {
       using value_type = typename ViewType::value_type;
       result = KE::is_sorted(member, KE::cbegin(myRowView), KE::cend(myRowView),
@@ -179,7 +179,7 @@ template <class LayoutTag, class ValueType>
 void run_all_scenarios(bool makeDataSortedOnPurpose) {
   for (int numTeams : teamSizesToTest) {
     for (const auto& numCols : {0, 1, 2, 13, 101, 1444, 5153}) {
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
       for (int apiId : {0, 1, 2, 3}) {
 #else
       for (int apiId : {0, 1}) {

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamIsSortedUntil.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamIsSortedUntil.cpp
@@ -73,7 +73,7 @@ struct TestFunctorA {
         m_distancesView(myRowIndex) = resultDist;
       });
     }
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
     else if (m_apiPick == 2) {
       using value_type = typename ViewType::value_type;
       auto it          = KE::is_sorted_until(member, KE::cbegin(myRowView),
@@ -226,7 +226,7 @@ template <class LayoutTag, class ValueType>
 void run_all_scenarios(const std::string& name, const std::vector<int>& cols) {
   for (int numTeams : teamSizesToTest) {
     for (const auto& numCols : cols) {
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
       for (int apiId : {0, 1, 2, 3}) {
 #else
       for (int apiId : {0, 1}) {

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamMaxElement.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamMaxElement.cpp
@@ -59,7 +59,7 @@ struct TestFunctorA {
         m_distancesView(myRowIndex) = resultDist;
       });
     }
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
     else if (m_apiPick == 2) {
       using value_type = typename ViewType::value_type;
       auto it =
@@ -170,7 +170,7 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_max_element_team_test, test) {
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedTwoRowsTag, double>();
   run_all_scenarios<StridedThreeRowsTag, int>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamMinElement.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamMinElement.cpp
@@ -59,7 +59,7 @@ struct TestFunctorA {
         m_distancesView(myRowIndex) = resultDist;
       });
     }
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
     else if (m_apiPick == 2) {
       using value_type = typename ViewType::value_type;
       auto it =
@@ -169,7 +169,7 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_min_element_team_test, test) {
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedTwoRowsTag, double>();
   run_all_scenarios<StridedThreeRowsTag, int>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamMinMaxElement.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamMinMaxElement.cpp
@@ -66,7 +66,7 @@ struct TestFunctorA {
         m_distancesView(myRowIndex, 1) = resultDist2;
       });
     }
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
     else if (m_apiPick == 2) {
       using value_type = typename ViewType::value_type;
       auto itPair =
@@ -188,7 +188,7 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_minmax_element_team_test, test) {
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedTwoRowsTag, double>();
   run_all_scenarios<StridedThreeRowsTag, int>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamReduce.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamReduce.cpp
@@ -16,7 +16,7 @@
 
 #include <TestStdAlgorithmsCommon.hpp>
 
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
 
 namespace Test {
 namespace stdalgos {

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamTransformExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamTransformExclusiveScan.cpp
@@ -16,7 +16,7 @@
 
 #include <TestStdAlgorithmsCommon.hpp>
 
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
 
 namespace Test {
 namespace stdalgos {

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamTransformInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamTransformInclusiveScan.cpp
@@ -16,7 +16,7 @@
 
 #include <TestStdAlgorithmsCommon.hpp>
 
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
 
 namespace Test {
 namespace stdalgos {

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamTransformReduce.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamTransformReduce.cpp
@@ -16,7 +16,7 @@
 
 #include <TestStdAlgorithmsCommon.hpp>
 
-#if not defined KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
 
 namespace Test {
 namespace stdalgos {


### PR DESCRIPTION
MSVC doesn't like "#if not defined" and emits warnings like
```
D:\a\kokkos\kokkos\algorithms\unit_tests\TestStdAlgorithmsTeamMinElement.cpp(172): warning C4067: unexpected tokens following preprocessor directive - expected a newline [D:\a\kokkos\kokkos\build\algorithms\unit_tests\Kokkos_AlgorithmsUnitTest_StdSet_Team_D.vcxproj]
```
It's not clear to me if this is valid preprocessor syntax or not but replacing it with `#ifndef` clearly is more standard.

Note that `MSVC` actually doesn't treat this correctly, see https://godbolt.org/z/x9nhG1sWq.