### PR TITLE
Resolve various bogus icpc -Werror

### DIFF
--- a/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
@@ -111,6 +111,9 @@ KOKKOS_INLINE_FUNCTION auto array_layout_from_mapping(
                        rank > 6 ? ext.extent(6) : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                        rank > 7 ? ext.extent(7) : KOKKOS_IMPL_CTOR_DEFAULT_ARG};
   }
+#if defined KOKKOS_COMPILER_INTEL
+  __builtin_unreachable();
+#endif
 }
 
 template <class MDSpanType, class VM>
@@ -143,6 +146,9 @@ KOKKOS_INLINE_FUNCTION auto mapping_from_view_mapping(const VM &view_mapping) {
   } else {
     return mapping_type(extents_from_view_mapping<extents_type>(view_mapping));
   }
+#if defined KOKKOS_COMPILER_INTEL
+  __builtin_unreachable();
+#endif
 }
 
 }  // namespace Kokkos::Impl

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
@@ -111,7 +111,7 @@ KOKKOS_INLINE_FUNCTION auto array_layout_from_mapping(
                        rank > 6 ? ext.extent(6) : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                        rank > 7 ? ext.extent(7) : KOKKOS_IMPL_CTOR_DEFAULT_ARG};
   }
-#if defined KOKKOS_COMPILER_INTEL
+#ifdef KOKKOS_COMPILER_INTEL
   __builtin_unreachable();
 #endif
 }
@@ -146,7 +146,7 @@ KOKKOS_INLINE_FUNCTION auto mapping_from_view_mapping(const VM &view_mapping) {
   } else {
     return mapping_type(extents_from_view_mapping<extents_type>(view_mapping));
   }
-#if defined KOKKOS_COMPILER_INTEL
+#ifdef KOKKOS_COMPILER_INTEL
   __builtin_unreachable();
 #endif
 }

--- a/tpls/mdspan/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/tpls/mdspan/include/experimental/__p2642_bits/layout_padded.hpp
@@ -59,9 +59,6 @@ MDSPAN_INLINE_FUNCTION constexpr size_t get_actual_static_padding_value() {
   } else {
     return dynamic_extent;
   }
-#ifdef __INTEL_COMPILER
-  __builtin_unreachable();
-#endif
   // Missing return statement warning from NVCC
 #ifdef __NVCC__
   return 0;
@@ -108,9 +105,6 @@ struct padded_extent {
     } else {
       return init_padding(exts, padding_value);
     }
-#ifdef __INTEL_COMPILER
-  __builtin_unreachable();
-#endif
   // Missing return statement warning from NVCC
 #ifdef __NVCC__
   return {};
@@ -126,9 +120,6 @@ struct padded_extent {
     } else {
       return {};
     }
-#ifdef __INTEL_COMPILER
-  __builtin_unreachable();
-#endif
   // Missing return statement warning from NVCC
 #ifdef __NVCC__
   return {};
@@ -144,9 +135,6 @@ struct padded_extent {
     } else {
       return {};
     }
-#ifdef __INTEL_COMPILER
-  __builtin_unreachable();
-#endif
   // Missing return statement warning from NVCC
 #ifdef __NVCC__
   return {};

--- a/tpls/mdspan/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/tpls/mdspan/include/experimental/__p2642_bits/layout_padded.hpp
@@ -59,6 +59,9 @@ MDSPAN_INLINE_FUNCTION constexpr size_t get_actual_static_padding_value() {
   } else {
     return dynamic_extent;
   }
+#ifdef __INTEL_COMPILER
+  __builtin_unreachable();
+#endif
   // Missing return statement warning from NVCC
 #ifdef __NVCC__
   return 0;
@@ -105,6 +108,9 @@ struct padded_extent {
     } else {
       return init_padding(exts, padding_value);
     }
+#ifdef __INTEL_COMPILER
+  __builtin_unreachable();
+#endif
   // Missing return statement warning from NVCC
 #ifdef __NVCC__
   return {};
@@ -120,6 +126,9 @@ struct padded_extent {
     } else {
       return {};
     }
+#ifdef __INTEL_COMPILER
+  __builtin_unreachable();
+#endif
   // Missing return statement warning from NVCC
 #ifdef __NVCC__
   return {};
@@ -135,6 +144,9 @@ struct padded_extent {
     } else {
       return {};
     }
+#ifdef __INTEL_COMPILER
+  __builtin_unreachable();
+#endif
   // Missing return statement warning from NVCC
 #ifdef __NVCC__
   return {};

--- a/tpls/mdspan/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/tpls/mdspan/include/experimental/__p2642_bits/layout_padded.hpp
@@ -59,8 +59,8 @@ MDSPAN_INLINE_FUNCTION constexpr size_t get_actual_static_padding_value() {
   } else {
     return dynamic_extent;
   }
-  // Missing return statement warning from NVCC
-#ifdef __NVCC__
+  // Missing return statement warning from NVCC and ICC
+#if defined(__NVCC__) || defined(__INTEL_COMPILER)
   return 0;
 #endif
 }
@@ -105,9 +105,9 @@ struct padded_extent {
     } else {
       return init_padding(exts, padding_value);
     }
-  // Missing return statement warning from NVCC
-#ifdef __NVCC__
-  return {};
+    // Missing return statement warning from NVCC and ICC
+#if defined(__NVCC__) || defined(__INTEL_COMPILER)
+    return {};
 #endif
   }
 
@@ -120,9 +120,9 @@ struct padded_extent {
     } else {
       return {};
     }
-  // Missing return statement warning from NVCC
-#ifdef __NVCC__
-  return {};
+    // Missing return statement warning from NVCC and ICC
+#if defined(__NVCC__) || defined(__INTEL_COMPILER)
+    return {};
 #endif
   }
 
@@ -135,9 +135,9 @@ struct padded_extent {
     } else {
       return {};
     }
-  // Missing return statement warning from NVCC
-#ifdef __NVCC__
-  return {};
+    // Missing return statement warning from NVCC and ICC
+#if defined(__NVCC__) || defined(__INTEL_COMPILER)
+    return {};
 #endif
   }
 };


### PR DESCRIPTION
Workaround some -Werror with icpc (intel classic compiler): error #1011: missing return statement at end of non-void function