### PR TITLE
Restrict to_array subtest to NVCC >= 11.4.0

### DIFF
--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -176,9 +176,10 @@ constexpr bool test_to_array() {
   static_assert(std::is_same_v<decltype(a2), Kokkos::Array<int, 4>>);
   maybe_unused(a2);
 
-// gcc8 and icc do not support the implicit conversion
-#if !(defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 910)) && \
-    !(defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL < 2021))
+// gcc8, icc, and nvcc 11.3 do not support the implicit conversion
+#if !(defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 910)) &&      \
+    !(defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL < 2021)) && \
+    !(defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1140))
   // deduces length with element type specified
   // implicit conversion happens
   [[maybe_unused]] auto a3 = Kokkos::to_array<long>({0, 1, 3});


### PR DESCRIPTION
Similar to https://github.com/kokkos/kokkos/pull/7041. The respective test case only works from `NVCC` 11.4.0 on, see https://godbolt.org/z/czEn7hes7.