### PR TITLE
Do not add CI and other tools configuration files to archive files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+.clang* export-ignore
+.git* export-ignore
+.jenkins* export-ignore
+.appveyor.yml export-ignore
+.*gitlab-ci.yml export-ignore
+scripts/ export-ignore


### PR DESCRIPTION
Ignore `scripts/` directory and configuration files when producing archive files for releases