### PR TITLE
Hidden friend operator== for Kokkos::Array

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -382,6 +382,26 @@ KOKKOS_FUNCTION constexpr auto to_array(T(&&a)[N]) {
   return Impl::to_array_impl(std::move(a), std::make_index_sequence<N>{});
 }
 
+template <typename T,
+          size_t LN, typename LP, 
+          size_t RN, typename RP>
+KOKKOS_INLINE_FUNCTION constexpr bool operator==(const Array<T, LN, LP>& lhs, 
+                                                 const Array<T, RN, RP>& rhs) {
+  if (lhs.size() != rhs.size()) return false;
+    for (int i = 0; i < (int)(lhs.size()); ++i) {
+      if (lhs[i] != rhs[i]) return false;
+    }
+    return true;
+}
+
+template <typename T,
+          size_t LN, typename LP, 
+          size_t RN, typename RP>
+KOKKOS_INLINE_FUNCTION constexpr bool operator!=(const Array<T, LN, LP>& lhs, 
+                                                 const Array<T, RN, RP>& rhs) {
+  return !(lhs == rhs);
+}
+
 }  // namespace Kokkos
 
 //<editor-fold desc="Support for structured binding">

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -382,23 +382,20 @@ KOKKOS_FUNCTION constexpr auto to_array(T(&&a)[N]) {
   return Impl::to_array_impl(std::move(a), std::make_index_sequence<N>{});
 }
 
