### PR TITLE
Add dependabot for GitHub Actions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: /
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adding `dependabot` should help avoid warnings in GitHub actions about outdated dependencies and increase the scorecard value. Thus, we wouldn't need pull requests like https://github.com/kokkos/kokkos/pull/6826 anymore.

Example: https://github.com/dealii/dealii/pull/16514, https://github.com/kokkos/kokkos-kernels/pull/2218. 

We (someone with write-access to the repository) should also check the configuration at https://github.com/kokkos/kokkos/settings/security_analysis). Also, see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates.