### PR TITLE
Skip Rangepolicy conversion check if roundtrip convertibility is not provided

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -261,8 +261,10 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
           "not preserve its original value.\n";
       bool warn = false;
 
-      if constexpr (std::is_signed_v<IndexType> !=
-                    std::is_signed_v<member_type>) {
+      if constexpr (std::is_arithmetic_v<IndexType> &&
+                    std::is_arithmetic_v<member_type> &&
+                    (std::is_signed_v<IndexType> !=
+                     std::is_signed_v<member_type>)) {
         // check signed to unsigned
         if constexpr (std::is_signed_v<IndexType>)
           warn |= (bound < static_cast<IndexType>(
@@ -334,20 +336,20 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   };
 };
 
-RangePolicy() -> RangePolicy<>;
+RangePolicy()->RangePolicy<>;
 
-RangePolicy(int64_t, int64_t) -> RangePolicy<>;
-RangePolicy(int64_t, int64_t, ChunkSize const&) -> RangePolicy<>;
+RangePolicy(int64_t, int64_t)->RangePolicy<>;
+RangePolicy(int64_t, int64_t, ChunkSize const&)->RangePolicy<>;
 
-RangePolicy(DefaultExecutionSpace const&, int64_t, int64_t) -> RangePolicy<>;
+RangePolicy(DefaultExecutionSpace const&, int64_t, int64_t)->RangePolicy<>;
 RangePolicy(DefaultExecutionSpace const&, int64_t, int64_t, ChunkSize const&)
-    -> RangePolicy<>;
+    ->RangePolicy<>;
 
 template <typename ES, typename = std::enable_if_t<is_execution_space_v<ES>>>
-RangePolicy(ES const&, int64_t, int64_t) -> RangePolicy<ES>;
+RangePolicy(ES const&, int64_t, int64_t)->RangePolicy<ES>;
 
 template <typename ES, typename = std::enable_if_t<is_execution_space_v<ES>>>
-RangePolicy(ES const&, int64_t, int64_t, ChunkSize const&) -> RangePolicy<ES>;
+RangePolicy(ES const&, int64_t, int64_t, ChunkSize const&)->RangePolicy<ES>;
 
 }  // namespace Kokkos
 
@@ -722,54 +724,55 @@ class TeamPolicy
 
 // Execution space not provided deduces to TeamPolicy<>
 
-TeamPolicy() -> TeamPolicy<>;
+TeamPolicy()->TeamPolicy<>;
 
-TeamPolicy(int, int) -> TeamPolicy<>;
-TeamPolicy(int, int, int) -> TeamPolicy<>;
-TeamPolicy(int, Kokkos::AUTO_t const&) -> TeamPolicy<>;
-TeamPolicy(int, Kokkos::AUTO_t const&, int) -> TeamPolicy<>;
-TeamPolicy(int, Kokkos::AUTO_t const&, Kokkos::AUTO_t const&) -> TeamPolicy<>;
-TeamPolicy(int, int, Kokkos::AUTO_t const&) -> TeamPolicy<>;
+TeamPolicy(int, int)->TeamPolicy<>;
+TeamPolicy(int, int, int)->TeamPolicy<>;
+TeamPolicy(int, Kokkos::AUTO_t const&)->TeamPolicy<>;
+TeamPolicy(int, Kokkos::AUTO_t const&, int)->TeamPolicy<>;
+TeamPolicy(int, Kokkos::AUTO_t const&, Kokkos::AUTO_t const&)->TeamPolicy<>;
+TeamPolicy(int, int, Kokkos::AUTO_t const&)->TeamPolicy<>;
 
 // DefaultExecutionSpace deduces to TeamPolicy<>
 
-TeamPolicy(DefaultExecutionSpace const&, int, int) -> TeamPolicy<>;
-TeamPolicy(DefaultExecutionSpace const&, int, int, int) -> TeamPolicy<>;
+TeamPolicy(DefaultExecutionSpace const&, int, int)->TeamPolicy<>;
+TeamPolicy(DefaultExecutionSpace const&, int, int, int)->TeamPolicy<>;
 TeamPolicy(DefaultExecutionSpace const&, int, Kokkos::AUTO_t const&)
-    -> TeamPolicy<>;
+    ->TeamPolicy<>;
 TeamPolicy(DefaultExecutionSpace const&, int, Kokkos::AUTO_t const&, int)
-    -> TeamPolicy<>;
+    ->TeamPolicy<>;
 TeamPolicy(DefaultExecutionSpace const&, int, Kokkos::AUTO_t const&,
-           Kokkos::AUTO_t const&) -> TeamPolicy<>;
+           Kokkos::AUTO_t const&)
+    ->TeamPolicy<>;
 TeamPolicy(DefaultExecutionSpace const&, int, int, Kokkos::AUTO_t const&)