-template <typename T,
-          size_t LN, typename LP, 
-          size_t RN, typename RP>
-KOKKOS_INLINE_FUNCTION constexpr bool operator==(const Array<T, LN, LP>& lhs, 
-                                                 const Array<T, RN, RP>& rhs) {
-  if (lhs.size() != rhs.size()) return false;
-    for (int i = 0; i < (int)(lhs.size()); ++i) {
-      if (lhs[i] != rhs[i]) return false;
-    }
-    return true;
+template <typename T, size_t N>
+KOKKOS_INLINE_FUNCTION constexpr bool operator==(const Array<T, N, void>& lhs,
+                                                 const Array<T, N, void>& rhs) {
+  // The cast to int is necessary to avoid a warning about a pointless
+  // comparison with zero in the case that an unsigned type is used.
+  for (int i = 0; i < static_cast<int>(lhs.size()); ++i) {
+    if (lhs[i] != rhs[i]) return false;
+  }
+  return true;
 }
 
-template <typename T,
-          size_t LN, typename LP, 
-          size_t RN, typename RP>
-KOKKOS_INLINE_FUNCTION constexpr bool operator!=(const Array<T, LN, LP>& lhs, 
-                                                 const Array<T, RN, RP>& rhs) {
+template <typename T, size_t N>
+KOKKOS_INLINE_FUNCTION constexpr bool operator!=(const Array<T, N, void>& lhs,
+                                                 const Array<T, N, void>& rhs) {
   return !(lhs == rhs);
 }
 

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -133,6 +133,18 @@ struct Array {
     return &m_internal_implementation_private_member_data[0];
   }
 
+  friend KOKKOS_FUNCTION constexpr bool operator==(Array const& lhs,
+                                                   Array const& rhs) noexcept {
+    for (size_t i = 0; i != N; ++i)
+      if (lhs[i] != rhs[i]) return false;
+    return true;
+  }
+
+  friend KOKKOS_FUNCTION constexpr bool operator!=(Array const& lhs,
+                                                   Array const& rhs) noexcept {
+    return !(lhs == rhs);
+  }
+
  private:
   template <class U = T>
   friend KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
@@ -185,6 +197,15 @@ struct Array<T, 0> {
 
   KOKKOS_INLINE_FUNCTION pointer data() { return nullptr; }
   KOKKOS_INLINE_FUNCTION const_pointer data() const { return nullptr; }
+
+  friend KOKKOS_FUNCTION constexpr bool operator==(Array const&,
+                                                   Array const&) noexcept {
+    return true;
+  }
+  friend KOKKOS_FUNCTION constexpr bool operator!=(Array const&,
+                                                   Array const&) noexcept {
+    return false;
+  }
 
   KOKKOS_DEFAULTED_FUNCTION ~Array()            = default;
   KOKKOS_DEFAULTED_FUNCTION Array()             = default;
@@ -380,23 +401,6 @@ KOKKOS_FUNCTION constexpr auto to_array(T (&a)[N]) {
 template <typename T, size_t N>
 KOKKOS_FUNCTION constexpr auto to_array(T(&&a)[N]) {
   return Impl::to_array_impl(std::move(a), std::make_index_sequence<N>{});
-}
-
-template <typename T, size_t N>
-KOKKOS_INLINE_FUNCTION constexpr bool operator==(const Array<T, N, void>& lhs,
-                                                 const Array<T, N, void>& rhs) {
-  // The cast to int is necessary to avoid a warning about a pointless
-  // comparison with zero in the case that an unsigned type is used.
-  for (int i = 0; i < static_cast<int>(lhs.size()); ++i) {
-    if (lhs[i] != rhs[i]) return false;
-  }
-  return true;
-}
-
-template <typename T, size_t N>
-KOKKOS_INLINE_FUNCTION constexpr bool operator!=(const Array<T, N, void>& lhs,
-                                                 const Array<T, N, void>& rhs) {
-  return !(lhs == rhs);
 }
 
 }  // namespace Kokkos

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #include <Kokkos_Array.hpp>
+#include <Kokkos_DetectionIdiom.hpp>
 
 namespace {
 
@@ -22,6 +23,9 @@ namespace {
 // Passing those variables to this function should eliminate the warning
 template <typename... Ts>
 KOKKOS_FUNCTION constexpr void maybe_unused(Ts&&...) {}
+
+template <typename T, typename U = T>
+using equality_comparable = decltype(std::declval<T&>() == std::declval<U&>());
 
 KOKKOS_FUNCTION constexpr bool test_array() {
   constexpr Kokkos::Array<int, 3> a{{1, 2}};
@@ -181,5 +185,60 @@ constexpr bool test_to_array() {
 }
 
 static_assert(test_to_array());
+
+constexpr bool test_array_equality_comparable() {
+  using C0 = Kokkos::Array<char, 0>;
+  using C2 = Kokkos::Array<char, 2>;
+  using C3 = Kokkos::Array<char, 3>;
+  using I0 = Kokkos::Array<int, 0>;
+  using I2 = Kokkos::Array<int, 2>;
+  using I3 = Kokkos::Array<int, 3>;
+
+  static_assert(Kokkos::is_detected_v<equality_comparable, C0, C0>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, C0, C2>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, C0, C3>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, C0, I0>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, C0, I2>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, C0, I3>);
+
+  static_assert(!Kokkos::is_detected_v<equality_comparable, C2, C0>);
+  static_assert(Kokkos::is_detected_v<equality_comparable, C2, C2>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, C2, C3>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, C2, I0>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, C2, I2>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, C2, I3>);
+
+  static_assert(!Kokkos::is_detected_v<equality_comparable, C3, C0>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, C3, C2>);
+  static_assert(Kokkos::is_detected_v<equality_comparable, C3, C3>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, C3, I0>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, C3, I2>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, C3, I3>);
+
+  static_assert(!Kokkos::is_detected_v<equality_comparable, I0, C0>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, I0, C2>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, I0, C3>);
+  static_assert(Kokkos::is_detected_v<equality_comparable, I0, I0>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, I0, I2>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, I0, I3>);
+
+  static_assert(!Kokkos::is_detected_v<equality_comparable, I2, C0>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, I2, C2>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, I2, C3>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, I2, I0>);
+  static_assert(Kokkos::is_detected_v<equality_comparable, I2, I2>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, I2, I3>);
+
+  static_assert(!Kokkos::is_detected_v<equality_comparable, I3, C0>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, I3, C2>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, I3, C3>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, I3, I0>);
+  static_assert(!Kokkos::is_detected_v<equality_comparable, I3, I2>);
+  static_assert(Kokkos::is_detected_v<equality_comparable, I3, I3>);
+
+  return true;
+}
+
+static_assert(test_array_equality_comparable());
 
 }  // namespace

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -25,7 +25,7 @@ template <typename... Ts>
 KOKKOS_FUNCTION constexpr void maybe_unused(Ts&&...) {}
 
 template <typename T, typename U = T>
-using equality_comparable = decltype(std::declval<T&>() == std::declval<U&>());
+using equality_comparable = decltype(std::declval<const T&>() == std::declval<const U&>());
 
 KOKKOS_FUNCTION constexpr bool test_array() {
   constexpr Kokkos::Array<int, 3> a{{1, 2}};

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -25,7 +25,8 @@ template <typename... Ts>
 KOKKOS_FUNCTION constexpr void maybe_unused(Ts&&...) {}
 
 template <typename T, typename U = T>
-using equality_comparable = decltype(std::declval<const T&>() == std::declval<const U&>());
+using equality_comparable =
+    decltype(std::declval<T const&>() == std::declval<U const&>());
 
 KOKKOS_FUNCTION constexpr bool test_array() {
   constexpr Kokkos::Array<int, 3> a{{1, 2}};

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -54,17 +54,6 @@ KOKKOS_FUNCTION constexpr bool test_array_structured_binding_support() {
 
 static_assert(test_array_structured_binding_support());
 
-template <typename L, typename R>
-KOKKOS_FUNCTION constexpr bool is_equal(L const& l, R const& r) {
-  if (l.size() != r.size()) return false;
-
-  for (size_t i = 0; i != l.size(); ++i) {
-    if (l[i] != r[i]) return false;
-  }
-
-  return true;
-}
-
 // Disable ctad test for intel versions < 2021, see issue #6702
 #if !defined(KOKKOS_COMPILER_INTEL) || KOKKOS_COMPILER_INTEL >= 2021
 KOKKOS_FUNCTION constexpr bool test_array_ctad() {
@@ -72,7 +61,7 @@ KOKKOS_FUNCTION constexpr bool test_array_ctad() {
   constexpr Kokkos::Array a{1, 2, 3, 5, x};
   constexpr Kokkos::Array<int, 5> b{1, 2, 3, 5, x};
 
-  return std::is_same_v<decltype(a), decltype(b)> && is_equal(a, b);
+  return std::is_same_v<decltype(a), decltype(b)> && a == b;
 }
 
 static_assert(test_array_ctad());

--- a/core/unit_test/TestArrayOps.hpp
+++ b/core/unit_test/TestArrayOps.hpp
@@ -92,6 +92,84 @@ TEST(TEST_CATEGORY, array_element_access) {
   ASSERT_EQ(ca.data()[index], a[index]);
 }
 
+TEST(TEST_CATEGORY, array_operator_equal) {
+  using A = Kokkos::Array<int, 2>;
+  constexpr A a{{3, 5}};
+  constexpr A b{{3, 5}};
+  constexpr A c{{5, 3}};
+
+  static_assert(a == b);
+  static_assert(!(a == c));
+  static_assert(a != c);
+
+  ASSERT_TRUE(a == b);
+  ASSERT_FALSE(a == c);
+  ASSERT_TRUE(a != c);
+
+  using E = Kokkos::Array<int, 0>;
+  constexpr E e;
+  constexpr E f;
+
+  static_assert(e == f);
+  static_assert(!(e != f));
+
+  ASSERT_TRUE(e == f);
+  ASSERT_FALSE(e != f);
+
+  static_assert(a != e);
+
+  ASSERT_TRUE(a != e);
+
+  using AC =
+    Kokkos::Array<int, KOKKOS_INVALID_INDEX, Kokkos::Array<>::contiguous>;
+
+  int ac_[] = {3, 5};
+  const AC ac(ac_, std::size(ac_));
+  int bc_[] = {3, 5};
+  const AC bc(bc_, std::size(bc_));
+
+  int dc_[] = {11, 13, 17, 19};
+  const AC dc(dc_, std::size(dc_));
+
+  ASSERT_TRUE(ac == bc);
+  ASSERT_TRUE(ac != dc);
+
+  ASSERT_TRUE(ac == a);
+  ASSERT_FALSE(ac == e);
+
+  const AC ec(nullptr, 0);
+  const AC fc(nullptr, 0);
+
+  ASSERT_TRUE(ec == fc);
+  ASSERT_FALSE(ec != fc);
+
+  ASSERT_FALSE(a == ec);
+  ASSERT_TRUE(e == ec);
+  ASSERT_FALSE(ac == ec);
+
+  using AS =
+    Kokkos::Array<int, KOKKOS_INVALID_INDEX, Kokkos::Array<>::strided>;
+
+  int as_[] = {3, 5, 7, 11, 13, 17, 19};
+  constexpr size_t asStride = 2;
+  const AS as(as_, std::size(as_) / asStride, asStride);
+  int bs_[] = {3, 5, 7, 11, 13, 17, 19};
+  constexpr size_t bsStride = 2;
+  const AS bs(bs_, std::size(bs_) / bsStride, bsStride);
+
+  int ds_[] = {3, 13, 5, 19};
+  constexpr size_t dsStride = 2;
+  const AS ds(ds_, std::size(ds_) / dsStride, dsStride);
+
+  ASSERT_TRUE(as == bs);
+  ASSERT_TRUE(as != ds);
+
+  ASSERT_TRUE(a == ds);
+  ASSERT_FALSE(e == as);
+  ASSERT_TRUE(ac == ds);
+  ASSERT_FALSE(ec == as);
+}
+
 TEST(TEST_CATEGORY, array_zero_capacity) {
   using A = Kokkos::Array<int, 0>;
   A e;

--- a/core/unit_test/TestArrayOps.hpp
+++ b/core/unit_test/TestArrayOps.hpp
@@ -115,59 +115,6 @@ TEST(TEST_CATEGORY, array_operator_equal) {
 
   ASSERT_TRUE(e == f);
   ASSERT_FALSE(e != f);
-
-  static_assert(a != e);
-
-  ASSERT_TRUE(a != e);
-
-  using AC =
-    Kokkos::Array<int, KOKKOS_INVALID_INDEX, Kokkos::Array<>::contiguous>;
-
-  int ac_[] = {3, 5};
-  const AC ac(ac_, std::size(ac_));
-  int bc_[] = {3, 5};
-  const AC bc(bc_, std::size(bc_));
-
-  int dc_[] = {11, 13, 17, 19};
-  const AC dc(dc_, std::size(dc_));
-
-  ASSERT_TRUE(ac == bc);
-  ASSERT_TRUE(ac != dc);
-
-  ASSERT_TRUE(ac == a);
-  ASSERT_FALSE(ac == e);
-
-  const AC ec(nullptr, 0);
-  const AC fc(nullptr, 0);
-
-  ASSERT_TRUE(ec == fc);
-  ASSERT_FALSE(ec != fc);
-
-  ASSERT_FALSE(a == ec);
-  ASSERT_TRUE(e == ec);
-  ASSERT_FALSE(ac == ec);
-
-  using AS =
-    Kokkos::Array<int, KOKKOS_INVALID_INDEX, Kokkos::Array<>::strided>;
-
-  int as_[] = {3, 5, 7, 11, 13, 17, 19};
-  constexpr size_t asStride = 2;
-  const AS as(as_, std::size(as_) / asStride, asStride);
-  int bs_[] = {3, 5, 7, 11, 13, 17, 19};
-  constexpr size_t bsStride = 2;
-  const AS bs(bs_, std::size(bs_) / bsStride, bsStride);
-
-  int ds_[] = {3, 13, 5, 19};
-  constexpr size_t dsStride = 2;
-  const AS ds(ds_, std::size(ds_) / dsStride, dsStride);
-
-  ASSERT_TRUE(as == bs);
-  ASSERT_TRUE(as != ds);
-
-  ASSERT_TRUE(a == ds);
-  ASSERT_FALSE(e == as);
-  ASSERT_TRUE(ac == ds);
-  ASSERT_FALSE(ec == as);
 }
 
 TEST(TEST_CATEGORY, array_zero_capacity) {


### PR DESCRIPTION
This supercedes #6599 (it incorporates the run time tests that @maartenarnst wrote there).

Adds hidden friends `==` and `!=` to `Kokkos::Array<T, N>` for all `N`, including 0.

Deliberately does not add them to the deprecated forms of `Kokkos::Array`.

Adds a compile time test for equality comparable.