### PR TITLE
Ignore codebase formatting commits in the blame view

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# Moved to clang-format-16
+60fb9cc94b40e698cbc3278c5538f58dee721276
+# Formatted the entire codebase with ClangFormat 8
+dd82c94f703311cda63d31d2893c09a43bd59106

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
 # Moved to clang-format-16
 60fb9cc94b40e698cbc3278c5538f58dee721276
 # Formatted the entire codebase with ClangFormat 8
-dd82c94f703311cda63d31d2893c09a43bd59106
+77d8965fa2b123e5172ac5ea361e731f7fc52fc8


### PR DESCRIPTION
See [blog post](https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/) and [doc](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revltrevgt)

60fb9cc94b40e698cbc3278c5538f58dee721276 [clang-format-16] <- actual commit that applies clang-format
~~dd82c94f703311cda63d31d2893c09a43bd59106 [clang-format-8] <- merge commit~~
77d8965fa2b123e5172ac5ea361e731f7fc52fc8 [clang-format-8] <- merge commit