### PR TITLE
Fix and test with -fsanitize=undefined in GitHub CI

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -106,7 +106,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/usr \
             ${{ matrix.clang-tidy }} \
             -Ddesul_ROOT=/usr/desul-install/ \
-            -DKokkos_ENABLE_DESUL_ATOMICS_EXTERNAL=ON \
+            -DKokkos_ENABLE_DESUL_ATOMICS_EXTERNAL=OFF \
             -DKokkos_ENABLE_HWLOC=ON \
             -DKokkos_ENABLE_${{ matrix.backend }}=ON \
             -DKokkos_ENABLE_TESTS=ON \

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -39,7 +39,8 @@ jobs:
             backend: 'OPENMP'
           - distro: 'ubuntu:intel'
             cxx: 'icpx'
-            cxx_extra_flags: '-fp-model=precise -Wno-pass-failed'
+            cxx_extra_flags: '-fp-model=precise -Wno-pass-failed -fsanitize=address,undefined -fno-sanitize=function -fno-sanitize-recover=all'
+            extra_linker_flags: '-fsanitize=address,undefined -fno-sanitize=function -fno-sanitize-recover=all'
             cmake_build_type: 'Release'
             backend: 'OPENMP'
           - distro: 'ubuntu:intel'
@@ -49,15 +50,15 @@ jobs:
             backend: 'OPENMP'
           - distro: 'ubuntu:latest'
             cxx: 'clang++'
-            cxx_extra_flags: '-fsanitize=address'
-            extra_linker_flags: '-fsanitize=address'
+            cxx_extra_flags: '-fsanitize=address,undefined -fno-sanitize=function -fno-sanitize-recover=all'
+            extra_linker_flags: '-fsanitize=address,undefined -fno-sanitize=function -fno-sanitize-recover=all'
             cmake_build_type: 'RelWithDebInfo'
             backend: 'THREADS'
             clang-tidy: '-DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*"'
           - distro: 'ubuntu:latest'
             cxx: 'clang++'
-            cxx_extra_flags: '-fsanitize=address'
-            extra_linker_flags: '-fsanitize=address'
+            cxx_extra_flags: '-fsanitize=address,undefined -fno-sanitize=function -fno-sanitize-recover=all'
+            extra_linker_flags: '-fsanitize=address,undefined -fno-sanitize=function -fno-sanitize-recover=all'
             cmake_build_type: 'RelWithDebInfo'
             backend: 'SERIAL'
           - distro: 'ubuntu:latest'
@@ -128,7 +129,7 @@ jobs:
         working-directory: builddir
         run: ctest --output-on-failure
       - name: Test linking against build dir
-        if: ${{ matrix.cxx_extra_flags != '-fsanitize=address' }}
+        if: ${{ !contains(matrix.cxx_extra_flags, '-fsanitize=address') }}
         working-directory: example/build_cmake_installed
         run: |
           cmake -B builddir_buildtree -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} -DKokkos_ROOT=../../builddir
@@ -139,7 +140,7 @@ jobs:
       - name: Install
         run: sudo cmake --build builddir --target install
       - name: Test install
-        if: ${{ matrix.cxx_extra_flags != '-fsanitize=address' }}
+        if: ${{ !contains(matrix.cxx_extra_flags, '-fsanitize=address') }}
         working-directory: example/build_cmake_installed
         run: |
           cmake -B builddir -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: desul/desul
-          ref: 60c1115af231f4bfe0d70a3e0cf54b2cc0ff1594
+          ref: 779d0441a778c7088a36d38c4cbf8df3cfa182cc
           path: desul
       - name: Install desul
         working-directory: desul
@@ -106,7 +106,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/usr \
             ${{ matrix.clang-tidy }} \
             -Ddesul_ROOT=/usr/desul-install/ \
-            -DKokkos_ENABLE_DESUL_ATOMICS_EXTERNAL=OFF \
+            -DKokkos_ENABLE_DESUL_ATOMICS_EXTERNAL=ON \
             -DKokkos_ENABLE_HWLOC=ON \
             -DKokkos_ENABLE_${{ matrix.backend }}=ON \
             -DKokkos_ENABLE_TESTS=ON \

--- a/containers/unit_tests/TestVector.hpp
+++ b/containers/unit_tests/TestVector.hpp
@@ -207,7 +207,6 @@ struct test_vector_combinations {
     Scalar test3 = 0;
     for (unsigned int i = 0; i < a.size(); i++) test3 += a[i];
 
-    std::cout << test1 << ' ' << test2 << ' ' << test3 << '\n';
     return (test1 * test2 + test3) * test2 + test1 * test3;
   }
 
