### PR TITLE
OpenMPTarget: throw when `omp_target_alloc()` returns `nullptr`

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
@@ -57,7 +57,11 @@ void* OpenMPTargetSpace::impl_allocate(
   void* ptr = omp_target_alloc(arg_alloc_size, omp_get_default_device());
 
   if (!ptr) {
-    Kokkos::Impl::throw_bad_alloc(arg_alloc_size, "omp_target_alloc()");
+    using FailureMode =
+        Kokkos::Experimental::RawMemoryAllocationFailure::FailureMode;
+    Kokkos::Impl::throw_bad_alloc(arg_alloc_size, std::align_val_t{1},
+                                  FailureMode::OutOfMemoryError,
+                                  "omp_target_alloc()");
   }
 
   if (Kokkos::Profiling::profileLibraryLoaded()) {

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
@@ -54,9 +54,11 @@ void* OpenMPTargetSpace::impl_allocate(
   static_assert(sizeof(void*) == sizeof(uintptr_t),
                 "Error sizeof(void*) != sizeof(uintptr_t)");
 
-  void* ptr;
+  void* ptr = omp_target_alloc(arg_alloc_size, omp_get_default_device());
 
-  ptr = omp_target_alloc(arg_alloc_size, omp_get_default_device());
+  if (!ptr) {
+    Kokkos::Impl::throw_bad_alloc(arg_alloc_size, "omp_target_alloc()");
+  }
 
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     const size_t reported_size =

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1573,11 +1573,6 @@ class TestViewAPI {
   }
 
   static void run_test_error() {
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
-    if (std::is_same<typename dView1::memory_space,
-                     Kokkos::Experimental::OpenMPTargetSpace>::value)
-      return;
-#endif
 // FIXME_MSVC_WITH_CUDA
 // This test doesn't behave as expected on Windows with CUDA
 #if defined(_WIN32) && defined(KOKKOS_ENABLE_CUDA)


### PR DESCRIPTION
(not tested)