-    -> TeamPolicy<>;
+    ->TeamPolicy<>;
 
 // ES != DefaultExecutionSpace deduces to TeamPolicy<ES>
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
-TeamPolicy(ES const&, int, int) -> TeamPolicy<ES>;
+TeamPolicy(ES const&, int, int)->TeamPolicy<ES>;
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
-TeamPolicy(ES const&, int, int, int) -> TeamPolicy<ES>;
+TeamPolicy(ES const&, int, int, int)->TeamPolicy<ES>;
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
-TeamPolicy(ES const&, int, Kokkos::AUTO_t const&) -> TeamPolicy<ES>;
+TeamPolicy(ES const&, int, Kokkos::AUTO_t const&)->TeamPolicy<ES>;
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
-TeamPolicy(ES const&, int, Kokkos::AUTO_t const&, int) -> TeamPolicy<ES>;
+TeamPolicy(ES const&, int, Kokkos::AUTO_t const&, int)->TeamPolicy<ES>;
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
 TeamPolicy(ES const&, int, Kokkos::AUTO_t const&, Kokkos::AUTO_t const&)
-    -> TeamPolicy<ES>;
+    ->TeamPolicy<ES>;
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
-TeamPolicy(ES const&, int, int, Kokkos::AUTO_t const&) -> TeamPolicy<ES>;
+TeamPolicy(ES const&, int, int, Kokkos::AUTO_t const&)->TeamPolicy<ES>;
 
 namespace Impl {
 
@@ -1041,7 +1044,7 @@ struct TeamThreadMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
 
 template <typename TeamHandle, typename... Args>
 KOKKOS_DEDUCTION_GUIDE TeamThreadMDRange(TeamHandle const&, Args&&...)
-    -> TeamThreadMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
+    ->TeamThreadMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
 
 template <typename Rank, typename TeamHandle>
 struct ThreadVectorMDRange;
@@ -1078,7 +1081,7 @@ struct ThreadVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
 
 template <typename TeamHandle, typename... Args>
 KOKKOS_DEDUCTION_GUIDE ThreadVectorMDRange(TeamHandle const&, Args&&...)
-    -> ThreadVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
+    ->ThreadVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
 
 template <typename Rank, typename TeamHandle>
 struct TeamVectorMDRange;
@@ -1115,7 +1118,7 @@ struct TeamVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
 
 template <typename TeamHandle, typename... Args>
 KOKKOS_DEDUCTION_GUIDE TeamVectorMDRange(TeamHandle const&, Args&&...)
-    -> TeamVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
+    ->TeamVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
 
 template <typename Rank, typename TeamHandle, typename Lambda,
           typename ReducerValueType>

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -289,13 +289,6 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
 #else
       (void)bound;
 #endif
-    } else {
-#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-      std::string msg =
-          "Kokkos RangePolicy bound type warning: Two-way convertibility requirement on policy index type and input bound type is not met.
-          Conversion safety check is skipped."
-          Kokkos::Impl::log_warning(msg);
-#endif
     }
   }
 

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -248,6 +248,7 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   // To be replaced with std::in_range (c++20)
   template <typename IndexType>
   static void check_conversion_safety(const IndexType bound) {
+    // Checking that the round-trip conversion preserves input index value
     if constexpr (std::is_convertible_v<member_type, IndexType>) {
 #if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) || \
     defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -336,20 +336,20 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   };
 };
 
-RangePolicy()->RangePolicy<>;
+RangePolicy() -> RangePolicy<>;
 
