### PR TITLE
Simplify constraints for trivial types

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1363,9 +1363,7 @@ struct ZeroMemset {
 
 template <typename ExecutionSpace, class DT, class... DP>
 inline std::enable_if_t<
-    std::is_trivial<typename ViewTraits<DT, DP...>::value_type>::value &&
-    std::is_trivially_copy_assignable<
-        typename ViewTraits<DT, DP...>::value_type>::value>
+    std::is_trivial_v<typename ViewTraits<DT, DP...>::value_type>>
 contiguous_fill_or_memset(
     const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {
@@ -1386,9 +1384,7 @@ contiguous_fill_or_memset(
 
 template <typename ExecutionSpace, class DT, class... DP>
 inline std::enable_if_t<
-    !(std::is_trivial<typename ViewTraits<DT, DP...>::value_type>::value &&
-      std::is_trivially_copy_assignable<
-          typename ViewTraits<DT, DP...>::value_type>::value)>
+    !std::is_trivial_v<typename ViewTraits<DT, DP...>::value_type>>
 contiguous_fill_or_memset(
     const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {
@@ -1397,9 +1393,7 @@ contiguous_fill_or_memset(
 
 template <class DT, class... DP>
 inline std::enable_if_t<
-    std::is_trivial<typename ViewTraits<DT, DP...>::value_type>::value &&
-    std::is_trivially_copy_assignable<
-        typename ViewTraits<DT, DP...>::value_type>::value>
+    std::is_trivial_v<typename ViewTraits<DT, DP...>::value_type>>
 contiguous_fill_or_memset(
     const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {
@@ -1423,9 +1417,7 @@ contiguous_fill_or_memset(
 
 template <class DT, class... DP>
 inline std::enable_if_t<
-    !(std::is_trivial<typename ViewTraits<DT, DP...>::value_type>::value &&
-      std::is_trivially_copy_assignable<
-          typename ViewTraits<DT, DP...>::value_type>::value)>
+    !std::is_trivial_v<typename ViewTraits<DT, DP...>::value_type>>
 contiguous_fill_or_memset(
     const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -105,9 +105,7 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
   }
 
   template <typename Dummy = ValueType>
-  std::enable_if_t<std::is_trivial<Dummy>::value &&
-                   std::is_trivially_copy_assignable<ValueType>::value>
-  construct_dispatch() {
+  std::enable_if_t<std::is_trivial_v<Dummy>> construct_dispatch() {
     ValueType value{};
 // On A64FX memset seems to do the wrong thing with regards to first touch
 // leading to the significant performance issues
@@ -141,9 +139,7 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
   }
 
   template <typename Dummy = ValueType>
-  std::enable_if_t<!(std::is_trivial<Dummy>::value &&
-                     std::is_trivially_copy_assignable<ValueType>::value)>
-  construct_dispatch() {
+  std::enable_if_t<!std::is_trivial_v<Dummy>> construct_dispatch() {
     parallel_for_implementation<ConstructTag>();
   }
 
@@ -241,9 +237,7 @@ struct ViewValueFunctor<DeviceType, ValueType, true /* is_scalar */> {
         default_exec_space(true) {}
 
   template <typename Dummy = ValueType>
-  std::enable_if_t<std::is_trivial<Dummy>::value &&
-                   std::is_trivially_copy_assignable<Dummy>::value>
-  construct_shared_allocation() {
+  std::enable_if_t<std::is_trivial_v<Dummy>> construct_shared_allocation() {
     // Shortcut for zero initialization
 // On A64FX memset seems to do the wrong thing with regards to first touch
 // leading to the significant performance issues
@@ -279,9 +273,7 @@ struct ViewValueFunctor<DeviceType, ValueType, true /* is_scalar */> {
   }
 
   template <typename Dummy = ValueType>
-  std::enable_if_t<!(std::is_trivial<Dummy>::value &&
-                     std::is_trivially_copy_assignable<Dummy>::value)>
-  construct_shared_allocation() {
+  std::enable_if_t<!std::is_trivial_v<Dummy>> construct_shared_allocation() {
     parallel_for_implementation();
   }
 


### PR DESCRIPTION
By definition, a trivial type is trivially-copyable [class.prop#2](https://eel.is/c++draft/class.prop#2) and a trivially-copyable type is trivially-assignable [class.prop#1](https://eel.is/c++draft/class.prop#1)