### PR TITLE
SYCL CI: Manually build oneDPL

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -112,6 +112,7 @@ pipeline {
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=clang++ \
                                 -DCMAKE_CXX_FLAGS="-fsycl-device-code-split=per_kernel -Wno-deprecated-declarations -Werror -Wno-gnu-zero-variadic-macro-arguments -Wno-unknown-cuda-version -Wno-sycl-target" \
+                                -DCMAKE_PREFIX_PATH="$ONE_DPL_DIR" \
                                 -DKOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED=0 \
                                 -DKokkos_ARCH_NATIVE=ON \
                                 -DKokkos_ARCH_AMPERE80=ON \

--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -51,10 +51,19 @@ RUN wget https://cloud.cees.ornl.gov/download/oneapi-for-nvidia-gpus-2023.0.0-li
     ./oneapi-for-nvidia-gpus-2023.0.0-linux.sh -y && \
     rm oneapi-for-nvidia-gpus-2023.0.0-linux.sh
 
-RUN wget https://registrationcenter-download.intel.com/akdlm/irc_nas/19133/l_oneDPL_p_2022.0.0.25335.sh &&\
-    chmod +x ./l_oneDPL_p_2022.0.0.25335.sh && \
-    ./l_oneDPL_p_2022.0.0.25335.sh -a -s --eula accept && \
-    rm l_oneDPL_p_2022.0.0.25335.sh
+ENV ONE_DPL_DIR=/opt/onedpl
+RUN . /opt/intel/oneapi/setvars.sh --include-intel-llvm && \
+    ONE_DPL_VERSION=oneDPL-2022.2.0 && \
+    ONE_DPL_URL=https://github.com/oneapi-src/oneDPL/archive && \
+    ONE_DPL_ARCHIVE=${ONE_DPL_VERSION}-rc1.tar.gz && \
+    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
+    wget --quiet ${ONE_DPL_URL}/${ONE_DPL_ARCHIVE} && \
+    mkdir onedpl && \
+    tar -xf ${ONE_DPL_ARCHIVE} -C onedpl --strip-components=1 && cd onedpl && \
+    mkdir build && cd build && \
+    cmake -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX=${ONE_DPL_DIR} -DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=TRUE -DONEDPL_BACKEND="dpcpp_only" .. && \
+    make -j${NPROCS} install && \
+    rm -rf ${SCRATCH_DIR}
 
 # clang++
 ENV PATH=/opt/intel/oneapi/compiler/latest/linux/bin-llvm/:$PATH


### PR DESCRIPTION
We are currently seeing
```
--2024-06-28 16:01:41--  (try: 2)  https://registrationcenter-download.intel.com/akdlm/irc_nas/19133/l_oneDPL_p_2022.0.0.25335.sh

Connecting to registrationcenter-download.intel.com (registrationcenter-download.intel.com)|23.211.176.50|:443... 
connected.

HTTP request sent, awaiting response... 
No data received.
```
when building the SYCL image used in the CI. It seems that the `oneDPL` installer we are using has become unavailable. Instead, this pull request fetches the respective `oneDPL` release from https://github.com/oneapi-src/oneDPL/releases and builds it manually. We can reevaluate this strategy when updating the minimum oneAPI compiler version.