### PR TITLE
Update to CUDA 12.4.1 in MSVC CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: Jimver/cuda-toolkit@v0.2.15
       id: cuda-toolkit
       with:
-        cuda: '12.1.0'
+        cuda: '12.4.1'
     - uses: actions/checkout@v4
     - name: configure
       shell: bash


### PR DESCRIPTION
https://github.com/kokkos/kokkos/pull/7063 and https://github.com/kokkos/kokkos/pull/7059 show
> C:\Program Files\NVIDIA GPU Computing
  Toolkit\CUDA\v12.1\include\crt/host_config.h(153): fatal error C1189:
  #error: -- unsupported Microsoft Visual Studio version! Only the versions
  between 2017 and 2022 (inclusive) are supported! The nvcc flag
  '-allow-unsupported-compiler' can be used to override this version check;
  however, using an unsupported host compiler may cause compilation failure
  or incorrect run time execution.  Use at your own risk.
  [D:\a\kokkos\kokkos\build\CMakeFiles\3.29.3\CompilerIdCUDA\CompilerIdCUDA.vcxproj]

This pull request tries to fix that issue by updating to the latest CUDA version available.