### PR TITLE
Fix Trilinos nightly failure due to `create_mirror*` refactor

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -2032,7 +2032,7 @@ inline auto create_mirror_view(
                                    T, P...>::HostMirror::data_type>::value) {
       return typename DynRankView<T, P...>::HostMirror(src);
     } else {
-      return Kokkos::create_mirror(arg_prop, src);
+      return Kokkos::Impl::choose_create_mirror(src, arg_prop);
     }
   } else {
     if constexpr (Impl::MirrorDRViewType<typename Impl::ViewCtorProp<
@@ -2042,7 +2042,7 @@ inline auto create_mirror_view(
           typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
           P...>::view_type(src);
     } else {
-      return Kokkos::create_mirror(arg_prop, src);
+      return Kokkos::Impl::choose_create_mirror(src, arg_prop);
     }
   }
 #if defined KOKKOS_COMPILER_INTEL

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -702,7 +702,7 @@ inline auto create_mirror_view(
       return
           typename Kokkos::Experimental::DynamicView<T, P...>::HostMirror(src);
     } else {
-      return Kokkos::create_mirror(arg_prop, src);
+      return Kokkos::Impl::choose_create_mirror(src, arg_prop);
     }
   } else {
     if constexpr (Impl::MirrorDynamicViewType<
@@ -713,7 +713,7 @@ inline auto create_mirror_view(
           typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
           P...>::view_type(src);
     } else {
-      return Kokkos::create_mirror(arg_prop, src);
+      return Kokkos::Impl::choose_create_mirror(src, arg_prop);
     }
   }
 #if defined KOKKOS_COMPILER_INTEL

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1816,7 +1816,7 @@ namespace Impl {
 // view_alloc
 template <class T, class... P, class... ViewCtorArgs>
 inline auto create_mirror(const Kokkos::Experimental::OffsetView<T, P...>& src,
-                          const ViewCtorProp<ViewCtorArgs...>& arg_prop) {
+                          const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
   check_view_ctor_args_create_mirror<ViewCtorArgs...>();
 
   if constexpr (Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space) {

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1816,7 +1816,7 @@ namespace Impl {
 // view_alloc
 template <class T, class... P, class... ViewCtorArgs>
 inline auto create_mirror(const Kokkos::Experimental::OffsetView<T, P...>& src,
-                          const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
+                          const ViewCtorProp<ViewCtorArgs...>& arg_prop) {
   check_view_ctor_args_create_mirror<ViewCtorArgs...>();
 
   if constexpr (Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space) {
@@ -1914,7 +1914,7 @@ inline auto create_mirror_view(
       return
           typename Kokkos::Experimental::OffsetView<T, P...>::HostMirror(src);
     } else {
-      return Kokkos::create_mirror(arg_prop, src);
+      return Kokkos::Impl::choose_create_mirror(src, arg_prop);
     }
   } else {
     if constexpr (Impl::MirrorOffsetViewType<typename Impl::ViewCtorProp<
@@ -1924,7 +1924,7 @@ inline auto create_mirror_view(
           typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
           P...>::view_type(src);
     } else {
-      return Kokkos::create_mirror(arg_prop, src);
+      return Kokkos::Impl::choose_create_mirror(src, arg_prop);
     }
   }
 #if defined KOKKOS_COMPILER_INTEL

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3602,17 +3602,13 @@ inline auto create_mirror_view(
 }  // namespace Impl
 
 // public interface
-template <class T, class... P,
-          typename = std::enable_if_t<
-              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
+template <class T, class... P>
 auto create_mirror_view(const Kokkos::View<T, P...>& src) {
   return Impl::create_mirror_view(src, view_alloc());
 }
 
 // public interface that accepts a without initializing flag
-template <class T, class... P,
-          typename = std::enable_if_t<
-              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
+template <class T, class... P>
 auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi,
                         Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror_view(src, view_alloc(wi));
@@ -3621,8 +3617,7 @@ auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi,
 // public interface that accepts a space
 template <class Space, class T, class... P,
           class Enable = std::enable_if_t<
-              Kokkos::is_space<Space>::value &&
-              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
+              Kokkos::is_space<Space>::value>>
 auto create_mirror_view(const Space&, const Kokkos::View<T, P...>& src) {
   return Impl::create_mirror_view(src,
                                   view_alloc(typename Space::memory_space()));
@@ -3631,8 +3626,7 @@ auto create_mirror_view(const Space&, const Kokkos::View<T, P...>& src) {
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<
-              Kokkos::is_space<Space>::value &&
-              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
+              Kokkos::is_space<Space>::value>>
 auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
                         Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror_view(

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3583,18 +3583,24 @@ inline auto choose_create_mirror(
       // if there are no view constructor args, call the specific public
       // function
       return Kokkos::create_mirror(src);
-    } else if constexpr (sizeof...(ViewCtorArgs) == 1 && ViewProp::has_memory_space) {
+    } else if constexpr (sizeof...(ViewCtorArgs) == 1 &&
+                         ViewProp::has_memory_space) {
       // if there is one view constructor arg and it has a memory space, call
       // the specific public function
-      return Kokkos::create_mirror(typename ViewProp::memory_space {}, src);
-    } else if constexpr (sizeof...(ViewCtorArgs) == 1 && !ViewProp::initialize) {
+      return Kokkos::create_mirror(typename ViewProp::memory_space{}, src);
+    } else if constexpr (sizeof...(ViewCtorArgs) == 1 &&
+                         !ViewProp::initialize) {
       // if there is one view constructor arg and it has a without initializing
       // mark, call the specific public function
-      return Kokkos::create_mirror(typename Kokkos::Impl::WithoutInitializing_t {}, src);
-    } else if constexpr (sizeof...(ViewCtorArgs) == 2 && ViewProp::has_memory_space && !ViewProp::initialize) {
+      return Kokkos::create_mirror(
+          typename Kokkos::Impl::WithoutInitializing_t{}, src);
+    } else if constexpr (sizeof...(ViewCtorArgs) == 2 &&
+                         ViewProp::has_memory_space && !ViewProp::initialize) {
       // if there is two view constructor args and they have a memory space and
       // a without initializing mark, call the specific public function
-      return Kokkos::create_mirror(typename Kokkos::Impl::WithoutInitializing_t {}, typename ViewProp::memory_space {}, src);
+      return Kokkos::create_mirror(
+          typename Kokkos::Impl::WithoutInitializing_t{},
+          typename ViewProp::memory_space{}, src);
     } else {
       // if there are other constructor args, call the generic public function
       return Kokkos::create_mirror(arg_prop, src);

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3616,8 +3616,7 @@ auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi,
 
 // public interface that accepts a space
 template <class Space, class T, class... P,
-          class Enable = std::enable_if_t<
-              Kokkos::is_space<Space>::value>>
+          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 auto create_mirror_view(const Space&, const Kokkos::View<T, P...>& src) {
   return Impl::create_mirror_view(src,
                                   view_alloc(typename Space::memory_space()));
@@ -3625,8 +3624,7 @@ auto create_mirror_view(const Space&, const Kokkos::View<T, P...>& src) {
 
 // public interface that accepts a space and a without initializing flag
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<
-              Kokkos::is_space<Space>::value>>
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi, Space const&,
                         Kokkos::View<T, P...> const& src) {
   return Impl::create_mirror_view(


### PR DESCRIPTION
This PR aims to fix #7125.

- [x] Release `specialize` checks on public interfaces of `create_mirror_view` that were mistakenly added;
- [x] Allow `Impl::create_mirror_view` to either call `Impl::create_mirror` or `create_mirror` (and its possible overloads); and
- [x] Generalize the fix for containers.

What to do after:

- Add tests for views that are `specialize`d, to ensure the problem doesn't occur again.