### PR TITLE
Copy print_configuration when combining two kokkos settings.

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -91,6 +91,7 @@ void combine(Kokkos::InitializationSettings& out,
   KOKKOS_IMPL_COMBINE_SETTING(map_device_id_by);
   KOKKOS_IMPL_COMBINE_SETTING(device_id);
   KOKKOS_IMPL_COMBINE_SETTING(disable_warnings);
+  KOKKOS_IMPL_COMBINE_SETTING(print_configuration);
   KOKKOS_IMPL_COMBINE_SETTING(tune_internals);
   KOKKOS_IMPL_COMBINE_SETTING(tools_help);
   KOKKOS_IMPL_COMBINE_SETTING(tools_libs);


### PR DESCRIPTION
[Combining](https://github.com/kokkos/kokkos/blob/develop/core/src/impl/Kokkos_Core.cpp#L83) two `Kokkos::InitializationSettings` skipped the `print_configuration` setting. 

We encountered this bug when initializing `Kokkos::ScopeGuard` using `Kokkos::InitializationSettings` with `set_print_configuration(true)`.
It also seems to occur when using `Kokkos::initialize` with the above setting.

According to the documentation setting this variable should be a valid member of the initialization setting.
https://kokkos.org/kokkos-core-wiki/API/core/initialize_finalize/InitializationSettings.html