### PR TITLE
Add missing concepts include in test

### DIFF
--- a/core/unit_test/TestSpaceAwareAccessor.hpp
+++ b/core/unit_test/TestSpaceAwareAccessor.hpp
@@ -18,6 +18,9 @@
 #include <type_traits>
 
 #include <gtest/gtest.h>
+#ifndef KOKKOS_ENABLE_CXX17
+#include <concepts>
+#endif
 
 template <class T>
 struct funky_data_handle {
@@ -91,8 +94,7 @@ void test_space_aware_accessor() {
             std::is_same_v<typename acc_t::memory_space, memory_space_t>);
         static_assert(
             std::is_same_v<typename acc_t::nested_accessor_type, FunkyAcc<T>>);
-#if defined(KOKKOS_ENABLE_CXX20) || defined(KOKKOS_ENABLE_CXX23) || \
-    defined(KOKKOS_ENABLE_CXX26)
+#ifndef KOKKOS_ENABLE_CXX17
         static_assert(std::copyable<acc_t>);
         static_assert(std::is_empty_v<acc_t>);
 #endif


### PR DESCRIPTION
Note this was implicitly likely there when mdspan is enabled.