### PR TITLE
Get rid of `RawMemoryAllocationFailure::AllocationMechanism` and derived backend-specific exceptions

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -73,8 +73,8 @@ void throw_cuda_allocation_failure(size_t alloc_size, cudaError_t error_code,
   msg += " returned error code \"";
   msg += cudaGetErrorName(error_code);
   msg += "\"";
-  throw_bad_alloc(alloc_size, std::align_val_t{1}, get_failure_mode(error_code),
-                  std::move(msg));
+  Kokkos::Impl::throw_bad_alloc(alloc_size, std::align_val_t{1},
+                                get_failure_mode(error_code), std::move(msg));
 }
 
 }  // namespace
@@ -221,7 +221,7 @@ void *impl_allocate_common(const int device_id,
     // we should do here since we're turning it into an
     // exception here
     cudaGetLastError();
-    throw_cuda_allocation_failure(arg_alloc_size, errot_code, "cudaMalloc()");
+    throw_cuda_allocation_failure(arg_alloc_size, error_code, "cudaMalloc()");
   }
 
   if (Kokkos::Profiling::profileLibraryLoaded()) {
@@ -275,7 +275,7 @@ void *CudaUVMSpace::impl_allocate(
       // we should do here since we're turning it into an
       // exception here
       cudaGetLastError();
-      throw_cuda_allocation_failure(arg_alloc_size, errot_code,
+      throw_cuda_allocation_failure(arg_alloc_size, error_code,
                                     "cudaMallocManaged()");
     }
 
@@ -317,7 +317,7 @@ void *CudaHostPinnedSpace::impl_allocate(
     // we should do here since we're turning it into an
     // exception here
     cudaGetLastError();
-    throw_cuda_allocation_failure(arg_alloc_size, errot_code,
+    throw_cuda_allocation_failure(arg_alloc_size, error_code,
                                   "cudaHostMalloc()");
   }
   if (Kokkos::Profiling::profileLibraryLoaded()) {

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -56,6 +56,29 @@ const std::unique_ptr<Kokkos::Cuda> &Kokkos::Impl::cuda_get_deep_copy_space(
   return space;
 }
 
+namespace {
+
+auto get_failure_mode(cudaError_t error_code) {
+  using FailureMode =
+      Kokkos::Experimental::RawMemoryAllocationFailure::FailureMode;
+  switch (error_code) {
+    case cudaErrorMemoryAllocation: return FailureMode::OutOfMemoryError;
+    case cudaErrorInvalidValue: return FailureMode::InvalidAllocationSize;
+    default: return FailureMode::Unknown;
+  }
+}
+
+void throw_cuda_allocation_failure(size_t alloc_size, cudaError_t error_code,
+                                   std::string msg) {
+  msg += " returned error code \"";
+  msg += cudaGetErrorName(error_code);
+  msg += "\"";
+  throw_bad_alloc(alloc_size, std::align_val_t{1}, get_failure_mode(error_code),
+                  std::move(msg));
+}
+
+}  // namespace
+
 namespace Kokkos {
 namespace Impl {
 
@@ -198,10 +221,7 @@ void *impl_allocate_common(const int device_id,
     // we should do here since we're turning it into an
     // exception here
     cudaGetLastError();
-    throw Experimental::CudaRawMemoryAllocationFailure(
-        arg_alloc_size, error_code,
-        Experimental::RawMemoryAllocationFailure::AllocationMechanism::
-            CudaMalloc);
+    throw_cuda_allocation_failure(arg_alloc_size, errot_code, "cudaMalloc()");
   }
 
   if (Kokkos::Profiling::profileLibraryLoaded()) {
@@ -255,10 +275,8 @@ void *CudaUVMSpace::impl_allocate(
       // we should do here since we're turning it into an
       // exception here
       cudaGetLastError();
-      throw Experimental::CudaRawMemoryAllocationFailure(
-          arg_alloc_size, error_code,
-          Experimental::RawMemoryAllocationFailure::AllocationMechanism::
-              CudaMallocManaged);
+      throw_cuda_allocation_failure(arg_alloc_size, errot_code,
+                                    "cudaMallocManaged()");
     }
 
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_PIN_UVM_TO_HOST
@@ -299,10 +317,8 @@ void *CudaHostPinnedSpace::impl_allocate(
     // we should do here since we're turning it into an
     // exception here
     cudaGetLastError();
-    throw Experimental::CudaRawMemoryAllocationFailure(
-        arg_alloc_size, error_code,
-        Experimental::RawMemoryAllocationFailure::AllocationMechanism::
-            CudaHostAlloc);
+    throw_cuda_allocation_failure(arg_alloc_size, errot_code,
+                                  "cudaHostMalloc()");
   }
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     const size_t reported_size =

--- a/core/src/Cuda/Kokkos_Cuda_Error.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Error.hpp
@@ -22,7 +22,6 @@
 
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Profiling.hpp>
-#include <iosfwd>
 
 namespace Kokkos {
 namespace Impl {
@@ -69,52 +68,6 @@ inline void cuda_internal_safe_call(cudaError e, const char* name,
   Kokkos::Impl::cuda_internal_safe_call(call, #call, __FILE__, __LINE__)
 
 }  // namespace Impl
-
-namespace Experimental {
-
-class CudaRawMemoryAllocationFailure : public RawMemoryAllocationFailure {
- private:
-  using base_t = RawMemoryAllocationFailure;
-
-  cudaError_t m_error_code = cudaSuccess;
-
-  static FailureMode get_failure_mode(cudaError_t error_code) {
-    switch (error_code) {
-      case cudaErrorMemoryAllocation: return FailureMode::OutOfMemoryError;
-      case cudaErrorInvalidValue: return FailureMode::InvalidAllocationSize;
-      // TODO handle cudaErrorNotSupported for cudaMallocManaged
-      default: return FailureMode::Unknown;
-    }
-  }
-
- public:
-  // using base_t::base_t;
-  // would trigger
-  //
-  // error: cannot determine the exception specification of the default
-  // constructor due to a circular dependency
-  //
-  // using NVCC 9.1 and gcc 7.4
-  CudaRawMemoryAllocationFailure(
-      size_t arg_attempted_size, size_t arg_attempted_alignment,
-      FailureMode arg_failure_mode = FailureMode::OutOfMemoryError,
-      AllocationMechanism arg_mechanism =
-          AllocationMechanism::StdMalloc) noexcept
-      : base_t(arg_attempted_size, arg_attempted_alignment, arg_failure_mode,
-               arg_mechanism) {}
-
-  CudaRawMemoryAllocationFailure(size_t arg_attempted_size,
-                                 cudaError_t arg_error_code,
-                                 AllocationMechanism arg_mechanism) noexcept
-      : base_t(arg_attempted_size, /* CudaSpace doesn't handle alignment? */ 1,
-               get_failure_mode(arg_error_code), arg_mechanism),
-        m_error_code(arg_error_code) {}
-
-  void append_additional_error_information(std::ostream& o) const override;
-};
-
-}  // end namespace Experimental
-
 }  // namespace Kokkos
 
 #endif  // KOKKOS_ENABLE_CUDA

--- a/core/src/HIP/Kokkos_HIP_Error.hpp
+++ b/core/src/HIP/Kokkos_HIP_Error.hpp
@@ -22,8 +22,6 @@
 
 #include <hip/hip_runtime.h>
 
-#include <ostream>
-
 namespace Kokkos {
 namespace Impl {
 
@@ -43,40 +41,5 @@ inline void hip_internal_safe_call(hipError_t e, const char* name,
 
 #define KOKKOS_IMPL_HIP_SAFE_CALL(call) \
   Kokkos::Impl::hip_internal_safe_call(call, #call, __FILE__, __LINE__)
-
-namespace Kokkos {
-namespace Experimental {
-
-class HIPRawMemoryAllocationFailure : public RawMemoryAllocationFailure {
- private:
-  hipError_t m_error_code = hipSuccess;
-
-  static FailureMode get_failure_mode(hipError_t error_code) {
-    switch (error_code) {
-      case hipErrorMemoryAllocation: return FailureMode::OutOfMemoryError;
-      case hipErrorInvalidValue: return FailureMode::InvalidAllocationSize;
-      default: return FailureMode::Unknown;
-    }
-  }
-
- public:
-  HIPRawMemoryAllocationFailure(size_t arg_attempted_size,
-                                hipError_t arg_error_code,
-                                AllocationMechanism arg_mechanism) noexcept
-      : RawMemoryAllocationFailure(
-            arg_attempted_size, /* HIPSpace doesn't handle alignment? */ 1,
-            get_failure_mode(arg_error_code), arg_mechanism),
-        m_error_code(arg_error_code) {}
-
-  void append_additional_error_information(std::ostream& o) const override {
-    if (m_error_code != hipSuccess) {
-      o << "  The HIP allocation returned the error code \""
-        << hipGetErrorName(m_error_code) << "\".";
-    }
-  }
-};
-
-}  // namespace Experimental
-}  // namespace Kokkos
 
 #endif

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -58,8 +58,8 @@ void throw_hip_allocation_failure(size_t alloc_size, hipError_t error_code,
   msg += "returned error code \"";
   msg += hipGetErrorName(error_code);
   msg += "\"";
-  throw_bad_alloc(alloc_size, std::align_val_t{1}, get_failure_mode(error_code),
-                  std::move(msg));
+  Kokkos::Impl::throw_bad_alloc(alloc_size, std::align_val_t{1},
+                                get_failure_mode(error_code), std::move(msg));
 }
 
 }  // namespace

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -43,6 +43,25 @@ namespace {
 
 static std::atomic<bool> is_first_hip_managed_allocation(true);
 
+auto get_failure_mode(hipError_t error_code) {
+  using FailureMode =
+      Kokkos::Experimental::RawMemoryAllocationFailure::FailureMode;
+  switch (error_code) {
+    case hipErrorMemoryAllocation: return FailureMode::OutOfMemoryError;
+    case hipErrorInvalidValue: return FailureMode::InvalidAllocationSize;
+    default: return FailureMode::Unknown;
+  }
+}
+
+void throw_hip_allocation_failure(size_t alloc_size, hipError_t error_code,
+                                  std::string msg) {
+  msg += "returned error code \"";
+  msg += hipGetErrorName(error_code);
+  msg += "\"";
+  throw_bad_alloc(alloc_size, std::align_val_t{1}, get_failure_mode(error_code),
+                  std::move(msg));
+}
+
 }  // namespace
 
 /*--------------------------------------------------------------------------*/
@@ -77,10 +96,7 @@ void* HIPSpace::impl_allocate(
     // This is the only way to clear the last error, which we should do here
     // since we're turning it into an exception here
     (void)hipGetLastError();
-    throw Experimental::HIPRawMemoryAllocationFailure(
-        arg_alloc_size, error_code,
-        Experimental::RawMemoryAllocationFailure::AllocationMechanism::
-            HIPMalloc);
+    throw_hip_allocation_failure(arg_alloc_size, error_code, "hipMalloc()");
   }
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     const size_t reported_size =
@@ -111,10 +127,7 @@ void* HIPHostPinnedSpace::impl_allocate(
     // This is the only way to clear the last error, which we should do here
     // since we're turning it into an exception here
     (void)hipGetLastError();
-    throw Experimental::HIPRawMemoryAllocationFailure(
-        arg_alloc_size, error_code,
-        Experimental::RawMemoryAllocationFailure::AllocationMechanism::
-            HIPHostMalloc);
+    throw_hip_allocation_failure(arg_alloc_size, error_code, "hipHostMalloc()");
   }
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     const size_t reported_size =
@@ -178,10 +191,8 @@ Kokkos::HIP::runtime WARNING: Kokkos did not find an environment variable 'HSA_X
       // This is the only way to clear the last error, which we should do here
       // since we're turning it into an exception here
       (void)hipGetLastError();
-      throw Experimental::HIPRawMemoryAllocationFailure(
-          arg_alloc_size, error_code,
-          Experimental::RawMemoryAllocationFailure::AllocationMechanism::
-              HIPMallocManaged);
+      throw_hip_allocation_failure(arg_alloc_size, error_code,
+                                   "hipMallocManaged()");
     }
     KOKKOS_IMPL_HIP_SAFE_CALL(hipMemAdvise(
         ptr, arg_alloc_size, hipMemAdviseSetCoarseGrain, m_device));

--- a/core/src/OpenACC/Kokkos_OpenACCSpace.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.cpp
@@ -67,16 +67,12 @@ void *Kokkos::Experimental::OpenACCSpace::impl_allocate(
   ptr = acc_malloc(arg_alloc_size);
 
   if (!ptr) {
-    size_t alignment = 1;  // OpenACC does not handle alignment
-    using Kokkos::Experimental::RawMemoryAllocationFailure;
-    auto failure_mode =
-        arg_alloc_size > 0
-            ? RawMemoryAllocationFailure::FailureMode::OutOfMemoryError
-            : RawMemoryAllocationFailure::FailureMode::InvalidAllocationSize;
-    auto alloc_mechanism =
-        RawMemoryAllocationFailure::AllocationMechanism::OpenACCMalloc;
-    throw RawMemoryAllocationFailure(arg_alloc_size, alignment, failure_mode,
-                                     alloc_mechanism);
+    using FailureMode =
+        Kokkos::Experimental::RawMemoryAllocationFailure::FailureMode;
+    auto failure_mode = arg_alloc_size > 0 ? FailureMode::OutOfMemoryError
+                                           : FailureMode::InvalidAllocationSize;
+    Kokkos::Impl::throw_bad_alloc(arg_alloc_size, std::align_val_t{1},
+                                  failure_mode, "acc_malloc()");
   }
 
   if (Kokkos::Profiling::profileLibraryLoaded()) {

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -56,6 +56,20 @@ void DeepCopyAsyncSYCL(void* dst, const void* src, size_t n) {
 
 /*--------------------------------------------------------------------------*/
 /*--------------------------------------------------------------------------*/
+namespace {
+
+std::string_view get_usm_alloc_function_name(sycl::usm::alloc kind) {
+  switch (allocation_kind) {
+    case sycl::usm::alloc::host: return "sycl::malloc_host()";
+    case sycl::usm::alloc::device: return "sycl::malloc_device()";
+    case sycl::usm::alloc::shared: return "sycl::malloc_shared()";
+    default:
+      Kokkos::abort("bug: unknown sycl allocation type");
+      return "unreachable";
+  }
+}
+
+}  // namespace
 
 namespace Kokkos {
 namespace Experimental {
@@ -75,17 +89,20 @@ SYCLHostUSMSpace::SYCLHostUSMSpace()
 SYCLHostUSMSpace::SYCLHostUSMSpace(sycl::queue queue)
     : m_queue(std::move(queue)) {}
 
-void* allocate_sycl(
-    const char* arg_label, const size_t arg_alloc_size,
-    const size_t arg_logical_size, const Kokkos::Tools::SpaceHandle arg_handle,
-    const RawMemoryAllocationFailure::AllocationMechanism failure_tag,
-    const sycl::usm::alloc allocation_kind, const sycl::queue& queue) {
+void* allocate_sycl(const char* arg_label, const size_t arg_alloc_size,
+                    const size_t arg_logical_size,
+                    const Kokkos::Tools::SpaceHandle arg_handle,
+                    const sycl::usm::alloc allocation_kind,
+                    const sycl::queue& queue) {
   void* const hostPtr = sycl::malloc(arg_alloc_size, queue, allocation_kind);
 
-  if (hostPtr == nullptr)
-    throw RawMemoryAllocationFailure(
-        arg_alloc_size, 1, RawMemoryAllocationFailure::FailureMode::Unknown,
-        failure_tag);
+  if (hostPtr == nullptr) {
+    using FailureMode =
+        Kokkos::Experimental::RawMemoryAllocationFailure::FailureMode;
+    Kokkos::Impl::throw_bad_alloc(arg_alloc_size, std::align_val_t{1},
+                                  FailureMode::Unknown,
+                                  get_usm_alloc_function_name(allocation_kind));
+  }
 
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     const size_t reported_size =
@@ -106,12 +123,10 @@ void* SYCLDeviceUSMSpace::allocate(const Kokkos::Experimental::SYCL& exec_space,
                                    const char* arg_label,
                                    const size_t arg_alloc_size,
                                    const size_t arg_logical_size) const {
-  return allocate_sycl(
-      arg_label, arg_alloc_size, arg_logical_size,
-      Kokkos::Tools::make_space_handle(name()),
-      RawMemoryAllocationFailure::AllocationMechanism::SYCLMallocDevice,
-      sycl::usm::alloc::device,
-      *exec_space.impl_internal_space_instance()->m_queue);
+  return allocate_sycl(arg_label, arg_alloc_size, arg_logical_size,
+                       Kokkos::Tools::make_space_handle(name()),
+                       sycl::usm::alloc::device,
+                       *exec_space.impl_internal_space_instance()->m_queue);
 }
 
 void* SYCLDeviceUSMSpace::allocate(const size_t arg_alloc_size) const {
@@ -121,11 +136,9 @@ void* SYCLDeviceUSMSpace::allocate(const size_t arg_alloc_size) const {
 void* SYCLDeviceUSMSpace::allocate(const char* arg_label,
                                    const size_t arg_alloc_size,
                                    const size_t arg_logical_size) const {
-  return allocate_sycl(
-      arg_label, arg_alloc_size, arg_logical_size,
-      Kokkos::Tools::make_space_handle(name()),
-      RawMemoryAllocationFailure::AllocationMechanism::SYCLMallocDevice,
-      sycl::usm::alloc::device, m_queue);
+  return allocate_sycl(arg_label, arg_alloc_size, arg_logical_size,
+                       Kokkos::Tools::make_space_handle(name()),
+                       sycl::usm::alloc::device, m_queue);
 }
 
 void* SYCLSharedUSMSpace::allocate(const SYCL& exec_space,
@@ -136,12 +149,10 @@ void* SYCLSharedUSMSpace::allocate(const SYCL& exec_space,
                                    const char* arg_label,
                                    const size_t arg_alloc_size,
                                    const size_t arg_logical_size) const {
-  return allocate_sycl(
-      arg_label, arg_alloc_size, arg_logical_size,
-      Kokkos::Tools::make_space_handle(name()),
-      RawMemoryAllocationFailure::AllocationMechanism::SYCLMallocShared,
-      sycl::usm::alloc::shared,
-      *exec_space.impl_internal_space_instance()->m_queue);
+  return allocate_sycl(arg_label, arg_alloc_size, arg_logical_size,
+                       Kokkos::Tools::make_space_handle(name()),
+                       sycl::usm::alloc::shared,
+                       *exec_space.impl_internal_space_instance()->m_queue);
 }
 
 void* SYCLSharedUSMSpace::allocate(const size_t arg_alloc_size) const {
@@ -150,11 +161,9 @@ void* SYCLSharedUSMSpace::allocate(const size_t arg_alloc_size) const {
 void* SYCLSharedUSMSpace::allocate(const char* arg_label,
                                    const size_t arg_alloc_size,
                                    const size_t arg_logical_size) const {
-  return allocate_sycl(
-      arg_label, arg_alloc_size, arg_logical_size,
-      Kokkos::Tools::make_space_handle(name()),
-      RawMemoryAllocationFailure::AllocationMechanism::SYCLMallocShared,
-      sycl::usm::alloc::shared, m_queue);
+  return allocate_sycl(arg_label, arg_alloc_size, arg_logical_size,
+                       Kokkos::Tools::make_space_handle(name()),
+                       sycl::usm::alloc::shared, m_queue);
 }
 
 void* SYCLHostUSMSpace::allocate(const SYCL& exec_space,
@@ -164,12 +173,10 @@ void* SYCLHostUSMSpace::allocate(const SYCL& exec_space,
 void* SYCLHostUSMSpace::allocate(const SYCL& exec_space, const char* arg_label,
                                  const size_t arg_alloc_size,
                                  const size_t arg_logical_size) const {
-  return allocate_sycl(
-      arg_label, arg_alloc_size, arg_logical_size,
-      Kokkos::Tools::make_space_handle(name()),
-      RawMemoryAllocationFailure::AllocationMechanism::SYCLMallocHost,
-      sycl::usm::alloc::host,
-      *exec_space.impl_internal_space_instance()->m_queue);
+  return allocate_sycl(arg_label, arg_alloc_size, arg_logical_size,
+                       Kokkos::Tools::make_space_handle(name()),
+                       sycl::usm::alloc::host,
+                       *exec_space.impl_internal_space_instance()->m_queue);
 }
 
 void* SYCLHostUSMSpace::allocate(const size_t arg_alloc_size) const {
@@ -178,11 +185,9 @@ void* SYCLHostUSMSpace::allocate(const size_t arg_alloc_size) const {
 void* SYCLHostUSMSpace::allocate(const char* arg_label,
                                  const size_t arg_alloc_size,
                                  const size_t arg_logical_size) const {
-  return allocate_sycl(
-      arg_label, arg_alloc_size, arg_logical_size,
-      Kokkos::Tools::make_space_handle(name()),
-      RawMemoryAllocationFailure::AllocationMechanism::SYCLMallocHost,
-      sycl::usm::alloc::host, m_queue);
+  return allocate_sycl(arg_label, arg_alloc_size, arg_logical_size,
+                       Kokkos::Tools::make_space_handle(name()),
+                       sycl::usm::alloc::host, m_queue);
 }
 
 void sycl_deallocate(const char* arg_label, void* const arg_alloc_ptr,

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -58,7 +58,7 @@ void DeepCopyAsyncSYCL(void* dst, const void* src, size_t n) {
 /*--------------------------------------------------------------------------*/
 namespace {
 
-std::string_view get_usm_alloc_function_name(sycl::usm::alloc kind) {
+std::string_view get_usm_alloc_function_name(sycl::usm::alloc allocation_kind) {
   switch (allocation_kind) {
     case sycl::usm::alloc::host: return "sycl::malloc_host()";
     case sycl::usm::alloc::device: return "sycl::malloc_device()";
@@ -99,9 +99,9 @@ void* allocate_sycl(const char* arg_label, const size_t arg_alloc_size,
   if (hostPtr == nullptr) {
     using FailureMode =
         Kokkos::Experimental::RawMemoryAllocationFailure::FailureMode;
-    Kokkos::Impl::throw_bad_alloc(arg_alloc_size, std::align_val_t{1},
-                                  FailureMode::Unknown,
-                                  get_usm_alloc_function_name(allocation_kind));
+    Kokkos::Impl::throw_bad_alloc(
+        arg_alloc_size, std::align_val_t{1}, FailureMode::Unknown,
+        std::string(get_usm_alloc_function_name(allocation_kind)));
   }
 
   if (Kokkos::Profiling::profileLibraryLoaded()) {

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -105,4 +105,3 @@ std::string Experimental::RawMemoryAllocationFailure::get_error_message()
 }
 
 }  // namespace Kokkos
-

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -27,10 +27,17 @@
 #include <stdexcept>
 #include <Kokkos_Core.hpp>  // show_warnings
 #include <impl/Kokkos_Error.hpp>
-#include <Cuda/Kokkos_Cuda_Error.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
+
+void Kokkos::Impl::throw_bad_alloc(
+    std::size_t size, std::align_val_t alignment,
+    Kokkos::Experimental::RawMemoryAllocationFailure::FailureMode failure_mode,
+    std::string what) {
+  throw Kokkos::Experimental::RawMemoryAllocationFailure(
+      size, static_cast<size_t>(alignment), failure_mode, std::move(what));
+}
 
 namespace Kokkos {
 namespace Impl {
@@ -87,32 +94,7 @@ void Experimental::RawMemoryAllocationFailure::print_error_message(
       break;
     case FailureMode::Unknown: o << " because of an unknown error."; break;
   }
-  o << "  (The allocation mechanism was ";
-  switch (m_mechanism) {
-    case AllocationMechanism::StdMalloc: o << "standard malloc()."; break;
-    case AllocationMechanism::CudaMalloc: o << "cudaMalloc()."; break;
-    case AllocationMechanism::CudaMallocManaged:
-      o << "cudaMallocManaged().";
-      break;
-    case AllocationMechanism::CudaHostAlloc: o << "cudaHostAlloc()."; break;
-    case AllocationMechanism::HIPMalloc: o << "hipMalloc()."; break;
-    case AllocationMechanism::HIPHostMalloc: o << "hipHostMalloc()."; break;
-    case AllocationMechanism::HIPMallocManaged:
-      o << "hipMallocManaged().";
-      break;
-    case AllocationMechanism::SYCLMallocDevice:
-      o << "sycl::malloc_device().";
-      break;
-    case AllocationMechanism::SYCLMallocShared:
-      o << "sycl::malloc_shared().";
-      break;
-    case AllocationMechanism::SYCLMallocHost:
-      o << "sycl::malloc_host().";
-      break;
-    default: o << "unsupported.";
-  }
-  append_additional_error_information(o);
-  o << ")" << std::endl;
+  o << "  (The allocation mechanism was " << m_msg << ")\n";
 }
 
 std::string Experimental::RawMemoryAllocationFailure::get_error_message()
@@ -124,23 +106,3 @@ std::string Experimental::RawMemoryAllocationFailure::get_error_message()
 
 }  // namespace Kokkos
 
-//----------------------------------------------------------------------------
-//----------------------------------------------------------------------------
-
-namespace Kokkos {
-
-#ifdef KOKKOS_ENABLE_CUDA
-namespace Experimental {
-
-void CudaRawMemoryAllocationFailure::append_additional_error_information(
-    std::ostream &o) const {
-  if (m_error_code != cudaSuccess) {
-    o << "  The Cuda allocation returned the error code \""
-      << cudaGetErrorName(m_error_code) << "\".";
-  }
-}
-
-}  // end namespace Experimental
-#endif
-
-}  // namespace Kokkos


### PR DESCRIPTION
All allocation errors are raised using `Impl::throw_bad_alloc()`.
We drop `RawMemoryAllocationFailure::AllocationMechanism` to get rid of the anti-pattern where core depends on backend-specific details.
I couldn't come up with a good way to split this up.  I plan on cleaning up further the `RawMemoryAllocationFailure` exception class in follow-up work.