-RangePolicy(int64_t, int64_t)->RangePolicy<>;
-RangePolicy(int64_t, int64_t, ChunkSize const&)->RangePolicy<>;
+RangePolicy(int64_t, int64_t) -> RangePolicy<>;
+RangePolicy(int64_t, int64_t, ChunkSize const&) -> RangePolicy<>;
 
-RangePolicy(DefaultExecutionSpace const&, int64_t, int64_t)->RangePolicy<>;
+RangePolicy(DefaultExecutionSpace const&, int64_t, int64_t) -> RangePolicy<>;
 RangePolicy(DefaultExecutionSpace const&, int64_t, int64_t, ChunkSize const&)
-    ->RangePolicy<>;
+    -> RangePolicy<>;
 
 template <typename ES, typename = std::enable_if_t<is_execution_space_v<ES>>>
-RangePolicy(ES const&, int64_t, int64_t)->RangePolicy<ES>;
+RangePolicy(ES const&, int64_t, int64_t) -> RangePolicy<ES>;
 
 template <typename ES, typename = std::enable_if_t<is_execution_space_v<ES>>>
-RangePolicy(ES const&, int64_t, int64_t, ChunkSize const&)->RangePolicy<ES>;
+RangePolicy(ES const&, int64_t, int64_t, ChunkSize const&) -> RangePolicy<ES>;
 
 }  // namespace Kokkos
 
@@ -724,55 +724,54 @@ class TeamPolicy
 
 // Execution space not provided deduces to TeamPolicy<>
 
-TeamPolicy()->TeamPolicy<>;
+TeamPolicy() -> TeamPolicy<>;
 
-TeamPolicy(int, int)->TeamPolicy<>;
-TeamPolicy(int, int, int)->TeamPolicy<>;
-TeamPolicy(int, Kokkos::AUTO_t const&)->TeamPolicy<>;
-TeamPolicy(int, Kokkos::AUTO_t const&, int)->TeamPolicy<>;
-TeamPolicy(int, Kokkos::AUTO_t const&, Kokkos::AUTO_t const&)->TeamPolicy<>;
-TeamPolicy(int, int, Kokkos::AUTO_t const&)->TeamPolicy<>;
+TeamPolicy(int, int) -> TeamPolicy<>;
+TeamPolicy(int, int, int) -> TeamPolicy<>;
+TeamPolicy(int, Kokkos::AUTO_t const&) -> TeamPolicy<>;
+TeamPolicy(int, Kokkos::AUTO_t const&, int) -> TeamPolicy<>;
+TeamPolicy(int, Kokkos::AUTO_t const&, Kokkos::AUTO_t const&) -> TeamPolicy<>;
+TeamPolicy(int, int, Kokkos::AUTO_t const&) -> TeamPolicy<>;
 
 // DefaultExecutionSpace deduces to TeamPolicy<>
 
-TeamPolicy(DefaultExecutionSpace const&, int, int)->TeamPolicy<>;
-TeamPolicy(DefaultExecutionSpace const&, int, int, int)->TeamPolicy<>;
+TeamPolicy(DefaultExecutionSpace const&, int, int) -> TeamPolicy<>;
+TeamPolicy(DefaultExecutionSpace const&, int, int, int) -> TeamPolicy<>;
 TeamPolicy(DefaultExecutionSpace const&, int, Kokkos::AUTO_t const&)
-    ->TeamPolicy<>;
+    -> TeamPolicy<>;
 TeamPolicy(DefaultExecutionSpace const&, int, Kokkos::AUTO_t const&, int)
-    ->TeamPolicy<>;
+    -> TeamPolicy<>;
 TeamPolicy(DefaultExecutionSpace const&, int, Kokkos::AUTO_t const&,
-           Kokkos::AUTO_t const&)
-    ->TeamPolicy<>;
+           Kokkos::AUTO_t const&) -> TeamPolicy<>;
 TeamPolicy(DefaultExecutionSpace const&, int, int, Kokkos::AUTO_t const&)
