### PR TITLE
Fix using View without corresponding mdspan-type

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1737,10 +1737,13 @@ class View : public ViewTraits<DataType, Properties...> {
   // Conversion to MDSpan
   template <class OtherElementType, class OtherExtents, class OtherLayoutPolicy,
             class OtherAccessor,
-            typename = std::enable_if_t<std::is_assignable_v<
-                mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy,
-                       OtherAccessor>,
-                typename Impl::MDSpanViewTraits<traits>::mdspan_type>>>
+            class Dummy = typename Impl::MDSpanViewTraits<traits>::mdspan_type,
+            typename    = std::enable_if_t<std::conditional_t<
+                std::is_same_v<Impl::UnsupportedKokkosArrayLayout, Dummy>,
+                std::false_type,
+                std::is_assignable<mdspan<OtherElementType, OtherExtents,
+                                          OtherLayoutPolicy, OtherAccessor>,
+                                   Dummy>>::value>>
   KOKKOS_INLINE_FUNCTION constexpr operator mdspan<
       OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>() {
     using mdspan_type = typename Impl::MDSpanViewTraits<traits>::mdspan_type;

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1737,13 +1737,15 @@ class View : public ViewTraits<DataType, Properties...> {
   // Conversion to MDSpan
   template <class OtherElementType, class OtherExtents, class OtherLayoutPolicy,
             class OtherAccessor,
-            class Dummy = typename Impl::MDSpanViewTraits<traits>::mdspan_type,
-            typename    = std::enable_if_t<std::conditional_t<
-                std::is_same_v<Impl::UnsupportedKokkosArrayLayout, Dummy>,
+            class ImplNaturalMDSpanType =
+                typename Impl::MDSpanViewTraits<traits>::mdspan_type,
+            typename = std::enable_if_t<std::conditional_t<
+                std::is_same_v<Impl::UnsupportedKokkosArrayLayout,
+                               ImplNaturalMDSpanType>,
                 std::false_type,
                 std::is_assignable<mdspan<OtherElementType, OtherExtents,
                                           OtherLayoutPolicy, OtherAccessor>,
-                                   Dummy>>::value>>
+                                   ImplNaturalMDSpanType>>::value>>
   KOKKOS_INLINE_FUNCTION constexpr operator mdspan<
       OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>() {
     using mdspan_type = typename Impl::MDSpanViewTraits<traits>::mdspan_type;


### PR DESCRIPTION
Fixes #7135. For some reason, the conversion operator only gets instantiated with clang++ when compiling Sacado.
There is no corresponding `mdspan`-type and so the instantiation fails. We have to use SFINAE with `std::conditional_t` to short-circuit the existing SFINAE guard.

We could think about crafting a test if testing with Trilinos is not good enough.