### PR TITLE
Update cmake and make configurations for Clacc/LLVM compiler

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -168,7 +168,7 @@ KOKKOS_INTERNAL_COMPILER_CRAY        := $(strip $(shell $(CXX) -craype-verbose 2
 KOKKOS_INTERNAL_COMPILER_NVCC        := $(strip $(shell echo "$(shell export OMPI_CXX=$(OMPI_CXX); export MPICH_CXX=$(MPICH_CXX); $(CXX) --version 2>&1 | grep -c nvcc)>0" | bc))
 KOKKOS_INTERNAL_COMPILER_NVHPC       := $(strip $(shell $(CXX) --version 2>&1 | grep -c "nvc++"))
 KOKKOS_INTERNAL_COMPILER_CLANG       := $(call kokkos_has_string,$(KOKKOS_CXX_VERSION),clang)
-KOKKOS_INTERNAL_COMPILER_CRAY_CLANG  := $(strip $(shell $(CXX) -craype-verbose 2>&1 | grep -c "clang++"))
+KOKKOS_INTERNAL_COMPILER_CRAY_CLANG  := $(strip $(shell $(CXX) -craype-verbose 2>&1 | grep -v "error:" | grep -c "clang++"))
 KOKKOS_INTERNAL_COMPILER_INTEL_CLANG := $(call kokkos_has_string,$(KOKKOS_CXX_VERSION),oneAPI)
 KOKKOS_INTERNAL_COMPILER_APPLE_CLANG := $(call kokkos_has_string,$(KOKKOS_CXX_VERSION),Apple clang)
 KOKKOS_INTERNAL_COMPILER_HCC         := $(call kokkos_has_string,$(KOKKOS_CXX_VERSION),HCC)
@@ -272,6 +272,8 @@ ifeq ($(KOKKOS_INTERNAL_USE_OPENMPTARGET), 1)
     KOKKOS_INTERNAL_OPENMPTARGET_FLAG := -fiopenmp -Wno-openmp-mapping
   else ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 1)
     KOKKOS_INTERNAL_OPENMPTARGET_FLAG := -mp=gpu 
+  else ifeq ($(KOKKOS_INTERNAL_COMPILER_CLANG), 1)
+    KOKKOS_INTERNAL_OPENMPTARGET_FLAG := -fopenmp -Xopenmp-target
   else ifeq ($(KOKKOS_INTERNAL_COMPILER_CLANG), 0)
     #Assume GCC
     KOKKOS_INTERNAL_OPENMPTARGET_FLAG := -fopenmp -foffload=nvptx-none
@@ -282,6 +284,8 @@ ifeq ($(KOKKOS_INTERNAL_USE_OPENACC), 1)
   # Set OpenACC flags.
   ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 1)
     KOKKOS_INTERNAL_OPENACC_FLAG := -acc
+  else ifeq ($(KOKKOS_INTERNAL_COMPILER_CLANG), 1)
+    KOKKOS_INTERNAL_OPENACC_FLAG := -fopenacc -fopenacc-fake-async-wait -fopenacc-implicit-worker=vector -Wno-openacc-and-cxx -Wno-openmp-mapping -Wno-unknown-cuda-version -Wno-pass-failed
   else
     $(error Makefile.kokkos: OpenACC is enabled but the compiler must be NVHPC (got version string $(KOKKOS_CXX_VERSION)))
   endif
@@ -401,12 +405,15 @@ ifeq ($(KOKKOS_INTERNAL_USE_ARCH_NVIDIA), 0)
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_ARCH_NVIDIA), 1)
+  KOKKOS_INTERNAL_NVCC_PATH := $(shell which nvcc)
   ifeq ($(KOKKOS_INTERNAL_COMPILER_CLANG), 1)
-    KOKKOS_INTERNAL_NVCC_PATH := $(shell which nvcc)
     CUDA_PATH ?= $(KOKKOS_INTERNAL_NVCC_PATH:/bin/nvcc=)
     ifeq ($(KOKKOS_INTERNAL_USE_OPENMPTARGET), 1)
       KOKKOS_INTERNAL_OPENMPTARGET_FLAG := $(KOKKOS_INTERNAL_OPENMPTARGET_FLAG) --cuda-path=$(CUDA_PATH)
     endif
+  endif
+  ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 1)
+    CUDA_PATH ?= $(KOKKOS_INTERNAL_NVCC_PATH:/bin/nvcc=)
   endif
 endif
 # ARM based.
