### PR TITLE
Fix GCC deprecated declarations warnings

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -498,7 +498,7 @@ pipeline {
                                 -DKokkos_ARCH_NATIVE=ON \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_DEPRECATED_CODE_4=ON \
-                                -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
+                                -DKokkos_ENABLE_DEPRECATION_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_BENCHMARKS=ON \
                                 -DKokkos_ENABLE_OPENMP=ON \

--- a/core/src/Kokkos_Pair.hpp
+++ b/core/src/Kokkos_Pair.hpp
@@ -449,6 +449,9 @@ struct KOKKOS_DEPRECATED pair<T1, void> {
 // Specialization of relational operators for Kokkos::pair<T1,void>.
 //
 
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1110)
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
+#endif
 template <class T1>
 KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION constexpr bool operator==(
     const pair<T1, void>& lhs, const pair<T1, void>& rhs) {
@@ -484,6 +487,9 @@ KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION constexpr bool operator>=(
     const pair<T1, void>& lhs, const pair<T1, void>& rhs) {
   return !(lhs < rhs);
 }
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1110)
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+#endif
 #endif
 
 namespace Impl {


### PR DESCRIPTION
We had report on Slack that GCC 10.2 warns about deprecated declaration
```
<prefix>/include/Kokkos_Pair.hpp:454:57: warning: 'pair' is deprecated [-Wdeprecated-declarations]
  454 |     const pair<T1, void>& lhs, const pair<T1, void>& rhs) {
```
This issue seems to affect GCC < 11 https://godbolt.org/z/G1sWvsKWo
It looks like we did not have coverage in the CI.