### PR TITLE
Drop `Experimental::RawMemoryAllocationFailure` and don't catch exceptions to rethrow them in shared alloc

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -58,23 +58,13 @@ const std::unique_ptr<Kokkos::Cuda> &Kokkos::Impl::cuda_get_deep_copy_space(
 
 namespace {
 
-auto get_failure_mode(cudaError_t error_code) {
-  using FailureMode =
-      Kokkos::Experimental::RawMemoryAllocationFailure::FailureMode;
-  switch (error_code) {
-    case cudaErrorMemoryAllocation: return FailureMode::OutOfMemoryError;
-    case cudaErrorInvalidValue: return FailureMode::InvalidAllocationSize;
-    default: return FailureMode::Unknown;
-  }
-}
-
 void throw_cuda_allocation_failure(size_t alloc_size, cudaError_t error_code,
                                    std::string msg) {
   msg += " returned error code \"";
   msg += cudaGetErrorName(error_code);
   msg += "\"";
   Kokkos::Impl::throw_bad_alloc(alloc_size, std::align_val_t{1},
-                                get_failure_mode(error_code), std::move(msg));
+                                std::move(msg));
 }
 
 }  // namespace

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -56,18 +56,6 @@ const std::unique_ptr<Kokkos::Cuda> &Kokkos::Impl::cuda_get_deep_copy_space(
   return space;
 }
 
