### PR TITLE
Fix SpaceAwareAccessor based on usage experiment in View

### DIFF
--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -50,21 +50,14 @@ struct SpaceAwareAccessor {
   KOKKOS_DEFAULTED_FUNCTION
   constexpr SpaceAwareAccessor() = default;
 
-  template <class OtherNestedAccessorType,
-            std::enable_if_t<std::is_constructible_v<NestedAccessor,
-                                                     OtherNestedAccessorType>,
-                             int> = 0>
+  template <
+      class OtherMemorySpace, class OtherNestedAccessorType,
+      std::enable_if_t<
+          MemorySpaceAccess<MemorySpace, OtherMemorySpace>::assignable &&
+              std::is_constructible_v<NestedAccessor, OtherNestedAccessorType>,
+          int> = 0>
   KOKKOS_FUNCTION constexpr SpaceAwareAccessor(
-      const SpaceAwareAccessor<MemorySpace, OtherNestedAccessorType>&
-          other) noexcept
-      : nested_acc(other.nested_acc) {}
-
-  template <class OtherNestedAccessorType,
-            std::enable_if_t<std::is_constructible_v<NestedAccessor,
-                                                     OtherNestedAccessorType>,
-                             int> = 0>
-  KOKKOS_FUNCTION constexpr SpaceAwareAccessor(
-      const SpaceAwareAccessor<AnonymousSpace, OtherNestedAccessorType>&
+      const SpaceAwareAccessor<OtherMemorySpace, OtherNestedAccessorType>&
           other) noexcept
       : nested_acc(other.nested_acc) {}
 

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -76,8 +76,17 @@ struct SpaceAwareAccessor {
   }
 
   KOKKOS_FUNCTION
-  constexpr auto offset(data_handle_type p, size_t i) const noexcept {
+  constexpr typename offset_policy::data_handle_type offset(data_handle_type p,
+                                                            size_t i) const
+      noexcept {
     return nested_acc.offset(p, i);
+  }
+
+  // Canonical way for accessing nested accessor see ISO C++
+  // [linalg.scaled.scaledaccessor]
+  KOKKOS_FUNCTION
+  constexpr const NestedAccessor& nested_accessor() const noexcept {
+    return nested_acc;
   }
 
  private:
@@ -133,8 +142,17 @@ struct SpaceAwareAccessor<AnonymousSpace, NestedAccessor> {
   }
 
   KOKKOS_FUNCTION
-  constexpr auto offset(data_handle_type p, size_t i) const noexcept {
+  constexpr typename offset_policy::data_handle_type offset(data_handle_type p,
+                                                            size_t i) const
+      noexcept {
     return nested_acc.offset(p, i);
+  }
+
+  // Canonical way for accessing nested accessor see ISO C++
+  // [linalg.scaled.scaledaccessor]
+  KOKKOS_FUNCTION
+  constexpr const NestedAccessor& nested_accessor() const noexcept {
+    return nested_acc;
   }
 
  private:

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -34,14 +34,16 @@ namespace Impl {
 
 template <class MemorySpace, class NestedAccessor>
 struct SpaceAwareAccessor {
+  // Part of Accessor Requirements
   using element_type     = typename NestedAccessor::element_type;
   using reference        = typename NestedAccessor::reference;
   using data_handle_type = typename NestedAccessor::data_handle_type;
-
   using offset_policy =
       SpaceAwareAccessor<MemorySpace, typename NestedAccessor::offset_policy>;
 
-  using memory_space = MemorySpace;
+  // Specific to SpaceAwareAccessor
+  using memory_space         = MemorySpace;
+  using nested_accessor_type = NestedAccessor;
 
   static_assert(is_memory_space_v<memory_space>);
 
@@ -81,8 +83,7 @@ struct SpaceAwareAccessor {
   }
 
   KOKKOS_FUNCTION
-  constexpr data_handle_type offset(data_handle_type p, size_t i) const
-      noexcept {
+  constexpr auto offset(data_handle_type p, size_t i) const noexcept {
     return nested_acc.offset(p, i);
   }
 
@@ -102,6 +103,7 @@ struct SpaceAwareAccessor {
 
 template <class NestedAccessor>
 struct SpaceAwareAccessor<AnonymousSpace, NestedAccessor> {
+  // Part of Accessor Requirements
   using element_type     = typename NestedAccessor::element_type;
   using reference        = typename NestedAccessor::reference;
   using data_handle_type = typename NestedAccessor::data_handle_type;
@@ -110,7 +112,9 @@ struct SpaceAwareAccessor<AnonymousSpace, NestedAccessor> {
       SpaceAwareAccessor<AnonymousSpace,
                          typename NestedAccessor::offset_policy>;
 
-  using memory_space = AnonymousSpace;
+  // Specific to SpaceAwareAccessor
+  using memory_space         = AnonymousSpace;
+  using nested_accessor_type = NestedAccessor;
 
   KOKKOS_DEFAULTED_FUNCTION
   constexpr SpaceAwareAccessor() = default;
@@ -136,8 +140,7 @@ struct SpaceAwareAccessor<AnonymousSpace, NestedAccessor> {
   }
 
   KOKKOS_FUNCTION
-  constexpr data_handle_type offset(data_handle_type p, size_t i) const
-      noexcept {
+  constexpr auto offset(data_handle_type p, size_t i) const noexcept {
     return nested_acc.offset(p, i);
   }
 

--- a/core/unit_test/TestSpaceAwareAccessor.hpp
+++ b/core/unit_test/TestSpaceAwareAccessor.hpp
@@ -123,8 +123,14 @@ void test_space_aware_accessor_conversion() {
         static_assert(std::is_convertible_v<acc_t, const_acc_t>);
         static_assert(!std::is_constructible_v<acc_t, const_acc_t>);
         static_assert(!std::is_constructible_v<acc_t, int_acc_t>);
-        static_assert(std::is_constructible_v<acc_t, host_acc_t> ==
-                      std::is_same_v<memory_space_t, Kokkos::HostSpace>);
+        static_assert(
+            std::is_constructible_v<acc_t, host_acc_t> ==
+            Kokkos::Impl::MemorySpaceAccess<memory_space_t,
+                                            Kokkos::HostSpace>::assignable);
+        static_assert(
+            std::is_constructible_v<host_acc_t, acc_t> ==
+            Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
+                                            memory_space_t>::assignable);
         static_assert(std::is_constructible_v<anon_acc_t, acc_t>);
         static_assert(std::is_constructible_v<acc_t, anon_acc_t>);
         static_assert(std::is_convertible_v<anon_acc_t, acc_t>);

--- a/core/unit_test/TestSpaceAwareAccessorAccessViolation.hpp
+++ b/core/unit_test/TestSpaceAwareAccessorAccessViolation.hpp
@@ -77,7 +77,8 @@ void test_memory_access_violations_from_device() {
 
 // FIXME_SYCL
 #if !(defined(KOKKOS_COMPILER_INTEL_LLVM) && defined(KOKKOS_ENABLE_SYCL))
-TEST(TEST_CATEGORY_DEATH, space_aware_accessor_invalid_access_from_host) {
+TEST(TEST_CATEGORY_DEATH,
+     mdspan_space_aware_accessor_invalid_access_from_host) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
   using ExecutionSpace = TEST_EXECSPACE;
@@ -92,7 +93,8 @@ TEST(TEST_CATEGORY_DEATH, space_aware_accessor_invalid_access_from_host) {
 }
 #endif
 
-TEST(TEST_CATEGORY_DEATH, space_aware_accessor_invalid_access_from_device) {
+TEST(TEST_CATEGORY_DEATH,
+     mdspan_space_aware_accessor_invalid_access_from_device) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
   using ExecutionSpace = TEST_EXECSPACE;


### PR DESCRIPTION
- fix offset type of SpaceAwareAccesor
- Improved test to catch the mistake, and added a typedef for nested_accessor which I believe every wrapping accessor should have
- fix convertibility properties to match View convertibility