### PR TITLE
Do not bother catching a memory allocation failure exception and rethrow it

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -126,14 +126,7 @@ void OpenMPInternal::resize_thread_data(size_t pool_reduce_bytes,
         space.deallocate(m_pool[rank], old_alloc_bytes);
       }
 
-      void *ptr = nullptr;
-      try {
-        ptr = space.allocate(alloc_bytes);
-      } catch (
-          Kokkos::Experimental::RawMemoryAllocationFailure const &failure) {
-        // For now, just rethrow the error message the existing way
-        Kokkos::Impl::throw_runtime_exception(failure.get_error_message());
-      }
+      void *ptr = space.allocate("Kokkos::OpenMP::scratch_mem", alloc_bytes);
 
       m_pool[rank] = new (ptr) HostThreadTeamData();
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.cpp
@@ -52,18 +52,7 @@ HostThreadTeamDataSingleton::HostThreadTeamDataSingleton()
       num_pool_reduce_bytes, num_team_reduce_bytes, num_team_shared_bytes,
       num_thread_local_bytes);
 
-  void* ptr = nullptr;
-  try {
-    ptr = space.allocate(alloc_bytes);
-  } catch (Kokkos::Experimental::RawMemoryAllocationFailure const& f) {
-    // For now, just rethrow the error message with a note
-    // Note that this could, in turn, trigger an out of memory exception,
-    // but it's pretty unlikely, so we won't worry about it for now.
-    // TODO reasonable error message when `std::string` causes OOM error
-    Kokkos::Impl::throw_runtime_exception(
-        std::string("Failure to allocate scratch memory:  ") +
-        f.get_error_message());
-  }
+  void* ptr = space.allocate("Kokkos::Impl::HostThreadTeamData", alloc_bytes);
 
   HostThreadTeamData::scratch_assign(
       ptr, alloc_bytes, num_pool_reduce_bytes, num_team_reduce_bytes,

--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -142,13 +142,7 @@ void SerialInternal::resize_thread_team_data(size_t pool_reduce_bytes,
         HostThreadTeamData::scratch_size(pool_reduce_bytes, team_reduce_bytes,
                                          team_shared_bytes, thread_local_bytes);
 
-    void* ptr = nullptr;
-    try {
-      ptr = space.allocate("Kokkos::Serial::scratch_mem", alloc_bytes);
-    } catch (Kokkos::Experimental::RawMemoryAllocationFailure const& failure) {
-      // For now, just rethrow the error message the existing way
-      Kokkos::Impl::throw_runtime_exception(failure.get_error_message());
-    }
+    void* ptr = space.allocate("Kokkos::Serial::scratch_mem", alloc_bytes);
 
     m_thread_team_data.scratch_assign(static_cast<char*>(ptr), alloc_bytes,
                                       pool_reduce_bytes, team_reduce_bytes,


### PR DESCRIPTION
If a "bad alloc" exception is thrown when resizing private scratch pads, there is little benefit to catch it and convert it to a `std::runtime_error` exception.
Instead prefer specifying a label when calling MemorySpace::allocate() and leave the exception alone.

This is loosely related to #7037 
Note that we don't bother with this pattern of intercepting allocation failure exception in device backends.