### PR TITLE
Add workflow to create releases with SLSA provenance generation

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,83 @@
+on:
+  push:
+    tags: '[0-9]+.[0-9]+.[0-9][0-9]'
+  
+
+permissions: read-all
+
+jobs:
+  # This step builds our artifacts, uploads them to the workflow run, and
+  # outputs their digest.
+  build:
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build artifacts
+        run: |
+          git archive -o kokkos-${{ github.ref_name }}.zip HEAD
+          git archive -o kokkos-${{ github.ref_name }}.tar.gz HEAD
+
+      - name: Generate hashes
+        shell: bash
+        id: hash
+        run: |
+          # sha256sum generates sha256 hash for all artifacts.
+          # base64 -w0 encodes to base64 and outputs on a single line.
+          echo "hashes=$(sha256sum kokkos-${{ github.ref_name }}.zip kokkos-${{ github.ref_name }}.tar.gz | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload source code (zip)
+        uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
+        with:
+          name: kokkos-${{ github.ref_name }}.zip
+          path: kokkos-${{ github.ref_name }}.zip
+          if-no-files-found: error
+          retention-days: 5
+
+      - name: Upload source code (tar.gz)
+        uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
+        with:
+          name: kokkos-${{ github.ref_name }}.tar.gz
+          path: kokkos-${{ github.ref_name }}.tar.gz
+          if-no-files-found: error
+          retention-days: 5
+
+  # This step calls the generic workflow to generate provenance.
+  provenance:
+    needs: [build]
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    with:
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      # Upload provenance to a new release
+      upload-assets: true
+      provenance-name: "kokkos-${{ github.ref_name }}.intoto.jsonl"
+
+  # This step uploads our artifacts to the tagged GitHub release.
+  release:
+    needs: [build, provenance]
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Download kokkos-${{ github.ref_name }}.zip
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: kokkos-${{ github.ref_name }}.zip
+
+      - name: Download kokkos-${{ github.ref_name }}.tar.gz
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: kokkos-${{ github.ref_name }}.tar.gz
+
+      - name: Upload assets
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
+        with:
+          files: |
+            kokkos-${{ github.ref_name }}.zip
+            kokkos-${{ github.ref_name }}.tar.gz


### PR DESCRIPTION
Will publish a release with tar.gz and zip archive artifacts and intoto.jsonl signature file when a tag is pushed to the repo