### PR TITLE
Workaround icpc "missing return statement at end of non-void function"

### DIFF
--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -493,6 +493,9 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
       return m_map.m_impl_handle[j0 * m_map.m_impl_offset.m_stride.S0 +
                                  j1 * m_map.m_impl_offset.m_stride.S1];
     }
+#if defined KOKKOS_COMPILER_INTEL
+    __builtin_unreachable();
+#endif
   }
 
   //------------------------------

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -970,6 +970,9 @@ class View : public ViewTraits<DataType, Properties...> {
       return m_map.m_impl_handle[i0 * m_map.m_impl_offset.m_stride.S0 +
                                  i1 * m_map.m_impl_offset.m_stride.S1];
     }
+#if defined KOKKOS_COMPILER_INTEL
+    __builtin_unreachable();
+#endif
   }
 
   // Rank 0 -> 8 operator() except for rank-1 and rank-2 with default map which
@@ -1083,6 +1086,9 @@ class View : public ViewTraits<DataType, Properties...> {
       return m_map.m_impl_handle[i0 * m_map.m_impl_offset.m_stride.S0 +
                                  i1 * m_map.m_impl_offset.m_stride.S1];
     }
+#if defined KOKKOS_COMPILER_INTEL
+    __builtin_unreachable();
+#endif
   }
 
   //------------------------------


### PR DESCRIPTION
Workaround "missing return statement at end of non-void function" warnings triggering -Werror with intel classic compilers Address issue #7071