@@ -454,6 +461,13 @@ KOKKOS_INTERNAL_USE_ARCH_AMD_GFX1100 := $(call kokkos_has_string,$(KOKKOS_ARCH),
 ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AMD_GFX1100), 0)
   KOKKOS_INTERNAL_USE_ARCH_AMD_GFX1100 := $(call kokkos_has_string,$(KOKKOS_ARCH),NAVI1100)
 endif
+KOKKOS_INTERNAL_USE_ARCH_AMD := $(shell expr $(KOKKOS_INTERNAL_USE_ARCH_AMD_GFX906)  \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_AMD_GFX908)  \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_AMD_GFX90A)  \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_AMD_GFX940)  \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_AMD_GFX942) \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_AMD_GFX1030) \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_AMD_GFX1100))
 
 # Any AVX?
 KOKKOS_INTERNAL_USE_ARCH_AVX        := $(shell expr $(KOKKOS_INTERNAL_USE_ARCH_SNB) + $(KOKKOS_INTERNAL_USE_ARCH_AMDAVX))
@@ -1000,90 +1014,127 @@ ifeq ($(KOKKOS_INTERNAL_USE_OPENMPTARGET), 1)
   ifeq ($(KOKKOS_INTERNAL_COMPILER_CRAY_CLANG), 1)
     KOKKOS_INTERNAL_CUDA_ARCH_FLAG=-fopenmp
     else ifeq ($(KOKKOS_INTERNAL_COMPILER_CLANG), 1)
-      KOKKOS_INTERNAL_CUDA_ARCH_FLAG=-fopenmp --offload-arch
+      KOKKOS_INTERNAL_CUDA_ARCH_FLAG=-fopenmp -fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target=nvptx64-nvidia-cuda -march
+  endif
+endif
+
+ifeq ($(KOKKOS_INTERNAL_USE_OPENACC), 1)
+  ifeq ($(KOKKOS_INTERNAL_COMPILER_CLANG), 1)
+      KOKKOS_INTERNAL_CUDA_ARCH_FLAG=-fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target=nvptx64-nvidia-cuda -march
+      KOKKOS_INTERNAL_AMD_ARCH_FLAG=-fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march
   endif
 endif
 
 # Do not add this flag if its the cray compiler or the nvhpc compiler.
 ifeq ($(KOKKOS_INTERNAL_COMPILER_CRAY_CLANG), 0)
-  ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
-    # Lets start with adding architecture defines
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_KEPLER30), 1)
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_KEPLER")
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_KEPLER30")
+  # Lets start with adding architecture defines
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_KEPLER30), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_KEPLER")
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_KEPLER30")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_30
     endif
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_KEPLER32), 1)
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_KEPLER")
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_KEPLER32")
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_KEPLER32), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_KEPLER")
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_KEPLER32")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_32
     endif
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_KEPLER35), 1)
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_KEPLER")
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_KEPLER35")
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_KEPLER35), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_KEPLER")
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_KEPLER35")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_35
     endif
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_KEPLER37), 1)
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_KEPLER")
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_KEPLER37")
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_KEPLER37), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_KEPLER")
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_KEPLER37")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_37
     endif
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_MAXWELL50), 1)
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_MAXWELL")
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_MAXWELL50")
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_MAXWELL50), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_MAXWELL")
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_MAXWELL50")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_50
     endif
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_MAXWELL52), 1)
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_MAXWELL")
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_MAXWELL52")
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_MAXWELL52), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_MAXWELL")
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_MAXWELL52")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_52
     endif
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_MAXWELL53), 1)
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_MAXWELL")
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_MAXWELL53")
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_MAXWELL53), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_MAXWELL")
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_MAXWELL53")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_53
     endif
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_PASCAL60), 1)
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_PASCAL")
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_PASCAL60")
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_PASCAL60), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_PASCAL")
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_PASCAL60")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_60
     endif
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_PASCAL61), 1)
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_PASCAL")
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_PASCAL61")
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_PASCAL61), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_PASCAL")
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_PASCAL61")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_61
     endif
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_VOLTA70), 1)
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_VOLTA")
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_VOLTA70")
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_VOLTA70), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_VOLTA")
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_VOLTA70")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_70
     endif
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_VOLTA72), 1)
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_VOLTA")
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_VOLTA72")
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_VOLTA72), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_VOLTA")
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_VOLTA72")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_72
     endif
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_TURING75), 1)
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_TURING75")
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_TURING75), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_TURING75")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_75
     endif
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AMPERE80), 1)
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMPERE")
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMPERE80")
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AMPERE80), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMPERE")
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMPERE80")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_80
     endif
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AMPERE86), 1)
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMPERE")
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMPERE86")
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AMPERE86), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMPERE")
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMPERE86")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_86
     endif
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_ADA89), 1)
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_ADA89")
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_ADA89), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_ADA89")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_89
     endif
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_HOPPER90), 1)
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_HOPPER")
-      tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_HOPPER90")
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_HOPPER90), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_HOPPER")
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_HOPPER90")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_90
     endif
   endif
