### PR TITLE
core(graph): promote `instantiate` to public API

### DIFF
--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -86,6 +86,11 @@ struct [[nodiscard]] Graph {
     return m_impl_ptr->get_execution_space();
   }
 
+  void instantiate() {
+    KOKKOS_EXPECTS(bool(m_impl_ptr))
+    (*m_impl_ptr).instantiate();
+  }
+
   void submit() const {
     KOKKOS_EXPECTS(bool(m_impl_ptr))
     (*m_impl_ptr).submit();

--- a/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
@@ -71,9 +71,12 @@ class GraphImpl<Kokkos::SYCL> {
   template <class... PredecessorRefs>
   auto create_aggregate_ptr(PredecessorRefs&&...);
 
- private:
-  void instantiate_graph() { m_graph_exec = m_graph.finalize(); }
+  void instantiate() {
+    KOKKOS_EXPECTS(!m_graph_exec.has_value());
+    m_graph_exec = m_graph.finalize();
+  }
 
+ private:
   Kokkos::SYCL m_execution_space;
   sycl::ext::oneapi::experimental::command_graph<
       sycl::ext::oneapi::experimental::graph_state::modifiable>
@@ -137,7 +140,7 @@ inline void GraphImpl<Kokkos::SYCL>::add_predecessor(
 
 inline void GraphImpl<Kokkos::SYCL>::submit() {
   if (!m_graph_exec) {
-    instantiate_graph();
+    instantiate();
   }
   m_execution_space.sycl_queue().ext_oneapi_graph(*m_graph_exec);
 }

--- a/core/src/impl/Kokkos_Default_Graph_Impl.hpp
+++ b/core/src/impl/Kokkos_Default_Graph_Impl.hpp
@@ -136,7 +136,13 @@ struct GraphImpl : private ExecutionSpaceInstanceStorage<ExecutionSpace> {
     return rv;
   }
 
+  void instantiate() {
+    KOKKOS_EXPECTS(!m_has_been_instantiated);
+    m_has_been_instantiated = true;
+  }
+
   void submit() {
+    if (!m_has_been_instantiated) instantiate();
     // This reset is gross, but for the purposes of our simple host
     // implementation...
     for (auto& sink : m_sinks) {
@@ -146,6 +152,9 @@ struct GraphImpl : private ExecutionSpaceInstanceStorage<ExecutionSpace> {
       sink->execute_node();
     }
   }
+
+ private:
+  bool m_has_been_instantiated = false;
 
   // </editor-fold> end required customizations }}}2
   //----------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

This PR adds `Kokkos::Graph::instantiate`. It allow to clearly separate the instantiation from the submission (see below).

Usage:
```c++
auto graph = Kokkos::Experimental::create_graph<...>(...);

graph.instantiate();

graph.submit();
```

### Description

It gives better opportunity to overlap graph instantiation with device workloads.

:four_leaf_clover: There is no breaking change for now. The user can still call `submit` without calling `instantiate` just before.

:bulb: The graph is composed of a *topological* graph, and an *executable* graph. Once `instantiate` is called, the *topological* graph is **locked**, *i.e.* the topology cannot be changed anymore, and the *executable* graph is created.

:warning: We restrict that the graph can only be instantiated once.

### Related

Emerged from #6904.