### PR TITLE
Add nightly CI on Frontier

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,13 @@
+test:
+  stage: test
+  tags: [frontier, shell]
+  id_tokens:
+    OLCF_ID_TOKEN:
+      aud: https://code.olcf.ornl.gov
+  script:
+    - module load rocm/6.0
+    - mkdir build
+    - cd build
+    - cmake -DCMAKE_CXX_COMPILER=hipcc -DKokkos_ENABLE_HIP=ON -DKokkos_ENABLE_TESTS=ON ..
+    - make -j16
+    - ctest -E Kokkos_CoreUnitTest_DeviceAndThreads -V

--- a/.olcf-gitlab-ci.yml
+++ b/.olcf-gitlab-ci.yml
@@ -6,8 +6,7 @@ test:
       aud: https://code.olcf.ornl.gov
   script:
     - module load rocm/6.0
-    - mkdir build
+    - cmake -B build -DCMAKE_CXX_COMPILER=hipcc -DKokkos_ENABLE_HIP=ON -DKokkos_ENABLE_TESTS=ON
+    - cmake --build build -j48
     - cd build
-    - cmake -DCMAKE_CXX_COMPILER=hipcc -DKokkos_ENABLE_HIP=ON -DKokkos_ENABLE_TESTS=ON ..
-    - make -j16
     - ctest -E Kokkos_CoreUnitTest_DeviceAndThreads -V


### PR DESCRIPTION
This PR adds a `.gitlab-ci.yml` configuration file to run a nightly CI on Frontier. I use a minimal configuration because that's the configuration used to create the Kokkos module on Frontier. I have disable the `DeviceAndThreads` test because the test uses python and there is an issue when we try to load some python module.