### PR TITLE
Make ExecutionSpace constructors explicit

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -166,8 +166,17 @@ class Cuda {
 
   Cuda();
 
-  Cuda(cudaStream_t stream,
-       Impl::ManageStream manage_stream = Impl::ManageStream::no);
+  explicit Cuda(cudaStream_t stream) : Cuda(stream, Impl::ManageStream::no) {}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  template <typename T = void>
+  KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Cuda execution space should be constructed explicitly.")
+  Cuda(cudaStream_t stream)
+      : Cuda(stream) {}
+#endif
+
+  Cuda(cudaStream_t stream, Impl::ManageStream manage_stream);
 
   KOKKOS_DEPRECATED Cuda(cudaStream_t stream, bool manage_stream);
 

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -60,7 +60,7 @@ class HIP {
 #endif
 
   HIP(hipStream_t stream, Impl::ManageStream manage_stream);
-  
+
   KOKKOS_DEPRECATED HIP(hipStream_t stream, bool manage_stream);
 
   //@}

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -48,8 +48,19 @@ class HIP {
   using scratch_memory_space = ScratchMemorySpace<HIP>;
 
   HIP();
-  HIP(hipStream_t stream,
-      Impl::ManageStream manage_stream = Impl::ManageStream::no);
+
+  explicit HIP(hipStream_t stream) : HIP(stream, Impl::ManageStream::no) {}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  template <typename T = void>
+  KOKKOS_DEPRECATED_WITH_COMMENT(
+      "HIP execution space should be constructed explicitly.")
+  HIP(hipStream_t stream)
+      : HIP(stream) {}
+#endif
+
+  HIP(hipStream_t stream, Impl::ManageStream manage_stream);
+  
   KOKKOS_DEPRECATED HIP(hipStream_t stream, bool manage_stream);
 
   //@}

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -168,16 +168,30 @@ class HPX {
       : m_instance_data(Kokkos::Impl::HostSharedPtr<instance_data>(
             &m_default_instance_data, &default_instance_deleter)) {}
   ~HPX() = default;
-  HPX(instance_mode mode)
+  explicit HPX(instance_mode mode)
       : m_instance_data(
             mode == instance_mode::independent
                 ? (Kokkos::Impl::HostSharedPtr<instance_data>(
                       new instance_data(m_next_instance_id++)))
                 : Kokkos::Impl::HostSharedPtr<instance_data>(
                       &m_default_instance_data, &default_instance_deleter)) {}
-  HPX(hpx::execution::experimental::unique_any_sender<> &&sender)
+  explicit HPX(hpx::execution::experimental::unique_any_sender<> &&sender)
       : m_instance_data(Kokkos::Impl::HostSharedPtr<instance_data>(
             new instance_data(m_next_instance_id++, std::move(sender)))) {}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  template <typename T = void>
+  KOKKOS_DEPRECATED_WITH_COMMENT(
+      "HPX execution space should be constructed explicitly.")
+  HPX(instance_mode mode)
+      : HPX(mode) {}
+
+  template <typename T = void>
+  KOKKOS_DEPRECATED_WITH_COMMENT(
+      "HPX execution space should be constructed explicitly.")
+  HPX(hpx::execution::experimental::unique_any_sender<> &&sender)
+      : HPX(std::move(sender)) {}
+#endif
 
   HPX(HPX &&other)      = default;
   HPX(const HPX &other) = default;

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -67,7 +67,15 @@ class OpenMP {
 
   OpenMP();
 
-  OpenMP(int pool_size);
+  explicit OpenMP(int pool_size);
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  template <typename T = void>
+  KOKKOS_DEPRECATED_WITH_COMMENT(
+      "OpenMP execution space should be constructed explicitly.")
+  OpenMP(int pool_size)
+      : OpenMP(pool_size) {}
+#endif
 
   /// \brief Print configuration information to the given output stream.
   void print_configuration(std::ostream& os, bool verbose = false) const;

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -161,7 +161,7 @@ inline std::vector<OpenMP> create_OpenMP_instances(
         "Kokkos::abort: Partition not enough resources left to create the last "
         "instance.");
   }
-  instances[weights.size() - 1] = resources_left;
+  instances[weights.size() - 1] = OpenMP(resources_left);
 
   return instances;
 }

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -116,7 +116,15 @@ class Serial {
 
   Serial();
 
-  Serial(NewInstance);
+  explicit Serial(NewInstance);
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  template <typename T = void>
+  KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Serial execution space should be constructed explicitly.")
+  Serial(NewInstance)
+      : Serial(NewInstance{}) {}
+#endif
 
   /// \brief True if and only if this method is being called in a
   ///   thread-parallel function.

--- a/core/unit_test/TestExecutionSpace.hpp
+++ b/core/unit_test/TestExecutionSpace.hpp
@@ -87,6 +87,9 @@ constexpr bool test_execspace_explicit_construction() {
 #endif
 #endif
 
+#ifdef KOKKOS_ENABLE_OPENACC
+  static_assert(!std::is_convertible_v<int, Kokkos::Experimental::OpenACC>);
+#endif
 #ifdef KOKKOS_ENABLE_SYCL
   static_assert(
       !std::is_convertible_v<sycl::queue, Kokkos::Experimental::SYCL>);

--- a/core/unit_test/TestExecutionSpace.hpp
+++ b/core/unit_test/TestExecutionSpace.hpp
@@ -44,9 +44,8 @@ TEST(TEST_CATEGORY, execution_space_as_class_data_member) {
 }
 #endif
 
-constexpr bool test_execspace_explicit() {
+constexpr bool test_execspace_explicit_construction() {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-
 #ifdef KOKKOS_ENABLE_SERIAL
   static_assert(std::is_convertible_v<Kokkos::NewInstance, Kokkos::Serial>);
 #endif
@@ -88,10 +87,14 @@ constexpr bool test_execspace_explicit() {
 #endif
 #endif
 
+#ifdef KOKKOS_ENABLE_SYCL
+  static_assert(
+      !std::is_convertible_v<sycl::queue, Kokkos::Experimental::SYCL>);
 #endif
+
   return true;
 }
 
-static_assert(test_execspace_explicit());
+static_assert(test_execspace_explicit_construction());
 
 }  // namespace

--- a/core/unit_test/TestExecutionSpace.hpp
+++ b/core/unit_test/TestExecutionSpace.hpp
@@ -56,6 +56,9 @@ constexpr bool test_execspace_explicit() {
 #ifdef KOKKOS_ENABLE_CUDA
   static_assert(std::is_convertible_v<cudaStream_t, Kokkos::Cuda>);
 #endif
+#ifdef KOKKOS_ENABLE_HIP
+  static_assert(std::is_convertible_v<hipStream_t, Kokkos::HIP>);
+#endif
 
 #else
 
@@ -67,6 +70,9 @@ constexpr bool test_execspace_explicit() {
 #endif
 #ifdef KOKKOS_ENABLE_CUDA
   static_assert(!std::is_convertible_v<cudaStream_t, Kokkos::Cuda>);
+#endif
+#ifdef KOKKOS_ENABLE_HIP
+  static_assert(!std::is_convertible_v<hipStream_t, Kokkos::HIP>);
 #endif
 
 #endif

--- a/core/unit_test/TestExecutionSpace.hpp
+++ b/core/unit_test/TestExecutionSpace.hpp
@@ -44,4 +44,23 @@ TEST(TEST_CATEGORY, execution_space_as_class_data_member) {
 }
 #endif
 
+constexpr bool test_execspace_explicit() {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+
+#ifdef KOKKOS_ENABLE_SERIAL
+  static_assert(std::is_convertible_v<Kokkos::NewInstance, Kokkos::Serial>);
+#endif
+
+#else
+
+#ifdef KOKKOS_ENABLE_SERIAL
+  static_assert(!std::is_convertible_v<Kokkos::NewInstance, Kokkos::Serial>);
+#endif
+
+#endif
+  return true;
+}
+
+static_assert(test_execspace_explicit());
+
 }  // namespace

--- a/core/unit_test/TestExecutionSpace.hpp
+++ b/core/unit_test/TestExecutionSpace.hpp
@@ -50,11 +50,17 @@ constexpr bool test_execspace_explicit() {
 #ifdef KOKKOS_ENABLE_SERIAL
   static_assert(std::is_convertible_v<Kokkos::NewInstance, Kokkos::Serial>);
 #endif
+#ifdef KOKKOS_ENABLE_OPENMP
+  static_assert(std::is_convertible_v<int, Kokkos::OpenMP>);
+#endif
 
 #else
 
 #ifdef KOKKOS_ENABLE_SERIAL
   static_assert(!std::is_convertible_v<Kokkos::NewInstance, Kokkos::Serial>);
+#endif
+#ifdef KOKKOS_ENABLE_OPENMP
+  static_assert(!std::is_convertible_v<int, Kokkos::OpenMP>);
 #endif
 
 #endif

--- a/core/unit_test/TestExecutionSpace.hpp
+++ b/core/unit_test/TestExecutionSpace.hpp
@@ -59,9 +59,14 @@ constexpr bool test_execspace_explicit() {
 #ifdef KOKKOS_ENABLE_HIP
   static_assert(std::is_convertible_v<hipStream_t, Kokkos::HIP>);
 #endif
-
+#ifdef KOKKOS_ENABLE_HPX
+  static_assert(std::is_convertible_v<Kokkos::Experimental::HPX::instance_mode,
+                                      Kokkos::Experimental::HPX>);
+  static_assert(
+      std::is_convertible_v<hpx::execution::experimental::unique_any_sender<>&&,
+                            Kokkos::Experimental::HPX>);
+#endif
 #else
-
 #ifdef KOKKOS_ENABLE_SERIAL
   static_assert(!std::is_convertible_v<Kokkos::NewInstance, Kokkos::Serial>);
 #endif
@@ -73,6 +78,14 @@ constexpr bool test_execspace_explicit() {
 #endif
 #ifdef KOKKOS_ENABLE_HIP
   static_assert(!std::is_convertible_v<hipStream_t, Kokkos::HIP>);
+#endif
+#ifdef KOKKOS_ENABLE_HPX
+  static_assert(!std::is_convertible_v<Kokkos::Experimental::HPX::instance_mode,
+                                       Kokkos::Experimental::HPX>);
+  static_assert(!std::is_convertible_v<
+                hpx::execution::experimental::unique_any_sender<>&&,
+                Kokkos::Experimental::HPX>);
+#endif
 #endif
 
 #endif

--- a/core/unit_test/TestExecutionSpace.hpp
+++ b/core/unit_test/TestExecutionSpace.hpp
@@ -53,6 +53,9 @@ constexpr bool test_execspace_explicit() {
 #ifdef KOKKOS_ENABLE_OPENMP
   static_assert(std::is_convertible_v<int, Kokkos::OpenMP>);
 #endif
+#ifdef KOKKOS_ENABLE_CUDA
+  static_assert(std::is_convertible_v<cudaStream_t, Kokkos::Cuda>);
+#endif
 
 #else
 
@@ -61,6 +64,9 @@ constexpr bool test_execspace_explicit() {
 #endif
 #ifdef KOKKOS_ENABLE_OPENMP
   static_assert(!std::is_convertible_v<int, Kokkos::OpenMP>);
+#endif
+#ifdef KOKKOS_ENABLE_CUDA
+  static_assert(!std::is_convertible_v<cudaStream_t, Kokkos::Cuda>);
 #endif
 
 #endif

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -204,6 +204,8 @@ constexpr bool test_chunk_size_explicit() {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static_assert(std::is_convertible_v<int, ChunkSize>);
   static_assert(std::is_constructible_v<ChunkSize, int>);
+  // Some execution spaces were implicitly constructible from int
+  // which made the constructor call ambiguous.
   static_assert(
       std::is_constructible_v<Kokkos::DefaultExecutionSpace, int> ||
       std::is_constructible_v<

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -204,8 +204,6 @@ constexpr bool test_chunk_size_explicit() {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static_assert(std::is_convertible_v<int, ChunkSize>);
   static_assert(std::is_constructible_v<ChunkSize, int>);
-  // FIXME some execution spaces are implicitly constructible from int
-  // which makes the constructor call ambiguous.
   static_assert(
       std::is_constructible_v<Kokkos::DefaultExecutionSpace, int> ||
       std::is_constructible_v<
@@ -220,10 +218,7 @@ constexpr bool test_chunk_size_explicit() {
 #else
   static_assert(!std::is_convertible_v<int, ChunkSize>);
   static_assert(std::is_constructible_v<ChunkSize, int>);
-  // FIXME some execution spaces are implicitly constructible from int
-  // which makes the constructor call work.
   static_assert(
-      std::is_constructible_v<Kokkos::DefaultExecutionSpace, int> ||
       !std::is_constructible_v<
           Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>, int, int, int>);
   static_assert(std::is_constructible_v<


### PR DESCRIPTION
Add deprecation constructor using the trick from @masterleinad 
```
explicit ExecSpace(Arg a) {}

template<typename T=void>
[[deprecated]]
ExecSpace(Arg a) : ExecSpace(a) {}
```
Notes:
- `OpenMP` was the only backend actually using implicit conversion internally.
- `Cuda(cudaStream_t stream, ManageStream manage_stream = ManageStream::no)` was split into 
```
Cuda(cudaStream_t stream, ManageStream manage_stream);
Cuda(cudaStream_t stream) : Cuda(stream, no) {}
```
per @nliber suggestion https://github.com/kokkos/kokkos/issues/7152#issuecomment-2248298545. Same for HIP. (Let me know if you had a different vision)
- Added test for SYCL to match non-deprecated from other backends since it was already using explicit conversions.

I still plam to search through Trilinos and see if any of these are being used implicitly.