### PR TITLE
Using CUDA limits to set extents for blocks,grids

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -95,14 +95,30 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
 
   inline void execute() const {
     if (m_rp.m_num_tiles == 0) return;
-    const auto maxblocks  = m_rp.space().cuda_device_prop().maxGridSize;
+    const auto maxblocks = m_rp.space().cuda_device_prop().maxGridSize;
     const auto maxthreads = m_rp.space().cuda_device_prop().maxThreadsDim;
-    const auto maxthreadsperblock =
+    const auto maxThreadsPerBlock =
         m_rp.space().cuda_device_prop().maxThreadsPerBlock;
+    // make sure the Z dimension (it is less than x,y limits) isn't exceeded
+    const auto validateZ = [&](const int input){
+        return (input > maxthreads[2] ? maxthreads[2] : input);
+    };
+    // make sure the block dimensions don't exceed the max number of threads allowed
+    const auto check_block_sizes = [&](const dim3& block){
+        KOKKOS_ASSERT(block.x > 0 && block.x <= maxthreads[0]);
+        KOKKOS_ASSERT(block.y > 0 && block.y <= maxthreads[1]);
+        KOKKOS_ASSERT(block.z > 0 && block.z <= maxthreads[2]);
+        KOKKOS_ASSERT(block.x * block.y * block.z <= maxThreadsPerBlock);
+    };
+    // make sure the grid dimensions don't exceed the max number of blocks allowed
+    const auto check_grid_sizes = [&](const dim3& grid){
+        KOKKOS_ASSERT(grid.x > 0 && grid.x <= maxblocks[0]);
+        KOKKOS_ASSERT(grid.y > 0 && grid.y <= maxblocks[1]);
+        KOKKOS_ASSERT(grid.z > 0 && grid.z <= maxblocks[2]);
+    };
     if (RP::rank == 2) {
       const dim3 block(m_rp.m_tile[0], m_rp.m_tile[1], 1);
-      KOKKOS_ASSERT(block.x > 0 && block.x <= maxthreads[0]);
-      KOKKOS_ASSERT(block.y > 0 && block.y <= maxthreads[1]);
+      check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(
               (m_rp.m_upper[0] - m_rp.m_lower[0] + block.x - 1) / block.x,
@@ -111,18 +127,13 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
               (m_rp.m_upper[1] - m_rp.m_lower[1] + block.y - 1) / block.y,
               maxblocks[1]),
           1);
-      KOKKOS_ASSERT(grid.x > 0 && grid.x <= maxblocks[0]);
-      KOKKOS_ASSERT(grid.y > 0 && grid.y <= maxblocks[1]);
+      check_grid_sizes(grid);
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
     } else if (RP::rank == 3) {
-      const dim3 block(
-          m_rp.m_tile[0], m_rp.m_tile[1],
-          ((m_rp.m_tile[2] > maxthreads[2]) ? maxthreads[2] : m_rp.m_tile[2]));
-      KOKKOS_ASSERT(block.x > 0 && block.x <= maxthreads[0]);
-      KOKKOS_ASSERT(block.y > 0 && block.y <= maxthreads[1]);
-      KOKKOS_ASSERT(block.z > 0 && block.z <= maxthreads[2]);
-      KOKKOS_ASSERT(block.x * block.y * block.z <= maxthreadsperblock);
+      const dim3 block( m_rp.m_tile[0], m_rp.m_tile[1],
+          validateZ(m_rp.m_tile[2]));
+      check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(
               (m_rp.m_upper[0] - m_rp.m_lower[0] + block.x - 1) / block.x,
@@ -134,21 +145,16 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
               (m_rp.m_upper[2] - m_rp.m_lower[2] + block.z - 1) / block.z,
               maxblocks[2]));
       // ensure we don't exceed the capability of the device
