### PR TITLE
Introduce new `SequentialHostInit` view allocation property

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -571,6 +571,8 @@ inline constexpr Kokkos::ALL_t ALL{};
 #pragma omp end declare target
 #endif
 
+inline constexpr Kokkos::Impl::HostSerialInit_t HostSerialInit{};
+
 inline constexpr Kokkos::Impl::WithoutInitializing_t WithoutInitializing{};
 
 inline constexpr Kokkos::Impl::AllowPadding_t AllowPadding{};

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -571,7 +571,7 @@ inline constexpr Kokkos::ALL_t ALL{};
 #pragma omp end declare target
 #endif
 
-inline constexpr Kokkos::Impl::HostSerialInit_t HostSerialInit{};
+inline constexpr Kokkos::Impl::SequentialHostInit_t SequentialHostInit{};
 
 inline constexpr Kokkos::Impl::WithoutInitializing_t WithoutInitializing{};
 

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -193,7 +193,6 @@ struct ViewValueFunctorSequentialHostInit {
   using ExecSpace = typename DeviceType::execution_space;
   using MemSpace  = typename DeviceType::memory_space;
   static_assert(SpaceAccessibility<HostSpace, MemSpace>::accessible);
-  static_assert(std::is_same_v<ExecSpace, typename MemSpace::execution_space>);
 
   ValueType* ptr;
   size_t n;

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -196,10 +196,6 @@ struct ViewValueFunctorSequentialHostInit {
   size_t n;
 
   ViewValueFunctorSequentialHostInit() = default;
-  ViewValueFunctorSequentialHostInit(
-      const ViewValueFunctorSequentialHostInit&) = default;
-  ViewValueFunctorSequentialHostInit& operator=(
-      const ViewValueFunctorSequentialHostInit&) = default;
 
   ViewValueFunctorSequentialHostInit(ExecSpace const& arg_space,
                                      ValueType* const arg_ptr,

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -189,29 +189,31 @@ struct ViewValueFunctor {
 };
 
 template <class DeviceType, class ValueType>
-struct ViewValueFunctorHostSerialInit {
+struct ViewValueFunctorSequentialHostInit {
   using ExecSpace = typename DeviceType::execution_space;
 
   ValueType* ptr;
   size_t n;
 
-  ViewValueFunctorHostSerialInit() = default;
-  ViewValueFunctorHostSerialInit(const ViewValueFunctorHostSerialInit&) =
-      default;
-  ViewValueFunctorHostSerialInit& operator=(
-      const ViewValueFunctorHostSerialInit&) = default;
+  ViewValueFunctorSequentialHostInit() = default;
+  ViewValueFunctorSequentialHostInit(
+      const ViewValueFunctorSequentialHostInit&) = default;
+  ViewValueFunctorSequentialHostInit& operator=(
+      const ViewValueFunctorSequentialHostInit&) = default;
 
-  ViewValueFunctorHostSerialInit(ExecSpace const& arg_space,
-                                 ValueType* const arg_ptr, size_t const arg_n,
-                                 std::string /*arg_name*/)
+  ViewValueFunctorSequentialHostInit(ExecSpace const& arg_space,
+                                     ValueType* const arg_ptr,
+                                     size_t const arg_n,
+                                     std::string /*arg_name*/)
       : ptr(arg_ptr), n(arg_n) {
     (void)arg_space;
     KOKKOS_ASSERT(arg_space == ExecSpace() &&
                   "FIXME if attached better be the default instance");
   }
 
-  ViewValueFunctorHostSerialInit(ValueType* const arg_ptr, size_t const arg_n,
-                                 std::string /*arg_name*/)
+  ViewValueFunctorSequentialHostInit(ValueType* const arg_ptr,
+                                     size_t const arg_n,
+                                     std::string /*arg_name*/)
       : ptr(arg_ptr), n(arg_n) {}
 
   void construct_shared_allocation() {

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -191,6 +191,8 @@ struct ViewValueFunctor {
 template <class DeviceType, class ValueType>
 struct ViewValueFunctorSequentialHostInit {
   using ExecSpace = typename DeviceType::execution_space;
+  using MemSpace  = typename DeviceType::memory_space;
+  static_assert(SpaceAccessibility<HostSpace, MemSpace>::accessible);
 
   ValueType* ptr;
   size_t n;
@@ -203,8 +205,7 @@ struct ViewValueFunctorSequentialHostInit {
                                      std::string /*arg_name*/)
       : ptr(arg_ptr), n(arg_n) {
     (void)arg_space;
-    KOKKOS_ASSERT(arg_space == ExecSpace() &&
-                  "FIXME if attached better be the default instance");
+    KOKKOS_ASSERT(arg_space == ExecSpace());
   }
 
   ViewValueFunctorSequentialHostInit(ValueType* const arg_ptr,

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -193,6 +193,7 @@ struct ViewValueFunctorSequentialHostInit {
   using ExecSpace = typename DeviceType::execution_space;
   using MemSpace  = typename DeviceType::memory_space;
   static_assert(SpaceAccessibility<HostSpace, MemSpace>::accessible);
+  static_assert(std::is_same_v<ExecSpace, typename MemSpace::execution_space>);
 
   ValueType* ptr;
   size_t n;

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -201,10 +201,11 @@ struct ViewValueFunctorHostSerialInit {
   ViewValueFunctorHostSerialInit& operator=(
       const ViewValueFunctorHostSerialInit&) = default;
 
-  ViewValueFunctorHostSerialInit([[maybe_unused]] ExecSpace const& arg_space,
+  ViewValueFunctorHostSerialInit(ExecSpace const& arg_space,
                                  ValueType* const arg_ptr, size_t const arg_n,
                                  std::string /*arg_name*/)
       : ptr(arg_ptr), n(arg_n) {
+    (void)arg_space;
     KOKKOS_ASSERT(arg_space == ExecSpace() &&
                   "FIXME if attached better be the default instance");
   }

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -195,28 +195,23 @@ struct ViewValueFunctorSequentialHostInit {
   static_assert(SpaceAccessibility<HostSpace, MemSpace>::accessible);
   static_assert(std::is_same_v<ExecSpace, typename MemSpace::execution_space>);
 
-  ExecSpace space;
   ValueType* ptr;
   size_t n;
-  bool default_exec_space;
 
   ViewValueFunctorSequentialHostInit() = default;
 
-  ViewValueFunctorSequentialHostInit(ExecSpace const& arg_space,
+  ViewValueFunctorSequentialHostInit(ExecSpace const& /*arg_space*/,
                                      ValueType* const arg_ptr,
                                      size_t const arg_n,
                                      std::string /*arg_name*/)
-      : space(arg_space), ptr(arg_ptr), n(arg_n), default_exec_space(false) {}
+      : ptr(arg_ptr), n(arg_n) {}
 
   ViewValueFunctorSequentialHostInit(ValueType* const arg_ptr,
                                      size_t const arg_n,
                                      std::string /*arg_name*/)
-      : space(ExecSpace{}), ptr(arg_ptr), n(arg_n), default_exec_space(true) {}
+      : ptr(arg_ptr), n(arg_n) {}
 
   void construct_shared_allocation() {
-    if (!default_exec_space) {
-      space.fence("Kokkos::View::initialization after allocate");
-    }
     if constexpr (std::is_trivial_v<ValueType>) {
       // value-initialization is equivalent to filling with zeros
       std::memset(static_cast<void*>(ptr), 0, n * sizeof(ValueType));

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -208,16 +208,15 @@ struct ViewCtorProp : public ViewCtorProp<void, P>... {
   static_assert(initialize || !sequential_host_init,
                 "Incompatible WithoutInitializing and SequentialHostInit view "
                 "alloc properties");
-
-  using memory_space    = typename var_memory_space::type;
-  using execution_space = typename var_execution_space::type;
-  using pointer_type    = typename var_pointer::type;
-
-  // FIXME can't quite do that to validate user in[ut because we sometimes
+  // FIXME can't quite do that to validate user input because we sometimes
   // attach default instances ourselves
   // static_assert(!sequential_host_init || !has_execution_space,
   //              "Incompatible SequentialHostInit view "
   //              "alloc property with execution space argument");
+
+  using memory_space    = typename var_memory_space::type;
+  using execution_space = typename var_execution_space::type;
+  using pointer_type    = typename var_pointer::type;
 
   /*  Copy from a matching argument list.
    *  Requires  std::is_same< P , ViewCtorProp< void , Args >::value ...

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -208,11 +208,6 @@ struct ViewCtorProp : public ViewCtorProp<void, P>... {
   static_assert(initialize || !sequential_host_init,
                 "Incompatible WithoutInitializing and SequentialHostInit view "
                 "alloc properties");
-  // FIXME can't quite do that to validate user input because we sometimes
-  // attach default instances ourselves
-  // static_assert(!sequential_host_init || !has_execution_space,
-  //              "Incompatible SequentialHostInit view "
-  //              "alloc property with execution space argument");
 
   using memory_space    = typename var_memory_space::type;
   using execution_space = typename var_execution_space::type;

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -23,11 +23,15 @@
 namespace Kokkos {
 namespace Impl {
 
+struct HostSerialInit_t {};
 struct WithoutInitializing_t {};
 struct AllowPadding_t {};
 
 template <typename>
 struct is_view_ctor_property : public std::false_type {};
+
+template <>
+struct is_view_ctor_property<HostSerialInit_t> : public std::true_type {};
 
 template <>
 struct is_view_ctor_property<WithoutInitializing_t> : public std::true_type {};
@@ -84,10 +88,10 @@ struct ViewCtorProp<void, CommonViewAllocProp<Specialize, T>> {
 
 /* Property flags have constexpr value */
 template <typename P>
-struct ViewCtorProp<
-    std::enable_if_t<std::is_same<P, AllowPadding_t>::value ||
-                     std::is_same<P, WithoutInitializing_t>::value>,
-    P> {
+struct ViewCtorProp<std::enable_if_t<std::is_same_v<P, AllowPadding_t> ||
+                                     std::is_same_v<P, WithoutInitializing_t> ||
+                                     std::is_same_v<P, HostSerialInit_t>>,
+                    P> {
   ViewCtorProp()                                = default;
   ViewCtorProp(const ViewCtorProp &)            = default;
   ViewCtorProp &operator=(const ViewCtorProp &) = default;
@@ -199,10 +203,21 @@ struct ViewCtorProp : public ViewCtorProp<void, P>... {
       Kokkos::Impl::has_type<AllowPadding_t, P...>::value;
   static constexpr bool initialize =
       !Kokkos::Impl::has_type<WithoutInitializing_t, P...>::value;
+  static constexpr bool host_serial_init =
+      Kokkos::Impl::has_type<HostSerialInit_t, P...>::value;
+  static_assert(initialize || !host_serial_init,
+                "Incompatible WithoutInitializing and HostSerialInit view "
+                "alloc properties");
 
   using memory_space    = typename var_memory_space::type;
   using execution_space = typename var_execution_space::type;
   using pointer_type    = typename var_pointer::type;
+
+  // FIXME can't quite do that to validate user in[ut because we sometimes
+  // attach default instances ourselves
+  // static_assert(!host_serial_init || !has_execution_space,
+  //              "Incompatible HostSerialInit view "
+  //              "alloc property with execution space argument");
 
   /*  Copy from a matching argument list.
    *  Requires  std::is_same< P , ViewCtorProp< void , Args >::value ...
@@ -251,7 +266,9 @@ auto with_properties_if_unset(const ViewCtorProp<P...> &view_ctor_prop,
                 (is_view_label<Property>::value &&
                  !ViewCtorProp<P...>::has_label) ||
                 (std::is_same_v<Property, WithoutInitializing_t> &&
-                 ViewCtorProp<P...>::initialize)) {
+                 ViewCtorProp<P...>::initialize) ||
+                (std::is_same_v<Property, HostSerialInit_t> &&
+                 !ViewCtorProp<P...>::host_serial_init)) {
     using NewViewCtorProp = ViewCtorProp<P..., Property>;
     NewViewCtorProp new_view_ctor_prop(view_ctor_prop);
     static_cast<ViewCtorProp<void, Property> &>(new_view_ctor_prop).value =
@@ -299,7 +316,9 @@ struct WithPropertiesIfUnset<ViewCtorProp<P...>, Property, Properties...> {
                   (is_view_label<Property>::value &&
                    !ViewCtorProp<P...>::has_label) ||
                   (std::is_same_v<Property, WithoutInitializing_t> &&
-                   ViewCtorProp<P...>::initialize)) {
+                   ViewCtorProp<P...>::initialize) ||
+                  (std::is_same_v<Property, HostSerialInit_t> &&
+                   !ViewCtorProp<P...>::host_serial_init)) {
       using NewViewCtorProp = ViewCtorProp<P..., Property>;
       NewViewCtorProp new_view_ctor_prop(view_ctor_prop);
       static_cast<ViewCtorProp<void, Property> &>(new_view_ctor_prop).value =

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2825,10 +2825,12 @@ class ViewMapping<
     using memory_space    = typename Traits::memory_space;
     static_assert(
         SpaceAccessibility<execution_space, memory_space>::accessible);
-    using value_type = typename Traits::value_type;
-    using functor_type =
-        ViewValueFunctor<Kokkos::Device<execution_space, memory_space>,
-                         value_type>;
+    using device_type  = Kokkos::Device<execution_space, memory_space>;
+    using value_type   = typename Traits::value_type;
+    using functor_type = std::conditional_t<
+        alloc_prop::host_serial_init,
+        ViewValueFunctorHostSerialInit<device_type, value_type>,
+        ViewValueFunctor<device_type, value_type>>;
     using record_type =
         Kokkos::Impl::SharedAllocationRecord<memory_space, functor_type>;
 

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2828,8 +2828,8 @@ class ViewMapping<
     using device_type  = Kokkos::Device<execution_space, memory_space>;
     using value_type   = typename Traits::value_type;
     using functor_type = std::conditional_t<
-        alloc_prop::host_serial_init,
-        ViewValueFunctorHostSerialInit<device_type, value_type>,
+        alloc_prop::sequential_host_init,
+        ViewValueFunctorSequentialHostInit<device_type, value_type>,
         ViewValueFunctor<device_type, value_type>>;
     using record_type =
         Kokkos::Impl::SharedAllocationRecord<memory_space, functor_type>;

--- a/core/unit_test/TestViewOfViews.hpp
+++ b/core/unit_test/TestViewOfViews.hpp
@@ -20,7 +20,7 @@
 
 namespace {
 
-// User-defined type with a View data member
+// User-defined types with a View data member
 template <class V>
 class S {
   V v_;
@@ -28,57 +28,102 @@ class S {
  public:
   template <class... Extents>
   S(std::string label, Extents... extents) : v_(std::move(label), extents...) {}
-  S() = default;
+  KOKKOS_DEFAULTED_FUNCTION S() = default;
 };
 
 template <class V>
-void test_view_of_views() {
+class N {  // not default constructible
+  V v_;
+
+ public:
+  template <class... Extents>
+  N(std::string label, Extents... extents) : v_(std::move(label), extents...) {}
+};
+
+template <class V>
+class H {  // constructible and destructible only from on the host side
+  V v_;
+
+ public:
+  template <class... Extents>
+  H(std::string label, Extents... extents) : v_(std::move(label), extents...) {}
+  H() {}
+  ~H() {}
+};
+
+template <class V>
+void test_view_of_views_default() {
+  // assigning a default-constructed view to destruct the inner objects
   using VoV = Kokkos::View<V**, Kokkos::HostSpace>;
-  {  // assigning a default-constructed view to destruct the inner objects
-    VoV vov("vov", 2, 3);
-    V a("a");
-    V b("b");
-    vov(0, 0) = a;
-    vov(1, 0) = a;
-    vov(0, 1) = b;
+  VoV vov("vov", 2, 3);
+  V a("a");
+  V b("b");
+  vov(0, 0) = a;
+  vov(1, 0) = a;
+  vov(0, 1) = b;
 #ifndef KOKKOS_ENABLE_IMPL_VIEW_OF_VIEWS_DESTRUCTOR_PRECONDITION_VIOLATION_WORKAROUND
-    vov(0, 0) = V();
-    vov(1, 0) = V();
-    vov(0, 1) = V();
+  vov(0, 0) = V();
+  vov(1, 0) = V();
+  vov(0, 1) = V();
 #endif
-  }
-  {  // using placement new to construct the inner objects and explicitly
-     // calling the destructor
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::WithoutInitializing), 2, 3);
-    V a("a");
-    V b("b");
-    new (&vov(0, 0)) V(a);
-    new (&vov(1, 0)) V(a);
-    new (&vov(0, 1)) V(b);
-#ifndef KOKKOS_ENABLE_IMPL_VIEW_OF_VIEWS_DESTRUCTOR_PRECONDITION_VIOLATION_WORKAROUND
-    vov(0, 0).~V();
-    vov(1, 0).~V();
-    vov(0, 1).~V();
-#else
-    // leaks memory
-#endif
-  }
-  {  // inner views value-initialized sequentially on the host, and also
-     // sequentially destructed on the host, without the need to cleanup
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 3);
-    V a("a");
-    V b("b");
-    vov(0, 0) = a;
-    vov(1, 0) = a;
-    vov(0, 1) = b;
-  }
 }
 
-TEST(TEST_CATEGORY, view_of_views) {
-  test_view_of_views<Kokkos::View<int, TEST_EXECSPACE>>();
-  test_view_of_views<Kokkos::View<int[4], TEST_EXECSPACE>>();
+template <class V>
+void test_view_of_views_without_initializing() {
+  // using placement new to construct the inner objects and explicitly
+  // calling the destructor
+  using VoV = Kokkos::View<V**, Kokkos::HostSpace>;
+  VoV vov(Kokkos::view_alloc("vov", Kokkos::WithoutInitializing), 2, 3);
+  V a("a");
+  V b("b");
+  new (&vov(0, 0)) V(a);
+  new (&vov(1, 0)) V(a);
+  new (&vov(0, 1)) V(b);
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_OF_VIEWS_DESTRUCTOR_PRECONDITION_VIOLATION_WORKAROUND
+  vov(0, 0).~V();
+  vov(1, 0).~V();
+  vov(0, 1).~V();
+#else
+  // leaks memory
+#endif
+}
+
+template <class V>
+void test_view_of_views_sequential_host_init() {
+  // inner views value-initialized sequentially on the host, and also
+  // sequentially destructed on the host, without the need to cleanup
+  using VoV = Kokkos::View<V**, Kokkos::HostSpace>;
+  VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 3);
+  V a("a");
+  V b("b");
+  vov(0, 0) = a;
+  vov(1, 0) = a;
+  vov(0, 1) = b;
+}
+
+TEST(TEST_CATEGORY, view_of_views_default) {
+  test_view_of_views_default<Kokkos::View<int, TEST_EXECSPACE>>();
+  test_view_of_views_default<Kokkos::View<int[4], TEST_EXECSPACE>>();
   // User-defined type with View data member
-  test_view_of_views<S<Kokkos::View<float, TEST_EXECSPACE>>>();
+  test_view_of_views_default<S<Kokkos::View<float, TEST_EXECSPACE>>>();
+}
+
+TEST(TEST_CATEGORY, view_of_views_without_initializing) {
+  test_view_of_views_without_initializing<Kokkos::View<int, TEST_EXECSPACE>>();
+  test_view_of_views_without_initializing<
+      S<Kokkos::View<float, TEST_EXECSPACE>>>();
+  test_view_of_views_without_initializing<
+      N<Kokkos::View<double, TEST_EXECSPACE>>>();
+  test_view_of_views_without_initializing<
+      H<Kokkos::View<int, TEST_EXECSPACE>>>();
+}
+
+TEST(TEST_CATEGORY, test_view_of_views_sequential_host_init) {
+  test_view_of_views_sequential_host_init<Kokkos::View<int, TEST_EXECSPACE>>();
+  test_view_of_views_sequential_host_init<
+      S<Kokkos::View<float, TEST_EXECSPACE>>>();
+  test_view_of_views_sequential_host_init<
+      H<Kokkos::View<int, TEST_EXECSPACE>>>();
 }
 
 }  // namespace

--- a/core/unit_test/TestViewOfViews.hpp
+++ b/core/unit_test/TestViewOfViews.hpp
@@ -63,6 +63,15 @@ void test_view_of_views() {
     // leaks memory
 #endif
   }
+  {  // inner views value-initialized on the host in serial and also destructed
+     // in serial on the host, without the need to cleanup
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::HostSerialInit), 2, 3);
+    V a("a");
+    V b("b");
+    vov(0, 0) = a;
+    vov(1, 0) = a;
+    vov(0, 1) = b;
+  }
 }
 
 TEST(TEST_CATEGORY, view_of_views) {

--- a/core/unit_test/TestViewOfViews.hpp
+++ b/core/unit_test/TestViewOfViews.hpp
@@ -63,8 +63,8 @@ void test_view_of_views() {
     // leaks memory
 #endif
   }
-  {  // inner views value-initialized on the host in serial and also destructed
-     // in serial on the host, without the need to cleanup
+  {  // inner views value-initialized sequentially on the host, and also
+     // sequentially destructed on the host, without the need to cleanup
     VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 3);
     V a("a");
     V b("b");

--- a/core/unit_test/TestViewOfViews.hpp
+++ b/core/unit_test/TestViewOfViews.hpp
@@ -65,7 +65,7 @@ void test_view_of_views() {
   }
   {  // inner views value-initialized on the host in serial and also destructed
      // in serial on the host, without the need to cleanup
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::HostSerialInit), 2, 3);
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 3);
     V a("a");
     V b("b");
     vov(0, 0) = a;


### PR DESCRIPTION
Motivation: View of views support

```C++
{
  View<TypeContainsView, HostSpace> v(view_alloc("v", SequentialHostInit));
  v() = TypeContainsView(/* ... */);
  // no cleanup, the destructor will handle it
}
```

Note that, in the current form, non-default-constructible element types are not supported.

cc @stanmoore1 @rppawlo @vbrunini
