### PR TITLE
[ci skip] Fix ROCm version to 6.1.2 in nightly CI

### DIFF
--- a/.jenkins_nightly
+++ b/.jenkins_nightly
@@ -108,7 +108,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.hipcc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-22.04:6.2-complete'
+                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-22.04:6.1.2-complete'
                             label 'rocm-docker && AMD_Radeon_Instinct_MI210'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
                         }


### PR DESCRIPTION
Our nightly HIP CI, see https://cloud.cees.ornl.gov/jenkins-ci/job/Kokkos_nightly/201/pipeline-console/,  is failing with
```
rocm/dev-ubuntu-22.04:6.2-complete: failed to resolve source metadata for docker.io/rocm/dev-ubuntu-22.04:6.2-complete: docker.io/rocm/dev-ubuntu-22.04:6.2-complete: not found
```
https://hub.docker.com/r/rocm/dev-ubuntu-22.04/tags shows that the latest version is 6.1.2 so use that instead of 6.2.