### PR TITLE
cmake: fix relative to find kokkos_compiler_launcher

### DIFF
--- a/cmake/KokkosConfigCommon.cmake.in
+++ b/cmake/KokkosConfigCommon.cmake.in
@@ -225,8 +225,13 @@ FUNCTION(kokkos_compilation)
     # if built w/o CUDA support, we want to basically make this a no-op
     SET(_Kokkos_ENABLE_CUDA @Kokkos_ENABLE_CUDA@)
 
+
+    IF(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+      SET(MAYBE_CURRENT_INSTALLATION_ROOT "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../../..")
+    ENDIF()
+
     # search relative first and then absolute
-    SET(_HINTS "${CMAKE_CURRENT_LIST_DIR}/../.." "@CMAKE_INSTALL_PREFIX@")
+    SET(_HINTS "${MAYBE_CURRENT_INSTALLATION_ROOT}" "@CMAKE_INSTALL_PREFIX@")
 
     # find kokkos_launch_compiler
     FIND_PROGRAM(Kokkos_COMPILE_LAUNCHER


### PR DESCRIPTION
In the KokkosConfig package, it currently it uses `CMAKE_PARENT_LIST_DIR` to find the dir containing the file where the kokkos_compilation function exists. This is wrong since `CMAKE_CURRENT_LIST_DIR` gives you the directory from where the function was invoked. This corrects this behavior by using `CMAKE_CURRENT_FUNCTION_LIST_DIR`.

This is needed for using kokkos installations where `CMAKE_INSTALL_PREFIX` was not used and instead the user invokes cmake --install . --prefix `xxyyzz`.