### PR TITLE
Check for LIBCXX 10 or later for C++20 and later

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
@@ -59,15 +59,7 @@ class RandomAccessIterator< ::Kokkos::View<DataType, Args...> > {
                                                 ptrdiff_t current_index)
       : m_view(view), m_current_index(current_index) {}
 
-// FIXME The C++20 requires expression is not supported with Clang 9 and GCC 9
-// The following guards is unsufficient until we increase our minimum CXX20
-// compiler requirements.
-//   #ifndef KOKKOS_ENABLE_CXX17  // C++20 and beyond
-// We replace the Kokkos guards with standard C++ feature testing in the
-// meantime.
-#if (defined(__cpp_concepts) && (__cpp_concepts >= 201907L)) && \
-    (defined(__cpp_conditional_explicit) &&                     \
-     (__cpp_conditional_explicit >= 201806L))
+#ifndef KOKKOS_ENABLE_CXX17  // C++20 and beyond
   template <class OtherViewType>
   requires(std::is_constructible_v<view_type, OtherViewType>) KOKKOS_FUNCTION
       explicit(!std::is_convertible_v<OtherViewType, view_type>)

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -58,15 +58,16 @@
 #include <impl/Kokkos_NvidiaGpuArchitectures.hpp>
 #endif
 
+#if !defined(KOKKOS_ENABLE_CXX17)
 #if __has_include(<version>)
 #include <version>
 #else
 #include <iso646.h>
 #endif
-#if !defined(KOKKOS_ENABLE_CXX17) && defined(_GLIBCXX_RELEASE) && \
-    _GLIBCXX_RELEASE < 10
+#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 10
 #error \
     "Compiling with support for C++20 or later requires a libstdc++ version later than 9"
+#endif
 #endif
 
 //----------------------------------------------------------------------------

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -62,7 +62,7 @@
 #if __has_include(<version>)
 #include <version>
 #else
-#include <iso646.h>
+#include <ciso646>
 #endif
 #if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 10
 #error \

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -58,7 +58,11 @@
 #include <impl/Kokkos_NvidiaGpuArchitectures.hpp>
 #endif
 
+#if __has_include(<version>)
+#include <version>
+#else
 #include <iso646.h>
+#endif
 #if !defined(KOKKOS_ENABLE_CXX17) && defined(_GLIBCXX_RELEASE) && \
     _GLIBCXX_RELEASE < 10
 #error \

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -58,7 +58,7 @@
 #include <impl/Kokkos_NvidiaGpuArchitectures.hpp>
 #endif
 
-#include <ciso646>
+#include <iso646.h>
 #if !defined(KOKKOS_ENABLE_CXX17) && defined(_GLIBCXX_RELEASE) && \
     _GLIBCXX_RELEASE < 10
 #error \

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -58,6 +58,13 @@
 #include <impl/Kokkos_NvidiaGpuArchitectures.hpp>
 #endif
 
+#include <ciso646>
+#if !defined(KOKKOS_ENABLE_CXX17) && defined(_GLIBCXX_RELEASE) && \
+    _GLIBCXX_RELEASE < 10
+#error \
+    "Compiling with support for C++20 or later requires a libstdc++ version later than 9"
+#endif
+
 //----------------------------------------------------------------------------
 /** Pick up compiler specific #define macros:
  *

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1705,9 +1705,7 @@ class View : public ViewTraits<DataType, Properties...> {
 #ifdef KOKKOS_ENABLE_IMPL_MDSPAN
   template <typename U = typename Impl::MDSpanViewTraits<traits>::mdspan_type>
   KOKKOS_INLINE_FUNCTION
-#if defined(__cpp_conditional_explicit) && \
-    (__cpp_conditional_explicit >= 201806L)
-      // FIXME C++20 reevaluate after determining minium compiler versions
+#ifndef KOKKOS_ENABLE_CXX17
       explicit(traits::is_managed)
 #endif
           View(const typename Impl::MDSpanViewTraits<traits>::mdspan_type& mds,
@@ -1724,9 +1722,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <class ElementType, class ExtentsType, class LayoutType,
             class AccessorType>
   KOKKOS_INLINE_FUNCTION
-#if defined(__cpp_conditional_explicit) && \
-    (__cpp_conditional_explicit >= 201806L)
-      // FIXME C++20 reevaluate after determining minium compiler versions
+#ifndef KOKKOS_ENABLE_CXX17
       explicit(!std::is_convertible_v<
                Kokkos::mdspan<ElementType, ExtentsType, LayoutType,
                               AccessorType>,


### PR DESCRIPTION
In response to https://github.com/kokkos/kokkos/pull/7114#issuecomment-2206731884.
We are already checking for ` __GNUC__` and Intel compiler versions in this file.

`LIBCXX_RELEASE`  might be defined for compilers other than `g++` that are using `libstdc++`. Version 10 is sufficient both for conditional explicit and concepts.