### PR TITLE
Fix atomic accessor for pre-volta GPU architectures

### DIFF
--- a/core/src/Kokkos_Atomics_Desul_Volatile_Wrapper.hpp
+++ b/core/src/Kokkos_Atomics_Desul_Volatile_Wrapper.hpp
@@ -22,7 +22,6 @@ static_assert(false,
 #ifndef KOKKOS_DESUL_ATOMICS_VOLATILE_WRAPPER_HPP_
 #define KOKKOS_DESUL_ATOMICS_VOLATILE_WRAPPER_HPP_
 #include <Kokkos_Macros.hpp>
-#include <Kokkos_Atomics_Desul_Config.hpp>
 #include <desul/atomics.hpp>
 
 #ifdef KOKKOS_ENABLE_ATOMICS_BYPASS

--- a/core/src/Kokkos_Atomics_Desul_Wrapper.hpp
+++ b/core/src/Kokkos_Atomics_Desul_Wrapper.hpp
@@ -22,8 +22,6 @@ static_assert(false,
 #ifndef KOKKOS_DESUL_ATOMICS_WRAPPER_HPP_
 #define KOKKOS_DESUL_ATOMICS_WRAPPER_HPP_
 #include <Kokkos_Macros.hpp>
-
-#include <Kokkos_Atomics_Desul_Config.hpp>
 #include <desul/atomics.hpp>
 
 #include <impl/Kokkos_Volatile_Load.hpp>

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -55,6 +55,7 @@
 
 #ifndef KOKKOS_DONT_INCLUDE_CORE_CONFIG_H
 #include <KokkosCore_config.h>
+#include <impl/Kokkos_DesulAtomicsConfig.hpp>
 #include <impl/Kokkos_NvidiaGpuArchitectures.hpp>
 #endif
 

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -25,6 +25,8 @@ static_assert(false,
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Concepts.hpp>
 #include <Kokkos_Core_fwd.hpp>
+
+#include <Kokkos_Atomics_Desul_Config.hpp>
 #include <desul/atomics.hpp>
 
 namespace Kokkos {

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -25,8 +25,6 @@ static_assert(false,
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Concepts.hpp>
 #include <Kokkos_Core_fwd.hpp>
-
-#include <Kokkos_Atomics_Desul_Config.hpp>
 #include <desul/atomics.hpp>
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_DesulAtomicsConfig.hpp
+++ b/core/src/impl/Kokkos_DesulAtomicsConfig.hpp
@@ -13,15 +13,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //@HEADER
-#ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-#include <Kokkos_Macros.hpp>
-static_assert(false,
-              "Including non-public Kokkos header files is not allowed.");
-#endif
-#ifndef KOKKOS_ATOMICS_DESUL_CONFIG_HPP
-#define KOKKOS_ATOMICS_DESUL_CONFIG_HPP
 
-#include <Kokkos_Macros.hpp>
+#ifndef KOKKOS_DESUL_ATOMICS_CONFIG_HPP
+#define KOKKOS_DESUL_ATOMICS_CONFIG_HPP
 
 #if defined(KOKKOS_ARCH_KEPLER) || defined(KOKKOS_ARCH_MAXWELL)
 #define DESUL_CUDA_ARCH_IS_PRE_PASCAL
@@ -32,4 +26,4 @@ static_assert(false,
 #define DESUL_CUDA_ARCH_IS_PRE_VOLTA
 #endif
 
-#endif  // KOKKOS_ATOMICS_DESUL_CONFIG_HPP
+#endif


### PR DESCRIPTION
Fix #7187 

We forgot to include that "Kokkos_Atomics_Desul_Config.hpp" configuration helper that translates Kokkos GPU macro architectures into Desul ones.

Admittedly this is not great that Desul expects these define macros to just be properly set by the user.  IIRC we didn't really want to handle architectures in the configuration which granted a lot of freedom downstream but alas also complicates usage.