### PR TITLE
Fix using shared libraries and -fvisibility=hidden

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -155,6 +155,7 @@ pipeline {
                         sh 'echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig'
                         sh '''rm -rf build && mkdir -p build && cd build && \
                               cmake \
+                                -DBUILD_SHARED_LIBS=ON \
                                 -DCMAKE_BUILD_TYPE=Debug \
                                 -DCMAKE_CXX_COMPILER=hipcc \
                                 -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument -DNDEBUG" \
@@ -445,6 +446,7 @@ pipeline {
                         sh 'ccache --zero-stats'
                         sh '''rm -rf build && mkdir -p build && cd build && \
                               cmake \
+                                -DBUILD_SHARED_LIBS=ON \
                                 -DCMAKE_BUILD_TYPE=Debug \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=$WORKSPACE/bin/nvcc_wrapper \

--- a/.jenkins
+++ b/.jenkins
@@ -155,7 +155,6 @@ pipeline {
                         sh 'echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig'
                         sh '''rm -rf build && mkdir -p build && cd build && \
                               cmake \
-                                -DBUILD_SHARED_LIBS=ON \
                                 -DCMAKE_BUILD_TYPE=Debug \
                                 -DCMAKE_CXX_COMPILER=hipcc \
                                 -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument -DNDEBUG" \
@@ -191,6 +190,7 @@ pipeline {
                         sh 'ccache --zero-stats'
                         sh '''rm -rf build && mkdir -p build && cd build && \
                               cmake \
+                                -DBUILD_SHARED_LIBS=ON \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                                 -DCMAKE_CXX_COMPILER=hipcc \
                                 -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument" \

--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -160,10 +160,11 @@ FUNCTION(KOKKOS_ADD_EXECUTABLE_AND_TEST ROOT_NAME)
             )
         ENDIF()
     ENDIF()
-    # We noticed problems with -fvisibility-hidden for inline static variables
+    # We noticed problems with -fvisibility=hidden for inline static variables
     # if Kokkos was built as shared library.
-    IF(BUILD_SHARED_LIBS AND NOT KOKKOS_CXX_HOST_COMPILER_ID MATCHES MSVC)
-      TARGET_COMPILE_OPTIONS(${PACKAGE_NAME}_${ROOT_NAME} PRIVATE -fvisibility=hidden)
+    IF(BUILD_SHARED_LIBS)
+      SET_PROPERTY(TARGET ${PACKAGE_NAME}_${ROOT_NAME} PROPERTY VISIBILITY_INLINES_HIDDEN ON)
+      SET_PROPERTY(TARGET ${PACKAGE_NAME}_${ROOT_NAME} PROPERTY CXX_VISIBILITY_PRESET hidden)
     ENDIF()
 ENDFUNCTION()
 

--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -160,6 +160,11 @@ FUNCTION(KOKKOS_ADD_EXECUTABLE_AND_TEST ROOT_NAME)
             )
         ENDIF()
     ENDIF()
