### PR TITLE
Fix Kokkos::Array<T, 0> default initialization for icpc

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -207,16 +207,6 @@ struct Array<T, 0> {
     return false;
   }
 
-  KOKKOS_DEFAULTED_FUNCTION ~Array()            = default;
-  KOKKOS_DEFAULTED_FUNCTION Array()             = default;
-  KOKKOS_DEFAULTED_FUNCTION Array(const Array&) = default;
-  KOKKOS_DEFAULTED_FUNCTION Array& operator=(const Array&) = default;
-
-  // Some supported compilers are not sufficiently C++11 compliant
-  // for default move constructor and move assignment operator.
-  // Array( Array && ) = default ;
-  // Array & operator = ( Array && ) = default ;
-
  private:
   friend KOKKOS_INLINE_FUNCTION constexpr void kokkos_swap(
       Array<T, 0>&, Array<T, 0>&) noexcept {}

--- a/core/unit_test/TestArrayOps.hpp
+++ b/core/unit_test/TestArrayOps.hpp
@@ -16,7 +16,6 @@
 
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
-#include <numeric>
 
 namespace {
 
@@ -107,8 +106,8 @@ TEST(TEST_CATEGORY, array_operator_equal) {
   ASSERT_TRUE(a != c);
 
   using E = Kokkos::Array<int, 0>;
-  constexpr E e;
-  constexpr E f;
+  constexpr E e{};
+  constexpr E f{};
 
   static_assert(e == f);
   static_assert(!(e != f));
@@ -119,7 +118,7 @@ TEST(TEST_CATEGORY, array_operator_equal) {
 
 TEST(TEST_CATEGORY, array_zero_capacity) {
   using A = Kokkos::Array<int, 0>;
-  A e;
+  A e{};
 
   ASSERT_TRUE(e.empty());
   ASSERT_EQ(e.size(), 0u);
@@ -129,7 +128,7 @@ TEST(TEST_CATEGORY, array_zero_capacity) {
 TEST(TEST_CATEGORY, array_zero_data_nullptr) {
   using A = Kokkos::Array<int, 0>;
 
-  A e;
+  A e{};
   ASSERT_EQ(e.data(), nullptr);
 
   const A& ce = e;

--- a/core/unit_test/TestArrayOps.hpp
+++ b/core/unit_test/TestArrayOps.hpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
+#include <numeric>
 
 namespace {
 
@@ -106,8 +107,8 @@ TEST(TEST_CATEGORY, array_operator_equal) {
   ASSERT_TRUE(a != c);
 
   using E = Kokkos::Array<int, 0>;
-  constexpr E e{};
-  constexpr E f{};
+  constexpr E e;
+  constexpr E f;
 
   static_assert(e == f);
   static_assert(!(e != f));
@@ -118,7 +119,7 @@ TEST(TEST_CATEGORY, array_operator_equal) {
 
 TEST(TEST_CATEGORY, array_zero_capacity) {
   using A = Kokkos::Array<int, 0>;
-  A e{};
+  A e;
 
   ASSERT_TRUE(e.empty());
   ASSERT_EQ(e.size(), 0u);
@@ -128,7 +129,7 @@ TEST(TEST_CATEGORY, array_zero_capacity) {
 TEST(TEST_CATEGORY, array_zero_data_nullptr) {
   using A = Kokkos::Array<int, 0>;
 
-  A e{};
+  A e;
   ASSERT_EQ(e.data(), nullptr);
 
   const A& ce = e;


### PR DESCRIPTION
This should address Issue #7153.

icpc incorrectly errors on `constexpr Kokkos::Array<T, 0>` needing initialization when it has a default constructor, as it is an empty specialization.

Prefer the suggestion of @masterleinad of removing the special member functions to address this issue.