-      KOKKOS_ASSERT(grid.x > 0 && grid.x <= maxblocks[0]);
-      KOKKOS_ASSERT(grid.y > 0 && grid.y <= maxblocks[1]);
-      KOKKOS_ASSERT(grid.z > 0 && grid.z <= maxblocks[2]);
+      check_grid_sizes(grid);
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
     } else if (RP::rank == 4) {
       // id0,id1 encoded within threadIdx.x; id2 to threadIdx.y; id3 to
       // threadIdx.z
       const dim3 block(
-          m_rp.m_tile[0] * m_rp.m_tile[1], m_rp.m_tile[2],
-          ((m_rp.m_tile[3] > maxthreads[2]) ? maxthreads[2] : m_rp.m_tile[3]));
-      KOKKOS_ASSERT(block.x > 0 && block.x <= maxthreads[0]);
-      KOKKOS_ASSERT(block.y > 0 && block.y <= maxthreads[1]);
-      KOKKOS_ASSERT(block.z > 0 && block.z <= maxthreads[2]);
-      KOKKOS_ASSERT(block.x * block.y * block.z <= maxthreadsperblock);
+        m_rp.m_tile[0] * m_rp.m_tile[1], m_rp.m_tile[2],
+        validateZ(m_rp.m_tile[3]));
+      check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(m_rp.m_tile_end[0] * m_rp.m_tile_end[1],
                                      maxblocks[0]),
@@ -158,9 +164,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
           std::min<array_index_type>(
               (m_rp.m_upper[3] - m_rp.m_lower[3] + block.z - 1) / block.z,
               maxblocks[2]));
-      KOKKOS_ASSERT(grid.x > 0 && grid.x <= maxblocks[0]);
-      KOKKOS_ASSERT(grid.y > 0 && grid.y <= maxblocks[1]);
-      KOKKOS_ASSERT(grid.z > 0 && grid.z <= maxblocks[2]);
+      check_grid_sizes(grid);
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
     } else if (RP::rank == 5) {
@@ -168,11 +172,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
       // threadIdx.z
       const dim3 block(
           m_rp.m_tile[0] * m_rp.m_tile[1], m_rp.m_tile[2] * m_rp.m_tile[3],
-          ((m_rp.m_tile[4] > maxthreads[2]) ? maxthreads[2] : m_rp.m_tile[4]));
-      KOKKOS_ASSERT(block.x > 0 && block.x <= maxthreads[0]);
-      KOKKOS_ASSERT(block.y > 0 && block.y <= maxthreads[1]);
-      KOKKOS_ASSERT(block.z > 0 && block.z <= maxthreads[2]);
-      KOKKOS_ASSERT(block.x * block.y * block.z <= maxthreadsperblock);
+          validateZ(m_rp.m_tile[4]));
+      check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(m_rp.m_tile_end[0] * m_rp.m_tile_end[1],
                                      maxblocks[0]),
@@ -181,9 +182,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
           std::min<array_index_type>(
               (m_rp.m_upper[4] - m_rp.m_lower[4] + block.z - 1) / block.z,
               maxblocks[2]));
-      KOKKOS_ASSERT(grid.x > 0 && grid.x <= maxblocks[0]);
-      KOKKOS_ASSERT(grid.y > 0 && grid.y <= maxblocks[1]);
-      KOKKOS_ASSERT(grid.z > 0 && grid.z <= maxblocks[2]);
+      check_grid_sizes(grid);
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
     } else if (RP::rank == 6) {
@@ -191,13 +190,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
       // threadIdx.z
       const dim3 block(m_rp.m_tile[0] * m_rp.m_tile[1],
                        m_rp.m_tile[2] * m_rp.m_tile[3],
-                       ((m_rp.m_tile[4] * m_rp.m_tile[5] > maxthreads[2])
-                            ? maxthreads[2]
-                            : m_rp.m_tile[4] * m_rp.m_tile[5]));
-      KOKKOS_ASSERT(block.x > 0 && block.x <= maxthreads[0]);
-      KOKKOS_ASSERT(block.y > 0 && block.y <= maxthreads[1]);
-      KOKKOS_ASSERT(block.z > 0 && block.z <= maxthreads[2]);
-      KOKKOS_ASSERT(block.x * block.y * block.z <= maxthreadsperblock);
+                       validateZ(m_rp.m_tile[4] * m_rp.m_tile[5]));
+      check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(m_rp.m_tile_end[0] * m_rp.m_tile_end[1],
                                      maxblocks[0]),
