### PR TITLE
Cleanup KokkosP hooks in `Profiling::`

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -972,69 +972,6 @@ void set_callbacks(Kokkos::Tools::Experimental::EventSet new_events) {
 }  // namespace Tools
 
 namespace Profiling {
-bool profileLibraryLoaded() { return Kokkos::Tools::profileLibraryLoaded(); }
-
-void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
-                      uint64_t* kernelID) {
-  Kokkos::Tools::beginParallelFor(kernelPrefix, devID, kernelID);
-}
-void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
-                         uint64_t* kernelID) {
-  Kokkos::Tools::beginParallelReduce(kernelPrefix, devID, kernelID);
-}
-void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
-                       uint64_t* kernelID) {
-  Kokkos::Tools::beginParallelScan(kernelPrefix, devID, kernelID);
-}
-void endParallelFor(const uint64_t kernelID) {
-  Kokkos::Tools::endParallelFor(kernelID);
-}
-void endParallelReduce(const uint64_t kernelID) {
-  Kokkos::Tools::endParallelReduce(kernelID);
-}
-void endParallelScan(const uint64_t kernelID) {
-  Kokkos::Tools::endParallelScan(kernelID);
-}
-
-void pushRegion(const std::string& kName) { Kokkos::Tools::pushRegion(kName); }
-void popRegion() { Kokkos::Tools::popRegion(); }
-
-void createProfileSection(const std::string& sectionName, uint32_t* secID) {
-  Kokkos::Tools::createProfileSection(sectionName, secID);
-}
-void destroyProfileSection(const uint32_t secID) {
-  Kokkos::Tools::destroyProfileSection(secID);
-}
-
-void startSection(const uint32_t secID) { Kokkos::Tools::startSection(secID); }
-
-void stopSection(const uint32_t secID) { Kokkos::Tools::stopSection(secID); }
-
-void markEvent(const std::string& eventName) {
-  Kokkos::Tools::markEvent(eventName);
-}
-void allocateData(const SpaceHandle handle, const std::string name,
-                  const void* data, const uint64_t size) {
-  Kokkos::Tools::allocateData(handle, name, data, size);
-}
-void deallocateData(const SpaceHandle space, const std::string label,
-                    const void* ptr, const uint64_t size) {
-  Kokkos::Tools::deallocateData(space, label, ptr, size);
-}
-
-void beginDeepCopy(const SpaceHandle dst_space, const std::string dst_label,
-                   const void* dst_ptr, const SpaceHandle src_space,
-                   const std::string src_label, const void* src_ptr,
-                   const uint64_t size) {
-  Kokkos::Tools::beginDeepCopy(dst_space, dst_label, dst_ptr, src_space,
-                               src_label, src_ptr, size);
-}
-void endDeepCopy() { Kokkos::Tools::endDeepCopy(); }
-
-void finalize() { Kokkos::Tools::finalize(); }
-void initialize(const std::string& profileLibrary) {
-  Kokkos::Tools::initialize(profileLibrary);
-}
 
 bool printHelp(const std::string& args) {
   return Kokkos::Tools::printHelp(args);
@@ -1044,9 +981,6 @@ void parseArgs(int _argc, char** _argv) {
   Kokkos::Tools::parseArgs(_argc, _argv);
 }
 
-SpaceHandle make_space_handle(const char* space_name) {
-  return Kokkos::Tools::make_space_handle(space_name);
-}
 }  // namespace Profiling
 
 // Tuning

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -971,18 +971,6 @@ void set_callbacks(Kokkos::Tools::Experimental::EventSet new_events) {
 }  // namespace Experimental
 }  // namespace Tools
 
-namespace Profiling {
-
-bool printHelp(const std::string& args) {
-  return Kokkos::Tools::printHelp(args);
-}
-void parseArgs(const std::string& args) { Kokkos::Tools::parseArgs(args); }
-void parseArgs(int _argc, char** _argv) {
-  Kokkos::Tools::parseArgs(_argc, _argv);
-}
-
-}  // namespace Profiling
-
 // Tuning
 
 namespace Tools {

--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -267,6 +267,9 @@ namespace Profiling {
 // clang-format off
 using Kokkos::Tools::profileLibraryLoaded;
 
+using Kokkos::Tools::printHelp;
+using Kokkos::Tools::parseArgs;
+
 using Kokkos::Tools::initialize;
 using Kokkos::Tools::finalize;
 

--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -263,40 +263,38 @@ size_t get_current_context_id();
 }  // namespace Tools
 namespace Profiling {
 
-bool profileLibraryLoaded();
+// don't let ClangFormat reorder the using-declarations below
+// clang-format off
+using Kokkos::Tools::profileLibraryLoaded;
 
-void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
-                      uint64_t* kernelID);
-void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
-                         uint64_t* kernelID);
-void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
-                       uint64_t* kernelID);
-void endParallelFor(const uint64_t kernelID);
-void endParallelReduce(const uint64_t kernelID);
-void endParallelScan(const uint64_t kernelID);
-void pushRegion(const std::string& kName);
-void popRegion();
+using Kokkos::Tools::initialize;
+using Kokkos::Tools::finalize;
 
-void createProfileSection(const std::string& sectionName, uint32_t* secID);
-void destroyProfileSection(const uint32_t secID);
-void startSection(const uint32_t secID);
+using Kokkos::Tools::beginParallelFor;
+using Kokkos::Tools::beginParallelReduce;
+using Kokkos::Tools::beginParallelScan;
+using Kokkos::Tools::endParallelFor;
+using Kokkos::Tools::endParallelReduce;
+using Kokkos::Tools::endParallelScan;
 
-void stopSection(const uint32_t secID);
+using Kokkos::Tools::allocateData;
+using Kokkos::Tools::deallocateData;
 
-void markEvent(const std::string& eventName);
-void allocateData(const SpaceHandle handle, const std::string name,
-                  const void* data, const uint64_t size);
-void deallocateData(const SpaceHandle space, const std::string label,
-                    const void* ptr, const uint64_t size);
-void beginDeepCopy(const SpaceHandle dst_space, const std::string dst_label,
-                   const void* dst_ptr, const SpaceHandle src_space,
-                   const std::string src_label, const void* src_ptr,
-                   const uint64_t size);
-void endDeepCopy();
-void finalize();
-void initialize(const std::string& = {});
+using Kokkos::Tools::beginDeepCopy;
+using Kokkos::Tools::endDeepCopy;
 
-SpaceHandle make_space_handle(const char* space_name);
+using Kokkos::Tools::pushRegion;
+using Kokkos::Tools::popRegion;
+
+using Kokkos::Tools::createProfileSection;
+using Kokkos::Tools::destroyProfileSection;
+using Kokkos::Tools::startSection;
+using Kokkos::Tools::stopSection;
+
+using Kokkos::Tools::markEvent;
+
+using Kokkos::Tools::make_space_handle;
+// clang-format on
 
 namespace Experimental {
 using Kokkos::Tools::Experimental::set_allocate_data_callback;


### PR DESCRIPTION
Prefer using-declarations to reduce boiler plate code.
In the process I realized that the definitions of `Profiling::{print_help, parse_args}` had no matching declarations.
I elected to add them as it looks as an oversight, let me know if you prefer to omit them.