### PR TITLE
Update mdspan tpl and fix accessor type in mdspan conversion test

### DIFF
--- a/core/unit_test/TestMDSpanConversion.hpp
+++ b/core/unit_test/TestMDSpanConversion.hpp
@@ -22,6 +22,17 @@
 
 namespace {
 
+template <class Accessor>
+struct MakeConstAccessorImpl;
+
+template <template <class> class Accessor, class T>
+struct MakeConstAccessorImpl<Accessor<T>> {
+  using type = Accessor<const T>;
+};
+
+template <class Accessor>
+using make_const_accessor = typename MakeConstAccessorImpl<Accessor>::type;
+
 template <class T, class ExecutionSpace>
 struct TestViewMDSpanConversion {
   using value_type = T;
@@ -125,7 +136,7 @@ struct TestViewMDSpanConversion {
           Kokkos::dextents<typename natural_mdspan_type::index_type,
                            natural_mdspan_type::rank()>,
           typename natural_mdspan_type::layout_type,
-          typename natural_mdspan_type::accessor_type>;
+          make_const_accessor<typename natural_mdspan_type::accessor_type>>;
       mdspan_type cvt = v;
       ASSERT_EQ(cvt.data_handle(), v.data());
       ASSERT_EQ(cvt.mapping(), ref_layout_mapping);

--- a/tpls/mdspan/include/experimental/__p0009_bits/config.hpp
+++ b/tpls/mdspan/include/experimental/__p0009_bits/config.hpp
@@ -205,7 +205,7 @@ static_assert(_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or 
 #endif
 
 #ifndef _MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION
-#  if (!defined(__NVCC__) || (__CUDACC_VER_MAJOR__ >= 11 && __CUDACC_VER_MINOR__ >= 7)) && \
+#  if (!defined(__NVCC__) || (__CUDACC_VER_MAJOR__ * 100 + __CUDACC_VER_MINOR__ * 10 >= 1170)) && \
       ((defined(__cpp_deduction_guides) && __cpp_deduction_guides >= 201703) || \
        (!defined(__cpp_deduction_guides) && MDSPAN_HAS_CXX_17))
 #    define _MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION 1

--- a/tpls/mdspan/include/experimental/__p0009_bits/extents.hpp
+++ b/tpls/mdspan/include/experimental/__p0009_bits/extents.hpp
@@ -16,12 +16,15 @@
 
 #pragma once
 #include "dynamic_extent.hpp"
+#include "utility.hpp"
 
 #ifdef __cpp_lib_span
 #include <span>
 #endif
 #include <array>
+#include <type_traits>
 
+#include <cassert>
 #include <cinttypes>
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
@@ -59,8 +62,8 @@ template<class IndexType, class ... Arguments>
 MDSPAN_INLINE_FUNCTION
 static constexpr bool are_valid_indices() {
     return
-      (std::is_convertible<Arguments, IndexType>::value && ... && true) &&
-      (std::is_nothrow_constructible<IndexType, Arguments>::value && ... && true);
+      _MDSPAN_FOLD_AND(std::is_convertible<Arguments, IndexType>::value) &&
+      _MDSPAN_FOLD_AND(std::is_nothrow_constructible<IndexType, Arguments>::value);
 }
 
 // ------------------------------------------------------------------
@@ -538,14 +541,9 @@ public:
   MDSPAN_INLINE_FUNCTION friend constexpr bool
   operator==(const extents &lhs,
              const extents<OtherIndexType, OtherExtents...> &rhs) noexcept {
-    if constexpr (rank() != extents<OtherIndexType, OtherExtents...>::rank()) {
-      return false;
-    } else {
-      using common_t = std::common_type_t<index_type, OtherIndexType>;
-      for (size_type r = 0; r < m_rank; r++)
-        if(static_cast<common_t>(rhs.extent(r)) != static_cast<common_t>(lhs.extent(r))) return false;
-    }
-    return true;
+    return
+      rank() == extents<OtherIndexType, OtherExtents...>::rank() &&
+      detail::rankwise_equal(detail::with_rank<rank()>{}, rhs, lhs, detail::extent);
   }
 
 #if !(MDSPAN_HAS_CXX_20)
@@ -613,6 +611,81 @@ inline
 static
 #endif
 constexpr bool __is_extents_v = __is_extents<T>::value;
+
+template<class InputIndexType, class ExtentsIndexType>
+MDSPAN_INLINE_FUNCTION
+constexpr void
+check_lower_bound(InputIndexType user_index,
+                  ExtentsIndexType /* current_extent */,
+                  std::true_type /* is_signed */)
+{
+  (void) user_index; // prevent unused variable warning
+#ifdef _MDSPAN_DEBUG
+  assert(static_cast<ExtentsIndexType>(user_index) >= 0);
+#endif
+}
+
+template<class InputIndexType, class ExtentsIndexType>
+MDSPAN_INLINE_FUNCTION
+constexpr void
+check_lower_bound(InputIndexType /* user_index */,
+                  ExtentsIndexType /* current_extent */,
+                  std::false_type /* is_signed */)
+{}
+
+template<class InputIndexType, class ExtentsIndexType>
+MDSPAN_INLINE_FUNCTION
+constexpr void
+check_upper_bound(InputIndexType user_index,
+                  ExtentsIndexType current_extent)
+{
+  (void) user_index; // prevent unused variable warnings
+  (void) current_extent;
+#ifdef _MDSPAN_DEBUG
+  assert(static_cast<ExtentsIndexType>(user_index) < current_extent);
+#endif
+}
+
+// Returning true to use AND fold instead of comma
+// CPP14 mode doesn't like the use of void expressions
+// with the way the _MDSPAN_FOLD_AND is set up
+template<class InputIndex, class ExtentsIndexType>
+MDSPAN_INLINE_FUNCTION
+constexpr bool
+check_one_index(InputIndex user_index,
+                ExtentsIndexType current_extent)
+{
+  check_lower_bound(user_index, current_extent,
+    std::integral_constant<bool, std::is_signed<ExtentsIndexType>::value>{});
+  check_upper_bound(user_index, current_extent);
+  return true;
+}
+
+template<size_t ... RankIndices,
+         class ExtentsIndexType, size_t ... Exts,
+         class ... Indices>
+MDSPAN_INLINE_FUNCTION
+constexpr void
+check_all_indices_helper(std::index_sequence<RankIndices...>,
+                         const extents<ExtentsIndexType, Exts...>& exts,
+                         Indices... indices)
+{
+  // Suppress warning about statement has no effect
+  (void) _MDSPAN_FOLD_AND(
+    (check_one_index(indices, exts.extent(RankIndices)))
+  );
+}
+
+template<class ExtentsIndexType, size_t ... Exts,
+         class ... Indices>
+MDSPAN_INLINE_FUNCTION
+constexpr void
+check_all_indices(const extents<ExtentsIndexType, Exts...>& exts,
+                  Indices... indices)
+{
+  check_all_indices_helper(std::make_index_sequence<sizeof...(Indices)>(),
+                           exts, indices...);
+}
 
 } // namespace detail
 } // namespace MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/tpls/mdspan/include/experimental/__p0009_bits/layout_left.hpp
+++ b/tpls/mdspan/include/experimental/__p0009_bits/layout_left.hpp
@@ -18,8 +18,11 @@
 #include "macros.hpp"
 #include "trait_backports.hpp"
 #include "extents.hpp"
+#include "layout_stride.hpp"
+#include "utility.hpp"
+#if MDSPAN_HAS_CXX_17
 #include "../__p2642_bits/layout_padded_fwd.hpp"
-#include <cassert>
+#endif
 #include <type_traits>
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
@@ -133,11 +136,11 @@ class layout_left::mapping {
       : __extents(__other.extents())
     {
       MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::
-          check_padded_layout_converting_constructor_mandates<extents_type,
-                                                                _Mapping>();
+          check_padded_layout_converting_constructor_mandates<
+            extents_type, _Mapping>(detail::with_rank<extents_type::rank()>{});
       MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::
           check_padded_layout_converting_constructor_preconditions<
-              extents_type>(__other);
+              extents_type>(detail::with_rank<extents_type::rank()>{}, __other);
     }
 #endif
 
@@ -156,17 +159,7 @@ class layout_left::mapping {
         * TODO: check precondition
         * other.required_span_size() is a representable value of type index_type
         */
-       #if !defined(_MDSPAN_HAS_CUDA) && !defined(_MDSPAN_HAS_HIP) && !defined(NDEBUG)
-       if constexpr (extents_type::rank() > 0) {
-         index_type stride = 1;
-         using common_t = std::common_type_t<index_type, typename OtherExtents::index_type>;
-         for(rank_type r=0; r<__extents.rank(); r++) {
-           if(static_cast<common_t>(stride) != static_cast<common_t>(other.stride(r)))
-             std::abort(); // ("Assigning layout_stride to layout_left with invalid strides.");
-           stride *= __extents.extent(r);
-         }
-       }
-       #endif
+       detail::validate_strides(detail::with_rank<extents_type::rank()>{}, layout_left{}, __extents, other);
     }
 
     MDSPAN_INLINE_FUNCTION_DEFAULTED _MDSPAN_CONSTEXPR_14_DEFAULTED mapping& operator=(mapping const&) noexcept = default;
@@ -194,6 +187,9 @@ class layout_left::mapping {
     )
     _MDSPAN_HOST_DEVICE
     constexpr index_type operator()(Indices... idxs) const noexcept {
+#if ! defined(NDEBUG)
+      detail::check_all_indices(this->extents(), idxs...);
+#endif // ! NDEBUG
       return __compute_offset(__rank_count<0, extents_type::rank()>(), static_cast<index_type>(idxs)...);
     }
 

--- a/tpls/mdspan/include/experimental/__p0009_bits/layout_right.hpp
+++ b/tpls/mdspan/include/experimental/__p0009_bits/layout_right.hpp
@@ -18,9 +18,11 @@
 #include "macros.hpp"
 #include "trait_backports.hpp"
 #include "extents.hpp"
-#include <stdexcept>
 #include "layout_stride.hpp"
+#include "utility.hpp"
+#if MDSPAN_HAS_CXX_17
 #include "../__p2642_bits/layout_padded_fwd.hpp"
+#endif
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 
@@ -134,11 +136,11 @@ class layout_right::mapping {
         : __extents(__other.extents())
     {
       MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::
-          check_padded_layout_converting_constructor_mandates<extents_type,
-                                                                _Mapping>();
+          check_padded_layout_converting_constructor_mandates<
+            extents_type, _Mapping>(detail::with_rank<extents_type::rank()>{});
       MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::
           check_padded_layout_converting_constructor_preconditions<
-              extents_type>(__other);
+            extents_type>(detail::with_rank<extents_type::rank()>{}, __other);
     }
 #endif
 
@@ -157,17 +159,7 @@ class layout_right::mapping {
         * TODO: check precondition
         * other.required_span_size() is a representable value of type index_type
         */
-       #if !defined(_MDSPAN_HAS_CUDA) && !defined(_MDSPAN_HAS_HIP) && !defined(NDEBUG)
-       if constexpr (extents_type::rank() > 0) {
-         index_type stride = 1;
-         using common_t = std::common_type_t<index_type, typename OtherExtents::index_type>;
-         for(rank_type r=__extents.rank(); r>0; r--) {
-           if(static_cast<common_t>(stride) != static_cast<common_t>(other.stride(r-1)))
-             std::abort(); // ("Assigning layout_stride to layout_right with invalid strides.");
-           stride *= __extents.extent(r-1);
-         }
-       }
-       #endif
+       detail::validate_strides(detail::with_rank<extents_type::rank()>{}, layout_right{}, __extents, other);
     }
 
     MDSPAN_INLINE_FUNCTION_DEFAULTED _MDSPAN_CONSTEXPR_14_DEFAULTED mapping& operator=(mapping const&) noexcept = default;
@@ -195,6 +187,9 @@ class layout_right::mapping {
     )
     _MDSPAN_HOST_DEVICE
     constexpr index_type operator()(Indices... idxs) const noexcept {
+#if ! defined(NDEBUG)
+      detail::check_all_indices(this->extents(), idxs...);
+#endif // ! NDEBUG
       return __compute_offset(__rank_count<0, extents_type::rank()>(), static_cast<index_type>(idxs)...);
     }
 

--- a/tpls/mdspan/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/tpls/mdspan/include/experimental/__p0009_bits/layout_stride.hpp
@@ -19,14 +19,16 @@
 #include "extents.hpp"
 #include "trait_backports.hpp"
 #include "compressed_pair.hpp"
+#include "utility.hpp"
 
 #if !defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 #  include "no_unique_address.hpp"
 #endif
 
-#include <algorithm>
-#include <numeric>
 #include <array>
+#include <type_traits>
+#include <utility>
+
 #ifdef __cpp_lib_span
 #include <span>
 #endif
@@ -38,11 +40,11 @@ namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 
 struct layout_left {
   template<class Extents>
-    class mapping;
+  class mapping;
 };
 struct layout_right {
   template<class Extents>
-    class mapping;
+  class mapping;
 };
 
 namespace detail {
@@ -79,6 +81,7 @@ namespace detail {
     std::bool_constant<M::is_always_unique()>::value;
   };
 #endif
+
 } // namespace detail
 
 struct layout_stride {
@@ -199,9 +202,17 @@ struct layout_stride {
         return __strides_storage_t{static_cast<index_type>(s[Idxs])...};
       }
 
-      template<class IntegralType>
+      MDSPAN_TEMPLATE_REQUIRES(
+        class IntegralType,
+        // The is_convertible condition is added to make sfinae valid
+        // the extents_type::rank() > 0 is added to avoid use of non-standard zero length c-array
+        (std::is_convertible<IntegralType, typename extents_type::index_type>::value && (extents_type::rank() > 0))
+      )
       MDSPAN_INLINE_FUNCTION
-      static constexpr const __strides_storage_t fill_strides(mdspan_non_standard_tag, const IntegralType (&s)[extents_type::rank()]) {
+      // despite the requirement some compilers still complain about zero length array during parsing
+      // making it length 1 now, but since the thing can't be instantiated due to requirement the actual
+      // instantiation of strides_storage will not fail despite mismatching length
+      static constexpr const __strides_storage_t fill_strides(mdspan_non_standard_tag, const IntegralType (&s)[extents_type::rank()>0?extents_type::rank():1]) {
         return __strides_storage_t{static_cast<index_type>(s[Idxs])...};
       }
 
@@ -231,7 +242,11 @@ struct layout_stride {
     // Can't use defaulted parameter in the __deduction_workaround template because of a bug in MSVC warning C4348.
     using __impl = __deduction_workaround<std::make_index_sequence<Extents::rank()>>;
 
-    static constexpr __strides_storage_t strides_storage(std::true_type) {
+    static constexpr __strides_storage_t strides_storage(detail::with_rank<0>) {
+      return {};
+    }
+    template <std::size_t N>
+    static constexpr __strides_storage_t strides_storage(detail::with_rank<N>) {
       __strides_storage_t s{};
 
       extents_type e;
@@ -242,9 +257,6 @@ struct layout_stride {
       }
 
       return s;
-    }
-    static constexpr __strides_storage_t strides_storage(std::false_type) {
-      return {};
     }
 
     //----------------------------------------------------------------------------
@@ -268,7 +280,7 @@ struct layout_stride {
       : __base_t(__base_t{__member_pair_t(
 #endif
           extents_type(),
-          __strides_storage_t(strides_storage(std::integral_constant<bool, (extents_type::rank() > 0)>{}))
+          __strides_storage_t(strides_storage(detail::with_rank<extents_type::rank()>{}))
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
@@ -321,7 +333,8 @@ struct layout_stride {
         // MSVC 19.32 does not like using index_type here, requires the typename Extents::index_type
         // error C2641: cannot deduce template arguments for 'MDSPAN_IMPL_STANDARD_NAMESPACE::layout_stride::mapping'
         _MDSPAN_TRAIT(std::is_convertible, const std::remove_const_t<IntegralTypes>&, typename Extents::index_type) &&
-        _MDSPAN_TRAIT(std::is_nothrow_constructible, typename Extents::index_type, const std::remove_const_t<IntegralTypes>&)
+        _MDSPAN_TRAIT(std::is_nothrow_constructible, typename Extents::index_type, const std::remove_const_t<IntegralTypes>&) &&
+        (Extents::rank() > 0)
       )
     )
     MDSPAN_INLINE_FUNCTION
@@ -329,7 +342,10 @@ struct layout_stride {
     mapping(
       mdspan_non_standard_tag,
       extents_type const& e,
-      IntegralTypes (&s)[extents_type::rank()]
+      // despite the requirement some compilers still complain about zero length array during parsing
+      // making it length 1 now, but since the thing can't be instantiated due to requirement the actual
+      // instantiation of strides_storage will not fail despite mismatching length
+      IntegralTypes (&s)[extents_type::rank()>0?extents_type::rank():1]
     ) noexcept
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __members{
@@ -478,6 +494,9 @@ struct layout_stride {
     )
     MDSPAN_FORCE_INLINE_FUNCTION
     constexpr index_type operator()(Indices... idxs) const noexcept {
+#if ! defined(NDEBUG)
+      detail::check_all_indices(this->extents(), idxs...);
+#endif // ! NDEBUG
       return static_cast<index_type>(__impl::_call_op_impl(*this, static_cast<index_type>(idxs)...));
     }
 
@@ -488,32 +507,48 @@ struct layout_stride {
     MDSPAN_INLINE_FUNCTION static constexpr bool is_always_strided() noexcept { return true; }
 
     MDSPAN_INLINE_FUNCTION static constexpr bool is_unique() noexcept { return true; }
-    MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 bool is_exhaustive() const noexcept {
-      if constexpr (extents_type::rank() == 0)
-        return true;
-      else {
-        index_type span_size = required_span_size();
-        if (span_size == static_cast<index_type>(0)) {
-          if constexpr (extents_type::rank() == 1) {
-            return stride(0) == 1;
-          } else {
-            rank_type r_largest = 0;
-            for (rank_type r = 1; r < extents_type::rank(); r++) {
-              if (stride(r) > stride(r_largest)) {
-                r_largest = r;
-              }
-            }
-            for (rank_type r = 0; r < extents_type::rank(); r++) {
-              if (extents().extent(r) == 0 && r != r_largest) {
-                return false;
-              }
-            }
-            return true;
-          }
-        } else {
-          return required_span_size() == __get_size(extents(), std::make_index_sequence<extents_type::rank()>());
+
+  private:
+    constexpr bool exhaustive_for_nonzero_span_size() const
+    {
+      return required_span_size() == __get_size(extents(), std::make_index_sequence<extents_type::rank()>());
+    }
+
+    constexpr bool is_exhaustive_impl(detail::with_rank<0>) const
+    {
+      return true;
+    }
+    constexpr bool is_exhaustive_impl(detail::with_rank<1>) const
+    {
+      if (required_span_size() != static_cast<index_type>(0)) {
+        return exhaustive_for_nonzero_span_size();
+      }
+      return stride(0) == 1;
+    }
+    template <std::size_t N>
+    constexpr bool is_exhaustive_impl(detail::with_rank<N>) const
+    {
+      if (required_span_size() != static_cast<index_type>(0)) {
+        return exhaustive_for_nonzero_span_size();
+      }
+
+      rank_type r_largest = 0;
+      for (rank_type r = 1; r < extents_type::rank(); r++) {
+        if (stride(r) > stride(r_largest)) {
+          r_largest = r;
         }
       }
+      for (rank_type r = 0; r < extents_type::rank(); r++) {
+        if (extents().extent(r) == 0 && r != r_largest) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+  public:
+    MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 bool is_exhaustive() const noexcept {
+      return is_exhaustive_impl(detail::with_rank<extents_type::rank()>{});
     }
     MDSPAN_INLINE_FUNCTION static constexpr bool is_strided() noexcept { return true; }
 
@@ -542,15 +577,9 @@ struct layout_stride {
 #endif
     MDSPAN_INLINE_FUNCTION
     friend constexpr bool operator==(const mapping& x, const StridedLayoutMapping& y) noexcept {
-      bool strides_match = true;
-      if constexpr (extents_type::rank() > 0) {
-        using common_t = std::common_type_t<index_type, typename StridedLayoutMapping::index_type>;
-        for(rank_type r = 0; r < extents_type::rank(); r++)
-          strides_match = strides_match && (static_cast<common_t>(x.stride(r)) == static_cast<common_t>(y.stride(r)));
-      }
       return (x.extents() == y.extents()) &&
              (__impl::__OFFSET(y) == static_cast<typename StridedLayoutMapping::index_type>(0)) &&
-             strides_match;
+             detail::rankwise_equal(detail::with_rank<extents_type::rank()>{}, x, y, detail::stride);
     }
 
     // This one is not technically part of the proposal. Just here to make implementation a bit more optimal hopefully
@@ -605,4 +634,34 @@ struct layout_stride {
   };
 };
 
+namespace detail {
+
+template <class Layout, class Extents, class Mapping>
+constexpr void validate_strides(with_rank<0>, Layout, const Extents&, const Mapping&)
+{}
+
+template <std::size_t N, class Layout, class Extents, class Mapping>
+constexpr void validate_strides(with_rank<N>, Layout, const Extents& ext, const Mapping& other)
+{
+  static_assert(std::is_same<typename Mapping::layout_type, layout_stride>::value and
+                (std::is_same<Layout, layout_left>::value or
+                 std::is_same<Layout, layout_right>::value)
+                , "This function is only intended to validate construction of "
+                  "a layout_left or layout_right mapping from a layout_stride mapping.");
+
+  constexpr auto is_left = std::is_same<Layout, layout_left>::value;
+
+  typename Extents::index_type stride = 1;
+
+  for (std::size_t r = 0; r < N; r++) {
+    const std::size_t s = is_left ? r : N - 1 - r;
+
+    MDSPAN_IMPL_PRECONDITION(common_integral_compare(stride, other.stride(s))
+                             and "invalid strides for layout_{left,right}");
+
+    stride *= ext.extent(s);
+  }
+}
+
+} // namespace detail
 } // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/tpls/mdspan/include/experimental/__p0009_bits/macros.hpp
+++ b/tpls/mdspan/include/experimental/__p0009_bits/macros.hpp
@@ -18,7 +18,12 @@
 
 #include "config.hpp"
 
+#include <cstdio>
+#include <cstdlib>
 #include <type_traits> // std::is_void
+#if defined(_MDSPAN_HAS_CUDA) || defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_SYCL)
+#include "assert.h"
+#endif
 
 #ifndef _MDSPAN_HOST_DEVICE
 #  if defined(_MDSPAN_HAS_CUDA) || defined(_MDSPAN_HAS_HIP)
@@ -100,6 +105,69 @@
 
 #define MDSPAN_IMPL_STANDARD_NAMESPACE_STRING MDSPAN_PP_STRINGIFY(MDSPAN_IMPL_STANDARD_NAMESPACE)
 #define MDSPAN_IMPL_PROPOSED_NAMESPACE_STRING MDSPAN_PP_STRINGIFY(MDSPAN_IMPL_STANDARD_NAMESPACE) "::" MDSPAN_PP_STRINGIFY(MDSPAN_IMPL_PROPOSED_NAMESPACE)
+
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace detail {
+
+#if defined(_MDSPAN_HAS_CUDA) || defined(_MDSPAN_HAS_HIP)
+MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* cond, const char* file, unsigned line)
+{
+  printf("%s:%u: precondition failure: `%s`\n", file, line, cond);
+  assert(0);
+}
+#elif defined(_MDSPAN_HAS_SYCL)
+MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* cond, const char* file, unsigned line)
+{
+  sycl::ext::oneapi::experimental::printf("%s:%u: precondition failure: `%s`\n", file, line, cond);
+  assert(0);
+}
+#else
+MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* cond, const char* file, unsigned line)
+{
+  std::fprintf(stderr, "%s:%u: precondition failure: `%s`\n", file, line, cond);
+  std::abort();
+}
+#endif
+
+} // namespace detail
+} // namespace MDSPAN_IMPL_STANDARD_NAMESPACE
+
+#ifndef MDSPAN_IMPL_PRECONDITION_VIOLATION_HANDLER
+#define MDSPAN_IMPL_PRECONDITION_VIOLATION_HANDLER(cond, file, line) \
+  MDSPAN_IMPL_STANDARD_NAMESPACE::detail::default_precondition_violation_handler(cond, file, line)
+#endif
+
+#ifndef MDSPAN_IMPL_CHECK_PRECONDITION
+  #ifndef NDEBUG
+    #define MDSPAN_IMPL_CHECK_PRECONDITION 0
+  #else
+    #define MDSPAN_IMPL_CHECK_PRECONDITION 1
+  #endif
+#endif
+
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace detail {
+
+template <bool check = MDSPAN_IMPL_CHECK_PRECONDITION>
+MDSPAN_FUNCTION constexpr void precondition(const char* cond, const char* file, unsigned line)
+{
+  if (not check) { return; }
+  // in case the macro doesn't use the arguments for custom macros
+  (void) cond;
+  (void) file;
+  (void) line;
+  MDSPAN_IMPL_PRECONDITION_VIOLATION_HANDLER(cond, file, line);
+}
+
+} // namespace detail
+} // namespace MDSPAN_IMPL_STANDARD_NAMESPACE
+
+#define MDSPAN_IMPL_PRECONDITION(...) \
+  do { \
+    if (not (__VA_ARGS__)) { \
+      MDSPAN_IMPL_STANDARD_NAMESPACE::detail::precondition(#__VA_ARGS__, __FILE__, __LINE__); \
+    } \
+  } while (0)
 
 // </editor-fold> end Preprocessor helpers }}}1
 //==============================================================================
@@ -629,8 +697,3 @@ struct __bools;
 
 // </editor-fold> end Pre-C++14 constexpr }}}1
 //==============================================================================
-
-namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
-constexpr struct mdspan_non_standard_tag {
-} mdspan_non_standard;
-} // namespace MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/tpls/mdspan/include/experimental/__p0009_bits/mdspan.hpp
+++ b/tpls/mdspan/include/experimental/__p0009_bits/mdspan.hpp
@@ -34,6 +34,8 @@ class mdspan
 private:
   static_assert(detail::__is_extents_v<Extents>,
                 MDSPAN_IMPL_STANDARD_NAMESPACE_STRING "::mdspan's Extents template parameter must be a specialization of " MDSPAN_IMPL_STANDARD_NAMESPACE_STRING "::extents.");
+  static_assert(std::is_same<ElementType, typename AccessorPolicy::element_type>::value,
+                MDSPAN_IMPL_STANDARD_NAMESPACE_STRING "::mdspan's ElementType template parameter must be the same as its AccessorPolicy::element_type.");
 
   // Workaround for non-deducibility of the index sequence template parameter if it's given at the top level
   template <class>

--- a/tpls/mdspan/include/experimental/__p0009_bits/utility.hpp
+++ b/tpls/mdspan/include/experimental/__p0009_bits/utility.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace detail {
+
+// type alias used for rank-based tag dispatch
+//
+// this is used to enable alternatives to constexpr if when building for C++14
+//
+template <std::size_t N>
+using with_rank = std::integral_constant<std::size_t, N>;
+
+template <class I1, class I2>
+constexpr bool common_integral_compare(I1 x, I2 y)
+{
+  static_assert(std::is_integral<I1>::value and
+                std::is_integral<I2>::value, "");
+
+  using I = std::common_type_t<I1, I2>;
+  return static_cast<I>(x) == static_cast<I>(y);
+}
+
+template <class T1, class T2, class F>
+constexpr bool rankwise_equal(with_rank<0>, const T1&, const T2&, F)
+{
+  return true;
+}
+template <std::size_t N, class T1, class T2, class F>
+constexpr bool rankwise_equal(with_rank<N>, const T1& x, const T2& y, F func)
+{
+  bool match = true;
+
+  for (std::size_t r = 0; r < N; r++) {
+    match = match && common_integral_compare(func(x, r), func(y, r));
+  }
+
+  return match;
+}
+
+constexpr struct
+{
+  template <class T, class I>
+  constexpr auto operator()(const T& x, I i) const
+  {
+    return x.extent(i);
+  }
+} extent;
+
+constexpr struct
+{
+  template <class T, class I>
+  constexpr auto operator()(const T& x, I i) const
+  {
+    return x.stride(i);
+  }
+} stride;
+
+} // namespace detail
+
+constexpr struct mdspan_non_standard_tag {
+} mdspan_non_standard;
+
+} // namespace MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/tpls/mdspan/include/experimental/__p2389_bits/dims.hpp
+++ b/tpls/mdspan/include/experimental/__p2389_bits/dims.hpp
@@ -1,0 +1,28 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#pragma once
+
+// backward compatibility import into experimental
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
+
+template< ::std::size_t Rank, class IndexType = std::size_t>
+using dims =
+  :: MDSPAN_IMPL_STANDARD_NAMESPACE :: dextents<IndexType, Rank>;
+
+} // namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // namespace MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/tpls/mdspan/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/tpls/mdspan/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -31,6 +31,48 @@ template <class LayoutMapping> struct submdspan_mapping_result {
 };
 
 namespace detail {
+
+// We use const Slice& and not Slice&& because the various
+// submdspan_mapping_impl overloads use their slices arguments
+// multiple times.  This makes perfect forwarding not useful, but we
+// still don't want to pass those (possibly of size 64 x 3 bits)
+// objects by value.
+template<class IndexType,
+         class Slice>
+MDSPAN_INLINE_FUNCTION
+constexpr bool
+one_slice_out_of_bounds(const IndexType& extent, const Slice& slice)
+{
+  using common_t = std::common_type_t<decltype(detail::first_of(slice)), IndexType>;
+  return static_cast<common_t>(detail::first_of(slice)) == static_cast<common_t>(extent);
+}
+
+template<size_t ... RankIndices,
+         class IndexType, size_t ... Exts,
+         class ... Slices>
+MDSPAN_INLINE_FUNCTION
+constexpr bool
+any_slice_out_of_bounds_helper(std::index_sequence<RankIndices...>,
+                               const extents<IndexType, Exts...>& exts,
+                               const Slices& ... slices)
+{
+  return _MDSPAN_FOLD_OR(
+    (one_slice_out_of_bounds(exts.extent(RankIndices), slices))
+  );
+}
+
+template<class IndexType, size_t ... Exts,
+         class ... Slices>
+MDSPAN_INLINE_FUNCTION
+constexpr bool
+any_slice_out_of_bounds(const extents<IndexType, Exts...>& exts,
+                        const Slices& ... slices)
+{
+  return any_slice_out_of_bounds_helper(
+    std::make_index_sequence<sizeof...(Slices)>(),
+    exts, slices...);
+}
+  
 // constructs sub strides
 template <class SrcMapping, class... slice_strides, size_t... InvMapIdxs>
 MDSPAN_INLINE_FUNCTION
@@ -111,11 +153,19 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(SliceSpecifiers... slices)
       std::conditional_t<preserve_layout, layout_left, layout_stride>;
   using dst_mapping_t = typename dst_layout_t::template mapping<dst_ext_t>;
 
+  // Figure out if any slice's lower bound equals the corresponding extent.
+  // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
+  const bool out_of_bounds =
+    detail::any_slice_out_of_bounds(this->extents(), slices...);
+  auto offset = static_cast<size_t>(
+    out_of_bounds ?
+    this->required_span_size() :
+    this->operator()(detail::first_of(slices)...)
+  );
+
   if constexpr (std::is_same_v<dst_layout_t, layout_left>) {
     // layout_left case
-    return submdspan_mapping_result<dst_mapping_t>{
-        dst_mapping_t(dst_ext),
-        static_cast<size_t>(this->operator()(detail::first_of(slices)...))};
+    return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t(dst_ext), offset};
   } else {
     // layout_stride case
     auto inv_map = detail::inv_map_rank(
@@ -127,12 +177,13 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(SliceSpecifiers... slices)
                                    *this, inv_map,
     // HIP needs deduction guides to have markups so we need to be explicit
     // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have the issue
-    #if defined(_MDSPAN_HAS_HIP) || (defined(__NVCC__) && (__CUDACC_VER_MAJOR__ * 100 + __CUDACC_VER_MINOR__ * 10) < 1120)
+    // But Clang-CUDA also doesn't accept the use of deduction guide so disable it for CUDA alltogether
+    #if defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_CUDA)
                                    std::tuple<decltype(detail::stride_of(slices))...>{detail::stride_of(slices)...})),
     #else
                                    std::tuple{detail::stride_of(slices)...})),
     #endif
-        static_cast<size_t>(this->operator()(detail::first_of(slices)...))};
+        offset};
   }
 #if defined(__NVCC__) && !defined(__CUDA_ARCH__) && defined(__GNUC__)
   __builtin_unreachable();
@@ -218,11 +269,19 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
       std::conditional_t<preserve_layout, layout_right, layout_stride>;
   using dst_mapping_t = typename dst_layout_t::template mapping<dst_ext_t>;
 
+  // Figure out if any slice's lower bound equals the corresponding extent.
+  // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
+  const bool out_of_bounds =
+    detail::any_slice_out_of_bounds(this->extents(), slices...);
+  auto offset = static_cast<size_t>(
+    out_of_bounds ?
+    this->required_span_size() :
+    this->operator()(detail::first_of(slices)...)
+  );
+  
   if constexpr (std::is_same_v<dst_layout_t, layout_right>) {
     // layout_right case
-    return submdspan_mapping_result<dst_mapping_t>{
-        dst_mapping_t(dst_ext),
-        static_cast<size_t>(this->operator()(detail::first_of(slices)...))};
+    return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t(dst_ext), offset};
   } else {
     // layout_stride case
     auto inv_map = detail::inv_map_rank(
@@ -234,12 +293,13 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
                                    *this, inv_map,
     // HIP needs deduction guides to have markups so we need to be explicit
     // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have the issue
-    #if defined(_MDSPAN_HAS_HIP) || (defined(__NVCC__) && (__CUDACC_VER_MAJOR__ * 100 + __CUDACC_VER_MINOR__ * 10) < 1120)
+    // But Clang-CUDA also doesn't accept the use of deduction guide so disable it for CUDA alltogether
+    #if defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_CUDA)
                                    std::tuple<decltype(detail::stride_of(slices))...>{detail::stride_of(slices)...})),
     #else
                                    std::tuple{detail::stride_of(slices)...})),
     #endif
-        static_cast<size_t>(this->operator()(detail::first_of(slices)...))};
+        offset};
   }
 #if defined(__NVCC__) && !defined(__CUDA_ARCH__) && defined(__GNUC__)
   __builtin_unreachable();