@@ -205,9 +199,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
                                      maxblocks[1]),
           std::min<array_index_type>(m_rp.m_tile_end[4] * m_rp.m_tile_end[5],
                                      maxblocks[2]));
-      KOKKOS_ASSERT(grid.x > 0 && grid.x <= maxblocks[0]);
-      KOKKOS_ASSERT(grid.y > 0 && grid.y <= maxblocks[1]);
-      KOKKOS_ASSERT(grid.z > 0 && grid.z <= maxblocks[2]);
+      check_grid_sizes(grid);
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
     } else {

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -106,18 +106,24 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
     // make sure the block dimensions don't exceed the max number of threads
     // allowed
     const auto check_block_sizes = [&]([[maybe_unused]] const dim3& block) {
-      KOKKOS_ASSERT(block.x > 0 && block.x <= (unsigned int)maxthreads[0]);
-      KOKKOS_ASSERT(block.y > 0 && block.y <= (unsigned int)maxthreads[1]);
-      KOKKOS_ASSERT(block.z > 0 && block.z <= (unsigned int)maxthreads[2]);
+      KOKKOS_ASSERT(block.x > 0 &&
+                    block.x <= static_cast<unsigned int>(maxthreads[0]));
+      KOKKOS_ASSERT(block.y > 0 &&
+                    block.y <= static_cast<unsigned int>(maxthreads[1]));
+      KOKKOS_ASSERT(block.z > 0 &&
+                    block.z <= static_cast<unsigned int>(maxthreads[2]));
       KOKKOS_ASSERT(block.x * block.y * block.z <=
-                    (unsigned int)maxThreadsPerBlock);
+                    static_cast<unsigned int>(maxThreadsPerBlock));
     };
     // make sure the grid dimensions don't exceed the max number of blocks
     // allowed
     const auto check_grid_sizes = [&]([[maybe_unused]] const dim3& grid) {
-      KOKKOS_ASSERT(grid.x > 0 && grid.x <= (unsigned int)maxblocks[0]);
-      KOKKOS_ASSERT(grid.y > 0 && grid.y <= (unsigned int)maxblocks[1]);
-      KOKKOS_ASSERT(grid.z > 0 && grid.z <= (unsigned int)maxblocks[2]);
+      KOKKOS_ASSERT(grid.x > 0 &&
+                    grid.x <= static_cast<unsigned int>(maxblocks[0]));
+      KOKKOS_ASSERT(grid.y > 0 &&
+                    grid.y <= static_cast<unsigned int>(maxblocks[1]));
+      KOKKOS_ASSERT(grid.z > 0 &&
+                    grid.z <= static_cast<unsigned int>(maxblocks[2]));
     };
     if (RP::rank == 2) {
       const dim3 block(m_rp.m_tile[0], m_rp.m_tile[1], 1);

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -109,7 +109,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
       KOKKOS_ASSERT(block.x > 0 && block.x <= (unsigned int)maxthreads[0]);
       KOKKOS_ASSERT(block.y > 0 && block.y <= (unsigned int)maxthreads[1]);
       KOKKOS_ASSERT(block.z > 0 && block.z <= (unsigned int)maxthreads[2]);
-      KOKKOS_ASSERT(block.x * block.y * block.z <= (unsigned int)maxThreadsPerBlock);
+      KOKKOS_ASSERT(block.x * block.y * block.z <=
+                    (unsigned int)maxThreadsPerBlock);
     };
     // make sure the grid dimensions don't exceed the max number of blocks
     // allowed