-    ->TeamPolicy<>;
+    -> TeamPolicy<>;
 
 // ES != DefaultExecutionSpace deduces to TeamPolicy<ES>
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
-TeamPolicy(ES const&, int, int)->TeamPolicy<ES>;
+TeamPolicy(ES const&, int, int) -> TeamPolicy<ES>;
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
-TeamPolicy(ES const&, int, int, int)->TeamPolicy<ES>;
+TeamPolicy(ES const&, int, int, int) -> TeamPolicy<ES>;
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
-TeamPolicy(ES const&, int, Kokkos::AUTO_t const&)->TeamPolicy<ES>;
+TeamPolicy(ES const&, int, Kokkos::AUTO_t const&) -> TeamPolicy<ES>;
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
-TeamPolicy(ES const&, int, Kokkos::AUTO_t const&, int)->TeamPolicy<ES>;
+TeamPolicy(ES const&, int, Kokkos::AUTO_t const&, int) -> TeamPolicy<ES>;
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
 TeamPolicy(ES const&, int, Kokkos::AUTO_t const&, Kokkos::AUTO_t const&)
-    ->TeamPolicy<ES>;
+    -> TeamPolicy<ES>;
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
-TeamPolicy(ES const&, int, int, Kokkos::AUTO_t const&)->TeamPolicy<ES>;
+TeamPolicy(ES const&, int, int, Kokkos::AUTO_t const&) -> TeamPolicy<ES>;
 
 namespace Impl {
 
@@ -1044,7 +1043,7 @@ struct TeamThreadMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
 
 template <typename TeamHandle, typename... Args>
 KOKKOS_DEDUCTION_GUIDE TeamThreadMDRange(TeamHandle const&, Args&&...)
-    ->TeamThreadMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
+    -> TeamThreadMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
 
 template <typename Rank, typename TeamHandle>
 struct ThreadVectorMDRange;
@@ -1081,7 +1080,7 @@ struct ThreadVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
 
 template <typename TeamHandle, typename... Args>
 KOKKOS_DEDUCTION_GUIDE ThreadVectorMDRange(TeamHandle const&, Args&&...)
-    ->ThreadVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
+    -> ThreadVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
 
 template <typename Rank, typename TeamHandle>
 struct TeamVectorMDRange;
@@ -1118,7 +1117,7 @@ struct TeamVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
 
 template <typename TeamHandle, typename... Args>
 KOKKOS_DEDUCTION_GUIDE TeamVectorMDRange(TeamHandle const&, Args&&...)
-    ->TeamVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
+    -> TeamVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
 
 template <typename Rank, typename TeamHandle, typename Lambda,
           typename ReducerValueType>

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -247,7 +247,7 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
 
   // To be replaced with std::in_range (c++20)
   template <typename IndexType>
-  static void check_conversion_safety(const IndexType bound) {
+  static void check_conversion_safety([[maybe_unused]] const IndexType bound) {
     // Checking that the round-trip conversion preserves input index value
     if constexpr (std::is_convertible_v<member_type, IndexType>) {
 #if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) || \
@@ -287,11 +287,7 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
         Kokkos::Impl::log_warning(msg);
 #endif
       }
-#else
-      (void)bound;
 #endif
-    } else {
-      (void)bound;
     }
   }
 

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -261,8 +261,7 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
           "not preserve its original value.\n";
       bool warn = false;
 
-      if constexpr (std::is_arithmetic_v<IndexType> &&
-                    std::is_arithmetic_v<member_type> &&
+      if constexpr (std::is_arithmetic_v<member_type> &&
                     (std::is_signed_v<IndexType> !=
                      std::is_signed_v<member_type>)) {
         // check signed to unsigned

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -248,45 +248,55 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   // To be replaced with std::in_range (c++20)
   template <typename IndexType>
   static void check_conversion_safety(const IndexType bound) {
+    if constexpr (std::is_convertible_v<member_type, IndexType>) {
 #if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) || \
     defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
 
-    std::string msg =
-        "Kokkos::RangePolicy bound type error: an unsafe implicit conversion "
-        "is performed on a bound (" +
-        std::to_string(bound) +
-        "), which may "
-        "not preserve its original value.\n";
-    bool warn = false;
+      std::string msg =
+          "Kokkos::RangePolicy bound type error: an unsafe implicit conversion "
+          "is performed on a bound (" +
+          std::to_string(bound) +
+          "), which may "
+          "not preserve its original value.\n";
+      bool warn = false;
 
-    if constexpr (std::is_signed_v<IndexType> !=
-                  std::is_signed_v<member_type>) {
-      // check signed to unsigned
-      if constexpr (std::is_signed_v<IndexType>)
-        warn |= (bound < static_cast<IndexType>(
-                             std::numeric_limits<member_type>::min()));
+      if constexpr (std::is_signed_v<IndexType> !=
+                    std::is_signed_v<member_type>) {
+        // check signed to unsigned
+        if constexpr (std::is_signed_v<IndexType>)
+          warn |= (bound < static_cast<IndexType>(
+                               std::numeric_limits<member_type>::min()));
 
-      // check unsigned to signed
-      if constexpr (std::is_signed_v<member_type>)
-        warn |= (bound > static_cast<IndexType>(
-                             std::numeric_limits<member_type>::max()));
-    }
+        // check unsigned to signed
+        if constexpr (std::is_signed_v<member_type>)
+          warn |= (bound > static_cast<IndexType>(
+                               std::numeric_limits<member_type>::max()));
+      }
 
-    // check narrowing
-    warn |= (static_cast<IndexType>(static_cast<member_type>(bound)) != bound);
+      // check narrowing
+      warn |=
+          (static_cast<IndexType>(static_cast<member_type>(bound)) != bound);
 
-    if (warn) {
+      if (warn) {
 #ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
-      Kokkos::abort(msg.c_str());
+        Kokkos::abort(msg.c_str());
 #endif
 
 #ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-      Kokkos::Impl::log_warning(msg);
+        Kokkos::Impl::log_warning(msg);
+#endif
+      }
+#else
+      (void)bound;
+#endif
+    } else {
+#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
+      std::string msg =
+          "Kokkos RangePolicy bound type warning: Two-way convertibility requirement on policy index type and input bound type is not met.
+          Conversion safety check is skipped."
+          Kokkos::Impl::log_warning(msg);
 #endif
     }
-#else
-    (void)bound;
-#endif
   }
 
  public:

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -290,6 +290,8 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
 #else
       (void)bound;
 #endif
+    } else {
+      (void)bound;
     }
   }
 

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -173,6 +173,48 @@ TEST(TEST_CATEGORY, range_policy_one_way_convertible_bounds) {
   ASSERT_NO_THROW((void)Policy(0, B(&n)));
 }
 
+TEST(TEST_CATEGORY, range_policy_check_sign_changes) {
+  using UInt32Policy =
+      Kokkos::RangePolicy<TEST_EXECSPACE, Kokkos::IndexType<std::uint32_t>>;
+
+  [[maybe_unused]] std::string msg =
+      "Kokkos::RangePolicy bound type error: an unsafe implicit conversion is "
+      "performed";
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  {
+    std::int64_t n = std::numeric_limits<std::int64_t>::max();
+    ASSERT_DEATH((void)UInt32Policy(0, n), msg);
+  }
+  {
+    std::int64_t n = std::numeric_limits<std::int64_t>::min();
+    ASSERT_DEATH((void)UInt32Policy(n, 0), msg);
+  }
+#else
+  {
+    ::testing::internal::CaptureStderr();
+    std::int64_t n = std::numeric_limits<std::int64_t>::max();
+    ASSERT_NO_THROW((void)UInt32Policy(0, n));
+    auto s = std::string(::testing::internal::GetCapturedStderr());
+#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
+    if (Kokkos::show_warnings()) {
+      ASSERT_NE(s.find(msg), std::string::npos) << msg;
+    }
+#endif
+  }
+  {
+    ::testing::internal::CaptureStderr();
+    std::int64_t n = std::numeric_limits<std::int64_t>::min();
+    ASSERT_NO_THROW((void)UInt32Policy(n, 0));
+    auto s = std::string(::testing::internal::GetCapturedStderr());
+#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
+    if (Kokkos::show_warnings()) {
+      ASSERT_NE(s.find(msg), std::string::npos) << msg;
+    }
+#endif
+  }
+#endif
+}
+
 TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {
   using UIntIndexType = Kokkos::IndexType<unsigned>;
   using IntIndexType  = Kokkos::IndexType<int>;

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -125,10 +125,10 @@ TEST(TEST_CATEGORY_DEATH, range_policy_invalid_bounds) {
 
 template <typename T>
 struct TestIndexConversionCheck {
-  explicit TestIndexConversionCheck(T value_) : value(value_) {}
-  operator T() const { return value; }
+  explicit TestIndexConversionCheck(T* value_) : value(value_) {}
+  operator T() const { return *value; }
 
-  T value;
+  T* const value;
 };
 
 TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {
@@ -167,12 +167,13 @@ TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {
                  get_error_msg(expected, test_val));
   }
   {
+    using test_type = TestIndexConversionCheck<typename IntPolicy::index_type>;
+
+    static_assert(std::is_convertible_v<test_type, IntPolicy::index_type>);
+    static_assert(!std::is_convertible_v<IntPolicy::index_type, test_type>);
+
     typename IntIndexType::type test_val = -1;
-    ASSERT_NO_THROW((void)IntPolicy(
-        -2,
-        TestIndexConversionCheck<typename IntPolicy::index_type>(test_val)));
-    ASSERT_NO_THROW((void)UIntPolicy(
-        0, TestIndexConversionCheck<typename IntPolicy::index_type>(test_val)));
+    ASSERT_NO_THROW((void)IntPolicy(-2, test_type(&test_val)));
   }
 
 #else

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -131,7 +131,7 @@ struct TestIndexConversionCheck {
   T* const value;
 };
 
-TEST(TEST_CATEGORAY, range_policy_one_way_convertible_bounds) {
+TEST(TEST_CATEGORY, range_policy_one_way_convertible_bounds) {
   using UIntIndexType = Kokkos::IndexType<unsigned>;
   using UIntPolicy    = Kokkos::RangePolicy<TEST_EXECSPACE, UIntIndexType>;
 

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -128,6 +128,8 @@ TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {
   using IntIndexType  = Kokkos::IndexType<int>;
   using UIntPolicy    = Kokkos::RangePolicy<TEST_EXECSPACE, UIntIndexType>;
   using IntPolicy     = Kokkos::RangePolicy<TEST_EXECSPACE, IntIndexType>;
+  using IntAtomicDataElementType =
+      Kokkos::Impl::AtomicDataElement<Kokkos::ViewTraits<int>>;
 
   std::string msg =
       "Kokkos::RangePolicy bound type error: an unsafe implicit conversion is "
@@ -157,6 +159,12 @@ TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {
     int test_val = -1;
     ASSERT_DEATH({ (void)UIntPolicy(test_val, 10, Kokkos::ChunkSize(2)); },
                  get_error_msg(expected, test_val));
+  }
+  {
+    int test_val = 1;
+    ASSERT_NO_THROW((void)IntPolicy(
+        test_val, IntAtomicDataElementType(
+                      &test_val, Kokkos::Impl::AtomicViewConstTag{})));
   }
 
 #else

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -123,27 +123,21 @@ TEST(TEST_CATEGORY_DEATH, range_policy_invalid_bounds) {
 #endif
 }
 
-template <typename T>
-struct TestIndexConversionCheck {
-  explicit TestIndexConversionCheck(T* value_) : value(value_) {}
-  operator T() const { return *value; }
+struct ConvertibleToInt {  // not constructible from int
+  explicit ConvertibleToInt(int const* value_) : value(value_) {}
+  operator int() const { return *value; }
 
-  T* const value;
+  int const* value;
 };
 
 TEST(TEST_CATEGORY, range_policy_one_way_convertible_bounds) {
-  using UIntIndexType = Kokkos::IndexType<unsigned>;
-  using IntIndexType  = Kokkos::IndexType<int>;
-  using UIntPolicy    = Kokkos::RangePolicy<TEST_EXECSPACE, UIntIndexType>;
-  using IntPolicy     = Kokkos::RangePolicy<TEST_EXECSPACE, IntIndexType>;
+  using Policy = Kokkos::RangePolicy<>;
 
-  using test_type = TestIndexConversionCheck<IntPolicy::index_type>;
+  static_assert(std::is_convertible_v<ConvertibleToInt, Policy::index_type>);
+  static_assert(!std::is_convertible_v<Policy::index_type, ConvertibleToInt>);
 
-  static_assert(std::is_convertible_v<test_type, UIntPolicy::index_type>);
-  static_assert(!std::is_convertible_v<UIntPolicy::index_type, test_type>);
-
-  IntIndexType::type test_val = -1;
-  ASSERT_NO_THROW((void)UIntPolicy(0, test_type(&test_val)));
+  int const n = 1;
+  ASSERT_NO_THROW((void)Policy(0, ConvertibleToInt(&n)));
 }
 
 TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -131,6 +131,19 @@ struct TestIndexConversionCheck {
   T* const value;
 };
 
+TEST(TEST_CATEGORAY, range_policy_one_way_convertible_bounds) {
+  using UIntIndexType = Kokkos::IndexType<unsigned>;
+  using UIntPolicy    = Kokkos::RangePolicy<TEST_EXECSPACE, UIntIndexType>;
+
+  using test_type = TestIndexConversionCheck<UIntPolicy::index_type>;
+
+  static_assert(std::is_convertible_v<test_type, UIntPolicy::index_type>);
+  static_assert(!std::is_convertible_v<UIntPolicy::index_type, test_type>);
+
+  UIntIndexType::type test_val = -1;
+  ASSERT_NO_THROW((void)UIntPolicy(0, test_type(&test_val)));
+}
+
 TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {
   using UIntIndexType = Kokkos::IndexType<unsigned>;
   using IntIndexType  = Kokkos::IndexType<int>;
@@ -165,15 +178,6 @@ TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {
     int test_val = -1;
     ASSERT_DEATH({ (void)UIntPolicy(test_val, 10, Kokkos::ChunkSize(2)); },
                  get_error_msg(expected, test_val));
-  }
-  {
-    using test_type = TestIndexConversionCheck<typename IntPolicy::index_type>;
-
-    static_assert(std::is_convertible_v<test_type, IntPolicy::index_type>);
-    static_assert(!std::is_convertible_v<IntPolicy::index_type, test_type>);
-
-    typename IntIndexType::type test_val = -1;
-    ASSERT_NO_THROW((void)IntPolicy(-2, test_type(&test_val)));
   }
 
 #else

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -133,14 +133,16 @@ struct TestIndexConversionCheck {
 
 TEST(TEST_CATEGORY, range_policy_one_way_convertible_bounds) {
   using UIntIndexType = Kokkos::IndexType<unsigned>;
+  using IntIndexType  = Kokkos::IndexType<int>;
   using UIntPolicy    = Kokkos::RangePolicy<TEST_EXECSPACE, UIntIndexType>;
+  using IntPolicy     = Kokkos::RangePolicy<TEST_EXECSPACE, IntIndexType>;
 
-  using test_type = TestIndexConversionCheck<UIntPolicy::index_type>;
+  using test_type = TestIndexConversionCheck<IntPolicy::index_type>;
 
   static_assert(std::is_convertible_v<test_type, UIntPolicy::index_type>);
   static_assert(!std::is_convertible_v<UIntPolicy::index_type, test_type>);
 
-  UIntIndexType::type test_val = -1;
+  IntIndexType::type test_val = -1;
   ASSERT_NO_THROW((void)UIntPolicy(0, test_type(&test_val)));
 }
 

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -152,7 +152,7 @@ TEST(TEST_CATEGORY, range_policy_round_trip_conversion_fires) {
     ASSERT_NE(s.find(msg), std::string::npos) << msg;
   } else
 #endif
-    ASSERT_TRUE(::testing::internal::GetCapturedStderr().empty());
+    ASSERT_TRUE(s.empty());
 #endif
 }
 


### PR DESCRIPTION
Resolves #7005

`check_conversion_safety` in `RangePolicy` was requiring roundtrip convertibility between `member_type` and `IndexType`. The RangePolicy construction would fail to compile if convertibility is not supported for either direction.

This PR loosens that requirement, allowing RangePolicy be constructible as long as the user input index type (`IndexType`) is convertible to `member_type`. If `member_type` is not convertible to `IndexType`, the conversion safety check will be skipped.