### PR TITLE
Generalize BinOp3D to ND and add BinOp2D

### DIFF
--- a/algorithms/src/sorting/Kokkos_BinOpsPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_BinOpsPublicAPI.hpp
@@ -22,7 +22,7 @@
 
 namespace Kokkos {
 
-namespace Experimental {
+namespace Impl {
 
 template <int DIM, class KeyViewType>
 struct BinOpND {
@@ -122,16 +122,16 @@ struct BinOpND<1, KeyViewType> {
   }
 };
 
-}  // namespace Experimental
+}  // namespace Impl
 
 template <class KeyViewType>
-using BinOp1D = Experimental::BinOpND<1, KeyViewType>;
+using BinOp1D = Impl::BinOpND<1, KeyViewType>;
 
 template <class KeyViewType>
-using BinOp2D = Experimental::BinOpND<2, KeyViewType>;
+using BinOp2D = Impl::BinOpND<2, KeyViewType>;
 
 template <class KeyViewType>
-using BinOp3D = Experimental::BinOpND<3, KeyViewType>;
+using BinOp3D = Impl::BinOpND<3, KeyViewType>;
 
 }  // namespace Kokkos
 #endif

--- a/algorithms/src/sorting/Kokkos_BinOpsPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_BinOpsPublicAPI.hpp
@@ -125,6 +125,9 @@ struct BinOpND {
 }  // namespace Experimental
 
 template <class KeyViewType>
+using BinOp2D = Experimental::BinOpND<2, KeyViewType>;
+
+template <class KeyViewType>
 using BinOp3D = Experimental::BinOpND<3, KeyViewType>;
 
 }  // namespace Kokkos


### PR DESCRIPTION
One user asked why there's no `BinOp2D`. This seems straightforward to fix, so I did it.

I'm not sure what performance tests to run to make sure it doesn't degrade the performance of `BinOp3D`. I hope that the compiler does the right stuff with the compile time known loop on `DIM`, needs verifying though.

I didn't add tests, as I thought that the new refactoring is being tested using `BinOp3D` test anyway.