@@ -273,6 +333,17 @@ layout_stride::mapping<Extents>::submdspan_mapping_impl(
       std::index_sequence<>(),
       slices...);
   using dst_mapping_t = typename layout_stride::template mapping<dst_ext_t>;
+
+  // Figure out if any slice's lower bound equals the corresponding extent.
+  // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
+  const bool out_of_bounds =
+    detail::any_slice_out_of_bounds(this->extents(), slices...);
+  auto offset = static_cast<size_t>(
+    out_of_bounds ?
+    this->required_span_size() :
+    this->operator()(detail::first_of(slices)...)
+  );
+
   return submdspan_mapping_result<dst_mapping_t>{
       dst_mapping_t(dst_ext, detail::construct_sub_strides(
                                  *this, inv_map,
@@ -283,7 +354,7 @@ layout_stride::mapping<Extents>::submdspan_mapping_impl(
 #else
                                  std::tuple(detail::stride_of(slices)...))),
 #endif
-      static_cast<size_t>(this->operator()(detail::first_of(slices)...))};
+      offset};
 }
 
 } // namespace MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/tpls/mdspan/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/tpls/mdspan/include/experimental/__p2642_bits/layout_padded.hpp
@@ -59,6 +59,10 @@ MDSPAN_INLINE_FUNCTION constexpr size_t get_actual_static_padding_value() {
   } else {
     return dynamic_extent;
   }
