### PR TITLE
Enforce modernize-type-traits

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,3 @@
-Checks: '-*,kokkos-*,modernize-use-using,modernize-use-nullptr,cppcoreguidelines-pro-type-cstyle-cast'
+Checks: '-*,kokkos-*,modernize-type-traits,modernize-use-using,modernize-use-nullptr,cppcoreguidelines-pro-type-cstyle-cast'
 FormatStyle: file
 HeaderFilterRegex: '(algorithms|benchmarks|containers|core|example|simd).*\.hpp'

--- a/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
@@ -77,12 +77,9 @@ namespace Kokkos::Impl {
 template <typename T>
 constexpr inline bool is_admissible_to_kokkos_sort_by_key =
     ::Kokkos::is_view<T>::value && T::rank() == 1 &&
-    (std::is_same<typename T::traits::array_layout,
-                  Kokkos::LayoutLeft>::value ||
-     std::is_same<typename T::traits::array_layout,
-                  Kokkos::LayoutRight>::value ||
-     std::is_same<typename T::traits::array_layout,
-                  Kokkos::LayoutStride>::value);
+    (std::is_same_v<typename T::traits::array_layout, Kokkos::LayoutLeft> ||
+     std::is_same_v<typename T::traits::array_layout, Kokkos::LayoutRight> ||
+     std::is_same_v<typename T::traits::array_layout, Kokkos::LayoutStride>);
 
 template <class ViewType>
 KOKKOS_INLINE_FUNCTION constexpr void
@@ -176,7 +173,7 @@ template <typename ExecutionSpace, typename PermutationView, typename ViewType>
 void applyPermutation(const ExecutionSpace& space,
                       const PermutationView& permutation,
                       const ViewType& view) {
-  static_assert(std::is_integral<typename PermutationView::value_type>::value);
+  static_assert(std::is_integral_v<typename PermutationView::value_type>);
 
   auto view_copy = Kokkos::create_mirror(
       Kokkos::view_alloc(space, typename ExecutionSpace::memory_space{},

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -146,7 +146,7 @@ void sort_via_binsort(const ExecutionSpace& exec,
   bool sort_in_bins = true;
   // TODO: figure out better max_bins then this ...
   int64_t max_bins = view.extent(0) / 2;
-  if (std::is_integral<typename ViewType::non_const_value_type>::value) {
+  if (std::is_integral_v<typename ViewType::non_const_value_type>) {
     // Cast to double to avoid possible overflow when using integer
     auto const max_val = static_cast<double>(result.max_val);
     auto const min_val = static_cast<double>(result.min_val);
@@ -157,7 +157,7 @@ void sort_via_binsort(const ExecutionSpace& exec,
       sort_in_bins = false;
     }
   }
-  if (std::is_floating_point<typename ViewType::non_const_value_type>::value) {
+  if (std::is_floating_point_v<typename ViewType::non_const_value_type>) {
     KOKKOS_ASSERT(std::isfinite(static_cast<double>(result.max_val) -
                                 static_cast<double>(result.min_val)));
   }

--- a/algorithms/src/std_algorithms/Kokkos_Reduce.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Reduce.hpp
@@ -91,7 +91,7 @@ template <typename ExecutionSpace, typename IteratorType, typename ValueType,
                            int> = 0>
 ValueType reduce(const ExecutionSpace& ex, IteratorType first,
                  IteratorType last, ValueType init_reduction_value) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   return Impl::reduce_default_functors_exespace_impl(
@@ -105,7 +105,7 @@ template <typename ExecutionSpace, typename IteratorType, typename ValueType,
 ValueType reduce(const std::string& label, const ExecutionSpace& ex,
                  IteratorType first, IteratorType last,
                  ValueType init_reduction_value) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   return Impl::reduce_default_functors_exespace_impl(label, ex, first, last,
@@ -119,7 +119,7 @@ template <typename ExecutionSpace, typename DataType, typename... Properties,
 ValueType reduce(const ExecutionSpace& ex,
                  const ::Kokkos::View<DataType, Properties...>& view,
                  ValueType init_reduction_value) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   namespace KE = ::Kokkos::Experimental;
@@ -137,7 +137,7 @@ template <typename ExecutionSpace, typename DataType, typename... Properties,
 ValueType reduce(const std::string& label, const ExecutionSpace& ex,
                  const ::Kokkos::View<DataType, Properties...>& view,
                  ValueType init_reduction_value) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   namespace KE = ::Kokkos::Experimental;
@@ -157,7 +157,7 @@ template <typename ExecutionSpace, typename IteratorType, typename ValueType,
 ValueType reduce(const ExecutionSpace& ex, IteratorType first,
                  IteratorType last, ValueType init_reduction_value,
                  BinaryOp joiner) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   return Impl::reduce_custom_functors_exespace_impl(
@@ -172,7 +172,7 @@ template <typename ExecutionSpace, typename IteratorType, typename ValueType,
 ValueType reduce(const std::string& label, const ExecutionSpace& ex,
                  IteratorType first, IteratorType last,
                  ValueType init_reduction_value, BinaryOp joiner) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   return Impl::reduce_custom_functors_exespace_impl(
@@ -186,7 +186,7 @@ template <typename ExecutionSpace, typename DataType, typename... Properties,
 ValueType reduce(const ExecutionSpace& ex,
                  const ::Kokkos::View<DataType, Properties...>& view,
                  ValueType init_reduction_value, BinaryOp joiner) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   namespace KE = ::Kokkos::Experimental;
@@ -204,7 +204,7 @@ template <typename ExecutionSpace, typename DataType, typename... Properties,
 ValueType reduce(const std::string& label, const ExecutionSpace& ex,
                  const ::Kokkos::View<DataType, Properties...>& view,
                  ValueType init_reduction_value, BinaryOp joiner) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   namespace KE = ::Kokkos::Experimental;
@@ -258,7 +258,7 @@ template <
 KOKKOS_FUNCTION ValueType reduce(const TeamHandleType& teamHandle,
                                  IteratorType first, IteratorType last,
                                  ValueType init_reduction_value) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   return Impl::reduce_default_functors_team_impl(teamHandle, first, last,
@@ -273,7 +273,7 @@ KOKKOS_FUNCTION ValueType
 reduce(const TeamHandleType& teamHandle,
        const ::Kokkos::View<DataType, Properties...>& view,
        ValueType init_reduction_value) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   namespace KE = ::Kokkos::Experimental;
@@ -294,7 +294,7 @@ KOKKOS_FUNCTION ValueType reduce(const TeamHandleType& teamHandle,
                                  IteratorType first, IteratorType last,
                                  ValueType init_reduction_value,
                                  BinaryOp joiner) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   return Impl::reduce_custom_functors_team_impl(teamHandle, first, last,
@@ -309,7 +309,7 @@ KOKKOS_FUNCTION ValueType
 reduce(const TeamHandleType& teamHandle,
        const ::Kokkos::View<DataType, Properties...>& view,
        ValueType init_reduction_value, BinaryOp joiner) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   namespace KE = ::Kokkos::Experimental;

--- a/algorithms/src/std_algorithms/Kokkos_TransformReduce.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_TransformReduce.hpp
@@ -117,7 +117,7 @@ ValueType transform_reduce(const ExecutionSpace& ex, IteratorType1 first1,
                            ValueType init_reduction_value,
                            BinaryJoinerType joiner,
                            BinaryTransform transformer) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   return Impl::transform_reduce_custom_functors_exespace_impl(
@@ -136,7 +136,7 @@ ValueType transform_reduce(const std::string& label, const ExecutionSpace& ex,
                            IteratorType2 first2, ValueType init_reduction_value,
                            BinaryJoinerType joiner,
                            BinaryTransform transformer) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   return Impl::transform_reduce_custom_functors_exespace_impl(
@@ -157,7 +157,7 @@ ValueType transform_reduce(
     ValueType init_reduction_value, BinaryJoinerType joiner,
     BinaryTransform transformer) {
   namespace KE = ::Kokkos::Experimental;
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(first_view);
@@ -182,7 +182,7 @@ ValueType transform_reduce(
     ValueType init_reduction_value, BinaryJoinerType joiner,
     BinaryTransform transformer) {
   namespace KE = ::Kokkos::Experimental;
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(first_view);
@@ -208,7 +208,7 @@ ValueType transform_reduce(const ExecutionSpace& ex, IteratorType first1,
                            IteratorType last1, ValueType init_reduction_value,
                            BinaryJoinerType joiner,
                            UnaryTransform transformer) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   return Impl::transform_reduce_custom_functors_exespace_impl(
@@ -228,7 +228,7 @@ ValueType transform_reduce(const std::string& label, const ExecutionSpace& ex,
                            ValueType init_reduction_value,
                            BinaryJoinerType joiner,
                            UnaryTransform transformer) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   return Impl::transform_reduce_custom_functors_exespace_impl(
@@ -248,7 +248,7 @@ ValueType transform_reduce(const ExecutionSpace& ex,
                            BinaryJoinerType joiner,
                            UnaryTransform transformer) {
   namespace KE = ::Kokkos::Experimental;
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view);
@@ -270,7 +270,7 @@ ValueType transform_reduce(const std::string& label, const ExecutionSpace& ex,
                            BinaryJoinerType joiner,
                            UnaryTransform transformer) {
   namespace KE = ::Kokkos::Experimental;
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view);
@@ -345,7 +345,7 @@ KOKKOS_FUNCTION ValueType transform_reduce(
     const TeamHandleType& teamHandle, IteratorType1 first1, IteratorType1 last1,
     IteratorType2 first2, ValueType init_reduction_value,
     BinaryJoinerType joiner, BinaryTransform transformer) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   return Impl::transform_reduce_custom_functors_team_impl(
@@ -366,7 +366,7 @@ transform_reduce(const TeamHandleType& teamHandle,
                  ValueType init_reduction_value, BinaryJoinerType joiner,
                  BinaryTransform transformer) {
   namespace KE = ::Kokkos::Experimental;
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(first_view);
@@ -393,7 +393,7 @@ KOKKOS_FUNCTION ValueType transform_reduce(const TeamHandleType& teamHandle,
                                            ValueType init_reduction_value,
                                            BinaryJoinerType joiner,
                                            UnaryTransform transformer) {
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   return Impl::transform_reduce_custom_functors_team_impl(
@@ -412,7 +412,7 @@ transform_reduce(const TeamHandleType& teamHandle,
                  ValueType init_reduction_value, BinaryJoinerType joiner,
                  UnaryTransform transformer) {
   namespace KE = ::Kokkos::Experimental;
-  static_assert(std::is_move_constructible<ValueType>::value,
+  static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view);

--- a/algorithms/src/std_algorithms/impl/Kokkos_Constraints.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Constraints.hpp
@@ -33,12 +33,12 @@ struct is_admissible_to_kokkos_std_algorithms : std::false_type {};
 template <typename T>
 struct is_admissible_to_kokkos_std_algorithms<
     T, std::enable_if_t<::Kokkos::is_view<T>::value && T::rank() == 1 &&
-                        (std::is_same<typename T::traits::array_layout,
-                                      Kokkos::LayoutLeft>::value ||
-                         std::is_same<typename T::traits::array_layout,
-                                      Kokkos::LayoutRight>::value ||
-                         std::is_same<typename T::traits::array_layout,
-                                      Kokkos::LayoutStride>::value)>>
+                        (std::is_same_v<typename T::traits::array_layout,
+                                        Kokkos::LayoutLeft> ||
+                         std::is_same_v<typename T::traits::array_layout,
+                                        Kokkos::LayoutRight> ||
+                         std::is_same_v<typename T::traits::array_layout,
+                                        Kokkos::LayoutStride>)>>
     : std::true_type {};
 
 template <class ViewType>
@@ -102,8 +102,8 @@ struct are_random_access_iterators;
 template <class T>
 struct are_random_access_iterators<T> {
   static constexpr bool value =
-      is_iterator_v<T> && std::is_base_of<std::random_access_iterator_tag,
-                                          typename T::iterator_category>::value;
+      is_iterator_v<T> && std::is_base_of_v<std::random_access_iterator_tag,
+                                            typename T::iterator_category>;
 };
 
 template <class Head, class... Tail>
@@ -165,9 +165,8 @@ struct iterators_have_matching_difference_type<T> {
 
 template <class T1, class T2>
 struct iterators_have_matching_difference_type<T1, T2> {
-  static constexpr bool value =
-      std::is_same<typename T1::difference_type,
-                   typename T2::difference_type>::value;
+  static constexpr bool value = std::is_same_v<typename T1::difference_type,
+                                               typename T2::difference_type>;
 };
 
 template <class T1, class T2, class... Tail>

--- a/algorithms/src/std_algorithms/impl/Kokkos_MoveBackward.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_MoveBackward.hpp
@@ -30,7 +30,7 @@ namespace Impl {
 template <class IteratorType1, class IteratorType2>
 struct StdMoveBackwardFunctor {
   using index_type = typename IteratorType1::difference_type;
-  static_assert(std::is_signed<index_type>::value,
+  static_assert(std::is_signed_v<index_type>,
                 "Kokkos: StdMoveBackwardFunctor requires signed index type");
 
   IteratorType1 m_last;

--- a/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
@@ -42,12 +42,12 @@ class RandomAccessIterator< ::Kokkos::View<DataType, Args...> > {
   using reference         = typename view_type::reference_type;
 
   static_assert(view_type::rank == 1 &&
-                    (std::is_same<typename view_type::traits::array_layout,
-                                  Kokkos::LayoutLeft>::value ||
-                     std::is_same<typename view_type::traits::array_layout,
-                                  Kokkos::LayoutRight>::value ||
-                     std::is_same<typename view_type::traits::array_layout,
-                                  Kokkos::LayoutStride>::value),
+                    (std::is_same_v<typename view_type::traits::array_layout,
+                                    Kokkos::LayoutLeft> ||
+                     std::is_same_v<typename view_type::traits::array_layout,
+                                    Kokkos::LayoutRight> ||
+                     std::is_same_v<typename view_type::traits::array_layout,
+                                    Kokkos::LayoutStride>),
                 "RandomAccessIterator only supports 1D Views with LayoutLeft, "
                 "LayoutRight, LayoutStride.");
 

--- a/algorithms/src/std_algorithms/impl/Kokkos_Reverse.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Reverse.hpp
@@ -30,7 +30,7 @@ namespace Impl {
 template <class InputIterator>
 struct StdReverseFunctor {
   using index_type = typename InputIterator::difference_type;
-  static_assert(std::is_signed<index_type>::value,
+  static_assert(std::is_signed_v<index_type>,
                 "Kokkos: StdReverseFunctor requires signed index type");
 
   InputIterator m_first;

--- a/algorithms/src/std_algorithms/impl/Kokkos_ReverseCopy.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ReverseCopy.hpp
@@ -30,7 +30,7 @@ namespace Impl {
 template <class InputIterator, class OutputIterator>
 struct StdReverseCopyFunctor {
   using index_type = typename InputIterator::difference_type;
-  static_assert(std::is_signed<index_type>::value,
+  static_assert(std::is_signed_v<index_type>,
                 "Kokkos: StdReverseCopyFunctor requires signed index type");
 
   InputIterator m_last;

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -534,10 +534,10 @@ void fill_views_inc(ViewType view, ViewHostType host_view) {
 }
 
 template <class ValueType, class ViewType>
-std::enable_if_t<!std::is_same<typename ViewType::traits::array_layout,
-                               Kokkos::LayoutStride>::value>
+std::enable_if_t<!std::is_same_v<typename ViewType::traits::array_layout,
+                                 Kokkos::LayoutStride>>
 verify_values(ValueType expected, const ViewType view) {
-  static_assert(std::is_same<ValueType, typename ViewType::value_type>::value,
+  static_assert(std::is_same_v<ValueType, typename ViewType::value_type>,
                 "Non-matching value types of view and reference value");
   auto view_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), view);
   for (std::size_t i = 0; i < view_h.extent(0); i++) {
@@ -546,10 +546,10 @@ verify_values(ValueType expected, const ViewType view) {
 }
 
 template <class ValueType, class ViewType>
-std::enable_if_t<std::is_same<typename ViewType::traits::array_layout,
-                              Kokkos::LayoutStride>::value>
+std::enable_if_t<std::is_same_v<typename ViewType::traits::array_layout,
+                                Kokkos::LayoutStride>>
 verify_values(ValueType expected, const ViewType view) {
-  static_assert(std::is_same<ValueType, typename ViewType::value_type>::value,
+  static_assert(std::is_same_v<ValueType, typename ViewType::value_type>,
                 "Non-matching value types of view and reference value");
 
   using non_strided_view_t = Kokkos::View<typename ViewType::value_type*>;
@@ -566,11 +566,11 @@ verify_values(ValueType expected, const ViewType view) {
 }
 
 template <class ViewType1, class ViewType2>
-std::enable_if_t<!std::is_same<typename ViewType2::traits::array_layout,
-                               Kokkos::LayoutStride>::value>
+std::enable_if_t<!std::is_same_v<typename ViewType2::traits::array_layout,
+                                 Kokkos::LayoutStride>>
 compare_views(ViewType1 expected, const ViewType2 actual) {
-  static_assert(std::is_same<typename ViewType1::value_type,
-                             typename ViewType2::value_type>::value,
+  static_assert(std::is_same_v<typename ViewType1::value_type,
+                               typename ViewType2::value_type>,
                 "Non-matching value types of expected and actual view");
   auto expected_h =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), expected);
@@ -583,11 +583,11 @@ compare_views(ViewType1 expected, const ViewType2 actual) {
 }
 
 template <class ViewType1, class ViewType2>
-std::enable_if_t<std::is_same<typename ViewType2::traits::array_layout,
-                              Kokkos::LayoutStride>::value>
+std::enable_if_t<std::is_same_v<typename ViewType2::traits::array_layout,
+                                Kokkos::LayoutStride>>
 compare_views(ViewType1 expected, const ViewType2 actual) {
-  static_assert(std::is_same<typename ViewType1::value_type,
-                             typename ViewType2::value_type>::value,
+  static_assert(std::is_same_v<typename ViewType1::value_type,
+                               typename ViewType2::value_type>,
                 "Non-matching value types of expected and actual view");
 
   using non_strided_view_t = Kokkos::View<typename ViewType2::value_type*>;

--- a/algorithms/unit_tests/TestStdAlgorithmsHelperFunctors.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsHelperFunctors.hpp
@@ -104,7 +104,7 @@ struct AssignIndexFunctor {
 
 template <class ValueType>
 struct IsEvenFunctor {
-  static_assert(std::is_integral<ValueType>::value,
+  static_assert(std::is_integral_v<ValueType>,
                 "IsEvenFunctor uses operator%, so ValueType must be int");
 
   KOKKOS_INLINE_FUNCTION

--- a/algorithms/unit_tests/TestStdAlgorithmsModOps.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsModOps.cpp
@@ -48,7 +48,7 @@ struct MyMovableType {
 TEST(std_algorithms_mod_ops_test, move) {
   MyMovableType a;
   using move_t = decltype(std::move(a));
-  static_assert(std::is_rvalue_reference<move_t>::value);
+  static_assert(std::is_rvalue_reference_v<move_t>);
 
   // move constr
   MyMovableType b(std::move(a));

--- a/algorithms/unit_tests/TestStdAlgorithmsPartitionCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsPartitionCopy.cpp
@@ -110,9 +110,9 @@ void verify_data(const std::string& name, ResultType my_result,
                  ViewTypeDestFalse view_dest_false, PredType pred) {
   using value_type = typename ViewTypeFrom::value_type;
   static_assert(
-      std::is_same<value_type, typename ViewTypeDestTrue::value_type>::value);
+      std::is_same_v<value_type, typename ViewTypeDestTrue::value_type>);
   static_assert(
-      std::is_same<value_type, typename ViewTypeDestFalse::value_type>::value);
+      std::is_same_v<value_type, typename ViewTypeDestFalse::value_type>);
 
   const std::size_t ext = view_from.extent(0);
 

--- a/algorithms/unit_tests/TestStdAlgorithmsTransformExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTransformExclusiveScan.cpp
@@ -161,7 +161,7 @@ void verify_data(ViewType1 data_view,  // contains data
       create_mirror_view_and_copy(Kokkos::HostSpace(), test_view_dc);
   if (test_view_h.extent(0) > 0) {
     for (std::size_t i = 0; i < test_view_h.extent(0); ++i) {
-      if (std::is_same<gold_view_value_type, int>::value) {
+      if (std::is_same_v<gold_view_value_type, int>) {
         ASSERT_EQ(gold_h(i), test_view_h(i));
       } else {
         const auto error = std::abs(gold_h(i) - test_view_h(i));

--- a/algorithms/unit_tests/TestStdAlgorithmsTransformInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTransformInclusiveScan.cpp
@@ -173,7 +173,7 @@ void verify_data(ViewType1 data_view,  // contains data
       create_mirror_view_and_copy(Kokkos::HostSpace(), test_view_dc);
   if (test_view_h.extent(0) > 0) {
     for (std::size_t i = 0; i < test_view_h.extent(0); ++i) {
-      if (std::is_same<gold_view_value_type, int>::value) {
+      if (std::is_same_v<gold_view_value_type, int>) {
         ASSERT_EQ(gold_h(i), test_view_h(i));
       } else {
         const auto error = std::abs(gold_h(i) - test_view_h(i));

--- a/algorithms/unit_tests/TestStdReducers.cpp
+++ b/algorithms/unit_tests/TestStdReducers.cpp
@@ -80,7 +80,7 @@ auto create_host_view_with_reduction_order_indices(
 
 template <int flag, class ExeSpace, class IndexType, class ViewType>
 auto run_min_or_max_test(ViewType view, StdReducersTestEnumOrder enValue) {
-  static_assert(std::is_same<ExeSpace, Kokkos::HostSpace>::value,
+  static_assert(std::is_same_v<ExeSpace, Kokkos::HostSpace>,
                 "test is only enabled for HostSpace");
 
   using view_value_type = typename ViewType::value_type;
@@ -191,7 +191,7 @@ template <class ExeSpace, class IndexType, class ViewType, class ValuesPair,
           class IndexPair>
 void run_min_max_test(ViewType view, StdReducersTestEnumOrder enValue,
                       const ValuesPair gold_values, const IndexPair gold_locs) {
-  static_assert(std::is_same<ExeSpace, Kokkos::HostSpace>::value,
+  static_assert(std::is_same_v<ExeSpace, Kokkos::HostSpace>,
                 "test is only enabled for HostSpace");
 
   using view_value_type = typename ViewType::value_type;

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -338,23 +338,21 @@ class DualView : public ViewTraits<DataType, Properties...> {
   // does the DualView have only one device
   struct impl_dualview_is_single_device {
     enum : bool {
-      value = std::is_same<typename t_dev::device_type,
-                           typename t_host::device_type>::value
+      value = std::is_same_v<typename t_dev::device_type,
+                             typename t_host::device_type>
     };
   };
 
   // does the given device match the device of t_dev?
   template <typename Device>
   struct impl_device_matches_tdev_device {
-    enum : bool {
-      value = std::is_same<typename t_dev::device_type, Device>::value
-    };
+    enum : bool { value = std::is_same_v<typename t_dev::device_type, Device> };
   };
   // does the given device match the device of t_host?
   template <typename Device>
   struct impl_device_matches_thost_device {
     enum : bool {
-      value = std::is_same<typename t_host::device_type, Device>::value
+      value = std::is_same_v<typename t_host::device_type, Device>
     };
   };
 
@@ -362,7 +360,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
   template <typename Device>
   struct impl_device_matches_thost_exec {
     enum : bool {
-      value = std::is_same<typename t_host::execution_space, Device>::value
+      value = std::is_same_v<typename t_host::execution_space, Device>
     };
   };
 
@@ -370,7 +368,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
   template <typename Device>
   struct impl_device_matches_tdev_exec {
     enum : bool {
-      value = std::is_same<typename t_dev::execution_space, Device>::value
+      value = std::is_same_v<typename t_dev::execution_space, Device>
     };
   };
 
@@ -378,8 +376,8 @@ class DualView : public ViewTraits<DataType, Properties...> {
   template <typename Device>
   struct impl_device_matches_tdev_memory_space {
     enum : bool {
-      value = std::is_same<typename t_dev::memory_space,
-                           typename Device::memory_space>::value
+      value = std::is_same_v<typename t_dev::memory_space,
+                             typename Device::memory_space>
     };
   };
 
@@ -475,27 +473,27 @@ class DualView : public ViewTraits<DataType, Properties...> {
   template <class Device>
   static int get_device_side() {
     constexpr bool device_is_memspace =
-        std::is_same<Device, typename Device::memory_space>::value;
+        std::is_same_v<Device, typename Device::memory_space>;
     constexpr bool device_is_execspace =
-        std::is_same<Device, typename Device::execution_space>::value;
+        std::is_same_v<Device, typename Device::execution_space>;
     constexpr bool device_exec_is_t_dev_exec =
-        std::is_same<typename Device::execution_space,
-                     typename t_dev::execution_space>::value;
+        std::is_same_v<typename Device::execution_space,
+                       typename t_dev::execution_space>;
     constexpr bool device_mem_is_t_dev_mem =
-        std::is_same<typename Device::memory_space,
-                     typename t_dev::memory_space>::value;
+        std::is_same_v<typename Device::memory_space,
+                       typename t_dev::memory_space>;
     constexpr bool device_exec_is_t_host_exec =
-        std::is_same<typename Device::execution_space,
-                     typename t_host::execution_space>::value;
+        std::is_same_v<typename Device::execution_space,
+                       typename t_host::execution_space>;
     constexpr bool device_mem_is_t_host_mem =
-        std::is_same<typename Device::memory_space,
-                     typename t_host::memory_space>::value;
+        std::is_same_v<typename Device::memory_space,
+                       typename t_host::memory_space>;
     constexpr bool device_is_t_host_device =
-        std::is_same<typename Device::execution_space,
-                     typename t_host::device_type>::value;
+        std::is_same_v<typename Device::execution_space,
+                       typename t_host::device_type>;
     constexpr bool device_is_t_dev_device =
-        std::is_same<typename Device::memory_space,
-                     typename t_host::device_type>::value;
+        std::is_same_v<typename Device::memory_space,
+                       typename t_host::device_type>;
 
     static_assert(
         device_is_t_dev_device || device_is_t_host_device ||
@@ -627,9 +625,9 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
   template <class Device>
   void sync(const std::enable_if_t<
-                (std::is_same<typename traits::data_type,
-                              typename traits::non_const_data_type>::value) ||
-                    (std::is_same<Device, int>::value),
+                (std::is_same_v<typename traits::data_type,
+                                typename traits::non_const_data_type>) ||
+                    (std::is_same_v<Device, int>),
                 int>& = 0) {
     sync_impl<Device>(std::true_type{});
   }
@@ -637,9 +635,9 @@ class DualView : public ViewTraits<DataType, Properties...> {
   template <class Device, class ExecutionSpace>
   void sync(const ExecutionSpace& exec,
             const std::enable_if_t<
-                (std::is_same<typename traits::data_type,
-                              typename traits::non_const_data_type>::value) ||
-                    (std::is_same<Device, int>::value),
+                (std::is_same_v<typename traits::data_type,
+                                typename traits::non_const_data_type>) ||
+                    (std::is_same_v<Device, int>),
                 int>& = 0) {
     sync_impl<Device>(std::true_type{}, exec);
   }
@@ -669,18 +667,18 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
   template <class Device>
   void sync(const std::enable_if_t<
-                (!std::is_same<typename traits::data_type,
-                               typename traits::non_const_data_type>::value) ||
-                    (std::is_same<Device, int>::value),
+                (!std::is_same_v<typename traits::data_type,
+                                 typename traits::non_const_data_type>) ||
+                    (std::is_same_v<Device, int>),
                 int>& = 0) {
     sync_impl<Device>(std::false_type{});
   }
   template <class Device, class ExecutionSpace>
   void sync(const ExecutionSpace& exec,
             const std::enable_if_t<
-                (!std::is_same<typename traits::data_type,
-                               typename traits::non_const_data_type>::value) ||
-                    (std::is_same<Device, int>::value),
+                (!std::is_same_v<typename traits::data_type,
+                                 typename traits::non_const_data_type>) ||
+                    (std::is_same_v<Device, int>),
                 int>& = 0) {
     sync_impl<Device>(std::false_type{}, exec);
   }
@@ -1182,15 +1180,15 @@ class DualView : public ViewTraits<DataType, Properties...> {
   }
 
   template <typename iType>
-  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-      std::is_integral<iType>::value, size_t>
+  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>,
+                                                    size_t>
   extent(const iType& r) const {
     return d_view.extent(r);
   }
 
   template <typename iType>
-  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-      std::is_integral<iType>::value, int>
+  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>,
+                                                    int>
   extent_int(const iType& r) const {
     return static_cast<int>(d_view.extent(r));
   }

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -599,12 +599,12 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   // This assumes a contiguous underlying memory (i.e. no padding, no
   // striding... AND a Trilinos/Sacado scalar type )
   template <typename iType>
-  KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<!std::is_same_v<typename drvtraits::value_type,
-                                       typename drvtraits::scalar_array_type> &&
-                           std::is_integral_v<iType>,
-                       reference_type>
-      operator[](const iType& i0) const {
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<
+      std::is_integral_v<iType> &&
+          !std::is_same_v<typename drvtraits::value_type,
+                          typename drvtraits::scalar_array_type>,
+      reference_type>
+  operator[](const iType& i0) const {
     //      auto map = impl_map();
     const size_t dim_scalar = m_map.dimension_scalar();
     const size_t bytes      = this->span() / dim_scalar;

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -94,8 +94,8 @@ struct DynRankDimTraits {
   // Non-strided Layout
   template <typename Layout>
   KOKKOS_INLINE_FUNCTION static std::enable_if_t<
-      (std::is_same<Layout, Kokkos::LayoutRight>::value ||
-       std::is_same<Layout, Kokkos::LayoutLeft>::value),
+      (std::is_same_v<Layout, Kokkos::LayoutRight> ||
+       std::is_same_v<Layout, Kokkos::LayoutLeft>),
       Layout>
   createLayout(const Layout& layout) {
     return Layout(layout.dimension[0] != unspecified ? layout.dimension[0] : 1,
@@ -111,7 +111,7 @@ struct DynRankDimTraits {
   // LayoutStride
   template <typename Layout>
   KOKKOS_INLINE_FUNCTION static std::enable_if_t<
-      (std::is_same<Layout, Kokkos::LayoutStride>::value), Layout>
+      (std::is_same_v<Layout, Kokkos::LayoutStride>), Layout>
   createLayout(const Layout& layout) {
     return Layout(layout.dimension[0] != unspecified ? layout.dimension[0] : 1,
                   layout.stride[0],
@@ -134,11 +134,9 @@ struct DynRankDimTraits {
   // Extra overload to match that for specialize types
   template <typename Traits, typename... P>
   KOKKOS_INLINE_FUNCTION static std::enable_if_t<
-      (std::is_same<typename Traits::array_layout,
-                    Kokkos::LayoutRight>::value ||
-       std::is_same<typename Traits::array_layout, Kokkos::LayoutLeft>::value ||
-       std::is_same<typename Traits::array_layout,
-                    Kokkos::LayoutStride>::value),
+      (std::is_same_v<typename Traits::array_layout, Kokkos::LayoutRight> ||
+       std::is_same_v<typename Traits::array_layout, Kokkos::LayoutLeft> ||
+       std::is_same_v<typename Traits::array_layout, Kokkos::LayoutStride>),
       typename Traits::array_layout>
   createLayout(const Kokkos::Impl::ViewCtorProp<P...>& /* prop */,
                const typename Traits::array_layout& layout) {
@@ -164,9 +162,8 @@ struct DynRankDimTraits {
 // Non-strided Layout
 template <typename Layout, typename iType>
 KOKKOS_INLINE_FUNCTION static std::enable_if_t<
-    (std::is_same<Layout, Kokkos::LayoutRight>::value ||
-     std::is_same<Layout, Kokkos::LayoutLeft>::value) &&
-        std::is_integral<iType>::value,
+    (std::is_same_v<Layout, Kokkos::LayoutRight> ||
+     std::is_same_v<Layout, Kokkos::LayoutLeft>)&&std::is_integral_v<iType>,
     Layout>
 reconstructLayout(const Layout& layout, iType dynrank) {
   return Layout(dynrank > 0 ? layout.dimension[0] : KOKKOS_INVALID_INDEX,
@@ -182,8 +179,7 @@ reconstructLayout(const Layout& layout, iType dynrank) {
 // LayoutStride
 template <typename Layout, typename iType>
 KOKKOS_INLINE_FUNCTION static std::enable_if_t<
-    (std::is_same<Layout, Kokkos::LayoutStride>::value) &&
-        std::is_integral<iType>::value,
+    (std::is_same_v<Layout, Kokkos::LayoutStride>)&&std::is_integral_v<iType>,
     Layout>
 reconstructLayout(const Layout& layout, iType dynrank) {
   return Layout(dynrank > 0 ? layout.dimension[0] : KOKKOS_INVALID_INDEX,
@@ -284,40 +280,43 @@ namespace Impl {
 template <class DstTraits, class SrcTraits>
 class ViewMapping<
     DstTraits, SrcTraits,
-    std::enable_if_t<(std::is_same<typename DstTraits::memory_space,
-                                   typename SrcTraits::memory_space>::value &&
-                      std::is_void<typename DstTraits::specialize>::value &&
-                      std::is_void<typename SrcTraits::specialize>::value &&
-                      (std::is_same<typename DstTraits::array_layout,
-                                    typename SrcTraits::array_layout>::value ||
-                       ((std::is_same<typename DstTraits::array_layout,
-                                      Kokkos::LayoutLeft>::value ||
-                         std::is_same<typename DstTraits::array_layout,
-                                      Kokkos::LayoutRight>::value ||
-                         std::is_same<typename DstTraits::array_layout,
-                                      Kokkos::LayoutStride>::value) &&
-                        (std::is_same<typename SrcTraits::array_layout,
-                                      Kokkos::LayoutLeft>::value ||
-                         std::is_same<typename SrcTraits::array_layout,
-                                      Kokkos::LayoutRight>::value ||
-                         std::is_same<typename SrcTraits::array_layout,
-                                      Kokkos::LayoutStride>::value)))),
-                     Kokkos::Impl::ViewToDynRankViewTag>> {
+    std::enable_if_t<
+        (std::is_same_v<typename DstTraits::memory_space,
+                        typename SrcTraits::memory_space> &&
+         std::is_void_v<typename DstTraits::specialize> &&
+         std::is_void_v<typename SrcTraits::specialize> &&
+         (std::is_same_v<typename DstTraits::array_layout,
+                         typename SrcTraits::array_layout> ||
+          ((std::is_same_v<typename DstTraits::array_layout,
+                           Kokkos::LayoutLeft> ||
+            std::is_same_v<typename DstTraits::array_layout,
+                           Kokkos::LayoutRight> ||
+            std::is_same_v<
+                typename DstTraits::array_layout,
+                Kokkos::LayoutStride>)&&(std::is_same_v<typename SrcTraits::
+                                                            array_layout,
+                                                        Kokkos::LayoutLeft> ||
+                                         std::is_same_v<
+                                             typename SrcTraits::array_layout,
+                                             Kokkos::LayoutRight> ||
+                                         std::is_same_v<
+                                             typename SrcTraits::array_layout,
+                                             Kokkos::LayoutStride>)))),
+        Kokkos::Impl::ViewToDynRankViewTag>> {
  private:
   enum {
     is_assignable_value_type =
-        std::is_same<typename DstTraits::value_type,
-                     typename SrcTraits::value_type>::value ||
-        std::is_same<typename DstTraits::value_type,
-                     typename SrcTraits::const_value_type>::value
+        std::is_same_v<typename DstTraits::value_type,
+                       typename SrcTraits::value_type> ||
+        std::is_same_v<typename DstTraits::value_type,
+                       typename SrcTraits::const_value_type>
   };
 
   enum {
     is_assignable_layout =
-        std::is_same<typename DstTraits::array_layout,
-                     typename SrcTraits::array_layout>::value ||
-        std::is_same<typename DstTraits::array_layout,
-                     Kokkos::LayoutStride>::value
+        std::is_same_v<typename DstTraits::array_layout,
+                       typename SrcTraits::array_layout> ||
+        std::is_same_v<typename DstTraits::array_layout, Kokkos::LayoutStride>
   };
 
  public:
@@ -380,8 +379,7 @@ inline constexpr bool is_dyn_rank_view_v = is_dyn_rank_view<T>::value;
 
 template <typename DataType, class... Properties>
 class DynRankView : public ViewTraits<DataType, Properties...> {
-  static_assert(!std::is_array<DataType>::value &&
-                    !std::is_pointer<DataType>::value,
+  static_assert(!std::is_array_v<DataType> && !std::is_pointer_v<DataType>,
                 "Cannot template DynRankView with array or pointer datatype - "
                 "must be pod");
 
@@ -443,15 +441,15 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   //  enum?
 
   template <typename iType>
-  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-      std::is_integral<iType>::value, size_t>
+  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>,
+                                                    size_t>
   extent(const iType& r) const {
     return m_map.extent(r);
   }
 
   template <typename iType>
-  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-      std::is_integral<iType>::value, int>
+  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>,
+                                                    int>
   extent_int(const iType& r) const {
     return static_cast<int>(m_map.extent(r));
   }
@@ -507,7 +505,7 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
 
   enum {
     reference_type_is_lvalue_reference =
-        std::is_lvalue_reference<reference_type>::value
+        std::is_lvalue_reference_v<reference_type>
   };
 
   KOKKOS_INLINE_FUNCTION constexpr size_t span() const { return m_map.span(); }
@@ -534,15 +532,15 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
  private:
   enum {
     is_layout_left =
-        std::is_same<typename traits::array_layout, Kokkos::LayoutLeft>::value,
+        std::is_same_v<typename traits::array_layout, Kokkos::LayoutLeft>,
 
     is_layout_right =
-        std::is_same<typename traits::array_layout, Kokkos::LayoutRight>::value,
+        std::is_same_v<typename traits::array_layout, Kokkos::LayoutRight>,
 
-    is_layout_stride = std::is_same<typename traits::array_layout,
-                                    Kokkos::LayoutStride>::value,
+    is_layout_stride =
+        std::is_same_v<typename traits::array_layout, Kokkos::LayoutStride>,
 
-    is_default_map = std::is_void<typename traits::specialize>::value &&
+    is_default_map = std::is_void_v<typename traits::specialize> &&
                      (is_layout_left || is_layout_right || is_layout_stride)
   };
 
@@ -586,12 +584,12 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   // This assumes a contiguous underlying memory (i.e. no padding, no
   // striding...)
   template <typename iType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_same<typename drvtraits::value_type,
-                   typename drvtraits::scalar_array_type>::value &&
-          std::is_integral<iType>::value,
-      reference_type>
-  operator[](const iType& i0) const {
+  KOKKOS_INLINE_FUNCTION
+      std::enable_if_t<std::is_same_v<typename drvtraits::value_type,
+                                      typename drvtraits::scalar_array_type> &&
+                           std::is_integral_v<iType>,
+                       reference_type>
+      operator[](const iType& i0) const {
     // Phalanx is violating this, since they use the operator to access ALL
     // elements in the allocation KOKKOS_IMPL_VIEW_OPERATOR_VERIFY( (1 ,
     // this->rank(), m_track, m_map) )
@@ -601,12 +599,12 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   // This assumes a contiguous underlying memory (i.e. no padding, no
   // striding... AND a Trilinos/Sacado scalar type )
   template <typename iType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      !std::is_same<typename drvtraits::value_type,
-                    typename drvtraits::scalar_array_type>::value &&
-          std::is_integral<iType>::value,
-      reference_type>
-  operator[](const iType& i0) const {
+  KOKKOS_INLINE_FUNCTION
+      std::enable_if_t<!std::is_same_v<typename drvtraits::value_type,
+                                       typename drvtraits::scalar_array_type> &&
+                           std::is_integral_v<iType>,
+                       reference_type>
+      operator[](const iType& i0) const {
     //      auto map = impl_map();
     const size_t dim_scalar = m_map.dimension_scalar();
     const size_t bytes      = this->span() / dim_scalar;
@@ -623,8 +621,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   // Rank 1 parenthesis
   template <typename iType>
   KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<(std::is_void<typename traits::specialize>::value &&
-                        std::is_integral<iType>::value),
+      std::enable_if_t<(std::is_void_v<typename traits::specialize> &&
+                        std::is_integral_v<iType>),
                        reference_type>
       operator()(const iType& i0) const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((1, this->rank(), m_track, m_map, i0))
@@ -633,8 +631,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<!(std::is_void<typename traits::specialize>::value &&
-                         std::is_integral<iType>::value),
+      std::enable_if_t<!(std::is_void_v<typename traits::specialize> &&
+                         std::is_integral_v<iType>),
                        reference_type>
       operator()(const iType& i0) const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((1, this->rank(), m_track, m_map, i0))
@@ -644,8 +642,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   // Rank 2
   template <typename iType0, typename iType1>
   KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      (std::is_void<typename traits::specialize>::value &&
-       std::is_integral<iType0>::value && std::is_integral<iType1>::value),
+      (std::is_void_v<typename traits::specialize> &&
+       std::is_integral_v<iType0> && std::is_integral_v<iType1>),
       reference_type>
   operator()(const iType0& i0, const iType1& i1) const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((2, this->rank(), m_track, m_map, i0, i1))
@@ -654,8 +652,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
 
   template <typename iType0, typename iType1>
   KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<!(std::is_void<typename drvtraits::specialize>::value &&
-                         std::is_integral<iType0>::value),
+      std::enable_if_t<!(std::is_void_v<typename drvtraits::specialize> &&
+                         std::is_integral_v<iType0>),
                        reference_type>
       operator()(const iType0& i0, const iType1& i1) const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((2, this->rank(), m_track, m_map, i0, i1))
@@ -665,9 +663,9 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   // Rank 3
   template <typename iType0, typename iType1, typename iType2>
   KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      (std::is_void<typename traits::specialize>::value &&
-       std::is_integral<iType0>::value && std::is_integral<iType1>::value &&
-       std::is_integral<iType2>::value),
+      (std::is_void_v<typename traits::specialize> &&
+       std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
+       std::is_integral_v<iType2>),
       reference_type>
   operator()(const iType0& i0, const iType1& i1, const iType2& i2) const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
@@ -677,8 +675,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
 
   template <typename iType0, typename iType1, typename iType2>
   KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<!(std::is_void<typename drvtraits::specialize>::value &&
-                         std::is_integral<iType0>::value),
+      std::enable_if_t<!(std::is_void_v<typename drvtraits::specialize> &&
+                         std::is_integral_v<iType0>),
                        reference_type>
       operator()(const iType0& i0, const iType1& i1, const iType2& i2) const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
@@ -689,9 +687,9 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   // Rank 4
   template <typename iType0, typename iType1, typename iType2, typename iType3>
   KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      (std::is_void<typename traits::specialize>::value &&
-       std::is_integral<iType0>::value && std::is_integral<iType1>::value &&
-       std::is_integral<iType2>::value && std::is_integral<iType3>::value),
+      (std::is_void_v<typename traits::specialize> &&
+       std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
+       std::is_integral_v<iType2> && std::is_integral_v<iType3>),
       reference_type>
   operator()(const iType0& i0, const iType1& i1, const iType2& i2,
              const iType3& i3) const {
@@ -702,8 +700,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
 
   template <typename iType0, typename iType1, typename iType2, typename iType3>
   KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<!(std::is_void<typename drvtraits::specialize>::value &&
-                         std::is_integral<iType0>::value),
+      std::enable_if_t<!(std::is_void_v<typename drvtraits::specialize> &&
+                         std::is_integral_v<iType0>),
                        reference_type>
       operator()(const iType0& i0, const iType1& i1, const iType2& i2,
                  const iType3& i3) const {
@@ -716,10 +714,10 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   template <typename iType0, typename iType1, typename iType2, typename iType3,
             typename iType4>
   KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      (std::is_void<typename traits::specialize>::value &&
-       std::is_integral<iType0>::value && std::is_integral<iType1>::value &&
-       std::is_integral<iType2>::value && std::is_integral<iType3>::value &&
-       std::is_integral<iType4>::value),
+      (std::is_void_v<typename traits::specialize> &&
+       std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
+       std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
+       std::is_integral_v<iType4>),
       reference_type>
   operator()(const iType0& i0, const iType1& i1, const iType2& i2,
              const iType3& i3, const iType4& i4) const {
@@ -731,8 +729,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   template <typename iType0, typename iType1, typename iType2, typename iType3,
             typename iType4>
   KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<!(std::is_void<typename drvtraits::specialize>::value &&
-                         std::is_integral<iType0>::value),
+      std::enable_if_t<!(std::is_void_v<typename drvtraits::specialize> &&
+                         std::is_integral_v<iType0>),
                        reference_type>
       operator()(const iType0& i0, const iType1& i1, const iType2& i2,
                  const iType3& i3, const iType4& i4) const {
@@ -745,10 +743,10 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   template <typename iType0, typename iType1, typename iType2, typename iType3,
             typename iType4, typename iType5>
   KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      (std::is_void<typename traits::specialize>::value &&
-       std::is_integral<iType0>::value && std::is_integral<iType1>::value &&
-       std::is_integral<iType2>::value && std::is_integral<iType3>::value &&
-       std::is_integral<iType4>::value && std::is_integral<iType5>::value),
+      (std::is_void_v<typename traits::specialize> &&
+       std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
+       std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
+       std::is_integral_v<iType4> && std::is_integral_v<iType5>),
       reference_type>
   operator()(const iType0& i0, const iType1& i1, const iType2& i2,
              const iType3& i3, const iType4& i4, const iType5& i5) const {
@@ -760,8 +758,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   template <typename iType0, typename iType1, typename iType2, typename iType3,
             typename iType4, typename iType5>
   KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<!(std::is_void<typename drvtraits::specialize>::value &&
-                         std::is_integral<iType0>::value),
+      std::enable_if_t<!(std::is_void_v<typename drvtraits::specialize> &&
+                         std::is_integral_v<iType0>),
                        reference_type>
       operator()(const iType0& i0, const iType1& i1, const iType2& i2,
                  const iType3& i3, const iType4& i4, const iType5& i5) const {
@@ -774,10 +772,10 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   template <typename iType0, typename iType1, typename iType2, typename iType3,
             typename iType4, typename iType5, typename iType6>
   KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      (std::is_integral<iType0>::value && std::is_integral<iType1>::value &&
-       std::is_integral<iType2>::value && std::is_integral<iType3>::value &&
-       std::is_integral<iType4>::value && std::is_integral<iType5>::value &&
-       std::is_integral<iType6>::value),
+      (std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
+       std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
+       std::is_integral_v<iType4> && std::is_integral_v<iType5> &&
+       std::is_integral_v<iType6>),
       reference_type>
   operator()(const iType0& i0, const iType1& i1, const iType2& i2,
              const iType3& i3, const iType4& i4, const iType5& i5,
@@ -799,8 +797,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   // Rank 1 parenthesis
   template <typename iType>
   KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<(std::is_void<typename traits::specialize>::value &&
-                        std::is_integral<iType>::value),
+      std::enable_if_t<(std::is_void_v<typename traits::specialize> &&
+                        std::is_integral_v<iType>),
                        reference_type>
       access(const iType& i0) const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((1, this->rank(), m_track, m_map, i0))
@@ -809,8 +807,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<!(std::is_void<typename traits::specialize>::value &&
-                         std::is_integral<iType>::value),
+      std::enable_if_t<!(std::is_void_v<typename traits::specialize> &&
+                         std::is_integral_v<iType>),
                        reference_type>
       access(const iType& i0) const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((1, this->rank(), m_track, m_map, i0))
@@ -820,8 +818,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   // Rank 2
   template <typename iType0, typename iType1>
   KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      (std::is_void<typename traits::specialize>::value &&
-       std::is_integral<iType0>::value && std::is_integral<iType1>::value),
+      (std::is_void_v<typename traits::specialize> &&
+       std::is_integral_v<iType0> && std::is_integral_v<iType1>),
       reference_type>
   access(const iType0& i0, const iType1& i1) const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((2, this->rank(), m_track, m_map, i0, i1))
@@ -830,8 +828,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
 
   template <typename iType0, typename iType1>
   KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<!(std::is_void<typename drvtraits::specialize>::value &&
-                         std::is_integral<iType0>::value),
+      std::enable_if_t<!(std::is_void_v<typename drvtraits::specialize> &&
+                         std::is_integral_v<iType0>),
                        reference_type>
       access(const iType0& i0, const iType1& i1) const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((2, this->rank(), m_track, m_map, i0, i1))
@@ -841,9 +839,9 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   // Rank 3
   template <typename iType0, typename iType1, typename iType2>
   KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      (std::is_void<typename traits::specialize>::value &&
-       std::is_integral<iType0>::value && std::is_integral<iType1>::value &&
-       std::is_integral<iType2>::value),
+      (std::is_void_v<typename traits::specialize> &&
+       std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
+       std::is_integral_v<iType2>),
       reference_type>
   access(const iType0& i0, const iType1& i1, const iType2& i2) const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
@@ -853,8 +851,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
 
   template <typename iType0, typename iType1, typename iType2>
   KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<!(std::is_void<typename drvtraits::specialize>::value &&
-                         std::is_integral<iType0>::value),
+      std::enable_if_t<!(std::is_void_v<typename drvtraits::specialize> &&
+                         std::is_integral_v<iType0>),
                        reference_type>
       access(const iType0& i0, const iType1& i1, const iType2& i2) const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
@@ -865,9 +863,9 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   // Rank 4
   template <typename iType0, typename iType1, typename iType2, typename iType3>
   KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      (std::is_void<typename traits::specialize>::value &&
-       std::is_integral<iType0>::value && std::is_integral<iType1>::value &&
-       std::is_integral<iType2>::value && std::is_integral<iType3>::value),
+      (std::is_void_v<typename traits::specialize> &&
+       std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
+       std::is_integral_v<iType2> && std::is_integral_v<iType3>),
       reference_type>
   access(const iType0& i0, const iType1& i1, const iType2& i2,
          const iType3& i3) const {
@@ -878,8 +876,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
 
   template <typename iType0, typename iType1, typename iType2, typename iType3>
   KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<!(std::is_void<typename drvtraits::specialize>::value &&
-                         std::is_integral<iType0>::value),
+      std::enable_if_t<!(std::is_void_v<typename drvtraits::specialize> &&
+                         std::is_integral_v<iType0>),
                        reference_type>
       access(const iType0& i0, const iType1& i1, const iType2& i2,
              const iType3& i3) const {
@@ -892,10 +890,10 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   template <typename iType0, typename iType1, typename iType2, typename iType3,
             typename iType4>
   KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      (std::is_void<typename traits::specialize>::value &&
-       std::is_integral<iType0>::value && std::is_integral<iType1>::value &&
-       std::is_integral<iType2>::value && std::is_integral<iType3>::value &&
-       std::is_integral<iType4>::value),
+      (std::is_void_v<typename traits::specialize> &&
+       std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
+       std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
+       std::is_integral_v<iType4>),
       reference_type>
   access(const iType0& i0, const iType1& i1, const iType2& i2, const iType3& i3,
          const iType4& i4) const {
@@ -907,8 +905,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   template <typename iType0, typename iType1, typename iType2, typename iType3,
             typename iType4>
   KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<!(std::is_void<typename drvtraits::specialize>::value &&
-                         std::is_integral<iType0>::value),
+      std::enable_if_t<!(std::is_void_v<typename drvtraits::specialize> &&
+                         std::is_integral_v<iType0>),
                        reference_type>
       access(const iType0& i0, const iType1& i1, const iType2& i2,
              const iType3& i3, const iType4& i4) const {
@@ -921,10 +919,10 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   template <typename iType0, typename iType1, typename iType2, typename iType3,
             typename iType4, typename iType5>
   KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      (std::is_void<typename traits::specialize>::value &&
-       std::is_integral<iType0>::value && std::is_integral<iType1>::value &&
-       std::is_integral<iType2>::value && std::is_integral<iType3>::value &&
-       std::is_integral<iType4>::value && std::is_integral<iType5>::value),
+      (std::is_void_v<typename traits::specialize> &&
+       std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
+       std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
+       std::is_integral_v<iType4> && std::is_integral_v<iType5>),
       reference_type>
   access(const iType0& i0, const iType1& i1, const iType2& i2, const iType3& i3,
          const iType4& i4, const iType5& i5) const {
@@ -936,8 +934,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   template <typename iType0, typename iType1, typename iType2, typename iType3,
             typename iType4, typename iType5>
   KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<!(std::is_void<typename drvtraits::specialize>::value &&
-                         std::is_integral<iType0>::value),
+      std::enable_if_t<!(std::is_void_v<typename drvtraits::specialize> &&
+                         std::is_integral_v<iType0>),
                        reference_type>
       access(const iType0& i0, const iType1& i1, const iType2& i2,
              const iType3& i3, const iType4& i4, const iType5& i5) const {
@@ -950,10 +948,10 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   template <typename iType0, typename iType1, typename iType2, typename iType3,
             typename iType4, typename iType5, typename iType6>
   KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      (std::is_integral<iType0>::value && std::is_integral<iType1>::value &&
-       std::is_integral<iType2>::value && std::is_integral<iType3>::value &&
-       std::is_integral<iType4>::value && std::is_integral<iType5>::value &&
-       std::is_integral<iType6>::value),
+      (std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
+       std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
+       std::is_integral_v<iType4> && std::is_integral_v<iType5> &&
+       std::is_integral_v<iType6>),
       reference_type>
   access(const iType0& i0, const iType1& i1, const iType2& i2, const iType3& i3,
          const iType4& i4, const iType5& i5, const iType6& i6) const {
@@ -1230,7 +1228,7 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
         (arg_N4 != KOKKOS_INVALID_INDEX) + (arg_N5 != KOKKOS_INVALID_INDEX) +
         (arg_N6 != KOKKOS_INVALID_INDEX) + (arg_N7 != KOKKOS_INVALID_INDEX);
 
-    if (std::is_void<typename traits::specialize>::value &&
+    if (std::is_void_v<typename traits::specialize> &&
         num_passed_args != traits::rank_dynamic) {
       Kokkos::abort(
           "Kokkos::View::shmem_size() rank_dynamic != number of arguments.\n");
@@ -1297,13 +1295,13 @@ namespace Impl {
 
 template <class SrcTraits, class... Args>
 class ViewMapping<
-    std::enable_if_t<(std::is_void<typename SrcTraits::specialize>::value &&
-                      (std::is_same<typename SrcTraits::array_layout,
-                                    Kokkos::LayoutLeft>::value ||
-                       std::is_same<typename SrcTraits::array_layout,
-                                    Kokkos::LayoutRight>::value ||
-                       std::is_same<typename SrcTraits::array_layout,
-                                    Kokkos::LayoutStride>::value)),
+    std::enable_if_t<(std::is_void_v<typename SrcTraits::specialize> &&
+                      (std::is_same_v<typename SrcTraits::array_layout,
+                                      Kokkos::LayoutLeft> ||
+                       std::is_same_v<typename SrcTraits::array_layout,
+                                      Kokkos::LayoutRight> ||
+                       std::is_same_v<typename SrcTraits::array_layout,
+                                      Kokkos::LayoutStride>)),
                      Kokkos::Impl::DynRankSubviewTag>,
     SrcTraits, Args...> {
  private:
@@ -1482,12 +1480,12 @@ KOKKOS_INLINE_FUNCTION bool operator==(const DynRankView<LT, LP...>& lhs,
   using lhs_traits = ViewTraits<LT, LP...>;
   using rhs_traits = ViewTraits<RT, RP...>;
 
-  return std::is_same<typename lhs_traits::const_value_type,
-                      typename rhs_traits::const_value_type>::value &&
-         std::is_same<typename lhs_traits::array_layout,
-                      typename rhs_traits::array_layout>::value &&
-         std::is_same<typename lhs_traits::memory_space,
-                      typename rhs_traits::memory_space>::value &&
+  return std::is_same_v<typename lhs_traits::const_value_type,
+                        typename rhs_traits::const_value_type> &&
+         std::is_same_v<typename lhs_traits::array_layout,
+                        typename rhs_traits::array_layout> &&
+         std::is_same_v<typename lhs_traits::memory_space,
+                        typename rhs_traits::memory_space> &&
          lhs.rank() == rhs.rank() && lhs.data() == rhs.data() &&
          lhs.span() == rhs.span() && lhs.extent(0) == rhs.extent(0) &&
          lhs.extent(1) == rhs.extent(1) && lhs.extent(2) == rhs.extent(2) &&
@@ -1640,9 +1638,8 @@ namespace Impl {
 template <unsigned N, typename T, typename... Args>
 KOKKOS_FUNCTION auto as_view_of_rank_n(
     DynRankView<T, Args...> v,
-    typename std::enable_if<std::is_same<
-        typename ViewTraits<T, Args...>::specialize, void>::value>::type* =
-        nullptr) {
+    std::enable_if_t<std::is_same_v<typename ViewTraits<T, Args...>::specialize,
+                                    void>>* = nullptr) {
   if (v.rank() != N) {
     KOKKOS_IF_ON_HOST(
         const std::string message =
@@ -1723,11 +1720,11 @@ template <class ExecSpace, class DT, class... DP>
 inline void deep_copy(
     const ExecSpace& e, const DynRankView<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<std::is_same<typename ViewTraits<DT, DP...>::specialize,
-                                  void>::value>* = nullptr) {
+    std::enable_if_t<std::is_same_v<typename ViewTraits<DT, DP...>::specialize,
+                                    void>>* = nullptr) {
   static_assert(
-      std::is_same<typename ViewTraits<DT, DP...>::non_const_value_type,
-                   typename ViewTraits<DT, DP...>::value_type>::value,
+      std::is_same_v<typename ViewTraits<DT, DP...>::non_const_value_type,
+                     typename ViewTraits<DT, DP...>::value_type>,
       "deep_copy requires non-const type");
 
   Impl::apply_to_view_of_static_rank(
@@ -1738,8 +1735,8 @@ template <class DT, class... DP>
 inline void deep_copy(
     const DynRankView<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<std::is_same<typename ViewTraits<DT, DP...>::specialize,
-                                  void>::value>* = nullptr) {
+    std::enable_if_t<std::is_same_v<typename ViewTraits<DT, DP...>::specialize,
+                                    void>>* = nullptr) {
   Impl::apply_to_view_of_static_rank([=](auto view) { deep_copy(view, value); },
                                      dst);
 }
@@ -1750,8 +1747,8 @@ inline void deep_copy(
     const ExecSpace& e,
     typename ViewTraits<ST, SP...>::non_const_value_type& dst,
     const DynRankView<ST, SP...>& src,
-    std::enable_if_t<std::is_same<typename ViewTraits<ST, SP...>::specialize,
-                                  void>::value>* = 0) {
+    std::enable_if_t<std::is_same_v<typename ViewTraits<ST, SP...>::specialize,
+                                    void>>* = 0) {
   deep_copy(e, dst, Impl::as_view_of_rank_n<0>(src));
 }
 
@@ -1759,8 +1756,8 @@ template <class ST, class... SP>
 inline void deep_copy(
     typename ViewTraits<ST, SP...>::non_const_value_type& dst,
     const DynRankView<ST, SP...>& src,
-    std::enable_if_t<std::is_same<typename ViewTraits<ST, SP...>::specialize,
-                                  void>::value>* = 0) {
+    std::enable_if_t<std::is_same_v<typename ViewTraits<ST, SP...>::specialize,
+                                    void>>* = 0) {
   deep_copy(dst, Impl::as_view_of_rank_n<0>(src));
 }
 
@@ -1773,15 +1770,13 @@ inline void deep_copy(
 template <class ExecSpace, class DstType, class SrcType>
 inline void deep_copy(
     const ExecSpace& exec_space, const DstType& dst, const SrcType& src,
-    std::enable_if_t<
-        (std::is_void<typename DstType::traits::specialize>::value &&
-         std::is_void<typename SrcType::traits::specialize>::value &&
-         (Kokkos::is_dyn_rank_view<DstType>::value ||
-          Kokkos::is_dyn_rank_view<SrcType>::value))>* = nullptr) {
-  static_assert(
-      std::is_same<typename DstType::traits::value_type,
-                   typename DstType::traits::non_const_value_type>::value,
-      "deep_copy requires non-const destination type");
+    std::enable_if_t<(std::is_void_v<typename DstType::traits::specialize> &&
+                      std::is_void_v<typename SrcType::traits::specialize> &&
+                      (Kokkos::is_dyn_rank_view<DstType>::value ||
+                       Kokkos::is_dyn_rank_view<SrcType>::value))>* = nullptr) {
+  static_assert(std::is_same_v<typename DstType::traits::value_type,
+                               typename DstType::traits::non_const_value_type>,
+                "deep_copy requires non-const destination type");
 
   switch (rank(dst)) {
     case 0:
@@ -1826,15 +1821,13 @@ inline void deep_copy(
 template <class DstType, class SrcType>
 inline void deep_copy(
     const DstType& dst, const SrcType& src,
-    std::enable_if_t<
-        (std::is_void<typename DstType::traits::specialize>::value &&
-         std::is_void<typename SrcType::traits::specialize>::value &&
-         (Kokkos::is_dyn_rank_view<DstType>::value ||
-          Kokkos::is_dyn_rank_view<SrcType>::value))>* = nullptr) {
-  static_assert(
-      std::is_same<typename DstType::traits::value_type,
-                   typename DstType::traits::non_const_value_type>::value,
-      "deep_copy requires non-const destination type");
+    std::enable_if_t<(std::is_void_v<typename DstType::traits::specialize> &&
+                      std::is_void_v<typename SrcType::traits::specialize> &&
+                      (Kokkos::is_dyn_rank_view<DstType>::value ||
+                       Kokkos::is_dyn_rank_view<SrcType>::value))>* = nullptr) {
+  static_assert(std::is_same_v<typename DstType::traits::value_type,
+                               typename DstType::traits::non_const_value_type>,
+                "deep_copy requires non-const destination type");
 
   switch (rank(dst)) {
     case 0:
@@ -1894,7 +1887,7 @@ struct MirrorDRViewType {
   // Check whether it is the same memory space
   enum {
     is_same_memspace =
-        std::is_same<memory_space, typename src_view_type::memory_space>::value
+        std::is_same_v<memory_space, typename src_view_type::memory_space>
   };
   // The array_layout
   using array_layout = typename src_view_type::array_layout;
@@ -1918,7 +1911,7 @@ struct MirrorDRVType {
   // Check whether it is the same memory space
   enum {
     is_same_memspace =
-        std::is_same<memory_space, typename src_view_type::memory_space>::value
+        std::is_same_v<memory_space, typename src_view_type::memory_space>
   };
   // The array_layout
   using array_layout = typename src_view_type::array_layout;
@@ -2026,12 +2019,12 @@ inline auto create_mirror_view(
     [[maybe_unused]] const typename Impl::ViewCtorProp<ViewCtorArgs...>&
         arg_prop) {
   if constexpr (!Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space) {
-    if constexpr (std::is_same<typename DynRankView<T, P...>::memory_space,
-                               typename DynRankView<
-                                   T, P...>::HostMirror::memory_space>::value &&
-                  std::is_same<typename DynRankView<T, P...>::data_type,
-                               typename DynRankView<
-                                   T, P...>::HostMirror::data_type>::value) {
+    if constexpr (std::is_same_v<typename DynRankView<T, P...>::memory_space,
+                                 typename DynRankView<
+                                     T, P...>::HostMirror::memory_space> &&
+                  std::is_same_v<
+                      typename DynRankView<T, P...>::data_type,
+                      typename DynRankView<T, P...>::HostMirror::data_type>) {
       return typename DynRankView<T, P...>::HostMirror(src);
     } else {
       return Kokkos::Impl::choose_create_mirror(src, arg_prop);
@@ -2102,7 +2095,7 @@ inline auto create_mirror_view(
 // view_alloc
 template <class... ViewCtorArgs, class T, class... P,
           class Enable = std::enable_if_t<
-              std::is_void<typename ViewTraits<T, P...>::specialize>::value>>
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror_view_and_copy(
     [[maybe_unused]] const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
     const Kokkos::DynRankView<T, P...>& src) {

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -250,7 +250,7 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
 
   // It is assumed that the value_type is trivially copyable;
   // when this is not the case, potential problems can occur.
-  static_assert(std::is_void<typename traits::specialize>::value,
+  static_assert(std::is_void_v<typename traits::specialize>,
                 "DynamicView only implemented for non-specialized View type");
 
  private:
@@ -363,7 +363,7 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
 
   enum {
     reference_type_is_lvalue_reference =
-        std::is_lvalue_reference<reference_type>::value
+        std::is_lvalue_reference_v<reference_type>
   };
 
   KOKKOS_INLINE_FUNCTION constexpr bool span_is_contiguous() const {
@@ -572,7 +572,7 @@ struct MirrorDynamicViewType {
   // Check whether it is the same memory space
   enum {
     is_same_memspace =
-        std::is_same<memory_space, typename src_view_type::memory_space>::value
+        std::is_same_v<memory_space, typename src_view_type::memory_space>
   };
   // The array_layout
   using array_layout = typename src_view_type::array_layout;
@@ -693,14 +693,14 @@ inline auto create_mirror_view(
     const Kokkos::Experimental::DynamicView<T, P...>& src,
     [[maybe_unused]] const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
   if constexpr (!Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space) {
-    if constexpr (std::is_same<typename Kokkos::Experimental::DynamicView<
-                                   T, P...>::memory_space,
-                               typename Kokkos::Experimental::DynamicView<
-                                   T, P...>::HostMirror::memory_space>::value &&
-                  std::is_same<typename Kokkos::Experimental::DynamicView<
-                                   T, P...>::data_type,
-                               typename Kokkos::Experimental::DynamicView<
-                                   T, P...>::HostMirror::data_type>::value) {
+    if constexpr (std::is_same_v<typename Kokkos::Experimental::DynamicView<
+                                     T, P...>::memory_space,
+                                 typename Kokkos::Experimental::DynamicView<
+                                     T, P...>::HostMirror::memory_space> &&
+                  std::is_same_v<typename Kokkos::Experimental::DynamicView<
+                                     T, P...>::data_type,
+                                 typename Kokkos::Experimental::DynamicView<
+                                     T, P...>::HostMirror::data_type>) {
       return
           typename Kokkos::Experimental::DynamicView<T, P...>::HostMirror(src);
     } else {
@@ -964,7 +964,7 @@ struct ViewCopy<Kokkos::Experimental::DynamicView<DP...>,
 // view_alloc
 template <class... ViewCtorArgs, class T, class... P,
           class Enable = std::enable_if_t<
-              std::is_void<typename ViewTraits<T, P...>::specialize>::value>>
+              std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
 auto create_mirror_view_and_copy(
     [[maybe_unused]] const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
     const Kokkos::Experimental::DynamicView<T, P...>& src) {

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -50,9 +50,9 @@ inline constexpr bool is_offset_view_v = is_offset_view<T>::value;
 #define KOKKOS_INVALID_INDEX_RANGE \
   { KOKKOS_INVALID_OFFSET, KOKKOS_INVALID_OFFSET }
 
-template <typename iType, std::enable_if_t<std::is_integral<iType>::value &&
-                                               std::is_signed<iType>::value,
-                                           iType> = 0>
+template <typename iType,
+          std::enable_if_t<std::is_integral_v<iType> && std::is_signed_v<iType>,
+                           iType> = 0>
 using IndexRange = Kokkos::Array<iType, 2>;
 
 using index_list_type = std::initializer_list<int64_t>;
@@ -200,7 +200,7 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
   using begins_type = Kokkos::Array<int64_t, Rank>;
 
   template <typename iType,
-            std::enable_if_t<std::is_integral<iType>::value, iType> = 0>
+            std::enable_if_t<std::is_integral_v<iType>, iType> = 0>
   KOKKOS_FUNCTION int64_t begin(const iType local_dimension) const {
     return local_dimension < Rank ? m_begins[local_dimension]
                                   : KOKKOS_INVALID_OFFSET;
@@ -210,7 +210,7 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
   begins_type begins() const { return m_begins; }
 
   template <typename iType,
-            std::enable_if_t<std::is_integral<iType>::value, iType> = 0>
+            std::enable_if_t<std::is_integral_v<iType>, iType> = 0>
   KOKKOS_FUNCTION int64_t end(const iType local_dimension) const {
     return begin(local_dimension) + m_map.extent(local_dimension);
   }
@@ -255,15 +255,13 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
   // constexpr unsigned rank() { return map_type::Rank; }
 
   template <typename iType>
-  KOKKOS_FUNCTION constexpr std::enable_if_t<std::is_integral<iType>::value,
-                                             size_t>
+  KOKKOS_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>, size_t>
   extent(const iType& r) const {
     return m_map.extent(r);
   }
 
   template <typename iType>
-  KOKKOS_FUNCTION constexpr std::enable_if_t<std::is_integral<iType>::value,
-                                             int>
+  KOKKOS_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>, int>
   extent_int(const iType& r) const {
     return static_cast<int>(m_map.extent(r));
   }
@@ -288,8 +286,7 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
   KOKKOS_FUNCTION constexpr size_t stride_7() const { return m_map.stride_7(); }
 
   template <typename iType>
-  KOKKOS_FUNCTION constexpr std::enable_if_t<std::is_integral<iType>::value,
-                                             size_t>
+  KOKKOS_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>, size_t>
   stride(iType r) const {
     return (
         r == 0
@@ -322,7 +319,7 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
 
   enum {
     reference_type_is_lvalue_reference =
-        std::is_lvalue_reference<reference_type>::value
+        std::is_lvalue_reference_v<reference_type>
   };
 
   KOKKOS_FUNCTION constexpr size_t span() const { return m_map.span(); }
@@ -346,16 +343,16 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
 
  private:
   static constexpr bool is_layout_left =
-      std::is_same<typename traits::array_layout, Kokkos::LayoutLeft>::value;
+      std::is_same_v<typename traits::array_layout, Kokkos::LayoutLeft>;
 
   static constexpr bool is_layout_right =
-      std::is_same<typename traits::array_layout, Kokkos::LayoutRight>::value;
+      std::is_same_v<typename traits::array_layout, Kokkos::LayoutRight>;
 
   static constexpr bool is_layout_stride =
-      std::is_same<typename traits::array_layout, Kokkos::LayoutStride>::value;
+      std::is_same_v<typename traits::array_layout, Kokkos::LayoutStride>;
 
   static constexpr bool is_default_map =
-      std::is_void<typename traits::specialize>::value &&
+      std::is_void_v<typename traits::specialize> &&
       (is_layout_left || is_layout_right || is_layout_stride);
 
 #if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
@@ -1185,8 +1182,8 @@ KOKKOS_INLINE_FUNCTION constexpr unsigned rank(const OffsetView<D, P...>& V) {
 namespace Impl {
 
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_integral<T>::value, T>
-shift_input(const T arg, const int64_t offset) {
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_integral_v<T>, T> shift_input(
+    const T arg, const int64_t offset) {
   return arg - offset;
 }
 
@@ -1197,13 +1194,13 @@ Kokkos::ALL_t shift_input(const Kokkos::ALL_t arg, const int64_t /*offset*/) {
 
 template <class T>
 KOKKOS_INLINE_FUNCTION
-    std::enable_if_t<std::is_integral<T>::value, Kokkos::pair<T, T>>
+    std::enable_if_t<std::is_integral_v<T>, Kokkos::pair<T, T>>
     shift_input(const Kokkos::pair<T, T> arg, const int64_t offset) {
   return Kokkos::make_pair<T, T>(arg.first - offset, arg.second - offset);
 }
 template <class T>
-inline std::enable_if_t<std::is_integral<T>::value, std::pair<T, T>>
-shift_input(const std::pair<T, T> arg, const int64_t offset) {
+inline std::enable_if_t<std::is_integral_v<T>, std::pair<T, T>> shift_input(
+    const std::pair<T, T> arg, const int64_t offset) {
   return std::make_pair<T, T>(arg.first - offset, arg.second - offset);
 }
 
@@ -1212,7 +1209,7 @@ KOKKOS_INLINE_FUNCTION void map_arg_to_new_begin(
     const size_t i, Kokkos::Array<int64_t, N>& subviewBegins,
     std::enable_if_t<N != 0, const Arg> shiftedArg, const Arg arg,
     const A viewBegins, size_t& counter) {
-  if (!std::is_integral<Arg>::value) {
+  if (!std::is_integral_v<Arg>) {
     subviewBegins[counter] = shiftedArg == arg ? viewBegins[i] : 0;
     counter++;
   }
@@ -1641,12 +1638,12 @@ KOKKOS_INLINE_FUNCTION bool operator==(const OffsetView<LT, LP...>& lhs,
   using lhs_traits = ViewTraits<LT, LP...>;
   using rhs_traits = ViewTraits<RT, RP...>;
 
-  return std::is_same<typename lhs_traits::const_value_type,
-                      typename rhs_traits::const_value_type>::value &&
-         std::is_same<typename lhs_traits::array_layout,
-                      typename rhs_traits::array_layout>::value &&
-         std::is_same<typename lhs_traits::memory_space,
-                      typename rhs_traits::memory_space>::value &&
+  return std::is_same_v<typename lhs_traits::const_value_type,
+                        typename rhs_traits::const_value_type> &&
+         std::is_same_v<typename lhs_traits::array_layout,
+                        typename rhs_traits::array_layout> &&
+         std::is_same_v<typename lhs_traits::memory_space,
+                        typename rhs_traits::memory_space> &&
          unsigned(lhs_traits::rank) == unsigned(rhs_traits::rank) &&
          lhs.data() == rhs.data() && lhs.span() == rhs.span() &&
          lhs.extent(0) == rhs.extent(0) && lhs.extent(1) == rhs.extent(1) &&
@@ -1672,12 +1669,12 @@ KOKKOS_INLINE_FUNCTION bool operator==(const View<LT, LP...>& lhs,
   using lhs_traits = ViewTraits<LT, LP...>;
   using rhs_traits = ViewTraits<RT, RP...>;
 
-  return std::is_same<typename lhs_traits::const_value_type,
-                      typename rhs_traits::const_value_type>::value &&
-         std::is_same<typename lhs_traits::array_layout,
-                      typename rhs_traits::array_layout>::value &&
-         std::is_same<typename lhs_traits::memory_space,
-                      typename rhs_traits::memory_space>::value &&
+  return std::is_same_v<typename lhs_traits::const_value_type,
+                        typename rhs_traits::const_value_type> &&
+         std::is_same_v<typename lhs_traits::array_layout,
+                        typename rhs_traits::array_layout> &&
+         std::is_same_v<typename lhs_traits::memory_space,
+                        typename rhs_traits::memory_space> &&
          unsigned(lhs_traits::rank) == unsigned(rhs_traits::rank) &&
          lhs.data() == rhs.data() && lhs.span() == rhs.span() &&
          lhs.extent(0) == rhs.extent(0) && lhs.extent(1) == rhs.extent(1) &&
@@ -1704,11 +1701,11 @@ template <class DT, class... DP>
 inline void deep_copy(
     const Experimental::OffsetView<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<std::is_same<typename ViewTraits<DT, DP...>::specialize,
-                                  void>::value>* = nullptr) {
+    std::enable_if_t<std::is_same_v<typename ViewTraits<DT, DP...>::specialize,
+                                    void>>* = nullptr) {
   static_assert(
-      std::is_same<typename ViewTraits<DT, DP...>::non_const_value_type,
-                   typename ViewTraits<DT, DP...>::value_type>::value,
+      std::is_same_v<typename ViewTraits<DT, DP...>::non_const_value_type,
+                     typename ViewTraits<DT, DP...>::value_type>,
       "deep_copy requires non-const type");
 
   auto dstView = dst.view();
@@ -1719,11 +1716,11 @@ template <class DT, class... DP, class ST, class... SP>
 inline void deep_copy(
     const Experimental::OffsetView<DT, DP...>& dst,
     const Experimental::OffsetView<ST, SP...>& value,
-    std::enable_if_t<std::is_same<typename ViewTraits<DT, DP...>::specialize,
-                                  void>::value>* = nullptr) {
+    std::enable_if_t<std::is_same_v<typename ViewTraits<DT, DP...>::specialize,
+                                    void>>* = nullptr) {
   static_assert(
-      std::is_same<typename ViewTraits<DT, DP...>::value_type,
-                   typename ViewTraits<ST, SP...>::non_const_value_type>::value,
+      std::is_same_v<typename ViewTraits<DT, DP...>::value_type,
+                     typename ViewTraits<ST, SP...>::non_const_value_type>,
       "deep_copy requires matching non-const destination type");
 
   auto dstView = dst.view();
@@ -1733,11 +1730,11 @@ template <class DT, class... DP, class ST, class... SP>
 inline void deep_copy(
     const Experimental::OffsetView<DT, DP...>& dst,
     const View<ST, SP...>& value,
-    std::enable_if_t<std::is_same<typename ViewTraits<DT, DP...>::specialize,
-                                  void>::value>* = nullptr) {
+    std::enable_if_t<std::is_same_v<typename ViewTraits<DT, DP...>::specialize,
+                                    void>>* = nullptr) {
   static_assert(
-      std::is_same<typename ViewTraits<DT, DP...>::value_type,
-                   typename ViewTraits<ST, SP...>::non_const_value_type>::value,
+      std::is_same_v<typename ViewTraits<DT, DP...>::value_type,
+                     typename ViewTraits<ST, SP...>::non_const_value_type>,
       "deep_copy requires matching non-const destination type");
 
   auto dstView = dst.view();
@@ -1748,11 +1745,11 @@ template <class DT, class... DP, class ST, class... SP>
 inline void deep_copy(
     const View<DT, DP...>& dst,
     const Experimental::OffsetView<ST, SP...>& value,
-    std::enable_if_t<std::is_same<typename ViewTraits<DT, DP...>::specialize,
-                                  void>::value>* = nullptr) {
+    std::enable_if_t<std::is_same_v<typename ViewTraits<DT, DP...>::specialize,
+                                    void>>* = nullptr) {
   static_assert(
-      std::is_same<typename ViewTraits<DT, DP...>::value_type,
-                   typename ViewTraits<ST, SP...>::non_const_value_type>::value,
+      std::is_same_v<typename ViewTraits<DT, DP...>::value_type,
+                     typename ViewTraits<ST, SP...>::non_const_value_type>,
       "deep_copy requires matching non-const destination type");
 
   Kokkos::deep_copy(dst, value.view());
@@ -1770,7 +1767,7 @@ struct MirrorOffsetViewType {
   // Check whether it is the same memory space
   enum {
     is_same_memspace =
-        std::is_same<memory_space, typename src_view_type::memory_space>::value
+        std::is_same_v<memory_space, typename src_view_type::memory_space>
   };
   // The array_layout
   using array_layout = typename src_view_type::array_layout;
@@ -1795,7 +1792,7 @@ struct MirrorOffsetType {
   // Check whether it is the same memory space
   enum {
     is_same_memspace =
-        std::is_same<memory_space, typename src_view_type::memory_space>::value
+        std::is_same_v<memory_space, typename src_view_type::memory_space>
   };
   // The array_layout
   using array_layout = typename src_view_type::array_layout;
@@ -1905,14 +1902,14 @@ inline auto create_mirror_view(
     const Kokkos::Experimental::OffsetView<T, P...>& src,
     [[maybe_unused]] const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
   if constexpr (!Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space) {
-    if constexpr (std::is_same<typename Kokkos::Experimental::OffsetView<
-                                   T, P...>::memory_space,
-                               typename Kokkos::Experimental::OffsetView<
-                                   T, P...>::HostMirror::memory_space>::value &&
-                  std::is_same<typename Kokkos::Experimental::OffsetView<
-                                   T, P...>::data_type,
-                               typename Kokkos::Experimental::OffsetView<
-                                   T, P...>::HostMirror::data_type>::value) {
+    if constexpr (std::is_same_v<typename Kokkos::Experimental::OffsetView<
+                                     T, P...>::memory_space,
+                                 typename Kokkos::Experimental::OffsetView<
+                                     T, P...>::HostMirror::memory_space> &&
+                  std::is_same_v<typename Kokkos::Experimental::OffsetView<
+                                     T, P...>::data_type,
+                                 typename Kokkos::Experimental::OffsetView<
+                                     T, P...>::HostMirror::data_type>) {
       return
           typename Kokkos::Experimental::OffsetView<T, P...>::HostMirror(src);
     } else {

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -905,7 +905,7 @@ class ScatterAccess<DataType, Op, DeviceType, Layout, ScatterNonDuplicated,
 
   template <typename Arg>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      view_type::original_view_type::rank == 1 && std::is_integral<Arg>::value,
+      view_type::original_view_type::rank == 1 && std::is_integral_v<Arg>,
       value_type>
   operator[](Arg arg) const {
     return view.at(arg);
@@ -1460,7 +1460,7 @@ class ScatterAccess<DataType, Op, DeviceType, Layout, ScatterDuplicated,
 
   template <typename Arg>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      view_type::original_view_type::rank == 1 && std::is_integral<Arg>::value,
+      view_type::original_view_type::rank == 1 && std::is_integral_v<Arg>,
       value_type>
   operator[](Arg arg) const {
     return view.at(thread_id, arg);
@@ -1497,16 +1497,16 @@ ScatterView<
     RT, typename ViewTraits<RT, RP...>::array_layout,
     typename ViewTraits<RT, RP...>::device_type, Op,
     std::conditional_t<
-        std::is_void<Duplication>::value,
+        std::is_void_v<Duplication>,
         typename Kokkos::Impl::Experimental::DefaultDuplication<
             typename ViewTraits<RT, RP...>::execution_space>::type,
         Duplication>,
     std::conditional_t<
-        std::is_void<Contribution>::value,
+        std::is_void_v<Contribution>,
         typename Kokkos::Impl::Experimental::DefaultContribution<
             typename ViewTraits<RT, RP...>::execution_space,
             typename std::conditional_t<
-                std::is_void<Duplication>::value,
+                std::is_void_v<Duplication>,
                 typename Kokkos::Impl::Experimental::DefaultDuplication<
                     typename ViewTraits<RT, RP...>::execution_space>::type,
                 Duplication>>::type,

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -905,7 +905,7 @@ class ScatterAccess<DataType, Op, DeviceType, Layout, ScatterNonDuplicated,
 
   template <typename Arg>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      view_type::original_view_type::rank == 1 && std::is_integral_v<Arg>,
+      std::is_integral_v<Arg> && view_type::original_view_type::rank == 1,
       value_type>
   operator[](Arg arg) const {
     return view.at(arg);
@@ -1460,7 +1460,7 @@ class ScatterAccess<DataType, Op, DeviceType, Layout, ScatterDuplicated,
 
   template <typename Arg>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      view_type::original_view_type::rank == 1 && std::is_integral_v<Arg>,
+      std::is_integral_v<Arg> && view_type::original_view_type::rank == 1,
       value_type>
   operator[](Arg arg) const {
     return view.at(thread_id, arg);

--- a/containers/src/Kokkos_StaticCrsGraph.hpp
+++ b/containers/src/Kokkos_StaticCrsGraph.hpp
@@ -190,7 +190,7 @@ struct GraphRowViewConst {
       const typename GraphType::entries_type& colidx_in,
       const ordinal_type& stride, const ordinal_type& count,
       const OffsetType& idx,
-      const std::enable_if_t<std::is_integral<OffsetType>::value, int>& = 0)
+      const std::enable_if_t<std::is_integral_v<OffsetType>, int>& = 0)
       : colidx_(&colidx_in(idx)), stride_(stride), length(count) {}
 
   /// \brief Number of entries in the row.

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -746,7 +746,7 @@ class UnorderedMap {
   /// 'const value_type' via Cuda texture fetch must return by value.
   template <typename Dummy = value_type>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      !std::is_void<Dummy>::value,  // !is_set
+      !std::is_void_v<Dummy>,  // !is_set
       std::conditional_t<has_const_value, impl_value_type, impl_value_type &>>
   value_at(size_type i) const {
     KOKKOS_EXPECTS(i < capacity());
@@ -808,8 +808,8 @@ class UnorderedMap {
   // Re-allocate the views of the calling UnorderedMap according to src
   // capacity, and deep copy the src data.
   template <typename SKey, typename SValue, typename SDevice>
-  std::enable_if_t<std::is_same<std::remove_const_t<SKey>, key_type>::value &&
-                   std::is_same<std::remove_const_t<SValue>, value_type>::value>
+  std::enable_if_t<std::is_same_v<std::remove_const_t<SKey>, key_type> &&
+                   std::is_same_v<std::remove_const_t<SValue>, value_type>>
   create_copy_view(
       UnorderedMap<SKey, SValue, SDevice, Hasher, EqualTo> const &src) {
     if (m_hash_lists.data() != src.m_hash_lists.data()) {
@@ -821,8 +821,8 @@ class UnorderedMap {
   // Allocate views of the calling UnorderedMap with the same capacity as the
   // src.
   template <typename SKey, typename SValue, typename SDevice>
-  std::enable_if_t<std::is_same<std::remove_const_t<SKey>, key_type>::value &&
-                   std::is_same<std::remove_const_t<SValue>, value_type>::value>
+  std::enable_if_t<std::is_same_v<std::remove_const_t<SKey>, key_type> &&
+                   std::is_same_v<std::remove_const_t<SValue>, value_type>>
   allocate_view(
       UnorderedMap<SKey, SValue, SDevice, Hasher, EqualTo> const &src) {
     insertable_map_type tmp;
@@ -852,8 +852,8 @@ class UnorderedMap {
   // Deep copy view data from src. This requires that the src capacity is
   // identical to the capacity of the calling UnorderedMap.
   template <typename SKey, typename SValue, typename SDevice>
-  std::enable_if_t<std::is_same<std::remove_const_t<SKey>, key_type>::value &&
-                   std::is_same<std::remove_const_t<SValue>, value_type>::value>
+  std::enable_if_t<std::is_same_v<std::remove_const_t<SKey>, key_type> &&
+                   std::is_same_v<std::remove_const_t<SValue>, value_type>>
   deep_copy_view(
       UnorderedMap<SKey, SValue, SDevice, Hasher, EqualTo> const &src) {
 #ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4

--- a/containers/src/Kokkos_Vector.hpp
+++ b/containers/src/Kokkos_Vector.hpp
@@ -172,9 +172,8 @@ class KOKKOS_DEPRECATED vector
 
  private:
   template <class T>
-  struct impl_is_input_iterator
-      : /* TODO replace this */ std::bool_constant<
-            !std::is_convertible<T, size_type>::value> {};
+  struct impl_is_input_iterator : /* TODO replace this */ std::bool_constant<
+                                      !std::is_convertible_v<T, size_type>> {};
 
  public:
   // TODO: can use detection idiom to generate better error message here later

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -792,9 +792,8 @@ class TestDynViewAPI {
       int equal_ptr_h2_d = a_h2.data() == a_d.data() ? 1 : 0;
 
       int is_same_memspace =
-          std::is_same<Kokkos::HostSpace, typename device::memory_space>::value
-              ? 1
-              : 0;
+          std::is_same_v<Kokkos::HostSpace, typename device::memory_space> ? 1
+                                                                           : 0;
       ASSERT_EQ(equal_ptr_h_h2, 1);
       ASSERT_EQ(equal_ptr_h_d, is_same_memspace);
       ASSERT_EQ(equal_ptr_h2_d, is_same_memspace);
@@ -817,9 +816,8 @@ class TestDynViewAPI {
       int equal_ptr_h2_d = a_h2.data() == a_d.data() ? 1 : 0;
 
       int is_same_memspace =
-          std::is_same<Kokkos::HostSpace, typename device::memory_space>::value
-              ? 1
-              : 0;
+          std::is_same_v<Kokkos::HostSpace, typename device::memory_space> ? 1
+                                                                           : 0;
       ASSERT_EQ(equal_ptr_h_h2, 1);
       ASSERT_EQ(equal_ptr_h_d, is_same_memspace);
       ASSERT_EQ(equal_ptr_h2_d, is_same_memspace);
@@ -846,9 +844,8 @@ class TestDynViewAPI {
       int equal_ptr_h2_d = a_h2.data() == a_d.data() ? 1 : 0;
 
       int is_same_memspace =
-          std::is_same<Kokkos::HostSpace, typename device::memory_space>::value
-              ? 1
-              : 0;
+          std::is_same_v<Kokkos::HostSpace, typename device::memory_space> ? 1
+                                                                           : 0;
       ASSERT_EQ(equal_ptr_h_h2, 1);
       ASSERT_EQ(equal_ptr_h_d, is_same_memspace);
       ASSERT_EQ(equal_ptr_h2_d, is_same_memspace);
@@ -879,8 +876,7 @@ class TestDynViewAPI {
       int equal_ptr_h3_d = a_h3.data() == a_d.data() ? 1 : 0;
 
       int is_same_memspace =
-          std::is_same<Kokkos::HostSpace,
-                       typename DeviceType::memory_space>::value
+          std::is_same_v<Kokkos::HostSpace, typename DeviceType::memory_space>
               ? 1
               : 0;
       ASSERT_EQ(equal_ptr_h_h2, 1);
@@ -915,8 +911,7 @@ class TestDynViewAPI {
       int equal_ptr_h3_d = a_h3.data() == a_d.data() ? 1 : 0;
 
       int is_same_memspace =
-          std::is_same<Kokkos::HostSpace,
-                       typename DeviceType::memory_space>::value
+          std::is_same_v<Kokkos::HostSpace, typename DeviceType::memory_space>
               ? 1
               : 0;
       ASSERT_EQ(equal_ptr_h_h2, 1);

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -714,7 +714,7 @@ void test_scatter_view(int64_t n) {
     test_sv_config.run_test(n);
   }
 #ifdef KOKKOS_ENABLE_SERIAL
-  if (!std::is_same<DeviceType, Kokkos::Serial>::value) {
+  if (!std::is_same_v<DeviceType, Kokkos::Serial>) {
 #endif
     test_scatter_view_config<DeviceType, Kokkos::LayoutRight,
                              Kokkos::Experimental::ScatterNonDuplicated,

--- a/containers/unit_tests/TestStaticCrsGraph.hpp
+++ b/containers/unit_tests/TestStaticCrsGraph.hpp
@@ -237,14 +237,14 @@ void run_test_graph4() {
   dx.row_map = typename dView::row_map_type(tmp_row_map.data(), numRows + 1);
   dx.entries = typename dView::entries_type(tmp_entries.data(), nnz);
 
-  ASSERT_TRUE((std::is_same<typename dView::row_map_type::memory_traits,
-                            Kokkos::MemoryUnmanaged>::value));
-  ASSERT_TRUE((std::is_same<typename dView::entries_type::memory_traits,
-                            Kokkos::MemoryUnmanaged>::value));
-  ASSERT_TRUE((std::is_same<typename hView::row_map_type::memory_traits,
-                            Kokkos::MemoryUnmanaged>::value));
-  ASSERT_TRUE((std::is_same<typename hView::entries_type::memory_traits,
-                            Kokkos::MemoryUnmanaged>::value));
+  ASSERT_TRUE((std::is_same_v<typename dView::row_map_type::memory_traits,
+                              Kokkos::MemoryUnmanaged>));
+  ASSERT_TRUE((std::is_same_v<typename dView::entries_type::memory_traits,
+                              Kokkos::MemoryUnmanaged>));
+  ASSERT_TRUE((std::is_same_v<typename hView::row_map_type::memory_traits,
+                              Kokkos::MemoryUnmanaged>));
+  ASSERT_TRUE((std::is_same_v<typename hView::entries_type::memory_traits,
+                              Kokkos::MemoryUnmanaged>));
 }
 
 } /* namespace TestStaticCrsGraph */

--- a/containers/unit_tests/TestViewCtorPropEmbeddedDim.hpp
+++ b/containers/unit_tests/TestViewCtorPropEmbeddedDim.hpp
@@ -78,7 +78,7 @@ struct TestViewCtorProp_EmbeddedDim {
         HostCVT hcv1 = Kokkos::create_mirror_view(cv1);
         Kokkos::deep_copy(hcv1, cv1);
 
-        ASSERT_EQ((std::is_same<CommonViewValueType, double>::value), true);
+        ASSERT_EQ((std::is_same_v<CommonViewValueType, double>), true);
 #if 0
       // debug output
       for ( int i = 0; i < N0*N1; ++i ) {
@@ -87,7 +87,7 @@ struct TestViewCtorProp_EmbeddedDim {
 
       printf( " Common value type view: %s \n", typeid( CVT() ).name() );
       printf( " Common value type: %s \n", typeid( CommonViewValueType() ).name() );
-      if ( std::is_same< CommonViewValueType, double >::value == true ) {
+      if ( std::is_same_v< CommonViewValueType, double > == true ) {
         printf("Proper common value_type\n");
       }
       else {
@@ -115,7 +115,7 @@ struct TestViewCtorProp_EmbeddedDim {
         HostCVT hcv1 = Kokkos::create_mirror_view(cv1);
         Kokkos::deep_copy(hcv1, cv1);
 
-        ASSERT_EQ((std::is_same<CommonViewValueType, int>::value), true);
+        ASSERT_EQ((std::is_same_v<CommonViewValueType, int>), true);
       }
     }
 
@@ -148,7 +148,7 @@ struct TestViewCtorProp_EmbeddedDim {
         HostCVT hcv1 = Kokkos::create_mirror_view(cv1);
         Kokkos::deep_copy(hcv1, cv1);
 
-        ASSERT_EQ((std::is_same<CommonViewValueType, double>::value), true);
+        ASSERT_EQ((std::is_same_v<CommonViewValueType, double>), true);
       }
 
       {
@@ -169,7 +169,7 @@ struct TestViewCtorProp_EmbeddedDim {
         HostCVT hcv1 = Kokkos::create_mirror_view(cv1);
         Kokkos::deep_copy(hcv1, cv1);
 
-        ASSERT_EQ((std::is_same<CommonViewValueType, int>::value), true);
+        ASSERT_EQ((std::is_same_v<CommonViewValueType, int>), true);
       }
     }
 

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -231,7 +231,7 @@ TEST(TEST_CATEGORY, realloc_exec_space_dynrankview) {
 
 // FIXME_THREADS The Threads backend fences every parallel_for
 #ifdef KOKKOS_ENABLE_THREADS
-  if (std::is_same<TEST_EXECSPACE, Kokkos::Threads>::value)
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Threads>)
     GTEST_SKIP() << "skipping since the Threads backend isn't asynchronous";
 #endif
 
@@ -370,13 +370,12 @@ TEST(TEST_CATEGORY, realloc_exec_space_scatterview) {
 
 // FIXME_THREADS The Threads backend fences every parallel_for
 #ifdef KOKKOS_ENABLE_THREADS
-  if (std::is_same<typename TEST_EXECSPACE, Kokkos::Threads>::value)
+  if (std::is_same_v<typename TEST_EXECSPACE, Kokkos::Threads>)
     GTEST_SKIP() << "skipping since the Threads backend isn't asynchronous";
 #endif
 #if defined(KOKKOS_ENABLE_HPX) && \
     !defined(KOKKOS_ENABLE_IMPL_HPX_ASYNC_DISPATCH)
-  if (std::is_same<Kokkos::DefaultExecutionSpace,
-                   Kokkos::Experimental::HPX>::value)
+  if (std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::Experimental::HPX>)
     GTEST_SKIP() << "skipping since the HPX backend always fences with async "
                     "dispatch disabled";
 #endif

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -61,13 +61,13 @@ namespace Impl {
 // NOTE the comparison below is encapsulated to silent warnings about pointless
 // comparison of unsigned integer with zero
 template <class T>
-constexpr std::enable_if_t<!std::is_signed<T>::value, bool>
+constexpr std::enable_if_t<!std::is_signed_v<T>, bool>
 is_less_than_value_initialized_variable(T) {
   return false;
 }
 
 template <class T>
-constexpr std::enable_if_t<std::is_signed<T>::value, bool>
+constexpr std::enable_if_t<std::is_signed_v<T>, bool>
 is_less_than_value_initialized_variable(T arg) {
   return arg < T{};
 }
@@ -76,7 +76,7 @@ is_less_than_value_initialized_variable(T arg) {
 template <class To, class From>
 constexpr To checked_narrow_cast(From arg, std::size_t idx) {
   constexpr const bool is_different_signedness =
-      (std::is_signed<To>::value != std::is_signed<From>::value);
+      (std::is_signed_v<To> != std::is_signed_v<From>);
   auto const ret = static_cast<To>(arg);
   if (static_cast<From>(ret) != arg ||
       (is_different_signedness &&
@@ -184,7 +184,7 @@ struct MDRangePolicy<P, Properties...>
   template <class... OtherProperties>
   friend struct MDRangePolicy;
 
-  static_assert(!std::is_void<typename traits::iteration_pattern>::value,
+  static_assert(!std::is_void_v<typename traits::iteration_pattern>,
                 "Kokkos Error: MD iteration pattern not defined");
 
   using iteration_pattern = typename traits::iteration_pattern;
@@ -239,9 +239,9 @@ struct MDRangePolicy<P, Properties...>
 
   template <typename LT, std::size_t LN, typename UT, std::size_t UN,
             typename TT = array_index_type, std::size_t TN = rank,
-            typename = std::enable_if_t<std::is_integral<LT>::value &&
-                                        std::is_integral<UT>::value &&
-                                        std::is_integral<TT>::value>>
+            typename = std::enable_if_t<std::is_integral_v<LT> &&
+                                        std::is_integral_v<UT> &&
+                                        std::is_integral_v<TT>>>
   MDRangePolicy(const LT (&lower)[LN], const UT (&upper)[UN],
                 const TT (&tile)[TN] = {})
       : MDRangePolicy(
@@ -258,9 +258,9 @@ struct MDRangePolicy<P, Properties...>
 
   template <typename LT, std::size_t LN, typename UT, std::size_t UN,
             typename TT = array_index_type, std::size_t TN = rank,
-            typename = std::enable_if_t<std::is_integral<LT>::value &&
-                                        std::is_integral<UT>::value &&
-                                        std::is_integral<TT>::value>>
+            typename = std::enable_if_t<std::is_integral_v<LT> &&
+                                        std::is_integral_v<UT> &&
+                                        std::is_integral_v<TT>>>
   MDRangePolicy(const typename traits::execution_space& work_space,
                 const LT (&lower)[LN], const UT (&upper)[UN],
                 const TT (&tile)[TN] = {})
@@ -292,14 +292,14 @@ struct MDRangePolicy<P, Properties...>
   }
 
   template <typename T, std::size_t NT = rank,
-            typename = std::enable_if_t<std::is_integral<T>::value>>
+            typename = std::enable_if_t<std::is_integral_v<T>>>
   MDRangePolicy(Kokkos::Array<T, rank> const& lower,
                 Kokkos::Array<T, rank> const& upper,
                 Kokkos::Array<T, NT> const& tile = Kokkos::Array<T, NT>{})
       : MDRangePolicy(typename traits::execution_space(), lower, upper, tile) {}
 
   template <typename T, std::size_t NT = rank,
-            typename = std::enable_if_t<std::is_integral<T>::value>>
+            typename = std::enable_if_t<std::is_integral_v<T>>>
   MDRangePolicy(const typename traits::execution_space& work_space,
                 Kokkos::Array<T, rank> const& lower,
                 Kokkos::Array<T, rank> const& upper,

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -35,7 +35,7 @@ namespace Kokkos {
 
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
 namespace Impl {
-template <typename Integral, bool Signed = std::is_signed<Integral>::value>
+template <typename Integral, bool Signed = std::is_signed_v<Integral>>
 struct ArrayBoundsCheck;
 
 template <typename Integral>

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -70,9 +70,8 @@ class
   complex& operator=(const complex&) noexcept = default;
 
   /// \brief Conversion constructor from compatible RType
-  template <
-      class RType,
-      std::enable_if_t<std::is_convertible<RType, RealType>::value, int> = 0>
+  template <class RType,
+            std::enable_if_t<std::is_convertible_v<RType, RealType>, int> = 0>
   KOKKOS_INLINE_FUNCTION complex(const complex<RType>& other) noexcept
       // Intentionally do the conversions implicitly here so that users don't
       // get any warnings about narrowing, etc., that they would expect to get
@@ -265,9 +264,8 @@ class
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   //! Copy constructor from volatile.
-  template <
-      class RType,
-      std::enable_if_t<std::is_convertible<RType, RealType>::value, int> = 0>
+  template <class RType,
+            std::enable_if_t<std::is_convertible_v<RType, RealType>, int> = 0>
   KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION
   complex(const volatile complex<RType>& src) noexcept
       // Intentionally do the conversions implicitly here so that users don't
@@ -296,7 +294,7 @@ class
   //    vl = r;
   //    vl = cr;
   template <class Complex,
-            std::enable_if_t<std::is_same<Complex, complex>::value, int> = 0>
+            std::enable_if_t<std::is_same_v<Complex, complex>, int> = 0>
   KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION void operator=(
       const Complex& src) volatile noexcept {
     re_ = src.re_;
@@ -319,7 +317,7 @@ class
   //    vl = vr;
   //    vl = cvr;
   template <class Complex,
-            std::enable_if_t<std::is_same<Complex, complex>::value, int> = 0>
+            std::enable_if_t<std::is_same_v<Complex, complex>, int> = 0>
   KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION volatile complex& operator=(
       const volatile Complex& src) volatile noexcept {
     re_ = src.re_;
@@ -341,7 +339,7 @@ class
   //    l = cvr;
   //
   template <class Complex,
-            std::enable_if_t<std::is_same<Complex, complex>::value, int> = 0>
+            std::enable_if_t<std::is_same_v<Complex, complex>, int> = 0>
   KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION complex& operator=(
       const volatile Complex& src) noexcept {
     re_ = src.re_;
@@ -539,7 +537,7 @@ inline bool operator==(complex<RealType1> const& x,
 template <
     class RealType1, class RealType2,
     // Constraints to avoid participation in oparator==() for every possible RHS
-    std::enable_if_t<std::is_convertible<RealType2, RealType1>::value, int> = 0>
+    std::enable_if_t<std::is_convertible_v<RealType2, RealType1>, int> = 0>
 KOKKOS_INLINE_FUNCTION bool operator==(complex<RealType1> const& x,
                                        RealType2 const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
@@ -551,7 +549,7 @@ KOKKOS_INLINE_FUNCTION bool operator==(complex<RealType1> const& x,
 template <
     class RealType1, class RealType2,
     // Constraints to avoid participation in oparator==() for every possible RHS
-    std::enable_if_t<std::is_convertible<RealType1, RealType2>::value, int> = 0>
+    std::enable_if_t<std::is_convertible_v<RealType1, RealType2>, int> = 0>
 KOKKOS_INLINE_FUNCTION bool operator==(RealType1 const& x,
                                        complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
@@ -590,7 +588,7 @@ inline bool operator!=(complex<RealType1> const& x,
 template <
     class RealType1, class RealType2,
     // Constraints to avoid participation in oparator==() for every possible RHS
-    std::enable_if_t<std::is_convertible<RealType2, RealType1>::value, int> = 0>
+    std::enable_if_t<std::is_convertible_v<RealType2, RealType1>, int> = 0>
 KOKKOS_INLINE_FUNCTION bool operator!=(complex<RealType1> const& x,
                                        RealType2 const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
@@ -602,7 +600,7 @@ KOKKOS_INLINE_FUNCTION bool operator!=(complex<RealType1> const& x,
 template <
     class RealType1, class RealType2,
     // Constraints to avoid participation in oparator==() for every possible RHS
-    std::enable_if_t<std::is_convertible<RealType1, RealType2>::value, int> = 0>
+    std::enable_if_t<std::is_convertible_v<RealType1, RealType2>, int> = 0>
 KOKKOS_INLINE_FUNCTION bool operator!=(RealType1 const& x,
                                        complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
@@ -778,16 +776,14 @@ KOKKOS_INLINE_FUNCTION complex<T> pow(const complex<T>& x,
   return x == T() ? T() : exp(y * log(x));
 }
 
-template <class T, class U,
-          class = std::enable_if_t<std::is_arithmetic<T>::value>>
+template <class T, class U, class = std::enable_if_t<std::is_arithmetic_v<T>>>
 KOKKOS_INLINE_FUNCTION complex<Impl::promote_2_t<T, U>> pow(
     const T& x, const complex<U>& y) {
   using type = Impl::promote_2_t<T, U>;
   return pow(type(x), complex<type>(y));
 }
 
-template <class T, class U,
-          class = std::enable_if_t<std::is_arithmetic<U>::value>>
+template <class T, class U, class = std::enable_if_t<std::is_arithmetic_v<U>>>
 KOKKOS_INLINE_FUNCTION complex<Impl::promote_2_t<T, U>> pow(const complex<T>& x,
                                                             const U& y) {
   using type = Impl::promote_2_t<T, U>;

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -41,8 +41,7 @@ struct Dynamic {};
 // Schedule Wrapper Type
 template <class T>
 struct Schedule {
-  static_assert(std::is_same<T, Static>::value ||
-                    std::is_same<T, Dynamic>::value,
+  static_assert(std::is_same_v<T, Static> || std::is_same_v<T, Dynamic>,
                 "Kokkos: Invalid Schedule<> type.");
   using schedule_type = Schedule;
   using type          = T;
@@ -51,7 +50,7 @@ struct Schedule {
 // Specify Iteration Index Type
 template <typename T>
 struct IndexType {
-  static_assert(std::is_integral<T>::value, "Kokkos: Invalid IndexType<>.");
+  static_assert(std::is_integral_v<T>, "Kokkos: Invalid IndexType<>.");
   using index_type = IndexType;
   using type       = T;
 };
@@ -139,8 +138,8 @@ namespace Kokkos {
                                                                \
    public:                                                     \
     static constexpr bool value =                              \
-        std::is_base_of<detected_t<have_t, T>, T>::value ||    \
-        std::is_base_of<detected_t<have_type_t, T>, T>::value; \
+        std::is_base_of_v<detected_t<have_t, T>, T> ||         \
+        std::is_base_of_v<detected_t<have_type_t, T>, T>;      \
     constexpr operator bool() const noexcept { return value; } \
   };                                                           \
   template <typename T>                                        \
@@ -301,7 +300,7 @@ struct is_space {
   // in do_not_use_host_memory_space and do_not_use_host_execution_space to be
   // able to use them within this class without deprecation warnings.
   using do_not_use_host_memory_space = std::conditional_t<
-      std::is_same<memory_space, Kokkos::HostSpace>::value
+      std::is_same_v<memory_space, Kokkos::HostSpace>
 #if defined(KOKKOS_ENABLE_CUDA)
           || std::is_same<memory_space, Kokkos::CudaUVMSpace>::value ||
           std::is_same<memory_space, Kokkos::CudaHostPinnedSpace>::value
@@ -355,7 +354,7 @@ struct MemorySpaceAccess {
    *  2. All execution spaces that can access DstMemorySpace can also access
    *     SrcMemorySpace.
    */
-  enum { assignable = std::is_same<DstMemorySpace, SrcMemorySpace>::value };
+  enum { assignable = std::is_same_v<DstMemorySpace, SrcMemorySpace> };
 
   /**\brief  For all DstExecSpace::memory_space == DstMemorySpace
    *         DstExecSpace can access SrcMemorySpace.
@@ -440,7 +439,7 @@ struct SpaceAccessibility {
   // If same memory space or not accessible use the AccessSpace
   // else construct a device with execution space and memory space.
   using space = std::conditional_t<
-      std::is_same<typename AccessSpace::memory_space, MemorySpace>::value ||
+      std::is_same_v<typename AccessSpace::memory_space, MemorySpace> ||
           !exe_access::accessible,
       AccessSpace,
       Kokkos::Device<typename AccessSpace::execution_space, MemorySpace>>;

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -561,21 +561,20 @@ void view_copy(const ExecutionSpace& space, const DstType& dst,
     int64_t strides[DstType::rank + 1];
     dst.stride(strides);
     Kokkos::Iterate iterate;
-    if (std::is_same<typename DstType::array_layout,
-                     Kokkos::LayoutRight>::value) {
+    if (std::is_same_v<typename DstType::array_layout, Kokkos::LayoutRight>) {
       iterate = Kokkos::Iterate::Right;
-    } else if (std::is_same<typename DstType::array_layout,
-                            Kokkos::LayoutLeft>::value) {
+    } else if (std::is_same_v<typename DstType::array_layout,
+                              Kokkos::LayoutLeft>) {
       iterate = Kokkos::Iterate::Left;
-    } else if (std::is_same<typename DstType::array_layout,
-                            Kokkos::LayoutStride>::value) {
+    } else if (std::is_same_v<typename DstType::array_layout,
+                              Kokkos::LayoutStride>) {
       if (strides[0] > strides[DstType::rank - 1])
         iterate = Kokkos::Iterate::Right;
       else
         iterate = Kokkos::Iterate::Left;
     } else {
-      if (std::is_same<typename DstType::execution_space::array_layout,
-                       Kokkos::LayoutRight>::value)
+      if (std::is_same_v<typename DstType::execution_space::array_layout,
+                         Kokkos::LayoutRight>)
         iterate = Kokkos::Iterate::Right;
       else
         iterate = Kokkos::Iterate::Left;
@@ -649,21 +648,20 @@ void view_copy(const DstType& dst, const SrcType& src) {
   int64_t strides[DstType::rank + 1];
   dst.stride(strides);
   Kokkos::Iterate iterate;
-  if (std::is_same<typename DstType::array_layout,
-                   Kokkos::LayoutRight>::value) {
+  if (std::is_same_v<typename DstType::array_layout, Kokkos::LayoutRight>) {
     iterate = Kokkos::Iterate::Right;
-  } else if (std::is_same<typename DstType::array_layout,
-                          Kokkos::LayoutLeft>::value) {
+  } else if (std::is_same_v<typename DstType::array_layout,
+                            Kokkos::LayoutLeft>) {
     iterate = Kokkos::Iterate::Left;
-  } else if (std::is_same<typename DstType::array_layout,
-                          Kokkos::LayoutStride>::value) {
+  } else if (std::is_same_v<typename DstType::array_layout,
+                            Kokkos::LayoutStride>) {
     if (strides[0] > strides[DstType::rank - 1])
       iterate = Kokkos::Iterate::Right;
     else
       iterate = Kokkos::Iterate::Left;
   } else {
-    if (std::is_same<typename DstType::execution_space::array_layout,
-                     Kokkos::LayoutRight>::value)
+    if (std::is_same_v<typename DstType::execution_space::array_layout,
+                       Kokkos::LayoutRight>)
       iterate = Kokkos::Iterate::Right;
     else
       iterate = Kokkos::Iterate::Left;
@@ -1433,8 +1431,8 @@ template <class DT, class... DP>
 inline void deep_copy(
     const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<std::is_same<typename ViewTraits<DT, DP...>::specialize,
-                                  void>::value>* = nullptr) {
+    std::enable_if_t<std::is_same_v<typename ViewTraits<DT, DP...>::specialize,
+                                    void>>* = nullptr) {
   using ViewType        = View<DT, DP...>;
   using exec_space_type = typename ViewType::execution_space;
 
@@ -1456,8 +1454,8 @@ inline void deep_copy(
   }
 
   Kokkos::fence("Kokkos::deep_copy: scalar copy, pre copy fence");
-  static_assert(std::is_same<typename ViewType::non_const_value_type,
-                             typename ViewType::value_type>::value,
+  static_assert(std::is_same_v<typename ViewType::non_const_value_type,
+                               typename ViewType::value_type>,
                 "deep_copy requires non-const type");
 
   // If contiguous we can simply do a 1D flat loop or use memset
@@ -1474,21 +1472,20 @@ inline void deep_copy(
   int64_t strides[ViewType::rank + 1];
   dst.stride(strides);
   Kokkos::Iterate iterate;
-  if (std::is_same<typename ViewType::array_layout,
-                   Kokkos::LayoutRight>::value) {
+  if (std::is_same_v<typename ViewType::array_layout, Kokkos::LayoutRight>) {
     iterate = Kokkos::Iterate::Right;
-  } else if (std::is_same<typename ViewType::array_layout,
-                          Kokkos::LayoutLeft>::value) {
+  } else if (std::is_same_v<typename ViewType::array_layout,
+                            Kokkos::LayoutLeft>) {
     iterate = Kokkos::Iterate::Left;
-  } else if (std::is_same<typename ViewType::array_layout,
-                          Kokkos::LayoutStride>::value) {
+  } else if (std::is_same_v<typename ViewType::array_layout,
+                            Kokkos::LayoutStride>) {
     if (strides[0] > strides[ViewType::rank > 0 ? ViewType::rank - 1 : 0])
       iterate = Kokkos::Iterate::Right;
     else
       iterate = Kokkos::Iterate::Left;
   } else {
-    if (std::is_same<typename ViewType::execution_space::array_layout,
-                     Kokkos::LayoutRight>::value)
+    if (std::is_same_v<typename ViewType::execution_space::array_layout,
+                       Kokkos::LayoutRight>)
       iterate = Kokkos::Iterate::Right;
     else
       iterate = Kokkos::Iterate::Left;
@@ -1531,8 +1528,8 @@ template <class ST, class... SP>
 inline void deep_copy(
     typename ViewTraits<ST, SP...>::non_const_value_type& dst,
     const View<ST, SP...>& src,
-    std::enable_if_t<std::is_same<typename ViewTraits<ST, SP...>::specialize,
-                                  void>::value>* = nullptr) {
+    std::enable_if_t<std::is_same_v<typename ViewTraits<ST, SP...>::specialize,
+                                    void>>* = nullptr) {
   using src_traits       = ViewTraits<ST, SP...>;
   using src_memory_space = typename src_traits::memory_space;
 
@@ -1568,8 +1565,8 @@ template <class DT, class... DP, class ST, class... SP>
 inline void deep_copy(
     const View<DT, DP...>& dst, const View<ST, SP...>& src,
     std::enable_if_t<
-        (std::is_void<typename ViewTraits<DT, DP...>::specialize>::value &&
-         std::is_void<typename ViewTraits<ST, SP...>::specialize>::value &&
+        (std::is_void_v<typename ViewTraits<DT, DP...>::specialize> &&
+         std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
          (unsigned(ViewTraits<DT, DP...>::rank) == unsigned(0) &&
           unsigned(ViewTraits<ST, SP...>::rank) == unsigned(0)))>* = nullptr) {
   using dst_type = View<DT, DP...>;
@@ -1579,8 +1576,8 @@ inline void deep_copy(
   using dst_memory_space = typename dst_type::memory_space;
   using src_memory_space = typename src_type::memory_space;
 
-  static_assert(std::is_same<typename dst_type::value_type,
-                             typename src_type::non_const_value_type>::value,
+  static_assert(std::is_same_v<typename dst_type::value_type,
+                               typename src_type::non_const_value_type>,
                 "deep_copy requires matching non-const destination type");
 
   if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
@@ -1620,8 +1617,8 @@ template <class DT, class... DP, class ST, class... SP>
 inline void deep_copy(
     const View<DT, DP...>& dst, const View<ST, SP...>& src,
     std::enable_if_t<
-        (std::is_void<typename ViewTraits<DT, DP...>::specialize>::value &&
-         std::is_void<typename ViewTraits<ST, SP...>::specialize>::value &&
+        (std::is_void_v<typename ViewTraits<DT, DP...>::specialize> &&
+         std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
          (unsigned(ViewTraits<DT, DP...>::rank) != 0 ||
           unsigned(ViewTraits<ST, SP...>::rank) != 0))>* = nullptr) {
   using dst_type            = View<DT, DP...>;
@@ -1633,8 +1630,8 @@ inline void deep_copy(
   using dst_value_type      = typename dst_type::value_type;
   using src_value_type      = typename src_type::value_type;
 
-  static_assert(std::is_same<typename dst_type::value_type,
-                             typename dst_type::non_const_value_type>::value,
+  static_assert(std::is_same_v<typename dst_type::value_type,
+                               typename dst_type::non_const_value_type>,
                 "deep_copy requires non-const destination type");
 
   static_assert((unsigned(dst_type::rank) == unsigned(src_type::rank)),
@@ -1764,10 +1761,10 @@ inline void deep_copy(
   // If same type, equal layout, equal dimensions, equal span, and contiguous
   // memory then can byte-wise copy
 
-  if (std::is_same<typename dst_type::value_type,
-                   typename src_type::non_const_value_type>::value &&
-      (std::is_same<typename dst_type::array_layout,
-                    typename src_type::array_layout>::value ||
+  if (std::is_same_v<typename dst_type::value_type,
+                     typename src_type::non_const_value_type> &&
+      (std::is_same_v<typename dst_type::array_layout,
+                      typename src_type::array_layout> ||
        (dst_type::rank == 1 && src_type::rank == 1)) &&
       dst.span_is_contiguous() && src.span_is_contiguous() &&
       ((dst_type::rank < 1) || (dst.stride_0() == src.stride_0())) &&
@@ -2183,8 +2180,8 @@ template <class TeamType, class DT, class... DP>
 void KOKKOS_INLINE_FUNCTION local_deep_copy_contiguous(
     const TeamType& team, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<std::is_same<typename ViewTraits<DT, DP...>::specialize,
-                                  void>::value>* = nullptr) {
+    std::enable_if_t<std::is_same_v<typename ViewTraits<DT, DP...>::specialize,
+                                    void>>* = nullptr) {
   Kokkos::parallel_for(Kokkos::TeamVectorRange(team, dst.span()),
                        [&](const int& i) { dst.data()[i] = value; });
 }
@@ -2193,8 +2190,8 @@ template <class DT, class... DP>
 void KOKKOS_INLINE_FUNCTION local_deep_copy_contiguous(
     const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
-    std::enable_if_t<std::is_same<typename ViewTraits<DT, DP...>::specialize,
-                                  void>::value>* = nullptr) {
+    std::enable_if_t<std::is_same_v<typename ViewTraits<DT, DP...>::specialize,
+                                    void>>* = nullptr) {
   for (size_t i = 0; i < dst.span(); ++i) {
     dst.data()[i] = value;
   }
@@ -2560,13 +2557,13 @@ inline void deep_copy(
     typename ViewTraits<DT, DP...>::const_value_type& value,
     std::enable_if_t<
         Kokkos::is_execution_space<ExecSpace>::value &&
-        std::is_void<typename ViewTraits<DT, DP...>::specialize>::value &&
+        std::is_void_v<typename ViewTraits<DT, DP...>::specialize> &&
         Kokkos::SpaceAccessibility<ExecSpace, typename ViewTraits<DT, DP...>::
                                                   memory_space>::accessible>* =
         nullptr) {
   using dst_traits = ViewTraits<DT, DP...>;
-  static_assert(std::is_same<typename dst_traits::non_const_value_type,
-                             typename dst_traits::value_type>::value,
+  static_assert(std::is_same_v<typename dst_traits::non_const_value_type,
+                               typename dst_traits::value_type>,
                 "deep_copy requires non-const type");
   using dst_memory_space = typename dst_traits::memory_space;
   if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
@@ -2586,21 +2583,20 @@ inline void deep_copy(
     int64_t strides[ViewType::rank + 1];
     dst.stride(strides);
     Kokkos::Iterate iterate;
-    if (std::is_same<typename ViewType::array_layout,
-                     Kokkos::LayoutRight>::value) {
+    if (std::is_same_v<typename ViewType::array_layout, Kokkos::LayoutRight>) {
       iterate = Kokkos::Iterate::Right;
-    } else if (std::is_same<typename ViewType::array_layout,
-                            Kokkos::LayoutLeft>::value) {
+    } else if (std::is_same_v<typename ViewType::array_layout,
+                              Kokkos::LayoutLeft>) {
       iterate = Kokkos::Iterate::Left;
-    } else if (std::is_same<typename ViewType::array_layout,
-                            Kokkos::LayoutStride>::value) {
+    } else if (std::is_same_v<typename ViewType::array_layout,
+                              Kokkos::LayoutStride>) {
       if (strides[0] > strides[ViewType::rank > 0 ? ViewType::rank - 1 : 0])
         iterate = Kokkos::Iterate::Right;
       else
         iterate = Kokkos::Iterate::Left;
     } else {
-      if (std::is_same<typename ViewType::execution_space::array_layout,
-                       Kokkos::LayoutRight>::value)
+      if (std::is_same_v<typename ViewType::execution_space::array_layout,
+                         Kokkos::LayoutRight>)
         iterate = Kokkos::Iterate::Right;
       else
         iterate = Kokkos::Iterate::Left;
@@ -2641,13 +2637,13 @@ inline void deep_copy(
     typename ViewTraits<DT, DP...>::const_value_type& value,
     std::enable_if_t<
         Kokkos::is_execution_space<ExecSpace>::value &&
-        std::is_void<typename ViewTraits<DT, DP...>::specialize>::value &&
+        std::is_void_v<typename ViewTraits<DT, DP...>::specialize> &&
         !Kokkos::SpaceAccessibility<ExecSpace, typename ViewTraits<DT, DP...>::
                                                    memory_space>::accessible>* =
         nullptr) {
   using dst_traits = ViewTraits<DT, DP...>;
-  static_assert(std::is_same<typename dst_traits::non_const_value_type,
-                             typename dst_traits::value_type>::value,
+  static_assert(std::is_same_v<typename dst_traits::non_const_value_type,
+                               typename dst_traits::value_type>,
                 "deep_copy requires non-const type");
   using dst_memory_space = typename dst_traits::memory_space;
   if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
@@ -2688,8 +2684,8 @@ inline void deep_copy(
     typename ViewTraits<ST, SP...>::non_const_value_type& dst,
     const View<ST, SP...>& src,
     std::enable_if_t<Kokkos::is_execution_space<ExecSpace>::value &&
-                     std::is_same<typename ViewTraits<ST, SP...>::specialize,
-                                  void>::value>* = nullptr) {
+                     std::is_same_v<typename ViewTraits<ST, SP...>::specialize,
+                                    void>>* = nullptr) {
   using src_traits       = ViewTraits<ST, SP...>;
   using src_memory_space = typename src_traits::memory_space;
   static_assert(src_traits::rank == 0,
@@ -2726,8 +2722,8 @@ inline void deep_copy(
     const View<ST, SP...>& src,
     std::enable_if_t<
         (Kokkos::is_execution_space<ExecSpace>::value &&
-         std::is_void<typename ViewTraits<DT, DP...>::specialize>::value &&
-         std::is_void<typename ViewTraits<ST, SP...>::specialize>::value &&
+         std::is_void_v<typename ViewTraits<DT, DP...>::specialize> &&
+         std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
          (unsigned(ViewTraits<DT, DP...>::rank) == unsigned(0) &&
           unsigned(ViewTraits<ST, SP...>::rank) == unsigned(0)))>* = nullptr) {
   using src_traits = ViewTraits<ST, SP...>;
@@ -2735,8 +2731,8 @@ inline void deep_copy(
 
   using src_memory_space = typename src_traits::memory_space;
   using dst_memory_space = typename dst_traits::memory_space;
-  static_assert(std::is_same<typename dst_traits::value_type,
-                             typename src_traits::non_const_value_type>::value,
+  static_assert(std::is_same_v<typename dst_traits::value_type,
+                               typename src_traits::non_const_value_type>,
                 "deep_copy requires matching non-const destination type");
 
   if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
@@ -2776,15 +2772,15 @@ inline void deep_copy(
     const View<ST, SP...>& src,
     std::enable_if_t<
         (Kokkos::is_execution_space<ExecSpace>::value &&
-         std::is_void<typename ViewTraits<DT, DP...>::specialize>::value &&
-         std::is_void<typename ViewTraits<ST, SP...>::specialize>::value &&
+         std::is_void_v<typename ViewTraits<DT, DP...>::specialize> &&
+         std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
          (unsigned(ViewTraits<DT, DP...>::rank) != 0 ||
           unsigned(ViewTraits<ST, SP...>::rank) != 0))>* = nullptr) {
   using dst_type = View<DT, DP...>;
   using src_type = View<ST, SP...>;
 
-  static_assert(std::is_same<typename dst_type::value_type,
-                             typename dst_type::non_const_value_type>::value,
+  static_assert(std::is_same_v<typename dst_type::value_type,
+                               typename dst_type::non_const_value_type>,
                 "deep_copy requires non-const destination type");
 
   static_assert((unsigned(dst_type::rank) == unsigned(src_type::rank)),
@@ -2914,10 +2910,10 @@ inline void deep_copy(
   // If same type, equal layout, equal dimensions, equal span, and contiguous
   // memory then can byte-wise copy
 
-  if (std::is_same<typename dst_type::value_type,
-                   typename src_type::non_const_value_type>::value &&
-      (std::is_same<typename dst_type::array_layout,
-                    typename src_type::array_layout>::value ||
+  if (std::is_same_v<typename dst_type::value_type,
+                     typename src_type::non_const_value_type> &&
+      (std::is_same_v<typename dst_type::array_layout,
+                      typename src_type::array_layout> ||
        (dst_type::rank == 1 && src_type::rank == 1)) &&
       dst.span_is_contiguous() && src.span_is_contiguous() &&
       ((dst_type::rank < 1) || (dst.stride_0() == src.stride_0())) &&
@@ -2986,11 +2982,11 @@ bool size_mismatch(const ViewType& view, unsigned int max_extent,
 /** \brief  Resize a view with copying old data to new data at the corresponding
  * indices. */
 template <class T, class... P, class... ViewCtorArgs>
-inline typename std::enable_if<
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutLeft>::value ||
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutRight>::value>::type
+inline std::enable_if_t<
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutLeft> ||
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutRight>>
 impl_resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
             Kokkos::View<T, P...>& v, const size_t n0, const size_t n1,
             const size_t n2, const size_t n3, const size_t n4, const size_t n5,
@@ -3040,10 +3036,10 @@ impl_resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
 
 template <class T, class... P, class... ViewCtorArgs>
 inline std::enable_if_t<
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutLeft>::value ||
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutRight>::value>
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutLeft> ||
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutRight>>
 resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
        Kokkos::View<T, P...>& v, const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
        const size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
@@ -3058,10 +3054,10 @@ resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
 
 template <class T, class... P>
 inline std::enable_if_t<
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutLeft>::value ||
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutRight>::value>
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutLeft> ||
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutRight>>
 resize(Kokkos::View<T, P...>& v, const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
        const size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
        const size_t n2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
@@ -3077,10 +3073,10 @@ template <class I, class T, class... P>
 inline std::enable_if_t<
     (Impl::is_view_ctor_property<I>::value ||
      Kokkos::is_execution_space<I>::value) &&
-    (std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                  Kokkos::LayoutLeft>::value ||
-     std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                  Kokkos::LayoutRight>::value)>
+    (std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                    Kokkos::LayoutLeft> ||
+     std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                    Kokkos::LayoutRight>)>
 resize(const I& arg_prop, Kokkos::View<T, P...>& v,
        const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
        const size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
@@ -3095,12 +3091,12 @@ resize(const I& arg_prop, Kokkos::View<T, P...>& v,
 
 template <class T, class... P, class... ViewCtorArgs>
 inline std::enable_if_t<
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutLeft>::value ||
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutRight>::value ||
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutStride>::value>
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutLeft> ||
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutRight> ||
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutStride>>
 impl_resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
             Kokkos::View<T, P...>& v,
             const typename Kokkos::View<T, P...>::array_layout& layout) {
@@ -3141,12 +3137,12 @@ impl_resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
 // the same as the existing one.
 template <class T, class... P, class... ViewCtorArgs>
 inline std::enable_if_t<
-    !(std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                   Kokkos::LayoutLeft>::value ||
-      std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                   Kokkos::LayoutRight>::value ||
-      std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                   Kokkos::LayoutStride>::value)>
+    !(std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                     Kokkos::LayoutLeft> ||
+      std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                     Kokkos::LayoutRight> ||
+      std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                     Kokkos::LayoutStride>)>
 impl_resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
             Kokkos::View<T, P...>& v,
             const typename Kokkos::View<T, P...>::array_layout& layout) {
@@ -3210,10 +3206,10 @@ inline void resize(Kokkos::View<T, P...>& v,
 /** \brief  Resize a view with discarding old data. */
 template <class T, class... P, class... ViewCtorArgs>
 inline std::enable_if_t<
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutLeft>::value ||
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutRight>::value>
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutLeft> ||
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutRight>>
 impl_realloc(Kokkos::View<T, P...>& v, const size_t n0, const size_t n1,
              const size_t n2, const size_t n3, const size_t n4, const size_t n5,
              const size_t n6, const size_t n7,
@@ -3256,10 +3252,10 @@ impl_realloc(Kokkos::View<T, P...>& v, const size_t n0, const size_t n1,
 
 template <class T, class... P, class... ViewCtorArgs>
 inline std::enable_if_t<
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutLeft>::value ||
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutRight>::value>
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutLeft> ||
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutRight>>
 realloc(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
         Kokkos::View<T, P...>& v,
         const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
@@ -3275,10 +3271,10 @@ realloc(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
 
 template <class T, class... P>
 inline std::enable_if_t<
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutLeft>::value ||
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutRight>::value>
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutLeft> ||
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutRight>>
 realloc(Kokkos::View<T, P...>& v,
         const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
         const size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
@@ -3294,10 +3290,10 @@ realloc(Kokkos::View<T, P...>& v,
 template <class I, class T, class... P>
 inline std::enable_if_t<
     Impl::is_view_ctor_property<I>::value &&
-    (std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                  Kokkos::LayoutLeft>::value ||
-     std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                  Kokkos::LayoutRight>::value)>
+    (std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                    Kokkos::LayoutLeft> ||
+     std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                    Kokkos::LayoutRight>)>
 realloc(const I& arg_prop, Kokkos::View<T, P...>& v,
         const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
         const size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
@@ -3312,12 +3308,12 @@ realloc(const I& arg_prop, Kokkos::View<T, P...>& v,
 
 template <class T, class... P, class... ViewCtorArgs>
 inline std::enable_if_t<
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutLeft>::value ||
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutRight>::value ||
-    std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutStride>::value>
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutLeft> ||
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutRight> ||
+    std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                   Kokkos::LayoutStride>>
 impl_realloc(Kokkos::View<T, P...>& v,
              const typename Kokkos::View<T, P...>::array_layout& layout,
              const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
@@ -3357,12 +3353,12 @@ impl_realloc(Kokkos::View<T, P...>& v,
 // the same as the existing one.
 template <class T, class... P, class... ViewCtorArgs>
 inline std::enable_if_t<
-    !(std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                   Kokkos::LayoutLeft>::value ||
-      std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                   Kokkos::LayoutRight>::value ||
-      std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                   Kokkos::LayoutStride>::value)>
+    !(std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                     Kokkos::LayoutLeft> ||
+      std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                     Kokkos::LayoutRight> ||
+      std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
+                     Kokkos::LayoutStride>)>
 impl_realloc(Kokkos::View<T, P...>& v,
              const typename Kokkos::View<T, P...>::array_layout& layout,
              const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
@@ -3427,7 +3423,7 @@ struct MirrorViewType {
   // Check whether it is the same memory space
   enum {
     is_same_memspace =
-        std::is_same<memory_space, typename src_view_type::memory_space>::value
+        std::is_same_v<memory_space, typename src_view_type::memory_space>
   };
   // The array_layout
   using array_layout = typename src_view_type::array_layout;
@@ -3451,7 +3447,7 @@ struct MirrorType {
   // Check whether it is the same memory space
   enum {
     is_same_memspace =
-        std::is_same<memory_space, typename src_view_type::memory_space>::value
+        std::is_same_v<memory_space, typename src_view_type::memory_space>
   };
   // The array_layout
   using array_layout = typename src_view_type::array_layout;
@@ -3628,12 +3624,12 @@ inline auto create_mirror_view(
     const Kokkos::View<T, P...>& src,
     [[maybe_unused]] const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
   if constexpr (!Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space) {
-    if constexpr (std::is_same<typename Kokkos::View<T, P...>::memory_space,
-                               typename Kokkos::View<
-                                   T, P...>::HostMirror::memory_space>::value &&
-                  std::is_same<typename Kokkos::View<T, P...>::data_type,
-                               typename Kokkos::View<
-                                   T, P...>::HostMirror::data_type>::value) {
+    if constexpr (std::is_same_v<typename Kokkos::View<T, P...>::memory_space,
+                                 typename Kokkos::View<
+                                     T, P...>::HostMirror::memory_space> &&
+                  std::is_same_v<
+                      typename Kokkos::View<T, P...>::data_type,
+                      typename Kokkos::View<T, P...>::HostMirror::data_type>) {
       check_view_ctor_args_create_mirror<ViewCtorArgs...>();
       return typename Kokkos::View<T, P...>::HostMirror(src);
     } else {
@@ -3777,8 +3773,7 @@ create_mirror_view_and_copy(
     const Space&, const Kokkos::View<T, P...>& src,
     std::string const& name = "",
     std::enable_if_t<
-        std::is_void<typename ViewTraits<T, P...>::specialize>::value>* =
-        nullptr) {
+        std::is_void_v<typename ViewTraits<T, P...>::specialize>>* = nullptr) {
   return create_mirror_view_and_copy(
       Kokkos::view_alloc(typename Space::memory_space{}, name), src);
 }

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -281,7 +281,7 @@ std::vector<ExecSpace> partition_space(ExecSpace const& space,
                 "Kokkos Error: partition_space expects an Execution Space as "
                 "first argument");
   static_assert(
-      std::is_arithmetic<T>::value,
+      std::is_arithmetic_v<T>,
       "Kokkos Error: partitioning arguments must be integers or floats");
 
   std::vector<ExecSpace> instances(weights.size());

--- a/core/src/Kokkos_DetectionIdiom.hpp
+++ b/core/src/Kokkos_DetectionIdiom.hpp
@@ -81,7 +81,7 @@ inline constexpr bool is_detected_v = is_detected<Op, Args...>::value;
 
 template <class Expected, template <class...> class Op, class... Args>
 inline constexpr bool is_detected_exact_v =
-    is_detected_exact<Expected, Op, Args...>::value;
+    is_detected_exact<Expected, Op, Args...>::value;  // NOLINT
 
 template <class Expected, template <class...> class Op, class... Args>
 inline constexpr bool is_detected_convertible_v =

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -514,24 +514,24 @@ struct PerThreadValue {
 template <class iType, class... Args>
 struct ExtractVectorLength {
   static inline iType value(
-      std::enable_if_t<std::is_integral<iType>::value, iType> val, Args...) {
+      std::enable_if_t<std::is_integral_v<iType>, iType> val, Args...) {
     return val;
   }
-  static inline std::enable_if_t<!std::is_integral<iType>::value, int> value(
-      std::enable_if_t<!std::is_integral<iType>::value, iType>, Args...) {
+  static inline std::enable_if_t<!std::is_integral_v<iType>, int> value(
+      std::enable_if_t<!std::is_integral_v<iType>, iType>, Args...) {
     return 1;
   }
 };
 
 template <class iType, class... Args>
-inline std::enable_if_t<std::is_integral<iType>::value, iType>
-extract_vector_length(iType val, Args...) {
+inline std::enable_if_t<std::is_integral_v<iType>, iType> extract_vector_length(
+    iType val, Args...) {
   return val;
 }
 
 template <class iType, class... Args>
-inline std::enable_if_t<!std::is_integral<iType>::value, int>
-extract_vector_length(iType, Args...) {
+inline std::enable_if_t<!std::is_integral_v<iType>, int> extract_vector_length(
+    iType, Args...) {
   return 1;
 }
 
@@ -1215,7 +1215,7 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
 namespace Impl {
 
 template <typename FunctorType, typename TagType,
-          bool HasTag = !std::is_void<TagType>::value>
+          bool HasTag = !std::is_void_v<TagType>>
 struct ParallelConstructName;
 
 template <typename FunctorType, typename TagType>

--- a/core/src/Kokkos_Future.hpp
+++ b/core/src/Kokkos_Future.hpp
@@ -418,8 +418,8 @@ struct is_future : public std::false_type {};
 template <typename ValueType, typename Scheduler, typename ExecSpace>
 struct is_future<BasicFuture<ValueType, Scheduler>, ExecSpace>
     : std::bool_constant<
-          std::is_same<ExecSpace, typename Scheduler::execution_space>::value ||
-          std::is_void<ExecSpace>::value> {};
+          std::is_same_v<ExecSpace, typename Scheduler::execution_space> ||
+          std::is_void_v<ExecSpace>> {};
 
 ////////////////////////////////////////////////////////////////////////////////
 // END OLD CODE
@@ -432,8 +432,8 @@ class ResolveFutureArgOrder {
  private:
   enum { Arg1_is_space = Kokkos::is_space<Arg1>::value };
   enum { Arg2_is_space = Kokkos::is_space<Arg2>::value };
-  enum { Arg1_is_value = !Arg1_is_space && !std::is_void<Arg1>::value };
-  enum { Arg2_is_value = !Arg2_is_space && !std::is_void<Arg2>::value };
+  enum { Arg1_is_value = !Arg1_is_space && !std::is_void_v<Arg1> };
+  enum { Arg2_is_value = !Arg2_is_space && !std::is_void_v<Arg2> };
 
   static_assert(!(Arg1_is_space && Arg2_is_space),
                 "Future cannot be given two spaces");

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -48,7 +48,7 @@ class GraphNodeRef {
   //       intended to be SFINAE-safe, so do validation before you instantiate.
 
   static_assert(
-      std::is_same<Predecessor, TypeErasedTag>::value ||
+      std::is_same_v<Predecessor, TypeErasedTag> ||
           Kokkos::Impl::is_specialization_of<Predecessor, GraphNodeRef>::value,
       "Invalid predecessor template parameter given to GraphNodeRef");
 
@@ -56,7 +56,7 @@ class GraphNodeRef {
       Kokkos::is_execution_space<ExecutionSpace>::value,
       "Invalid execution space template parameter given to GraphNodeRef");
 
-  static_assert(std::is_same<Predecessor, TypeErasedTag>::value ||
+  static_assert(std::is_same_v<Predecessor, TypeErasedTag> ||
                     Kokkos::Impl::is_graph_kernel<Kernel>::value,
                 "Invalid kernel template parameter given to GraphNodeRef");
 
@@ -197,19 +197,19 @@ class GraphNodeRef {
   //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   // <editor-fold desc="Type-erasing converting ctor and assignment"> {{{3
 
-  template <
-      class OtherKernel, class OtherPredecessor,
-      std::enable_if_t<
-          // Not a copy/move constructor
-          !std::is_same<GraphNodeRef, GraphNodeRef<execution_space, OtherKernel,
-                                                   OtherPredecessor>>::value &&
-              // must be an allowed type erasure of the kernel
-              Kokkos::Impl::is_compatible_type_erasure<OtherKernel,
-                                                       graph_kernel>::value &&
-              // must be an allowed type erasure of the predecessor
-              Kokkos::Impl::is_compatible_type_erasure<
-                  OtherPredecessor, graph_predecessor>::value,
-          int> = 0>
+  template <class OtherKernel, class OtherPredecessor,
+            std::enable_if_t<
+                // Not a copy/move constructor
+                !std::is_same_v<GraphNodeRef,
+                                GraphNodeRef<execution_space, OtherKernel,
+                                             OtherPredecessor>> &&
+                    // must be an allowed type erasure of the kernel
+                    Kokkos::Impl::is_compatible_type_erasure<
+                        OtherKernel, graph_kernel>::value &&
+                    // must be an allowed type erasure of the predecessor
+                    Kokkos::Impl::is_compatible_type_erasure<
+                        OtherPredecessor, graph_predecessor>::value,
+                int> = 0>
   /* implicit */
   GraphNodeRef(
       GraphNodeRef<execution_space, OtherKernel, OtherPredecessor> const& other)

--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -114,7 +114,7 @@ template <> struct signaling_NaN_helper<long double> { static constexpr long dou
 #endif
 template <class> struct digits_helper {};
 template <> struct digits_helper<bool> { static constexpr int value = 1; };
-template <> struct digits_helper<char> { static constexpr int value = CHAR_BIT - std::is_signed<char>::value; };
+template <> struct digits_helper<char> { static constexpr int value = CHAR_BIT - std::is_signed_v<char>; };
 template <> struct digits_helper<signed char> { static constexpr int value = CHAR_BIT - 1; };
 template <> struct digits_helper<unsigned char> { static constexpr int value = CHAR_BIT; };
 template <> struct digits_helper<short> { static constexpr int value = CHAR_BIT*sizeof(short)-1; };

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -72,19 +72,19 @@ struct FunctorPolicyExecutionSpace {
   static_assert(
       !is_detected<execution_space_t, Policy>::value ||
           !is_detected<execution_space_t, Functor>::value ||
-          std::is_same<policy_execution_space, functor_execution_space>::value,
+          std::is_same_v<policy_execution_space, functor_execution_space>,
       "A policy with an execution space and a functor with an execution space "
       "are given but the execution space types do not match!");
   static_assert(!is_detected<execution_space_t, Policy>::value ||
                     !is_detected<device_type_t, Functor>::value ||
-                    std::is_same<policy_execution_space,
-                                 functor_device_type_execution_space>::value,
+                    std::is_same_v<policy_execution_space,
+                                   functor_device_type_execution_space>,
                 "A policy with an execution space and a functor with a device "
                 "type are given but the execution space types do not match!");
   static_assert(!is_detected<device_type_t, Functor>::value ||
                     !is_detected<execution_space_t, Functor>::value ||
-                    std::is_same<functor_device_type_execution_space,
-                                 functor_execution_space>::value,
+                    std::is_same_v<functor_device_type_execution_space,
+                                   functor_execution_space>,
                 "A functor with both an execution space and device type is "
                 "given but their execution space types do not match!");
 

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1401,9 +1401,9 @@ struct ParallelReduceReturnValue<
 template <class ReturnType, class FunctorType>
 struct ParallelReduceReturnValue<
     std::enable_if_t<!Kokkos::is_view<ReturnType>::value &&
-                     (!std::is_array<ReturnType>::value &&
-                      !std::is_pointer<ReturnType>::value) &&
-                     !Kokkos::is_reducer<ReturnType>::value>,
+                     (!std::is_array_v<ReturnType> &&
+                      !std::is_pointer_v<
+                          ReturnType>)&&!Kokkos::is_reducer<ReturnType>::value>,
     ReturnType, FunctorType> {
   using return_type =
       Kokkos::View<ReturnType, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>;
@@ -1419,8 +1419,8 @@ struct ParallelReduceReturnValue<
 
 template <class ReturnType, class FunctorType>
 struct ParallelReduceReturnValue<
-    std::enable_if_t<(std::is_array<ReturnType>::value ||
-                      std::is_pointer<ReturnType>::value)>,
+    std::enable_if_t<(std::is_array_v<ReturnType> ||
+                      std::is_pointer_v<ReturnType>)>,
     ReturnType, FunctorType> {
   using return_type = Kokkos::View<std::remove_const_t<ReturnType>,
                                    Kokkos::HostSpace, Kokkos::MemoryUnmanaged>;
@@ -1431,7 +1431,7 @@ struct ParallelReduceReturnValue<
 
   static return_type return_value(ReturnType& return_val,
                                   const FunctorType& functor) {
-    if (std::is_array<ReturnType>::value)
+    if (std::is_array_v<ReturnType>)
       return return_type(return_val);
     else
       return return_type(return_val, functor.value_count);
@@ -1464,8 +1464,7 @@ struct ParallelReducePolicyType<
 
 template <class PolicyType, class FunctorType>
 struct ParallelReducePolicyType<
-    std::enable_if_t<std::is_integral<PolicyType>::value>, PolicyType,
-    FunctorType> {
+    std::enable_if_t<std::is_integral_v<PolicyType>>, PolicyType, FunctorType> {
   using execution_space =
       typename Impl::FunctorPolicyExecutionSpace<FunctorType,
                                                  void>::execution_space;
@@ -1503,7 +1502,7 @@ struct ParallelReduceAdaptor {
         inner_policy, functor, label, kpID);
 
     using ReducerSelector =
-        Kokkos::Impl::if_c<std::is_same<InvalidType, PassedReducerType>::value,
+        Kokkos::Impl::if_c<std::is_same_v<InvalidType, PassedReducerType>,
                            FunctorType, PassedReducerType>;
     using Analysis = FunctorAnalysis<FunctorPatternInterface::REDUCE,
                                      PolicyType, typename ReducerSelector::type,
@@ -1533,7 +1532,7 @@ struct ParallelReduceAdaptor {
 
   template <typename Dummy = ReturnType>
   static inline std::enable_if_t<!(is_array_reduction &&
-                                   std::is_pointer<Dummy>::value)>
+                                   std::is_pointer_v<Dummy>)>
   execute(const std::string& label, const PolicyType& policy,
           const FunctorType& functor, ReturnType& return_value) {
     execute_impl(label, policy, functor, return_value);
@@ -1565,7 +1564,7 @@ struct ReducerHasTestReferenceFunction {
   static std::false_type test_func(...);
 
   enum {
-    value = std::is_same<std::true_type, decltype(test_func<T>(nullptr))>::value
+    value = std::is_same_v<std::true_type, decltype(test_func<T>(nullptr))>
   };
 };
 
@@ -1660,11 +1659,11 @@ template <class PolicyType, class FunctorType, class ReturnType>
 inline std::enable_if_t<Kokkos::is_execution_policy<PolicyType>::value &&
                         !(Kokkos::is_view<ReturnType>::value ||
                           Kokkos::is_reducer<ReturnType>::value ||
-                          std::is_pointer<ReturnType>::value)>
+                          std::is_pointer_v<ReturnType>)>
 parallel_reduce(const std::string& label, const PolicyType& policy,
                 const FunctorType& functor, ReturnType& return_value) {
   static_assert(
-      !std::is_const<ReturnType>::value,
+      !std::is_const_v<ReturnType>,
       "A const reduction result type is only allowed for a View, pointer or "
       "reducer return type!");
 
@@ -1681,11 +1680,11 @@ template <class PolicyType, class FunctorType, class ReturnType>
 inline std::enable_if_t<Kokkos::is_execution_policy<PolicyType>::value &&
                         !(Kokkos::is_view<ReturnType>::value ||
                           Kokkos::is_reducer<ReturnType>::value ||
-                          std::is_pointer<ReturnType>::value)>
+                          std::is_pointer_v<ReturnType>)>
 parallel_reduce(const PolicyType& policy, const FunctorType& functor,
                 ReturnType& return_value) {
   static_assert(
-      !std::is_const<ReturnType>::value,
+      !std::is_const_v<ReturnType>,
       "A const reduction result type is only allowed for a View, pointer or "
       "reducer return type!");
 
@@ -1701,11 +1700,11 @@ parallel_reduce(const PolicyType& policy, const FunctorType& functor,
 template <class FunctorType, class ReturnType>
 inline std::enable_if_t<!(Kokkos::is_view<ReturnType>::value ||
                           Kokkos::is_reducer<ReturnType>::value ||
-                          std::is_pointer<ReturnType>::value)>
+                          std::is_pointer_v<ReturnType>)>
 parallel_reduce(const size_t& policy, const FunctorType& functor,
                 ReturnType& return_value) {
   static_assert(
-      !std::is_const<ReturnType>::value,
+      !std::is_const_v<ReturnType>,
       "A const reduction result type is only allowed for a View, pointer or "
       "reducer return type!");
 
@@ -1725,11 +1724,11 @@ parallel_reduce(const size_t& policy, const FunctorType& functor,
 template <class FunctorType, class ReturnType>
 inline std::enable_if_t<!(Kokkos::is_view<ReturnType>::value ||
                           Kokkos::is_reducer<ReturnType>::value ||
-                          std::is_pointer<ReturnType>::value)>
+                          std::is_pointer_v<ReturnType>)>
 parallel_reduce(const std::string& label, const size_t& policy,
                 const FunctorType& functor, ReturnType& return_value) {
   static_assert(
-      !std::is_const<ReturnType>::value,
+      !std::is_const_v<ReturnType>,
       "A const reduction result type is only allowed for a View, pointer or "
       "reducer return type!");
 
@@ -1751,7 +1750,7 @@ template <class PolicyType, class FunctorType, class ReturnType>
 inline std::enable_if_t<Kokkos::is_execution_policy<PolicyType>::value &&
                         (Kokkos::is_view<ReturnType>::value ||
                          Kokkos::is_reducer<ReturnType>::value ||
-                         std::is_pointer<ReturnType>::value)>
+                         std::is_pointer_v<ReturnType>)>
 parallel_reduce(const std::string& label, const PolicyType& policy,
                 const FunctorType& functor, const ReturnType& return_value) {
   ReturnType return_value_impl = return_value;
@@ -1768,7 +1767,7 @@ template <class PolicyType, class FunctorType, class ReturnType>
 inline std::enable_if_t<Kokkos::is_execution_policy<PolicyType>::value &&
                         (Kokkos::is_view<ReturnType>::value ||
                          Kokkos::is_reducer<ReturnType>::value ||
-                         std::is_pointer<ReturnType>::value)>
+                         std::is_pointer_v<ReturnType>)>
 parallel_reduce(const PolicyType& policy, const FunctorType& functor,
                 const ReturnType& return_value) {
   ReturnType return_value_impl = return_value;
@@ -1784,7 +1783,7 @@ parallel_reduce(const PolicyType& policy, const FunctorType& functor,
 template <class FunctorType, class ReturnType>
 inline std::enable_if_t<Kokkos::is_view<ReturnType>::value ||
                         Kokkos::is_reducer<ReturnType>::value ||
-                        std::is_pointer<ReturnType>::value>
+                        std::is_pointer_v<ReturnType>>
 parallel_reduce(const size_t& policy, const FunctorType& functor,
                 const ReturnType& return_value) {
   using policy_type =
@@ -1803,7 +1802,7 @@ parallel_reduce(const size_t& policy, const FunctorType& functor,
 template <class FunctorType, class ReturnType>
 inline std::enable_if_t<Kokkos::is_view<ReturnType>::value ||
                         Kokkos::is_reducer<ReturnType>::value ||
-                        std::is_pointer<ReturnType>::value>
+                        std::is_pointer_v<ReturnType>>
 parallel_reduce(const std::string& label, const size_t& policy,
                 const FunctorType& functor, const ReturnType& return_value) {
   using policy_type =

--- a/core/src/Kokkos_TaskScheduler.hpp
+++ b/core/src/Kokkos_TaskScheduler.hpp
@@ -520,10 +520,10 @@ Impl::TaskPolicyWithScheduler<Kokkos::Impl::TaskType::TaskTeam, Scheduler,
                                   Kokkos::is_future<PredecessorFuture>::value,
                               TaskPriority>
                  arg_priority = TaskPriority::Regular) {
-  static_assert(std::is_same<typename PredecessorFuture::scheduler_type,
-                             Scheduler>::value,
-                "Can't create a task policy from a scheduler and a future from "
-                "a different scheduler");
+  static_assert(
+      std::is_same_v<typename PredecessorFuture::scheduler_type, Scheduler>,
+      "Can't create a task policy from a scheduler and a future from "
+      "a different scheduler");
 
   return {std::move(arg_scheduler), std::move(arg_future), arg_priority};
 }
@@ -557,10 +557,10 @@ Impl::TaskPolicyWithScheduler<Kokkos::Impl::TaskType::TaskSingle, Scheduler,
                                     Kokkos::is_future<PredecessorFuture>::value,
                                 TaskPriority>
                    arg_priority = TaskPriority::Regular) {
-  static_assert(std::is_same<typename PredecessorFuture::scheduler_type,
-                             Scheduler>::value,
-                "Can't create a task policy from a scheduler and a future from "
-                "a different scheduler");
+  static_assert(
+      std::is_same_v<typename PredecessorFuture::scheduler_type, Scheduler>,
+      "Can't create a task policy from a scheduler and a future from "
+      "a different scheduler");
 
   return {std::move(arg_scheduler), std::move(arg_future), arg_priority};
 }

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -68,7 +68,7 @@ template <typename IntType>
 constexpr KOKKOS_INLINE_FUNCTION std::size_t count_valid_integers(
     const IntType i0, const IntType i1, const IntType i2, const IntType i3,
     const IntType i4, const IntType i5, const IntType i6, const IntType i7) {
-  static_assert(std::is_integral<IntType>::value,
+  static_assert(std::is_integral_v<IntType>,
                 "count_valid_integers() must have integer arguments.");
 
   return (i0 != KOKKOS_INVALID_INDEX) + (i1 != KOKKOS_INVALID_INDEX) +
@@ -229,14 +229,14 @@ struct ViewTraits<std::enable_if_t<Kokkos::is_space<Space>::value>, Space,
   // Specify Space, memory traits should be the only subsequent argument.
 
   static_assert(
-      std::is_same<typename ViewTraits<void, Prop...>::execution_space,
-                   void>::value &&
-          std::is_same<typename ViewTraits<void, Prop...>::memory_space,
-                       void>::value &&
-          std::is_same<typename ViewTraits<void, Prop...>::HostMirrorSpace,
-                       void>::value &&
-          std::is_same<typename ViewTraits<void, Prop...>::array_layout,
-                       void>::value,
+      std::is_same_v<typename ViewTraits<void, Prop...>::execution_space,
+                     void> &&
+          std::is_same_v<typename ViewTraits<void, Prop...>::memory_space,
+                         void> &&
+          std::is_same_v<typename ViewTraits<void, Prop...>::HostMirrorSpace,
+                         void> &&
+          std::is_same_v<typename ViewTraits<void, Prop...>::array_layout,
+                         void>,
       "Only one View Execution or Memory Space template argument");
 
   using execution_space = typename Space::execution_space;
@@ -256,16 +256,16 @@ struct ViewTraits<
   // Specify memory trait, should not be any subsequent arguments
 
   static_assert(
-      std::is_same<typename ViewTraits<void, Prop...>::execution_space,
-                   void>::value &&
-          std::is_same<typename ViewTraits<void, Prop...>::memory_space,
-                       void>::value &&
-          std::is_same<typename ViewTraits<void, Prop...>::array_layout,
-                       void>::value &&
-          std::is_same<typename ViewTraits<void, Prop...>::memory_traits,
-                       void>::value &&
-          std::is_same<typename ViewTraits<void, Prop...>::hooks_policy,
-                       void>::value,
+      std::is_same_v<typename ViewTraits<void, Prop...>::execution_space,
+                     void> &&
+          std::is_same_v<typename ViewTraits<void, Prop...>::memory_space,
+                         void> &&
+          std::is_same_v<typename ViewTraits<void, Prop...>::array_layout,
+                         void> &&
+          std::is_same_v<typename ViewTraits<void, Prop...>::memory_traits,
+                         void> &&
+          std::is_same_v<typename ViewTraits<void, Prop...>::hooks_policy,
+                         void>,
       "MemoryTrait is the final optional template argument for a View");
 
   using execution_space = void;
@@ -284,32 +284,32 @@ struct ViewTraits {
   using prop = ViewTraits<void, Properties...>;
 
   using ExecutionSpace =
-      std::conditional_t<!std::is_void<typename prop::execution_space>::value,
+      std::conditional_t<!std::is_void_v<typename prop::execution_space>,
                          typename prop::execution_space,
                          Kokkos::DefaultExecutionSpace>;
 
   using MemorySpace =
-      std::conditional_t<!std::is_void<typename prop::memory_space>::value,
+      std::conditional_t<!std::is_void_v<typename prop::memory_space>,
                          typename prop::memory_space,
                          typename ExecutionSpace::memory_space>;
 
   using ArrayLayout =
-      std::conditional_t<!std::is_void<typename prop::array_layout>::value,
+      std::conditional_t<!std::is_void_v<typename prop::array_layout>,
                          typename prop::array_layout,
                          typename ExecutionSpace::array_layout>;
 
   using HostMirrorSpace = std::conditional_t<
-      !std::is_void<typename prop::HostMirrorSpace>::value,
+      !std::is_void_v<typename prop::HostMirrorSpace>,
       typename prop::HostMirrorSpace,
       typename Kokkos::Impl::HostMirror<ExecutionSpace>::Space>;
 
   using MemoryTraits =
-      std::conditional_t<!std::is_void<typename prop::memory_traits>::value,
+      std::conditional_t<!std::is_void_v<typename prop::memory_traits>,
                          typename prop::memory_traits,
                          typename Kokkos::MemoryManaged>;
 
   using HooksPolicy =
-      std::conditional_t<!std::is_void<typename prop::hooks_policy>::value,
+      std::conditional_t<!std::is_void_v<typename prop::hooks_policy>,
                          typename prop::hooks_policy,
                          Kokkos::Experimental::DefaultViewHooks>;
 
@@ -348,7 +348,7 @@ struct ViewTraits {
   using dimension    = typename data_analysis::dimension;
 
   using specialize = std::conditional_t<
-      std::is_void<typename data_analysis::specialize>::value,
+      std::is_void_v<typename data_analysis::specialize>,
       typename prop::specialize,
       typename data_analysis::specialize>; /* mapping specialization tag */
 
@@ -367,7 +367,7 @@ struct ViewTraits {
 
   using size_type = typename MemorySpace::size_type;
 
-  enum { is_hostspace = std::is_same<MemorySpace, HostSpace>::value };
+  enum { is_hostspace = std::is_same_v<MemorySpace, HostSpace> };
   enum { is_managed = MemoryTraits::is_unmanaged == 0 };
   enum { is_random_access = MemoryTraits::is_random_access == 1 };
 
@@ -722,8 +722,8 @@ class View : public ViewTraits<DataType, Properties...> {
 #endif
 
   template <typename iType>
-  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-      std::is_integral<iType>::value, size_t>
+  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>,
+                                                    size_t>
   extent(const iType& r) const noexcept {
     return m_map.extent(r);
   }
@@ -734,8 +734,8 @@ class View : public ViewTraits<DataType, Properties...> {
   }
 
   template <typename iType>
-  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-      std::is_integral<iType>::value, int>
+  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>,
+                                                    int>
   extent_int(const iType& r) const noexcept {
     return static_cast<int>(m_map.extent(r));
   }
@@ -782,8 +782,8 @@ class View : public ViewTraits<DataType, Properties...> {
   }
 
   template <typename iType>
-  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-      std::is_integral<iType>::value, size_t>
+  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>,
+                                                    size_t>
   stride(iType r) const {
     return (
         r == 0
@@ -816,7 +816,7 @@ class View : public ViewTraits<DataType, Properties...> {
 
   enum {
     reference_type_is_lvalue_reference =
-        std::is_lvalue_reference<reference_type>::value
+        std::is_lvalue_reference_v<reference_type>
   };
 
   KOKKOS_INLINE_FUNCTION constexpr size_t span() const { return m_map.span(); }
@@ -846,16 +846,16 @@ class View : public ViewTraits<DataType, Properties...> {
 
  private:
   static constexpr bool is_layout_left =
-      std::is_same<typename traits::array_layout, Kokkos::LayoutLeft>::value;
+      std::is_same_v<typename traits::array_layout, Kokkos::LayoutLeft>;
 
   static constexpr bool is_layout_right =
-      std::is_same<typename traits::array_layout, Kokkos::LayoutRight>::value;
+      std::is_same_v<typename traits::array_layout, Kokkos::LayoutRight>;
 
   static constexpr bool is_layout_stride =
-      std::is_same<typename traits::array_layout, Kokkos::LayoutStride>::value;
+      std::is_same_v<typename traits::array_layout, Kokkos::LayoutStride>;
 
   static constexpr bool is_default_map =
-      std::is_void<typename traits::specialize>::value &&
+      std::is_void_v<typename traits::specialize> &&
       (is_layout_left || is_layout_right || is_layout_stride);
 
 #if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
@@ -1646,7 +1646,7 @@ class View : public ViewTraits<DataType, Properties...> {
     const size_t num_passed_args = Impl::count_valid_integers(
         arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7);
 
-    if (std::is_void<typename traits::specialize>::value &&
+    if (std::is_void_v<typename traits::specialize> &&
         num_passed_args != rank_dynamic) {
       Kokkos::abort(
           "Kokkos::View::shmem_size() rank_dynamic != number of arguments.\n");
@@ -1796,7 +1796,7 @@ struct RankDataType<ValueType, 0> {
 template <unsigned N, typename... Args>
 KOKKOS_FUNCTION std::enable_if_t<
     N == View<Args...>::rank() &&
-        std::is_same<typename ViewTraits<Args...>::specialize, void>::value,
+        std::is_same_v<typename ViewTraits<Args...>::specialize, void>,
     View<Args...>>
 as_view_of_rank_n(View<Args...> v) {
   return v;
@@ -1807,7 +1807,7 @@ as_view_of_rank_n(View<Args...> v) {
 template <unsigned N, typename T, typename... Args>
 KOKKOS_FUNCTION std::enable_if_t<
     N != View<T, Args...>::rank() &&
-        std::is_same<typename ViewTraits<T, Args...>::specialize, void>::value,
+        std::is_same_v<typename ViewTraits<T, Args...>::specialize, void>,
     View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,
          Args...>>
 as_view_of_rank_n(View<T, Args...>) {
@@ -1899,12 +1899,12 @@ KOKKOS_INLINE_FUNCTION bool operator==(const View<LT, LP...>& lhs,
   using lhs_traits = ViewTraits<LT, LP...>;
   using rhs_traits = ViewTraits<RT, RP...>;
 
-  return std::is_same<typename lhs_traits::const_value_type,
-                      typename rhs_traits::const_value_type>::value &&
-         std::is_same<typename lhs_traits::array_layout,
-                      typename rhs_traits::array_layout>::value &&
-         std::is_same<typename lhs_traits::memory_space,
-                      typename rhs_traits::memory_space>::value &&
+  return std::is_same_v<typename lhs_traits::const_value_type,
+                        typename rhs_traits::const_value_type> &&
+         std::is_same_v<typename lhs_traits::array_layout,
+                        typename rhs_traits::array_layout> &&
+         std::is_same_v<typename lhs_traits::memory_space,
+                        typename rhs_traits::memory_space> &&
          View<LT, LP...>::rank() == View<RT, RP...>::rank() &&
          lhs.data() == rhs.data() && lhs.span() == rhs.span() &&
          lhs.extent(0) == rhs.extent(0) && lhs.extent(1) == rhs.extent(1) &&
@@ -1982,18 +1982,19 @@ struct DeduceCommonViewAllocProp<FirstView, NextViews...> {
   // determine specialize type
   // if first and next specialize differ, but are not the same specialize, error
   // out
-  static_assert(!(!std::is_same<first_specialize, next_specialize>::value &&
-                  !std::is_void<first_specialize>::value &&
-                  !std::is_void<next_specialize>::value),
+  static_assert(!(!std::is_same_v<first_specialize, next_specialize> &&
+                  !std::is_void_v<first_specialize> &&
+                  !std::is_void_v<next_specialize>),
                 "Kokkos DeduceCommonViewAllocProp ERROR: Only one non-void "
                 "specialize trait allowed");
 
   // otherwise choose non-void specialize if either/both are non-void
-  using specialize = std::conditional_t<
-      std::is_same<first_specialize, next_specialize>::value, first_specialize,
-      std::conditional_t<(std::is_void<first_specialize>::value &&
-                          !std::is_void<next_specialize>::value),
-                         next_specialize, first_specialize>>;
+  using specialize =
+      std::conditional_t<std::is_same_v<first_specialize, next_specialize>,
+                         first_specialize,
+                         std::conditional_t<(std::is_void_v<first_specialize> &&
+                                             !std::is_void_v<next_specialize>),
+                                            next_specialize, first_specialize>>;
 
   using value_type = typename CommonViewValueType<specialize, first_value_type,
                                                   next_value_type>::value_type;

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -267,7 +267,7 @@ template <class T>
 std::vector<Serial> partition_space(const Serial&,
                                     std::vector<T> const& weights) {
   static_assert(
-      std::is_arithmetic<T>::value,
+      std::is_arithmetic_v<T>,
       "Kokkos Error: partitioning arguments must be integers or floats");
 
   // We only care about the number of instances to create and ignore weights

--- a/core/src/Serial/Kokkos_Serial_Parallel_Range.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Range.hpp
@@ -31,7 +31,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Serial> {
   const Policy m_policy;
 
   template <class TagType>
-  std::enable_if_t<std::is_void<TagType>::value> exec() const {
+  std::enable_if_t<std::is_void_v<TagType>> exec() const {
     const typename Policy::member_type e = m_policy.end();
     for (typename Policy::member_type i = m_policy.begin(); i < e; ++i) {
       m_functor(i);
@@ -39,7 +39,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Serial> {
   }
 
   template <class TagType>
-  std::enable_if_t<!std::is_void<TagType>::value> exec() const {
+  std::enable_if_t<!std::is_void_v<TagType>> exec() const {
     const TagType t{};
     const typename Policy::member_type e = m_policy.end();
     for (typename Policy::member_type i = m_policy.begin(); i < e; ++i) {
@@ -79,7 +79,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   const pointer_type m_result_ptr;
 
   template <class TagType>
-  inline std::enable_if_t<std::is_void<TagType>::value> exec(
+  inline std::enable_if_t<std::is_void_v<TagType>> exec(
       reference_type update) const {
     const typename Policy::member_type e = m_policy.end();
     for (typename Policy::member_type i = m_policy.begin(); i < e; ++i) {
@@ -88,7 +88,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   }
 
   template <class TagType>
-  inline std::enable_if_t<!std::is_void<TagType>::value> exec(
+  inline std::enable_if_t<!std::is_void_v<TagType>> exec(
       reference_type update) const {
     const TagType t{};
 
@@ -166,7 +166,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
   const Policy m_policy;
 
   template <class TagType>
-  inline std::enable_if_t<std::is_void<TagType>::value> exec(
+  inline std::enable_if_t<std::is_void_v<TagType>> exec(
       reference_type update) const {
     const typename Policy::member_type e = m_policy.end();
     for (typename Policy::member_type i = m_policy.begin(); i < e; ++i) {
@@ -175,7 +175,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
   }
 
   template <class TagType>
-  inline std::enable_if_t<!std::is_void<TagType>::value> exec(
+  inline std::enable_if_t<!std::is_void_v<TagType>> exec(
       reference_type update) const {
     const TagType t{};
     const typename Policy::member_type e = m_policy.end();
@@ -235,7 +235,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
   const pointer_type m_result_ptr;
 
   template <class TagType>
-  inline std::enable_if_t<std::is_void<TagType>::value> exec(
+  inline std::enable_if_t<std::is_void_v<TagType>> exec(
       reference_type update) const {
     const typename Policy::member_type e = m_policy.end();
     for (typename Policy::member_type i = m_policy.begin(); i < e; ++i) {
@@ -244,7 +244,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
   }
 
   template <class TagType>
-  inline std::enable_if_t<!std::is_void<TagType>::value> exec(
+  inline std::enable_if_t<!std::is_void_v<TagType>> exec(
       reference_type update) const {
     const TagType t{};
     const typename Policy::member_type e = m_policy.end();

--- a/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
@@ -223,7 +223,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   const size_t m_shared;
 
   template <class TagType>
-  inline std::enable_if_t<std::is_void<TagType>::value> exec(
+  inline std::enable_if_t<std::is_void_v<TagType>> exec(
       HostThreadTeamData& data) const {
     for (int ileague = 0; ileague < m_league; ++ileague) {
       m_functor(Member(data, ileague, m_league));
@@ -231,7 +231,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
   template <class TagType>
-  inline std::enable_if_t<!std::is_void<TagType>::value> exec(
+  inline std::enable_if_t<!std::is_void_v<TagType>> exec(
       HostThreadTeamData& data) const {
     const TagType t{};
     for (int ileague = 0; ileague < m_league; ++ileague) {
@@ -293,7 +293,7 @@ class ParallelReduce<CombinedFunctorReducerType,
   size_t m_shared;
 
   template <class TagType>
-  inline std::enable_if_t<std::is_void<TagType>::value> exec(
+  inline std::enable_if_t<std::is_void_v<TagType>> exec(
       HostThreadTeamData& data, reference_type update) const {
     for (int ileague = 0; ileague < m_league; ++ileague) {
       m_functor_reducer.get_functor()(Member(data, ileague, m_league), update);
@@ -301,7 +301,7 @@ class ParallelReduce<CombinedFunctorReducerType,
   }
 
   template <class TagType>
-  inline std::enable_if_t<!std::is_void<TagType>::value> exec(
+  inline std::enable_if_t<!std::is_void_v<TagType>> exec(
       HostThreadTeamData& data, reference_type update) const {
     const TagType t{};
 

--- a/core/src/Serial/Kokkos_Serial_Task.hpp
+++ b/core/src/Serial/Kokkos_Serial_Task.hpp
@@ -102,9 +102,8 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::Serial, QueueType>> {
 
 template <class Scheduler>
 class TaskQueueSpecializationConstrained<
-    Scheduler,
-    std::enable_if_t<std::is_same<typename Scheduler::execution_space,
-                                  Kokkos::Serial>::value>> {
+    Scheduler, std::enable_if_t<std::is_same_v<
+                   typename Scheduler::execution_space, Kokkos::Serial>>> {
  public:
   // Note: Scheduler may be an incomplete type at class scope (but not inside
   // of the methods, obviously)

--- a/core/src/Serial/Kokkos_Serial_WorkGraphPolicy.hpp
+++ b/core/src/Serial/Kokkos_Serial_WorkGraphPolicy.hpp
@@ -30,13 +30,13 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
   FunctorType m_functor;
 
   template <class TagType>
-  std::enable_if_t<std::is_void<TagType>::value> exec_one(
+  std::enable_if_t<std::is_void_v<TagType>> exec_one(
       const std::int32_t w) const noexcept {
     m_functor(w);
   }
 
   template <class TagType>
-  std::enable_if_t<!std::is_void<TagType>::value> exec_one(
+  std::enable_if_t<!std::is_void_v<TagType>> exec_one(
       const std::int32_t w) const noexcept {
     const TagType t{};
     m_functor(t, w);

--- a/core/src/Serial/Kokkos_Serial_ZeroMemset.hpp
+++ b/core/src/Serial/Kokkos_Serial_ZeroMemset.hpp
@@ -33,7 +33,7 @@ namespace Impl {
 struct DummyExecutionSpace;
 template <class T, class... P>
 struct ZeroMemset<
-    std::conditional_t<!std::is_same<Serial, DefaultHostExecutionSpace>::value,
+    std::conditional_t<!std::is_same_v<Serial, DefaultHostExecutionSpace>,
                        Serial, DummyExecutionSpace>,
     View<T, P...>> {
   ZeroMemset(const Serial&, const View<T, P...>& dst) {

--- a/core/src/Threads/Kokkos_Threads_ParallelFor_MDRange.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelFor_MDRange.hpp
@@ -51,7 +51,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   }
 
   template <class Schedule>
-  static std::enable_if_t<std::is_same<Schedule, Kokkos::Static>::value>
+  static std::enable_if_t<std::is_same_v<Schedule, Kokkos::Static>>
   exec_schedule(ThreadsInternal &instance, const void *arg) {
     const ParallelFor &self = *((const ParallelFor *)arg);
 
@@ -65,7 +65,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   }
 
   template <class Schedule>
-  static std::enable_if_t<std::is_same<Schedule, Kokkos::Dynamic>::value>
+  static std::enable_if_t<std::is_same_v<Schedule, Kokkos::Dynamic>>
   exec_schedule(ThreadsInternal &instance, const void *arg) {
     const ParallelFor &self = *((const ParallelFor *)arg);
 

--- a/core/src/Threads/Kokkos_Threads_ParallelFor_Range.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelFor_Range.hpp
@@ -35,7 +35,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
   const Policy m_policy;
 
   template <class TagType>
-  inline static std::enable_if_t<std::is_void<TagType>::value> exec_range(
+  inline static std::enable_if_t<std::is_void_v<TagType>> exec_range(
       const FunctorType &functor, const Member ibeg, const Member iend) {
 #if defined(KOKKOS_ENABLE_AGGRESSIVE_VECTORIZATION) && \
     defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
@@ -47,7 +47,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
   }
 
   template <class TagType>
-  inline static std::enable_if_t<!std::is_void<TagType>::value> exec_range(
+  inline static std::enable_if_t<!std::is_void_v<TagType>> exec_range(
       const FunctorType &functor, const Member ibeg, const Member iend) {
     const TagType t{};
 #if defined(KOKKOS_ENABLE_AGGRESSIVE_VECTORIZATION) && \
@@ -64,7 +64,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
   }
 
   template <class Schedule>
-  static std::enable_if_t<std::is_same<Schedule, Kokkos::Static>::value>
+  static std::enable_if_t<std::is_same_v<Schedule, Kokkos::Static>>
   exec_schedule(ThreadsInternal &instance, const void *arg) {
     const ParallelFor &self = *((const ParallelFor *)arg);
 
@@ -77,7 +77,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
   }
 
   template <class Schedule>
-  static std::enable_if_t<std::is_same<Schedule, Kokkos::Dynamic>::value>
+  static std::enable_if_t<std::is_same_v<Schedule, Kokkos::Dynamic>>
   exec_schedule(ThreadsInternal &instance, const void *arg) {
     const ParallelFor &self = *((const ParallelFor *)arg);
 

--- a/core/src/Threads/Kokkos_Threads_ParallelFor_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelFor_Team.hpp
@@ -36,8 +36,8 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   const size_t m_shared;
 
   template <class TagType, class Schedule>
-  inline static std::enable_if_t<std::is_void<TagType>::value &&
-                                 std::is_same<Schedule, Kokkos::Static>::value>
+  inline static std::enable_if_t<std::is_void_v<TagType> &&
+                                 std::is_same_v<Schedule, Kokkos::Static>>
   exec_team(const FunctorType &functor, Member member) {
     for (; member.valid_static(); member.next_static()) {
       functor(member);
@@ -45,8 +45,8 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
   template <class TagType, class Schedule>
-  inline static std::enable_if_t<!std::is_void<TagType>::value &&
-                                 std::is_same<Schedule, Kokkos::Static>::value>
+  inline static std::enable_if_t<!std::is_void_v<TagType> &&
+                                 std::is_same_v<Schedule, Kokkos::Static>>
   exec_team(const FunctorType &functor, Member member) {
     const TagType t{};
     for (; member.valid_static(); member.next_static()) {
@@ -55,8 +55,8 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
   template <class TagType, class Schedule>
-  inline static std::enable_if_t<std::is_void<TagType>::value &&
-                                 std::is_same<Schedule, Kokkos::Dynamic>::value>
+  inline static std::enable_if_t<std::is_void_v<TagType> &&
+                                 std::is_same_v<Schedule, Kokkos::Dynamic>>
   exec_team(const FunctorType &functor, Member member) {
     for (; member.valid_dynamic(); member.next_dynamic()) {
       functor(member);
@@ -64,8 +64,8 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
   template <class TagType, class Schedule>
-  inline static std::enable_if_t<!std::is_void<TagType>::value &&
-                                 std::is_same<Schedule, Kokkos::Dynamic>::value>
+  inline static std::enable_if_t<!std::is_void_v<TagType> &&
+                                 std::is_same_v<Schedule, Kokkos::Dynamic>>
   exec_team(const FunctorType &functor, Member member) {
     const TagType t{};
     for (; member.valid_dynamic(); member.next_dynamic()) {

--- a/core/src/Threads/Kokkos_Threads_ParallelReduce_MDRange.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelReduce_MDRange.hpp
@@ -59,7 +59,7 @@ class ParallelReduce<CombinedFunctorReducerType,
   }
 
   template <class Schedule>
-  static std::enable_if_t<std::is_same<Schedule, Kokkos::Static>::value>
+  static std::enable_if_t<std::is_same_v<Schedule, Kokkos::Static>>
   exec_schedule(ThreadsInternal &instance, const void *arg) {
     const ParallelReduce &self = *((const ParallelReduce *)arg);
 
@@ -76,7 +76,7 @@ class ParallelReduce<CombinedFunctorReducerType,
   }
 
   template <class Schedule>
-  static std::enable_if_t<std::is_same<Schedule, Kokkos::Dynamic>::value>
+  static std::enable_if_t<std::is_same_v<Schedule, Kokkos::Dynamic>>
   exec_schedule(ThreadsInternal &instance, const void *arg) {
     const ParallelReduce &self = *((const ParallelReduce *)arg);
 

--- a/core/src/Threads/Kokkos_Threads_ParallelReduce_Range.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelReduce_Range.hpp
@@ -42,7 +42,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   const pointer_type m_result_ptr;
 
   template <class TagType>
-  inline static std::enable_if_t<std::is_void<TagType>::value> exec_range(
+  inline static std::enable_if_t<std::is_void_v<TagType>> exec_range(
       const FunctorType &functor, const Member &ibeg, const Member &iend,
       reference_type update) {
 #if defined(KOKKOS_ENABLE_AGGRESSIVE_VECTORIZATION) && \
@@ -55,7 +55,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   }
 
   template <class TagType>
-  inline static std::enable_if_t<!std::is_void<TagType>::value> exec_range(
+  inline static std::enable_if_t<!std::is_void_v<TagType>> exec_range(
       const FunctorType &functor, const Member &ibeg, const Member &iend,
       reference_type update) {
     const TagType t{};
@@ -73,7 +73,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   }
 
   template <class Schedule>
-  static std::enable_if_t<std::is_same<Schedule, Kokkos::Static>::value>
+  static std::enable_if_t<std::is_same_v<Schedule, Kokkos::Static>>
   exec_schedule(ThreadsInternal &instance, const void *arg) {
     const ParallelReduce &self = *((const ParallelReduce *)arg);
     const WorkRange range(self.m_policy, instance.pool_rank(),
@@ -89,7 +89,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   }
 
   template <class Schedule>
-  static std::enable_if_t<std::is_same<Schedule, Kokkos::Dynamic>::value>
+  static std::enable_if_t<std::is_same_v<Schedule, Kokkos::Dynamic>>
   exec_schedule(ThreadsInternal &instance, const void *arg) {
     const ParallelReduce &self = *((const ParallelReduce *)arg);
     const WorkRange range(self.m_policy, instance.pool_rank(),

--- a/core/src/Threads/Kokkos_Threads_ParallelReduce_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelReduce_Team.hpp
@@ -42,7 +42,7 @@ class ParallelReduce<CombinedFunctorReducerType,
   const size_t m_shared;
 
   template <class TagType>
-  inline static std::enable_if_t<std::is_void<TagType>::value> exec_team(
+  inline static std::enable_if_t<std::is_void_v<TagType>> exec_team(
       const FunctorType &functor, Member member, reference_type update) {
     for (; member.valid_static(); member.next_static()) {
       functor(member, update);
@@ -50,7 +50,7 @@ class ParallelReduce<CombinedFunctorReducerType,
   }
 
   template <class TagType>
-  inline static std::enable_if_t<!std::is_void<TagType>::value> exec_team(
+  inline static std::enable_if_t<!std::is_void_v<TagType>> exec_team(
       const FunctorType &functor, Member member, reference_type update) {
     const TagType t{};
     for (; member.valid_static(); member.next_static()) {

--- a/core/src/Threads/Kokkos_Threads_ParallelScan_Range.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelScan_Range.hpp
@@ -39,7 +39,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
   const Policy m_policy;
 
   template <class TagType>
-  inline static std::enable_if_t<std::is_void<TagType>::value> exec_range(
+  inline static std::enable_if_t<std::is_void_v<TagType>> exec_range(
       const FunctorType &functor, const Member &ibeg, const Member &iend,
       reference_type update, const bool final) {
 #if defined(KOKKOS_ENABLE_AGGRESSIVE_VECTORIZATION) && \
@@ -52,7 +52,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
   }
 
   template <class TagType>
-  inline static std::enable_if_t<!std::is_void<TagType>::value> exec_range(
+  inline static std::enable_if_t<!std::is_void_v<TagType>> exec_range(
       const FunctorType &functor, const Member &ibeg, const Member &iend,
       reference_type update, const bool final) {
     const TagType t{};
@@ -119,7 +119,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
   const pointer_type m_result_ptr;
 
   template <class TagType>
-  inline static std::enable_if_t<std::is_void<TagType>::value> exec_range(
+  inline static std::enable_if_t<std::is_void_v<TagType>> exec_range(
       const FunctorType &functor, const Member &ibeg, const Member &iend,
       reference_type update, const bool final) {
 #if defined(KOKKOS_ENABLE_AGGRESSIVE_VECTORIZATION) && \
@@ -132,7 +132,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
   }
 
   template <class TagType>
-  inline static std::enable_if_t<!std::is_void<TagType>::value> exec_range(
+  inline static std::enable_if_t<!std::is_void_v<TagType>> exec_range(
       const FunctorType &functor, const Member &ibeg, const Member &iend,
       reference_type update, const bool final) {
     const TagType t{};

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -1049,7 +1049,7 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
       typename Impl::FunctorAnalysis<Impl::FunctorPatternInterface::SCAN,
                                      TeamPolicy<Threads>, FunctorType,
                                      void>::value_type;
-  static_assert(std::is_same<closure_value_type, ValueType>::value,
+  static_assert(std::is_same_v<closure_value_type, ValueType>,
                 "Non-matching value types of closure and return type");
 
   ValueType scan_val = ValueType();

--- a/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
+++ b/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
@@ -36,13 +36,13 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
   FunctorType m_functor;
 
   template <class TagType>
-  std::enable_if_t<std::is_void<TagType>::value> exec_one(
+  std::enable_if_t<std::is_void_v<TagType>> exec_one(
       const std::int32_t w) const noexcept {
     m_functor(w);
   }
 
   template <class TagType>
-  std::enable_if_t<!std::is_void<TagType>::value> exec_one(
+  std::enable_if_t<!std::is_void_v<TagType>> exec_one(
       const std::int32_t w) const noexcept {
     const TagType t{};
     m_functor(t, w);

--- a/core/src/impl/KokkosExp_Host_IterateTile.hpp
+++ b/core/src/impl/KokkosExp_Host_IterateTile.hpp
@@ -1458,7 +1458,7 @@ struct Tile_Loop_Type<8, IsLeft, IType, void, void> {
 
 template <bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type<1, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void<Tagged>::value>> {
+                      std::enable_if_t<!std::is_void_v<Tagged>>> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
@@ -1477,7 +1477,7 @@ struct Tile_Loop_Type<1, IsLeft, IType, Tagged,
 
 template <bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type<2, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void<Tagged>::value>> {
+                      std::enable_if_t<!std::is_void_v<Tagged>>> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
@@ -1496,7 +1496,7 @@ struct Tile_Loop_Type<2, IsLeft, IType, Tagged,
 
 template <bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type<3, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void<Tagged>::value>> {
+                      std::enable_if_t<!std::is_void_v<Tagged>>> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
@@ -1515,7 +1515,7 @@ struct Tile_Loop_Type<3, IsLeft, IType, Tagged,
 
 template <bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type<4, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void<Tagged>::value>> {
+                      std::enable_if_t<!std::is_void_v<Tagged>>> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
@@ -1534,7 +1534,7 @@ struct Tile_Loop_Type<4, IsLeft, IType, Tagged,
 
 template <bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type<5, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void<Tagged>::value>> {
+                      std::enable_if_t<!std::is_void_v<Tagged>>> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
@@ -1553,7 +1553,7 @@ struct Tile_Loop_Type<5, IsLeft, IType, Tagged,
 
 template <bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type<6, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void<Tagged>::value>> {
+                      std::enable_if_t<!std::is_void_v<Tagged>>> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
@@ -1572,7 +1572,7 @@ struct Tile_Loop_Type<6, IsLeft, IType, Tagged,
 
 template <bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type<7, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void<Tagged>::value>> {
+                      std::enable_if_t<!std::is_void_v<Tagged>>> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
@@ -1591,7 +1591,7 @@ struct Tile_Loop_Type<7, IsLeft, IType, Tagged,
 
 template <bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type<8, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void<Tagged>::value>> {
+                      std::enable_if_t<!std::is_void_v<Tagged>>> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
@@ -1616,7 +1616,7 @@ struct HostIterateTile;
 // For ParallelFor
 template <typename RP, typename Functor, typename Tag, typename ValueType>
 struct HostIterateTile<RP, Functor, Tag, ValueType,
-                       std::enable_if_t<std::is_void<ValueType>::value>> {
+                       std::enable_if_t<std::is_void_v<ValueType>>> {
   using index_type = typename RP::index_type;
   using point_type = typename RP::point_type;
 
@@ -1999,30 +1999,28 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
 #endif
 
   template <typename... Args>
-  std::enable_if_t<(sizeof...(Args) == RP::rank && std::is_void<Tag>::value),
-                   void>
+  std::enable_if_t<(sizeof...(Args) == RP::rank && std::is_void_v<Tag>), void>
   apply(Args&&... args) const {
     m_func(args...);
   }
 
   template <typename... Args>
-  std::enable_if_t<(sizeof...(Args) == RP::rank && !std::is_void<Tag>::value),
-                   void>
+  std::enable_if_t<(sizeof...(Args) == RP::rank && !std::is_void_v<Tag>), void>
   apply(Args&&... args) const {
     m_func(m_tag, args...);
   }
 
   RP const m_rp;
   Functor const m_func;
-  std::conditional_t<std::is_void<Tag>::value, int, Tag> m_tag;
+  std::conditional_t<std::is_void_v<Tag>, int, Tag> m_tag;
 };
 
 // For ParallelReduce
 // ValueType - scalar: For reductions
 template <typename RP, typename Functor, typename Tag, typename ValueType>
 struct HostIterateTile<RP, Functor, Tag, ValueType,
-                       std::enable_if_t<!std::is_void<ValueType>::value &&
-                                        !std::is_array<ValueType>::value>> {
+                       std::enable_if_t<!std::is_void_v<ValueType> &&
+                                        !std::is_array_v<ValueType>>> {
   using index_type = typename RP::index_type;
   using point_type = typename RP::point_type;
 
@@ -2428,7 +2426,7 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
 
   RP const m_rp;
   Functor const m_func;
-  std::conditional_t<std::is_void<Tag>::value, int, Tag> m_tag;
+  std::conditional_t<std::is_void_v<Tag>, int, Tag> m_tag;
 };
 
 // For ParallelReduce
@@ -2436,8 +2434,8 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
 // ValueType[]: For array reductions
 template <typename RP, typename Functor, typename Tag, typename ValueType>
 struct HostIterateTile<RP, Functor, Tag, ValueType,
-                       std::enable_if_t<!std::is_void<ValueType>::value &&
-                                        std::is_array<ValueType>::value>> {
+                       std::enable_if_t<!std::is_void_v<ValueType> &&
+                                        std::is_array_v<ValueType>>> {
   using index_type = typename RP::index_type;
   using point_type = typename RP::point_type;
 
@@ -2839,7 +2837,7 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
 
   RP const m_rp;
   Functor const m_func;
-  std::conditional_t<std::is_void<Tag>::value, int, Tag> m_tag;
+  std::conditional_t<std::is_void_v<Tag>, int, Tag> m_tag;
 };
 
 // ------------------------------------------------------------------ //

--- a/core/src/impl/Kokkos_AnalyzePolicy.hpp
+++ b/core/src/impl/Kokkos_AnalyzePolicy.hpp
@@ -143,7 +143,7 @@ struct AnalyzeExecPolicyUseMatcher<void, type_list<>, Trait, Traits...> {
   static constexpr auto trigger_error_message =
       show_name_of_invalid_execution_policy_trait<Trait>{};
   static_assert(
-      /* always false: */ std::is_void<Trait>::value,
+      /* always false: */ std::is_void_v<Trait>,
       "Unknown execution policy trait. Search compiler output for "
       "'show_name_of_invalid_execution_policy_trait' to see the type of the "
       "invalid trait.");

--- a/core/src/impl/Kokkos_ChaseLev.hpp
+++ b/core/src/impl/Kokkos_ChaseLev.hpp
@@ -138,7 +138,7 @@ struct ChaseLevDeque {
  public:
   template <class _ignore = void,
             class         = std::enable_if_t<
-                std::is_default_constructible<CircularBufferT>::value>>
+                std::is_default_constructible_v<CircularBufferT>>>
   ChaseLevDeque() : m_array() {}
 
   explicit ChaseLevDeque(CircularBufferT buffer) : m_array(std::move(buffer)) {}

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -369,7 +369,7 @@ struct CombinedReductionFunctorWrapperImpl<
   template <class... IdxOrMemberTypes, class IdxOrMemberType1,
             class... IdxOrMemberTypesThenValueType>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      !std::is_same<remove_cvref_t<IdxOrMemberType1>, value_type>::value>
+      !std::is_same_v<remove_cvref_t<IdxOrMemberType1>, value_type>>
   _call_op_impl(IdxOrMemberTypes&&... idxs, IdxOrMemberType1&& idx,
                 IdxOrMemberTypesThenValueType&&... args) const {
     this->template _call_op_impl<IdxOrMemberTypes&&..., IdxOrMemberType1&&>(

--- a/core/src/impl/Kokkos_EBO.hpp
+++ b/core/src/impl/Kokkos_EBO.hpp
@@ -52,16 +52,16 @@ struct EBOBaseImpl;
 template <class T, template <class...> class CtorNotOnDevice>
 struct EBOBaseImpl<T, true, CtorNotOnDevice> {
   template <class... Args, class _ignored = void,
-            std::enable_if_t<std::is_void<_ignored>::value &&
-                                 std::is_constructible<T, Args...>::value &&
+            std::enable_if_t<std::is_void_v<_ignored> &&
+                                 std::is_constructible_v<T, Args...> &&
                                  !CtorNotOnDevice<Args...>::value,
                              int> = 0>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit EBOBaseImpl(
       Args&&...) noexcept {}
 
   template <class... Args, class _ignored = void,
-            std::enable_if_t<std::is_void<_ignored>::value &&
-                                 std::is_constructible<T, Args...>::value &&
+            std::enable_if_t<std::is_void_v<_ignored> &&
+                                 std::is_constructible_v<T, Args...> &&
                                  CtorNotOnDevice<Args...>::value,
                              long> = 0>
   inline constexpr explicit EBOBaseImpl(Args&&...) noexcept {}
@@ -110,18 +110,18 @@ struct EBOBaseImpl<T, false, CTorsNotOnDevice> {
   T m_ebo_object;
 
   template <class... Args, class _ignored = void,
-            std::enable_if_t<std::is_void<_ignored>::value &&
+            std::enable_if_t<std::is_void_v<_ignored> &&
                                  !CTorsNotOnDevice<Args...>::value &&
-                                 std::is_constructible<T, Args...>::value,
+                                 std::is_constructible_v<T, Args...>,
                              int> = 0>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit EBOBaseImpl(
       Args&&... args) noexcept(noexcept(T(std::forward<Args>(args)...)))
       : m_ebo_object(std::forward<Args>(args)...) {}
 
   template <class... Args, class _ignored = void,
-            std::enable_if_t<std::is_void<_ignored>::value &&
+            std::enable_if_t<std::is_void_v<_ignored> &&
                                  CTorsNotOnDevice<Args...>::value &&
-                                 std::is_constructible<T, Args...>::value,
+                                 std::is_constructible_v<T, Args...>,
                              long> = 0>
   inline constexpr explicit EBOBaseImpl(Args&&... args) noexcept(
       noexcept(T(std::forward<Args>(args)...)))
@@ -167,9 +167,9 @@ struct EBOBaseImpl<T, false, CTorsNotOnDevice> {
 template <class T,
           template <class...> class CtorsNotOnDevice = NoCtorsNotOnDevice>
 struct StandardLayoutNoUniqueAddressMemberEmulation
-    : EBOBaseImpl<T, std::is_empty<T>::value, CtorsNotOnDevice> {
+    : EBOBaseImpl<T, std::is_empty_v<T>, CtorsNotOnDevice> {
  private:
-  using ebo_base_t = EBOBaseImpl<T, std::is_empty<T>::value, CtorsNotOnDevice>;
+  using ebo_base_t = EBOBaseImpl<T, std::is_empty_v<T>, CtorsNotOnDevice>;
 
  public:
   using ebo_base_t::ebo_base_t;

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -118,8 +118,8 @@ struct FunctorAnalysis {
   using functor_has_space = has_execution_space<Functor>;
 
   static_assert(!policy_has_space::value || !functor_has_space::value ||
-                    std::is_same<typename policy_has_space::type,
-                                 typename functor_has_space::type>::value,
+                    std::is_same_v<typename policy_has_space::type,
+                                   typename functor_has_space::type>,
                 "Execution Policy and Functor execution space must match");
 
   //----------------------------------------
@@ -136,9 +136,8 @@ struct FunctorAnalysis {
                         typename std::is_void<typename F::value_type>::type> {
     using type = typename F::value_type;
 
-    static_assert(!std::is_reference<type>::value &&
-                      std::rank<type>::value <= 1 &&
-                      std::extent<type>::value == 0,
+    static_assert(!std::is_reference_v<type> && std::rank_v<type> <= 1 &&
+                      std::extent_v<type> == 0,
                   "Kokkos Functor::value_type is T or T[]");
   };
 
@@ -149,7 +148,7 @@ struct FunctorAnalysis {
 
   template <typename F, typename P = PatternInterface,
             typename V = typename has_value_type<F>::type,
-            bool T     = std::is_void<Tag>::value>
+            bool T     = std::is_void_v<Tag>>
   struct deduce_value_type {
     using type = V;
   };
@@ -290,8 +289,8 @@ struct FunctorAnalysis {
   using candidate_type = typename deduce_value_type<Functor>::type;
 
   enum {
-    candidate_is_void  = std::is_void<candidate_type>::value,
-    candidate_is_array = std::rank<candidate_type>::value == 1
+    candidate_is_void  = std::is_void_v<candidate_type>,
+    candidate_is_array = std::rank_v<candidate_type> == 1
   };
 
   //----------------------------------------
@@ -306,7 +305,7 @@ struct FunctorAnalysis {
 
   using value_type = std::remove_extent_t<candidate_type>;
 
-  static_assert(!std::is_const<value_type>::value,
+  static_assert(!std::is_const_v<value_type>,
                 "Kokkos functor operator reduce argument cannot be const");
 
  private:
@@ -614,21 +613,20 @@ struct FunctorAnalysis {
   };
 
   template <class F>
-  struct DeduceJoinNoTag<F, std::enable_if_t<(is_reducer<F>::value ||
-                                              (!is_reducer<F>::value &&
-                                               std::is_void<Tag>::value)) &&
-                                             detected_join_no_tag<F>::value>>
+  struct DeduceJoinNoTag<
+      F, std::enable_if_t<(is_reducer<F>::value ||
+                           (!is_reducer<F>::value && std::is_void_v<Tag>)) &&
+                          detected_join_no_tag<F>::value>>
       : public has_join_no_tag_function<F> {
     enum : bool { value = true };
   };
 
   template <class F>
   struct DeduceJoinNoTag<
-      F,
-      std::enable_if_t<(is_reducer<F>::value ||
-                        (!is_reducer<F>::value && std::is_void<Tag>::value)) &&
-                       (!detected_join_no_tag<F>::value &&
-                        detected_volatile_join_no_tag<F>::value)>>
+      F, std::enable_if_t<(is_reducer<F>::value ||
+                           (!is_reducer<F>::value && std::is_void_v<Tag>)) &&
+                          (!detected_join_no_tag<F>::value &&
+                           detected_volatile_join_no_tag<F>::value)>>
       : public has_volatile_join_no_tag_function<F> {
     enum : bool { value = true };
     static_assert(Impl::dependent_false_v<F>,
@@ -735,8 +733,8 @@ struct FunctorAnalysis {
 
   template <class F>
   struct DeduceInitNoTag<
-      F, std::enable_if_t<is_reducer<F>::value || (!is_reducer<F>::value &&
-                                                   std::is_void<Tag>::value),
+      F, std::enable_if_t<is_reducer<F>::value ||
+                              (!is_reducer<F>::value && std::is_void_v<Tag>),
                           decltype(has_init_no_tag_function<F>::enable_if(
                               &F::init))>>
       : public has_init_no_tag_function<F> {
@@ -835,8 +833,8 @@ struct FunctorAnalysis {
 
   template <class F>
   struct DeduceFinalNoTag<
-      F, std::enable_if_t<is_reducer<F>::value || (!is_reducer<F>::value &&
-                                                   std::is_void<Tag>::value),
+      F, std::enable_if_t<is_reducer<F>::value ||
+                              (!is_reducer<F>::value && std::is_void_v<Tag>),
                           decltype(has_final_no_tag_function<F>::enable_if(
                               &F::final))>>
       : public has_final_no_tag_function<F> {

--- a/core/src/impl/Kokkos_GraphImpl_Utilities.hpp
+++ b/core/src/impl/Kokkos_GraphImpl_Utilities.hpp
@@ -54,9 +54,9 @@ template <template <class, class, class> class Template, class TSrc, class USrc,
 struct is_compatible_type_erasure<
     Template<TSrc, USrc, VSrc>, Template<TDst, UDst, VDst>,
     // Because gcc thinks this is ambiguous, we need to add this:
-    std::enable_if_t<!std::is_same<TSrc, TDst>::value ||
-                     !std::is_same<USrc, UDst>::value ||
-                     !std::is_same<VSrc, VDst>::value>>
+    std::enable_if_t<!std::is_same_v<TSrc, TDst> ||
+                     !std::is_same_v<USrc, UDst> ||
+                     !std::is_same_v<VSrc, VDst>>>
     : std::bool_constant<is_compatible_type_erasure<TSrc, TDst>::value &&
                          is_compatible_type_erasure<USrc, UDst>::value &&
                          is_compatible_type_erasure<VSrc, VDst>::value> {};

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -987,13 +987,12 @@ half_t cast_to_half(unsigned long long val) { return half_t(val); }
 // example don't include char
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<
-    std::is_same<T, float>::value || std::is_same<T, bool>::value ||
-        std::is_same<T, double>::value || std::is_same<T, short>::value ||
-        std::is_same<T, unsigned short>::value || std::is_same<T, int>::value ||
-        std::is_same<T, unsigned int>::value || std::is_same<T, long>::value ||
-        std::is_same<T, unsigned long>::value ||
-        std::is_same<T, long long>::value ||
-        std::is_same<T, unsigned long long>::value,
+    std::is_same_v<T, float> || std::is_same_v<T, bool> ||
+        std::is_same_v<T, double> || std::is_same_v<T, short> ||
+        std::is_same_v<T, unsigned short> || std::is_same_v<T, int> ||
+        std::is_same_v<T, unsigned int> || std::is_same_v<T, long> ||
+        std::is_same_v<T, unsigned long> || std::is_same_v<T, long long> ||
+        std::is_same_v<T, unsigned long long>,
     T>
 cast_from_half(half_t val) {
   return T(val);
@@ -1047,13 +1046,12 @@ bhalf_t cast_to_bhalf(unsigned long long val) { return bhalf_t(val); }
 // cast_from_bhalf
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<
-    std::is_same<T, float>::value || std::is_same<T, bool>::value ||
-        std::is_same<T, double>::value || std::is_same<T, short>::value ||
-        std::is_same<T, unsigned short>::value || std::is_same<T, int>::value ||
-        std::is_same<T, unsigned int>::value || std::is_same<T, long>::value ||
-        std::is_same<T, unsigned long>::value ||
-        std::is_same<T, long long>::value ||
-        std::is_same<T, unsigned long long>::value,
+    std::is_same_v<T, float> || std::is_same_v<T, bool> ||
+        std::is_same_v<T, double> || std::is_same_v<T, short> ||
+        std::is_same_v<T, unsigned short> || std::is_same_v<T, int> ||
+        std::is_same_v<T, unsigned int> || std::is_same_v<T, long> ||
+        std::is_same_v<T, unsigned long> || std::is_same_v<T, long long> ||
+        std::is_same_v<T, unsigned long long>,
     T>
 cast_from_bhalf(bhalf_t val) {
   return T(val);

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -887,7 +887,7 @@ KOKKOS_INLINE_FUNCTION
   using ClosureValueType = typename Kokkos::Impl::FunctorAnalysis<
       Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure,
       void>::value_type;
-  static_assert(std::is_same<ClosureValueType, ValueType>::value,
+  static_assert(std::is_same_v<ClosureValueType, ValueType>,
                 "Non-matching value types of closure and return type");
 
   ValueType accum = ValueType();
@@ -939,7 +939,7 @@ KOKKOS_INLINE_FUNCTION
   using ClosureValueType = typename Kokkos::Impl::FunctorAnalysis<
       Kokkos::Impl::FunctorPatternInterface::SCAN, void, ClosureType,
       void>::value_type;
-  static_assert(std::is_same<ClosureValueType, ValueType>::value,
+  static_assert(std::is_same_v<ClosureValueType, ValueType>,
                 "Non-matching value types of closure and return type");
 
   ValueType scan_val = ValueType();

--- a/core/src/impl/Kokkos_LinkedListNode.hpp
+++ b/core/src/impl/Kokkos_LinkedListNode.hpp
@@ -43,7 +43,7 @@ template <uintptr_t NotEnqueuedValue             = 0,
 struct SimpleSinglyLinkedListNode {
  private:
   using pointer_type =
-      typename PointerTemplate<SimpleSinglyLinkedListNode>::type;
+      typename PointerTemplate<SimpleSinglyLinkedListNode>::type;  // NOLINT
 
   pointer_type m_next = reinterpret_cast<pointer_type>(NotEnqueuedValue);
 

--- a/core/src/impl/Kokkos_MultipleTaskQueue.hpp
+++ b/core/src/impl/Kokkos_MultipleTaskQueue.hpp
@@ -95,7 +95,7 @@ struct MultipleTaskQueueTeamEntry {
   KOKKOS_INLINE_FUNCTION OptionalRef<task_base_type> _pop_failed_insertion(
       int priority, TaskType type,
       std::enable_if_t<task_queue_traits::ready_queue_insertion_may_fail &&
-                           std::is_void<_always_void>::value,
+                           std::is_void_v<_always_void>,
                        void*> = nullptr) {
     auto* rv_ptr = m_failed_heads[priority][(int)type];
     if (rv_ptr) {
@@ -113,7 +113,7 @@ struct MultipleTaskQueueTeamEntry {
   KOKKOS_INLINE_FUNCTION OptionalRef<task_base_type> _pop_failed_insertion(
       int /*priority*/, TaskType /*type*/,
       std::enable_if_t<!task_queue_traits::ready_queue_insertion_may_fail &&
-                           std::is_void<_always_void>::value,
+                           std::is_void_v<_always_void>,
                        void*> = nullptr) {
     return OptionalRef<task_base_type>{nullptr};
   }
@@ -171,7 +171,7 @@ struct MultipleTaskQueueTeamEntry {
   KOKKOS_INLINE_FUNCTION void do_handle_failed_insertion(
       runnable_task_base_type&& task,
       std::enable_if_t<task_queue_traits::ready_queue_insertion_may_fail &&
-                           std::is_void<_always_void>::value,
+                           std::is_void_v<_always_void>,
                        void*> = nullptr) {
     // failed insertions, if they happen, must be from the only thread that
     // is allowed to push to m_ready_queues, so this linked-list insertion is
@@ -186,7 +186,7 @@ struct MultipleTaskQueueTeamEntry {
   KOKKOS_INLINE_FUNCTION void do_handle_failed_insertion(
       runnable_task_base_type&& /*task*/,
       std::enable_if_t<!task_queue_traits::ready_queue_insertion_may_fail &&
-                           std::is_void<_always_void>::value,
+                           std::is_void_v<_always_void>,
                        void*> = nullptr) {
     Kokkos::abort("should be unreachable!");
   }
@@ -194,11 +194,11 @@ struct MultipleTaskQueueTeamEntry {
   template <class _always_void = void>
   KOKKOS_INLINE_FUNCTION void flush_failed_insertions(
       int priority, int task_type,
-      std::enable_if_t<
-          task_queue_traits::ready_queue_insertion_may_fail &&
-              std::is_void<_always_void>::value,  // just to make this dependent
-                                                  // on template parameter
-          int> = 0) {
+      std::enable_if_t<task_queue_traits::ready_queue_insertion_may_fail &&
+                           std::is_void_v<_always_void>,  // just to make this
+                                                          // dependent on
+                                                          // template parameter
+                       int> = 0) {
     // TODO @tasking @minor DSH this somethimes gets some things out of LIFO
     // order, which may be undesirable (but not a bug)
 
@@ -223,11 +223,11 @@ struct MultipleTaskQueueTeamEntry {
   template <class _always_void = void>
   KOKKOS_INLINE_FUNCTION void flush_failed_insertions(
       int, int,
-      std::enable_if_t<
-          !task_queue_traits::ready_queue_insertion_may_fail &&
-              std::is_void<_always_void>::value,  // just to make this dependent
-                                                  // on template parameter
-          int> = 0) {}
+      std::enable_if_t<!task_queue_traits::ready_queue_insertion_may_fail &&
+                           std::is_void_v<_always_void>,  // just to make this
+                                                          // dependent on
+                                                          // template parameter
+                       int> = 0) {}
 
   KOKKOS_INLINE_FUNCTION
   void flush_all_failed_insertions() {

--- a/core/src/impl/Kokkos_MultipleTaskQueue.hpp
+++ b/core/src/impl/Kokkos_MultipleTaskQueue.hpp
@@ -94,8 +94,8 @@ struct MultipleTaskQueueTeamEntry {
   template <class _always_void = void>
   KOKKOS_INLINE_FUNCTION OptionalRef<task_base_type> _pop_failed_insertion(
       int priority, TaskType type,
-      std::enable_if_t<task_queue_traits::ready_queue_insertion_may_fail &&
-                           std::is_void_v<_always_void>,
+      std::enable_if_t<std::is_void_v<_always_void> &&
+                           task_queue_traits::ready_queue_insertion_may_fail,
                        void*> = nullptr) {
     auto* rv_ptr = m_failed_heads[priority][(int)type];
     if (rv_ptr) {
@@ -170,8 +170,8 @@ struct MultipleTaskQueueTeamEntry {
   template <class _always_void = void>
   KOKKOS_INLINE_FUNCTION void do_handle_failed_insertion(
       runnable_task_base_type&& task,
-      std::enable_if_t<task_queue_traits::ready_queue_insertion_may_fail &&
-                           std::is_void_v<_always_void>,
+      std::enable_if_t<std::is_void_v<_always_void> &&
+                           task_queue_traits::ready_queue_insertion_may_fail,
                        void*> = nullptr) {
     // failed insertions, if they happen, must be from the only thread that
     // is allowed to push to m_ready_queues, so this linked-list insertion is
@@ -194,10 +194,8 @@ struct MultipleTaskQueueTeamEntry {
   template <class _always_void = void>
   KOKKOS_INLINE_FUNCTION void flush_failed_insertions(
       int priority, int task_type,
-      std::enable_if_t<task_queue_traits::ready_queue_insertion_may_fail &&
-                           std::is_void_v<_always_void>,  // just to make this
-                                                          // dependent on
-                                                          // template parameter
+      std::enable_if_t<std::is_void_v<_always_void> &&
+                           task_queue_traits::ready_queue_insertion_may_fail,
                        int> = 0) {
     // TODO @tasking @minor DSH this somethimes gets some things out of LIFO
     // order, which may be undesirable (but not a bug)

--- a/core/src/impl/Kokkos_MultipleTaskQueue.hpp
+++ b/core/src/impl/Kokkos_MultipleTaskQueue.hpp
@@ -112,8 +112,8 @@ struct MultipleTaskQueueTeamEntry {
   template <class _always_void = void>
   KOKKOS_INLINE_FUNCTION OptionalRef<task_base_type> _pop_failed_insertion(
       int /*priority*/, TaskType /*type*/,
-      std::enable_if_t<!task_queue_traits::ready_queue_insertion_may_fail &&
-                           std::is_void_v<_always_void>,
+      std::enable_if_t<std::is_void_v<_always_void> &&
+                           !task_queue_traits::ready_queue_insertion_may_fail,
                        void*> = nullptr) {
     return OptionalRef<task_base_type>{nullptr};
   }
@@ -185,8 +185,8 @@ struct MultipleTaskQueueTeamEntry {
   template <class _always_void = void>
   KOKKOS_INLINE_FUNCTION void do_handle_failed_insertion(
       runnable_task_base_type&& /*task*/,
-      std::enable_if_t<!task_queue_traits::ready_queue_insertion_may_fail &&
-                           std::is_void_v<_always_void>,
+      std::enable_if_t<std::is_void_v<_always_void> &&
+                           !task_queue_traits::ready_queue_insertion_may_fail,
                        void*> = nullptr) {
     Kokkos::abort("should be unreachable!");
   }
@@ -221,10 +221,8 @@ struct MultipleTaskQueueTeamEntry {
   template <class _always_void = void>
   KOKKOS_INLINE_FUNCTION void flush_failed_insertions(
       int, int,
-      std::enable_if_t<!task_queue_traits::ready_queue_insertion_may_fail &&
-                           std::is_void_v<_always_void>,  // just to make this
-                                                          // dependent on
-                                                          // template parameter
+      std::enable_if_t<std::is_void_v<_always_void> &&
+                           !task_queue_traits::ready_queue_insertion_may_fail,
                        int> = 0) {}
 
   KOKKOS_INLINE_FUNCTION

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -123,8 +123,8 @@ KOKKOS_INLINE_FUNCTION constexpr char *strncat(char *dest, const char *src,
 template <class Unsigned>
 KOKKOS_FUNCTION constexpr unsigned int to_chars_len(Unsigned val) {
   unsigned int const base = 10;
-  static_assert(std::is_integral<Unsigned>::value, "implementation bug");
-  static_assert(std::is_unsigned<Unsigned>::value, "implementation bug");
+  static_assert(std::is_integral_v<Unsigned>, "implementation bug");
+  static_assert(std::is_unsigned_v<Unsigned>, "implementation bug");
   unsigned int n = 1;
   while (val >= base) {
     val /= base;
@@ -136,8 +136,8 @@ template <class Unsigned>
 KOKKOS_FUNCTION constexpr void to_chars_impl(char *first, unsigned int len,
                                              Unsigned val) {
   unsigned int const base = 10;
-  static_assert(std::is_integral<Unsigned>::value, "implementation bug");
-  static_assert(std::is_unsigned<Unsigned>::value, "implementation bug");
+  static_assert(std::is_integral_v<Unsigned>, "implementation bug");
+  static_assert(std::is_unsigned_v<Unsigned>, "implementation bug");
   unsigned int pos = len - 1;
   while (val > 0) {
     auto const num = val % base;
@@ -167,7 +167,7 @@ KOKKOS_FUNCTION constexpr to_chars_result to_chars_i(char *first, char *last,
   if (value == 0) {
     *first = '0';
     return {first + 1, {}};
-  } else if constexpr (std::is_signed<Integral>::value) {
+  } else if constexpr (std::is_signed_v<Integral>) {
     if (value < 0) {
       *first++     = '-';
       unsigned_val = Unsigned(~value) + Unsigned(1);

--- a/core/src/impl/Kokkos_TaskPolicyData.hpp
+++ b/core/src/impl/Kokkos_TaskPolicyData.hpp
@@ -127,7 +127,7 @@ struct TaskPolicyWithScheduler {
 
   KOKKOS_INLINE_FUNCTION
   static constexpr bool has_predecessor() noexcept {
-    return !std::is_same<PredecessorFuture, std::nullptr_t>::value;
+    return !std::is_same_v<PredecessorFuture, std::nullptr_t>;
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/core/src/impl/Kokkos_TaskQueueCommon.hpp
+++ b/core/src/impl/Kokkos_TaskQueueCommon.hpp
@@ -455,10 +455,9 @@ class TaskQueueCommonMixin {
   //            && Same<MemoryPool, typename Derived::memory_pool>
   {
     static_assert(
-        std::is_same<ExecutionSpace,
-                     typename Derived::execution_space>::value &&
-            std::is_same<MemorySpace, typename Derived::memory_space>::value &&
-            std::is_same<MemoryPool, typename Derived::memory_pool>::value,
+        std::is_same_v<ExecutionSpace, typename Derived::execution_space> &&
+            std::is_same_v<MemorySpace, typename Derived::memory_space> &&
+            std::is_same_v<MemoryPool, typename Derived::memory_pool>,
         "Type mismatch in task_queue_allocation_size customization point");
 
     return sizeof(Derived);

--- a/core/src/impl/Kokkos_TaskTeamMember.hpp
+++ b/core/src/impl/Kokkos_TaskTeamMember.hpp
@@ -52,8 +52,7 @@ class TaskTeamMemberAdapter : public TeamMember {
   // type that we're adapting
   template <typename... Args>
   KOKKOS_INLINE_FUNCTION explicit TaskTeamMemberAdapter(
-      std::enable_if_t<std::is_constructible<TeamMember, Args...>::value,
-                       Scheduler>
+      std::enable_if_t<std::is_constructible_v<TeamMember, Args...>, Scheduler>
           arg_scheduler,
       Args&&... args)  // TODO @tasking @minor DSH noexcept specification
       : TeamMember(std::forward<Args>(args)...),

--- a/core/src/impl/Kokkos_Traits.hpp
+++ b/core/src/impl/Kokkos_Traits.hpp
@@ -53,7 +53,7 @@ struct has_type {
 template <typename T, typename S, typename... Pack>
 struct has_type<T, S, Pack...> {
  private:
-  enum { self_value = std::is_same<T, S>::value };
+  enum { self_value = std::is_same_v<T, S> };
 
   using next = has_type<T, Pack...>;
 
@@ -102,8 +102,7 @@ struct are_integral<T, Args...> {
         // Accept std::is_integral OR std::is_enum as an integral value
         // since a simple enum value is automically convertible to an
         // integral value.
-    (std::is_integral<T>::value || std::is_enum<T>::value) &&
-    are_integral<Args...>::value
+    (std::is_integral_v<T> || std::is_enum_v<T>)&&are_integral<Args...>::value
   };
 };
 

--- a/core/src/impl/Kokkos_ViewDataAnalysis.hpp
+++ b/core/src/impl/Kokkos_ViewDataAnalysis.hpp
@@ -370,8 +370,7 @@ struct ViewDataAnalysis {
   // ValueType is opportunity for partial specialization.
   // Must match array analysis when this default template is used.
   static_assert(
-      std::is_same<ValueType,
-                   typename array_analysis::non_const_value_type>::value);
+      std::is_same_v<ValueType, typename array_analysis::non_const_value_type>);
 
  public:
   using specialize = void;  // No specialization

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -66,23 +66,23 @@ namespace Impl {
 
 template <class T>
 struct is_integral_extent_type {
-  enum : bool { value = std::is_same<T, Kokkos::ALL_t>::value ? 1 : 0 };
+  enum : bool { value = std::is_same_v<T, Kokkos::ALL_t> ? 1 : 0 };
 };
 
 template <class iType>
 struct is_integral_extent_type<std::pair<iType, iType>> {
-  enum : bool { value = std::is_integral<iType>::value ? 1 : 0 };
+  enum : bool { value = std::is_integral_v<iType> ? 1 : 0 };
 };
 
 template <class iType>
 struct is_integral_extent_type<Kokkos::pair<iType, iType>> {
-  enum : bool { value = std::is_integral<iType>::value ? 1 : 0 };
+  enum : bool { value = std::is_integral_v<iType> ? 1 : 0 };
 };
 
 // Assuming '2 == initializer_list<iType>::size()'
 template <class iType>
 struct is_integral_extent_type<std::initializer_list<iType>> {
-  enum : bool { value = std::is_integral<iType>::value ? 1 : 0 };
+  enum : bool { value = std::is_integral_v<iType> ? 1 : 0 };
 };
 
 template <unsigned I, class... Args>
@@ -93,8 +93,7 @@ struct is_integral_extent {
 
   enum : bool { value = is_integral_extent_type<type>::value };
 
-  static_assert(value || std::is_integral<type>::value ||
-                    std::is_void<type>::value,
+  static_assert(value || std::is_integral_v<type> || std::is_void_v<type>,
                 "subview argument must be either integral or integral extent");
 };
 
@@ -112,16 +111,16 @@ struct SubviewLegalArgsCompileTime<Kokkos::LayoutLeft, Kokkos::LayoutLeft,
                                    RankDest, RankSrc, CurrentArg, Arg,
                                    SubViewArgs...> {
   enum {
-    value = (((CurrentArg == RankDest - 1) &&
-              (Kokkos::Impl::is_integral_extent_type<Arg>::value)) ||
-             ((CurrentArg >= RankDest) && (std::is_integral<Arg>::value)) ||
-             ((CurrentArg < RankDest) &&
-              (std::is_same<Arg, Kokkos::ALL_t>::value)) ||
-             ((CurrentArg == 0) &&
-              (Kokkos::Impl::is_integral_extent_type<Arg>::value))) &&
-            (SubviewLegalArgsCompileTime<Kokkos::LayoutLeft, Kokkos::LayoutLeft,
-                                         RankDest, RankSrc, CurrentArg + 1,
-                                         SubViewArgs...>::value)
+    value =
+        (((CurrentArg == RankDest - 1) &&
+          (Kokkos::Impl::is_integral_extent_type<Arg>::value)) ||
+         ((CurrentArg >= RankDest) && (std::is_integral_v<Arg>)) ||
+         ((CurrentArg < RankDest) && (std::is_same_v<Arg, Kokkos::ALL_t>)) ||
+         ((CurrentArg == 0) &&
+          (Kokkos::Impl::is_integral_extent_type<Arg>::value))) &&
+        (SubviewLegalArgsCompileTime<Kokkos::LayoutLeft, Kokkos::LayoutLeft,
+                                     RankDest, RankSrc, CurrentArg + 1,
+                                     SubViewArgs...>::value)
   };
 };
 
@@ -129,7 +128,7 @@ template <int RankDest, int RankSrc, int CurrentArg, class Arg>
 struct SubviewLegalArgsCompileTime<Kokkos::LayoutLeft, Kokkos::LayoutLeft,
                                    RankDest, RankSrc, CurrentArg, Arg> {
   enum {
-    value = ((CurrentArg == RankDest - 1) || (std::is_integral<Arg>::value)) &&
+    value = ((CurrentArg == RankDest - 1) || (std::is_integral_v<Arg>)) &&
             (CurrentArg == RankSrc - 1)
   };
 };
@@ -144,10 +143,9 @@ struct SubviewLegalArgsCompileTime<Kokkos::LayoutRight, Kokkos::LayoutRight,
   enum {
     value = (((CurrentArg == RankSrc - RankDest) &&
               (Kokkos::Impl::is_integral_extent_type<Arg>::value)) ||
-             ((CurrentArg < RankSrc - RankDest) &&
-              (std::is_integral<Arg>::value)) ||
+             ((CurrentArg < RankSrc - RankDest) && (std::is_integral_v<Arg>)) ||
              ((CurrentArg >= RankSrc - RankDest) &&
-              (std::is_same<Arg, Kokkos::ALL_t>::value))) &&
+              (std::is_same_v<Arg, Kokkos::ALL_t>))) &&
             (SubviewLegalArgsCompileTime<Kokkos::LayoutRight,
                                          Kokkos::LayoutRight, RankDest, RankSrc,
                                          CurrentArg + 1, SubViewArgs...>::value)
@@ -158,8 +156,8 @@ template <int RankDest, int RankSrc, int CurrentArg, class Arg>
 struct SubviewLegalArgsCompileTime<Kokkos::LayoutRight, Kokkos::LayoutRight,
                                    RankDest, RankSrc, CurrentArg, Arg> {
   enum {
-    value = ((CurrentArg == RankSrc - 1) &&
-             (std::is_same<Arg, Kokkos::ALL_t>::value))
+    value =
+        ((CurrentArg == RankSrc - 1) && (std::is_same_v<Arg, Kokkos::ALL_t>))
   };
 };
 
@@ -2398,9 +2396,9 @@ struct ViewDataHandle {
 template <class Traits>
 struct ViewDataHandle<
     Traits,
-    std::enable_if_t<(std::is_same<typename Traits::non_const_value_type,
-                                   typename Traits::value_type>::value &&
-                      std::is_void<typename Traits::specialize>::value &&
+    std::enable_if_t<(std::is_same_v<typename Traits::non_const_value_type,
+                                     typename Traits::value_type> &&
+                      std::is_void_v<typename Traits::specialize> &&
                       Traits::memory_traits::is_atomic)>> {
   using value_type  = typename Traits::value_type;
   using handle_type = typename Kokkos::Impl::AtomicViewDataHandle<Traits>;
@@ -2422,11 +2420,10 @@ struct ViewDataHandle<
 
 template <class Traits>
 struct ViewDataHandle<
-    Traits,
-    std::enable_if_t<(std::is_void<typename Traits::specialize>::value &&
-                      (!Traits::memory_traits::is_aligned) &&
-                      Traits::memory_traits::is_restrict &&
-                      (!Traits::memory_traits::is_atomic))>> {
+    Traits, std::enable_if_t<(std::is_void_v<typename Traits::specialize> &&
+                              (!Traits::memory_traits::is_aligned) &&
+                              Traits::memory_traits::is_restrict &&
+                              (!Traits::memory_traits::is_atomic))>> {
   using value_type  = typename Traits::value_type;
   using handle_type = typename Traits::value_type* KOKKOS_RESTRICT;
   using return_type = typename Traits::value_type& KOKKOS_RESTRICT;
@@ -2446,11 +2443,10 @@ struct ViewDataHandle<
 
 template <class Traits>
 struct ViewDataHandle<
-    Traits,
-    std::enable_if_t<(std::is_void<typename Traits::specialize>::value &&
-                      Traits::memory_traits::is_aligned &&
-                      (!Traits::memory_traits::is_restrict) &&
-                      (!Traits::memory_traits::is_atomic))>> {
+    Traits, std::enable_if_t<(std::is_void_v<typename Traits::specialize> &&
+                              Traits::memory_traits::is_aligned &&
+                              (!Traits::memory_traits::is_restrict) &&
+                              (!Traits::memory_traits::is_atomic))>> {
   using value_type = typename Traits::value_type;
   // typedef work-around for intel compilers error #3186: expected typedef
   // declaration
@@ -2485,11 +2481,10 @@ struct ViewDataHandle<
 
 template <class Traits>
 struct ViewDataHandle<
-    Traits,
-    std::enable_if_t<(std::is_void<typename Traits::specialize>::value &&
-                      Traits::memory_traits::is_aligned &&
-                      Traits::memory_traits::is_restrict &&
-                      (!Traits::memory_traits::is_atomic))>> {
+    Traits, std::enable_if_t<(std::is_void_v<typename Traits::specialize> &&
+                              Traits::memory_traits::is_aligned &&
+                              Traits::memory_traits::is_restrict &&
+                              (!Traits::memory_traits::is_atomic))>> {
   using value_type = typename Traits::value_type;
   // typedef work-around for intel compilers error #3186: expected typedef
   // declaration
@@ -2533,11 +2528,10 @@ namespace Impl {
 /** \brief  View mapping for non-specialized data type and standard layout */
 template <class Traits>
 class ViewMapping<
-    Traits,
-    std::enable_if_t<(
-        std::is_void<typename Traits::specialize>::value &&
-        ViewOffset<typename Traits::dimension, typename Traits::array_layout,
-                   void>::is_mapping_plugin::value)>> {
+    Traits, std::enable_if_t<(std::is_void_v<typename Traits::specialize> &&
+                              ViewOffset<typename Traits::dimension,
+                                         typename Traits::array_layout,
+                                         void>::is_mapping_plugin::value)>> {
  public:
   using offset_type = ViewOffset<typename Traits::dimension,
                                  typename Traits::array_layout, void>;
@@ -2680,28 +2674,26 @@ class ViewMapping<
   reference_type reference() const { return m_impl_handle[0]; }
 
   template <typename I0>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(std::is_integral<I0>::value &&
-                        // if layout is neither stride nor irregular,
-                        // then just use the handle directly
-                        !(std::is_same<typename Traits::array_layout,
-                                       Kokkos::LayoutStride>::value ||
-                          !is_regular::value)),
-                       reference_type>
-      reference(const I0& i0) const {
+  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
+      (std::is_integral_v<I0> &&
+       // if layout is neither stride nor irregular,
+       // then just use the handle directly
+       !(std::is_same_v<typename Traits::array_layout, Kokkos::LayoutStride> ||
+         !is_regular::value)),
+      reference_type>
+  reference(const I0& i0) const {
     return m_impl_handle[i0];
   }
 
   template <typename I0>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(std::is_integral<I0>::value &&
-                        // if the layout is strided or irregular, then
-                        // we have to use the offset
-                        (std::is_same<typename Traits::array_layout,
-                                      Kokkos::LayoutStride>::value ||
-                         !is_regular::value)),
-                       reference_type>
-      reference(const I0& i0) const {
+  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
+      (std::is_integral_v<I0> &&
+       // if the layout is strided or irregular, then
+       // we have to use the offset
+       (std::is_same_v<typename Traits::array_layout, Kokkos::LayoutStride> ||
+        !is_regular::value)),
+      reference_type>
+  reference(const I0& i0) const {
     return m_impl_handle[m_impl_offset(i0)];
   }
 
@@ -2894,29 +2886,34 @@ template <class DstTraits, class SrcTraits>
 class ViewMapping<
     DstTraits, SrcTraits,
     std::enable_if_t<(
-        !(std::is_same<typename SrcTraits::array_layout, LayoutStride>::
-              value) &&  // Added to have a new specialization for SrcType of
-                         // LayoutStride
+        !(std::is_same_v<typename SrcTraits::array_layout,
+                         LayoutStride>)&&  // Added to have a new
+                                           // specialization for
+                                           // SrcType of
+                                           // LayoutStride
         // default mappings
-        std::is_void<typename DstTraits::specialize>::value &&
-        std::is_void<typename SrcTraits::specialize>::value &&
+        std::is_void_v<typename DstTraits::specialize> &&
+        std::is_void_v<typename SrcTraits::specialize> &&
         (
             // same layout
-            std::is_same<typename DstTraits::array_layout,
-                         typename SrcTraits::array_layout>::value ||
+            std::is_same_v<typename DstTraits::array_layout,
+                           typename SrcTraits::array_layout> ||
             // known layout
-            ((std::is_same<typename DstTraits::array_layout,
-                           Kokkos::LayoutLeft>::value ||
-              std::is_same<typename DstTraits::array_layout,
-                           Kokkos::LayoutRight>::value ||
-              std::is_same<typename DstTraits::array_layout,
-                           Kokkos::LayoutStride>::value) &&
-             (std::is_same<typename SrcTraits::array_layout,
-                           Kokkos::LayoutLeft>::value ||
-              std::is_same<typename SrcTraits::array_layout,
-                           Kokkos::LayoutRight>::value ||
-              std::is_same<typename SrcTraits::array_layout,
-                           Kokkos::LayoutStride>::value))))>> {
+            ((std::is_same_v<typename DstTraits::array_layout,
+                             Kokkos::LayoutLeft> ||
+              std::is_same_v<typename DstTraits::array_layout,
+                             Kokkos::LayoutRight> ||
+              std::is_same_v<
+                  typename DstTraits::array_layout,
+                  Kokkos::LayoutStride>)&&(std::is_same_v<typename SrcTraits::
+                                                              array_layout,
+                                                          Kokkos::LayoutLeft> ||
+                                           std::is_same_v<
+                                               typename SrcTraits::array_layout,
+                                               Kokkos::LayoutRight> ||
+                                           std::is_same_v<
+                                               typename SrcTraits::array_layout,
+                                               Kokkos::LayoutStride>))))>> {
  private:
   enum {
     is_assignable_space = Kokkos::Impl::MemorySpaceAccess<
@@ -2926,10 +2923,10 @@ class ViewMapping<
 
   enum {
     is_assignable_value_type =
-        std::is_same<typename DstTraits::value_type,
-                     typename SrcTraits::value_type>::value ||
-        std::is_same<typename DstTraits::value_type,
-                     typename SrcTraits::const_value_type>::value
+        std::is_same_v<typename DstTraits::value_type,
+                       typename SrcTraits::value_type> ||
+        std::is_same_v<typename DstTraits::value_type,
+                       typename SrcTraits::const_value_type>
   };
 
   enum {
@@ -2939,12 +2936,12 @@ class ViewMapping<
   };
 
   enum {
-    is_assignable_layout =
-        std::is_same<typename DstTraits::array_layout,
-                     typename SrcTraits::array_layout>::value ||
-        std::is_same<typename DstTraits::array_layout,
-                     Kokkos::LayoutStride>::value ||
-        (DstTraits::dimension::rank == 0) || (DstTraits::dimension::rank == 1)
+    is_assignable_layout = std::is_same_v<typename DstTraits::array_layout,
+                                          typename SrcTraits::array_layout> ||
+                           std::is_same_v<typename DstTraits::array_layout,
+                                          Kokkos::LayoutStride> ||
+                           (DstTraits::dimension::rank == 0) ||
+                           (DstTraits::dimension::rank == 1)
   };
 
  public:
@@ -3032,22 +3029,21 @@ class ViewMapping<
 template <class DstTraits, class SrcTraits>
 class ViewMapping<
     DstTraits, SrcTraits,
-    std::enable_if_t<(
-        std::is_same<typename SrcTraits::array_layout,
-                     Kokkos::LayoutStride>::value &&
-        std::is_void<typename DstTraits::specialize>::value &&
-        std::is_void<typename SrcTraits::specialize>::value &&
-        (
-            // same layout
-            std::is_same<typename DstTraits::array_layout,
-                         typename SrcTraits::array_layout>::value ||
-            // known layout
-            (std::is_same<typename DstTraits::array_layout,
-                          Kokkos::LayoutLeft>::value ||
-             std::is_same<typename DstTraits::array_layout,
-                          Kokkos::LayoutRight>::value ||
-             std::is_same<typename DstTraits::array_layout,
-                          Kokkos::LayoutStride>::value)))>> {
+    std::enable_if_t<(std::is_same_v<typename SrcTraits::array_layout,
+                                     Kokkos::LayoutStride> &&
+                      std::is_void_v<typename DstTraits::specialize> &&
+                      std::is_void_v<typename SrcTraits::specialize> &&
+                      (
+                          // same layout
+                          std::is_same_v<typename DstTraits::array_layout,
+                                         typename SrcTraits::array_layout> ||
+                          // known layout
+                          (std::is_same_v<typename DstTraits::array_layout,
+                                          Kokkos::LayoutLeft> ||
+                           std::is_same_v<typename DstTraits::array_layout,
+                                          Kokkos::LayoutRight> ||
+                           std::is_same_v<typename DstTraits::array_layout,
+                                          Kokkos::LayoutStride>)))>> {
  private:
   enum {
     is_assignable_space = Kokkos::Impl::MemorySpaceAccess<
@@ -3057,10 +3053,10 @@ class ViewMapping<
 
   enum {
     is_assignable_value_type =
-        std::is_same<typename DstTraits::value_type,
-                     typename SrcTraits::value_type>::value ||
-        std::is_same<typename DstTraits::value_type,
-                     typename SrcTraits::const_value_type>::value
+        std::is_same_v<typename DstTraits::value_type,
+                       typename SrcTraits::value_type> ||
+        std::is_same_v<typename DstTraits::value_type,
+                       typename SrcTraits::const_value_type>
   };
 
   enum {
@@ -3091,8 +3087,7 @@ class ViewMapping<
     bool assignable = true;
     src.stride(strides);
     size_t exp_stride = 1;
-    if (std::is_same<typename DstTraits::array_layout,
-                     Kokkos::LayoutLeft>::value) {
+    if (std::is_same_v<typename DstTraits::array_layout, Kokkos::LayoutLeft>) {
       for (int i = 0; i < (int)src.Rank; i++) {
         if (i > 0) exp_stride *= src.extent(i - 1);
         if (strides[i] != exp_stride) {
@@ -3100,8 +3095,8 @@ class ViewMapping<
           break;
         }
       }
-    } else if (std::is_same<typename DstTraits::array_layout,
-                            Kokkos::LayoutRight>::value) {
+    } else if (std::is_same_v<typename DstTraits::array_layout,
+                              Kokkos::LayoutRight>) {
       for (int i = 0; i < (int)src.Rank; i++) {
         if (i > 0) exp_stride *= src.extent(src.Rank - i);
         if (strides[src.Rank - 1 - i] != exp_stride) {
@@ -3197,8 +3192,8 @@ struct SubViewDataTypeImpl<void, ValueType, Kokkos::Experimental::Extents<>> {
 template <class ValueType, size_t Ext, size_t... Exts, class Integral,
           class... Args>
 struct SubViewDataTypeImpl<
-    std::enable_if_t<std::is_integral<std::decay_t<Integral>>::value>,
-    ValueType, Kokkos::Experimental::Extents<Ext, Exts...>, Integral, Args...>
+    std::enable_if_t<std::is_integral_v<std::decay_t<Integral>>>, ValueType,
+    Kokkos::Experimental::Extents<Ext, Exts...>, Integral, Args...>
     : SubViewDataTypeImpl<void, ValueType,
                           Kokkos::Experimental::Extents<Exts...>, Args...> {};
 
@@ -3230,13 +3225,13 @@ struct SubViewDataType : SubViewDataTypeImpl<void, ValueType, Exts, Args...> {};
 
 template <class SrcTraits, class... Args>
 class ViewMapping<
-    std::enable_if_t<(std::is_void<typename SrcTraits::specialize>::value &&
-                      (std::is_same<typename SrcTraits::array_layout,
-                                    Kokkos::LayoutLeft>::value ||
-                       std::is_same<typename SrcTraits::array_layout,
-                                    Kokkos::LayoutRight>::value ||
-                       std::is_same<typename SrcTraits::array_layout,
-                                    Kokkos::LayoutStride>::value))>,
+    std::enable_if_t<(
+        std::is_void_v<typename SrcTraits::specialize> &&
+        (std::is_same_v<typename SrcTraits::array_layout, Kokkos::LayoutLeft> ||
+         std::is_same_v<typename SrcTraits::array_layout,
+                        Kokkos::LayoutRight> ||
+         std::is_same_v<typename SrcTraits::array_layout,
+                        Kokkos::LayoutStride>))>,
     SrcTraits, Args...> {
  private:
   static_assert(SrcTraits::rank == sizeof...(Args),
@@ -3292,14 +3287,14 @@ class ViewMapping<
        // OutputRank 1 or 2, InputLayout Left, Interval 0
        // because single stride one or second index has a stride.
        (rank <= 2 && R0 &&
-        std::is_same<typename SrcTraits::array_layout,
-                     Kokkos::LayoutLeft>::value)  // replace with input rank
+        std::is_same_v<typename SrcTraits::array_layout,
+                       Kokkos::LayoutLeft>)  // replace with input rank
        ||
        // OutputRank 1 or 2, InputLayout Right, Interval [InputRank-1]
        // because single stride one or second index has a stride.
        (rank <= 2 && R0_rev &&
-        std::is_same<typename SrcTraits::array_layout,
-                     Kokkos::LayoutRight>::value)  // replace input rank
+        std::is_same_v<typename SrcTraits::array_layout,
+                       Kokkos::LayoutRight>)  // replace input rank
        ),
       typename SrcTraits::array_layout, Kokkos::LayoutStride>;
 

--- a/core/src/traits/Kokkos_IndexTypeTrait.hpp
+++ b/core/src/traits/Kokkos_IndexTypeTrait.hpp
@@ -83,7 +83,7 @@ struct IndexTypePolicyMixin : AnalyzeNextTrait {
                 "Kokkos Error: More than one index type given. Search "
                 "compiler output for 'show_extra_index_type' to see the "
                 "type of the errant tag.");
-  static_assert(std::is_integral<IntegralIndexType>::value);
+  static_assert(std::is_integral_v<IntegralIndexType>);
   static constexpr bool index_type_is_defaulted = false;
   using index_type = Kokkos::IndexType<IntegralIndexType>;
 };
@@ -101,8 +101,8 @@ struct PolicyTraitMatcher<IndexTypeTrait, IndexType<IntegralIndexType>>
 template <class IntegralIndexType>
 struct PolicyTraitMatcher<
     IndexTypeTrait, IntegralIndexType,
-    std::enable_if_t<std::is_integral<IntegralIndexType>::value>>
-    : std::true_type {};
+    std::enable_if_t<std::is_integral_v<IntegralIndexType>>> : std::true_type {
+};
 
 // </editor-fold> end PolicyTraitMatcher specialization"> }}}1
 //==============================================================================

--- a/core/src/traits/Kokkos_IterationPatternTrait.hpp
+++ b/core/src/traits/Kokkos_IterationPatternTrait.hpp
@@ -47,7 +47,7 @@ struct IterationPatternTrait : TraitSpecificationBase<IterationPatternTrait> {
         show_extra_iteration_pattern_erroneously_given_to_execution_policy<
             typename base_t::iteration_pattern>{};
     static_assert(
-        std::is_void<typename base_t::iteration_pattern>::value,
+        std::is_void_v<typename base_t::iteration_pattern>,
         "Kokkos Error: More than one index type given. Search "
         "compiler output for 'show_extra_iteration_pattern' to see the "
         "type of the errant tag.");

--- a/core/src/traits/Kokkos_OccupancyControlTrait.hpp
+++ b/core/src/traits/Kokkos_OccupancyControlTrait.hpp
@@ -75,8 +75,8 @@ struct OccupancyControlTrait : TraitSpecificationBase<OccupancyControlTrait> {
       OccupancyControlPolicyMixin<OccControl, AnalyzeNextTrait>;
   template <class T>
   using trait_matches_specification = std::bool_constant<
-      std::is_same<T, Kokkos::Experimental::DesiredOccupancy>::value ||
-      std::is_same<T, Kokkos::Experimental::MaximizeOccupancy>::value>;
+      std::is_same_v<T, Kokkos::Experimental::DesiredOccupancy> ||
+      std::is_same_v<T, Kokkos::Experimental::MaximizeOccupancy>>;
 };
 
 // </editor-fold> end Occupancy control trait specification }}}1

--- a/core/src/traits/Kokkos_WorkTagTrait.hpp
+++ b/core/src/traits/Kokkos_WorkTagTrait.hpp
@@ -60,7 +60,7 @@ struct WorkTagTrait : TraitSpecificationBase<WorkTagTrait> {
         show_extra_work_tag_erroneously_given_to_execution_policy<
             typename base_t::work_tag>{};
     static_assert(
-        std::is_void<typename base_t::work_tag>::value,
+        std::is_void_v<typename base_t::work_tag>,
         "Kokkos Error: More than one work tag given. Search compiler output "
         "for 'show_extra_work_tag' to see the type of the errant tag.");
   };
@@ -81,7 +81,7 @@ struct WorkTagTrait : TraitSpecificationBase<WorkTagTrait> {
   //   we should benchmark this assumption if it becomes a problem.
   template <class T>
   using trait_matches_specification = std::bool_constant<
-      std::is_empty<T>::value &&
+      std::is_empty_v<T> &&
       !type_list_any<_trait_matches_spec_predicate<T>::template apply,
                      _exec_policy_traits_without_work_tag>::value>;
 };

--- a/core/unit_test/TestAtomicViews.hpp
+++ b/core/unit_test/TestAtomicViews.hpp
@@ -781,7 +781,7 @@ T ModEqualAtomicViewCheck(const int64_t input_length, const int64_t remainder) {
 
 template <class T, class DeviceType>
 bool ModEqualAtomicViewTest(const int64_t input_length) {
-  static_assert(std::is_integral<T>::value,
+  static_assert(std::is_integral_v<T>,
                 "ModEqualAtomicView Error: Type must be integral type for this "
                 "unit test");
 
@@ -909,7 +909,7 @@ T RSEqualAtomicViewCheck(const int64_t input_length, const int64_t value,
 
 template <class T, class DeviceType>
 bool RSEqualAtomicViewTest(const int64_t input_length) {
-  static_assert(std::is_integral<T>::value,
+  static_assert(std::is_integral_v<T>,
                 "RSEqualAtomicViewTest: Must be integral type for test");
 
   const int64_t remainder = 61042;       // prime - 1
@@ -1036,7 +1036,7 @@ T LSEqualAtomicViewCheck(const int64_t input_length, const int64_t value,
 
 template <class T, class DeviceType>
 bool LSEqualAtomicViewTest(const int64_t input_length) {
-  static_assert(std::is_integral<T>::value,
+  static_assert(std::is_integral_v<T>,
                 "LSEqualAtomicViewTest: Must be integral type for test");
 
   const int64_t remainder = 61042;  // prime - 1
@@ -1131,7 +1131,7 @@ T AndEqualAtomicViewCheck(const int64_t input_length) {
 
 template <class T, class DeviceType>
 bool AndEqualAtomicViewTest(int64_t input_length) {
-  static_assert(std::is_integral<T>::value,
+  static_assert(std::is_integral_v<T>,
                 "AndEqualAtomicViewTest: Must be integral type for test");
 
   T res       = AndEqualAtomicView<T, DeviceType>(input_length);
@@ -1223,7 +1223,7 @@ T OrEqualAtomicViewCheck(const int64_t input_length) {
 
 template <class T, class DeviceType>
 bool OrEqualAtomicViewTest(int64_t input_length) {
-  static_assert(std::is_integral<T>::value,
+  static_assert(std::is_integral_v<T>,
                 "OrEqualAtomicViewTest: Must be integral type for test");
 
   T res       = OrEqualAtomicView<T, DeviceType>(input_length);
@@ -1315,7 +1315,7 @@ T XOrEqualAtomicViewCheck(const int64_t input_length) {
 
 template <class T, class DeviceType>
 bool XOrEqualAtomicViewTest(int64_t input_length) {
-  static_assert(std::is_integral<T>::value,
+  static_assert(std::is_integral_v<T>,
                 "XOrEqualAtomicViewTest: Must be integral type for test");
 
   T res       = XOrEqualAtomicView<T, DeviceType>(input_length);
@@ -1342,7 +1342,7 @@ bool XOrEqualAtomicViewTest(int64_t input_length) {
 
 template <class T, class DeviceType>
 bool AtomicViewsTestIntegralType(const int length, int test) {
-  static_assert(std::is_integral<T>::value,
+  static_assert(std::is_integral_v<T>,
                 "TestAtomicViews Error: Non-integral type passed into "
                 "IntegralType tests");
 

--- a/core/unit_test/TestAtomics.hpp
+++ b/core/unit_test/TestAtomics.hpp
@@ -377,9 +377,9 @@ T ExchLoop(int loop) {
 }
 
 template <class T>
-T ExchLoopSerial(std::conditional_t<
-                 !std::is_same<T, Kokkos::complex<double> >::value, int, void>
-                     loop) {
+T ExchLoopSerial(
+    std::conditional_t<!std::is_same_v<T, Kokkos::complex<double> >, int, void>
+        loop) {
   T* data  = new T[1];
   T* data2 = new T[1];
   data[0]  = 0;
@@ -399,9 +399,9 @@ T ExchLoopSerial(std::conditional_t<
 }
 
 template <class T>
-T ExchLoopSerial(std::conditional_t<
-                 std::is_same<T, Kokkos::complex<double> >::value, int, void>
-                     loop) {
+T ExchLoopSerial(
+    std::conditional_t<std::is_same_v<T, Kokkos::complex<double> >, int, void>
+        loop) {
   T* data  = new T[1];
   T* data2 = new T[1];
   data[0]  = 0;

--- a/core/unit_test/TestCXX11.hpp
+++ b/core/unit_test/TestCXX11.hpp
@@ -324,7 +324,7 @@ bool Test(int test) {
 
 namespace Test {
 TEST(TEST_CATEGORY, cxx11) {
-  if (std::is_same<Kokkos::DefaultExecutionSpace, TEST_EXECSPACE>::value) {
+  if (std::is_same_v<Kokkos::DefaultExecutionSpace, TEST_EXECSPACE>) {
     ASSERT_TRUE((TestCXX11::Test<TEST_EXECSPACE>(1)));
     ASSERT_TRUE((TestCXX11::Test<TEST_EXECSPACE>(2)));
     ASSERT_TRUE((TestCXX11::Test<TEST_EXECSPACE>(3)));

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -417,8 +417,8 @@ TEST(TEST_CATEGORY, complex_trivially_copyable) {
   using RealType = double;
   // clang claims compatibility with gcc 4.2.1 but all versions tested know
   // about std::is_trivially_copyable.
-  ASSERT_TRUE(std::is_trivially_copyable<Kokkos::complex<RealType>>::value ||
-              !std::is_trivially_copyable<RealType>::value);
+  ASSERT_TRUE(std::is_trivially_copyable_v<Kokkos::complex<RealType>> ||
+              !std::is_trivially_copyable_v<RealType>);
 }
 
 template <class ExecSpace>
@@ -514,21 +514,19 @@ TEST(TEST_CATEGORY, complex_operations_arithmetic_types_overloads) {
   static_assert(Kokkos::real(2.f) == 2.f);
   static_assert(Kokkos::real(3.) == 3.);
   static_assert(Kokkos::real(4.l) == 4.l);
-  static_assert((std::is_same<decltype(Kokkos::real(1)), double>::value));
-  static_assert((std::is_same<decltype(Kokkos::real(2.f)), float>::value));
-  static_assert((std::is_same<decltype(Kokkos::real(3.)), double>::value));
-  static_assert(
-      (std::is_same<decltype(Kokkos::real(4.l)), long double>::value));
+  static_assert((std::is_same_v<decltype(Kokkos::real(1)), double>));
+  static_assert((std::is_same_v<decltype(Kokkos::real(2.f)), float>));
+  static_assert((std::is_same_v<decltype(Kokkos::real(3.)), double>));
+  static_assert((std::is_same_v<decltype(Kokkos::real(4.l)), long double>));
 
   static_assert(Kokkos::imag(1) == 0.);
   static_assert(Kokkos::imag(2.f) == 0.f);
   static_assert(Kokkos::imag(3.) == 0.);
   static_assert(Kokkos::imag(4.l) == 0.l);
-  static_assert((std::is_same<decltype(Kokkos::imag(1)), double>::value));
-  static_assert((std::is_same<decltype(Kokkos::imag(2.f)), float>::value));
-  static_assert((std::is_same<decltype(Kokkos::imag(3.)), double>::value));
-  static_assert(
-      (std::is_same<decltype(Kokkos::real(4.l)), long double>::value));
+  static_assert((std::is_same_v<decltype(Kokkos::imag(1)), double>));
+  static_assert((std::is_same_v<decltype(Kokkos::imag(2.f)), float>));
+  static_assert((std::is_same_v<decltype(Kokkos::imag(3.)), double>));
+  static_assert((std::is_same_v<decltype(Kokkos::real(4.l)), long double>));
 
   // FIXME in principle could be checked at compile time too
   ASSERT_EQ(Kokkos::conj(1), Kokkos::complex<double>(1));
@@ -538,15 +536,15 @@ TEST(TEST_CATEGORY, complex_operations_arithmetic_types_overloads) {
 // power of two.
 #ifndef KOKKOS_IMPL_32BIT
   ASSERT_EQ(Kokkos::conj(4.l), Kokkos::complex<long double>(4.l));
-  static_assert((
-      std::is_same<decltype(Kokkos::conj(1)), Kokkos::complex<double>>::value));
+  static_assert(
+      (std::is_same_v<decltype(Kokkos::conj(1)), Kokkos::complex<double>>));
 #endif
-  static_assert((std::is_same<decltype(Kokkos::conj(2.f)),
-                              Kokkos::complex<float>>::value));
-  static_assert((std::is_same<decltype(Kokkos::conj(3.)),
-                              Kokkos::complex<double>>::value));
-  static_assert((std::is_same<decltype(Kokkos::conj(4.l)),
-                              Kokkos::complex<long double>>::value));
+  static_assert(
+      (std::is_same_v<decltype(Kokkos::conj(2.f)), Kokkos::complex<float>>));
+  static_assert(
+      (std::is_same_v<decltype(Kokkos::conj(3.)), Kokkos::complex<double>>));
+  static_assert((std::is_same_v<decltype(Kokkos::conj(4.l)),
+                                Kokkos::complex<long double>>));
 }
 
 template <class ExecSpace>

--- a/core/unit_test/TestDeepCopyAlignment.hpp
+++ b/core/unit_test/TestDeepCopyAlignment.hpp
@@ -240,10 +240,10 @@ struct TestDeepCopyScalarConversion {
   using view_type_s2_2d = Kokkos::View<Scalar2**, Layout2, TEST_EXECSPACE>;
 
   using base_layout1 =
-      std::conditional_t<std::is_same<Layout1, Kokkos::LayoutStride>::value,
+      std::conditional_t<std::is_same_v<Layout1, Kokkos::LayoutStride>,
                          Kokkos::LayoutLeft, Layout1>;
   using base_layout2 =
-      std::conditional_t<std::is_same<Layout2, Kokkos::LayoutStride>::value,
+      std::conditional_t<std::is_same_v<Layout2, Kokkos::LayoutStride>,
                          Kokkos::LayoutLeft, Layout2>;
 
   using base_type_s1_1d = Kokkos::View<Scalar1*, base_layout1, TEST_EXECSPACE>;

--- a/core/unit_test/TestDetectionIdiom.cpp
+++ b/core/unit_test/TestDetectionIdiom.cpp
@@ -18,11 +18,11 @@
 
 void test_nonesuch() {
   using Kokkos::nonesuch;
-  static_assert(!std::is_constructible<nonesuch>::value);
-  static_assert(!std::is_destructible<nonesuch>::value);
-  static_assert(!std::is_copy_constructible<nonesuch>::value);
-  static_assert(!std::is_move_constructible<nonesuch>::value);
-  static_assert(!std::is_aggregate<nonesuch>::value);
+  static_assert(!std::is_constructible_v<nonesuch>);
+  static_assert(!std::is_destructible_v<nonesuch>);
+  static_assert(!std::is_copy_constructible_v<nonesuch>);
+  static_assert(!std::is_move_constructible_v<nonesuch>);
+  static_assert(!std::is_aggregate_v<nonesuch>);
 }
 
 namespace Example {
@@ -39,7 +39,7 @@ static_assert(Kokkos::is_detected<copy_assign_t, Meow>::value,
               "Meow should be copy assignable!");
 static_assert(!Kokkos::is_detected<copy_assign_t, Purr>::value,
               "Purr should not be copy assignable!");
-static_assert(Kokkos::is_detected_exact<Meow&, copy_assign_t, Meow>::value,
+static_assert(Kokkos::is_detected_exact_v<Meow&, copy_assign_t, Meow>,
               "Copy assignment of Meow should return Meow&!");
 
 template <class T>
@@ -53,8 +53,8 @@ struct Woof {
 };
 struct Bark {};
 
-static_assert(std::is_same<difference_type<Woof>, int>::value,
+static_assert(std::is_same_v<difference_type<Woof>, int>,
               "Woof's difference_type should be int!");
-static_assert(std::is_same<difference_type<Bark>, std::ptrdiff_t>::value,
+static_assert(std::is_same_v<difference_type<Bark>, std::ptrdiff_t>,
               "Bark's difference_type should be ptrdiff_t!");
 }  // namespace Example

--- a/core/unit_test/TestFunctorAnalysis.hpp
+++ b/core/unit_test/TestFunctorAnalysis.hpp
@@ -59,10 +59,10 @@ void test_functor_analysis() {
 
   using R01 = typename A01::Reducer;
 
-  static_assert(std::is_void<typename A01::value_type>::value);
-  static_assert(std::is_void<typename A01::pointer_type>::value);
-  static_assert(std::is_void<typename A01::reference_type>::value);
-  static_assert(std::is_same<typename R01::functor_type, decltype(c01)>::value);
+  static_assert(std::is_void_v<typename A01::value_type>);
+  static_assert(std::is_void_v<typename A01::pointer_type>);
+  static_assert(std::is_void_v<typename A01::reference_type>);
+  static_assert(std::is_same_v<typename R01::functor_type, decltype(c01)>);
 
   static_assert(!A01::has_join_member_function);
   static_assert(!A01::has_init_member_function);
@@ -77,10 +77,10 @@ void test_functor_analysis() {
       Kokkos::RangePolicy<ExecSpace>, decltype(c02), void>;
   using R02 = typename A02::Reducer;
 
-  static_assert(std::is_same<typename A02::value_type, double>::value);
-  static_assert(std::is_same<typename A02::pointer_type, double*>::value);
-  static_assert(std::is_same<typename A02::reference_type, double&>::value);
-  static_assert(std::is_same<typename R02::functor_type, decltype(c02)>::value);
+  static_assert(std::is_same_v<typename A02::value_type, double>);
+  static_assert(std::is_same_v<typename A02::pointer_type, double*>);
+  static_assert(std::is_same_v<typename A02::reference_type, double&>);
+  static_assert(std::is_same_v<typename R02::functor_type, decltype(c02)>);
 
   static_assert(!A02::has_join_member_function);
   static_assert(!A02::has_init_member_function);
@@ -96,14 +96,14 @@ void test_functor_analysis() {
       Kokkos::RangePolicy<ExecSpace>, TestFunctorAnalysis_03, void>;
   using R03 = typename A03::Reducer;
 
-  static_assert(std::is_same<typename A03::value_type,
-                             TestFunctorAnalysis_03::value_type>::value);
-  static_assert(std::is_same<typename A03::pointer_type,
-                             TestFunctorAnalysis_03::value_type*>::value);
-  static_assert(std::is_same<typename A03::reference_type,
-                             TestFunctorAnalysis_03::value_type&>::value);
+  static_assert(std::is_same_v<typename A03::value_type,
+                               TestFunctorAnalysis_03::value_type>);
+  static_assert(std::is_same_v<typename A03::pointer_type,
+                               TestFunctorAnalysis_03::value_type*>);
+  static_assert(std::is_same_v<typename A03::reference_type,
+                               TestFunctorAnalysis_03::value_type&>);
   static_assert(
-      std::is_same<typename R03::functor_type, TestFunctorAnalysis_03>::value);
+      std::is_same_v<typename R03::functor_type, TestFunctorAnalysis_03>);
 
   static_assert(A03::has_join_member_function);
   static_assert(A03::has_init_member_function);

--- a/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
+++ b/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
@@ -37,7 +37,7 @@ template <class SmartPtr>
 struct CheckAccessStoredPointerAndDereferenceOnDevice {
   SmartPtr m_device_ptr;
   using ElementType = typename SmartPtr::element_type;
-  static_assert(std::is_same<ElementType, Data>::value);
+  static_assert(std::is_same_v<ElementType, Data>);
 
   CheckAccessStoredPointerAndDereferenceOnDevice(SmartPtr device_ptr)
       : m_device_ptr(device_ptr) {
@@ -154,7 +154,7 @@ void host_shared_ptr_test_reference_counting() {
         static_cast<Foo*>(Kokkos::kokkos_malloc<DevMemSpace>(sizeof(Foo)));
     Kokkos::View<Foo, DevMemSpace> fp_d(fp_d_ptr);
     // If using UVM or on the CPU don't make an extra HostCopy
-    Foo* fp_h_ptr = std::is_same<DevMemSpace, HostMemSpace>::value
+    Foo* fp_h_ptr = std::is_same_v<DevMemSpace, HostMemSpace>
                         ? fp_d_ptr
                         : static_cast<Foo*>(
                               Kokkos::kokkos_malloc<HostMemSpace>(sizeof(Foo)));

--- a/core/unit_test/TestInitializationSettings.cpp
+++ b/core/unit_test/TestInitializationSettings.cpp
@@ -39,14 +39,14 @@ TEST(defaultdevicetype, initialization_settings) {
 
 constexpr bool test_initialization_settings_getter() {
 #define CHECK_INITIALIZATION_SETTINGS_GETTER_RETURN_TYPE(NAME, TYPE)           \
-  static_assert(std::is_same<                                                  \
+  static_assert(std::is_same_v<                                                \
                 decltype(std::declval<Kokkos::InitializationSettings const&>() \
                              .has_##NAME()),                                   \
-                bool>::value);                                                 \
-  static_assert(std::is_same<                                                  \
+                bool>);                                                        \
+  static_assert(std::is_same_v<                                                \
                 decltype(std::declval<Kokkos::InitializationSettings const&>() \
                              .get_##NAME()),                                   \
-                TYPE>::value);
+                TYPE>);
   CHECK_INITIALIZATION_SETTINGS_GETTER_RETURN_TYPE(num_threads, int);
   CHECK_INITIALIZATION_SETTINGS_GETTER_RETURN_TYPE(device_id, int);
   CHECK_INITIALIZATION_SETTINGS_GETTER_RETURN_TYPE(disable_warnings, bool);
@@ -60,7 +60,6 @@ constexpr bool test_initialization_settings_getter() {
 
 static_assert(test_initialization_settings_getter());
 
-static_assert(
-    std::is_default_constructible<Kokkos::InitializationSettings>::value);
+static_assert(std::is_default_constructible_v<Kokkos::InitializationSettings>);
 
 }  // namespace

--- a/core/unit_test/TestInterOp.cpp
+++ b/core/unit_test/TestInterOp.cpp
@@ -20,119 +20,120 @@
 
 // View
 static_assert(
-    std::is_same<
+    std::is_same_v<
         Kokkos::Experimental::python_view_type_t<Kokkos::View<double*>>,
         Kokkos::View<double*,
                      typename Kokkos::DefaultExecutionSpace::array_layout,
                      typename Kokkos::DefaultExecutionSpace::memory_space,
-                     Kokkos::Experimental::DefaultViewHooks>>::value,
+                     Kokkos::Experimental::DefaultViewHooks>>,
     "Error! Unexpected python_view_type for: View");
 
 // DynRankView
 static_assert(
-    std::is_same<
+    std::is_same_v<
         Kokkos::Experimental::python_view_type_t<Kokkos::DynRankView<double>>,
         Kokkos::DynRankView<
             double, typename Kokkos::DefaultExecutionSpace::array_layout,
-            typename Kokkos::DefaultExecutionSpace::memory_space>>::value,
+            typename Kokkos::DefaultExecutionSpace::memory_space>>,
     "Error! Unexpected python_view_type for: DynRankView");
 
 // View + Execution Space
 static_assert(
-    std::is_same<
+    std::is_same_v<
         Kokkos::Experimental::python_view_type_t<
             Kokkos::View<double*, Kokkos::DefaultExecutionSpace>>,
         Kokkos::View<double*,
                      typename Kokkos::DefaultExecutionSpace::array_layout,
                      typename Kokkos::DefaultExecutionSpace::memory_space,
-                     Kokkos::Experimental::DefaultViewHooks>>::value,
+                     Kokkos::Experimental::DefaultViewHooks>>,
     "Error! Unexpected python_view_type for: View + Execution Space");
 
 // DynRankView + Execution Space
 static_assert(
-    std::is_same<
+    std::is_same_v<
         Kokkos::Experimental::python_view_type_t<
             Kokkos::DynRankView<double, Kokkos::DefaultExecutionSpace>>,
         Kokkos::DynRankView<
             double, typename Kokkos::DefaultExecutionSpace::array_layout,
-            typename Kokkos::DefaultExecutionSpace::memory_space>>::value,
+            typename Kokkos::DefaultExecutionSpace::memory_space>>,
     "Error! Unexpected python_view_type for: DynRankView + Execution Space");
 
 // View + Memory space
-static_assert(
-    std::is_same<Kokkos::Experimental::python_view_type_t<
-                     Kokkos::View<int64_t*, Kokkos::HostSpace>>,
-                 Kokkos::View<int64_t*, Kokkos::LayoutRight, Kokkos::HostSpace,
-                              Kokkos::Experimental::DefaultViewHooks>>::value,
-    "Error! Unexpected python_view_type for: View + Memory space");
+static_assert(std::is_same_v<
+                  Kokkos::Experimental::python_view_type_t<
+                      Kokkos::View<int64_t*, Kokkos::HostSpace>>,
+                  Kokkos::View<int64_t*, Kokkos::LayoutRight, Kokkos::HostSpace,
+                               Kokkos::Experimental::DefaultViewHooks>>,
+              "Error! Unexpected python_view_type for: View + Memory space");
 
 // DynRankView + Memory space
 static_assert(
-    std::is_same<Kokkos::Experimental::python_view_type_t<
-                     Kokkos::DynRankView<int16_t, Kokkos::HostSpace>>,
-                 Kokkos::DynRankView<int16_t, Kokkos::LayoutRight,
-                                     Kokkos::HostSpace>>::value,
+    std::is_same_v<
+        Kokkos::Experimental::python_view_type_t<
+            Kokkos::DynRankView<int16_t, Kokkos::HostSpace>>,
+        Kokkos::DynRankView<int16_t, Kokkos::LayoutRight, Kokkos::HostSpace>>,
     "Error! Unexpected python_view_type for: DynRankView + Memory space");
 
 // View + Layout + Execution space
 static_assert(
-    std::is_same<
+    std::is_same_v<
         Kokkos::Experimental::python_view_type_t<Kokkos::View<
             int**, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace>>,
         Kokkos::View<int**, Kokkos::LayoutLeft,
                      typename Kokkos::DefaultExecutionSpace::memory_space,
-                     Kokkos::Experimental::DefaultViewHooks>>::value,
+                     Kokkos::Experimental::DefaultViewHooks>>,
     "Error! Unexpected python_view_type for: View + Layout + Execution space");
 
 // DynRankView + Layout + Execution space
 static_assert(
-    std::is_same<Kokkos::Experimental::python_view_type_t<Kokkos::DynRankView<
-                     int, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace>>,
-                 Kokkos::DynRankView<int, Kokkos::LayoutLeft,
-                                     typename Kokkos::DefaultExecutionSpace::
-                                         memory_space>>::value,
+    std::is_same_v<Kokkos::Experimental::python_view_type_t<Kokkos::DynRankView<
+                       int, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace>>,
+                   Kokkos::DynRankView<
+                       int, Kokkos::LayoutLeft,
+                       typename Kokkos::DefaultExecutionSpace::memory_space>>,
     "Error! Unexpected python_view_type for: DynRankView + Layout + Execution "
     "space");
 
 // View + Layout + Memory Space
 static_assert(
-    std::is_same<Kokkos::Experimental::python_view_type_t<Kokkos::View<
-                     uint32_t**, Kokkos::LayoutLeft, Kokkos::HostSpace>>,
-                 Kokkos::View<uint32_t**, Kokkos::LayoutLeft, Kokkos::HostSpace,
-                              Kokkos::Experimental::DefaultViewHooks>>::value,
+    std::is_same_v<
+        Kokkos::Experimental::python_view_type_t<
+            Kokkos::View<uint32_t**, Kokkos::LayoutLeft, Kokkos::HostSpace>>,
+        Kokkos::View<uint32_t**, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                     Kokkos::Experimental::DefaultViewHooks>>,
     "Error! Unexpected python_view_type for: View + Layout + Memory Space");
 
 // DynRankView + Layout + Memory Space
 static_assert(
-    std::is_same<Kokkos::Experimental::python_view_type_t<Kokkos::DynRankView<
-                     uint64_t, Kokkos::LayoutLeft, Kokkos::HostSpace>>,
-                 Kokkos::DynRankView<uint64_t, Kokkos::LayoutLeft,
-                                     Kokkos::HostSpace>>::value,
+    std::is_same_v<
+        Kokkos::Experimental::python_view_type_t<Kokkos::DynRankView<
+            uint64_t, Kokkos::LayoutLeft, Kokkos::HostSpace>>,
+        Kokkos::DynRankView<uint64_t, Kokkos::LayoutLeft, Kokkos::HostSpace>>,
     "Error! Unexpected python_view_type for: DynRankView + Layout + Memory "
     "Space");
 
 // View + Layout + Execution space + Memory Trait
 static_assert(
-    std::is_same<
+    std::is_same_v<
         Kokkos::Experimental::python_view_type_t<Kokkos::View<
             float***, Kokkos::LayoutLeft, Kokkos::DefaultHostExecutionSpace,
             Kokkos::MemoryTraits<Kokkos::RandomAccess>>>,
         Kokkos::View<float***, Kokkos::LayoutLeft,
                      typename Kokkos::DefaultHostExecutionSpace::memory_space,
                      Kokkos::Experimental::DefaultViewHooks,
-                     Kokkos::MemoryTraits<Kokkos::RandomAccess>>>::value,
+                     Kokkos::MemoryTraits<Kokkos::RandomAccess>>>,
     "Error! Unexpected python_view_type for: View + Layout + Execution space + "
     "Memory Trait");
 
 // DynRankView + Layout + Execution space  + Memory trait
 static_assert(
-    std::is_same<
+    std::is_same_v<
         Kokkos::Experimental::python_view_type_t<Kokkos::DynRankView<
             float, Kokkos::LayoutLeft, Kokkos::DefaultHostExecutionSpace,
             Kokkos::MemoryTraits<Kokkos::Atomic>>>,
         Kokkos::DynRankView<
             float, Kokkos::LayoutLeft,
             typename Kokkos::DefaultHostExecutionSpace::memory_space,
-            Kokkos::MemoryTraits<Kokkos::Atomic>>>::value,
+            Kokkos::MemoryTraits<Kokkos::Atomic>>>,
     "Error! Unexpected python_view_type for: DynRankView + Layout + Execution "
     "space  + Memory trait");

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -274,13 +274,13 @@ struct FloatingPointComparison {
 #endif
   // Using absolute here instead of abs, since we actually test abs ...
   template <class T>
-  KOKKOS_FUNCTION std::enable_if_t<std::is_signed<T>::value, T> absolute(
+  KOKKOS_FUNCTION std::enable_if_t<std::is_signed_v<T>, T> absolute(
       T val) const {
     return val < T(0) ? -val : val;
   }
 
   template <class T>
-  KOKKOS_FUNCTION std::enable_if_t<!std::is_signed<T>::value, T> absolute(
+  KOKKOS_FUNCTION std::enable_if_t<!std::is_signed_v<T>, T> absolute(
       T val) const {
     return val;
   }
@@ -325,60 +325,56 @@ struct FloatingPointComparison {
 template <class>
 struct math_function_name;
 
-#define DEFINE_UNARY_FUNCTION_EVAL(FUNC, ULP_FACTOR)                    \
-  struct MathUnaryFunction_##FUNC {                                     \
-    template <typename T>                                               \
-    static KOKKOS_FUNCTION auto eval(T x) {                             \
-      static_assert(                                                    \
-          std::is_same<decltype(Kokkos::FUNC((T)0)),                    \
-                       math_unary_function_return_type_t<T>>::value);   \
-      return Kokkos::FUNC(x);                                           \
-    }                                                                   \
-    template <typename T>                                               \
-    static auto eval_std(T x) {                                         \
-      if constexpr (std::is_same<T, KE::half_t>::value ||               \
-                    std::is_same<T, KE::bhalf_t>::value) {              \
-        return std::FUNC(static_cast<float>(x));                        \
-      } else {                                                          \
-        static_assert(                                                  \
-            std::is_same<decltype(std::FUNC((T)0)),                     \
-                         math_unary_function_return_type_t<T>>::value); \
-        return std::FUNC(x);                                            \
-      }                                                                 \
-      MATHEMATICAL_FUNCTIONS_TEST_UNREACHABLE                           \
-    }                                                                   \
-    static KOKKOS_FUNCTION int ulp_factor() { return ULP_FACTOR; }      \
-  };                                                                    \
-  using kk_##FUNC = MathUnaryFunction_##FUNC;                           \
-  template <>                                                           \
-  struct math_function_name<MathUnaryFunction_##FUNC> {                 \
-    static constexpr char name[] = #FUNC;                               \
-  };                                                                    \
+#define DEFINE_UNARY_FUNCTION_EVAL(FUNC, ULP_FACTOR)                         \
+  struct MathUnaryFunction_##FUNC {                                          \
+    template <typename T>                                                    \
+    static KOKKOS_FUNCTION auto eval(T x) {                                  \
+      static_assert(std::is_same_v<decltype(Kokkos::FUNC((T)0)),             \
+                                   math_unary_function_return_type_t<T>>);   \
+      return Kokkos::FUNC(x);                                                \
+    }                                                                        \
+    template <typename T>                                                    \
+    static auto eval_std(T x) {                                              \
+      if constexpr (std::is_same_v<T, KE::half_t> ||                         \
+                    std::is_same_v<T, KE::bhalf_t>) {                        \
+        return std::FUNC(static_cast<float>(x));                             \
+      } else {                                                               \
+        static_assert(std::is_same_v<decltype(std::FUNC((T)0)),              \
+                                     math_unary_function_return_type_t<T>>); \
+        return std::FUNC(x);                                                 \
+      }                                                                      \
+      MATHEMATICAL_FUNCTIONS_TEST_UNREACHABLE                                \
+    }                                                                        \
+    static KOKKOS_FUNCTION int ulp_factor() { return ULP_FACTOR; }           \
+  };                                                                         \
+  using kk_##FUNC = MathUnaryFunction_##FUNC;                                \
+  template <>                                                                \
+  struct math_function_name<MathUnaryFunction_##FUNC> {                      \
+    static constexpr char name[] = #FUNC;                                    \
+  };                                                                         \
   constexpr char math_function_name<MathUnaryFunction_##FUNC>::name[]
 
-#define DEFINE_UNARY_FUNCTION_EVAL_CUSTOM(FUNC, ULP_FACTOR, REF_FUNC) \
-  struct MathUnaryFunction_##FUNC {                                   \
-    template <typename T>                                             \
-    static KOKKOS_FUNCTION auto eval(T x) {                           \
-      static_assert(                                                  \
-          std::is_same<decltype(Kokkos::FUNC((T)0)),                  \
-                       math_unary_function_return_type_t<T>>::value); \
-      return Kokkos::FUNC(x);                                         \
-    }                                                                 \
-    template <typename T>                                             \
-    static auto eval_std(T x) {                                       \
-      static_assert(                                                  \
-          std::is_same<decltype(REF_FUNC),                            \
-                       math_unary_function_return_type_t<T>>::value); \
-      return REF_FUNC;                                                \
-    }                                                                 \
-    static KOKKOS_FUNCTION int ulp_factor() { return ULP_FACTOR; }    \
-  };                                                                  \
-  using kk_##FUNC = MathUnaryFunction_##FUNC;                         \
-  template <>                                                         \
-  struct math_function_name<MathUnaryFunction_##FUNC> {               \
-    static constexpr char name[] = #FUNC;                             \
-  };                                                                  \
+#define DEFINE_UNARY_FUNCTION_EVAL_CUSTOM(FUNC, ULP_FACTOR, REF_FUNC)      \
+  struct MathUnaryFunction_##FUNC {                                        \
+    template <typename T>                                                  \
+    static KOKKOS_FUNCTION auto eval(T x) {                                \
+      static_assert(std::is_same_v<decltype(Kokkos::FUNC((T)0)),           \
+                                   math_unary_function_return_type_t<T>>); \
+      return Kokkos::FUNC(x);                                              \
+    }                                                                      \
+    template <typename T>                                                  \
+    static auto eval_std(T x) {                                            \
+      static_assert(std::is_same_v<decltype(REF_FUNC),                     \
+                                   math_unary_function_return_type_t<T>>); \
+      return REF_FUNC;                                                     \
+    }                                                                      \
+    static KOKKOS_FUNCTION int ulp_factor() { return ULP_FACTOR; }         \
+  };                                                                       \
+  using kk_##FUNC = MathUnaryFunction_##FUNC;                              \
+  template <>                                                              \
+  struct math_function_name<MathUnaryFunction_##FUNC> {                    \
+    static constexpr char name[] = #FUNC;                                  \
+  };                                                                       \
   constexpr char math_function_name<MathUnaryFunction_##FUNC>::name[]
 
 #ifndef KOKKOS_MATHEMATICAL_FUNCTIONS_SKIP_3
@@ -451,9 +447,8 @@ DEFINE_UNARY_FUNCTION_EVAL(logb, 2);
   struct MathBinaryFunction_##FUNC {                                           \
     template <typename T, typename U>                                          \
     static KOKKOS_FUNCTION auto eval(T x, U y) {                               \
-      static_assert(                                                           \
-          std::is_same<decltype(Kokkos::FUNC((T)0, (U)0)),                     \
-                       math_binary_function_return_type_t<T, U>>::value);      \
+      static_assert(std::is_same_v<decltype(Kokkos::FUNC((T)0, (U)0)),         \
+                                   math_binary_function_return_type_t<T, U>>); \
       return Kokkos::FUNC(x, y);                                               \
     }                                                                          \
     template <typename T, typename U>                                          \
@@ -470,8 +465,8 @@ DEFINE_UNARY_FUNCTION_EVAL(logb, 2);
         return std::FUNC(x, static_cast<float>(y));                            \
       else {                                                                   \
         static_assert(                                                         \
-            std::is_same<decltype(std::FUNC((T)0, (U)0)),                      \
-                         math_binary_function_return_type_t<T, U>>::value);    \
+            std::is_same_v<decltype(std::FUNC((T)0, (U)0)),                    \
+                           math_binary_function_return_type_t<T, U>>);         \
         return std::FUNC(x, y);                                                \
       }                                                                        \
       MATHEMATICAL_FUNCTIONS_TEST_UNREACHABLE                                  \
@@ -494,29 +489,29 @@ DEFINE_BINARY_FUNCTION_EVAL(copysign, 1);
 
 #undef DEFINE_BINARY_FUNCTION_EVAL
 
-#define DEFINE_TERNARY_FUNCTION_EVAL(FUNC, ULP_FACTOR)                        \
-  struct MathTernaryFunction_##FUNC {                                         \
-    template <typename T, typename U, typename V>                             \
-    static KOKKOS_FUNCTION auto eval(T x, U y, V z) {                         \
-      static_assert(                                                          \
-          std::is_same<decltype(Kokkos::FUNC((T)0, (U)0, (V)0)),              \
-                       math_ternary_function_return_type_t<T, U, V>>::value); \
-      return Kokkos::FUNC(x, y, z);                                           \
-    }                                                                         \
-    template <typename T, typename U, typename V>                             \
-    static auto eval_std(T x, U y, V z) {                                     \
-      static_assert(                                                          \
-          std::is_same<decltype(std::FUNC((T)0, (U)0, (V)0)),                 \
-                       math_ternary_function_return_type_t<T, U, V>>::value); \
-      return std::FUNC(x, y, z);                                              \
-    }                                                                         \
-    static KOKKOS_FUNCTION int ulp_factor() { return ULP_FACTOR; }            \
-  };                                                                          \
-  using kk3_##FUNC = MathTernaryFunction_##FUNC;                              \
-  template <>                                                                 \
-  struct math_function_name<MathTernaryFunction_##FUNC> {                     \
-    static constexpr char name[] = #FUNC;                                     \
-  };                                                                          \
+#define DEFINE_TERNARY_FUNCTION_EVAL(FUNC, ULP_FACTOR)                   \
+  struct MathTernaryFunction_##FUNC {                                    \
+    template <typename T, typename U, typename V>                        \
+    static KOKKOS_FUNCTION auto eval(T x, U y, V z) {                    \
+      static_assert(                                                     \
+          std::is_same_v<decltype(Kokkos::FUNC((T)0, (U)0, (V)0)),       \
+                         math_ternary_function_return_type_t<T, U, V>>); \
+      return Kokkos::FUNC(x, y, z);                                      \
+    }                                                                    \
+    template <typename T, typename U, typename V>                        \
+    static auto eval_std(T x, U y, V z) {                                \
+      static_assert(                                                     \
+          std::is_same_v<decltype(std::FUNC((T)0, (U)0, (V)0)),          \
+                         math_ternary_function_return_type_t<T, U, V>>); \
+      return std::FUNC(x, y, z);                                         \
+    }                                                                    \
+    static KOKKOS_FUNCTION int ulp_factor() { return ULP_FACTOR; }       \
+  };                                                                     \
+  using kk3_##FUNC = MathTernaryFunction_##FUNC;                         \
+  template <>                                                            \
+  struct math_function_name<MathTernaryFunction_##FUNC> {                \
+    static constexpr char name[] = #FUNC;                                \
+  };                                                                     \
   constexpr char math_function_name<MathTernaryFunction_##FUNC>::name[]
 
 #ifndef KOKKOS_MATHEMATICAL_FUNCTIONS_SKIP_2
@@ -1331,17 +1326,17 @@ struct TestAbsoluteValueFunction {
       Kokkos::printf("failed abs(floating_point) special values\n");
     }
 
-    static_assert(std::is_same<decltype(abs(1)), int>::value);
-    static_assert(std::is_same<decltype(abs(2l)), long>::value);
-    static_assert(std::is_same<decltype(abs(3ll)), long long>::value);
+    static_assert(std::is_same_v<decltype(abs(1)), int>);
+    static_assert(std::is_same_v<decltype(abs(2l)), long>);
+    static_assert(std::is_same_v<decltype(abs(3ll)), long long>);
     static_assert(std::is_same<decltype(abs(static_cast<KE::half_t>(4.f))),
                                KE::half_t>::value);
     static_assert(std::is_same<decltype(abs(static_cast<KE::bhalf_t>(4.f))),
                                KE::bhalf_t>::value);
-    static_assert(std::is_same<decltype(abs(4.f)), float>::value);
-    static_assert(std::is_same<decltype(abs(5.)), double>::value);
+    static_assert(std::is_same_v<decltype(abs(4.f)), float>);
+    static_assert(std::is_same_v<decltype(abs(5.)), double>);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same<decltype(abs(6.l)), long double>::value);
+    static_assert(std::is_same_v<decltype(abs(6.l)), long double>);
 #endif
   }
 };
@@ -1396,10 +1391,10 @@ struct TestFloatingPointAbsoluteValueFunction {
                                KE::half_t>::value);
     static_assert(std::is_same<decltype(fabs(static_cast<KE::bhalf_t>(4.f))),
                                KE::bhalf_t>::value);
-    static_assert(std::is_same<decltype(fabs(4.f)), float>::value);
-    static_assert(std::is_same<decltype(fabs(5.)), double>::value);
+    static_assert(std::is_same_v<decltype(fabs(4.f)), float>);
+    static_assert(std::is_same_v<decltype(fabs(5.)), double>);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same<decltype(fabs(6.l)), long double>::value);
+    static_assert(std::is_same_v<decltype(fabs(6.l)), long double>);
 #endif
   }
 };
@@ -1467,10 +1462,10 @@ struct TestFloatingPointRemainderFunction : FloatingPointComparison {
     static_assert(std::is_same<decltype(fmod(static_cast<KE::bhalf_t>(4.f),
                                              static_cast<KE::bhalf_t>(4.f))),
                                KE::bhalf_t>::value);
-    static_assert(std::is_same<decltype(fmod(4.f, 4.f)), float>::value);
-    static_assert(std::is_same<decltype(fmod(5., 5.)), double>::value);
+    static_assert(std::is_same_v<decltype(fmod(4.f, 4.f)), float>);
+    static_assert(std::is_same_v<decltype(fmod(5., 5.)), double>);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same<decltype(fmod(6.l, 6.l)), long double>::value);
+    static_assert(std::is_same_v<decltype(fmod(6.l, 6.l)), long double>);
 #endif
   }
 };
@@ -1544,11 +1539,11 @@ struct TestIEEEFloatingPointRemainderFunction : FloatingPointComparison {
         std::is_same<decltype(remainder(static_cast<KE::bhalf_t>(4.f),
                                         static_cast<KE::bhalf_t>(4.f))),
                      KE::bhalf_t>::value);
-    static_assert(std::is_same<decltype(remainder(4.f, 4.f)), float>::value);
-    static_assert(std::is_same<decltype(remainder(5., 5.)), double>::value);
+    static_assert(std::is_same_v<decltype(remainder(4.f, 4.f)), float>);
+    static_assert(std::is_same_v<decltype(remainder(5., 5.)), double>);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     static_assert(
-        std::is_same<decltype(remainder(6.l, 6.l)), long double>::value);
+        std::is_same_v<decltype(remainder(6.l, 6.l)), long double>);
 #endif
   }
 };
@@ -1620,11 +1615,11 @@ struct TestIsFinite {
       Kokkos::printf("failed isfinite(floating_point) special values\n");
     }
 
-    static_assert(std::is_same<decltype(isfinite(1)), bool>::value);
-    static_assert(std::is_same<decltype(isfinite(2.f)), bool>::value);
-    static_assert(std::is_same<decltype(isfinite(3.)), bool>::value);
+    static_assert(std::is_same_v<decltype(isfinite(1)), bool>);
+    static_assert(std::is_same_v<decltype(isfinite(2.f)), bool>);
+    static_assert(std::is_same_v<decltype(isfinite(3.)), bool>);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same<decltype(isfinite(4.l)), bool>::value);
+    static_assert(std::is_same_v<decltype(isfinite(4.l)), bool>);
 #endif
   }
 };
@@ -1691,11 +1686,11 @@ struct TestIsInf {
       Kokkos::printf("failed isinf(floating_point) special values\n");
     }
 
-    static_assert(std::is_same<decltype(isinf(1)), bool>::value);
-    static_assert(std::is_same<decltype(isinf(2.f)), bool>::value);
-    static_assert(std::is_same<decltype(isinf(3.)), bool>::value);
+    static_assert(std::is_same_v<decltype(isinf(1)), bool>);
+    static_assert(std::is_same_v<decltype(isinf(2.f)), bool>);
+    static_assert(std::is_same_v<decltype(isinf(3.)), bool>);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same<decltype(isinf(4.l)), bool>::value);
+    static_assert(std::is_same_v<decltype(isinf(4.l)), bool>);
 #endif
   }
 };
@@ -1762,11 +1757,11 @@ struct TestIsNaN {
       Kokkos::printf("failed isnan(floating_point) special values\n");
     }
 
-    static_assert(std::is_same<decltype(isnan(1)), bool>::value);
-    static_assert(std::is_same<decltype(isnan(2.f)), bool>::value);
-    static_assert(std::is_same<decltype(isnan(3.)), bool>::value);
+    static_assert(std::is_same_v<decltype(isnan(1)), bool>);
+    static_assert(std::is_same_v<decltype(isnan(2.f)), bool>);
+    static_assert(std::is_same_v<decltype(isnan(3.)), bool>);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same<decltype(isnan(4.l)), bool>::value);
+    static_assert(std::is_same_v<decltype(isnan(4.l)), bool>);
 #endif
   }
 };

--- a/core/unit_test/TestMemoryPool.hpp
+++ b/core/unit_test/TestMemoryPool.hpp
@@ -455,9 +455,8 @@ struct TestMemoryPoolHuge {
 
 template <class DeviceType>
 struct TestMemoryPoolHuge<
-    DeviceType,
-    std::enable_if_t<std::is_same<Kokkos::HostSpace,
-                                  typename DeviceType::memory_space>::value>> {
+    DeviceType, std::enable_if_t<std::is_same_v<
+                    Kokkos::HostSpace, typename DeviceType::memory_space>>> {
   using ptrs_type    = Kokkos::View<uintptr_t*, DeviceType>;
   using pool_type    = Kokkos::MemoryPool<DeviceType>;
   using memory_space = typename DeviceType::memory_space;

--- a/core/unit_test/TestReduceCombinatorical.hpp
+++ b/core/unit_test/TestReduceCombinatorical.hpp
@@ -492,23 +492,21 @@ struct TestReduceCombinatoricalInstantiation {
   template <class... Args>
   static void AddFunctorLambdaRange(int N, Args... args) {
     AddFunctor<0, Args...>(N, args...);
-    AddLambdaRange(
-        N,
-        std::conditional_t<
-            std::is_same<ExecSpace, Kokkos::DefaultExecutionSpace>::value,
-            void*, Kokkos::InvalidType>(),
-        args...);
+    AddLambdaRange(N,
+                   std::conditional_t<
+                       std::is_same_v<ExecSpace, Kokkos::DefaultExecutionSpace>,
+                       void*, Kokkos::InvalidType>(),
+                   args...);
   }
 
   template <class... Args>
   static void AddFunctorLambdaTeam(int N, Args... args) {
     AddFunctor<1, Args...>(N, args...);
-    AddLambdaTeam(
-        N,
-        std::conditional_t<
-            std::is_same<ExecSpace, Kokkos::DefaultExecutionSpace>::value,
-            void*, Kokkos::InvalidType>(),
-        args...);
+    AddLambdaTeam(N,
+                  std::conditional_t<
+                      std::is_same_v<ExecSpace, Kokkos::DefaultExecutionSpace>,
+                      void*, Kokkos::InvalidType>(),
+                  args...);
   }
 
   template <class... Args>

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -466,10 +466,9 @@ struct TestReducers {
       // This mask addresses #4719 for N <= 51.
       // The mask is not needed for N <= 25.
       // clang-format on
-      int mask =
-          std::is_same<Scalar, Kokkos::Experimental::bhalf_t>::value && N > 25
-              ? (int)0xfffffffe
-              : (int)0xffffffff;
+      int mask = std::is_same_v<Scalar, Kokkos::Experimental::bhalf_t> && N > 25
+                     ? (int)0xfffffffe
+                     : (int)0xffffffff;
       h_values(i) = (Scalar)((rand() % denom) & mask);
       reference_sum += h_values(i);
     }

--- a/core/unit_test/TestTypeList.cpp
+++ b/core/unit_test/TestTypeList.cpp
@@ -25,21 +25,21 @@ using TypeList223NoVoid = Kokkos::Impl::type_list<bool, bool, char, short, int>;
 
 // concat_type_list
 using ConcatTypeList2 = Kokkos::Impl::concat_type_list_t<TypeList2>;
-static_assert(std::is_same<TypeList2, ConcatTypeList2>::value,
+static_assert(std::is_same_v<TypeList2, ConcatTypeList2>,
               "concat_type_list of a single type_list failed");
 
 using ConcatTypeList223 =
     Kokkos::Impl::concat_type_list_t<TypeList2, TypeList2, TypeList3>;
-static_assert(std::is_same<TypeList223, ConcatTypeList223>::value,
+static_assert(std::is_same_v<TypeList223, ConcatTypeList223>,
               "concat_type_list of three type_lists failed");
 
 // filter_type_list
 using FilterTypeList223Void =
     Kokkos::Impl::filter_type_list_t<std::is_void, TypeList223>;
-static_assert(std::is_same<TypeList223Void, FilterTypeList223Void>::value,
+static_assert(std::is_same_v<TypeList223Void, FilterTypeList223Void>,
               "filter_type_list with predicate value==true failed");
 
 using FilterTypeList223NoVoid =
     Kokkos::Impl::filter_type_list_t<std::is_void, TypeList223, false>;
-static_assert(std::is_same<TypeList223NoVoid, FilterTypeList223NoVoid>::value,
+static_assert(std::is_same_v<TypeList223NoVoid, FilterTypeList223NoVoid>,
               "filter_type_list with predicate value==false failed");

--- a/core/unit_test/TestUtilities.hpp
+++ b/core/unit_test/TestUtilities.hpp
@@ -92,37 +92,37 @@ void test_is_scoped_enum() {
   using Kokkos::Impl::is_scoped_enum_v;
 
   static_assert(!is_scoped_enum<int>{});
-  static_assert(!is_scoped_enum<int>::value);
+  static_assert(!is_scoped_enum<int>::value);  // NOLINT
   static_assert(!is_scoped_enum_v<int>);
   static_assert(
       is_public_unambiguous_base_of_v<std::false_type, is_scoped_enum<int>>);
 
   static_assert(!is_scoped_enum<Class>{});
-  static_assert(!is_scoped_enum<Class>::value);
+  static_assert(!is_scoped_enum<Class>::value);  // NOLINT
   static_assert(!is_scoped_enum_v<Class>);
   static_assert(
       is_public_unambiguous_base_of_v<std::false_type, is_scoped_enum<Class>>);
 
   static_assert(!is_scoped_enum<Enum>{});
-  static_assert(!is_scoped_enum<Enum>::value);
+  static_assert(!is_scoped_enum<Enum>::value);  // NOLINT
   static_assert(!is_scoped_enum_v<Enum>);
   static_assert(
       is_public_unambiguous_base_of_v<std::false_type, is_scoped_enum<Enum>>);
 
   static_assert(!is_scoped_enum<EnumBool>{});
-  static_assert(!is_scoped_enum<EnumBool>::value);
+  static_assert(!is_scoped_enum<EnumBool>::value);  // NOLINT
   static_assert(!is_scoped_enum_v<EnumBool>);
   static_assert(is_public_unambiguous_base_of_v<std::false_type,
                                                 is_scoped_enum<EnumBool>>);
 
   static_assert(is_scoped_enum<ScopedEnum>{});
-  static_assert(is_scoped_enum<ScopedEnum>::value);
+  static_assert(is_scoped_enum<ScopedEnum>::value);  // NOLINT
   static_assert(is_scoped_enum_v<ScopedEnum>);
   static_assert(is_public_unambiguous_base_of_v<std::true_type,
                                                 is_scoped_enum<ScopedEnum>>);
 
   static_assert(is_scoped_enum<ScopedEnumShort>{});
-  static_assert(is_scoped_enum<ScopedEnumShort>::value);
+  static_assert(is_scoped_enum<ScopedEnumShort>::value);  // NOLINT
   static_assert(is_scoped_enum_v<ScopedEnumShort>);
   static_assert(
       is_public_unambiguous_base_of_v<std::true_type,

--- a/core/unit_test/TestViewCtorPropEmbeddedDim.hpp
+++ b/core/unit_test/TestViewCtorPropEmbeddedDim.hpp
@@ -74,11 +74,11 @@ struct TestViewCtorProp_EmbeddedDim {
         HostCVT hcv1 = Kokkos::create_mirror_view(cv1);
         Kokkos::deep_copy(hcv1, cv1);
 
-        ASSERT_EQ((std::is_same<CommonViewValueType, double>::value), true);
-        ASSERT_EQ(
-            (std::is_same<typename decltype(view_alloc_arg)::scalar_array_type,
-                          CommonViewValueType>::value),
-            true);
+        ASSERT_EQ((std::is_same_v<CommonViewValueType, double>), true);
+        ASSERT_EQ((std::is_same_v<
+                      typename decltype(view_alloc_arg)::scalar_array_type,
+                      CommonViewValueType>),
+                  true);
 #if 0
       // debug output
       for ( int i = 0; i < N0*N1; ++i ) {
@@ -87,7 +87,7 @@ struct TestViewCtorProp_EmbeddedDim {
 
       printf( " Common value type view: %s \n", typeid( CVT() ).name() );
       printf( " Common value type: %s \n", typeid( CommonViewValueType() ).name() );
-      if ( std::is_same< CommonViewValueType, double >::value == true ) {
+      if ( std::is_same_v< CommonViewValueType, double > == true ) {
         printf("Proper common value_type\n");
       }
       else {
@@ -115,7 +115,7 @@ struct TestViewCtorProp_EmbeddedDim {
         HostCVT hcv1 = Kokkos::create_mirror_view(cv1);
         Kokkos::deep_copy(hcv1, cv1);
 
-        ASSERT_EQ((std::is_same<CommonViewValueType, int>::value), true);
+        ASSERT_EQ((std::is_same_v<CommonViewValueType, int>), true);
       }
     }
 

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -866,10 +866,10 @@ struct FillView_3D {
   using view_t = Kokkos::View<int***, Layout, Space>;
   using rank_t = Kokkos::Rank<
       view_t::rank,
-      std::is_same<Layout, Kokkos::LayoutLeft>::value ? Kokkos::Iterate::Left
-                                                      : Kokkos::Iterate::Right,
-      std::is_same<Layout, Kokkos::LayoutLeft>::value ? Kokkos::Iterate::Left
-                                                      : Kokkos::Iterate::Right>;
+      std::is_same_v<Layout, Kokkos::LayoutLeft> ? Kokkos::Iterate::Left
+                                                 : Kokkos::Iterate::Right,
+      std::is_same_v<Layout, Kokkos::LayoutLeft> ? Kokkos::Iterate::Left
+                                                 : Kokkos::Iterate::Right>;
   using policy_t = Kokkos::MDRangePolicy<exec_t, rank_t>;
 
   view_t a;
@@ -894,10 +894,10 @@ struct FillView_4D {
   using view_t = Kokkos::View<int****, Layout, Space>;
   using rank_t = Kokkos::Rank<
       view_t::rank,
-      std::is_same<Layout, Kokkos::LayoutLeft>::value ? Kokkos::Iterate::Left
-                                                      : Kokkos::Iterate::Right,
-      std::is_same<Layout, Kokkos::LayoutLeft>::value ? Kokkos::Iterate::Left
-                                                      : Kokkos::Iterate::Right>;
+      std::is_same_v<Layout, Kokkos::LayoutLeft> ? Kokkos::Iterate::Left
+                                                 : Kokkos::Iterate::Right,
+      std::is_same_v<Layout, Kokkos::LayoutLeft> ? Kokkos::Iterate::Left
+                                                 : Kokkos::Iterate::Right>;
   using policy_t = Kokkos::MDRangePolicy<exec_t, rank_t>;
 
   view_t a;
@@ -923,10 +923,10 @@ struct FillView_5D {
   using view_t = Kokkos::View<int*****, Layout, Space>;
   using rank_t = Kokkos::Rank<
       view_t::rank,
-      std::is_same<Layout, Kokkos::LayoutLeft>::value ? Kokkos::Iterate::Left
-                                                      : Kokkos::Iterate::Right,
-      std::is_same<Layout, Kokkos::LayoutLeft>::value ? Kokkos::Iterate::Left
-                                                      : Kokkos::Iterate::Right>;
+      std::is_same_v<Layout, Kokkos::LayoutLeft> ? Kokkos::Iterate::Left
+                                                 : Kokkos::Iterate::Right,
+      std::is_same_v<Layout, Kokkos::LayoutLeft> ? Kokkos::Iterate::Left
+                                                 : Kokkos::Iterate::Right>;
   using policy_t = Kokkos::MDRangePolicy<exec_t, rank_t>;
 
   view_t a;

--- a/core/unit_test/default/TestDefaultDeviceTypeViewAPI.cpp
+++ b/core/unit_test/default/TestDefaultDeviceTypeViewAPI.cpp
@@ -39,7 +39,7 @@ struct TestViewAPI<
   using view_type =
       Kokkos::View<data_type, layout_type, space_type, traits_type>;
   using alloc_layout_type =
-      std::conditional_t<std::is_same<layout_type, Kokkos::LayoutStride>::value,
+      std::conditional_t<std::is_same_v<layout_type, Kokkos::LayoutStride>,
                          Kokkos::LayoutLeft, layout_type>;
   using d_alloc_type = Kokkos::View<data_type, alloc_layout_type, space_type>;
   using h_alloc_type = typename Kokkos::View<data_type, alloc_layout_type,

--- a/core/unit_test/incremental/Test04_ParallelFor_RangePolicy.hpp
+++ b/core/unit_test/incremental/Test04_ParallelFor_RangePolicy.hpp
@@ -131,7 +131,7 @@ struct TestParallel_For {
 };
 
 TEST(TEST_CATEGORY, IncrTest_04_simple_parallelFor) {
-  if (std::is_same<Kokkos::DefaultExecutionSpace, TEST_EXECSPACE>::value) {
+  if (std::is_same_v<Kokkos::DefaultExecutionSpace, TEST_EXECSPACE>) {
     TestParallel_For<TEST_EXECSPACE> test;
     test.simple_test();
   }

--- a/core/unit_test/tools/TestEventCorrectness.hpp
+++ b/core/unit_test/tools/TestEventCorrectness.hpp
@@ -107,7 +107,7 @@ struct TestScanFunctor {
 
 template <typename Lambda>
 void test_wrapper(const Lambda& lambda) {
-  if (!std::is_same<Kokkos::DefaultExecutionSpace, Kokkos::Serial>::value) {
+  if (!std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::Serial>) {
     lambda();
   }
 }

--- a/core/unit_test/tools/TestEventCorrectness.hpp
+++ b/core/unit_test/tools/TestEventCorrectness.hpp
@@ -282,8 +282,8 @@ TEST(kokkosp, test_streams) {
 TEST(kokkosp, async_deep_copy) {
 // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
-  if (std::is_same<Kokkos::DefaultExecutionSpace,
-                   Kokkos::Experimental::OpenMPTarget>::value)
+  if (std::is_same_v<Kokkos::DefaultExecutionSpace,
+                     Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP()
         << "skipping since the OpenMPTarget backend has unexpected fences";
 #endif
@@ -363,8 +363,8 @@ TEST(kokkosp, parallel_reduce) {
 TEST(kokkosp, parallel_scan) {
   // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
-  if (std::is_same<Kokkos::DefaultExecutionSpace,
-                   Kokkos::Experimental::OpenMPTarget>::value)
+  if (std::is_same_v<Kokkos::DefaultExecutionSpace,
+                     Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP()
         << "skipping since the OpenMPTarget backend reports unexpected events";
 #endif
@@ -391,20 +391,19 @@ TEST(kokkosp, parallel_scan) {
 TEST(kokkosp, parallel_scan_no_fence) {
   // FIXME_THREADS
 #ifdef KOKKOS_ENABLE_THREADS
-  if (std::is_same<Kokkos::DefaultExecutionSpace, Kokkos::Threads>::value)
+  if (std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::Threads>)
     GTEST_SKIP() << "skipping since the Thread backend always fences";
 #endif
 #if defined(KOKKOS_ENABLE_HPX) && \
     !defined(KOKKOS_ENABLE_IMPL_HPX_ASYNC_DISPATCH)
-  if (std::is_same<Kokkos::DefaultExecutionSpace,
-                   Kokkos::Experimental::HPX>::value)
+  if (std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::Experimental::HPX>)
     GTEST_SKIP() << "skipping since the HPX backend always fences with async "
                     "dispatch disabled";
 #endif
     // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
-  if (std::is_same<Kokkos::DefaultExecutionSpace,
-                   Kokkos::Experimental::OpenMPTarget>::value)
+  if (std::is_same_v<Kokkos::DefaultExecutionSpace,
+                     Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP()
         << "skipping since the OpenMPTarget backend has unexpected fences";
 #endif
@@ -437,20 +436,19 @@ TEST(kokkosp, parallel_scan_no_fence) {
 TEST(kokkosp, parallel_scan_no_fence_view) {
   // FIXME_THREADS
 #ifdef KOKKOS_ENABLE_THREADS
-  if (std::is_same<Kokkos::DefaultExecutionSpace, Kokkos::Threads>::value)
+  if (std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::Threads>)
     GTEST_SKIP() << "skipping since the Thread backend always fences";
 #endif
 #if defined(KOKKOS_ENABLE_HPX) && \
     !defined(KOKKOS_ENABLE_IMPL_HPX_ASYNC_DISPATCH)
-  if (std::is_same<Kokkos::DefaultExecutionSpace,
-                   Kokkos::Experimental::HPX>::value)
+  if (std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::Experimental::HPX>)
     GTEST_SKIP() << "skipping since the HPX backend always fences with async "
                     "dispatch disabled";
 #endif
     // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
-  if (std::is_same<Kokkos::DefaultExecutionSpace,
-                   Kokkos::Experimental::OpenMPTarget>::value)
+  if (std::is_same_v<Kokkos::DefaultExecutionSpace,
+                     Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP()
         << "skipping since the OpenMPTarget backend has unexpected fences";
 #endif
@@ -522,8 +520,8 @@ TEST(kokkosp, fences) {
 TEST(kokkosp, raw_allocation) {
   // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
-  if (std::is_same<Kokkos::DefaultExecutionSpace,
-                   Kokkos::Experimental::OpenMPTarget>::value)
+  if (std::is_same_v<Kokkos::DefaultExecutionSpace,
+                     Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP()
         << "skipping since the OpenMPTarget backend reports unexpected events";
 #endif
@@ -561,8 +559,8 @@ TEST(kokkosp, raw_allocation) {
 TEST(kokkosp, view) {
 // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
-  if (std::is_same<Kokkos::DefaultExecutionSpace,
-                   Kokkos::Experimental::OpenMPTarget>::value)
+  if (std::is_same_v<Kokkos::DefaultExecutionSpace,
+                     Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP()
         << "skipping since the OpenMPTarget backend reports unexpected events";
 #endif

--- a/core/unit_test/tools/TestProfilingSection.cpp
+++ b/core/unit_test/tools/TestProfilingSection.cpp
@@ -108,8 +108,8 @@ TEST(defaultdevicetype, profiling_section) {
 }
 
 using Kokkos::Profiling::ProfilingSection;
-static_assert(!std::is_default_constructible<ProfilingSection>::value);
-static_assert(!std::is_copy_constructible<ProfilingSection>::value);
-static_assert(!std::is_move_constructible<ProfilingSection>::value);
-static_assert(!std::is_copy_assignable<ProfilingSection>::value);
-static_assert(!std::is_move_assignable<ProfilingSection>::value);
+static_assert(!std::is_default_constructible_v<ProfilingSection>);
+static_assert(!std::is_copy_constructible_v<ProfilingSection>);
+static_assert(!std::is_move_constructible_v<ProfilingSection>);
+static_assert(!std::is_copy_assignable_v<ProfilingSection>);
+static_assert(!std::is_move_assignable_v<ProfilingSection>);

--- a/core/unit_test/tools/TestScopedRegion.cpp
+++ b/core/unit_test/tools/TestScopedRegion.cpp
@@ -63,10 +63,10 @@ TEST(defaultdevicetype, scoped_profile_region) {
 }
 
 using Kokkos::Profiling::ScopedRegion;
-static_assert(!std::is_default_constructible<ScopedRegion>::value);
-static_assert(!std::is_copy_constructible<ScopedRegion>::value);
-static_assert(!std::is_move_constructible<ScopedRegion>::value);
-static_assert(!std::is_copy_assignable<ScopedRegion>::value);
-static_assert(!std::is_move_assignable<ScopedRegion>::value);
+static_assert(!std::is_default_constructible_v<ScopedRegion>);
+static_assert(!std::is_copy_constructible_v<ScopedRegion>);
+static_assert(!std::is_move_constructible_v<ScopedRegion>);
+static_assert(!std::is_copy_assignable_v<ScopedRegion>);
+static_assert(!std::is_move_assignable_v<ScopedRegion>);
 
 }  // namespace

--- a/example/tutorial/Advanced_Views/04_dualviews/dual_view.cpp
+++ b/example/tutorial/Advanced_Views/04_dualviews/dual_view.cpp
@@ -49,7 +49,7 @@ struct localsum {
   using execution_space = ExecutionSpace;
 
   using memory_space = typename Kokkos::Impl::if_c<
-      std::is_same<ExecutionSpace, Kokkos::DefaultExecutionSpace>::value,
+      std::is_same_v<ExecutionSpace, Kokkos::DefaultExecutionSpace>,
       idx_type::memory_space, idx_type::host_mirror_space>::type;
 
   // Get the view types on the particular device for which the functor

--- a/tpls/gtest/gtest/gtest.h
+++ b/tpls/gtest/gtest/gtest.h
@@ -4770,11 +4770,10 @@ class NeverThrown {
 #endif  // GTEST_HAS_RTTI
 
 #define GTEST_TEST_THROW_CATCH_STD_EXCEPTION_(statement, expected_exception)   \
-  catch (typename std::conditional<                                            \
-         std::is_same<typename std::remove_cv<typename std::remove_reference<  \
-                          expected_exception>::type>::type,                    \
-                      std::exception>::value,                                  \
-         const ::testing::internal::NeverThrown&, const std::exception&>::type \
+  catch (std::conditional_t<                                                   \
+         std::is_same_v<std::remove_cv_t<std::remove_reference_t<              \
+                          expected_exception>>, std::exception>,               \
+         const ::testing::internal::NeverThrown&, const std::exception&>       \
              e) {                                                              \
     gtest_msg.value = "Expected: " #statement                                  \
                       " throws an exception of type " #expected_exception      \


### PR DESCRIPTION
This pull request enforces using C++14's and C++17's abbreviated type traits which we want to use.
Most of the changes in this pull request are mechanical and contained in one commit. 
However, MSVC and nvcc required flipping some SFINAE constraints around so that the constraint that is dependent on a template parameter comes first. 
Also, this pull request makes sure we only consider headers in our own implementations and not in the `tpls` (we have to list the directories explicitly since a negative regex will only be available from clang-tidy 19 on). For some reason, I still had to replace some type traits in gtest. 