### PR TITLE
Fix Kokkos_CoreUnitTest_DeviceAndThreads

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -1277,7 +1277,7 @@ if (NOT KOKKOS_HAS_TRILINOS)
     )
     add_test(
       NAME Kokkos_CoreUnitTest_DeviceAndThreads
-      COMMAND ${Python3_EXECUTABLE} -m unittest -v $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py
+      COMMAND ${Python3_EXECUTABLE} $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py
     )
   endif()
 endif()

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -1277,7 +1277,7 @@ if (NOT KOKKOS_HAS_TRILINOS)
     )
     add_test(
       NAME Kokkos_CoreUnitTest_DeviceAndThreads
-      COMMAND ${Python3_EXECUTABLE} $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py
+      COMMAND ${Python3_EXECUTABLE} $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py -v
     )
   endif()
 endif()

--- a/core/unit_test/TestDeviceAndThreads.py
+++ b/core/unit_test/TestDeviceAndThreads.py
@@ -118,4 +118,4 @@ class KokkosInitializationTestCase(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(verbosity=2)

--- a/core/unit_test/TestDeviceAndThreads.py
+++ b/core/unit_test/TestDeviceAndThreads.py
@@ -118,4 +118,4 @@ class KokkosInitializationTestCase(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main()


### PR DESCRIPTION
Fixes #6326. I am seeing
```
28: Test command: /usr/bin/python3.9 "-m" "unittest" "-v" "/home/users/darndt/kokkos/build/core/unit_test/TestDeviceAndThreads.py"
28: Test timeout computed to be: 1500
28: /home/users/darndt/kokkos/build/core/unit_test/TestDeviceAndThreads (unittest.loader._FailedTest) ... ERROR
28: 
28: ======================================================================
28: ERROR: /home/users/darndt/kokkos/build/core/unit_test/TestDeviceAndThreads (unittest.loader._FailedTest)
28: ----------------------------------------------------------------------
28: ImportError: Failed to import test module: /home/users/darndt/kokkos/build/core/unit_test/TestDeviceAndThreads
28: Traceback (most recent call last):
28:   File "/usr/lib64/python3.9/unittest/loader.py", line 154, in loadTestsFromName
28:     module = __import__(module_name)
28: ModuleNotFoundError: No module named '/home/users/darndt/kokkos/build/core/unit_test/TestDeviceAndThreads'
28: 
28: 
28: ----------------------------------------------------------------------
28: Ran 1 test in 0.000s
28: 
28: FAILED (errors=1)
1/1 Test #28: Kokkos_CoreUnitTest_DeviceAndThreads ...***Failed    0.03 sec
```
when trying to test with GH200. It seems that executing the test file directly works.