### PR TITLE
Fix mdspan test for conversion to different mdspan type

### DIFF
--- a/core/unit_test/TestMDSpanConversion.hpp
+++ b/core/unit_test/TestMDSpanConversion.hpp
@@ -120,12 +120,13 @@ struct TestViewMDSpanConversion {
     }
     // test conversion operator to different mdspan type
     {
-      using mdspan_type = Kokkos::mdspan<
-          const typename natural_mdspan_type::element_type,
+      using element_type = const typename natural_mdspan_type::element_type;
+      using mdspan_type  = Kokkos::mdspan<
+          element_type,
           Kokkos::dextents<typename natural_mdspan_type::index_type,
                            natural_mdspan_type::rank()>,
           typename natural_mdspan_type::layout_type,
-          typename natural_mdspan_type::accessor_type>;
+          Kokkos::default_accessor<element_type>>;
       mdspan_type cvt = v;
       ASSERT_EQ(cvt.data_handle(), v.data());
       ASSERT_EQ(cvt.mapping(), ref_layout_mapping);


### PR DESCRIPTION
As discussed in https://kokkosteam.slack.com/archives/G5CBLMFLP/p1718229890342809?thread_ts=1718228221.306479&cid=G5CBLMFLP we need the accessor to match the (changed) element type. In particular, the element type is made `const` in this test case.

This breaks with a recent `mdspan` version (while the bundled one is fine).