+  // Missing return statement warning from NVCC
+#ifdef __NVCC__
+  return 0;
+#endif
 }
 
 template <size_t _PaddingValue, typename _Extents, size_t _ExtentToPadIdx, size_t _Rank, typename Enabled = void>
@@ -101,6 +105,10 @@ struct padded_extent {
     } else {
       return init_padding(exts, padding_value);
     }
+  // Missing return statement warning from NVCC
+#ifdef __NVCC__
+  return {};
+#endif
   }
 
   MDSPAN_INLINE_FUNCTION static constexpr static_array_type
@@ -112,6 +120,10 @@ struct padded_extent {
     } else {
       return {};
     }
+  // Missing return statement warning from NVCC
+#ifdef __NVCC__
+  return {};
+#endif
   }
 
   template <typename _Mapping, size_t _PaddingStrideIdx>
@@ -123,6 +135,10 @@ struct padded_extent {
     } else {
       return {};
     }
+  // Missing return statement warning from NVCC
+#ifdef __NVCC__
+  return {};
+#endif
   }
 };
 } // namespace detail
@@ -391,6 +407,10 @@ public:
                            are_valid_indices<index_type, _Indices...>())))
   MDSPAN_INLINE_FUNCTION constexpr size_t
   operator()(_Indices... idxs) const noexcept {
+#if !defined(NDEBUG)
+    ::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::check_all_indices(this->extents(),
+                                                                idxs...);
+#endif // ! NDEBUG
     return compute_offset(std::index_sequence_for<_Indices...>{}, idxs...);
   }
 