@@ -1099,6 +1150,9 @@ ifneq ($(KOKKOS_INTERNAL_USE_ARCH_NVIDIA), 0)
     ifeq ($(KOKKOS_INTERNAL_USE_OPENMPTARGET), 1)
       KOKKOS_LDFLAGS += $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)
     endif
+    ifeq ($(KOKKOS_INTERNAL_USE_OPENACC), 1)
+      KOKKOS_LDFLAGS += $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)
+    endif
   endif
 endif
 
@@ -1108,36 +1162,43 @@ ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AMD_GFX906), 1)
   tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMD_GFX906")
   tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMD_GPU")
   KOKKOS_INTERNAL_HIP_ARCH_FLAG := --offload-arch=gfx906
+  KOKKOS_INTERNAL_AMD_ARCH_FLAG := $(KOKKOS_INTERNAL_AMD_ARCH_FLAG)=gfx906
 endif
 ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AMD_GFX908), 1)
   tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMD_GFX908")
   tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMD_GPU")
   KOKKOS_INTERNAL_HIP_ARCH_FLAG := --offload-arch=gfx908
+  KOKKOS_INTERNAL_AMD_ARCH_FLAG := $(KOKKOS_INTERNAL_AMD_ARCH_FLAG)=gfx908
 endif
 ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AMD_GFX90A), 1)
   tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMD_GFX90A")
   tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMD_GPU")
   KOKKOS_INTERNAL_HIP_ARCH_FLAG := --offload-arch=gfx90a
+  KOKKOS_INTERNAL_AMD_ARCH_FLAG := $(KOKKOS_INTERNAL_AMD_ARCH_FLAG)=gfx90a
 endif
 ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AMD_GFX940), 1)
   tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMD_GFX940")
   tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMD_GPU")
   KOKKOS_INTERNAL_HIP_ARCH_FLAG := --offload-arch=gfx940
+  KOKKOS_INTERNAL_AMD_ARCH_FLAG := $(KOKKOS_INTERNAL_AMD_ARCH_FLAG)=gfx940
 endif
 ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AMD_GFX942), 1)
   tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMD_GFX942")
   tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMD_GPU")
   KOKKOS_INTERNAL_HIP_ARCH_FLAG := --offload-arch=gfx942
+  KOKKOS_INTERNAL_AMD_ARCH_FLAG := $(KOKKOS_INTERNAL_AMD_ARCH_FLAG)=gfx942
 endif
 ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AMD_GFX1030), 1)
   tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMD_GFX1030")
   tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMD_GPU")
   KOKKOS_INTERNAL_HIP_ARCH_FLAG := --offload-arch=gfx1030
+  KOKKOS_INTERNAL_AMD_ARCH_FLAG := $(KOKKOS_INTERNAL_AMD_ARCH_FLAG)=gfx1030
 endif
 ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AMD_GFX1100), 1)
   tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMD_GFX1100")
   tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMD_GPU")
   KOKKOS_INTERNAL_HIP_ARCH_FLAG := --offload-arch=gfx1100
+  KOKKOS_INTERNAL_AMD_ARCH_FLAG := $(KOKKOS_INTERNAL_AMD_ARCH_FLAG)=gfx1100
 endif
 
 
@@ -1156,6 +1217,15 @@ ifeq ($(KOKKOS_INTERNAL_USE_HIP), 1)
   else
     KOKKOS_CXXFLAGS+=-fno-gpu-rdc
     KOKKOS_LDFLAGS+=-fno-gpu-rdc
+  endif
+endif
+
+ifneq ($(KOKKOS_INTERNAL_USE_ARCH_AMD), 0)
+  ifeq ($(KOKKOS_INTERNAL_COMPILER_CLANG), 1)
+    ifeq ($(KOKKOS_INTERNAL_USE_OPENACC), 1)
+      KOKKOS_CXXFLAGS += $(KOKKOS_INTERNAL_AMD_ARCH_FLAG)
+      KOKKOS_LDFLAGS += $(KOKKOS_INTERNAL_AMD_ARCH_FLAG)
+    endif
   endif
 endif
 
