### PR TITLE
Cuda: Check if device support cudaMallocAsync

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -179,6 +179,7 @@ void *impl_allocate_common(const int device_id,
 #ifndef CUDART_VERSION
 #error CUDART_VERSION undefined!
 #elif (defined(KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC) && CUDART_VERSION >= 11020)
+  // FIXME_KEPLER Everything after Kepler should support cudaMallocAsync
   int device_supports_cuda_malloc_async;
   KOKKOS_IMPL_CUDA_SAFE_CALL(
       cudaDeviceGetAttribute(&device_supports_cuda_malloc_async,

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -185,7 +185,7 @@ void *impl_allocate_common(const int device_id,
                              cudaDevAttrMemoryPoolsSupported, device_id));
 
   if (arg_alloc_size >= memory_threshold_g &&
-      device_supports_cuda_malloc_async) {
+      device_supports_cuda_malloc_async == 1) {
     error_code = cudaMallocAsync(&ptr, arg_alloc_size, stream);
 
     if (error_code == cudaSuccess) {

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -179,7 +179,13 @@ void *impl_allocate_common(const int device_id,
 #ifndef CUDART_VERSION
 #error CUDART_VERSION undefined!
 #elif (defined(KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC) && CUDART_VERSION >= 11020)
-  if (arg_alloc_size >= memory_threshold_g) {
+  int device_supports_cuda_malloc_async;
+  KOKKOS_IMPL_CUDA_SAFE_CALL(
+      cudaDeviceGetAttribute(&device_supports_cuda_malloc_async,
+                             cudaDevAttrMemoryPoolsSupported, device_id));
+
+  if (arg_alloc_size >= memory_threshold_g &&
+      device_supports_cuda_malloc_async) {
     error_code = cudaMallocAsync(&ptr, arg_alloc_size, stream);
 
     if (error_code == cudaSuccess) {


### PR DESCRIPTION
Fixes #7044. According to https://developer.nvidia.com/blog/cuda-pro-tip-the-fast-way-to-query-device-properties, this should be fast so checking for every allocation should not be noticeable.