### PR TITLE
Make struct "ChunkSize" constructor explicit to avoid implicit construction in RangePolicy

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -40,7 +40,7 @@ struct ParallelReduceTag {};
 
 struct ChunkSize {
   int value;
-  ChunkSize(int value_) : value(value_) {}
+  explicit ChunkSize(int value_) : value(value_) {}
 };
 
 /** \brief  Execution policy for work over a range of an integral type.

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -38,9 +38,22 @@ struct ParallelForTag {};
 struct ParallelScanTag {};
 struct ParallelReduceTag {};
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+namespace Impl {
+struct OverloadHelper {};
+}  // namespace Impl
+#endif
+
 struct ChunkSize {
   int value;
   explicit ChunkSize(int value_) : value(value_) {}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED_WITH_COMMENT(
+      "In RangePolicy constructor, ChunkSize struct was constructed implicitly "
+      "from a convertable type. Instead, pass Kokkos::ChunkSize(int).")
+  ChunkSize(int value_, Impl::OverloadHelper = {}) : value(value_) {}
+#endif
 };
 
 /** \brief  Execution policy for work over a range of an integral type.

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -38,21 +38,13 @@ struct ParallelForTag {};
 struct ParallelScanTag {};
 struct ParallelReduceTag {};
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-namespace Impl {
-struct OverloadHelper {};
-}  // namespace Impl
-#endif
-
 struct ChunkSize {
   int value;
   explicit ChunkSize(int value_) : value(value_) {}
-
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED_WITH_COMMENT(
-      "In RangePolicy constructor, ChunkSize struct was constructed implicitly "
-      "from a convertable type. Instead, pass Kokkos::ChunkSize(int).")
-  ChunkSize(int value_, Impl::OverloadHelper = {}) : value(value_) {}
+  template <typename T = void>
+  KOKKOS_DEPRECATED_WITH_COMMENT("ChunkSize should be constructed explicitly.")
+  ChunkSize(int value_) : value(value_) {}
 #endif
 };
 

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -20,6 +20,7 @@
 
 #include <regex>
 #include <limits>
+#include <type_traits>
 
 namespace {
 
@@ -195,5 +196,41 @@ TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {
   }
 #endif
 }
+
+constexpr bool test_chunk_size_explicit() {
+  using ExecutionSpace = TEST_EXECSPACE;
+  using Kokkos::ChunkSize;
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  static_assert(std::is_convertible_v<int, ChunkSize>);
+  static_assert(std::is_constructible_v<ChunkSize, int>);
+  static_assert(
+      std::is_constructible_v<
+          Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>, int, int, int>);
+  static_assert(std::is_constructible_v<
+                Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>, int, int,
+                ChunkSize>);
+  static_assert(std::is_constructible_v<Kokkos::RangePolicy<ExecutionSpace>,
+                                        ExecutionSpace, int, int, int>);
+  static_assert(std::is_constructible_v<Kokkos::RangePolicy<ExecutionSpace>,
+                                        ExecutionSpace, int, int, ChunkSize>);
+#else
+  static_assert(!std::is_convertible_v<int, ChunkSize>);
+  static_assert(std::is_constructible_v<ChunkSize, int>);
+  static_assert(
+      !std::is_constructible_v<
+          Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>, int, int, int>);
+  static_assert(std::is_constructible_v<
+                Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>, int, int,
+                ChunkSize>);
+  static_assert(!std::is_constructible_v<Kokkos::RangePolicy<ExecutionSpace>,
+                                         ExecutionSpace, int, int, int>);
+  static_assert(std::is_constructible_v<Kokkos::RangePolicy<ExecutionSpace>,
+                                        ExecutionSpace, int, int, ChunkSize>);
+#endif
+  return true;
+}
+
+static_assert(test_chunk_size_explicit());
 
 }  // namespace

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -204,7 +204,10 @@ constexpr bool test_chunk_size_explicit() {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static_assert(std::is_convertible_v<int, ChunkSize>);
   static_assert(std::is_constructible_v<ChunkSize, int>);
+  // FIXME some execution spaces are implicitly constructible from int
+  // which makes the constructor call ambiguous.
   static_assert(
+      std::is_constructible_v<Kokkos::DefaultExecutionSpace, int> ||
       std::is_constructible_v<
           Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>, int, int, int>);
   static_assert(std::is_constructible_v<
@@ -217,7 +220,10 @@ constexpr bool test_chunk_size_explicit() {
 #else
   static_assert(!std::is_convertible_v<int, ChunkSize>);
   static_assert(std::is_constructible_v<ChunkSize, int>);
+  // FIXME some execution spaces are implicitly constructible from int
+  // which makes the constructor call work.
   static_assert(
+      std::is_constructible_v<Kokkos::DefaultExecutionSpace, int> ||
       !std::is_constructible_v<
           Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>, int, int, int>);
   static_assert(std::is_constructible_v<


### PR DESCRIPTION
Release 4.3 unintentionally introduced the ability for `RangePolicy` constructor to take as it's final argument any type convertible to `ChunkSize` and implicitly construct a `ChunkSize` object for the input. Remove that by making the `ChunkSize(int)` constructor explicit.