### PR TITLE
SYCL: Add missing include for std::stringstream

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
@@ -22,6 +22,7 @@
 #include <SYCL/Kokkos_SYCL_Team.hpp>
 #include <SYCL/Kokkos_SYCL_TeamPolicy.hpp>
 
+#include <sstream>
 #include <vector>
 
 template <typename FunctorType, typename... Properties>

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -23,6 +23,7 @@
 #include <SYCL/Kokkos_SYCL_TeamPolicy.hpp>
 #include <SYCL/Kokkos_SYCL_WorkgroupReduction.hpp>
 
+#include <sstream>
 #include <vector>
 
 template <class CombinedFunctorReducerType, class... Properties>


### PR DESCRIPTION
Both files use `stringstream` and recent compiler versions are complaining about missing includes for it.