### PR TITLE
Refactor: Move logic of `create_mirror*` to `Impl::create_mirror*`

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -1039,7 +1039,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
       if (sizeMismatch) {
         ::Kokkos::resize(properties, d_view, n0, n1, n2, n3, n4, n5, n6, n7);
         // this part of the lambda was relocated in a method as it contains a
-        // `if constexpr` whose, in some cases, both branches can be evaluated,
+        // `if constexpr`. In some cases, both branches were evaluated
         // leading to a compile error
         resync_host(properties);
 
@@ -1053,7 +1053,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
       if (sizeMismatch) {
         ::Kokkos::resize(properties, h_view, n0, n1, n2, n3, n4, n5, n6, n7);
         // this part of the lambda was relocated in a method as it contains a
-        // `if constexpr` whose, in some cases, both branches can be evaluated,
+        // `if constexpr`. In some cases, both branches were evaluated
         // leading to a compile error
         resync_device(properties);
 
@@ -1096,9 +1096,8 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
  private:
   // resync host mirror from device
-  // this code was relocated from a lambda as it contains a `if constexpr`
-  // whose, in some cases, both branches can be evaluated, leading to a compile
-  // error
+  // this code was relocated from a lambda as it contains a `if constexpr`.
+  // In some cases, both branches were evaluated, leading to a compile error
   template <class... ViewCtorArgs>
   inline void resync_host(Impl::ViewCtorProp<ViewCtorArgs...> const&) {
     using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
@@ -1113,8 +1112,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
   // resync device mirror from host
   // this code was relocated from a lambda as it contains a `if constexpr`
-  // whose, in some cases, both branches can be evaluated, leading to a compile
-  // error
+  // In some cases, both branches were evaluated leading to a compile error
   template <class... ViewCtorArgs>
   inline void resync_device(Impl::ViewCtorProp<ViewCtorArgs...> const&) {
     using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -1038,6 +1038,9 @@ class DualView : public ViewTraits<DataType, Properties...> {
       /* Resize on Device */
       if (sizeMismatch) {
         ::Kokkos::resize(properties, d_view, n0, n1, n2, n3, n4, n5, n6, n7);
+        // this part of the lambda was relocated in a method as it contains a
+        // `if constexpr` whose, in some cases, both branches can be evaluated,
+        // leading to a compile error
         resync_host(properties);
 
         /* Mark Device copy as modified */
@@ -1049,6 +1052,9 @@ class DualView : public ViewTraits<DataType, Properties...> {
       /* Resize on Host */
       if (sizeMismatch) {
         ::Kokkos::resize(properties, h_view, n0, n1, n2, n3, n4, n5, n6, n7);
+        // this part of the lambda was relocated in a method as it contains a
+        // `if constexpr` whose, in some cases, both branches can be evaluated,
+        // leading to a compile error
         resync_device(properties);
 
         /* Mark Host copy as modified */
@@ -1090,6 +1096,9 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
  private:
   // resync host mirror from device
+  // this code was relocated from a lambda as it contains a `if constexpr`
+  // whose, in some cases, both branches can be evaluated, leading to a compile
+  // error
   template <class... ViewCtorArgs>
   inline void resync_host(Impl::ViewCtorProp<ViewCtorArgs...> const&) {
     using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
@@ -1103,6 +1112,9 @@ class DualView : public ViewTraits<DataType, Properties...> {
   }
 
   // resync device mirror from host
+  // this code was relocated from a lambda as it contains a `if constexpr`
+  // whose, in some cases, both branches can be evaluated, leading to a compile
+  // error
   template <class... ViewCtorArgs>
   inline void resync_device(Impl::ViewCtorProp<ViewCtorArgs...> const&) {
     using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -1088,11 +1088,10 @@ class DualView : public ViewTraits<DataType, Properties...> {
     }
   }
 
-  private:
-
+ private:
   // resync host mirror from device
   template <class... ViewCtorArgs>
-  inline void resync_host(Impl::ViewCtorProp<ViewCtorArgs...> const &) {
+  inline void resync_host(Impl::ViewCtorProp<ViewCtorArgs...> const&) {
     using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
 
     if constexpr (alloc_prop_input::initialize) {
@@ -1105,7 +1104,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
   // resync device mirror from host
   template <class... ViewCtorArgs>
-  inline void resync_device(Impl::ViewCtorProp<ViewCtorArgs...> const &) {
+  inline void resync_device(Impl::ViewCtorProp<ViewCtorArgs...> const&) {
     using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
 
     if constexpr (alloc_prop_input::initialize) {
@@ -1117,8 +1116,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
     }
   }
 
-  public:
-
+ public:
   void resize(const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
               const size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
               const size_t n2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1967,7 +1967,7 @@ inline auto create_mirror(const DynRankView<T, P...>& src,
 
 // public interface
 template <class T, class... P,
-          class = std::enable_if<
+          class Enable = std::enable_if_t<
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(const DynRankView<T, P...>& src) {
   return Impl::create_mirror(src, Kokkos::view_alloc());
@@ -1975,7 +1975,7 @@ inline auto create_mirror(const DynRankView<T, P...>& src) {
 
 // public interface that accepts a without initializing flag
 template <class T, class... P,
-          class = std::enable_if<
+          class Enable = std::enable_if_t<
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
                           const DynRankView<T, P...>& src) {
@@ -1984,8 +1984,7 @@ inline auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
-          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
-          typename     = std::enable_if<
+          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror(const Space&, const Kokkos::DynRankView<T, P...>& src) {
   return Impl::create_mirror(
@@ -1994,8 +1993,7 @@ auto create_mirror(const Space&, const Kokkos::DynRankView<T, P...>& src) {
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
-          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
-          typename     = std::enable_if<
+          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
                    const Kokkos::DynRankView<T, P...>& src) {
@@ -2006,7 +2004,7 @@ auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
 // public interface that accepts arbitrary view constructor args passed by a
 // view_alloc
 template <class T, class... P, class... ViewCtorArgs,
-          typename = std::enable_if<
+          typename Enable = std::enable_if_t<
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
                           const DynRankView<T, P...>& src) {
@@ -2097,7 +2095,7 @@ inline auto create_mirror_view(
 // public interface that accepts arbitrary view constructor args passed by a
 // view_alloc
 template <class... ViewCtorArgs, class T, class... P,
-          class = std::enable_if<
+          class Enable = std::enable_if_t<
               std::is_void<typename ViewTraits<T, P...>::specialize>::value>>
 auto create_mirror_view_and_copy(
     [[maybe_unused]] const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1966,13 +1966,17 @@ inline auto create_mirror(const DynRankView<T, P...>& src,
 }  // namespace Impl
 
 // public interface
-template <class T, class... P>
+template <class T, class... P,
+          class = std::enable_if<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(const DynRankView<T, P...>& src) {
   return Impl::create_mirror(src, Kokkos::view_alloc());
 }
 
 // public interface that accepts a without initializing flag
-template <class T, class... P>
+template <class T, class... P,
+          class = std::enable_if<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
                           const DynRankView<T, P...>& src) {
   return Impl::create_mirror(src, Kokkos::view_alloc(wi));
@@ -1980,7 +1984,9 @@ inline auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
-          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
+          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
+          typename     = std::enable_if<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror(const Space&, const Kokkos::DynRankView<T, P...>& src) {
   return Impl::create_mirror(
       src, Kokkos::view_alloc(typename Space::memory_space{}));
@@ -1988,7 +1994,9 @@ auto create_mirror(const Space&, const Kokkos::DynRankView<T, P...>& src) {
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
-          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
+          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
+          typename     = std::enable_if<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
                    const Kokkos::DynRankView<T, P...>& src) {
   return Impl::create_mirror(
@@ -1997,7 +2005,9 @@ auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
 
 // public interface that accepts arbitrary view constructor args passed by a
 // view_alloc
-template <class T, class... P, class... ViewCtorArgs>
+template <class T, class... P, class... ViewCtorArgs,
+          typename = std::enable_if<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
                           const DynRankView<T, P...>& src) {
   return Impl::create_mirror(src, arg_prop);
@@ -2022,7 +2032,7 @@ inline auto create_mirror_view(
                                    T, P...>::HostMirror::data_type>::value) {
       return typename DynRankView<T, P...>::HostMirror(src);
     } else {
-      return Kokkos::Impl::create_mirror(src, arg_prop);
+      return Kokkos::create_mirror(arg_prop, src);
     }
   } else {
     if constexpr (Impl::MirrorDRViewType<typename Impl::ViewCtorProp<
@@ -2032,7 +2042,7 @@ inline auto create_mirror_view(
           typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
           P...>::view_type(src);
     } else {
-      return Kokkos::Impl::create_mirror(src, arg_prop);
+      return Kokkos::create_mirror(arg_prop, src);
     }
   }
 #if defined KOKKOS_COMPILER_INTEL

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1933,25 +1933,6 @@ struct MirrorDRVType {
 
 namespace Impl {
 
-// collection of static asserts for create_mirror
-template <class... ViewCtorArgs>
-void check_view_ctor_args_create_mirror_drv() {
-  using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
-
-  static_assert(
-      !alloc_prop_input::has_label,
-      "The view constructor arguments passed to Kokkos::create_mirror "
-      "must not include a label!");
-  static_assert(
-      !alloc_prop_input::has_pointer,
-      "The view constructor arguments passed to Kokkos::create_mirror must "
-      "not include a pointer!");
-  static_assert(
-      !alloc_prop_input::allow_padding,
-      "The view constructor arguments passed to Kokkos::create_mirror must "
-      "not explicitly allow padding!");
-}
-
 // create a mirror
 // private interface that accepts arbitrary view constructor args passed by a
 // view_alloc
@@ -1984,40 +1965,41 @@ inline auto create_mirror(const DynRankView<T, P...>& src,
 
 }  // namespace Impl
 
-// Create a mirror in host space
+// public interface
 template <class T, class... P>
-inline auto create_mirror(
-    const DynRankView<T, P...>& src) {
+inline auto create_mirror(const DynRankView<T, P...>& src) {
   return Impl::create_mirror(src, Kokkos::view_alloc());
 }
 
+// public interface that accepts a without initializing flag
 template <class T, class... P>
-inline auto create_mirror(
-    Kokkos::Impl::WithoutInitializing_t wi, const DynRankView<T, P...>& src) {
+inline auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
+                          const DynRankView<T, P...>& src) {
   return Impl::create_mirror(src, Kokkos::view_alloc(wi));
 }
 
+// public interface that accepts a space
 template <class Space, class T, class... P,
           class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
-auto create_mirror(
-    const Space&, const Kokkos::DynRankView<T, P...>& src) {
+auto create_mirror(const Space&, const Kokkos::DynRankView<T, P...>& src) {
   return Impl::create_mirror(
       src, Kokkos::view_alloc(typename Space::memory_space{}));
 }
 
+// public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
           class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
-auto create_mirror(
-    Kokkos::Impl::WithoutInitializing_t wi, const Space&,
-    const Kokkos::DynRankView<T, P...>& src) {
+auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
+                   const Kokkos::DynRankView<T, P...>& src) {
   return Impl::create_mirror(
       src, Kokkos::view_alloc(wi, typename Space::memory_space{}));
 }
 
+// public interface that accepts arbitrary view constructor args passed by a
+// view_alloc
 template <class T, class... P, class... ViewCtorArgs>
-inline auto create_mirror(
-    const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
-    const DynRankView<T, P...>& src) {
+inline auto create_mirror(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
+                          const DynRankView<T, P...>& src) {
   return Impl::create_mirror(src, arg_prop);
 }
 
@@ -2060,26 +2042,29 @@ inline auto create_mirror_view(
 
 }  // namespace Impl
 
-// Create a mirror view in host space
+// public interface
 template <class T, class... P>
 inline auto create_mirror_view(const Kokkos::DynRankView<T, P...>& src) {
   return Impl::create_mirror_view(src, Kokkos::view_alloc());
 }
 
+// public interface that accepts a without initializing flag
 template <class T, class... P>
 inline auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi,
                                const DynRankView<T, P...>& src) {
   return Impl::create_mirror_view(src, Kokkos::view_alloc(wi));
 }
 
-// Create a mirror view in a new space
+// public interface that accepts a space
 template <class Space, class T, class... P,
           class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
-inline auto create_mirror_view(
-    const Space&, const Kokkos::DynRankView<T, P...>& src) {
-  return Impl::create_mirror_view(src, Kokkos::view_alloc(typename Space::memory_space()));
+inline auto create_mirror_view(const Space&,
+                               const Kokkos::DynRankView<T, P...>& src) {
+  return Impl::create_mirror_view(
+      src, Kokkos::view_alloc(typename Space::memory_space()));
 }
 
+// public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 inline auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi,
@@ -2089,6 +2074,8 @@ inline auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi,
       src, Kokkos::view_alloc(typename Space::memory_space{}, wi));
 }
 
+// public interface that accepts arbitrary view constructor args passed by a
+// view_alloc
 template <class T, class... P, class... ViewCtorArgs>
 inline auto create_mirror_view(
     const typename Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1984,7 +1984,8 @@ inline auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
-          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
+          class Enable = std::enable_if_t<
+              Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror(const Space&, const Kokkos::DynRankView<T, P...>& src) {
   return Impl::create_mirror(
@@ -1993,7 +1994,8 @@ auto create_mirror(const Space&, const Kokkos::DynRankView<T, P...>& src) {
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
-          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
+          class Enable = std::enable_if_t<
+              Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
                    const Kokkos::DynRankView<T, P...>& src) {

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -628,13 +628,14 @@ inline auto create_mirror(const Kokkos::Experimental::DynamicView<T, P...>& src,
 
 }  // namespace Impl
 
-// Create a mirror in host space
+// public interface
 template <class T, class... P>
 inline auto create_mirror(
     const Kokkos::Experimental::DynamicView<T, P...>& src) {
   return Impl::create_mirror(src, Impl::ViewCtorProp<>{});
 }
 
+// public interface that accepts a without initializing flag
 template <class T, class... P>
 inline auto create_mirror(
     Kokkos::Impl::WithoutInitializing_t wi,
@@ -642,6 +643,7 @@ inline auto create_mirror(
   return Impl::create_mirror(src, Kokkos::view_alloc(wi));
 }
 
+// public interface that accepts a space
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 inline auto create_mirror(
@@ -650,6 +652,7 @@ inline auto create_mirror(
       src, Kokkos::view_alloc(typename Space::memory_space{}));
 }
 
+// public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 typename Kokkos::Impl::MirrorDynamicViewType<Space, T, P...>::view_type
@@ -659,6 +662,8 @@ create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
       src, Kokkos::view_alloc(wi, typename Space::memory_space{}));
 }
 
+// public interface that accepts arbitrary view constructor args passed by a
+// view_alloc
 template <class T, class... P, class... ViewCtorArgs>
 inline auto create_mirror(
     const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
@@ -708,13 +713,14 @@ inline auto create_mirror_view(
 
 }  // namespace Impl
 
-// Create a mirror view in host space
+// public interface
 template <class T, class... P>
 inline auto create_mirror_view(
     const typename Kokkos::Experimental::DynamicView<T, P...>& src) {
   return Impl::create_mirror_view(src, Impl::ViewCtorProp<>{});
 }
 
+// public interface that accepts a without initializing flag
 template <class T, class... P>
 inline auto create_mirror_view(
     Kokkos::Impl::WithoutInitializing_t wi,
@@ -722,6 +728,7 @@ inline auto create_mirror_view(
   return Impl::create_mirror_view(src, Kokkos::view_alloc(wi));
 }
 
+// public interface that accepts a space
 template <class Space, class T, class... P,
           class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 inline auto create_mirror_view(
@@ -730,6 +737,7 @@ inline auto create_mirror_view(
                                   view_alloc(typename Space::memory_space{}));
 }
 
+// public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
           class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 inline auto create_mirror_view(
@@ -739,6 +747,8 @@ inline auto create_mirror_view(
       src, Kokkos::view_alloc(wi, typename Space::memory_space{}));
 }
 
+// public interface that accepts arbitrary view constructor args passed by a
+// view_alloc
 template <class T, class... P, class... ViewCtorArgs>
 inline auto create_mirror_view(
     const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -642,15 +642,16 @@ inline auto create_mirror(
   return Impl::create_mirror(src, Kokkos::view_alloc(wi));
 }
 
-// Create a mirror in a new space
-template <class Space, class T, class... P>
+template <class Space, class T, class... P,
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 inline auto create_mirror(
     const Space&, const Kokkos::Experimental::DynamicView<T, P...>& src) {
   return Impl::create_mirror(
       src, Kokkos::view_alloc(typename Space::memory_space{}));
 }
 
-template <class Space, class T, class... P>
+template <class Space, class T, class... P,
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 typename Kokkos::Impl::MirrorDynamicViewType<Space, T, P...>::view_type
 create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
               const Kokkos::Experimental::DynamicView<T, P...>& src) {
@@ -721,15 +722,16 @@ inline auto create_mirror_view(
   return Impl::create_mirror_view(src, Kokkos::view_alloc(wi));
 }
 
-// Create a mirror in a new space
-template <class Space, class T, class... P>
+template <class Space, class T, class... P,
+          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 inline auto create_mirror_view(
     const Space&, const Kokkos::Experimental::DynamicView<T, P...>& src) {
   return Impl::create_mirror_view(src,
                                   view_alloc(typename Space::memory_space{}));
 }
 
-template <class Space, class T, class... P>
+template <class Space, class T, class... P,
+          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 inline auto create_mirror_view(
     Kokkos::Impl::WithoutInitializing_t wi, const Space&,
     const Kokkos::Experimental::DynamicView<T, P...>& src) {

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -629,14 +629,18 @@ inline auto create_mirror(const Kokkos::Experimental::DynamicView<T, P...>& src,
 }  // namespace Impl
 
 // public interface
-template <class T, class... P>
+template <class T, class... P,
+          typename = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(
     const Kokkos::Experimental::DynamicView<T, P...>& src) {
   return Impl::create_mirror(src, Impl::ViewCtorProp<>{});
 }
 
 // public interface that accepts a without initializing flag
-template <class T, class... P>
+template <class T, class... P,
+          typename = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(
     Kokkos::Impl::WithoutInitializing_t wi,
     const Kokkos::Experimental::DynamicView<T, P...>& src) {
@@ -645,7 +649,9 @@ inline auto create_mirror(
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
+          typename        = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(
     const Space&, const Kokkos::Experimental::DynamicView<T, P...>& src) {
   return Impl::create_mirror(
@@ -654,7 +660,9 @@ inline auto create_mirror(
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
+          typename        = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 typename Kokkos::Impl::MirrorDynamicViewType<Space, T, P...>::view_type
 create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
               const Kokkos::Experimental::DynamicView<T, P...>& src) {
@@ -664,7 +672,9 @@ create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
 
 // public interface that accepts arbitrary view constructor args passed by a
 // view_alloc
-template <class T, class... P, class... ViewCtorArgs>
+template <class T, class... P, class... ViewCtorArgs,
+          typename = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(
     const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
     const Kokkos::Experimental::DynamicView<T, P...>& src) {

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -630,7 +630,7 @@ inline auto create_mirror(const Kokkos::Experimental::DynamicView<T, P...>& src,
 
 // public interface
 template <class T, class... P,
-          typename = std::enable_if_t<
+          typename Enable = std::enable_if_t<
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(
     const Kokkos::Experimental::DynamicView<T, P...>& src) {
@@ -639,7 +639,7 @@ inline auto create_mirror(
 
 // public interface that accepts a without initializing flag
 template <class T, class... P,
-          typename = std::enable_if_t<
+          typename Enable = std::enable_if_t<
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(
     Kokkos::Impl::WithoutInitializing_t wi,
@@ -649,8 +649,7 @@ inline auto create_mirror(
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
-          typename        = std::enable_if_t<
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(
     const Space&, const Kokkos::Experimental::DynamicView<T, P...>& src) {
@@ -660,8 +659,7 @@ inline auto create_mirror(
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
-          typename        = std::enable_if_t<
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 typename Kokkos::Impl::MirrorDynamicViewType<Space, T, P...>::view_type
 create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
@@ -673,7 +671,7 @@ create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
 // public interface that accepts arbitrary view constructor args passed by a
 // view_alloc
 template <class T, class... P, class... ViewCtorArgs,
-          typename = std::enable_if_t<
+          typename Enable = std::enable_if_t<
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(
     const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
@@ -959,7 +957,7 @@ struct ViewCopy<Kokkos::Experimental::DynamicView<DP...>,
 // public interface that accepts arbitrary view constructor args passed by a
 // view_alloc
 template <class... ViewCtorArgs, class T, class... P,
-          class = std::enable_if<
+          class Enable = std::enable_if_t<
               std::is_void<typename ViewTraits<T, P...>::specialize>::value>>
 auto create_mirror_view_and_copy(
     [[maybe_unused]] const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -649,7 +649,8 @@ inline auto create_mirror(
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
+          typename Enable = std::enable_if_t<
+              Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(
     const Space&, const Kokkos::Experimental::DynamicView<T, P...>& src) {
@@ -659,7 +660,8 @@ inline auto create_mirror(
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
+          typename Enable = std::enable_if_t<
+              Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 typename Kokkos::Impl::MirrorDynamicViewType<Space, T, P...>::view_type
 create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -692,7 +692,7 @@ inline auto create_mirror_view(
       return
           typename Kokkos::Experimental::DynamicView<T, P...>::HostMirror(src);
     } else {
-      return Kokkos::Impl::create_mirror(src, arg_prop);
+      return Kokkos::create_mirror(arg_prop, src);
     }
   } else {
     if constexpr (Impl::MirrorDynamicViewType<
@@ -703,7 +703,7 @@ inline auto create_mirror_view(
           typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
           P...>::view_type(src);
     } else {
-      return Kokkos::Impl::create_mirror(src, arg_prop);
+      return Kokkos::create_mirror(arg_prop, src);
     }
   }
 #if defined KOKKOS_COMPILER_INTEL

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1935,7 +1935,7 @@ inline auto create_mirror_view(
       return
           typename Kokkos::Experimental::OffsetView<T, P...>::HostMirror(src);
     } else {
-      return Kokkos::Impl::create_mirror(src, arg_prop);
+      return Kokkos::create_mirror(arg_prop, src);
     }
   } else {
     if constexpr (Impl::MirrorOffsetViewType<typename Impl::ViewCtorProp<
@@ -1945,7 +1945,7 @@ inline auto create_mirror_view(
           typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
           P...>::view_type(src);
     } else {
-      return Kokkos::Impl::create_mirror(src, arg_prop);
+      return Kokkos::create_mirror(arg_prop, src);
     }
   }
 #if defined KOKKOS_COMPILER_INTEL

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1892,8 +1892,7 @@ inline auto create_mirror(
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
-          typename        = std::enable_if_t<
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(
     const Space&, const Kokkos::Experimental::OffsetView<T, P...>& src) {
@@ -1903,8 +1902,7 @@ inline auto create_mirror(
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
-          typename        = std::enable_if_t<
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 typename Kokkos::Impl::MirrorOffsetType<Space, T, P...>::view_type
 create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1871,13 +1871,14 @@ inline auto create_mirror(const Kokkos::Experimental::OffsetView<T, P...>& src,
 
 }  // namespace Impl
 
-// Create a mirror in host space
+// public interface
 template <class T, class... P>
 inline auto create_mirror(
     const Kokkos::Experimental::OffsetView<T, P...>& src) {
   return Impl::create_mirror(src, Impl::ViewCtorProp<>{});
 }
 
+// public interface that accepts a without initializing flag
 template <class T, class... P>
 inline auto create_mirror(
     Kokkos::Impl::WithoutInitializing_t wi,
@@ -1885,7 +1886,7 @@ inline auto create_mirror(
   return Impl::create_mirror(src, Kokkos::view_alloc(wi));
 }
 
-// Create a mirror in a new space
+// public interface that accepts a space
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 inline auto create_mirror(
@@ -1894,6 +1895,7 @@ inline auto create_mirror(
       src, Kokkos::view_alloc(typename Space::memory_space{}));
 }
 
+// public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 typename Kokkos::Impl::MirrorOffsetType<Space, T, P...>::view_type
@@ -1903,6 +1905,8 @@ create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
       src, Kokkos::view_alloc(typename Space::memory_space{}, wi));
 }
 
+// public interface that accepts arbitrary view constructor args passed by a
+// view_alloc
 template <class T, class... P, class... ViewCtorArgs>
 inline auto create_mirror(
     const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
@@ -1951,13 +1955,14 @@ inline auto create_mirror_view(
 
 }  // namespace Impl
 
-// Create a mirror view in host space
+// public interface
 template <class T, class... P>
 inline auto create_mirror_view(
     const typename Kokkos::Experimental::OffsetView<T, P...>& src) {
   return Impl::create_mirror_view(src, Impl::ViewCtorProp<>{});
 }
 
+// public interface that accepts a without initializing flag
 template <class T, class... P>
 inline auto create_mirror_view(
     Kokkos::Impl::WithoutInitializing_t wi,
@@ -1965,7 +1970,7 @@ inline auto create_mirror_view(
   return Impl::create_mirror_view(src, Kokkos::view_alloc(wi));
 }
 
-// Create a mirror view in a new space
+// public interface that accepts a space
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 inline auto create_mirror_view(
@@ -1974,6 +1979,7 @@ inline auto create_mirror_view(
       src, Kokkos::view_alloc(typename Space::memory_space{}));
 }
 
+// public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 inline auto create_mirror_view(
@@ -1983,6 +1989,8 @@ inline auto create_mirror_view(
       src, Kokkos::view_alloc(typename Space::memory_space{}, wi));
 }
 
+// public interface that accepts arbitrary view constructor args passed by a
+// view_alloc
 template <class T, class... P, class... ViewCtorArgs>
 inline auto create_mirror_view(
     const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
@@ -1990,7 +1998,9 @@ inline auto create_mirror_view(
   return Impl::create_mirror_view(src, arg_prop);
 }
 
-// Create a mirror view and deep_copy in a new space
+// create a mirror view and deep copy it
+// public interface that accepts arbitrary view constructor args passed by a
+// view_alloc
 template <class... ViewCtorArgs, class T, class... P>
 typename Kokkos::Impl::MirrorOffsetViewType<
     typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1872,14 +1872,18 @@ inline auto create_mirror(const Kokkos::Experimental::OffsetView<T, P...>& src,
 }  // namespace Impl
 
 // public interface
-template <class T, class... P>
+template <class T, class... P,
+          typename = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(
     const Kokkos::Experimental::OffsetView<T, P...>& src) {
   return Impl::create_mirror(src, Impl::ViewCtorProp<>{});
 }
 
 // public interface that accepts a without initializing flag
-template <class T, class... P>
+template <class T, class... P,
+          typename = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(
     Kokkos::Impl::WithoutInitializing_t wi,
     const Kokkos::Experimental::OffsetView<T, P...>& src) {
@@ -1888,7 +1892,9 @@ inline auto create_mirror(
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
+          typename        = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(
     const Space&, const Kokkos::Experimental::OffsetView<T, P...>& src) {
   return Impl::create_mirror(
@@ -1897,7 +1903,9 @@ inline auto create_mirror(
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
+          typename        = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 typename Kokkos::Impl::MirrorOffsetType<Space, T, P...>::view_type
 create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
               const Kokkos::Experimental::OffsetView<T, P...>& src) {
@@ -1907,7 +1915,9 @@ create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
 
 // public interface that accepts arbitrary view constructor args passed by a
 // view_alloc
-template <class T, class... P, class... ViewCtorArgs>
+template <class T, class... P, class... ViewCtorArgs,
+          typename = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(
     const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
     const Kokkos::Experimental::OffsetView<T, P...>& src) {

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1894,7 +1894,8 @@ inline auto create_mirror(
       src, Kokkos::view_alloc(typename Space::memory_space{}));
 }
 
-template <class Space, class T, class... P>
+template <class Space, class T, class... P,
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 typename Kokkos::Impl::MirrorOffsetType<Space, T, P...>::view_type
 create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
               const Kokkos::Experimental::OffsetView<T, P...>& src) {
@@ -1973,7 +1974,8 @@ inline auto create_mirror_view(
       src, Kokkos::view_alloc(typename Space::memory_space{}));
 }
 
-template <class Space, class T, class... P>
+template <class Space, class T, class... P,
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 inline auto create_mirror_view(
     Kokkos::Impl::WithoutInitializing_t wi, const Space&,
     const Kokkos::Experimental::OffsetView<T, P...>& src) {

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1892,7 +1892,8 @@ inline auto create_mirror(
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
+          typename Enable = std::enable_if_t<
+              Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 inline auto create_mirror(
     const Space&, const Kokkos::Experimental::OffsetView<T, P...>& src) {
@@ -1902,7 +1903,8 @@ inline auto create_mirror(
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
+          typename Enable = std::enable_if_t<
+              Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 typename Kokkos::Impl::MirrorOffsetType<Space, T, P...>::view_type
 create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3520,7 +3520,8 @@ auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
+          typename Enable = std::enable_if_t<
+              Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror(Space const&, Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, view_alloc(typename Space::memory_space{}));
@@ -3538,7 +3539,8 @@ auto create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
+          typename Enable = std::enable_if_t<
+              Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
                    Kokkos::View<T, P...> const& src) {
@@ -3604,7 +3606,8 @@ auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi,
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
-          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
+          class Enable = std::enable_if_t<
+              Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror_view(const Space&, const Kokkos::View<T, P...>& src) {
   return Impl::create_mirror_view(src,
@@ -3613,7 +3616,8 @@ auto create_mirror_view(const Space&, const Kokkos::View<T, P...>& src) {
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
+          typename Enable = std::enable_if_t<
+              Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
                         Kokkos::View<T, P...> const& src) {

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3541,7 +3541,7 @@ namespace Impl {
 // create a mirror view
 // private interface that accepts arbitrary view constructor args passed by a
 // view_alloc
-template <class T, class... P, class... ViewCtorArgs>
+template <class T, class... P, class... ViewCtorArgs, class = std::enable_if<std::is_void<typename ViewTraits<T, P...>::specialize>::value>>
 inline auto create_mirror_view(
     const Kokkos::View<T, P...>& src,
     [[maybe_unused]] const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3429,7 +3429,7 @@ struct MirrorViewType {
   // deep_copy to it.
   using data_type = typename src_view_type::non_const_data_type;
   // The destination view type if it is not the same memory space
-  using dest_view_type = Kokkos::View<data_type, array_layout, Space>;
+  using dest_view_type = Kokkos::View<data_type, array_layout, memory_space>;
   // If it is the same memory_space return the existsing view_type
   // This will also keep the unmanaged trait if necessary
   using view_type =
@@ -3453,7 +3453,7 @@ struct MirrorType {
   // deep_copy to it.
   using data_type = typename src_view_type::non_const_data_type;
   // The destination view type if it is not the same memory space
-  using view_type = Kokkos::View<data_type, array_layout, Space>;
+  using view_type = Kokkos::View<data_type, array_layout, memory_space>;
 };
 
 // collection of static asserts for create_mirror and create_mirror_view

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3555,7 +3555,7 @@ inline auto create_mirror_view(
       check_view_ctor_args_create_mirror<ViewCtorArgs...>();
       return typename Kokkos::View<T, P...>::HostMirror(src);
     } else {
-      return Impl::create_mirror(src, arg_prop);
+      return Kokkos::Impl::create_mirror(src, arg_prop);
     }
   } else {
     if constexpr (Impl::MirrorViewType<typename Impl::ViewCtorProp<
@@ -3566,7 +3566,7 @@ inline auto create_mirror_view(
           typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
           P...>::view_type(src);
     } else {
-      return Impl::create_mirror(src, arg_prop);
+      return Kokkos::Impl::create_mirror(src, arg_prop);
     }
   }
 #if defined KOKKOS_COMPILER_INTEL

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3520,8 +3520,7 @@ auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
-          typename        = std::enable_if_t<
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror(Space const&, Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, view_alloc(typename Space::memory_space{}));
@@ -3539,8 +3538,7 @@ auto create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
-          typename        = std::enable_if_t<
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
                    Kokkos::View<T, P...> const& src) {
@@ -3606,8 +3604,7 @@ auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi,
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
-          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
-          typename     = std::enable_if_t<
+          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror_view(const Space&, const Kokkos::View<T, P...>& src) {
   return Impl::create_mirror_view(src,
@@ -3616,8 +3613,7 @@ auto create_mirror_view(const Space&, const Kokkos::View<T, P...>& src) {
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
-          typename        = std::enable_if_t<
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
                         Kokkos::View<T, P...> const& src) {
@@ -3662,8 +3658,8 @@ void check_view_ctor_args_create_mirror_view_and_copy() {
 // public interface that accepts arbitrary view constructor args passed by a
 // view_alloc
 template <class... ViewCtorArgs, class T, class... P,
-          class = std::enable_if<
-              std::is_void<typename ViewTraits<T, P...>::specialize>::value>>
+          class Enable = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror_view_and_copy(
     [[maybe_unused]] const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
     const Kokkos::View<T, P...>& src) {

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3555,7 +3555,7 @@ inline auto create_mirror_view(
       check_view_ctor_args_create_mirror<ViewCtorArgs...>();
       return typename Kokkos::View<T, P...>::HostMirror(src);
     } else {
-      return Kokkos::Impl::create_mirror(src, arg_prop);
+      return Impl::create_mirror(src, arg_prop);
     }
   } else {
     if constexpr (Impl::MirrorViewType<typename Impl::ViewCtorProp<
@@ -3566,7 +3566,7 @@ inline auto create_mirror_view(
           typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
           P...>::view_type(src);
     } else {
-      return Kokkos::Impl::create_mirror(src, arg_prop);
+      return Impl::create_mirror(src, arg_prop);
     }
   }
 #if defined KOKKOS_COMPILER_INTEL
@@ -3578,14 +3578,14 @@ inline auto create_mirror_view(
 // public interface
 template <class T, class... P>
 auto create_mirror_view(const Kokkos::View<T, P...>& src) {
-  return Kokkos::Impl::create_mirror_view(src, view_alloc());
+  return Impl::create_mirror_view(src, view_alloc());
 }
 
 // public interface that accepts a without initializing flag
 template <class T, class... P>
 auto create_mirror_view(
     Kokkos::Impl::WithoutInitializing_t wi, Kokkos::View<T, P...> const& src) {
-  return Kokkos::Impl::create_mirror_view(src, view_alloc(wi));
+  return Impl::create_mirror_view(src, view_alloc(wi));
 }
 
 // public interface that accepts a space
@@ -3593,7 +3593,7 @@ template <class Space, class T, class... P,
           class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 auto create_mirror_view(
     const Space& space, const Kokkos::View<T, P...>& src) {
-  return Kokkos::Impl::create_mirror_view(src, view_alloc(typename Space::memory_space()));
+  return Impl::create_mirror_view(src, view_alloc(typename Space::memory_space()));
 }
 
 // public interface that accepts a space and a without initializing flag
@@ -3602,7 +3602,7 @@ template <class Space, class T, class... P,
 auto create_mirror_view(
     Kokkos::Impl::WithoutInitializing_t wi, Space const&,
     Kokkos::View<T, P...> const& src) {
-  return Kokkos::Impl::create_mirror_view(
+  return Impl::create_mirror_view(
       src, view_alloc(typename Space::memory_space{}, wi));
 }
 
@@ -3610,7 +3610,7 @@ auto create_mirror_view(
 template <class T, class... P, class... ViewCtorArgs>
 auto create_mirror_view(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
                         const Kokkos::View<T, P...>& src) {
-  return Kokkos::Impl::create_mirror_view(src, arg_prop);
+  return Impl::create_mirror_view(src, arg_prop);
 }
 
 namespace Impl {

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3429,7 +3429,7 @@ struct MirrorViewType {
   // deep_copy to it.
   using data_type = typename src_view_type::non_const_data_type;
   // The destination view type if it is not the same memory space
-  using dest_view_type = Kokkos::View<data_type, array_layout, memory_space>;
+  using dest_view_type = Kokkos::View<data_type, array_layout, Space>;
   // If it is the same memory_space return the existsing view_type
   // This will also keep the unmanaged trait if necessary
   using view_type =
@@ -3453,7 +3453,7 @@ struct MirrorType {
   // deep_copy to it.
   using data_type = typename src_view_type::non_const_data_type;
   // The destination view type if it is not the same memory space
-  using view_type = Kokkos::View<data_type, array_layout, memory_space>;
+  using view_type = Kokkos::View<data_type, array_layout, Space>;
 };
 
 // collection of static asserts for create_mirror and create_mirror_view

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3597,7 +3597,7 @@ auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi,
 // public interface that accepts a space
 template <class Space, class T, class... P,
           class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
-auto create_mirror_view(const Space& space, const Kokkos::View<T, P...>& src) {
+auto create_mirror_view(const Space&, const Kokkos::View<T, P...>& src) {
   return Impl::create_mirror_view(src,
                                   view_alloc(typename Space::memory_space()));
 }

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3506,28 +3506,28 @@ auto create_mirror(Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, Impl::ViewCtorProp<>{});
 }
 
-// without_initializing
+// public interface that accepts a without initializing flag
 template <class T, class... P>
 auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
               Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, view_alloc(wi));
 }
 
-// space
+// public interface that accepts a space
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 auto create_mirror(Space const&, Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, view_alloc(typename Space::memory_space{}));
 }
 
-// view_constructor_args
+// public interface that accepts arbitrary view constructor args passed by a view_alloc
 template <class T, class... P, class... ViewCtorArgs>
 auto create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
                    Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, arg_prop);
 }
 
-// space & without_initializing
+// public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
@@ -3575,19 +3575,20 @@ inline auto create_mirror_view(
 }
 }  // namespace Impl
 
+// public interface
 template <class T, class... P>
 auto create_mirror_view(const Kokkos::View<T, P...>& src) {
   return Kokkos::Impl::create_mirror_view(src, view_alloc());
 }
 
-// without_initializing
+// public interface that accepts a without initializing flag
 template <class T, class... P>
 auto create_mirror_view(
     Kokkos::Impl::WithoutInitializing_t wi, Kokkos::View<T, P...> const& src) {
   return Kokkos::Impl::create_mirror_view(src, view_alloc(wi));
 }
 
-// space
+// public interface that accepts a space
 template <class Space, class T, class... P,
           class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 auto create_mirror_view(
@@ -3595,7 +3596,7 @@ auto create_mirror_view(
   return Kokkos::Impl::create_mirror_view(src, view_alloc(typename Space::memory_space()));
 }
 
-//space & without_initializing
+// public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 auto create_mirror_view(
@@ -3605,7 +3606,7 @@ auto create_mirror_view(
       src, view_alloc(typename Space::memory_space{}, wi));
 }
 
-// view_constructor_args
+// public interface that accepts arbitrary view constructor args passed by a view_alloc
 template <class T, class... P, class... ViewCtorArgs>
 auto create_mirror_view(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
                         const Kokkos::View<T, P...>& src) {
@@ -3633,7 +3634,7 @@ void check_view_ctor_args_create_mirror_view_and_copy() {
                 "not explicitly allow padding!");
 }
 
-}  // namespace Impl
+} // namespace Impl
 
 // create a mirror view and deep copy it
 // public interface that accepts arbitrary view constructor args passed by a

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3503,6 +3503,7 @@ inline auto create_mirror(const Kokkos::View<T, P...>& src,
 }
 }  // namespace Impl
 
+// public interface
 template <class T, class... P>
 auto create_mirror(Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, Impl::ViewCtorProp<>{});

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3478,7 +3478,9 @@ void check_view_ctor_args_create_mirror() {
 // create a mirror
 // private interface that accepts arbitrary view constructor args passed by a
 // view_alloc
-template <class T, class... P, class... ViewCtorArgs, class = std::enable_if_t<std::is_void<typename ViewTraits<T, P...>::specialize>::value>>
+template <class T, class... P, class... ViewCtorArgs,
+          class = std::enable_if_t<
+              std::is_void<typename ViewTraits<T, P...>::specialize>::value>>
 inline auto create_mirror(const Kokkos::View<T, P...>& src,
                           const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
   check_view_ctor_args_create_mirror<ViewCtorArgs...>();
@@ -3509,7 +3511,7 @@ auto create_mirror(Kokkos::View<T, P...> const& src) {
 // public interface that accepts a without initializing flag
 template <class T, class... P>
 auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
-              Kokkos::View<T, P...> const& src) {
+                   Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, view_alloc(wi));
 }
 
@@ -3520,7 +3522,8 @@ auto create_mirror(Space const&, Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, view_alloc(typename Space::memory_space{}));
 }
 
-// public interface that accepts arbitrary view constructor args passed by a view_alloc
+// public interface that accepts arbitrary view constructor args passed by a
+// view_alloc
 template <class T, class... P, class... ViewCtorArgs>
 auto create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
                    Kokkos::View<T, P...> const& src) {
@@ -3531,7 +3534,7 @@ auto create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
-              Kokkos::View<T, P...> const& src) {
+                   Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src,
                              view_alloc(typename Space::memory_space{}, wi));
 }
@@ -3541,7 +3544,9 @@ namespace Impl {
 // create a mirror view
 // private interface that accepts arbitrary view constructor args passed by a
 // view_alloc
-template <class T, class... P, class... ViewCtorArgs, class = std::enable_if<std::is_void<typename ViewTraits<T, P...>::specialize>::value>>
+template <class T, class... P, class... ViewCtorArgs,
+          class = std::enable_if<
+              std::is_void<typename ViewTraits<T, P...>::specialize>::value>>
 inline auto create_mirror_view(
     const Kokkos::View<T, P...>& src,
     [[maybe_unused]] const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
@@ -3583,30 +3588,30 @@ auto create_mirror_view(const Kokkos::View<T, P...>& src) {
 
 // public interface that accepts a without initializing flag
 template <class T, class... P>
-auto create_mirror_view(
-    Kokkos::Impl::WithoutInitializing_t wi, Kokkos::View<T, P...> const& src) {
+auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi,
+                        Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror_view(src, view_alloc(wi));
 }
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
           class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
-auto create_mirror_view(
-    const Space& space, const Kokkos::View<T, P...>& src) {
-  return Impl::create_mirror_view(src, view_alloc(typename Space::memory_space()));
+auto create_mirror_view(const Space& space, const Kokkos::View<T, P...>& src) {
+  return Impl::create_mirror_view(src,
+                                  view_alloc(typename Space::memory_space()));
 }
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
-auto create_mirror_view(
-    Kokkos::Impl::WithoutInitializing_t wi, Space const&,
-    Kokkos::View<T, P...> const& src) {
+auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
+                        Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror_view(
       src, view_alloc(typename Space::memory_space{}, wi));
 }
 
-// public interface that accepts arbitrary view constructor args passed by a view_alloc
+// public interface that accepts arbitrary view constructor args passed by a
+// view_alloc
 template <class T, class... P, class... ViewCtorArgs>
 auto create_mirror_view(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
                         const Kokkos::View<T, P...>& src) {
@@ -3634,7 +3639,7 @@ void check_view_ctor_args_create_mirror_view_and_copy() {
                 "not explicitly allow padding!");
 }
 
-} // namespace Impl
+}  // namespace Impl
 
 // create a mirror view and deep copy it
 // public interface that accepts arbitrary view constructor args passed by a

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3478,9 +3478,7 @@ void check_view_ctor_args_create_mirror() {
 // create a mirror
 // private interface that accepts arbitrary view constructor args passed by a
 // view_alloc
-template <class T, class... P, class... ViewCtorArgs,
-          class = std::enable_if_t<
-              std::is_void<typename ViewTraits<T, P...>::specialize>::value>>
+template <class T, class... P, class... ViewCtorArgs>
 inline auto create_mirror(const Kokkos::View<T, P...>& src,
                           const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
   check_view_ctor_args_create_mirror<ViewCtorArgs...>();
@@ -3504,13 +3502,17 @@ inline auto create_mirror(const Kokkos::View<T, P...>& src,
 }  // namespace Impl
 
 // public interface
-template <class T, class... P>
+template <class T, class... P,
+          typename = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror(Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, Impl::ViewCtorProp<>{});
 }
 
 // public interface that accepts a without initializing flag
-template <class T, class... P>
+template <class T, class... P,
+          typename = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
                    Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, view_alloc(wi));
@@ -3518,14 +3520,18 @@ auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
+          typename        = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror(Space const&, Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, view_alloc(typename Space::memory_space{}));
 }
 
 // public interface that accepts arbitrary view constructor args passed by a
 // view_alloc
-template <class T, class... P, class... ViewCtorArgs>
+template <class T, class... P, class... ViewCtorArgs,
+          typename = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
                    Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src, arg_prop);
@@ -3533,7 +3539,9 @@ auto create_mirror(Impl::ViewCtorProp<ViewCtorArgs...> const& arg_prop,
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
+          typename        = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
                    Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror(src,
@@ -3545,9 +3553,7 @@ namespace Impl {
 // create a mirror view
 // private interface that accepts arbitrary view constructor args passed by a
 // view_alloc
-template <class T, class... P, class... ViewCtorArgs,
-          class = std::enable_if<
-              std::is_void<typename ViewTraits<T, P...>::specialize>::value>>
+template <class T, class... P, class... ViewCtorArgs>
 inline auto create_mirror_view(
     const Kokkos::View<T, P...>& src,
     [[maybe_unused]] const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
@@ -3561,7 +3567,7 @@ inline auto create_mirror_view(
       check_view_ctor_args_create_mirror<ViewCtorArgs...>();
       return typename Kokkos::View<T, P...>::HostMirror(src);
     } else {
-      return Kokkos::Impl::create_mirror(src, arg_prop);
+      return Kokkos::create_mirror(arg_prop, src);
     }
   } else {
     if constexpr (Impl::MirrorViewType<typename Impl::ViewCtorProp<
@@ -3572,7 +3578,7 @@ inline auto create_mirror_view(
           typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
           P...>::view_type(src);
     } else {
-      return Kokkos::Impl::create_mirror(src, arg_prop);
+      return Kokkos::create_mirror(arg_prop, src);
     }
   }
 #if defined KOKKOS_COMPILER_INTEL
@@ -3582,13 +3588,17 @@ inline auto create_mirror_view(
 }  // namespace Impl
 
 // public interface
-template <class T, class... P>
+template <class T, class... P,
+          typename = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror_view(const Kokkos::View<T, P...>& src) {
   return Impl::create_mirror_view(src, view_alloc());
 }
 
 // public interface that accepts a without initializing flag
-template <class T, class... P>
+template <class T, class... P,
+          typename = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi,
                         Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror_view(src, view_alloc(wi));
@@ -3596,7 +3606,9 @@ auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi,
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
-          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
+          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
+          typename     = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror_view(const Space&, const Kokkos::View<T, P...>& src) {
   return Impl::create_mirror_view(src,
                                   view_alloc(typename Space::memory_space()));
@@ -3604,7 +3616,9 @@ auto create_mirror_view(const Space&, const Kokkos::View<T, P...>& src) {
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>,
+          typename        = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
                         Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror_view(
@@ -3613,7 +3627,9 @@ auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
 
 // public interface that accepts arbitrary view constructor args passed by a
 // view_alloc
-template <class T, class... P, class... ViewCtorArgs>
+template <class T, class... P, class... ViewCtorArgs,
+          typename = std::enable_if_t<
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror_view(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
                         const Kokkos::View<T, P...>& src) {
   return Impl::create_mirror_view(src, arg_prop);

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -842,7 +842,7 @@ struct TestViewMirror {
     View a_d;
 
     KOKKOS_INLINE_FUNCTION
-    explicit CopyUnInit(View const & a_d_) : a_d(a_d_) {}
+    explicit CopyUnInit(View const &a_d_) : a_d(a_d_) {}
 
     KOKKOS_INLINE_FUNCTION
     void operator()(const typename View::size_type i) const {

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -872,6 +872,7 @@ struct TestViewMirror {
 
     Kokkos::parallel_for(
         Kokkos::RangePolicy<typename DeviceType::execution_space>(0, int(10)),
+        // decltype required for Intel classics, that doesn't recognize the CTAD
         CopyUnInit<decltype(a_d)>(a_d));
 
     Kokkos::deep_copy(a_h, a_d);

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -842,7 +842,7 @@ struct TestViewMirror {
     View a_d;
 
     KOKKOS_INLINE_FUNCTION
-    explicit CopyUnInit(View &a_d_) : a_d(a_d_) {}
+    explicit CopyUnInit(View const & a_d_) : a_d(a_d_) {}
 
     KOKKOS_INLINE_FUNCTION
     void operator()(const typename View::size_type i) const {

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -837,18 +837,15 @@ struct TestViewMirror {
                                                     view_const_cast(v));
   }
 
-  template <class MemoryTraits, class Space>
+  template <class View>
   struct CopyUnInit {
-    using mirror_view_type = typename Kokkos::Impl::MirrorViewType<
-        Space, double *, Layout, Kokkos::HostSpace, MemoryTraits>::view_type;
-
-    mirror_view_type a_d;
+    View a_d;
 
     KOKKOS_INLINE_FUNCTION
-    CopyUnInit(mirror_view_type &a_d_) : a_d(a_d_) {}
+    explicit CopyUnInit(View &a_d_) : a_d(a_d_) {}
 
     KOKKOS_INLINE_FUNCTION
-    void operator()(const typename Space::size_type i) const {
+    void operator()(const typename View::size_type i) const {
       a_d(i) = (double)(10 - i);
     }
   };
@@ -875,7 +872,7 @@ struct TestViewMirror {
 
     Kokkos::parallel_for(
         Kokkos::RangePolicy<typename DeviceType::execution_space>(0, int(10)),
-        CopyUnInit<MemoryTraits, DeviceType>(a_d));
+        CopyUnInit<decltype(a_d)>(a_d));
 
     Kokkos::deep_copy(a_h, a_d);
 


### PR DESCRIPTION
This PR is a refactor.

Its idea is to simplify the code by moving the duplicated logic of the various `create_mirror` and `create_mirror_view` (public functions) to `Impl::create_mirror` and `Impl::create_mirror_view` (private functions). The public functions now behave as pass-troughs that only call their private counterpart. All the public functions have an `auto` type, which means their actual type is also decided by the private functions they call.

This PR makes the code cleaner and more maintainable, as it removes most of the extraneous SFINAE of the public functions, and merges some of them.

As deducing the type of the public functions is more indirect, this PR induces more work for the compiler, which may have consequences.

This PR is part of a of a larger effort which aims to assess #6842, and is the following of #6955.

We faced two difficulties when creating this PR:

1. The `core/unit_test/TestViewAPI.hpp` test file used the [implementation object](https://github.com/kokkos/kokkos/blob/63f05204d0eaeec83e25f87eeb8025a188683f92/core/unit_test/TestViewAPI.hpp#L842) `Impl::MirrorViewType` incorrectly by passing it a whole `Space` when a `Space::memory_space` should be passed (note that this test file is the only one explicitly mentioning an implementation object, which is used in a functor for one test). The test code was simplified by removing this hard-coded type and obtaining it from a template argument instead; and
2. The `containers/src/Kokkos_DualView.hpp` source file defined [lambda functions](https://github.com/kokkos/kokkos/blob/63f05204d0eaeec83e25f87eeb8025a188683f92/containers/src/Kokkos_DualView.hpp#L1037) using `if constexpr` on template arguments to decide how to call `Kokkos::create_mirror_view`. We encountered a very surprising bug with GCC 11 and CUDA 12.2, where both branches where evaluated by the compiler when the type of `create_mirror_view` was `auto`, resulting in a compilation error. The problem was fixed by moving the `if constexpr` part in a templated function, which unfortunately makes the code less readable.

As discussed below, this PR reintroduced that public `create_mirror` functions check the input view is not `specialize`d, and extended this concept to offset views and dynamic views.