-namespace {
-
-void throw_cuda_allocation_failure(size_t alloc_size, cudaError_t error_code,
-                                   std::string msg) {
-  msg += " returned error code \"";
-  msg += cudaGetErrorName(error_code);
-  msg += "\"";
-  Kokkos::Impl::throw_bad_alloc(alloc_size, std::move(msg));
-}
-
-}  // namespace
-
 namespace Kokkos {
 namespace Impl {
 
@@ -210,7 +198,7 @@ void *impl_allocate_common(const int device_id,
     // we should do here since we're turning it into an
     // exception here
     cudaGetLastError();
-    throw_cuda_allocation_failure(arg_alloc_size, error_code, "cudaMalloc()");
+    throw_bad_alloc(name(), arg_alloc_size, arg_label);
   }
 
   if (Kokkos::Profiling::profileLibraryLoaded()) {
@@ -264,8 +252,7 @@ void *CudaUVMSpace::impl_allocate(
       // we should do here since we're turning it into an
       // exception here
       cudaGetLastError();
-      throw_cuda_allocation_failure(arg_alloc_size, error_code,
-                                    "cudaMallocManaged()");
+      throw_bad_alloc(name(), arg_alloc_size, arg_label);
     }
 
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_PIN_UVM_TO_HOST
@@ -306,8 +293,7 @@ void *CudaHostPinnedSpace::impl_allocate(
     // we should do here since we're turning it into an
     // exception here
     cudaGetLastError();
-    throw_cuda_allocation_failure(arg_alloc_size, error_code,
-                                  "cudaHostMalloc()");
+    throw_bad_alloc(name(), arg_alloc_size, arg_label);
   }
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     const size_t reported_size =

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -198,7 +198,7 @@ void *impl_allocate_common(const int device_id,
     // we should do here since we're turning it into an
     // exception here
     cudaGetLastError();
-    Kokkos::Impl::throw_bad_alloc(name(), arg_alloc_size, arg_label);
+    Kokkos::Impl::throw_bad_alloc(arg_handle.name, arg_alloc_size, arg_label);
   }
 
   if (Kokkos::Profiling::profileLibraryLoaded()) {

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -63,8 +63,7 @@ void throw_cuda_allocation_failure(size_t alloc_size, cudaError_t error_code,
   msg += " returned error code \"";
   msg += cudaGetErrorName(error_code);
   msg += "\"";
-  Kokkos::Impl::throw_bad_alloc(alloc_size, std::align_val_t{1},
-                                std::move(msg));
+  Kokkos::Impl::throw_bad_alloc(alloc_size, std::move(msg));
 }
 
 }  // namespace

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -198,7 +198,7 @@ void *impl_allocate_common(const int device_id,
     // we should do here since we're turning it into an
     // exception here
     cudaGetLastError();
-    throw_bad_alloc(name(), arg_alloc_size, arg_label);
+    Kokkos::Impl::throw_bad_alloc(name(), arg_alloc_size, arg_label);
   }
 
   if (Kokkos::Profiling::profileLibraryLoaded()) {
@@ -252,7 +252,7 @@ void *CudaUVMSpace::impl_allocate(
       // we should do here since we're turning it into an
       // exception here
       cudaGetLastError();
-      throw_bad_alloc(name(), arg_alloc_size, arg_label);
+      Kokkos::Impl::throw_bad_alloc(name(), arg_alloc_size, arg_label);
     }
 
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_PIN_UVM_TO_HOST
@@ -293,7 +293,7 @@ void *CudaHostPinnedSpace::impl_allocate(
     // we should do here since we're turning it into an
     // exception here
     cudaGetLastError();
-    throw_bad_alloc(name(), arg_alloc_size, arg_label);
+    Kokkos::Impl::throw_bad_alloc(name(), arg_alloc_size, arg_label);
   }
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     const size_t reported_size =

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -40,6 +40,15 @@
 /*--------------------------------------------------------------------------*/
 /*--------------------------------------------------------------------------*/
 
+namespace {
+
+static std::atomic<bool> is_first_hip_managed_allocation(true);
+
+}  // namespace
+
+/*--------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------*/
+
 namespace Kokkos {
 
 HIPSpace::HIPSpace() : m_device(HIP().hip_device()) {}
@@ -163,8 +172,7 @@ Kokkos::HIP::runtime WARNING: Kokkos did not find an environment variable 'HSA_X
       // This is the only way to clear the last error, which we should do here
       // since we're turning it into an exception here
       (void)hipGetLastError();
-      Kokkos::Impl::Kokkos::Impl::throw_bad_alloc(name(), arg_alloc_size,
-                                                  arg_label);
+      Kokkos::Impl::throw_bad_alloc(name(), arg_alloc_size, arg_label);
     }
     KOKKOS_IMPL_HIP_SAFE_CALL(hipMemAdvise(
         ptr, arg_alloc_size, hipMemAdviseSetCoarseGrain, m_device));

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -43,23 +43,13 @@ namespace {
 
 static std::atomic<bool> is_first_hip_managed_allocation(true);
 
-auto get_failure_mode(hipError_t error_code) {
-  using FailureMode =
-      Kokkos::Experimental::RawMemoryAllocationFailure::FailureMode;
-  switch (error_code) {
-    case hipErrorMemoryAllocation: return FailureMode::OutOfMemoryError;
-    case hipErrorInvalidValue: return FailureMode::InvalidAllocationSize;
-    default: return FailureMode::Unknown;
-  }
-}
-
 void throw_hip_allocation_failure(size_t alloc_size, hipError_t error_code,
                                   std::string msg) {
   msg += "returned error code \"";
   msg += hipGetErrorName(error_code);
   msg += "\"";
   Kokkos::Impl::throw_bad_alloc(alloc_size, std::align_val_t{1},
-                                get_failure_mode(error_code), std::move(msg));
+                                std::move(msg));
 }
 
 }  // namespace

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -68,7 +68,7 @@ void* HIPSpace::impl_allocate(
     // This is the only way to clear the last error, which we should do here
     // since we're turning it into an exception here
     (void)hipGetLastError();
-    throw_bad_alloc(name(), arg_alloc_size, arg_label);
+    Kokkos::Impl::throw_bad_alloc(name(), arg_alloc_size, arg_label);
   }
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     const size_t reported_size =
@@ -99,7 +99,7 @@ void* HIPHostPinnedSpace::impl_allocate(
     // This is the only way to clear the last error, which we should do here
     // since we're turning it into an exception here
     (void)hipGetLastError();
-    throw_bad_alloc(name(), arg_alloc_size, arg_label);
+    Kokkos::Impl::throw_bad_alloc(name(), arg_alloc_size, arg_label);
   }
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     const size_t reported_size =
@@ -163,7 +163,8 @@ Kokkos::HIP::runtime WARNING: Kokkos did not find an environment variable 'HSA_X
       // This is the only way to clear the last error, which we should do here
       // since we're turning it into an exception here
       (void)hipGetLastError();
-      throw_bad_alloc(name(), arg_alloc_size, arg_label);
+      Kokkos::Impl::Kokkos::Impl::throw_bad_alloc(name(), arg_alloc_size,
+                                                  arg_label);
     }
     KOKKOS_IMPL_HIP_SAFE_CALL(hipMemAdvise(
         ptr, arg_alloc_size, hipMemAdviseSetCoarseGrain, m_device));

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -48,8 +48,7 @@ void throw_hip_allocation_failure(size_t alloc_size, hipError_t error_code,
   msg += "returned error code \"";
   msg += hipGetErrorName(error_code);
   msg += "\"";
-  Kokkos::Impl::throw_bad_alloc(alloc_size, std::align_val_t{1},
-                                std::move(msg));
+  Kokkos::Impl::throw_bad_alloc(alloc_size, std::move(msg));
 }
 
 }  // namespace

--- a/core/src/OpenACC/Kokkos_OpenACCSpace.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.cpp
@@ -67,12 +67,8 @@ void *Kokkos::Experimental::OpenACCSpace::impl_allocate(
   ptr = acc_malloc(arg_alloc_size);
 
   if (!ptr) {
-    using FailureMode =
-        Kokkos::Experimental::RawMemoryAllocationFailure::FailureMode;
-    auto failure_mode = arg_alloc_size > 0 ? FailureMode::OutOfMemoryError
-                                           : FailureMode::InvalidAllocationSize;
     Kokkos::Impl::throw_bad_alloc(arg_alloc_size, std::align_val_t{1},
-                                  failure_mode, "acc_malloc()");
+                                  "acc_malloc()");
   }
 
   if (Kokkos::Profiling::profileLibraryLoaded()) {

--- a/core/src/OpenACC/Kokkos_OpenACCSpace.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.cpp
@@ -67,8 +67,7 @@ void *Kokkos::Experimental::OpenACCSpace::impl_allocate(
   ptr = acc_malloc(arg_alloc_size);
 
   if (!ptr) {
-    Kokkos::Impl::throw_bad_alloc(arg_alloc_size, std::align_val_t{1},
-                                  "acc_malloc()");
+    Kokkos::Impl::throw_bad_alloc(arg_alloc_size, "acc_malloc()");
   }
 
   if (Kokkos::Profiling::profileLibraryLoaded()) {

--- a/core/src/OpenACC/Kokkos_OpenACCSpace.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.cpp
@@ -67,7 +67,7 @@ void *Kokkos::Experimental::OpenACCSpace::impl_allocate(
   ptr = acc_malloc(arg_alloc_size);
 
   if (!ptr) {
-    Kokkos::Impl::throw_bad_alloc(arg_alloc_size, "acc_malloc()");
+    Kokkos::Impl::throw_bad_alloc(name(), arg_alloc_size, arg_label);
   }
 
   if (Kokkos::Profiling::profileLibraryLoaded()) {

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
@@ -57,7 +57,7 @@ void* OpenMPTargetSpace::impl_allocate(
   void* ptr = omp_target_alloc(arg_alloc_size, omp_get_default_device());
 
   if (!ptr) {
-    Kokkos::Impl::throw_bad_alloc(arg_alloc_size, "omp_target_alloc()");
+    Kokkos::Impl::throw_bad_alloc(name(), arg_alloc_size, arg_label);
   }
 
   if (Kokkos::Profiling::profileLibraryLoaded()) {

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
@@ -57,11 +57,7 @@ void* OpenMPTargetSpace::impl_allocate(
   void* ptr = omp_target_alloc(arg_alloc_size, omp_get_default_device());
 
   if (!ptr) {
-    using FailureMode =
-        Kokkos::Experimental::RawMemoryAllocationFailure::FailureMode;
-    Kokkos::Impl::throw_bad_alloc(arg_alloc_size, std::align_val_t{1},
-                                  FailureMode::OutOfMemoryError,
-                                  "omp_target_alloc()");
+    Kokkos::Impl::throw_bad_alloc(arg_alloc_size, "omp_target_alloc()");
   }
 
   if (Kokkos::Profiling::profileLibraryLoaded()) {

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -98,7 +98,7 @@ void* allocate_sycl(const char* arg_label, const size_t arg_alloc_size,
 
   if (hostPtr == nullptr) {
     Kokkos::Impl::throw_bad_alloc(
-        arg_alloc_size, std::align_val_t{1},
+        arg_alloc_size,
         std::string(get_usm_alloc_function_name(allocation_kind)));
   }
 

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -97,10 +97,8 @@ void* allocate_sycl(const char* arg_label, const size_t arg_alloc_size,
   void* const hostPtr = sycl::malloc(arg_alloc_size, queue, allocation_kind);
 
   if (hostPtr == nullptr) {
-    using FailureMode =
-        Kokkos::Experimental::RawMemoryAllocationFailure::FailureMode;
     Kokkos::Impl::throw_bad_alloc(
-        arg_alloc_size, std::align_val_t{1}, FailureMode::Unknown,
+        arg_alloc_size, std::align_val_t{1},
         std::string(get_usm_alloc_function_name(allocation_kind)));
   }
 

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -28,9 +28,7 @@
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-namespace {
-
-std::string human_memory_size(size_t arg_bytes) {
+std::string Kokkos::Impl::human_memory_size(size_t arg_bytes) {
   double bytes   = arg_bytes;
   const double K = 1024;
   const double M = K * 1024;
@@ -55,8 +53,6 @@ std::string human_memory_size(size_t arg_bytes) {
   }
   return out.str();
 }
-
-}  // namespace
 
 void Kokkos::Impl::throw_bad_alloc(std::string_view memory_space_name,
                                    std::size_t size, std::string_view label) {

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -67,18 +67,12 @@ void Kokkos::Impl::throw_bad_alloc(std::string_view memory_space_name,
   throw std::runtime_error(ss.str());
 }
 
-namespace Kokkos {
-namespace Impl {
-
-void throw_runtime_exception(const std::string &msg) {
+void Kokkos::Impl::throw_runtime_exception(const std::string &msg) {
   throw std::runtime_error(msg);
 }
 
-void log_warning(const std::string &msg) {
+void Kokkos::Impl::log_warning(const std::string &msg) {
   if (show_warnings()) {
     std::cerr << msg << std::flush;
   }
 }
-
-}  // namespace Impl
-}  // namespace Kokkos

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -18,12 +18,9 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE
 #endif
 
-#include <cstring>
-#include <cstdlib>
-
 #include <iostream>
-#include <sstream>
 #include <iomanip>
+#include <sstream>
 #include <stdexcept>
 #include <Kokkos_Core.hpp>  // show_warnings
 #include <impl/Kokkos_Error.hpp>
@@ -62,15 +59,12 @@ std::string human_memory_size(size_t arg_bytes) {
 }  // namespace
 
 void Kokkos::Impl::throw_bad_alloc(std::string_view memory_space_name,
-                                   std::size_t size, std::string label) {
-  std::string msg = "Kokkos ERROR: memory space \"";
-  msg += memory_space_name;
-  msg += "\" failed to allocate ";
-  msg += human_memory_size(size);
-  msg += " (label=\"";
-  msg += label;
-  msg += "\").";
-  throw std::runtime_error(msg);
+                                   std::size_t size, std::string_view label) {
+  std::stringstream ss;
+  ss << "Kokkos ERROR: " << memory_space_name
+     << " memory space failed to allocate " << human_memory_size(size)
+     << " (label=\"" << label << "\").";
+  throw std::runtime_error(ss.str());
 }
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -70,7 +70,7 @@ void Kokkos::Impl::throw_bad_alloc(std::string_view memory_space_name,
   msg += " (label=\"";
   msg += label;
   msg += "\").";
-  throw Kokkos::Experimental::RawMemoryAllocationFailure(std::move(msg));
+  throw std::runtime_error(msg);
 }
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -31,10 +31,8 @@
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-void Kokkos::Impl::throw_bad_alloc(std::size_t size, std::align_val_t alignment,
-                                   std::string what) {
-  throw Kokkos::Experimental::RawMemoryAllocationFailure(
-      size, static_cast<size_t>(alignment), std::move(what));
+void Kokkos::Impl::throw_bad_alloc(std::size_t size, std::string what) {
+  throw Kokkos::Experimental::RawMemoryAllocationFailure(size, std::move(what));
 }
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -25,8 +25,24 @@
 #include <Kokkos_Core.hpp>  // show_warnings
 #include <impl/Kokkos_Error.hpp>
 
-//----------------------------------------------------------------------------
-//----------------------------------------------------------------------------
+void Kokkos::Impl::throw_runtime_exception(const std::string &msg) {
+  throw std::runtime_error(msg);
+}
+
+void Kokkos::Impl::throw_bad_alloc(std::string_view memory_space_name,
+                                   std::size_t size, std::string_view label) {
+  std::stringstream ss;
+  ss << "Kokkos ERROR: " << memory_space_name
+     << " memory space failed to allocate " << human_memory_size(size)
+     << " (label=\"" << label << "\").";
+  throw std::runtime_error(ss.str());
+}
+
+void Kokkos::Impl::log_warning(const std::string &msg) {
+  if (show_warnings()) {
+    std::cerr << msg << std::flush;
+  }
+}
 
 std::string Kokkos::Impl::human_memory_size(size_t arg_bytes) {
   double bytes   = arg_bytes;
@@ -52,23 +68,4 @@ std::string Kokkos::Impl::human_memory_size(size_t arg_bytes) {
     out << std::setprecision(4) << bytes << " TiB";
   }
   return out.str();
-}
-
-void Kokkos::Impl::throw_bad_alloc(std::string_view memory_space_name,
-                                   std::size_t size, std::string_view label) {
-  std::stringstream ss;
-  ss << "Kokkos ERROR: " << memory_space_name
-     << " memory space failed to allocate " << human_memory_size(size)
-     << " (label=\"" << label << "\").";
-  throw std::runtime_error(ss.str());
-}
-
-void Kokkos::Impl::throw_runtime_exception(const std::string &msg) {
-  throw std::runtime_error(msg);
-}
-
-void Kokkos::Impl::log_warning(const std::string &msg) {
-  if (show_warnings()) {
-    std::cerr << msg << std::flush;
-  }
 }

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -31,12 +31,10 @@
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-void Kokkos::Impl::throw_bad_alloc(
-    std::size_t size, std::align_val_t alignment,
-    Kokkos::Experimental::RawMemoryAllocationFailure::FailureMode failure_mode,
-    std::string what) {
+void Kokkos::Impl::throw_bad_alloc(std::size_t size, std::align_val_t alignment,
+                                   std::string what) {
   throw Kokkos::Experimental::RawMemoryAllocationFailure(
-      size, static_cast<size_t>(alignment), failure_mode, std::move(what));
+      size, static_cast<size_t>(alignment), std::move(what));
 }
 
 namespace Kokkos {
@@ -80,20 +78,7 @@ void Experimental::RawMemoryAllocationFailure::print_error_message(
     std::ostream &o) const {
   o << "Allocation of size "
     << ::Kokkos::Impl::human_memory_size(m_attempted_size);
-  o << " failed";
-  switch (m_failure_mode) {
-    case FailureMode::OutOfMemoryError:
-      o << ", likely due to insufficient memory.";
-      break;
-    case FailureMode::AllocationNotAligned:
-      o << " because the allocation was improperly aligned.";
-      break;
-    case FailureMode::InvalidAllocationSize:
-      o << " because the requested allocation size is not a valid size for the"
-           " requested allocation mechanism (it's probably too large).";
-      break;
-    case FailureMode::Unknown: o << " because of an unknown error."; break;
-  }
+  o << " failed.";
   o << "  (The allocation mechanism was " << m_msg << ")\n";
 }
 

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -80,11 +80,4 @@ void Experimental::RawMemoryAllocationFailure::print_error_message(
   o << "  (The allocation mechanism was " << m_msg << ")\n";
 }
 
-std::string Experimental::RawMemoryAllocationFailure::get_error_message()
-    const {
-  std::ostringstream out;
-  print_error_message(out);
-  return out.str();
-}
-
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -28,6 +28,7 @@ namespace Kokkos::Impl {
 [[noreturn]] void throw_bad_alloc(std::string_view memory_space_name,
                                   std::size_t size, std::string_view label);
 void log_warning(const std::string &msg);
+std::string Kokkos::Impl::human_memory_size(size_t bytes);
 
 }  // namespace Kokkos::Impl
 

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -66,7 +66,6 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
   }
 
   void print_error_message(std::ostream &o) const;
-  [[nodiscard]] std::string get_error_message() const;
 };
 
 }  // namespace Experimental

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -17,64 +17,33 @@
 #ifndef KOKKOS_IMPL_ERROR_HPP
 #define KOKKOS_IMPL_ERROR_HPP
 
+#include <new>  // bad_alloc
 #include <string>
-#include <iosfwd>
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Abort.hpp>
 #include <Kokkos_Assert.hpp>
 
-namespace Kokkos {
-namespace Impl {
+namespace Kokkos::Impl {
 
 [[noreturn]] void throw_runtime_exception(const std::string &msg);
-
+[[noreturn]] void throw_bad_alloc(std::string_view memory_space_name,
+                                  std::size_t size, std::string label);
 void log_warning(const std::string &msg);
 
-std::string human_memory_size(size_t arg_bytes);
+}  // namespace Kokkos::Impl
 
-}  // namespace Impl
-
-namespace Experimental {
+namespace Kokkos::Experimental {
 
 class RawMemoryAllocationFailure : public std::bad_alloc {
   std::string m_msg;
-  size_t m_attempted_size;
 
  public:
-  RawMemoryAllocationFailure(size_t size, std::string what) noexcept
-      : m_msg(std::move(what)), m_attempted_size(size) {}
+  explicit RawMemoryAllocationFailure(std::string msg) noexcept
+      : m_msg(std::move(msg)) {}
 
-  RawMemoryAllocationFailure() noexcept = delete;
-
-  RawMemoryAllocationFailure(RawMemoryAllocationFailure const &) noexcept =
-      default;
-  RawMemoryAllocationFailure(RawMemoryAllocationFailure &&) noexcept = default;
-
-  RawMemoryAllocationFailure &operator             =(
-      RawMemoryAllocationFailure const &) noexcept = default;
-  RawMemoryAllocationFailure &operator             =(
-      RawMemoryAllocationFailure &&) noexcept = default;
-
-  ~RawMemoryAllocationFailure() noexcept override = default;
-
-  [[nodiscard]] const char *what() const noexcept override {
-    return "Memory allocation error";
-  }
-
-  [[nodiscard]] size_t attempted_size() const noexcept {
-    return m_attempted_size;
-  }
-
-  void print_error_message(std::ostream &o) const;
+  const char *what() const noexcept override { return m_msg.c_str(); }
 };
 
-}  // namespace Experimental
+}  // namespace Kokkos::Experimental
 
-namespace Impl {
-
-[[noreturn]] void throw_bad_alloc(std::size_t size, std::string what);
-
-}  // namespace Impl
-}  // namespace Kokkos
-
-#endif /* #ifndef KOKKOS_IMPL_ERROR_HPP */
+#endif

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -37,17 +37,6 @@ std::string human_memory_size(size_t arg_bytes);
 namespace Experimental {
 
 class RawMemoryAllocationFailure : public std::bad_alloc {
- public:
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  enum class KOKKOS_DEPRECATED FailureMode {
-    OutOfMemoryError,
-    AllocationNotAligned,
-    InvalidAllocationSize,
-    Unknown
-  };
-#endif
-
- private:
   std::string m_msg;
   size_t m_attempted_size;
 

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -28,7 +28,7 @@ namespace Kokkos::Impl {
 [[noreturn]] void throw_bad_alloc(std::string_view memory_space_name,
                                   std::size_t size, std::string_view label);
 void log_warning(const std::string &msg);
-std::string Kokkos::Impl::human_memory_size(size_t bytes);
+std::string human_memory_size(size_t bytes);
 
 }  // namespace Kokkos::Impl
 

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -39,27 +39,26 @@ namespace Experimental {
 
 class RawMemoryAllocationFailure : public std::bad_alloc {
  public:
-  enum class FailureMode {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  enum class KOKKOS_DEPRECATED FailureMode {
     OutOfMemoryError,
     AllocationNotAligned,
     InvalidAllocationSize,
     Unknown
   };
+#endif
 
  private:
   std::string m_msg;
   size_t m_attempted_size;
   size_t m_attempted_alignment;
-  FailureMode m_failure_mode;
 
  public:
   RawMemoryAllocationFailure(size_t size, size_t alignment,
-                             FailureMode failure_mode,
                              std::string what) noexcept
       : m_msg(std::move(what)),
         m_attempted_size(size),
-        m_attempted_alignment(alignment),
-        m_failure_mode(failure_mode) {}
+        m_attempted_alignment(alignment) {}
 
   RawMemoryAllocationFailure() noexcept = delete;
 
@@ -75,13 +74,7 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
   ~RawMemoryAllocationFailure() noexcept override = default;
 
   [[nodiscard]] const char *what() const noexcept override {
-    if (m_failure_mode == FailureMode::OutOfMemoryError) {
-      return "Memory allocation error: out of memory";
-    } else if (m_failure_mode == FailureMode::AllocationNotAligned) {
-      return "Memory allocation error: allocation result was under-aligned";
-    }
-
-    return nullptr;  // unreachable
+    return "Memory allocation error";
   }
 
   [[nodiscard]] size_t attempted_size() const noexcept {
@@ -92,22 +85,16 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
     return m_attempted_alignment;
   }
 
-  [[nodiscard]] FailureMode failure_mode() const noexcept {
-    return m_failure_mode;
-  }
-
   void print_error_message(std::ostream &o) const;
   [[nodiscard]] std::string get_error_message() const;
 };
 
-}  // end namespace Experimental
+}  // namespace Experimental
 
 namespace Impl {
 
-[[noreturn]] void throw_bad_alloc(
-    std::size_t size, std::align_val_t alignment,
-    Kokkos::Experimental::RawMemoryAllocationFailure::FailureMode failure_mode,
-    std::string what);
+[[noreturn]] void throw_bad_alloc(std::size_t size, std::align_val_t alignment,
+                                  std::string what);
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -26,7 +26,7 @@ namespace Kokkos::Impl {
 
 [[noreturn]] void throw_runtime_exception(const std::string &msg);
 [[noreturn]] void throw_bad_alloc(std::string_view memory_space_name,
-                                  std::size_t size, std::string label);
+                                  std::size_t size, std::string_view label);
 void log_warning(const std::string &msg);
 
 }  // namespace Kokkos::Impl

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -17,7 +17,6 @@
 #ifndef KOKKOS_IMPL_ERROR_HPP
 #define KOKKOS_IMPL_ERROR_HPP
 
-#include <new>  // bad_alloc
 #include <string>
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Abort.hpp>
@@ -31,19 +30,5 @@ namespace Kokkos::Impl {
 void log_warning(const std::string &msg);
 
 }  // namespace Kokkos::Impl
-
-namespace Kokkos::Experimental {
-
-class RawMemoryAllocationFailure : public std::bad_alloc {
-  std::string m_msg;
-
- public:
-  explicit RawMemoryAllocationFailure(std::string msg) noexcept
-      : m_msg(std::move(msg)) {}
-
-  const char *what() const noexcept override { return m_msg.c_str(); }
-};
-
-}  // namespace Kokkos::Experimental
 
 #endif

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -17,7 +17,6 @@
 #ifndef KOKKOS_IMPL_ERROR_HPP
 #define KOKKOS_IMPL_ERROR_HPP
 
-#include <new>  // align_val_t
 #include <string>
 #include <iosfwd>
 #include <Kokkos_Macros.hpp>
@@ -51,14 +50,10 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
  private:
   std::string m_msg;
   size_t m_attempted_size;
-  size_t m_attempted_alignment;
 
  public:
-  RawMemoryAllocationFailure(size_t size, size_t alignment,
-                             std::string what) noexcept
-      : m_msg(std::move(what)),
-        m_attempted_size(size),
-        m_attempted_alignment(alignment) {}
+  RawMemoryAllocationFailure(size_t size, std::string what) noexcept
+      : m_msg(std::move(what)), m_attempted_size(size) {}
 
   RawMemoryAllocationFailure() noexcept = delete;
 
@@ -81,10 +76,6 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
     return m_attempted_size;
   }
 
-  [[nodiscard]] size_t attempted_alignment() const noexcept {
-    return m_attempted_alignment;
-  }
-
   void print_error_message(std::ostream &o) const;
   [[nodiscard]] std::string get_error_message() const;
 };
@@ -93,8 +84,7 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
 
 namespace Impl {
 
-[[noreturn]] void throw_bad_alloc(std::size_t size, std::align_val_t alignment,
-                                  std::string what);
+[[noreturn]] void throw_bad_alloc(std::size_t size, std::string what);
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -28,6 +28,7 @@ namespace Kokkos::Impl {
 [[noreturn]] void throw_bad_alloc(std::string_view memory_space_name,
                                   std::size_t size, std::string_view label);
 void log_warning(const std::string &msg);
+
 std::string human_memory_size(size_t bytes);
 
 }  // namespace Kokkos::Impl

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -79,15 +79,9 @@ void *HostSpace::impl_allocate(
     ptr = operator new (arg_alloc_size, std::align_val_t(alignment),
                         std::nothrow_t{});
 
-  using FailureMode = Experimental::RawMemoryAllocationFailure::FailureMode;
-  if (!ptr) {
-    Impl::throw_bad_alloc(arg_alloc_size, std::align_val_t{alignment},
-                          FailureMode::OutOfMemoryError, "standard malloc()");
-  }
-  if ((reinterpret_cast<uintptr_t>(ptr) == ~uintptr_t(0)) ||
+  if (!ptr || (reinterpret_cast<uintptr_t>(ptr) == ~uintptr_t(0)) ||
       (reinterpret_cast<uintptr_t>(ptr) & alignment_mask)) {
     Impl::throw_bad_alloc(arg_alloc_size, std::align_val_t{alignment},
-                          FailureMode::AllocationNotAligned,
                           "standard malloc()");
   }
   if (Kokkos::Profiling::profileLibraryLoaded()) {

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -81,8 +81,7 @@ void *HostSpace::impl_allocate(
 
   if (!ptr || (reinterpret_cast<uintptr_t>(ptr) == ~uintptr_t(0)) ||
       (reinterpret_cast<uintptr_t>(ptr) & alignment_mask)) {
-    Impl::throw_bad_alloc(arg_alloc_size, std::align_val_t{alignment},
-                          "standard malloc()");
+    Impl::throw_bad_alloc(arg_alloc_size, "standard malloc()");
   }
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     Kokkos::Profiling::allocateData(arg_handle, arg_label, ptr, reported_size);

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -81,7 +81,7 @@ void *HostSpace::impl_allocate(
 
   if (!ptr || (reinterpret_cast<uintptr_t>(ptr) == ~uintptr_t(0)) ||
       (reinterpret_cast<uintptr_t>(ptr) & alignment_mask)) {
-    Impl::throw_bad_alloc(arg_alloc_size, "standard malloc()");
+    Impl::throw_bad_alloc(name(), arg_alloc_size, arg_label);
   }
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     Kokkos::Profiling::allocateData(arg_handle, arg_label, ptr, reported_size);

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -331,13 +331,6 @@ void safe_throw_allocation_with_header_failure(
       << "\".  Allocation using MemorySpace named \"" << space_name
       << "\" failed with the following error:  ";
     failure.print_error_message(o);
-    if (failure.failure_mode() ==
-        Kokkos::Experimental::RawMemoryAllocationFailure::FailureMode::
-            AllocationNotAligned) {
-      // TODO: delete the misaligned memory?
-      o << "Warning: Allocation failed due to misalignment; memory may "
-           "be leaked.\n";
-    }
     o.flush();
   };
   try {

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -323,34 +323,6 @@ void SharedAllocationRecord<void, void>::print_host_accessible_records(
 }
 #endif
 
-void safe_throw_allocation_with_header_failure(
-    std::string const& space_name, std::string const& label,
-    Kokkos::Experimental::RawMemoryAllocationFailure const& failure) {
-  auto generate_failure_message = [&](std::ostream& o) {
-    o << "Kokkos failed to allocate memory for label \"" << label
-      << "\".  Allocation using MemorySpace named \"" << space_name
-      << "\" failed with the following error:  ";
-    failure.print_error_message(o);
-    o.flush();
-  };
-  try {
-    std::ostringstream sstr;
-    generate_failure_message(sstr);
-    Kokkos::Impl::throw_runtime_exception(sstr.str());
-  } catch (std::bad_alloc const&) {
-    // Probably failed to allocate the string because we're so close to out
-    // of memory. Try printing to std::cerr instead
-    try {
-      generate_failure_message(std::cerr);
-    } catch (std::bad_alloc const&) {
-      // oh well, we tried...
-    }
-    Kokkos::Impl::throw_runtime_exception(
-        "Kokkos encountered an allocation failure, then another allocation "
-        "failure while trying to create the error message.");
-  }
-}
-
 void fill_host_accessible_header_info(
     SharedAllocationRecord<void, void>* arg_record,
     SharedAllocationHeader& arg_header, std::string const& arg_label) {

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -196,36 +196,21 @@ class SharedAllocationRecord<void, void> {
       const SharedAllocationRecord* const root, const bool detail);
 };
 
-void safe_throw_allocation_with_header_failure(
-    std::string const& space_name, std::string const& label,
-    Kokkos::Experimental::RawMemoryAllocationFailure const& failure);
-
 template <class MemorySpace>
 SharedAllocationHeader* checked_allocation_with_header(MemorySpace const& space,
                                                        std::string const& label,
                                                        size_t alloc_size) {
-  try {
-    return reinterpret_cast<SharedAllocationHeader*>(space.allocate(
-        label.c_str(), alloc_size + sizeof(SharedAllocationHeader),
-        alloc_size));
-  } catch (Kokkos::Experimental::RawMemoryAllocationFailure const& failure) {
-    safe_throw_allocation_with_header_failure(space.name(), label, failure);
-  }
-  return nullptr;  // unreachable
+  return reinterpret_cast<SharedAllocationHeader*>(space.allocate(
+      label.c_str(), alloc_size + sizeof(SharedAllocationHeader), alloc_size));
 }
 
 template <class ExecutionSpace, class MemorySpace>
 SharedAllocationHeader* checked_allocation_with_header(
     ExecutionSpace const& exec_space, MemorySpace const& space,
     std::string const& label, size_t alloc_size) {
-  try {
-    return reinterpret_cast<SharedAllocationHeader*>(space.allocate(
-        exec_space, label.c_str(), alloc_size + sizeof(SharedAllocationHeader),
-        alloc_size));
-  } catch (Kokkos::Experimental::RawMemoryAllocationFailure const& failure) {
-    safe_throw_allocation_with_header_failure(space.name(), label, failure);
-  }
-  return nullptr;  // unreachable
+  return reinterpret_cast<SharedAllocationHeader*>(
+      space.allocate(exec_space, label.c_str(),
+                     alloc_size + sizeof(SharedAllocationHeader), alloc_size));
 }
 
 void fill_host_accessible_header_info(SharedAllocationHeader& arg_header,

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -255,6 +255,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       ViewAPI_c
       ViewAPI_d
       ViewAPI_e
+      ViewBadAlloc
       ViewCopy_a
       ViewCopy_b
       ViewCopy_c

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1571,51 +1571,6 @@ class TestViewAPI {
     typename multivector_type::const_type cmvX(cmv);
     typename const_multivector_type::const_type ccmvX(cmv);
   }
-
-  static void run_test_error() {
-// FIXME_MSVC_WITH_CUDA
-// This test doesn't behave as expected on Windows with CUDA
-#if defined(_WIN32) && defined(KOKKOS_ENABLE_CUDA)
-    if (std::is_same<typename dView1::memory_space,
-                     Kokkos::CudaUVMSpace>::value)
-      return;
-#endif
-    bool did_throw  = false;
-    auto alloc_size = std::numeric_limits<size_t>::max() - 42;
-    try {
-      auto should_always_fail = dView1("hello_world_failure", alloc_size);
-    } catch (std::runtime_error const &error) {
-      // TODO once we remove the conversion to std::runtime_error, catch the
-      //      appropriate Kokkos error here
-      std::string msg = error.what();
-      ASSERT_PRED_FORMAT2(::testing::IsSubstring, "hello_world_failure", msg);
-      ASSERT_PRED_FORMAT2(::testing::IsSubstring,
-                          typename device::memory_space{}.name(), msg);
-      // Can't figure out how to make assertions either/or, so we'll just use
-      // an if statement here for now.  Test failure message will be a bit
-      // misleading, but developers should figure out what's going on pretty
-      // quickly.
-      if (msg.find("is not a valid size") != std::string::npos) {
-        ASSERT_PRED_FORMAT2(::testing::IsSubstring, "is not a valid size", msg);
-      } else
-#ifdef KOKKOS_ENABLE_SYCL
-          if (msg.find("insufficient memory") != std::string::npos)
-#endif
-      {
-        ASSERT_PRED_FORMAT2(::testing::IsSubstring, "insufficient memory", msg);
-      }
-      // SYCL cannot tell the reason why a memory allocation failed
-#ifdef KOKKOS_ENABLE_SYCL
-      else {
-        // Otherwise, there has to be some sort of "unknown error" error
-        ASSERT_PRED_FORMAT2(::testing::IsSubstring,
-                            "because of an unknown error.", msg);
-      }
-#endif
-      did_throw = true;
-    }
-    ASSERT_TRUE(did_throw);
-  }
 };
 
 }  // namespace Test

--- a/core/unit_test/TestViewAPI_d.hpp
+++ b/core/unit_test/TestViewAPI_d.hpp
@@ -26,22 +26,4 @@ TEST(TEST_CATEGORY, view_api_d) {
   TestViewAPI<double, TEST_EXECSPACE>::run_test_view_operator_c();
 }
 
-TEST(TEST_CATEGORY, view_allocation_error) {
-#if defined(__has_feature)
-#if __has_feature(address_sanitizer)
-  GTEST_SKIP() << "AddressSanitzer detects allocating too much memory "
-                  "preventing our checks to run";
-#endif
-#endif
-#if ((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 3))
-  GTEST_SKIP() << "ROCm 5.3 segfaults when trying to allocate too much memory";
-#endif
-#if defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
-    GTEST_SKIP() << "acc_malloc() not properly returning nullptr";
-  }
-#endif
-  TestViewAPI<double, TEST_EXECSPACE>::run_test_error();
-}
-
 }  // namespace Test

--- a/core/unit_test/TestViewBadAlloc.hpp
+++ b/core/unit_test/TestViewBadAlloc.hpp
@@ -63,4 +63,3 @@ TEST(TEST_CATEGORY, view_bad_alloc) {
 }
 
 }  // namespace
-

--- a/core/unit_test/TestViewBadAlloc.hpp
+++ b/core/unit_test/TestViewBadAlloc.hpp
@@ -1,0 +1,66 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+template <class MemorySpace>
+void test_view_bad_alloc() {
+  bool did_throw    = false;
+  auto too_large    = std::numeric_limits<size_t>::max() - 42;
+  std::string label = "my_label";
+  try {
+    auto should_always_fail =
+        Kokkos::View<double *, MemorySpace>(label, too_large);
+  } catch (std::runtime_error const &error) {
+    std::string msg = error.what();
+    std::cout << msg << '\n';
+    ASSERT_PRED_FORMAT2(
+        ::testing::IsSubstring,
+        std::string(MemorySpace::name()) + " memory space failed to allocate",
+        msg)
+        << "memory space name is missing";
+    ASSERT_PRED_FORMAT2(::testing::IsSubstring,
+                        std::string("(label=\"") + label + "\")", msg)
+        << "label is missing";
+    did_throw = true;
+  }
+  ASSERT_TRUE(did_throw);
+}
+
+TEST(TEST_CATEGORY, view_bad_alloc) {
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+  GTEST_SKIP() << "AddressSanitzer detects allocating too much memory "
+                  "preventing our checks to run";
+#endif
+#endif
+#if ((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 3))
+  GTEST_SKIP() << "ROCm 5.3 segfaults when trying to allocate too much memory";
+#endif
+#if defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
+    GTEST_SKIP() << "acc_malloc() not properly returning nullptr";
+  }
+#endif
+  test_view_bad_alloc<TEST_EXECSPACE::memory_space>();
+}
+
+}  // namespace
+

--- a/core/unit_test/TestViewBadAlloc.hpp
+++ b/core/unit_test/TestViewBadAlloc.hpp
@@ -30,7 +30,6 @@ void test_view_bad_alloc() {
         Kokkos::View<double *, MemorySpace>(label, too_large);
   } catch (std::runtime_error const &error) {
     std::string msg = error.what();
-    std::cout << msg << '\n';
     ASSERT_PRED_FORMAT2(
         ::testing::IsSubstring,
         std::string(MemorySpace::name()) + " memory space failed to allocate",

--- a/core/unit_test/TestViewBadAlloc.hpp
+++ b/core/unit_test/TestViewBadAlloc.hpp
@@ -49,7 +49,7 @@ TEST(TEST_CATEGORY, view_bad_alloc) {
 #if defined(__has_feature)
 #if __has_feature(address_sanitizer)
   if (std::is_same_v<MemorySpace, Kokkos::HostSpace>) {
-    GTEST_SKIP() << "AddressSanitzer detects allocating too much memory "
+    GTEST_SKIP() << "AddressSanitizer detects allocating too much memory "
                     "preventing our checks to run";
   }
 #endif


### PR DESCRIPTION
Motivation to get rid of `Experimental::RawMemoryAllocationFailure`:
* backends do not really distinguish failure modes and it is not clear it is useful
* the alignment is not controlled by the user, its value is static, so there is little point in attaching it to the exception
* we were actually catching them to rethrow a regular runtime error
* in the end, the most important thing is to raise an error with a good quality error message

The changes in this PR simplify the bad alloc error reporting.
New error messages are along these lines:
```
Kokkos ERROR: Host memory space failed to allocate 1.678e+07 TiB (label="hello_world_failure").
```

I also got rid of the "catch the exception, append to the error message, and rethrow" pattern in shared alloc because we have all the necessary information when we first throw.