@@ -1349,6 +1419,43 @@ ifeq ($(KOKKOS_INTERNAL_USE_OPENACC), 1)
   KOKKOS_CXXFLAGS += $(KOKKOS_INTERNAL_OPENACC_FLAG)
   KOKKOS_LDFLAGS += $(KOKKOS_INTERNAL_OPENACC_FLAG)
   KOKKOS_LIBS += $(KOKKOS_INTERNAL_OPENACC_LIB)
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_NVIDIA), 1)
+    ifneq ($(CUDA_PATH),)
+      ifeq ($(call kokkos_path_exists,$(CUDA_PATH)/lib), 1)
+        CUDA_PATH := $(CUDA_PATH:/compilers=/cuda)
+      endif
+    endif
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_CLANG), 1)
+      ifneq ($(CUDA_PATH),)
+        KOKKOS_LDFLAGS += -L$(CUDA_PATH)/lib64
+      endif
+      KOKKOS_LIBS += -lcudart
+    endif
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 1)
+      ifneq ($(CUDA_PATH),)
+        KOKKOS_LDFLAGS += -L$(CUDA_PATH)/lib64
+      endif
+      KOKKOS_LIBS += -lcudart
+    endif
+  else ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AMD), 1)
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_CLANG), 1)
+      ifneq ($(ROCM_PATH),)
+        KOKKOS_CPPFLAGS += -I$(ROCM_PATH)/include
+        KOKKOS_LDFLAGS += -L$(ROCM_PATH)/lib
+      endif
+      KOKKOS_LIBS += -lamdhip64
+    endif
+  else
+    # When not compiling for offload to any GPU, we're compiling for kernel
+    # execution on the host.  In that case, memory is shared between the OpenACC
+    # space and the host space.
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_CLANG), 1)
+      KOKKOS_CXXFLAGS += -DKOKKOS_OPENACC_WITHOUT_GPU
+    endif
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 1)
+      KOKKOS_CXXFLAGS += -DKOKKOS_OPENACC_WITHOUT_GPU -acc=multicore
+    endif
+  endif
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_OPENMP), 1)

