### PR TITLE
Update HIP nightly build base image Ubuntu 20.04 -> 22.04

### DIFF
--- a/.jenkins_nightly
+++ b/.jenkins_nightly
@@ -108,7 +108,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.hipcc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:6.1.1-complete'
+                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-22.04:6.2-complete'
                             label 'rocm-docker && AMD_Radeon_Instinct_MI210'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
                         }


### PR DESCRIPTION
The motivation for changing is that the system libstdc++ does not support concepts.

Also bumping from ROCm 6.1.1 to the current latest that is 6.2