### PR TITLE
SYCL: Use sycl::shift_group_[left|right] and sycl::select_from_group

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_SYCL_PARALLEL_SCAN_RANGE_HPP
 
 #include <Kokkos_Macros.hpp>
+#include <SYCL/Kokkos_SYCL_WorkgroupReduction.hpp>
 #include <memory>
 #include <vector>
 

--- a/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
@@ -40,7 +40,8 @@ void workgroup_scan(sycl::nd_item<dim> item, const FunctorType& final_reducer,
 #if defined(KOKKOS_ARCH_INTEL_GPU) || defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
   auto shuffle_combine = [&](int stride) {
     if (stride < local_range) {
-      auto tmp = sg.shuffle_up(local_value, stride);
+      auto tmp = Kokkos::Impl::SYCLReduction::shift_group_right(sg, local_value,
+                                                                stride);
       if (id_in_sg >= stride) final_reducer.join(&local_value, &tmp);
     }
   };
@@ -52,7 +53,8 @@ void workgroup_scan(sycl::nd_item<dim> item, const FunctorType& final_reducer,
   KOKKOS_ASSERT(local_range <= 32);
 #else
   for (int stride = 1; stride < local_range; stride <<= 1) {
-    auto tmp = sg.shuffle_up(local_value, stride);
+    auto tmp =
+        Kokkos::Impl::SYCLReduction::shift_group_right(sg, local_value, stride);
     if (id_in_sg >= stride) final_reducer.join(&local_value, &tmp);
   }
 #endif
@@ -63,7 +65,8 @@ void workgroup_scan(sycl::nd_item<dim> item, const FunctorType& final_reducer,
 
   if (id_in_sg == local_range - 1 && sg_group_id < n_active_subgroups)
     local_mem[sg_group_id] = local_value;
-  local_value = sg.shuffle_up(local_value, 1);
+  local_value =
+      Kokkos::Impl::SYCLReduction::shift_group_right(sg, local_value, 1);
   if (id_in_sg == 0) final_reducer.init(&local_value);
   sycl::group_barrier(item.get_group());
 
@@ -79,7 +82,8 @@ void workgroup_scan(sycl::nd_item<dim> item, const FunctorType& final_reducer,
 #if defined(KOKKOS_ARCH_INTEL_GPU) || defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
         auto shuffle_combine_sg = [&](int stride) {
           if (stride < upper_bound) {
-            auto tmp = sg.shuffle_up(local_sg_value, stride);
+            auto tmp = Kokkos::Impl::SYCLReduction::shift_group_right(
+                sg, local_sg_value, stride);
             if (id_in_sg >= stride) {
               if (idx < n_active_subgroups)
                 final_reducer.join(&local_sg_value, &tmp);
@@ -96,7 +100,8 @@ void workgroup_scan(sycl::nd_item<dim> item, const FunctorType& final_reducer,
         KOKKOS_ASSERT(upper_bound <= 32);
 #else
         for (int stride = 1; stride < upper_bound; stride <<= 1) {
-          auto tmp = sg.shuffle_up(local_sg_value, stride);
+          auto tmp = Kokkos::Impl::SYCLReduction::shift_group_right(
+              sg, local_sg_value, stride);
           if (id_in_sg >= stride) {
             if (idx < n_active_subgroups)
               final_reducer.join(&local_sg_value, &tmp);

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -22,6 +22,7 @@
 #ifdef KOKKOS_ENABLE_SYCL
 
 #include <utility>
+#include <SYCL/Kokkos_SYCL_WorkgroupReduction.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -136,7 +137,8 @@ class SYCLTeamMember {
 #if defined(KOKKOS_ARCH_INTEL_GPU) || defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
     auto shuffle_combine = [&](int shift) {
       if (vector_range * shift < sub_group_range) {
-        const value_type tmp = sg.shuffle_down(value, vector_range * shift);
+        const value_type tmp = Kokkos::Impl::SYCLReduction::shift_group_left(
+            sg, value, vector_range * shift);
         if (team_rank_ + shift < team_size_) reducer.join(value, tmp);
       }
     };
@@ -149,11 +151,12 @@ class SYCLTeamMember {
 #else
     for (unsigned int shift = 1; vector_range * shift < sub_group_range;
          shift <<= 1) {
-      const value_type tmp = sg.shuffle_down(value, vector_range * shift);
+      auto tmp = Kokkos::Impl::SYCLReduction::shift_group_left(
+          sg, value, vector_range * shift);
       if (team_rank_ + shift < team_size_) reducer.join(value, tmp);
     }
 #endif
-    value = sg.shuffle(value, 0);
+    value = Kokkos::Impl::SYCLReduction::select_from_group(sg, value, 0);
 
     const int n_subgroups = sg.get_group_range()[0];
     if (n_subgroups == 1) {
@@ -220,7 +223,8 @@ class SYCLTeamMember {
     // First combine the values in the same subgroup
     for (unsigned int stride = 1; vector_range * stride < sub_group_range;
          stride <<= 1) {
-      auto tmp = sg.shuffle_up(value, vector_range * stride);
+      auto tmp = Kokkos::Impl::SYCLReduction::shift_group_right(
+          sg, value, vector_range * stride);
       if (id_in_sg >= vector_range * stride) value += tmp;
     }
 
@@ -246,7 +250,8 @@ class SYCLTeamMember {
               sub_group_range, n_active_subgroups - round * sub_group_range);
           auto local_value = base_data[idx];
           for (unsigned int stride = 1; stride < upper_bound; stride <<= 1) {
-            auto tmp = sg.shuffle_up(local_value, stride);
+            auto tmp = Kokkos::Impl::SYCLReduction::shift_group_right(
+                sg, local_value, stride);
             if (id_in_sg >= stride) {
               if (idx < n_active_subgroups)
                 local_value += tmp;
@@ -264,7 +269,8 @@ class SYCLTeamMember {
     }
     auto total = base_data[n_active_subgroups - 1];
 
-    const auto update = sg.shuffle_up(value, vector_range);
+    const auto update =
+        Kokkos::Impl::SYCLReduction::shift_group_right(sg, value, vector_range);
     Type intermediate = (group_id > 0 ? base_data[group_id - 1] : 0) +
                         (id_in_sg >= vector_range ? update : 0);
 
@@ -317,7 +323,7 @@ class SYCLTeamMember {
     typename ReducerType::value_type tmp2 = tmp;
 
     for (int i = grange1; (i >>= 1);) {
-      tmp2 = sg.shuffle_down(tmp, i);
+      tmp2 = Kokkos::Impl::SYCLReduction::shift_group_left(sg, tmp, i);
       if (static_cast<int>(tidx1) < i) {
         reducer.join(tmp, tmp2);
       }
@@ -328,8 +334,9 @@ class SYCLTeamMember {
     // because floating point summation is not associative
     // and thus different threads could have different results.
 
-    tmp2  = sg.shuffle(tmp, (sg.get_local_id() / grange1) * grange1);
-    value = tmp2;
+    tmp2 = Kokkos::Impl::SYCLReduction::select_from_group(
+        sg, tmp, (sg.get_local_id() / grange1) * grange1);
+    value               = tmp2;
     reducer.reference() = tmp2;
   }
 
@@ -836,7 +843,8 @@ parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
     //  [t] += [t-4] if t >= 4
     //  ...
     for (int j = 1; j < static_cast<int>(grange1); j <<= 1) {
-      value_type tmp = sg.shuffle_up(val, j);
+      value_type tmp =
+          Kokkos::Impl::SYCLReduction::shift_group_right(sg, val, j);
       if (j <= static_cast<int>(tidx1)) {
         reducer.join(val, tmp);
       }
@@ -847,7 +855,8 @@ parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
 
     // Update i's contribution into the val and add it to accum for next round
     if (i < loop_boundaries.end) closure(i, val, true);
-    accum = sg.shuffle(val, mask + vector_offset);
+    accum = Kokkos::Impl::SYCLReduction::select_from_group(
+        sg, val, mask + vector_offset);
   }
   reducer.reference() = accum;
 }
@@ -924,7 +933,8 @@ KOKKOS_INLINE_FUNCTION void single(
   const auto grange1          = item.get_local_range(1);
   const auto sg               = item.get_sub_group();
   if (item.get_local_id(1) == 0) lambda(val);
-  val = sg.shuffle(val, (sg.get_local_id() / grange1) * grange1);
+  val = Kokkos::Impl::SYCLReduction::select_from_group(
+      sg, val, (sg.get_local_id() / grange1) * grange1);
 }
 
 template <class FunctorType, class ValueType>

--- a/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
@@ -26,6 +26,7 @@ struct TrivialWrapper {
   std::byte array[N];
 };
 
+// shuffle down
 template <typename T>
 T shift_group_left(sycl::sub_group sg, T x,
                    sycl::sub_group::linear_id_type delta) {
@@ -38,6 +39,7 @@ T shift_group_left(sycl::sub_group sg, T x,
   }
 }
 
+// shuffle up
 template <typename T>
 T shift_group_right(sycl::sub_group sg, T x,
                     sycl::sub_group::linear_id_type delta) {
@@ -50,6 +52,7 @@ T shift_group_right(sycl::sub_group sg, T x,
   }
 }
 
+// shuffle
 template <typename T>
 T select_from_group(sycl::sub_group sg, T x,
                     sycl::sub_group::id_type remote_local_id) {


### PR DESCRIPTION
https://github.com/intel/llvm/pull/13666 removes `shuffle_*` which is replaced by `sycl::shift_group*` and `sycl::select_from_group` to be conformant with SYCL2020, see https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_shift_left_and_shift_right. Unfortunately, the new functions check that the type is trivially copyable which creates some problems for us since we don't impose that restriction in implementations that use shuffles.
The current approach is to `reinterpret_cast` to some trivially-copyable type. The underlying implementation is using
- __spirv_SubgroupShuffleINTEL
- __spirv_SubgroupShuffleDownINTEL
- __spirv_SubgroupShuffleUpINTEL 