--- a/cmake/kokkos_enable_devices.cmake
+++ b/cmake/kokkos_enable_devices.cmake
@@ -63,7 +63,7 @@ KOKKOS_DEVICE_OPTION(HPX OFF HOST "Whether to build HPX backend (experimental)")
 KOKKOS_DEVICE_OPTION(OPENACC OFF DEVICE "Whether to build the OpenACC backend")
 IF (KOKKOS_ENABLE_OPENACC)
   COMPILER_SPECIFIC_FLAGS(
-    Clang -fopenacc -fopenacc-fake-async-wait
+    Clang -fopenacc -fopenacc-fake-async-wait -fopenacc-implicit-worker=vector
           -Wno-openacc-and-cxx -Wno-openmp-mapping -Wno-unknown-cuda-version
           -Wno-pass-failed
   )

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -613,6 +613,7 @@ IF(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_RangePolicy.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_RangePolicyRequire.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_Reducers_a.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_Reducers_c.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_Reducers_d.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_Reductions.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_Reductions_DeviceView.cpp
@@ -639,6 +640,8 @@ IF(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewMemoryAccessViolation.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_WithoutInitializing.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewAPI_d.cpp
+	#Below test is disabled because it uses atomic operations not supported by Clacc.
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ExecSpaceThreadSafety.cpp
     )
   # When tested on a systme with AMD MI60 GPU and ROCm V5.4.0, these cause
   # clang-linker-wrapper to hang for a long time while building the unit tests.
@@ -979,11 +982,16 @@ endif()
 
 # FIXME_OPENACC - Comment non-passing tests with the Clang compiler
 if (KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
-  SET(DEFAULT_DEVICE_SOURCES
-    TestCompilerMacros.cpp
-    UnitTestMainInit.cpp
-    TestInitializationSettings.cpp
-    TestParseCmdLineArgsAndEnvVars.cpp
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES
+    default/TestDefaultDeviceType_a1.cpp
+    default/TestDefaultDeviceType_b1.cpp
+    default/TestDefaultDeviceType_c1.cpp
+    default/TestDefaultDeviceType_a2.cpp
+    default/TestDefaultDeviceType_b2.cpp
+    default/TestDefaultDeviceType_c2.cpp
+    default/TestDefaultDeviceType_a3.cpp
+    default/TestDefaultDeviceType_b3.cpp
+    default/TestDefaultDeviceType_c3.cpp
     default/TestDefaultDeviceType_d.cpp
     default/TestDefaultDeviceTypeResize.cpp
     default/TestDefaultDeviceTypeViewAPI.cpp

--- a/core/unit_test/TestAbort.hpp
+++ b/core/unit_test/TestAbort.hpp
@@ -103,5 +103,12 @@ void test_abort_from_device() {
 
 TEST(TEST_CATEGORY_DEATH, abort_from_device) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+// FIXME_OPENACC FIXME_NVHPC: NVHPC fails when targetting CPUs.
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC) && \
+    defined(KOKKOS_OPENACC_WITHOUT_GPU)
+  GTEST_SKIP()
+      << "skipping since the OpenACC backend compiled by NVHPC for CPU "
+         "crashes at runtime.";
+#endif
   test_abort_from_device<TEST_EXECSPACE>();
 }

--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -78,8 +78,10 @@ void run_exec_space_thread_safety_range() {
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_range) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
+#ifdef KOKKOS_OPENACC_WITHOUT_GPU
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
     GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
+#endif
 #endif
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
@@ -118,6 +120,12 @@ void run_exec_space_thread_safety_mdrange() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange) {
+#ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
+#ifdef KOKKOS_OPENACC_WITHOUT_GPU
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+    GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
+#endif
+#endif
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP() << "skipping since test is known to fail for OpenMPTarget";
@@ -157,6 +165,12 @@ void run_exec_space_thread_safety_team_policy() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy) {
+#ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
+#ifdef KOKKOS_OPENACC_WITHOUT_GPU
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+    GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
+#endif
+#endif
 // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
@@ -196,6 +210,12 @@ void run_exec_space_thread_safety_range_reduce() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_range_reduce) {
+#ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
+#ifdef KOKKOS_OPENACC_WITHOUT_GPU
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+    GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
+#endif
+#endif
   run_exec_space_thread_safety_range_reduce();
 }
 
@@ -230,6 +250,12 @@ void run_exec_space_thread_safety_mdrange_reduce() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange_reduce) {
+#ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
+#ifdef KOKKOS_OPENACC_WITHOUT_GPU
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+    GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
+#endif
+#endif
 // FIXME_INTEL
 #if defined(KOKKOS_COMPILER_INTEL) && defined(KOKKOS_ENABLE_OPENMP)
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::OpenMP>)
@@ -271,6 +297,12 @@ void run_exec_space_thread_safety_team_policy_reduce() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy_reduce) {
+#ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
+#ifdef KOKKOS_OPENACC_WITHOUT_GPU
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+    GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
+#endif
+#endif
 // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -317,6 +317,14 @@ TEST(simd, device_math_ops) {
          "Failure to synchronize stream (nil): Error in "
          "cuStreamSynchronize: an illegal memory access was encountered";
 #endif
+#ifdef KOKKOS_ENABLE_OPENACC
+#ifdef KOKKOS_COMPILER_CLANG  // FIXME_CLACC
+  GTEST_SKIP()
+      << "skipping because of a non-deterministic failure reporting: "
+         "Failure to synchronize stream (nil): Error in "
+         "cuStreamSynchronize: an illegal memory access was encountered";
+#endif
+#endif
   Kokkos::parallel_for(1, simd_device_math_ops_functor());
 }
 

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -186,6 +186,14 @@ TEST(simd, device_reductions) {
          "Failure to synchronize stream (nil): Error in "
          "cuStreamSynchronize: an illegal memory access was encountered";
 #endif
+#ifdef KOKKOS_ENABLE_OPENACC
+#ifdef KOKKOS_COMPILER_CLANG  // FIXME_CLACC
+  GTEST_SKIP()
+      << "skipping because of a non-deterministic failure reporting: "
+         "Failure to synchronize stream (nil): Error in "
+         "cuStreamSynchronize: an illegal memory access was encountered";
+#endif
+#endif
   Kokkos::parallel_for(1, simd_device_reduction_functor());
 }
 

--- a/tpls/desul/include/desul/atomics/Macros.hpp
+++ b/tpls/desul/include/desul/atomics/Macros.hpp
@@ -58,7 +58,10 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #endif
 
 #if defined(DESUL_ATOMICS_ENABLE_OPENACC)
+#ifdef __NVCOMPILER
+// Enable OpenACC atomics only for NVHPC compiler
 #define DESUL_HAVE_OPENACC_ATOMICS
+#endif
 #endif
 
 // ONLY use GNUC atomics if not explicitly say to use OpenMP atomics


### PR DESCRIPTION
Update cmake and make configurations for Clacc/LLVM compiler to compile the OpenACC backend.
	- Disable the OpenACC atomic implementations when using Clacc.
	- Disable unsupported unit tests for Clacc.
	- Support optional CUDA_PATH and ROCM_PATH, which are used for the OpenACC backend to calculate concurrency for NVIDIA GPUs and AMD GPUs (actual OpenACC bakcend implementation will be added in a separate PR).