### PR TITLE
Fix clang-tidy header guard to ignore tpls

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,3 @@
 Checks: '-*,kokkos-*,modernize-use-using,modernize-use-nullptr,cppcoreguidelines-pro-type-cstyle-cast'
 FormatStyle: file
-HeaderFilterRegex: '.*/*.hpp'
+HeaderFilterRegex: '(algorithms|benchmarks|containers|core|example|simd).*\.hpp'

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -29,11 +29,11 @@ IF (NOT desul_FOUND)
     SET(DESUL_ATOMICS_ENABLE_OPENACC ON)
   ENDIF()
   CONFIGURE_FILE(
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../tpls/desul/Config.hpp.cmake.in
+    ${KOKKOS_SOURCE_DIR}/tpls/desul/Config.hpp.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/desul/atomics/Config.hpp
   )
   KOKKOS_INCLUDE_DIRECTORIES(
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../tpls/desul/include
+    ${KOKKOS_SOURCE_DIR}/tpls/desul/include
   )
 ENDIF()
 
@@ -98,20 +98,20 @@ ENDIF()
 
 IF (NOT desul_FOUND)
   IF (KOKKOS_ENABLE_CUDA)
-    APPEND_GLOB(KOKKOS_CORE_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/../../tpls/desul/src/Lock_Array_CUDA.cpp)
+    APPEND_GLOB(KOKKOS_CORE_SRCS ${KOKKOS_SOURCE_DIR}/tpls/desul/src/Lock_Array_CUDA.cpp)
   ELSEIF (KOKKOS_ENABLE_HIP)
-    APPEND_GLOB(KOKKOS_CORE_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/../../tpls/desul/src/Lock_Array_HIP.cpp)
+    APPEND_GLOB(KOKKOS_CORE_SRCS ${KOKKOS_SOURCE_DIR}/tpls/desul/src/Lock_Array_HIP.cpp)
   ELSEIF (KOKKOS_ENABLE_SYCL)
-    APPEND_GLOB(KOKKOS_CORE_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/../../tpls/desul/src/Lock_Array_SYCL.cpp)
+    APPEND_GLOB(KOKKOS_CORE_SRCS ${KOKKOS_SOURCE_DIR}/tpls/desul/src/Lock_Array_SYCL.cpp)
   ENDIF()
-  APPEND_GLOB(KOKKOS_CORE_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/../../tpls/desul/include/desul/*.hpp)
-  APPEND_GLOB(KOKKOS_CORE_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/../../tpls/desul/include/desul/*/*.hpp)
-  APPEND_GLOB(KOKKOS_CORE_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/../../tpls/desul/include/desul/*/*/*.hpp)
-  APPEND_GLOB(KOKKOS_CORE_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/../../tpls/desul/include/*/*/*.inc*)
+  APPEND_GLOB(KOKKOS_CORE_HEADERS ${KOKKOS_SOURCE_DIR}/tpls/desul/include/desul/*.hpp)
+  APPEND_GLOB(KOKKOS_CORE_HEADERS ${KOKKOS_SOURCE_DIR}/tpls/desul/include/desul/*/*.hpp)
+  APPEND_GLOB(KOKKOS_CORE_HEADERS ${KOKKOS_SOURCE_DIR}/tpls/desul/include/desul/*/*/*.hpp)
+  APPEND_GLOB(KOKKOS_CORE_HEADERS ${KOKKOS_SOURCE_DIR}/tpls/desul/include/*/*/*.inc*)
   APPEND_GLOB(KOKKOS_CORE_HEADERS ${CMAKE_CURRENT_BINARY_DIR}/desul/*.hpp)
 
   INSTALL (DIRECTORY
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../tpls/desul/include/desul"
+    "${KOKKOS_SOURCE_DIR}/tpls/desul/include/desul"
     "${CMAKE_CURRENT_BINARY_DIR}/desul"
     DESTINATION ${KOKKOS_HEADER_DIR}
     FILES_MATCHING
@@ -141,7 +141,7 @@ KOKKOS_LIB_INCLUDE_DIRECTORIES(kokkoscore
 )
 IF (NOT desul_FOUND)
   KOKKOS_LIB_INCLUDE_DIRECTORIES(kokkoscore
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../tpls/desul/include
+    ${KOKKOS_SOURCE_DIR}/tpls/desul/include
   )
 ENDIF()
 
@@ -164,20 +164,20 @@ IF (Kokkos_ENABLE_IMPL_MDSPAN)
   else()
     KOKKOS_LIB_INCLUDE_DIRECTORIES(
       kokkoscore
-      ${CMAKE_CURRENT_SOURCE_DIR}/../../tpls/mdspan/include
+      ${KOKKOS_SOURCE_DIR}/tpls/mdspan/include
     )
 
-    APPEND_GLOB(KOKKOS_CORE_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/../../tpls/mdspan/include/experimental/__p0009_bits/*.hpp)
-    APPEND_GLOB(KOKKOS_CORE_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/../../tpls/mdspan/include/experimental/mdspan)
+    APPEND_GLOB(KOKKOS_CORE_HEADERS ${KOKKOS_SOURCE_DIR}/tpls/mdspan/include/experimental/__p0009_bits/*.hpp)
+    APPEND_GLOB(KOKKOS_CORE_HEADERS ${KOKKOS_SOURCE_DIR}/tpls/mdspan/include/experimental/mdspan)
 
     INSTALL (DIRECTORY
-      "${CMAKE_CURRENT_SOURCE_DIR}/../../tpls/mdspan/include/"
+      "${KOKKOS_SOURCE_DIR}/tpls/mdspan/include/"
       DESTINATION ${KOKKOS_HEADER_DIR}
       FILES_MATCHING
       PATTERN "mdspan"
       PATTERN "*.hpp"
     )
-    MESSAGE(STATUS "Using internal mdspan directory ${CMAKE_CURRENT_SOURCE_DIR}/../../tpls/mdspan/include")
+    MESSAGE(STATUS "Using internal mdspan directory ${KOKKOS_SOURCE_DIR}/tpls/mdspan/include")
   endif()
 ENDIF()
 


### PR DESCRIPTION
Part of #7227. Currently, `clang-tidy` takes all header files (that end in `hpp`) in the source directory into account. This pull request makes sure that we only check header files in the
- algorithms,
- benchmarks,
- containers,
- core,
- example, and
- simd

directories to ignore `tpls`. A negative regex is only available from `clang-tidy` 19 on. For this to work properly, we also can't include tpl directories via a relative path from one of the above directories but must use absolute paths via `KOKKOS_SOURCE_DIR`.