### PR TITLE
Fix gcc-14 C++26 nightly jenkins build

### DIFF
--- a/.jenkins_nightly
+++ b/.jenkins_nightly
@@ -79,10 +79,6 @@ pipeline {
                     }
                     steps {
                         sh '''
-                          DEBIAN_FRONTEND=noninteractive && \
-                          apt-get update && apt-get upgrade -y && \
-                          apt-get clean && rm -rf /var/lib/apt/lists/*
-
                           wget https://github.com/Kitware/CMake/releases/download/v3.30.0/cmake-3.30.0-linux-x86_64.sh && \
                           chmod +x cmake-3.30.0-linux-x86_64.sh && ./cmake-3.30.0-linux-x86_64.sh --skip-license --prefix=/usr
 

--- a/.jenkins_nightly
+++ b/.jenkins_nightly
@@ -80,10 +80,11 @@ pipeline {
                     steps {
                         sh '''
                           DEBIAN_FRONTEND=noninteractive && \
-                          apt-get update && apt-get upgrade -y && apt-get install -y \
-                          cmake \
-                          && \
+                          apt-get update && apt-get upgrade -y && \
                           apt-get clean && rm -rf /var/lib/apt/lists/*
+
+                          wget https://github.com/Kitware/CMake/releases/download/v3.30.0/cmake-3.30.0-linux-x86_64.sh && \
+                          chmod +x cmake-3.30.0-linux-x86_64.sh && ./cmake-3.30.0-linux-x86_64.sh --skip-license --prefix=/usr
 
                           mkdir -p build && cd build && \
                           cmake \

--- a/core/unit_test/TestMDSpan.hpp
+++ b/core/unit_test/TestMDSpan.hpp
@@ -38,7 +38,7 @@ void test_mdspan_minimal_functional() {
 #if !defined(KOKKOS_ENABLE_OPENACC)
         Kokkos::mdspan<int, Kokkos::dextents<int, 1>> b_mds(a.data(), N);
 #endif
-#ifdef KOKKOS_ENABLE_CXX23
+#if !defined(KOKKOS_ENABLE_CXX17) && !defined(KOKKOS_ENABLE_CXX20)
         if (a_mds[i] != i) err++;
 #if !defined(KOKKOS_ENABLE_OPENACC)
         if (b_mds[i] != i) err++;

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -135,8 +135,8 @@ class load_masked {
     for (std::size_t i = 0; i < n; ++i) {
       mask[i] = true;
     }
+    result  = T(0);
     where(mask, result).copy_from(mem, Kokkos::Experimental::simd_flag_default);
-    where(!mask, result) = 0;
     return true;
   }
   template <class T, class Abi>

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -135,7 +135,7 @@ class load_masked {
     for (std::size_t i = 0; i < n; ++i) {
       mask[i] = true;
     }
-    result  = T(0);
+    result = T(0);
     where(mask, result).copy_from(mem, Kokkos::Experimental::simd_flag_default);
     return true;
   }


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/pull/7081#issuecomment-2227543500 and addresses the warnings in that build.
- We need to install a recent CMake version and it was easiest to just install CMake 3.30 by hand.
- one of our guards only addressed C++23 but not C++26
- g++-14 complained about uninitialized variables (likely spurious):
```
In file included from /app/kokkos/simd/unit_tests/TestSIMD.cpp:20:
In function 'void host_check_shift_by_lanes_on_one_loader(ShiftOp, DataType*, Kokkos::Experimental::simd<T, Abi>&) [with Abi = Kokkos::Experimental::simd_abi::avx2_fixed_size<4>; Loader = load_masked; ShiftOp = shift_right; DataType = long unsigned int]',
    inlined from 'void host_check_shift_op_all_loaders(ShiftOp, DataType*, DataType*, std::size_t) [with Abi = Kokkos::Experimental::simd_abi::avx2_fixed_size<4>; ShiftOp = shift_right; DataType = long unsigned int]' at /app/kokkos/simd/unit_tests/include/TestSIMD_ShiftOps.hpp:96:60,
    inlined from 'void host_check_shift_ops() [with Abi = Kokkos::Experimental::simd_abi::avx2_fixed_size<4>; DataType = long unsigned int]' at /app/kokkos/simd/unit_tests/include/TestSIMD_ShiftOps.hpp:123:41:
/app/kokkos/simd/unit_tests/include/TestSIMD_ShiftOps.hpp:68:14: error: 'simd_vals' may be used uninitialized [-Werror=maybe-uninitialized]
   68 |     DataType value = simd_vals[lane];
      |              ^~~~~
/app/kokkos/simd/unit_tests/include/TestSIMD_ShiftOps.hpp: In function 'void host_check_shift_ops() [with Abi = Kokkos::Experimental::simd_abi::avx2_fixed_size<4>; DataType = long unsigned int]':
/app/kokkos/simd/unit_tests/include/TestSIMD_ShiftOps.hpp:61:13: note: 'simd_vals' declared here
   61 |   simd_type simd_vals;
      |             ^~~~~~~~~
In function 'void host_check_shift_by_lanes_on_one_loader(ShiftOp, DataType*, Kokkos::Experimental::simd<T, Abi>&) [with Abi = Kokkos::Experimental::simd_abi::avx2_fixed_size<4>; Loader = load_masked; ShiftOp = shift_left; DataType = long unsigned int]',
    inlined from 'void host_check_shift_op_all_loaders(ShiftOp, DataType*, DataType*, std::size_t) [with Abi = Kokkos::Experimental::simd_abi::avx2_fixed_size<4>; ShiftOp = shift_left; DataType = long unsigned int' at /app/kokkos/simd/unit_tests/include/TestSIMD_ShiftOps.hpp:96:60,
    inlined from 'void host_check_shift_ops() [with Abi = Kokkos::Experimental::simd_abi::avx2_fixed_size<4>; DataType = long unsigned int]' at /app/kokkos/simd/unit_tests/include/TestSIMD_ShiftOps.hpp:125:41:
/app/kokkos/simd/unit_tests/include/TestSIMD_ShiftOps.hpp:68:14: error: 'simd_vals' may be used uninitialized [-Werror=maybe-uninitialized]
   68 |     DataType value = simd_vals[lane];
      |              ^~~~~
/app/kokkos/simd/unit_tests/include/TestSIMD_ShiftOps.hpp: In function 'void host_check_shift_ops() [with Abi = Kokkos::Experimental::simd_abi::avx2_fixed_size<4>; DataType = long unsigned int]':
/app/kokkos/simd/unit_tests/include/TestSIMD_ShiftOps.hpp:61:13: note: 'simd_vals' declared here
   61 |   simd_type simd_vals;
      |             ^~~~~~~~~
cc1plus: all warnings being treated as errors
```