--- a/tpls/mdspan/include/experimental/__p2642_bits/layout_padded_fwd.hpp
+++ b/tpls/mdspan/include/experimental/__p2642_bits/layout_padded_fwd.hpp
@@ -17,6 +17,7 @@
 
 #include <cassert>
 #include "../__p0009_bits/dynamic_extent.hpp"
+#include "../__p0009_bits/utility.hpp"
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
@@ -82,36 +83,49 @@ struct is_layout_right_padded_mapping<_Mapping,
   std::enable_if_t<std::is_same<_Mapping, typename layout_right_padded<_Mapping::padding_value>::template mapping<typename _Mapping::extents_type>>::value>>
     : std::true_type {};
 
+
 template <class _LayoutExtentsType, class _PaddedLayoutMappingType>
-constexpr void check_padded_layout_converting_constructor_mandates()
+constexpr void check_padded_layout_converting_constructor_mandates(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::with_rank<0>) {}
+
+template <class _LayoutExtentsType, class _PaddedLayoutMappingType>
+constexpr void check_padded_layout_converting_constructor_mandates(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::with_rank<1>) {}
+
+template <class _LayoutExtentsType, class _PaddedLayoutMappingType, std::size_t N>
+constexpr void check_padded_layout_converting_constructor_mandates(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::with_rank<N>)
 {
-  if constexpr (_LayoutExtentsType::rank() > 1) {
-    using extents_type = typename _PaddedLayoutMappingType::extents_type;
-    constexpr auto padding_value = _PaddedLayoutMappingType::padding_value;
-    constexpr auto idx = layout_padded_constants<typename _PaddedLayoutMappingType::layout_type, _LayoutExtentsType >::extent_to_pad_idx;
-    if constexpr ((_LayoutExtentsType::static_extent(idx) != dynamic_extent) &&
-                  (extents_type::static_extent(idx) != dynamic_extent) &&
-                  (padding_value != dynamic_extent)) {
-      if constexpr (padding_value == 0) {
-        static_assert(_LayoutExtentsType::static_extent(idx) == 0);
-      } else {
-        static_assert(
-            _LayoutExtentsType::static_extent(idx) % padding_value == 0);
-      }
-    }
-  }
+  using extents_type = typename _PaddedLayoutMappingType::extents_type;
+  constexpr auto padding_value = _PaddedLayoutMappingType::padding_value;
+  constexpr auto idx = layout_padded_constants<typename _PaddedLayoutMappingType::layout_type, _LayoutExtentsType >::extent_to_pad_idx;
+
+  constexpr auto statically_determinable =
+    (_LayoutExtentsType::static_extent(idx) != dynamic_extent) &&
+    (extents_type::static_extent(idx) != dynamic_extent) &&
+    (padding_value != dynamic_extent);
+
+  static_assert(not statically_determinable or
+                (padding_value == 0
+                 ? _LayoutExtentsType::static_extent(idx) == 0
+                 : _LayoutExtentsType::static_extent(idx) % padding_value == 0),
+                "");
 }
 
 template <typename _ExtentsType, typename _OtherMapping>
