### PR TITLE
Move `layout_iterate_type_selector` into Impl namespace

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -297,9 +297,11 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 2, iType> {
   ViewTypeA a;
   ViewTypeB b;
   static const Kokkos::Iterate outer_iteration_pattern =
-      Kokkos::layout_iterate_type_selector<Layout>::outer_iteration_pattern;
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
   static const Kokkos::Iterate inner_iteration_pattern =
-      Kokkos::layout_iterate_type_selector<Layout>::inner_iteration_pattern;
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
   using iterate_type =
       Kokkos::Rank<2, outer_iteration_pattern, inner_iteration_pattern>;
   using policy_type =
@@ -327,9 +329,11 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 3, iType> {
   ViewTypeB b;
 
   static const Kokkos::Iterate outer_iteration_pattern =
-      Kokkos::layout_iterate_type_selector<Layout>::outer_iteration_pattern;
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
   static const Kokkos::Iterate inner_iteration_pattern =
-      Kokkos::layout_iterate_type_selector<Layout>::inner_iteration_pattern;
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
   using iterate_type =
       Kokkos::Rank<3, outer_iteration_pattern, inner_iteration_pattern>;
   using policy_type =
@@ -358,9 +362,11 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 4, iType> {
   ViewTypeB b;
 
   static const Kokkos::Iterate outer_iteration_pattern =
-      Kokkos::layout_iterate_type_selector<Layout>::outer_iteration_pattern;
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
   static const Kokkos::Iterate inner_iteration_pattern =
-      Kokkos::layout_iterate_type_selector<Layout>::inner_iteration_pattern;
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
   using iterate_type =
       Kokkos::Rank<4, outer_iteration_pattern, inner_iteration_pattern>;
   using policy_type =
@@ -390,9 +396,11 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 5, iType> {
   ViewTypeB b;
 
   static const Kokkos::Iterate outer_iteration_pattern =
-      Kokkos::layout_iterate_type_selector<Layout>::outer_iteration_pattern;
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
   static const Kokkos::Iterate inner_iteration_pattern =
-      Kokkos::layout_iterate_type_selector<Layout>::inner_iteration_pattern;
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
   using iterate_type =
       Kokkos::Rank<5, outer_iteration_pattern, inner_iteration_pattern>;
   using policy_type =
@@ -422,9 +430,11 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 6, iType> {
   ViewTypeB b;
 
   static const Kokkos::Iterate outer_iteration_pattern =
-      Kokkos::layout_iterate_type_selector<Layout>::outer_iteration_pattern;
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
   static const Kokkos::Iterate inner_iteration_pattern =
-      Kokkos::layout_iterate_type_selector<Layout>::inner_iteration_pattern;
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
   using iterate_type =
       Kokkos::Rank<6, outer_iteration_pattern, inner_iteration_pattern>;
   using policy_type =
@@ -454,9 +464,11 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 7, iType> {
   ViewTypeB b;
 
   static const Kokkos::Iterate outer_iteration_pattern =
-      Kokkos::layout_iterate_type_selector<Layout>::outer_iteration_pattern;
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
   static const Kokkos::Iterate inner_iteration_pattern =
-      Kokkos::layout_iterate_type_selector<Layout>::inner_iteration_pattern;
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
   using iterate_type =
       Kokkos::Rank<6, outer_iteration_pattern, inner_iteration_pattern>;
   using policy_type =
@@ -489,9 +501,11 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 8, iType> {
   ViewTypeB b;
 
   static const Kokkos::Iterate outer_iteration_pattern =
-      Kokkos::layout_iterate_type_selector<Layout>::outer_iteration_pattern;
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::outer_iteration_pattern;
   static const Kokkos::Iterate inner_iteration_pattern =
-      Kokkos::layout_iterate_type_selector<Layout>::inner_iteration_pattern;
+      Kokkos::Impl::layout_iterate_type_selector<
+          Layout>::inner_iteration_pattern;
   using iterate_type =
       Kokkos::Rank<6, outer_iteration_pattern, inner_iteration_pattern>;
   using policy_type =

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -1020,9 +1020,9 @@ struct TeamThreadMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
   static constexpr auto par_vector = Impl::TeamMDRangeParVector::NotParVector;
 
   static constexpr Iterate direction =
-      OuterDir == Iterate::Default
-          ? layout_iterate_type_selector<ArrayLayout>::outer_iteration_pattern
-          : iter;
+      OuterDir == Iterate::Default ? Impl::layout_iterate_type_selector<
+                                         ArrayLayout>::outer_iteration_pattern
+                                   : iter;
 
   template <class... Args>
   KOKKOS_FUNCTION TeamThreadMDRange(TeamHandleType const& team_, Args&&... args)
@@ -1056,9 +1056,9 @@ struct ThreadVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
   static constexpr auto par_vector = Impl::TeamMDRangeParVector::ParVector;
 
   static constexpr Iterate direction =
-      OuterDir == Iterate::Default
-          ? layout_iterate_type_selector<ArrayLayout>::outer_iteration_pattern
-          : iter;
+      OuterDir == Iterate::Default ? Impl::layout_iterate_type_selector<
+                                         ArrayLayout>::outer_iteration_pattern
+                                   : iter;
 
   template <class... Args>
   KOKKOS_INLINE_FUNCTION ThreadVectorMDRange(TeamHandleType const& team_,
@@ -1093,9 +1093,9 @@ struct TeamVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
   static constexpr auto par_vector = Impl::TeamMDRangeParVector::ParVector;
 
   static constexpr Iterate direction =
-      iter == Iterate::Default
-          ? layout_iterate_type_selector<ArrayLayout>::outer_iteration_pattern
-          : iter;
+      iter == Iterate::Default ? Impl::layout_iterate_type_selector<
+                                     ArrayLayout>::outer_iteration_pattern
+                               : iter;
 
   template <class... Args>
   KOKKOS_INLINE_FUNCTION TeamVectorMDRange(TeamHandleType const& team_,

--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -222,38 +222,6 @@ template <typename Layout, class Enable = void>
 struct KOKKOS_DEPRECATED is_layouttiled : std::false_type {};
 #endif
 
-// The layout_iterate_type_selector is now deprecated.
-// Please use the Kokkos::Impl::layout_iterate_type_selector instead.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-template <typename... Layout>
-struct KOKKOS_DEPRECATED layout_iterate_type_selector {
-  static const Kokkos::Iterate outer_iteration_pattern =
-      Kokkos::Iterate::Default;
-  static const Kokkos::Iterate inner_iteration_pattern =
-      Kokkos::Iterate::Default;
-};
-
-template <>
-struct KOKKOS_DEPRECATED layout_iterate_type_selector<Kokkos::LayoutRight> {
-  static const Kokkos::Iterate outer_iteration_pattern = Kokkos::Iterate::Right;
-  static const Kokkos::Iterate inner_iteration_pattern = Kokkos::Iterate::Right;
-};
-
-template <>
-struct KOKKOS_DEPRECATED layout_iterate_type_selector<Kokkos::LayoutLeft> {
-  static const Kokkos::Iterate outer_iteration_pattern = Kokkos::Iterate::Left;
-  static const Kokkos::Iterate inner_iteration_pattern = Kokkos::Iterate::Left;
-};
-
-template <>
-struct KOKKOS_DEPRECATED layout_iterate_type_selector<Kokkos::LayoutStride> {
-  static const Kokkos::Iterate outer_iteration_pattern =
-      Kokkos::Iterate::Default;
-  static const Kokkos::Iterate inner_iteration_pattern =
-      Kokkos::Iterate::Default;
-};
-#endif
-
 namespace Impl {
 // For use with view_copy
 template <typename... Layout>
@@ -284,6 +252,14 @@ struct layout_iterate_type_selector<Kokkos::LayoutStride> {
       Kokkos::Iterate::Default;
 };
 }  // namespace Impl
+
+// The layout_iterate_type_selector is now deprecated.
+// Please use the Kokkos::Impl::layout_iterate_type_selector instead.
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+template <typename... Layout>
+using layout_iterate_type_selector KOKKOS_DEPRECATED =
+    Impl::layout_iterate_type_selector<Layout...>;
+#endif
 
 }  // namespace Kokkos
 

--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -253,8 +253,6 @@ struct layout_iterate_type_selector<Kokkos::LayoutStride> {
 };
 }  // namespace Impl
 
-// The layout_iterate_type_selector is now deprecated.
-// Please use the Kokkos::Impl::layout_iterate_type_selector instead.
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <typename... Layout>
 using layout_iterate_type_selector KOKKOS_DEPRECATED =

--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -222,7 +222,9 @@ template <typename Layout, class Enable = void>
 struct KOKKOS_DEPRECATED is_layouttiled : std::false_type {};
 #endif
 
-// For use with view_copy
+// The layout_iterate_type_selector is now deprecated.
+// Please use the Kokkos::Impl::layout_iterate_type_selector instead.
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <typename... Layout>
 struct KOKKOS_DEPRECATED layout_iterate_type_selector {
   static const Kokkos::Iterate outer_iteration_pattern =
@@ -250,6 +252,7 @@ struct KOKKOS_DEPRECATED layout_iterate_type_selector<Kokkos::LayoutStride> {
   static const Kokkos::Iterate inner_iteration_pattern =
       Kokkos::Iterate::Default;
 };
+#endif
 
 namespace Impl {
 // For use with view_copy

--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -224,6 +224,36 @@ struct KOKKOS_DEPRECATED is_layouttiled : std::false_type {};
 
 // For use with view_copy
 template <typename... Layout>
+struct KOKKOS_DEPRECATED layout_iterate_type_selector {
+  static const Kokkos::Iterate outer_iteration_pattern =
+      Kokkos::Iterate::Default;
+  static const Kokkos::Iterate inner_iteration_pattern =
+      Kokkos::Iterate::Default;
+};
+
+template <>
+struct KOKKOS_DEPRECATED layout_iterate_type_selector<Kokkos::LayoutRight> {
+  static const Kokkos::Iterate outer_iteration_pattern = Kokkos::Iterate::Right;
+  static const Kokkos::Iterate inner_iteration_pattern = Kokkos::Iterate::Right;
+};
+
+template <>
+struct KOKKOS_DEPRECATED layout_iterate_type_selector<Kokkos::LayoutLeft> {
+  static const Kokkos::Iterate outer_iteration_pattern = Kokkos::Iterate::Left;
+  static const Kokkos::Iterate inner_iteration_pattern = Kokkos::Iterate::Left;
+};
+
+template <>
+struct KOKKOS_DEPRECATED layout_iterate_type_selector<Kokkos::LayoutStride> {
+  static const Kokkos::Iterate outer_iteration_pattern =
+      Kokkos::Iterate::Default;
+  static const Kokkos::Iterate inner_iteration_pattern =
+      Kokkos::Iterate::Default;
+};
+
+namespace Impl {
+// For use with view_copy
+template <typename... Layout>
 struct layout_iterate_type_selector {
   static const Kokkos::Iterate outer_iteration_pattern =
       Kokkos::Iterate::Default;
@@ -250,6 +280,7 @@ struct layout_iterate_type_selector<Kokkos::LayoutStride> {
   static const Kokkos::Iterate inner_iteration_pattern =
       Kokkos::Iterate::Default;
 };
+}  // namespace Impl
 
 }  // namespace Kokkos
 


### PR DESCRIPTION
  - Address issue #6923
  - Copied the `layout_iterate_type_selector` into the Impl namespace
  - Deprecated the `layout_iterate_type_selector` in parent namespace

The CI runs successfully on [github-windows](https://github.com/jbadwaik/kokkos/actions/runs/9562090958) and [clang-format-check](https://github.com/jbadwaik/kokkos/actions/runs/9562492103). The first attempt had the wrong code format so running it again with the correctly formatted code. 

A question is that, should the `Impl` namespace be put in a separate Impl file? `impl/Kokkos_Layout.hpp` for example? 