### PR TITLE
simd: avoid div-by-zero case in testing

### DIFF
--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -122,31 +122,30 @@ inline void host_check_abi_size() {
 template <typename Abi, typename DataType>
 inline void host_check_math_ops() {
   if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
-    constexpr size_t n = 16;
     constexpr size_t alignment =
         Kokkos::Experimental::simd<DataType, Abi>::size() * sizeof(DataType);
 
     host_check_abi_size<Abi, DataType>();
 
     if constexpr (!std::is_integral_v<DataType>) {
-      alignas(alignment) DataType const first_args[n] = {
+      alignas(alignment) DataType const first_args[] = {
           0.1, 0.4, 0.5,  0.7, 1.0, 1.5,  -2.0, 10.0,
           0.0, 1.2, -2.8, 3.0, 4.0, -0.1, 5.0,  -0.2};
-      alignas(alignment) DataType const second_args[n] = {
+      alignas(alignment) DataType const second_args[] = {
           1.0,  0.2,  1.1,  1.8, -0.1,  -3.0, -2.4, 1.0,
-          13.0, -3.2, -2.1, 3.0, -15.0, -0.5, -0.2};
+          13.0, -3.2, -2.1, 3.0, -15.0, -0.5, -0.2, -0.2};
       host_check_all_math_ops<Abi>(first_args, second_args);
     } else {
       if constexpr (std::is_signed_v<DataType>) {
-        alignas(alignment) DataType const first_args[n] = {
+        alignas(alignment) DataType const first_args[] = {
+            1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2, -3, 7, 4, -9, -15};
+        alignas(alignment) DataType const second_args[] = {
             1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2, 10, -15, 7, 2, -10};
-        alignas(alignment) DataType const second_args[n] = {
-            1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2};
         host_check_all_math_ops<Abi>(first_args, second_args);
       } else {
-        alignas(alignment) DataType const first_args[n] = {
+        alignas(alignment) DataType const first_args[] = {
             1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2, 11, 5, 8, 2, 14};
-        alignas(alignment) DataType const second_args[n] = {
+        alignas(alignment) DataType const second_args[] = {
             1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2, 3, 6, 20, 5, 14};
         host_check_all_math_ops<Abi>(first_args, second_args);
       }
@@ -258,30 +257,28 @@ KOKKOS_INLINE_FUNCTION void device_check_abi_size() {
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_math_ops() {
   if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
-    constexpr size_t n = 16;
-
     device_check_abi_size<Abi, DataType>();
 
     if constexpr (!std::is_integral_v<DataType>) {
-      DataType const first_args[n]  = {0.1,  0.4,  0.5, 0.7, 1.0,  1.5,
-                                      -2.0, 10.0, 0.0, 1.2, -2.8, 3.0,
-                                      4.0,  -0.1, 5.0, -0.2};
-      DataType const second_args[n] = {1.0,  0.2,  1.1,   1.8,  -0.1,
-                                       -3.0, -2.4, 1.0,   13.0, -3.2,
-                                       -2.1, 3.0,  -15.0, -0.5, -0.2};
+      DataType const first_args[]  = {0.1,  0.4,  0.5, 0.7, 1.0,  1.5,
+                                     -2.0, 10.0, 0.0, 1.2, -2.8, 3.0,
+                                     4.0,  -0.1, 5.0, -0.2};
+      DataType const second_args[] = {1.0,   0.2,  1.1,  1.8,  -0.1, -3.0,
+                                      -2.4,  1.0,  13.0, -3.2, -2.1, 3.0,
+                                      -15.0, -0.5, -0.2, -0.2};
       device_check_all_math_ops<Abi>(first_args, second_args);
     } else {
       if constexpr (std::is_signed_v<DataType>) {
-        DataType const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10,
-                                        0, 1, -2, -3, 7, 4, -9, -15};
-        DataType const second_args[n] = {1,  2,  1,  1,  1,   -3, -2, 1,
-                                         13, -3, -2, 10, -15, 7,  2,  -10};
+        DataType const first_args[]  = {1, 2, -1, 10, 0, 1, -2, 10,
+                                       0, 1, -2, -3, 7, 4, -9, -15};
+        DataType const second_args[] = {1,  2,  1,  1,  1,   -3, -2, 1,
+                                        13, -3, -2, 10, -15, 7,  2,  -10};
         device_check_all_math_ops<Abi>(first_args, second_args);
       } else {
-        DataType const first_args[n]  = {1, 2, 1, 10, 0, 1, 2, 10,
-                                        0, 1, 2, 11, 5, 8, 2, 14};
-        DataType const second_args[n] = {1,  2, 1, 1, 1, 3,  2, 1,
-                                         13, 3, 2, 3, 6, 20, 5, 14};
+        DataType const first_args[]  = {1, 2, 1, 10, 0, 1, 2, 10,
+                                       0, 1, 2, 11, 5, 8, 2, 14};
+        DataType const second_args[] = {1,  2, 1, 1, 1, 3,  2, 1,
+                                        13, 3, 2, 3, 6, 20, 5, 14};
         device_check_all_math_ops<Abi>(first_args, second_args);
       }
     }


### PR DESCRIPTION
Fixes #7111 

The problem came from unintentionally using zeroes as denominators for division testing, producing div-by-zero cases.

For other compilers, div-by-zero consistently produced `inf` or `-inf` with floating point literal division and simd division.
But for intel/2023.2.0 icpc, float literal division produced `nan` or `-nan`, while simd division produced `inf` or `-inf`.

Ironically, this inconsistency in icpc exposed the error in the test file.