### PR TITLE
Switch to using functors in sort_by_key_via_sort

### DIFF
--- a/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
@@ -189,8 +189,8 @@ void applyPermutation(const ExecutionSpace& space,
       KOKKOS_LAMBDA(int i) { view(i) = view_copy(permutation(i)); });
 }
 
-// Use functors as nvcc errors out on trying to get the address of a function
-// with variadic template arguments
+// FIXME_NVCC: nvcc has trouble compiling lambdas inside a function with
+// variadic templates (sort_by_key_via_sort). Switch to using functors instead.
 template <typename Permute>
 struct IotaFunctor {
   Permute _permute;

--- a/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
@@ -189,6 +189,21 @@ void applyPermutation(const ExecutionSpace& space,
       KOKKOS_LAMBDA(int i) { view(i) = view_copy(permutation(i)); });
 }
 
+// Use functors as nvcc errors out on trying to get the address of a function
+// with variadic template arguments
+template <typename Permute>
+struct IotaFunctor {
+  Permute _permute;
+  KOKKOS_FUNCTION void operator()(int i) const { _permute(i) = i; }
+};
+template <typename Keys>
+struct LessFunctor {
+  Keys _keys;
+  KOKKOS_FUNCTION bool operator()(int i, int j) const {
+    return _keys(i) < _keys(j);
+  }
+};
+
 template <class ExecutionSpace, class KeysDataType, class... KeysProperties,
           class ValuesDataType, class... ValuesProperties,
           class... MaybeComparator>
@@ -207,10 +222,9 @@ void sort_by_key_via_sort(
       n);
 
   // iota
-  Kokkos::parallel_for(
-      "Kokkos::sort_by_key_via_sort::iota",
-      Kokkos::RangePolicy<ExecutionSpace>(exec, 0, n),
-      KOKKOS_LAMBDA(int i) { permute(i) = i; });
+  Kokkos::parallel_for("Kokkos::sort_by_key_via_sort::iota",
+                       Kokkos::RangePolicy<ExecutionSpace>(exec, 0, n),
+                       IotaFunctor<decltype(permute)>{permute});
 
   using Layout =
       typename Kokkos::View<unsigned int*, ExecutionSpace>::array_layout;
@@ -228,9 +242,8 @@ void sort_by_key_via_sort(
     Kokkos::DefaultHostExecutionSpace host_exec;
 
     if constexpr (sizeof...(MaybeComparator) == 0) {
-      Kokkos::sort(
-          host_exec, host_permute,
-          KOKKOS_LAMBDA(int i, int j) { return host_keys(i) < host_keys(j); });
+      Kokkos::sort(host_exec, host_permute,
+                   LessFunctor<decltype(host_keys)>{host_keys});
     } else {
       auto keys_comparator =
           std::get<0>(std::tuple<MaybeComparator...>(maybeComparator...));

--- a/algorithms/unit_tests/TestSortByKey.hpp
+++ b/algorithms/unit_tests/TestSortByKey.hpp
@@ -69,7 +69,7 @@ void iota(ExecutionSpace const &space, ViewType const &v,
           typename ViewType::value_type value = 0) {
   using ValueType = typename ViewType::value_type;
   Kokkos::parallel_for(
-      "ArborX::Algorithms::iota",
+      "Kokkos::Algorithms::iota",
       Kokkos::RangePolicy<ExecutionSpace>(space, 0, v.extent(0)),
       KOKKOS_LAMBDA(int i) { v(i) = value + (ValueType)i; });
 }
@@ -78,6 +78,18 @@ void iota(ExecutionSpace const &space, ViewType const &v,
 
 TEST(TEST_CATEGORY, SortByKeyEmptyView) {
   using ExecutionSpace = TEST_EXECSPACE;
+
+  // does not matter if we use int or something else
+  Kokkos::View<int *, ExecutionSpace> keys("keys", 0);
+  Kokkos::View<float *, ExecutionSpace> values("values", 0);
+
+  ASSERT_NO_THROW(
+      Kokkos::Experimental::sort_by_key(ExecutionSpace(), keys, values));
+}
+
+// Test #7036
+TEST(TEST_CATEGORY, SortByKeyEmptyViewHost) {
+  using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
 
   // does not matter if we use int or something else
   Kokkos::View<int *, ExecutionSpace> keys("keys", 0);


### PR DESCRIPTION
Fix #7036.

For some reason, nvcc has trouble getting the address of a function with variadic template arguments. Could reproduce with nvcc/11.5 and gcc/9.3.0. I switched to using functors instead.

If anyone has a better idea/more knowledge, it would be welcome.

Drive-by change: fix a label in `iota` that was copied from ArborX.