### PR TITLE
Improve GH action to produce release artifacts

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Build artifacts
         run: |
-          git archive -o kokkos-${{ github.ref_name }}.zip HEAD
-          git archive -o kokkos-${{ github.ref_name }}.tar.gz HEAD
+          git archive --prefix=kokkos-${{ github.ref_name }}/ -o kokkos-${{ github.ref_name }}.zip HEAD
+          git archive --prefix=kokkos-${{ github.ref_name }}/ -o kokkos-${{ github.ref_name }}.tar.gz HEAD
 
       - name: Generate hashes
         shell: bash

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -29,19 +29,11 @@ jobs:
           sha256sum kokkos-${{ github.ref_name }}.tar.gz >> kokkos-${{ github.ref_name }}-SHA-256.txt
           echo "hashes=$(base64 -w0 kokkos-${{ github.ref_name }}-SHA-256.txt)" >> "$GITHUB_OUTPUT"
 
-      - name: Upload source code (zip)
+      - name: Upload artifacts
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
-          name: kokkos-${{ github.ref_name }}.zip
-          path: kokkos-${{ github.ref_name }}.zip
-          if-no-files-found: error
-          retention-days: 5
-
-      - name: Upload source code (tar.gz)
-        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
-        with:
-          name: kokkos-${{ github.ref_name }}.tar.gz
-          path: kokkos-${{ github.ref_name }}.tar.gz
+          name: release-artifacts
+          path: kokkos-${{ github.ref_name }}*
           if-no-files-found: error
           retention-days: 5
 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -59,19 +59,14 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - name: Download kokkos-${{ github.ref_name }}.zip
+      - name: Download artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          name: kokkos-${{ github.ref_name }}.zip
-
-      - name: Download kokkos-${{ github.ref_name }}.tar.gz
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-        with:
-          name: kokkos-${{ github.ref_name }}.tar.gz
-
+          name: release-artifacts
       - name: Upload assets
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         with:
           files: |
             kokkos-${{ github.ref_name }}.zip
             kokkos-${{ github.ref_name }}.tar.gz
+            kokkos-${{ github.ref_name }}-SHA-256.txt

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -25,8 +25,7 @@ jobs:
         run: |
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
-          sha256sum kokkos-${{ github.ref_name }}.zip > kokkos-${{ github.ref_name }}-SHA-256.txt
-          sha256sum kokkos-${{ github.ref_name }}.tar.gz >> kokkos-${{ github.ref_name }}-SHA-256.txt
+          sha256sum kokkos-${{ github.ref_name }}.zip kokkos-${{ github.ref_name }}.tar.gz > kokkos-${{ github.ref_name }}-SHA-256.txt
           echo "hashes=$(base64 -w0 kokkos-${{ github.ref_name }}-SHA-256.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifacts

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -25,7 +25,9 @@ jobs:
         run: |
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
-          echo "hashes=$(sha256sum kokkos-${{ github.ref_name }}.zip kokkos-${{ github.ref_name }}.tar.gz | base64 -w0)" >> "$GITHUB_OUTPUT"
+          sha256sum kokkos-${{ github.ref_name }}.zip > kokkos-${{ github.ref_name }}-SHA-256.txt
+          sha256sum kokkos-${{ github.ref_name }}.tar.gz >> kokkos-${{ github.ref_name }}-SHA-256.txt
+          echo "hashes=$(base64 -w0 kokkos-${{ github.ref_name }}-SHA-256.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Upload source code (zip)
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6


### PR DESCRIPTION
* Generate the `kokkos-4.X.YZ-SHA-256.txt` hashes
* Consolidate upload and download steps

The maintainer is only left with certifying the cryptographic hashes.
```
curl -sL https://github.com/kokkos/kokkos/releases/download/4.X.YZ/kokkos-4.X.YZ.zip -o kokkos-4.X.YZ.zip
curl -sL https://github.com/kokkos/kokkos/releases/download/4.X.YZ/kokkos-4.X.YZ.tar.gz -o kokkos-4.X.YZ.tar.gz
curl -sL https://github.com/kokkos/kokkos/releases/download/4.X.YZ/kokkos-4.X.YZ-SHA-256.txt -o kokkos-4.X.YZ-SHA-256.txt
curl -sL https://github.com/kokkos/kokkos/releases/download/4.X.YZ/kokkos-4.X.YZ.intoto.jsonl -o kokkos-4.X.YZ.intoto.jsonl
grep kokkos-4.X.YZ.tar.gz kokkos-4.X.YZ-SHA-256.txt | shasum -c
grep kokkos-4.X.YZ.zip kokkos-4.X.YZ-SHA-256.txt | shasum -c
slsa-verifier verify-artifact kokkos-4.X.YZ.tar.gz --provenance-path kokkos-4.X.YZ.intoto.jsonl --source-uri github.com/kokkos/kokkos --source-tag 4.X.YZ
slsa-verifier verify-artifact kokkos-4.X.YZ.zip --provenance-path kokkos-4.X.YZ.intoto.jsonl --source-uri github.com/kokkos/kokkos --source-tag 4.X.YZ
```
Then unarchive both the zip and tar.gz and diff it with your local copy before certifying and uploading the signature.
