### PR TITLE
Restrict jenkins CI not to run on hopper for nvcc < 11.8

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -366,7 +366,7 @@ pipeline {
                             filename 'Dockerfile.nvcc'
                             dir 'scripts/docker'
                             additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.0.3-devel-ubuntu18.04 --build-arg ADDITIONAL_PACKAGES="g++-8 gfortran clang" --build-arg CMAKE_VERSION=3.17.3'
-                            label 'nvidia-docker'
+                            label 'nvidia-docker && (volta || ampere)'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }
                     }
@@ -437,7 +437,7 @@ pipeline {
                             filename 'Dockerfile.nvcc'
                             dir 'scripts/docker'
                             additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.6.2-devel-ubuntu20.04'
-                            label 'nvidia-docker'
+                            label 'nvidia-docker && (volta || ampere)'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }
                     }


### PR DESCRIPTION
We are seeing
```
nvcc fatal   : Value 'sm_90' is not defined for option 'gpu-architecture'
```
in some builds so we have to restrict existing builds using `Cuda` version earlier than 11.8 (all of them) not to use the `hopper` runner. Alternatively, we could update the Cuda version in these two builds to at least 11.8 but this is the simpler change.