-constexpr void check_padded_layout_converting_constructor_preconditions([[maybe_unused]] const _OtherMapping &other_mapping) {
-  if constexpr (_ExtentsType::rank() > 1) {
-    constexpr auto padded_stride_idx =
-        layout_padded_constants<typename _OtherMapping::layout_type,
-                                  _ExtentsType>::padded_stride_idx;
-    constexpr auto extent_to_pad_idx = layout_padded_constants<typename _OtherMapping::layout_type, _ExtentsType>::extent_to_pad_idx;
-    assert(other_mapping.stride(padded_stride_idx) == other_mapping.extents().extent(extent_to_pad_idx));
-  }
+constexpr void check_padded_layout_converting_constructor_preconditions(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::with_rank<0>,
+                                                                        const _OtherMapping&) {}
+template <typename _ExtentsType, typename _OtherMapping>
+constexpr void check_padded_layout_converting_constructor_preconditions(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::with_rank<1>,
+                                                                        const _OtherMapping&) {}
+template <typename _ExtentsType, typename _OtherMapping, std::size_t N>
+constexpr void check_padded_layout_converting_constructor_preconditions(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::with_rank<N>,
+                                                                        const _OtherMapping &other_mapping) {
+  constexpr auto padded_stride_idx =
+    layout_padded_constants<typename _OtherMapping::layout_type,
+                            _ExtentsType>::padded_stride_idx;
+  constexpr auto extent_to_pad_idx = layout_padded_constants<typename _OtherMapping::layout_type, _ExtentsType>::extent_to_pad_idx;
+  MDSPAN_IMPL_PRECONDITION(other_mapping.stride(padded_stride_idx) == other_mapping.extents().extent(extent_to_pad_idx));
 }
+
+
 }
 }
 }

--- a/tpls/mdspan/include/mdspan/mdspan.hpp
+++ b/tpls/mdspan/include/mdspan/mdspan.hpp
@@ -38,5 +38,6 @@
 #include "../experimental/__p2642_bits/layout_padded.hpp"
 #include "../experimental/__p2630_bits/submdspan.hpp"
 #endif
+#include "../experimental/__p2389_bits/dims.hpp"
 
 #endif // MDSPAN_HPP_


### PR DESCRIPTION
This is a mostly a update of mdspan to https://github.com/kokkos/mdspan/commit/18c332e07efc66991707a4d443fd7562b5746ccf

The update breaks one test in mdspan so this has a fix (please review core/unit_test/TestMDSpanConversion.hpp)