@@ -234,7 +233,7 @@ void test_vector_allocate(unsigned int size) {
 TEST(TEST_CATEGORY, vector_combination) {
   test_vector_allocate<int, TEST_EXECSPACE>(10);
   test_vector_combinations<int, TEST_EXECSPACE>(10);
-  test_vector_combinations<long, TEST_EXECSPACE>(3057);
+  test_vector_combinations<long long int, TEST_EXECSPACE>(3057);
 }
 
 TEST(TEST_CATEGORY, vector_insert) {

--- a/containers/unit_tests/TestVector.hpp
+++ b/containers/unit_tests/TestVector.hpp
@@ -207,6 +207,7 @@ struct test_vector_combinations {
     Scalar test3 = 0;
     for (unsigned int i = 0; i < a.size(); i++) test3 += a[i];
 
+    std::cout << test1 << ' ' << test2 << ' ' << test3 << '\n';
     return (test1 * test2 + test3) * test2 + test1 * test3;
   }
 
@@ -233,7 +234,7 @@ void test_vector_allocate(unsigned int size) {
 TEST(TEST_CATEGORY, vector_combination) {
   test_vector_allocate<int, TEST_EXECSPACE>(10);
   test_vector_combinations<int, TEST_EXECSPACE>(10);
-  test_vector_combinations<int, TEST_EXECSPACE>(3057);
+  test_vector_combinations<long, TEST_EXECSPACE>(3057);
 }
 
 TEST(TEST_CATEGORY, vector_insert) {

--- a/core/perf_test/test_atomic.cpp
+++ b/core/perf_test/test_atomic.cpp
@@ -390,7 +390,7 @@ static void Test_Atomic(benchmark::State& state) {
 
 static constexpr int LOOP = 100'000;
 
-BENCHMARK(Test_Atomic<int>)->Arg(LOOP)->Iterations(10);
+BENCHMARK(Test_Atomic<int>)->Arg(30'000)->Iterations(10);
 BENCHMARK(Test_Atomic<long int>)->Arg(LOOP)->Iterations(10);
 BENCHMARK(Test_Atomic<long long int>)->Arg(LOOP)->Iterations(10);
 BENCHMARK(Test_Atomic<unsigned int>)->Arg(LOOP)->Iterations(10);
@@ -398,4 +398,3 @@ BENCHMARK(Test_Atomic<unsigned long int>)->Arg(LOOP)->Iterations(10);
 BENCHMARK(Test_Atomic<unsigned long long int>)->Arg(LOOP)->Iterations(10);
 BENCHMARK(Test_Atomic<float>)->Arg(LOOP)->Iterations(10);
 BENCHMARK(Test_Atomic<double>)->Arg(LOOP)->Iterations(10);
-BENCHMARK(Test_Atomic<int>)->Arg(LOOP)->Iterations(10);

--- a/core/perf_test/test_atomic_minmax_simple.cpp
+++ b/core/perf_test/test_atomic_minmax_simple.cpp
@@ -183,7 +183,8 @@ double atomic_contentious_max_replacement(benchmark::State& state,
   Kokkos::parallel_reduce(
       con_length,
       KOKKOS_LAMBDA(const int i, T& inner) {
-        inner = Kokkos::atomic_max_fetch(&(input(0)), inner + 1);
+        inner = Kokkos::atomic_max_fetch(&(input(0)),
+                                         Kokkos::min(inner, max - 1) + 1);
         if (i == con_length - 1) {
           Kokkos::atomic_max_fetch(&(input(0)), max);
           inner = max;
@@ -223,7 +224,8 @@ double atomic_contentious_min_replacement(benchmark::State& state,
   Kokkos::parallel_reduce(
       con_length,
       KOKKOS_LAMBDA(const int i, T& inner) {
-        inner = Kokkos::atomic_min_fetch(&(input(0)), inner - 1);
+        inner = Kokkos::atomic_min_fetch(&(input(0)),
+                                         Kokkos::max(inner, min + 1) - 1);
         if (i == con_length - 1) {
           Kokkos::atomic_min_fetch(&(input(0)), min);
           inner = min;
@@ -246,7 +248,7 @@ static void Atomic_ContentiousMinReplacements(benchmark::State& state) {
   auto inp          = prepare_input(1, std::numeric_limits<T>::max());
 
   for (auto _ : state) {
-    const auto time = atomic_contentious_max_replacement(state, inp, length);
+    const auto time = atomic_contentious_min_replacement(state, inp, length);
 
     state.SetIterationTime(time);
   }

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -106,7 +106,11 @@ class HostThreadTeamData {
 
  public:
   inline bool team_rendezvous() const noexcept {
-    int* ptr = reinterpret_cast<int*>(m_team_scratch + m_team_rendezvous);
+    // FIXME_OPENMP The tasking framework creates an instance with
+    // m_team_scratch == nullptr and m_team_rendezvous != 0:
+    int* ptr = m_team_scratch == nullptr
+                   ? nullptr
+                   : reinterpret_cast<int*>(m_team_scratch + m_team_rendezvous);
     HostBarrier::split_arrive(ptr, m_team_size, m_team_rendezvous_step);
     if (m_team_rank != 0) {
       HostBarrier::wait(ptr, m_team_size, m_team_rendezvous_step);
@@ -130,9 +134,13 @@ class HostThreadTeamData {
   }
 
   inline void team_rendezvous_release() const noexcept {
+    // FIXME_OPENMP The tasking framework creates an instance with
+    // m_team_scratch == nullptr and m_team_rendezvous != 0:
     HostBarrier::split_release(
-        reinterpret_cast<int*>(m_team_scratch + m_team_rendezvous), m_team_size,
-        m_team_rendezvous_step);
+        (m_team_scratch == nullptr)
+            ? nullptr
+            : reinterpret_cast<int*>(m_team_scratch + m_team_rendezvous),
+        m_team_size, m_team_rendezvous_step);
   }
 
   inline int pool_rendezvous() const noexcept {
@@ -271,6 +279,9 @@ class HostThreadTeamData {
   }
 
   int64_t* team_shared() const noexcept {
+    // FIXME_OPENMP The tasking framework creates an instance with
+    // m_team_scratch == nullptr and m_team_shared != 0
+    if (m_team_scratch == nullptr) return nullptr;
     return m_team_scratch + m_team_shared;
   }
 
@@ -400,8 +411,12 @@ class HostThreadTeamMember {
   int const m_league_size;
 
  public:
+  // FIXME_OPENMP The tasking framework creates an instance with
+  // m_team_scratch == nullptr and m_team_shared != 0:
   constexpr HostThreadTeamMember(HostThreadTeamData& arg_data) noexcept
-      : m_scratch(arg_data.team_shared(), arg_data.team_shared_bytes()),
+      : m_scratch(arg_data.team_shared(), (arg_data.team_shared() == nullptr)
+                                              ? 0
+                                              : arg_data.team_shared_bytes()),
         m_data(arg_data),
         m_league_rank(arg_data.m_league_rank),
         m_league_size(arg_data.m_league_size) {}

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -32,6 +32,10 @@
 
 // Profiling
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct Kokkos_Profiling_KokkosPDeviceInfo {
   size_t deviceID;
 };
@@ -266,5 +270,9 @@ struct Kokkos_Profiling_EventSet {
                                                     // interface without
                                                     // changing struct layout
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // KOKKOS_PROFILING_C_INTERFACE_HPP

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -385,11 +385,9 @@ SharedAllocationRecord<void, void>
   template class Kokkos::Impl::HostInaccessibleSharedAllocationRecordCommon<           \
       MEMORY_SPACE>
 
-namespace {
-
 /* Taking the address of this function so make sure it is unique */
 template <class MemorySpace, class DestroyFunctor>
-void deallocate(SharedAllocationRecord<void, void>* record_ptr) {
+inline void deallocate(SharedAllocationRecord<void, void>* record_ptr) {
   using base_type = SharedAllocationRecord<MemorySpace, void>;
   using this_type = SharedAllocationRecord<MemorySpace, DestroyFunctor>;
 
@@ -400,8 +398,6 @@ void deallocate(SharedAllocationRecord<void, void>* record_ptr) {
 
   delete ptr;
 }
-
-}  // namespace
 
 /*
  *  Memory space specialization of SharedAllocationRecord< Space , void >

--- a/core/unit_test/TestAtomicOperations.hpp
+++ b/core/unit_test/TestAtomicOperations.hpp
@@ -459,9 +459,11 @@ bool AtomicOperationsTestIntegralType(int old_val_in, int update_in, int test) {
     case 12: return true;
 #else
     case 11:
-      return update_in >= 0 ? atomic_op_test<LShiftAtomicTest, T, ExecSpace>(
-                                  old_val, update)
-                            : true;
+      return (std::make_signed_t<T>(update_in) >= 0 &&
+              std::make_signed_t<T>(old_val) >= 0)
+                 ? atomic_op_test<LShiftAtomicTest, T, ExecSpace>(old_val,
+                                                                  update)
+                 : true;
     case 12:
       return update_in >= 0 ? atomic_op_test<RShiftAtomicTest, T, ExecSpace>(
                                   old_val, update)

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -131,8 +131,6 @@ inline void host_check_shift_ops() {
         for (std::size_t i = 0; i < width; ++i) test_vals[i] *= -1;
         host_check_shift_op_all_loaders<Abi>(shift_right(), test_vals, shift_by,
                                              num_cases);
-        host_check_shift_op_all_loaders<Abi>(shift_left(), test_vals, shift_by,
-                                             num_cases);
       }
     }
   }
@@ -253,8 +251,6 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_ops() {
       if constexpr (std::is_signed_v<DataType>) {
         for (std::size_t i = 0; i < width; ++i) test_vals[i] *= -1;
         device_check_shift_op_all_loaders<Abi>(shift_right(), test_vals,
-                                               shift_by, num_cases);
-        device_check_shift_op_all_loaders<Abi>(shift_left(), test_vals,
                                                shift_by, num_cases);
       }
     }

--- a/tpls/desul/include/desul/atomics/Fetch_Op_Generic.hpp
+++ b/tpls/desul/include/desul/atomics/Fetch_Op_Generic.hpp
@@ -78,6 +78,8 @@ DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(rshift)
 #undef DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE
 #undef DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT
 
+// NOTE: using atomic_oper_fetch in the fallback implementation of atomic_store to avoid
+// reading potentially uninitialized values which would yield undefined behavior.
 #define DESUL_IMPL_ATOMIC_LOAD_AND_STORE(ANNOTATION, HOST_OR_DEVICE)           \
   template <class T, class MemoryOrder, class MemoryScope>                     \
   ANNOTATION T HOST_OR_DEVICE##_atomic_load(                                   \
@@ -86,9 +88,6 @@ DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(rshift)
         load_operator<T, const T>(), const_cast<T*>(dest), T(), order, scope); \
   }                                                                            \
                                                                                \
-  /* NOTE: using atomic_oper_fetch in the fallback implementation of           \
-   * atomic_store to avoid reading potentially uninitialized values            \
-   * which would yield undefined behavior. */                                  \
   template <class T, class MemoryOrder, class MemoryScope>                     \
   ANNOTATION void HOST_OR_DEVICE##_atomic_store(                               \
       T* const dest, const T val, MemoryOrder order, MemoryScope scope) {      \

--- a/tpls/desul/include/desul/atomics/Fetch_Op_Generic.hpp
+++ b/tpls/desul/include/desul/atomics/Fetch_Op_Generic.hpp
@@ -86,10 +86,13 @@ DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(rshift)
         load_operator<T, const T>(), const_cast<T*>(dest), T(), order, scope); \
   }                                                                            \
                                                                                \
+  /* NOTE: using atomic_oper_fetch in the fallback implementation of           \
+   * atomic_store to avoid reading potentially uninitialized values            \
+   * which would yield undefined behavior. */                                  \
   template <class T, class MemoryOrder, class MemoryScope>                     \
   ANNOTATION void HOST_OR_DEVICE##_atomic_store(                               \
       T* const dest, const T val, MemoryOrder order, MemoryScope scope) {      \
-    (void)HOST_OR_DEVICE##_atomic_fetch_oper(                                  \
+    (void)HOST_OR_DEVICE##_atomic_oper_fetch(                                  \
         store_operator<T, const T>(), dest, val, order, scope);                \
   }
 


### PR DESCRIPTION
Fixes #7086. The respective `desul` changes are in desul/desul#128.


- Fix signed overflow in tests
- Make sure to use C-linkage for profiling C-interface
- Prefer inline over anonymous namespace in Kokkos_SharedAlloc.hpp
- Don't test left shift for negative values 
- Fix using uninitialized memory in generic HOST_OR_DEVICE##_atomic_store
- avoid offsetting nullptr
- fix bug in atomic_max/min tests