### PR TITLE
Allow extracting host and device views from DualView with const value type

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -387,11 +387,6 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
   /// \brief Return a View on a specific device \c Device.
   ///
-  /// Please don't be afraid of the nested if_c expressions in the return
-  /// value's type.  That just tells the method what the return type
-  /// should be: t_dev if the \c Device template parameter matches
-  /// this DualView's device type, else t_host.
-  ///
   /// For example, suppose you create a DualView on Cuda, like this:
   /// \code
   ///   using dual_view_type =
@@ -408,56 +403,44 @@ class DualView : public ViewTraits<DataType, Properties...> {
   ///   typename dual_view_type::t_host hostView = DV.view<host_device_type> ();
   /// \endcode
   template <class Device>
-  KOKKOS_INLINE_FUNCTION const typename std::conditional_t<
-      impl_device_matches_tdev_device<Device>::value, t_dev,
-      typename std::conditional_t<
-          impl_device_matches_thost_device<Device>::value, t_host,
-          typename std::conditional_t<
-              impl_device_matches_thost_exec<Device>::value, t_host,
-              typename std::conditional_t<
-                  impl_device_matches_tdev_exec<Device>::value, t_dev,
-                  typename std::conditional_t<
-                      impl_device_matches_tdev_memory_space<Device>::value,
-                      t_dev, t_host>>>>>
-  view() const {
-    constexpr bool device_is_memspace =
-        std::is_same<Device, typename Device::memory_space>::value;
-    constexpr bool device_is_execspace =
-        std::is_same<Device, typename Device::execution_space>::value;
-    constexpr bool device_exec_is_t_dev_exec =
-        std::is_same<typename Device::execution_space,
-                     typename t_dev::execution_space>::value;
-    constexpr bool device_mem_is_t_dev_mem =
-        std::is_same<typename Device::memory_space,
-                     typename t_dev::memory_space>::value;
-    constexpr bool device_exec_is_t_host_exec =
-        std::is_same<typename Device::execution_space,
-                     typename t_host::execution_space>::value;
-    constexpr bool device_mem_is_t_host_mem =
-        std::is_same<typename Device::memory_space,
-                     typename t_host::memory_space>::value;
-    constexpr bool device_is_t_host_device =
-        std::is_same<typename Device::execution_space,
-                     typename t_host::device_type>::value;
-    constexpr bool device_is_t_dev_device =
-        std::is_same<typename Device::memory_space,
-                     typename t_host::device_type>::value;
-
-    static_assert(
-        device_is_t_dev_device || device_is_t_host_device ||
-            (device_is_memspace &&
-             (device_mem_is_t_dev_mem || device_mem_is_t_host_mem)) ||
-            (device_is_execspace &&
-             (device_exec_is_t_dev_exec || device_exec_is_t_host_exec)) ||
-            ((!device_is_execspace && !device_is_memspace) &&
-             ((device_mem_is_t_dev_mem || device_mem_is_t_host_mem) ||
-              (device_exec_is_t_dev_exec || device_exec_is_t_host_exec))),
-        "Template parameter to .view() must exactly match one of the "
-        "DualView's device types or one of the execution or memory spaces");
-
-    return Impl::if_c<std::is_same<typename t_dev::memory_space,
-                                   typename Device::memory_space>::value,
-                      t_dev, t_host>::select(d_view, h_view);
+  KOKKOS_FUNCTION auto view() const {
+    if constexpr (std::is_same_v<Device, typename Device::memory_space>) {
+      if constexpr (std::is_same_v<typename Device::memory_space,
+                                   typename t_dev::memory_space>) {
+        return d_view;
+      } else {
+        static_assert(std::is_same_v<typename Device::memory_space,
+                                     typename t_host::memory_space>,
+                      "The template argument is a memory space but doesn't "
+                      "match either of DualView's memory spaces!");
+        return h_view;
+      }
+    } else {
+      if constexpr (std::is_same_v<Device, typename Device::execution_space>) {
+        if constexpr (std::is_same_v<typename Device::execution_space,
+                                     typename t_dev::execution_space>) {
+          return d_view;
+        } else {
+          static_assert(std::is_same_v<typename Device::execution_space,
+                                       typename t_host::execution_space>,
+                        "The template argument is an execution space but "
+                        "doesn't match either of DualView's execution spaces!");
+          return h_view;
+        }
+      } else {
+        static_assert(std::is_same_v<Device, typename Device::device_type>,
+                      "The template argument is neither a memory space, "
+                      "execution space, or device!");
+        if constexpr (std::is_same_v<Device, typename t_dev::device_type>)
+          return d_view;
+        else {
+          static_assert(std::is_same_v<Device, typename t_host::device_type>,
+                        "The template argument is a device but "
+                        "doesn't match either of DualView's devices!");
+          return h_view;
+        }
+      }
+    }
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -523,14 +523,14 @@ namespace {
 
 #ifdef KOKKOS_HAS_SHARED_SPACE
 template <typename ExecutionSpace>
-using SharedTestSpace = Kokkos::SharedSpace;
+using TestSharedSpace = Kokkos::SharedSpace;
 #else
 template <typename ExecutionSpace>
-using SharedTestSpace = typename ExecutionSpace::memory_space;
+using TestSharedSpace = typename ExecutionSpace::memory_space;
 #endif
 
 using ExecSpace  = Kokkos::DefaultExecutionSpace;
-using MemSpace   = SharedTestSpace<Kokkos::DefaultExecutionSpace>;
+using MemSpace   = TestSharedSpace<Kokkos::DefaultExecutionSpace>;
 using DeviceType = Kokkos::Device<ExecSpace, MemSpace>;
 
 using DualViewType = Kokkos::DualView<double*, Kokkos::LayoutLeft, DeviceType>;
@@ -539,7 +539,7 @@ using ConstDualViewType =
 using d_device = DeviceType;
 using h_device =
     Kokkos::Device<Kokkos::DefaultHostExecutionSpace,
-                   SharedTestSpace<Kokkos::DefaultHostExecutionSpace>>;
+                   TestSharedSpace<Kokkos::DefaultHostExecutionSpace>>;
 
 TEST(TEST_CATEGORY, dualview_device_correct_kokkos_device) {
   DualViewType dv("myView", 100);

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -603,8 +603,8 @@ TEST(TEST_CATEGORY,
      dualview_template_views_return_correct_executionspace_views) {
   DualViewType dv("myView", 100);
   dv.clear_sync_state();
-  using hvt = decltype(dv.view<typename Kokkos::DefaultHostExecutionSpace>());
-  using dvt = decltype(dv.view<typename Kokkos::DefaultExecutionSpace>());
+  using hvt = decltype(dv.view<Kokkos::DefaultHostExecutionSpace>());
+  using dvt = decltype(dv.view<Kokkos::DefaultExecutionSpace>());
   ASSERT_STREQ(Kokkos::DefaultExecutionSpace::name(),
                dvt::device_type::execution_space::name());
   ASSERT_STREQ(Kokkos::DefaultHostExecutionSpace::name(),
@@ -616,10 +616,10 @@ TEST(TEST_CATEGORY,
   DualViewType dv("myView", 100);
   ConstDualViewType const_dv = dv;
   dv.clear_sync_state();
-  ASSERT_EQ(dv.view<typename Kokkos::DefaultHostExecutionSpace>(),
-            const_dv.view<typename Kokkos::DefaultHostExecutionSpace>());
-  ASSERT_EQ(dv.view<typename Kokkos::DefaultExecutionSpace>(),
-            const_dv.view<typename Kokkos::DefaultExecutionSpace>());
+  ASSERT_EQ(dv.view<Kokkos::DefaultHostExecutionSpace>(),
+            const_dv.view<Kokkos::DefaultHostExecutionSpace>());
+  ASSERT_EQ(dv.view<Kokkos::DefaultExecutionSpace>(),
+            const_dv.view<Kokkos::DefaultExecutionSpace>());
 }
 
 }  // anonymous namespace

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -520,58 +520,26 @@ namespace {
  * that we keep the semantics of UVM DualViews intact.
  */
 // modify if we have other UVM enabled backends
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_SYCL) || \
-    defined(KOKKOS_ENABLE_HIP)  // OR other UVM builds
-#define UVM_ENABLED_BUILD
-#endif
 
-#ifdef UVM_ENABLED_BUILD
-template <typename ExecSpace>
-struct UVMSpaceFor;
-#endif
-
-#ifdef KOKKOS_ENABLE_CUDA  // specific to CUDA
-template <>
-struct UVMSpaceFor<Kokkos::Cuda> {
-  using type = Kokkos::CudaUVMSpace;
-};
-#endif
-
-#ifdef KOKKOS_ENABLE_SYCL  // specific to SYCL
-template <>
-struct UVMSpaceFor<Kokkos::SYCL> {
-  using type = Kokkos::SYCLSharedUSMSpace;
-};
-#endif
-
-#ifdef KOKKOS_ENABLE_HIP  // specific to HIP
-template <>
-struct UVMSpaceFor<Kokkos::HIP> {
-  using type = Kokkos::HIPManagedSpace;
-};
-#endif
-
-#ifdef UVM_ENABLED_BUILD
-template <>
-struct UVMSpaceFor<Kokkos::DefaultHostExecutionSpace> {
-  using type = typename UVMSpaceFor<Kokkos::DefaultExecutionSpace>::type;
-};
+#ifdef KOKKOS_HAS_SHARED_SPACE
+template <typename ExecutionSpace>
+using SharedTestSpace = Kokkos::SharedSpace;
 #else
-template <typename ExecSpace>
-struct UVMSpaceFor {
-  using type = typename ExecSpace::memory_space;
-};
+template <typename ExecutionSpace>
+using SharedTestSpace = typename ExecutionSpace::memory_space;
 #endif
 
 using ExecSpace  = Kokkos::DefaultExecutionSpace;
-using MemSpace   = typename UVMSpaceFor<Kokkos::DefaultExecutionSpace>::type;
+using MemSpace   = SharedTestSpace<Kokkos::DefaultExecutionSpace>;
 using DeviceType = Kokkos::Device<ExecSpace, MemSpace>;
 
 using DualViewType = Kokkos::DualView<double*, Kokkos::LayoutLeft, DeviceType>;
-using d_device     = DeviceType;
-using h_device     = Kokkos::Device<
-    Kokkos::DefaultHostExecutionSpace,
-    typename UVMSpaceFor<Kokkos::DefaultHostExecutionSpace>::type>;
+using ConstDualViewType =
+    Kokkos::DualView<const double*, Kokkos::LayoutLeft, DeviceType>;
+using d_device = DeviceType;
+using h_device =
+    Kokkos::Device<Kokkos::DefaultHostExecutionSpace,
+                   SharedTestSpace<Kokkos::DefaultHostExecutionSpace>>;
 
 TEST(TEST_CATEGORY, dualview_device_correct_kokkos_device) {
   DualViewType dv("myView", 100);
@@ -641,6 +609,17 @@ TEST(TEST_CATEGORY,
                dvt::device_type::execution_space::name());
   ASSERT_STREQ(Kokkos::DefaultHostExecutionSpace::name(),
                hvt::device_type::execution_space::name());
+}
+
+TEST(TEST_CATEGORY,
+     dualview_template_views_return_correct_views_from_const_dual_view) {
+  DualViewType dv("myView", 100);
+  ConstDualViewType const_dv = dv;
+  dv.clear_sync_state();
+  ASSERT_EQ(dv.view<typename Kokkos::DefaultHostExecutionSpace>(),
+            const_dv.view<typename Kokkos::DefaultHostExecutionSpace>());
+  ASSERT_EQ(dv.view<typename Kokkos::DefaultExecutionSpace>(),
+            const_dv.view<typename Kokkos::DefaultExecutionSpace>());
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
We discussed in https://kokkosteam.slack.com/archives/C5BGU5NDQ/p1724189696168339 that you can't get the underlying host and device `View`s of a `DualView` with `const` value type due to a mismatch between the respective return type and the the actual `View` returned. This pull request fixes that by just deducing the return type via `auto`.