### PR TITLE
Hands off reserved identifiers

### DIFF
--- a/algorithms/src/sorting/Kokkos_BinOpsPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_BinOpsPublicAPI.hpp
@@ -35,11 +35,11 @@ struct BinOp1D {
 #endif
 
   // Construct BinOp with number of bins, minimum value and maximum value
-  BinOp1D(int max_bins__, typename KeyViewType::const_value_type min,
+  BinOp1D(int max_bins, typename KeyViewType::const_value_type min,
           typename KeyViewType::const_value_type max)
-      : max_bins_(max_bins__ + 1),
+      : max_bins_(max_bins + 1),
         // Cast to double to avoid possible overflow when using integer
-        mul_(static_cast<double>(max_bins__) /
+        mul_(static_cast<double>(max_bins) /
              (static_cast<double>(max) - static_cast<double>(min))),
         min_(static_cast<double>(min)) {
     // For integral types the number of bins may be larger than the range
@@ -47,7 +47,7 @@ struct BinOp1D {
     // and then don't need to sort bins.
     if (std::is_integral<typename KeyViewType::const_value_type>::value &&
         (static_cast<double>(max) - static_cast<double>(min)) <=
-            static_cast<double>(max_bins__)) {
+            static_cast<double>(max_bins)) {
       mul_ = 1.;
     }
   }
@@ -82,16 +82,16 @@ struct BinOp3D {
   BinOp3D() = delete;
 #endif
 
-  BinOp3D(int max_bins__[], typename KeyViewType::const_value_type min[],
+  BinOp3D(int max_bins[], typename KeyViewType::const_value_type min[],
           typename KeyViewType::const_value_type max[]) {
-    max_bins_[0] = max_bins__[0];
-    max_bins_[1] = max_bins__[1];
-    max_bins_[2] = max_bins__[2];
-    mul_[0]      = static_cast<double>(max_bins__[0]) /
+    max_bins_[0] = max_bins[0];
+    max_bins_[1] = max_bins[1];
+    max_bins_[2] = max_bins[2];
+    mul_[0]      = static_cast<double>(max_bins[0]) /
               (static_cast<double>(max[0]) - static_cast<double>(min[0]));
-    mul_[1] = static_cast<double>(max_bins__[1]) /
+    mul_[1] = static_cast<double>(max_bins[1]) /
               (static_cast<double>(max[1]) - static_cast<double>(min[1]));
-    mul_[2] = static_cast<double>(max_bins__[2]) /
+    mul_[2] = static_cast<double>(max_bins[2]) /
               (static_cast<double>(max[2]) - static_cast<double>(min[2]));
     min_[0] = static_cast<double>(min[0]);
     min_[1] = static_cast<double>(min[1]);

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -68,9 +68,9 @@ struct ViewValueFunctor<DeviceType, ValueType, /*IsTrivial=*/false> {
   std::string name;
   bool default_exec_space;
 
-  template <class _ValueType = ValueType>
+  template <class SameValueType = ValueType>
   KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<std::is_default_constructible<_ValueType>::value>
+      std::enable_if_t<std::is_default_constructible<SameValueType>::value>
       operator()(ConstructTag const&, const size_t i) const {
     new (ptr + i) ValueType();
   }

--- a/core/unit_test/TestTeamScan.hpp
+++ b/core/unit_test/TestTeamScan.hpp
@@ -54,14 +54,14 @@ struct TestTeamScan {
                           });
   }
 
-  auto operator()(int32_t _M, int32_t _N) {
+  auto operator()(int32_t M_, int32_t N_) {
     std::stringstream ss;
     ss << Kokkos::Impl::demangle(typeid(*this).name());
-    ss << "(/*M=*/" << _M << ", /*N=*/" << _N << ")";
+    ss << "(/*M=*/" << M_ << ", /*N=*/" << N_ << ")";
     std::string const test_id = ss.str();
 
-    M   = _M;
-    N   = _N;
+    M   = M_;
+    N   = N_;
     a_d = view_type("a_d", M, N);
     a_r = view_type("a_r", M, N);
 
@@ -172,14 +172,14 @@ struct TestTeamScanRetVal {
     Kokkos::single(Kokkos::PerTeam(team), [&]() { a_s(leagueRank) = accum; });
   }
 
-  auto operator()(int32_t _M, int32_t _N) {
+  auto operator()(int32_t M_, int32_t N_) {
     std::stringstream ss;
     ss << Kokkos::Impl::demangle(typeid(*this).name());
-    ss << "(/*M=*/" << _M << ", /*N=*/" << _N << ")";
+    ss << "(/*M=*/" << M_ << ", /*N=*/" << N_ << ")";
     std::string const test_id = ss.str();
 
-    M   = _M;
-    N   = _N;
+    M   = M_;
+    N   = N_;
     a_d = view_2d_type("a_d", M, N);
     a_r = view_2d_type("a_r", M, N);
     a_s = view_1d_type("a_s", M);


### PR DESCRIPTION
Avoid our using identifiers that contain double underscore or that begin with an underscore followed by an uppercase letter.
Any program using them is "ill-formed, no diagnostic required".