### PR TITLE
Do not swallow errors when deallocating memory with CUDA

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -333,27 +333,24 @@ void CudaSpace::impl_deallocate(
     Kokkos::Profiling::deallocateData(arg_handle, arg_label, arg_alloc_ptr,
                                       reported_size);
   }
-  try {
 #ifndef CUDART_VERSION
 #error CUDART_VERSION undefined!
 #elif (defined(KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC) && CUDART_VERSION >= 11020)
-    if (arg_alloc_size >= memory_threshold_g) {
-      Impl::cuda_device_synchronize(
-          "Kokkos::Cuda: backend fence before async free");
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(m_device));
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeAsync(arg_alloc_ptr, m_stream));
-      Impl::cuda_device_synchronize(
-          "Kokkos::Cuda: backend fence after async free");
-    } else {
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(m_device));
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(arg_alloc_ptr));
-    }
-#else
+  if (arg_alloc_size >= memory_threshold_g) {
+    Impl::cuda_device_synchronize(
+        "Kokkos::Cuda: backend fence before async free");
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(m_device));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeAsync(arg_alloc_ptr, m_stream));
+    Impl::cuda_device_synchronize(
+        "Kokkos::Cuda: backend fence after async free");
+  } else {
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(m_device));
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(arg_alloc_ptr));
-#endif
-  } catch (...) {
   }
+#else
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(m_device));
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(arg_alloc_ptr));
+#endif
 }
 void CudaUVMSpace::deallocate(void *const arg_alloc_ptr,
                               const size_t arg_alloc_size) const {
@@ -379,12 +376,9 @@ void CudaUVMSpace::impl_deallocate(
     Kokkos::Profiling::deallocateData(arg_handle, arg_label, arg_alloc_ptr,
                                       reported_size);
   }
-  try {
-    if (arg_alloc_ptr != nullptr) {
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(m_device));
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(arg_alloc_ptr));
-    }
-  } catch (...) {
+  if (arg_alloc_ptr != nullptr) {
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(m_device));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(arg_alloc_ptr));
   }
   Cuda::impl_static_fence(
       "Kokkos::CudaUVMSpace::impl_deallocate: Post UVM Deallocation");
@@ -411,11 +405,8 @@ void CudaHostPinnedSpace::impl_deallocate(
     Kokkos::Profiling::deallocateData(arg_handle, arg_label, arg_alloc_ptr,
                                       reported_size);
   }
-  try {
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(m_device));
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeHost(arg_alloc_ptr));
-  } catch (...) {
-  }
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(m_device));
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeHost(arg_alloc_ptr));
 }
 
 }  // namespace Kokkos


### PR DESCRIPTION
Get rid of
```C++
try {
  /* call CUDA runtime to deallocate and throw if an error code is returned */
} catch(...) { /* gulp */ }
```
This code is in place since the dawn of times and hasn't been challenged until now.

Tip to reviewers: hide whitespaces