### PR TITLE
Fix more icpc issues

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -456,6 +456,9 @@ KOKKOS_FUNCTION constexpr RealType& get(complex<RealType>& z) noexcept {
     return z.real();
   else
     return z.imag();
+#ifdef KOKKOS_COMPILER_INTEL
+  __builtin_unreachable();
+#endif
 }
 
 template <size_t I, typename RealType>
@@ -475,6 +478,9 @@ KOKKOS_FUNCTION constexpr const RealType& get(
     return z.re_;
   else
     return z.im_;
+#ifdef KOKKOS_COMPILER_INTEL
+  __builtin_unreachable();
+#endif
 }
 
 template <size_t I, typename RealType>

--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -231,7 +231,7 @@ void run_exec_space_thread_safety_mdrange_reduce() {
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange_reduce) {
 // FIXME_INTEL
-#ifdef KOKKOS_COMPILER_INTEL
+#if defined(KOKKOS_COMPILER_INTEL) && defined(KOKKOS_ENABLE_OPENMP)
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::OpenMP>)
     GTEST_SKIP() << "skipping since test is known to fail for OpenMP using the "
                     "legacy Intel compiler";


### PR DESCRIPTION
* Fix more bogus "missing return statement at end of non-void function" -Werror
* Fix unit test guard to only check for Kokkos::OpenMP when the OpenMP backend is enabled