### PR TITLE
SYCL: Address oneAPI 2025.0.0 deprecations

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -261,8 +261,6 @@ std::ostream& SYCL::impl_sycl_info(std::ostream& os,
             << device.get_info<device::image3d_max_depth>()
             << "\nImage Max Buffer Size: "
             << device.get_info<device::image_max_buffer_size>()
-            << "\nImage Max Array Size: "
-            << device.get_info<device::image_max_array_size>()
             << "\nMax Samplers: " << device.get_info<device::max_samplers>()
             << "\nMax Parameter Size: "
             << device.get_info<device::max_parameter_size>()

--- a/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
@@ -75,7 +75,11 @@ class UniqueToken<SYCL, UniqueTokenScope::Global> {
   /// \brief acquire value such that 0 <= value < size()
   KOKKOS_INLINE_FUNCTION
   size_type impl_acquire() const {
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20250000
+    auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
+#else
     auto item = sycl::ext::oneapi::experimental::this_nd_item<3>();
+#endif
     std::size_t threadIdx[3] = {item.get_local_id(2), item.get_local_id(1),
                                 item.get_local_id(0)};
     std::size_t blockIdx[3]  = {item.get_group(2), item.get_group(1),

--- a/tpls/desul/include/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/tpls/desul/include/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -83,7 +83,11 @@ device_atomic_compare_exchange(
   // This is a way to avoid deadlock in a subgroup
   T return_val;
   int done = 0;
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20250000
+  auto sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+#else
   auto sg = sycl::ext::oneapi::experimental::this_sub_group();
+#endif
   using sycl::ext::oneapi::group_ballot;
   using sycl::ext::oneapi::sub_group_mask;
   sub_group_mask active = group_ballot(sg, 1);
@@ -114,7 +118,11 @@ std::enable_if_t<(sizeof(T) != 8) && (sizeof(T) != 4), T> device_atomic_exchange
   // This is a way to avoid deadlock in a subgroup
   T return_val;
   int done = 0;
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20250000
+  auto sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+#else
   auto sg = sycl::ext::oneapi::experimental::this_sub_group();
+#endif
   using sycl::ext::oneapi::group_ballot;
   using sycl::ext::oneapi::sub_group_mask;
   sub_group_mask active = group_ballot(sg, 1);

--- a/tpls/desul/include/desul/atomics/Lock_Based_Fetch_Op_SYCL.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Based_Fetch_Op_SYCL.hpp
@@ -32,7 +32,11 @@ T device_atomic_fetch_oper(const Oper& op,
   // This is a way to avoid deadlock in a subgroup
   T return_val;
   int done = 0;
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20250000
+  auto sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+#else
   auto sg = sycl::ext::oneapi::experimental::this_sub_group();
+#endif  
   using sycl::ext::oneapi::group_ballot;
   using sycl::ext::oneapi::sub_group_mask;
   sub_group_mask active = group_ballot(sg, 1);
@@ -68,7 +72,11 @@ T device_atomic_oper_fetch(const Oper& op,
   // This is a way to avoid deadlock in a subgroup
   T return_val;
   int done = 0;
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20250000
+  auto sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+#else
   auto sg = sycl::ext::oneapi::experimental::this_sub_group();
+#endif
   using sycl::ext::oneapi::group_ballot;
   using sycl::ext::oneapi::sub_group_mask;
   sub_group_mask active = group_ballot(sg, 1);


### PR DESCRIPTION
Corresponds to https://github.com/desul/desul/pull/131.
 - The free function queries were moved and deprecated in https://github.com/intel/llvm/pull/13257.
 - `device::image_max_array_size>` was deprecated in https://github.com/intel/llvm/pull/13279.