### PR TITLE
remove usage of ENABLE_CXX11_DISPATCH_LAMBDA

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsForEach.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsForEach.cpp
@@ -55,7 +55,6 @@ void test_for_each(const ViewType view) {
   std::for_each(KE::begin(expected), KE::end(expected), non_mod_functor);
   compare_views(expected, view);
 
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
   const auto mod_lambda = KOKKOS_LAMBDA(value_t & i) { ++i; };
 
   // pass view, lambda takes non-const ref
@@ -79,7 +78,6 @@ void test_for_each(const ViewType view) {
   KE::for_each(exespace(), KE::cbegin(view), KE::cend(view), non_mod_lambda);
   std::for_each(KE::cbegin(expected), KE::cend(expected), non_mod_lambda);
   compare_views(expected, view);
-#endif
 }
 
 // std::for_each_n is C++17, so we cannot compare results directly

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -943,8 +943,6 @@ class TestDynViewAPI {
 
     dView0 d("d");
 
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
-
     // Rank 0
     Kokkos::resize(d);
 
@@ -1121,8 +1119,6 @@ class TestDynViewAPI {
     Kokkos::deep_copy(error_flag_host, error_flag);
     ASSERT_EQ(error_flag_host(), 0);
 #endif  // MDRangePolict Rank < 7
-
-#endif  // defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
   }
 
   static void run_test_scalar() {

--- a/containers/unit_tests/TestDynamicView.hpp
+++ b/containers/unit_tests/TestDynamicView.hpp
@@ -71,7 +71,6 @@ struct TestDynamicView {
       da.resize_serial(da_size);
       ASSERT_EQ(da.size(), da_size);
 
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
       Kokkos::parallel_for(
           Kokkos::RangePolicy<execution_space>(0, da_size),
           KOKKOS_LAMBDA(const int i) { da(i) = Scalar(i); });
@@ -85,7 +84,6 @@ struct TestDynamicView {
           result_sum);
 
       ASSERT_EQ(result_sum, (value_type)(da_size * (da_size - 1) / 2));
-#endif
 
       // add 3x more entries i.e. 4x larger than previous size
       // the first 1/4 should remain the same
@@ -93,7 +91,6 @@ struct TestDynamicView {
       da.resize_serial(da_resize);
       ASSERT_EQ(da.size(), da_resize);
 
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
       Kokkos::parallel_for(
           Kokkos::RangePolicy<execution_space>(da_size, da_resize),
           KOKKOS_LAMBDA(const int i) { da(i) = Scalar(i); });
@@ -108,7 +105,6 @@ struct TestDynamicView {
 
       ASSERT_EQ(new_result_sum + result_sum,
                 (value_type)(da_resize * (da_resize - 1) / 2));
-#endif
     }  // end scope
 
     // Test: Create DynamicView, initialize size (via resize), run through
@@ -123,7 +119,6 @@ struct TestDynamicView {
       da.resize_serial(da_size);
       ASSERT_EQ(da.size(), da_size);
 
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
       Kokkos::parallel_for(
           Kokkos::RangePolicy<execution_space>(0, da_size),
           KOKKOS_LAMBDA(const int i) { da(i) = Scalar(i); });
@@ -137,7 +132,6 @@ struct TestDynamicView {
           result_sum);
 
       ASSERT_EQ(result_sum, (value_type)(da_size * (da_size - 1) / 2));
-#endif
 
       // add 3x more entries i.e. 4x larger than previous size
       // the first 1/4 should remain the same
@@ -145,7 +139,6 @@ struct TestDynamicView {
       da.resize_serial(da_resize);
       ASSERT_EQ(da.size(), da_resize);
 
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
       Kokkos::parallel_for(
           Kokkos::RangePolicy<execution_space>(da_size, da_resize),
           KOKKOS_LAMBDA(const int i) { da(i) = Scalar(i); });
@@ -160,7 +153,6 @@ struct TestDynamicView {
 
       ASSERT_EQ(new_result_sum + result_sum,
                 (value_type)(da_resize * (da_resize - 1) / 2));
-#endif
     }  // end scope
 
     // Test: Create DynamicView, initialize size (via resize), run through
@@ -175,7 +167,6 @@ struct TestDynamicView {
       da.resize_serial(da_size);
       ASSERT_EQ(da.size(), da_size);
 
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
       Kokkos::parallel_for(
           Kokkos::RangePolicy<execution_space>(0, da_size),
           KOKKOS_LAMBDA(const int i) { da(i) = Scalar(i); });
@@ -189,14 +180,12 @@ struct TestDynamicView {
           result_sum);
 
       ASSERT_EQ(result_sum, (value_type)(da_size * (da_size - 1) / 2));
-#endif
 
       // remove the final 3/4 entries i.e. first 1/4 remain
       unsigned da_resize = arg_total_size / 8;
       da.resize_serial(da_resize);
       ASSERT_EQ(da.size(), da_resize);
 
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
       Kokkos::parallel_for(
           Kokkos::RangePolicy<execution_space>(0, da_resize),
           KOKKOS_LAMBDA(const int i) { da(i) = Scalar(i); });
@@ -210,7 +199,6 @@ struct TestDynamicView {
           new_result_sum);
 
       ASSERT_EQ(new_result_sum, (value_type)(da_resize * (da_resize - 1) / 2));
-#endif
     }  // end scope
 
     // Test: Reproducer to demonstrate compile-time error of deep_copy
@@ -229,7 +217,6 @@ struct TestDynamicView {
       device_dynamic_view.resize_serial(da_size);
 
       // Use parallel_for to populate device_dynamic_view and verify values
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
       Kokkos::parallel_for(
           Kokkos::RangePolicy<execution_space>(0, da_size),
           KOKKOS_LAMBDA(const int i) { device_dynamic_view(i) = Scalar(i); });
@@ -243,7 +230,6 @@ struct TestDynamicView {
           result_sum);
 
       ASSERT_EQ(result_sum, (value_type)(da_size * (da_size - 1) / 2));
-#endif
 
       // Use an on-device View as intermediate to deep_copy the
       // device_dynamic_view to host, zero out the device_dynamic_view,
@@ -251,13 +237,11 @@ struct TestDynamicView {
       Kokkos::deep_copy(device_view, device_dynamic_view);
       Kokkos::deep_copy(host_view, device_view);
       Kokkos::deep_copy(device_view, host_view);
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
       Kokkos::parallel_for(
           Kokkos::RangePolicy<execution_space>(0, da_size),
           KOKKOS_LAMBDA(const int i) { device_dynamic_view(i) = Scalar(0); });
-#endif
       Kokkos::deep_copy(device_dynamic_view, device_view);
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
+
       value_type new_result_sum = 0.0;
       Kokkos::parallel_reduce(
           Kokkos::RangePolicy<execution_space>(0, da_size),
@@ -267,7 +251,6 @@ struct TestDynamicView {
           new_result_sum);
 
       ASSERT_EQ(new_result_sum, (value_type)(da_size * (da_size - 1) / 2));
-#endif
 
       // Try to deep_copy device_dynamic_view directly to/from host.
       // host-to-device currently fails to compile because DP and SP are

--- a/core/perf_test/PerfTest_CustomReduction.cpp
+++ b/core/perf_test/PerfTest_CustomReduction.cpp
@@ -21,7 +21,6 @@
 #include <Kokkos_Random.hpp>
 #include <utility>
 
-#ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
 namespace Test {
 template <class Scalar>
 std::pair<double, Scalar> custom_reduction_test(int N, int R) {
@@ -130,4 +129,3 @@ BENCHMARK(CustomReduction<double>)
     ->UseManualTime();
 
 }  // namespace Test
-#endif

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -693,12 +693,6 @@ void Cuda::print_configuration(std::ostream &os, bool /*verbose*/) const {
 #else
   os << "no\n";
 #endif
-  os << "  KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA: ";
-#ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
-  os << "yes\n";
-#else
-  os << "no\n";
-#endif
   os << "  KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC: ";
 #ifdef KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC
   os << "yes\n";

--- a/core/unit_test/IncrementalTest.cpp.in
+++ b/core/unit_test/IncrementalTest.cpp.in
@@ -23,9 +23,7 @@
 #define TEST_CATEGORY @DEVICE@
 #define TEST_EXECSPACE Kokkos::@DEVICE_NAME@
 
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 #include <@CURRENT_FILE_NAME@>
-#endif
 
 #endif
 

--- a/core/unit_test/TestCXX11.hpp
+++ b/core/unit_test/TestCXX11.hpp
@@ -87,7 +87,6 @@ double AddTestFunctor() {
   return result;
 }
 
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 template <class DeviceType, bool PWRTest>
 double AddTestLambda() {
   Kokkos::View<double**, DeviceType> a("A", 100, 5);
@@ -144,12 +143,6 @@ double AddTestLambda() {
 
   return result;
 }
-#else
-template <class DeviceType, bool PWRTest>
-double AddTestLambda() {
-  return AddTestFunctor<DeviceType, PWRTest>();
-}
-#endif
 
 template <class DeviceType>
 struct FunctorReduceTest {
@@ -224,7 +217,6 @@ double ReduceTestFunctor() {
   return result;
 }
 
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 template <class DeviceType, bool PWRTest>
 double ReduceTestLambda() {
   using policy_type = Kokkos::TeamPolicy<DeviceType>;
@@ -277,12 +269,6 @@ double ReduceTestLambda() {
 
   return result;
 }
-#else
-template <class DeviceType, bool PWRTest>
-double ReduceTestLambda() {
-  return ReduceTestFunctor<DeviceType, PWRTest>();
-}
-#endif
 
 template <class DeviceType>
 double TestVariantLambda(int test) {
@@ -310,7 +296,6 @@ double TestVariantFunctor(int test) {
 
 template <class DeviceType>
 bool Test(int test) {
-#ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
   double res_functor = TestVariantFunctor<DeviceType>(test);
   double res_lambda  = TestVariantLambda<DeviceType>(test);
 
@@ -333,10 +318,6 @@ bool Test(int test) {
   }
 
   return passed;
-#else
-  (void)test;
-  return true;
-#endif
 }
 
 }  // namespace TestCXX11

--- a/core/unit_test/TestCompilerMacros.cpp
+++ b/core/unit_test/TestCompilerMacros.cpp
@@ -30,13 +30,11 @@
 #endif
 
 #if defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_CUDA_LAMBDA)
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
-#error "Macro bug: KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA shouldn't be defined"
+#error "Macro bug: KOKKOS_ENABLE_CUDA_LAMBDA should be defined"
 #endif
-#else
+
 #if !defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 #error "Macro bug: KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA should be defined"
-#endif
 #endif
 
 namespace TestCompilerMacros {

--- a/core/unit_test/TestDeepCopyAlignment.hpp
+++ b/core/unit_test/TestDeepCopyAlignment.hpp
@@ -19,7 +19,6 @@
 
 namespace Test {
 
-#ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
 namespace Impl {
 template <class MemorySpaceA, class MemorySpaceB>
 struct TestDeepCopy {
@@ -228,7 +227,6 @@ TEST(TEST_CATEGORY, deep_copy_alignment) {
                        Kokkos::HostSpace>::run_test(100000);
   }
 }
-#endif
 
 namespace Impl {
 template <class Scalar1, class Scalar2, class Layout1, class Layout2>

--- a/core/unit_test/TestHalfConversion.hpp
+++ b/core/unit_test/TestHalfConversion.hpp
@@ -26,7 +26,6 @@ void test_half_conversion_type() {
   T b                            = Kokkos::Experimental::cast_from_half<T>(a);
   ASSERT_LT((double(b - base) / double(base)), epsilon);
 
-#ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
   Kokkos::View<T> b_v("b_v");
   Kokkos::parallel_for(
       "TestHalfConversion", 1, KOKKOS_LAMBDA(int) {
@@ -37,7 +36,6 @@ void test_half_conversion_type() {
 
   Kokkos::deep_copy(b, b_v);
   ASSERT_LT((double(b - base) / double(base)), epsilon);
-#endif  // KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
 }
 
 template <class T>
@@ -48,7 +46,6 @@ void test_bhalf_conversion_type() {
   T b                             = Kokkos::Experimental::cast_from_bhalf<T>(a);
   ASSERT_LT((double(b - base) / double(base)), epsilon);
 
-#ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
   Kokkos::View<T> b_v("b_v");
   Kokkos::parallel_for(
       "TestHalfConversion", 1, KOKKOS_LAMBDA(int) {
@@ -59,7 +56,6 @@ void test_bhalf_conversion_type() {
 
   Kokkos::deep_copy(b, b_v);
   ASSERT_LT((double(b - base) / double(base)), epsilon);
-#endif  // KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
 }
 
 void test_half_conversion() {

--- a/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
+++ b/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
@@ -127,8 +127,7 @@ TEST(TEST_CATEGORY, host_shared_ptr_special_members_on_device) {
 #endif
 
 // FIXME_OPENMPTARGET
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA) && \
-    !defined(KOKKOS_ENABLE_OPENMPTARGET)
+#if !defined(KOKKOS_ENABLE_OPENMPTARGET)
 namespace {
 
 struct Bar {
@@ -258,4 +257,4 @@ TEST(TEST_CATEGORY, host_shared_ptr_tracking) {
 #endif
 }
 
-#endif  // KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
+#endif

--- a/core/unit_test/TestInit.hpp
+++ b/core/unit_test/TestInit.hpp
@@ -23,8 +23,6 @@
 namespace Test {
 TEST(TEST_CATEGORY, init) { ; }
 
-#ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
-
 template <class ExecSpace>
 void test_dispatch() {
   const int repeat = 100;
@@ -37,6 +35,5 @@ void test_dispatch() {
 }
 
 TEST(TEST_CATEGORY, dispatch) { test_dispatch<TEST_EXECSPACE>(); }
-#endif
 
 }  // namespace Test

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -904,7 +904,6 @@ void impl_test_local_deepcopy_rangepolicy_rank_7(const int N) {
 }
 //-------------------------------------------------------------------------------------------------------------
 
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutleft) {
   using ExecSpace = TEST_EXECSPACE;
   using ViewType  = Kokkos::View<double********, Kokkos::LayoutLeft, ExecSpace>;
@@ -1013,7 +1012,6 @@ TEST(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutright) {
     impl_test_local_deepcopy_rangepolicy_rank_7<ExecSpace, ViewType>(8);
   }
 }
-#endif
 
 namespace Impl {
 template <typename T, typename SHMEMTYPE>

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -212,7 +212,6 @@ struct TestMDRange_2D {
   }
 
   static void test_reduce2(const int N0, const int N1) {
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>,
@@ -231,7 +230,6 @@ struct TestMDRange_2D {
           sum);
       ASSERT_EQ(sum, N0 * N1);
     }
-#endif
 
     {
       using range_type =
@@ -315,7 +313,6 @@ struct TestMDRange_2D {
       ASSERT_EQ(sum, 2 * N0 * N1);
     }
     // Test Min reducer with lambda
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>,
@@ -341,7 +338,7 @@ struct TestMDRange_2D {
 
       ASSERT_EQ(min, 4.0);
     }
-#endif
+
     // Tagged operator test
     {
       using range_type = typename Kokkos::MDRangePolicy<
@@ -478,7 +475,6 @@ struct TestMDRange_2D {
   }  // end test_reduce2
 
   static void test_for2(const int N0, const int N1) {
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>,
@@ -517,7 +513,6 @@ struct TestMDRange_2D {
 
       ASSERT_EQ(counter, 0);
     }
-#endif
 
     {
       using range_type =
@@ -846,7 +841,6 @@ struct TestMDRange_3D {
   }
 
   static void test_reduce3(const int N0, const int N1, const int N2) {
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>,
@@ -864,7 +858,6 @@ struct TestMDRange_3D {
           sum);
       ASSERT_EQ(sum, N0 * N1 * N2);
     }
-#endif
 
     {
       using range_type =
@@ -947,7 +940,6 @@ struct TestMDRange_3D {
       ASSERT_EQ(sum, 2 * N0 * N1 * N2);
     }
     // Test Min reducer with lambda
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>,
@@ -980,7 +972,6 @@ struct TestMDRange_3D {
         ASSERT_EQ(min, min_identity);
       }
     }
-#endif
 
     // Tagged operator test
     {
@@ -1119,7 +1110,6 @@ struct TestMDRange_3D {
   }  // end test_reduce3
 
   static void test_for3(const int N0, const int N1, const int N2) {
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>,
@@ -1162,7 +1152,6 @@ struct TestMDRange_3D {
 
       ASSERT_EQ(counter, 0);
     }
-#endif
 
     {
       using range_type =
@@ -1473,7 +1462,6 @@ struct TestMDRange_4D {
 
   static void test_reduce4(const int N0, const int N1, const int N2,
                            const int N3) {
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>,
@@ -1491,7 +1479,6 @@ struct TestMDRange_4D {
           sum);
       ASSERT_EQ(sum, N0 * N1 * N2 * N3);
     }
-#endif
 
     {
       using range_type =
@@ -1578,7 +1565,6 @@ struct TestMDRange_4D {
     }
 
     // Test Min reducer with lambda
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>,
@@ -1606,7 +1592,6 @@ struct TestMDRange_4D {
 
       ASSERT_EQ(min, 16.0);
     }
-#endif
 
     // Tagged operator test
     {
@@ -1748,7 +1733,6 @@ struct TestMDRange_4D {
 
   static void test_for4(const int N0, const int N1, const int N2,
                         const int N3) {
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>,
@@ -1792,7 +1776,6 @@ struct TestMDRange_4D {
 
       ASSERT_EQ(counter, 0);
     }
-#endif
 
     {
       using range_type =
@@ -2118,7 +2101,6 @@ struct TestMDRange_5D {
 
   static void test_reduce5(const int N0, const int N1, const int N2,
                            const int N3, const int N4) {
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>,
@@ -2138,7 +2120,6 @@ struct TestMDRange_5D {
           sum);
       ASSERT_EQ(sum, N0 * N1 * N2 * N3 * N4);
     }
-#endif
 
     {
       using range_type =
@@ -2231,7 +2212,6 @@ struct TestMDRange_5D {
     }
 
     // Test Min reducer with lambda
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>,
@@ -2263,7 +2243,6 @@ struct TestMDRange_5D {
 
       ASSERT_EQ(min, 32.0);
     }
-#endif
 
     // Tagged operator test
     {
@@ -2312,7 +2291,6 @@ struct TestMDRange_5D {
 
   static void test_for5(const int N0, const int N1, const int N2, const int N3,
                         const int N4) {
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>,
@@ -2360,7 +2338,6 @@ struct TestMDRange_5D {
 
       ASSERT_EQ(counter, 0);
     }
-#endif
 
     {
       using range_type =
@@ -2706,7 +2683,6 @@ struct TestMDRange_6D {
 
   static void test_reduce6(const int N0, const int N1, const int N2,
                            const int N3, const int N4, const int N5) {
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
 #if defined(KOKKOS_COMPILER_INTEL)
       // Launchbounds causes hang with intel compilers
@@ -2735,7 +2711,6 @@ struct TestMDRange_6D {
           sum);
       ASSERT_EQ(sum, N0 * N1 * N2 * N3 * N4 * N5);
     }
-#endif
 
     {
 #if defined(KOKKOS_COMPILER_INTEL)
@@ -2889,7 +2864,6 @@ struct TestMDRange_6D {
     }
 
     // Test Min reducer with lambda
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
 #if defined(KOKKOS_COMPILER_INTEL)
       // Launchbounds causes hang with intel compilers
@@ -2931,7 +2905,6 @@ struct TestMDRange_6D {
 
       ASSERT_EQ(min, 64.0);
     }
-#endif
 
     // Tagged operator test
     {
@@ -2997,7 +2970,6 @@ struct TestMDRange_6D {
 
   static void test_for6(const int N0, const int N1, const int N2, const int N3,
                         const int N4, const int N5) {
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
 #if defined(KOKKOS_COMPILER_INTEL)
       // Launchbounds causes hang with intel compilers
@@ -3056,7 +3028,6 @@ struct TestMDRange_6D {
 
       ASSERT_EQ(counter, 0);
     }
-#endif
 
     {
 #if defined(KOKKOS_COMPILER_INTEL)
@@ -3855,7 +3826,6 @@ struct TestMDRange_ReduceScalar {
   };
 
   static void test_scalar_reduce(const int N0, const int N1) {
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     Scalar sum;
     using range_type =
         typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>,
@@ -3873,10 +3843,6 @@ struct TestMDRange_ReduceScalar {
         },
         sum);
     for (int i = 0; i < 4; i++) ASSERT_EQ(sum.v[i], N0 * N1);
-#else
-    std::ignore = N0;
-    std::ignore = N1;
-#endif
   }
 };
 

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -202,7 +202,6 @@ struct TestRange {
   }
 
   void test_dynamic_policy() {
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     auto const N_no_implicit_capture = N;
     using policy_t =
         Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic> >;
@@ -288,7 +287,6 @@ struct TestRange {
         //}
       }
     }
-#endif
   }
 };
 

--- a/core/unit_test/TestRangePolicyRequire.hpp
+++ b/core/unit_test/TestRangePolicyRequire.hpp
@@ -214,7 +214,6 @@ struct TestRangeRequire {
   //----------------------------------------
 
   void test_dynamic_policy() {
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     auto const N_no_implicit_capture = N;
     using policy_t =
         Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic> >;
@@ -300,7 +299,6 @@ struct TestRangeRequire {
         //}
       }
     }
-#endif
   }
 };
 

--- a/core/unit_test/TestReduceCombinatorical.hpp
+++ b/core/unit_test/TestReduceCombinatorical.hpp
@@ -492,27 +492,23 @@ struct TestReduceCombinatoricalInstantiation {
   template <class... Args>
   static void AddFunctorLambdaRange(int N, Args... args) {
     AddFunctor<0, Args...>(N, args...);
-#ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
     AddLambdaRange(
         N,
         std::conditional_t<
             std::is_same<ExecSpace, Kokkos::DefaultExecutionSpace>::value,
             void*, Kokkos::InvalidType>(),
         args...);
-#endif
   }
 
   template <class... Args>
   static void AddFunctorLambdaTeam(int N, Args... args) {
     AddFunctor<1, Args...>(N, args...);
-#ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
     AddLambdaTeam(
         N,
         std::conditional_t<
             std::is_same<ExecSpace, Kokkos::DefaultExecutionSpace>::value,
             void*, Kokkos::InvalidType>(),
         args...);
-#endif
   }
 
   template <class... Args>

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -595,7 +595,6 @@ struct TestSharedTeam {
 
 namespace Test {
 
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 template <class MemorySpace, class ExecSpace, class ScheduleType>
 struct TestLambdaSharedTeam {
   TestLambdaSharedTeam() { run(); }
@@ -617,7 +616,7 @@ struct TestLambdaSharedTeam {
         std::is_same<ExecSpace, Kokkos::Experimental::OpenMPTarget>::value ? 32
                                                                            : 1;
 #else
-    int team_size = 1;
+    int team_size    = 1;
 #endif
 
 #ifdef KOKKOS_ENABLE_CUDA
@@ -676,7 +675,6 @@ struct TestLambdaSharedTeam {
     ASSERT_EQ(error_count, 0);
   }
 };
-#endif
 
 }  // namespace Test
 
@@ -807,7 +805,7 @@ struct TestScratchTeam {
             ? p_type(64 / team_size, team_size)
             : p_type(8192 / team_size, team_size);
 #else
-    team_exec          = p_type(8192 / team_size, team_size);
+    team_exec     = p_type(8192 / team_size, team_size);
 #endif
 
     Kokkos::parallel_reduce(
@@ -993,7 +991,7 @@ struct ClassNoShmemSizeFunction {
 #ifdef KOKKOS_ENABLE_SYCL
     int team_size = 4;
 #else
-    int team_size      = 8;
+    int team_size = 8;
 #endif
     int const concurrency = ExecSpace().concurrency();
     if (team_size > concurrency) team_size = concurrency;
@@ -1117,7 +1115,6 @@ struct ClassWithShmemSizeFunction {
 
 template <class ExecSpace, class ScheduleType>
 void test_team_mulit_level_scratch_test_lambda() {
-#ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
   Kokkos::View<int, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic>> errors;
   Kokkos::View<int, ExecSpace> d_errors("Errors");
   errors = d_errors;
@@ -1181,7 +1178,6 @@ void test_team_mulit_level_scratch_test_lambda() {
       },
       error);
   ASSERT_EQ(error, 0);
-#endif
 }
 
 }  // namespace Test
@@ -1193,9 +1189,7 @@ struct TestMultiLevelScratchTeam {
   TestMultiLevelScratchTeam() { run(); }
 
   void run() {
-#ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
     Test::test_team_mulit_level_scratch_test_lambda<ExecSpace, ScheduleType>();
-#endif
     Test::ClassNoShmemSizeFunction<ExecSpace, ScheduleType> c1;
     c1.run();
 
@@ -1539,7 +1533,7 @@ struct TestScratchAlignment {
         std::is_same<ExecSpace, Kokkos::Experimental::OpenMPTarget>::value ? 32
                                                                            : 1;
 #else
-    int team_size      = 1;
+    int team_size = 1;
 #endif
     if (allocate_small) shmem_size += ScratchViewInt::shmem_size(1);
     Kokkos::parallel_for(
@@ -1564,7 +1558,7 @@ struct TestScratchAlignment {
         std::is_same<ExecSpace, Kokkos::Experimental::OpenMPTarget>::value ? 32
                                                                            : 1;
 #else
-    int team_size      = 1;
+    int team_size = 1;
 #endif
     Kokkos::TeamPolicy<ExecSpace> policy(1, team_size);
     size_t scratch_size = sizeof(int);
@@ -1590,7 +1584,7 @@ struct TestScratchAlignment {
         std::is_same<ExecSpace, Kokkos::Experimental::OpenMPTarget>::value ? 32
                                                                            : 1;
 #else
-    int team_size      = 1;
+    int team_size = 1;
 #endif
     Kokkos::TeamPolicy<ExecSpace> policy(1, team_size);
     Kokkos::View<int, ExecSpace> flag("Flag");
@@ -1663,7 +1657,6 @@ struct TestTeamPolicyHandleByValue {
   TestTeamPolicyHandleByValue() { test(); }
 
   void test() {
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     const int M = 1, N = 1;
     Kokkos::View<scalar **, mem_space> a("a", M, N);
     Kokkos::View<scalar **, mem_space> b("b", M, N);
@@ -1678,7 +1671,6 @@ struct TestTeamPolicyHandleByValue {
           Kokkos::parallel_for(Kokkos::TeamThreadRange(team, 0, N),
                                [&](const int j) { a(i, j) += b(i, j); });
         });
-#endif
   }
 };
 

--- a/core/unit_test/TestTeamScratch.hpp
+++ b/core/unit_test/TestTeamScratch.hpp
@@ -30,7 +30,6 @@ TEST(TEST_CATEGORY, team_scratch_request) {
   TestScratchTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >();
 }
 
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 TEST(TEST_CATEGORY, team_lambda_shared_request) {
   TestLambdaSharedTeam<Kokkos::HostSpace, TEST_EXECSPACE,
                        Kokkos::Schedule<Kokkos::Static> >();
@@ -38,7 +37,6 @@ TEST(TEST_CATEGORY, team_lambda_shared_request) {
                        Kokkos::Schedule<Kokkos::Dynamic> >();
 }
 TEST(TEST_CATEGORY, scratch_align) { TestScratchAlignment<TEST_EXECSPACE>(); }
-#endif
 
 TEST(TEST_CATEGORY, shmem_size) { TestShmemSize<TEST_EXECSPACE>(); }
 

--- a/core/unit_test/TestViewAPI_e.hpp
+++ b/core/unit_test/TestViewAPI_e.hpp
@@ -152,7 +152,6 @@ inline void test_anonymous_space() {
     host_anon_assign_view(i)                       = 142;
   }
   Kokkos::View<int**, Kokkos::LayoutRight, ExecSpace> d_view("d_view", 100, 10);
-#ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
   Kokkos::parallel_for(
       Kokkos::RangePolicy<ExecSpace, int>(0, 100), KOKKOS_LAMBDA(int i) {
         int* ptr = &(d_view(i, 0));
@@ -167,7 +166,6 @@ inline void test_anonymous_space() {
         }
       });
   Kokkos::fence();
-#endif
 }
 
 TEST(TEST_CATEGORY, anonymous_space) { test_anonymous_space(); }

--- a/core/unit_test/TestView_64bit.hpp
+++ b/core/unit_test/TestView_64bit.hpp
@@ -20,7 +20,6 @@ namespace Test {
 
 template <class Device>
 void test_64bit() {
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
   // We are running out of device memory on Intel GPUs
 #ifdef KOKKOS_ENABLE_SYCL
   int64_t N = 4000000000;
@@ -106,7 +105,6 @@ void test_64bit() {
         (P * (P - 1) / 2) * int64_t(N0 / P) + (N0 % P) * (N0 % P - 1) / 2;
     ASSERT_EQ(expected, sum0);
   }
-#endif
 }
 
 #ifdef KOKKOS_ENABLE_LARGE_MEM_TESTS

--- a/example/tutorial/01_hello_world_lambda/hello_world_lambda.cpp
+++ b/example/tutorial/01_hello_world_lambda/hello_world_lambda.cpp
@@ -67,16 +67,13 @@ int main(int argc, char* argv[]) {
   //
   // You may notice that the printed numbers do not print out in
   // order.  Parallel for loops may execute in any order.
-  // We also need to protect the usage of a lambda against compiling
-  // with a backend which doesn't support it (i.e. Cuda 6.5/7.0).
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
   Kokkos::parallel_for(
       15, KOKKOS_LAMBDA(const int i) {
         // Kokko::printf works for all backends in a parallel kernel;
         // std::ostream does not.
         Kokkos::printf("Hello from i = %i\n", i);
       });
-#endif
+
   // You must call finalize() after you are done using Kokkos.
   Kokkos::finalize();
 }

--- a/example/tutorial/02_simple_reduce_lambda/simple_reduce_lambda.cpp
+++ b/example/tutorial/02_simple_reduce_lambda/simple_reduce_lambda.cpp
@@ -37,14 +37,11 @@ int main(int argc, char* argv[]) {
   // functor.  The lambda takes the same arguments as the functor's
   // operator().
   int sum = 0;
-// The KOKKOS_LAMBDA macro replaces the capture-by-value clause [=].
-// It also handles any other syntax needed for CUDA.
-// We also need to protect the usage of a lambda against compiling
-// with a backend which doesn't support it (i.e. Cuda 6.5/7.0).
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
+  // The KOKKOS_LAMBDA macro replaces the capture-by-value clause [=].
+  // It also handles any other syntax needed for CUDA.
   Kokkos::parallel_reduce(
       n, KOKKOS_LAMBDA(const int i, int& lsum) { lsum += i * i; }, sum);
-#endif
+
   printf(
       "Sum of squares of integers from 0 to %i, "
       "computed in parallel, is %i\n",
@@ -60,9 +57,6 @@ int main(int argc, char* argv[]) {
       "computed sequentially, is %i\n",
       n - 1, seqSum);
   Kokkos::finalize();
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
+
   return (sum == seqSum) ? 0 : -1;
-#else
-  return 0;
-#endif
 }

--- a/example/tutorial/03_simple_view_lambda/simple_view_lambda.cpp
+++ b/example/tutorial/03_simple_view_lambda/simple_view_lambda.cpp
@@ -61,19 +61,16 @@ int main(int argc, char* argv[]) {
     // Different Views may have the same label.
     view_type a("A", 10);
 
-// Fill the View with some data.  The parallel_for loop will iterate
-// over the View's first dimension N.
-//
-// Note that the View is passed by value into the lambda.  The macro
-// KOKKOS_LAMBDA includes the "capture by value" clause [=].  This
-// tells the lambda to "capture all variables in the enclosing scope
-// by value."  Views have "view semantics"; they behave like
-// pointers, not like std::vector.  Passing them by value does a
-// shallow copy.  A deep copy never happens unless you explicitly
-// ask for one.
-// We also need to protect the usage of a lambda against compiling
-// with a backend which doesn't support it (i.e. Cuda 6.5/7.0).
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
+    // Fill the View with some data.  The parallel_for loop will iterate
+    // over the View's first dimension N.
+    //
+    // Note that the View is passed by value into the lambda.  The macro
+    // KOKKOS_LAMBDA includes the "capture by value" clause [=].  This
+    // tells the lambda to "capture all variables in the enclosing scope
+    // by value."  Views have "view semantics"; they behave like
+    // pointers, not like std::vector.  Passing them by value does a
+    // shallow copy.  A deep copy never happens unless you explicitly
+    // ask for one.
     Kokkos::parallel_for(
         10, KOKKOS_LAMBDA(const int i) {
           // Acesss the View just like a Fortran array.  The layout depends
@@ -92,7 +89,6 @@ int main(int argc, char* argv[]) {
         },
         sum);
     printf("Result: %f\n", sum);
-#endif
   }
   Kokkos::finalize();
 }

--- a/example/tutorial/Hierarchical_Parallelism/01_thread_teams_lambda/thread_teams_lambda.cpp
+++ b/example/tutorial/Hierarchical_Parallelism/01_thread_teams_lambda/thread_teams_lambda.cpp
@@ -50,9 +50,6 @@ int main(int narg, char* args[]) {
   // region."  That is, every team member is active and will execute
   // the body of the lambda.
   int sum = 0;
-// We also need to protect the usage of a lambda against compiling
-// with a backend which doesn't support it (i.e. Cuda 6.5/7.0).
-#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
   parallel_reduce(
       policy,
       KOKKOS_LAMBDA(const team_member& thread, int& lsum) {
@@ -65,7 +62,7 @@ int main(int narg, char* args[]) {
                        thread.team_size());
       },
       sum);
-#endif
+
   // The result will be 12*team_policy::team_size_max([=]{})
   printf("Result %i\n", sum);
 


### PR DESCRIPTION
The macro KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA is set unconditionally for a long time, so there should not be any reason to check it in the examples or tests.

FYI @masterleinad 