@@ -133,8 +134,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
     } else if (RP::rank == 3) {
-      const dim3 block(m_rp.m_tile[0], m_rp.m_tile[1],
-                       clampZ(m_rp.m_tile[2]));
+      const dim3 block(m_rp.m_tile[0], m_rp.m_tile[1], clampZ(m_rp.m_tile[2]));
       check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(
@@ -172,8 +172,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
       // id0,id1 encoded within threadIdx.x; id2,id3 to threadIdx.y; id4 to
       // threadIdx.z
       const dim3 block(m_rp.m_tile[0] * m_rp.m_tile[1],
-                       m_rp.m_tile[2] * m_rp.m_tile[3],
-                       clampZ(m_rp.m_tile[4]));
+                       m_rp.m_tile[2] * m_rp.m_tile[3], clampZ(m_rp.m_tile[4]));
       check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(m_rp.m_tile_end[0] * m_rp.m_tile_end[1],

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -95,26 +95,28 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
 
   inline void execute() const {
     if (m_rp.m_num_tiles == 0) return;
-    const auto maxblocks = m_rp.space().cuda_device_prop().maxGridSize;
+    const auto maxblocks  = m_rp.space().cuda_device_prop().maxGridSize;
     const auto maxthreads = m_rp.space().cuda_device_prop().maxThreadsDim;
     const auto maxThreadsPerBlock =
         m_rp.space().cuda_device_prop().maxThreadsPerBlock;
     // make sure the Z dimension (it is less than x,y limits) isn't exceeded
-    const auto validateZ = [&](const int input){
-        return (input > maxthreads[2] ? maxthreads[2] : input);
+    const auto validateZ = [&](const int input) {
+      return (input > maxthreads[2] ? maxthreads[2] : input);
     };
-    // make sure the block dimensions don't exceed the max number of threads allowed
-    const auto check_block_sizes = [&](const dim3& block){
-        KOKKOS_ASSERT(block.x > 0 && block.x <= maxthreads[0]);
-        KOKKOS_ASSERT(block.y > 0 && block.y <= maxthreads[1]);
-        KOKKOS_ASSERT(block.z > 0 && block.z <= maxthreads[2]);
-        KOKKOS_ASSERT(block.x * block.y * block.z <= maxThreadsPerBlock);
+    // make sure the block dimensions don't exceed the max number of threads
+    // allowed
+    const auto check_block_sizes = [&](const dim3& block) {
+      KOKKOS_ASSERT(block.x > 0 && block.x <= maxthreads[0]);
+      KOKKOS_ASSERT(block.y > 0 && block.y <= maxthreads[1]);
+      KOKKOS_ASSERT(block.z > 0 && block.z <= maxthreads[2]);
+      KOKKOS_ASSERT(block.x * block.y * block.z <= maxThreadsPerBlock);
     };
-    // make sure the grid dimensions don't exceed the max number of blocks allowed
-    const auto check_grid_sizes = [&](const dim3& grid){
-        KOKKOS_ASSERT(grid.x > 0 && grid.x <= maxblocks[0]);
-        KOKKOS_ASSERT(grid.y > 0 && grid.y <= maxblocks[1]);
-        KOKKOS_ASSERT(grid.z > 0 && grid.z <= maxblocks[2]);
+    // make sure the grid dimensions don't exceed the max number of blocks
+    // allowed
+    const auto check_grid_sizes = [&](const dim3& grid) {
+      KOKKOS_ASSERT(grid.x > 0 && grid.x <= maxblocks[0]);
+      KOKKOS_ASSERT(grid.y > 0 && grid.y <= maxblocks[1]);
+      KOKKOS_ASSERT(grid.z > 0 && grid.z <= maxblocks[2]);
     };
     if (RP::rank == 2) {
       const dim3 block(m_rp.m_tile[0], m_rp.m_tile[1], 1);
@@ -131,8 +133,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
     } else if (RP::rank == 3) {
-      const dim3 block( m_rp.m_tile[0], m_rp.m_tile[1],
-          validateZ(m_rp.m_tile[2]));
+      const dim3 block(m_rp.m_tile[0], m_rp.m_tile[1],
+                       validateZ(m_rp.m_tile[2]));
       check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(
@@ -151,9 +153,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
     } else if (RP::rank == 4) {
       // id0,id1 encoded within threadIdx.x; id2 to threadIdx.y; id3 to
       // threadIdx.z
-      const dim3 block(
-        m_rp.m_tile[0] * m_rp.m_tile[1], m_rp.m_tile[2],
-        validateZ(m_rp.m_tile[3]));
+      const dim3 block(m_rp.m_tile[0] * m_rp.m_tile[1], m_rp.m_tile[2],
+                       validateZ(m_rp.m_tile[3]));
       check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(m_rp.m_tile_end[0] * m_rp.m_tile_end[1],
@@ -170,9 +171,9 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
     } else if (RP::rank == 5) {
       // id0,id1 encoded within threadIdx.x; id2,id3 to threadIdx.y; id4 to
       // threadIdx.z
-      const dim3 block(
-          m_rp.m_tile[0] * m_rp.m_tile[1], m_rp.m_tile[2] * m_rp.m_tile[3],
-          validateZ(m_rp.m_tile[4]));
+      const dim3 block(m_rp.m_tile[0] * m_rp.m_tile[1],
+                       m_rp.m_tile[2] * m_rp.m_tile[3],
+                       validateZ(m_rp.m_tile[4]));
       check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(m_rp.m_tile_end[0] * m_rp.m_tile_end[1],

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -105,7 +105,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
     };
     // make sure the block dimensions don't exceed the max number of threads
     // allowed
-    const auto check_block_sizes = [&](const dim3& block) {
+    const auto check_block_sizes = [&]([[maybe_unused]] const dim3& block) {
       KOKKOS_ASSERT(block.x > 0 && block.x <= maxthreads[0]);
       KOKKOS_ASSERT(block.y > 0 && block.y <= maxthreads[1]);
       KOKKOS_ASSERT(block.z > 0 && block.z <= maxthreads[2]);
@@ -113,7 +113,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
     };
     // make sure the grid dimensions don't exceed the max number of blocks
     // allowed
-    const auto check_grid_sizes = [&](const dim3& grid) {
+    const auto check_grid_sizes = [&]([[maybe_unused]] const dim3& grid) {
       KOKKOS_ASSERT(grid.x > 0 && grid.x <= maxblocks[0]);
       KOKKOS_ASSERT(grid.y > 0 && grid.y <= maxblocks[1]);
       KOKKOS_ASSERT(grid.z > 0 && grid.z <= maxblocks[2]);

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -97,7 +97,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
     if (m_rp.m_num_tiles == 0) return;
     const auto maxblocks  = m_rp.space().cuda_device_prop().maxGridSize;
     const auto maxthreads = m_rp.space().cuda_device_prop().maxThreadsDim;
-    const auto maxThreadsPerBlock =
+    [[maybe_unused]] const auto maxThreadsPerBlock =
         m_rp.space().cuda_device_prop().maxThreadsPerBlock;
     // make sure the Z dimension (it is less than x,y limits) isn't exceeded
     const auto validateZ = [&](const int input) {

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -100,23 +100,23 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
     [[maybe_unused]] const auto maxThreadsPerBlock =
         m_rp.space().cuda_device_prop().maxThreadsPerBlock;
     // make sure the Z dimension (it is less than x,y limits) isn't exceeded
-    const auto validateZ = [&](const int input) {
+    const auto clampZ = [&](const int input) {
       return (input > maxthreads[2] ? maxthreads[2] : input);
     };
     // make sure the block dimensions don't exceed the max number of threads
     // allowed
     const auto check_block_sizes = [&]([[maybe_unused]] const dim3& block) {
-      KOKKOS_ASSERT(block.x > 0 && block.x <= maxthreads[0]);
-      KOKKOS_ASSERT(block.y > 0 && block.y <= maxthreads[1]);
-      KOKKOS_ASSERT(block.z > 0 && block.z <= maxthreads[2]);
-      KOKKOS_ASSERT(block.x * block.y * block.z <= maxThreadsPerBlock);
+      KOKKOS_ASSERT(block.x > 0 && block.x <= (unsigned int)maxthreads[0]);
+      KOKKOS_ASSERT(block.y > 0 && block.y <= (unsigned int)maxthreads[1]);
+      KOKKOS_ASSERT(block.z > 0 && block.z <= (unsigned int)maxthreads[2]);
+      KOKKOS_ASSERT(block.x * block.y * block.z <= (unsigned int)maxThreadsPerBlock);
     };
     // make sure the grid dimensions don't exceed the max number of blocks
     // allowed
     const auto check_grid_sizes = [&]([[maybe_unused]] const dim3& grid) {
-      KOKKOS_ASSERT(grid.x > 0 && grid.x <= maxblocks[0]);
-      KOKKOS_ASSERT(grid.y > 0 && grid.y <= maxblocks[1]);
-      KOKKOS_ASSERT(grid.z > 0 && grid.z <= maxblocks[2]);
+      KOKKOS_ASSERT(grid.x > 0 && grid.x <= (unsigned int)maxblocks[0]);
+      KOKKOS_ASSERT(grid.y > 0 && grid.y <= (unsigned int)maxblocks[1]);
+      KOKKOS_ASSERT(grid.z > 0 && grid.z <= (unsigned int)maxblocks[2]);
     };
     if (RP::rank == 2) {
       const dim3 block(m_rp.m_tile[0], m_rp.m_tile[1], 1);
@@ -134,7 +134,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
     } else if (RP::rank == 3) {
       const dim3 block(m_rp.m_tile[0], m_rp.m_tile[1],
-                       validateZ(m_rp.m_tile[2]));
+                       clampZ(m_rp.m_tile[2]));
       check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(
@@ -154,7 +154,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
       // id0,id1 encoded within threadIdx.x; id2 to threadIdx.y; id3 to
       // threadIdx.z
       const dim3 block(m_rp.m_tile[0] * m_rp.m_tile[1], m_rp.m_tile[2],
-                       validateZ(m_rp.m_tile[3]));
+                       clampZ(m_rp.m_tile[3]));
       check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(m_rp.m_tile_end[0] * m_rp.m_tile_end[1],
@@ -173,7 +173,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
       // threadIdx.z
       const dim3 block(m_rp.m_tile[0] * m_rp.m_tile[1],
                        m_rp.m_tile[2] * m_rp.m_tile[3],
-                       validateZ(m_rp.m_tile[4]));
+                       clampZ(m_rp.m_tile[4]));
       check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(m_rp.m_tile_end[0] * m_rp.m_tile_end[1],
@@ -191,7 +191,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
       // threadIdx.z
       const dim3 block(m_rp.m_tile[0] * m_rp.m_tile[1],
                        m_rp.m_tile[2] * m_rp.m_tile[3],
-                       validateZ(m_rp.m_tile[4] * m_rp.m_tile[5]));
+                       clampZ(m_rp.m_tile[4] * m_rp.m_tile[5]));
       check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(m_rp.m_tile_end[0] * m_rp.m_tile_end[1],


### PR DESCRIPTION
Using the CUDA device metadata, set limits for the maximum block and grid dimensions. Adding additional debug assertions to make sure that we don't exceed legal limits. This fixes issue https://github.com/kokkos/kokkos/issues/7105