### PR TITLE
OpenMPTarget: Update dockerfile for clang.

### DIFF
--- a/scripts/docker/Dockerfile.openmptarget
+++ b/scripts/docker/Dockerfile.openmptarget
@@ -55,6 +55,7 @@ RUN LLVM_URL=https://github.com/llvm/llvm-project/archive &&\
       -DCMAKE_CXX_COMPILER=g++ \
       -DLLVM_ENABLE_PROJECTS="clang" \
       -DLLVM_ENABLE_RUNTIMES="openmp" \
+      -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" \
       -DLIBOMPTARGET_DEVICE_ARCHITECTURES=sm_70 \
     ../llvm && \
     make -j${NPROC} && \


### PR DESCRIPTION
Draft:
The PR attempts to fix the random errors of "No GPU found" by updating the docker with options that build the NVIDIA target arch.