### PR TITLE
Deprecate `RawMemoryAllocationFailure::FailureMode::MaximumCudaUVMAllocationsExceeded`

### DIFF
--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -86,6 +86,10 @@ void Experimental::RawMemoryAllocationFailure::print_error_message(
            " requested allocation mechanism (it's probably too large).";
       break;
     case FailureMode::Unknown: o << " because of an unknown error."; break;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+    default:  // silent warnings enumeration value
+      break;  // 'MaximumCudaUVMAllocationsExceeded' not handled in switch
+#endif
   }
   o << "  (The allocation mechanism was ";
   switch (m_mechanism) {

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -85,10 +85,6 @@ void Experimental::RawMemoryAllocationFailure::print_error_message(
       o << " because the requested allocation size is not a valid size for the"
            " requested allocation mechanism (it's probably too large).";
       break;
-    // TODO move this to the subclass for Cuda-related things
-    case FailureMode::MaximumCudaUVMAllocationsExceeded:
-      o << " because the maximum Cuda UVM allocations was exceeded.";
-      break;
     case FailureMode::Unknown: o << " because of an unknown error."; break;
   }
   o << "  (The allocation mechanism was ";

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -86,10 +86,6 @@ void Experimental::RawMemoryAllocationFailure::print_error_message(
            " requested allocation mechanism (it's probably too large).";
       break;
     case FailureMode::Unknown: o << " because of an unknown error."; break;
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-    default:  // silent warnings enumeration value
-      break;  // 'MaximumCudaUVMAllocationsExceeded' not handled in switch
-#endif
   }
   o << "  (The allocation mechanism was ";
   switch (m_mechanism) {

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -42,9 +42,6 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
     OutOfMemoryError,
     AllocationNotAligned,
     InvalidAllocationSize,
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-    MaximumCudaUVMAllocationsExceeded KOKKOS_DEPRECATED,
-#endif
     Unknown
   };
   enum class AllocationMechanism {

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -42,7 +42,9 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
     OutOfMemoryError,
     AllocationNotAligned,
     InvalidAllocationSize,
-    MaximumCudaUVMAllocationsExceeded,
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+    MaximumCudaUVMAllocationsExceeded KOKKOS_DEPRECATED,
+#endif
     Unknown
   };
   enum class AllocationMechanism {


### PR DESCRIPTION
Oversight in #2707
It is in namespace `Experimental::` so we could just remove it but I suggest we mark it as deprecated to be safe.