+    # We noticed problems with -fvisibility-hidden for inline static variables
+    # if Kokkos was built as shared library.
+    IF(BUILD_SHARED_LIBS AND NOT KOKKOS_CXX_HOST_COMPILER_ID MATCHES MSVC)
+      TARGET_COMPILE_OPTIONS(${PACKAGE_NAME}_${ROOT_NAME} PRIVATE -fvisibility=hidden)
+    ENDIF()
 ENDFUNCTION()
 
 FUNCTION(KOKKOS_SET_EXE_PROPERTY ROOT_NAME)

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -737,6 +737,14 @@ namespace Impl {
 int g_cuda_space_factory_initialized =
     initialize_space_factory<Cuda>("150_Cuda");
 
+int CudaInternal::m_cudaArch = -1;
+cudaDeviceProp CudaInternal::m_deviceProp;
+std::set<int> CudaInternal::cuda_devices = {};
+std::map<int, unsigned long *> CudaInternal::constantMemHostStagingPerDevice =
+    {};
+std::map<int, cudaEvent_t> CudaInternal::constantMemReusablePerDevice = {};
+std::map<int, std::mutex> CudaInternal::constantMemMutexPerDevice     = {};
+
 }  // namespace Impl
 
 }  // namespace Kokkos

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -91,10 +91,10 @@ class CudaInternal {
   int m_cudaDev = -1;
 
   // Device Properties
-  inline static int m_cudaArch = -1;
+  static int m_cudaArch;
   static int concurrency();
 
-  inline static cudaDeviceProp m_deviceProp;
+  static cudaDeviceProp m_deviceProp;
 
   // Scratch Spaces for Reductions
   mutable std::size_t m_scratchSpaceCount;
@@ -120,11 +120,10 @@ class CudaInternal {
   bool was_initialized = false;
   bool was_finalized   = false;
 
-  inline static std::set<int> cuda_devices = {};
-  inline static std::map<int, unsigned long*> constantMemHostStagingPerDevice =
-      {};
-  inline static std::map<int, cudaEvent_t> constantMemReusablePerDevice = {};
-  inline static std::map<int, std::mutex> constantMemMutexPerDevice     = {};
+  static std::set<int> cuda_devices;
+  static std::map<int, unsigned long*> constantMemHostStagingPerDevice;
+  static std::map<int, cudaEvent_t> constantMemReusablePerDevice;
+  static std::map<int, std::mutex> constantMemMutexPerDevice;
 
   static CudaInternal& singleton();
 

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -353,6 +353,22 @@ void HIPInternal::finalize() {
   m_num_scratch_locks = 0;
 }
 
+int HIPInternal::m_hipDev                                     = -1;
+unsigned HIPInternal::m_multiProcCount                        = 0;
+unsigned HIPInternal::m_maxWarpCount                          = 0;
+std::array<HIPInternal::size_type, 3> HIPInternal::m_maxBlock = {0, 0, 0};
+unsigned HIPInternal::m_maxWavesPerCU                         = 0;
+int HIPInternal::m_shmemPerSM                                 = 0;
+int HIPInternal::m_maxShmemPerBlock                           = 0;
+int HIPInternal::m_maxThreadsPerSM                            = 0;
+
+hipDeviceProp_t HIPInternal::m_deviceProp;
+
+std::mutex HIPInternal::scratchFunctorMutex;
+unsigned long *HIPInternal::constantMemHostStaging = nullptr;
+hipEvent_t HIPInternal::constantMemReusable        = nullptr;
+std::mutex HIPInternal::constantMemMutex;
+
 //----------------------------------------------------------------------------
 
 Kokkos::HIP::size_type hip_internal_multiprocessor_count() {

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -70,16 +70,16 @@ class HIPInternal {
  public:
   using size_type = ::Kokkos::HIP::size_type;
 
-  inline static int m_hipDev                        = -1;
-  inline static unsigned m_multiProcCount           = 0;
-  inline static unsigned m_maxWarpCount             = 0;
-  inline static std::array<size_type, 3> m_maxBlock = {0, 0, 0};
-  inline static unsigned m_maxWavesPerCU            = 0;
-  inline static int m_shmemPerSM                    = 0;
-  inline static int m_maxShmemPerBlock              = 0;
-  inline static int m_maxThreadsPerSM               = 0;
+  static int m_hipDev;
+  static unsigned m_multiProcCount;
+  static unsigned m_maxWarpCount;
+  static std::array<size_type, 3> m_maxBlock;
+  static unsigned m_maxWavesPerCU;
+  static int m_shmemPerSM;
+  static int m_maxShmemPerBlock;
+  static int m_maxThreadsPerSM;
 
-  inline static hipDeviceProp_t m_deviceProp;
+  static hipDeviceProp_t m_deviceProp;
 
   static int concurrency();
 
@@ -92,7 +92,7 @@ class HIPInternal {
   size_type *m_scratchFlags               = nullptr;
   mutable size_type *m_scratchFunctor     = nullptr;
   mutable size_type *m_scratchFunctorHost = nullptr;
-  inline static std::mutex scratchFunctorMutex;
+  static std::mutex scratchFunctorMutex;
 
   hipStream_t m_stream = nullptr;
   uint32_t m_instance_id =
@@ -111,9 +111,9 @@ class HIPInternal {
 
   // FIXME_HIP: these want to be per-device, not per-stream...  use of 'static'
   // here will break once there are multiple devices though
-  inline static unsigned long *constantMemHostStaging = nullptr;
-  inline static hipEvent_t constantMemReusable        = nullptr;
-  inline static std::mutex constantMemMutex;
+  static unsigned long *constantMemHostStaging;
+  static hipEvent_t constantMemReusable;
+  static std::mutex constantMemMutex;
 
   static HIPInternal &singleton();
 


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/7029. Fixes #6178. Related to https://github.com/kokkos/kokkos/pull/6224. As reported in https://github.com/kokkos/kokkos/pull/5473#issuecomment-1299102792, we run into issues if using `inline static` variables when downstream code compiles with `-fvisibility-hidden`. This pull request makes sure that we test this case (by adding that flag to all the tests when building with shared libraries) and replace the respective variables for `Cuda` and `HIP`.