### PR TITLE
Fix Deep_copy(serial_exec, dst, src) with multiple host backends

### DIFF
--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -192,8 +192,8 @@ struct DeepCopy<HostSpace, HostSpace, ExecutionSpace> {
   DeepCopy(const ExecutionSpace& exec, void* dst, const void* src, size_t n) {
     // If ExecutionSpace is a Device ExecutionSpace, we should call
     // this from DefaultHostExecutionSpace
-    if constexpr (std::is_same_v<ExecutionSpace, DefaultExecutionSpace> &&
-                  !std::is_same_v<ExecutionSpace, DefaultHostExecutionSpace>) {
+    if constexpr (!Kokkos::SpaceAccessibility<ExecutionSpace,
+                                              Kokkos::HostSpace>::accessible) {
       exec.fence(
           "Kokkos::Impl::DeepCopy<HostSpace, HostSpace, "
           "ExecutionSpace>::DeepCopy: fence before copy");

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -205,7 +205,13 @@ struct DeepCopy<HostSpace, HostSpace, ExecutionSpace> {
     exec.fence(
         "Kokkos::Impl::DeepCopy<HostSpace, HostSpace, "
         "ExecutionSpace>::DeepCopy: fence before copy");
-    hostspace_parallel_deepcopy_async(exec, dst, src, n);
+    // If ExecutionSpace is a Device ExecutionSpace, we should call
+    // this from DefaultHostExecutionSpace
+    if constexpr (std::is_same_v<ExecutionSpace, DefaultExecutionSpace>) {
+      hostspace_parallel_deepcopy_async(dst, src, n);
+    } else {
+      hostspace_parallel_deepcopy_async(exec, dst, src, n);
+    }
   }
 };
 

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -204,7 +204,8 @@ struct DeepCopy<HostSpace, HostSpace, ExecutionSpace> {
   DeepCopy(const ExecutionSpace& exec, void* dst, const void* src, size_t n) {
     // If ExecutionSpace is a Device ExecutionSpace, we should call
     // this from DefaultHostExecutionSpace
-    if constexpr (std::is_same_v<ExecutionSpace, DefaultExecutionSpace>) {
+    if constexpr (std::is_same_v<ExecutionSpace, DefaultExecutionSpace> &&
+                  !std::is_same_v<ExecutionSpace, DefaultHostExecutionSpace>) {
       exec.fence(
           "Kokkos::Impl::DeepCopy<HostSpace, HostSpace, "
           "ExecutionSpace>::DeepCopy: fence before copy");

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -190,8 +190,6 @@ struct DeepCopy<HostSpace, HostSpace, ExecutionSpace> {
   }
 
   DeepCopy(const ExecutionSpace& exec, void* dst, const void* src, size_t n) {
-    // If ExecutionSpace is a Device ExecutionSpace, we should call
-    // this from DefaultHostExecutionSpace
     if constexpr (!Kokkos::SpaceAccessibility<ExecutionSpace,
                                               Kokkos::HostSpace>::accessible) {
       exec.fence(

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -183,18 +183,6 @@ namespace Kokkos {
 
 namespace Impl {
 
-template <>
-struct DeepCopy<HostSpace, HostSpace, DefaultHostExecutionSpace> {
-  DeepCopy(void* dst, const void* src, size_t n) {
-    hostspace_parallel_deepcopy(dst, src, n);
-  }
-
-  DeepCopy(const DefaultHostExecutionSpace& exec, void* dst, const void* src,
-           size_t n) {
-    hostspace_parallel_deepcopy_async(exec, dst, src, n);
-  }
-};
-
 template <class ExecutionSpace>
 struct DeepCopy<HostSpace, HostSpace, ExecutionSpace> {
   DeepCopy(void* dst, const void* src, size_t n) {

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -205,7 +205,7 @@ struct DeepCopy<HostSpace, HostSpace, ExecutionSpace> {
     exec.fence(
         "Kokkos::Impl::DeepCopy<HostSpace, HostSpace, "
         "ExecutionSpace>::DeepCopy: fence before copy");
-    hostspace_parallel_deepcopy_async(dst, src, n);
+    hostspace_parallel_deepcopy_async(exec, dst, src, n);
   }
 };
 

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -202,12 +202,12 @@ struct DeepCopy<HostSpace, HostSpace, ExecutionSpace> {
   }
 
   DeepCopy(const ExecutionSpace& exec, void* dst, const void* src, size_t n) {
-    exec.fence(
-        "Kokkos::Impl::DeepCopy<HostSpace, HostSpace, "
-        "ExecutionSpace>::DeepCopy: fence before copy");
     // If ExecutionSpace is a Device ExecutionSpace, we should call
     // this from DefaultHostExecutionSpace
     if constexpr (std::is_same_v<ExecutionSpace, DefaultExecutionSpace>) {
+      exec.fence(
+          "Kokkos::Impl::DeepCopy<HostSpace, HostSpace, "
+          "ExecutionSpace>::DeepCopy: fence before copy");
       hostspace_parallel_deepcopy_async(dst, src, n);
     } else {
       hostspace_parallel_deepcopy_async(exec, dst, src, n);

--- a/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
+++ b/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
@@ -137,7 +137,7 @@ void hostspace_parallel_deepcopy_async(const ExecutionSpace& exec, void* dst,
   }
 }
 
-// Explicit instanciation
+// Explicit instantiation
 template void hostspace_parallel_deepcopy_async<DefaultHostExecutionSpace>(
     const DefaultHostExecutionSpace&, void*, const void*, ptrdiff_t);
 

--- a/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
+++ b/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
@@ -43,10 +43,10 @@ void hostspace_parallel_deepcopy_async(void* dst, const void* src,
       "Kokkos::Impl::hostspace_parallel_deepcopy_async: fence after copy");
 }
 
-void hostspace_parallel_deepcopy_async(const DefaultHostExecutionSpace& exec,
-                                       void* dst, const void* src,
-                                       ptrdiff_t n) {
-  using policy_t = Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>;
+template <typename ExecutionSpace>
+void hostspace_parallel_deepcopy_async(const ExecutionSpace& exec, void* dst,
+                                       const void* src, ptrdiff_t n) {
+  using policy_t = Kokkos::RangePolicy<ExecutionSpace>;
 
   // If the asynchronous HPX backend is enabled, do *not* copy anything
   // synchronously. The deep copy must be correctly sequenced with respect to
@@ -55,8 +55,7 @@ void hostspace_parallel_deepcopy_async(const DefaultHostExecutionSpace& exec,
 #if !(defined(KOKKOS_ENABLE_HPX) && \
       defined(KOKKOS_ENABLE_IMPL_HPX_ASYNC_DISPATCH))
   constexpr int host_deep_copy_serial_limit = 10 * 8192;
-  if ((n < host_deep_copy_serial_limit) ||
-      (DefaultHostExecutionSpace().concurrency() == 1)) {
+  if ((n < host_deep_copy_serial_limit) || (exec.concurrency() == 1)) {
     if (0 < n) std::memcpy(dst, src, n);
     return;
   }
@@ -138,6 +137,18 @@ void hostspace_parallel_deepcopy_async(const DefaultHostExecutionSpace& exec,
   }
 }
 
+// Explicit instanciation
+template void hostspace_parallel_deepcopy_async<DefaultHostExecutionSpace>(
+    const DefaultHostExecutionSpace&, void*, const void*, ptrdiff_t);
+
+#if defined(KOKKOS_ENABLE_SERIAL) &&                                    \
+    (defined(KOKKOS_ENABLE_OPENMP) || defined(KOKKOS_ENABLE_THREADS) || \
+     defined(KOKKOS_ENABLE_HPX))
+// Instanciate only if both the Serial backend and some other host parallel
+// backend are enabled
+template void hostspace_parallel_deepcopy_async<Kokkos::Serial>(
+    const Kokkos::Serial&, void*, const void*, ptrdiff_t);
+#endif
 }  // namespace Impl
 
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
+++ b/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
@@ -144,7 +144,7 @@ template void hostspace_parallel_deepcopy_async<DefaultHostExecutionSpace>(
 #if defined(KOKKOS_ENABLE_SERIAL) &&                                    \
     (defined(KOKKOS_ENABLE_OPENMP) || defined(KOKKOS_ENABLE_THREADS) || \
      defined(KOKKOS_ENABLE_HPX))
-// Instanciate only if both the Serial backend and some other host parallel
+// Instantiate only if both the Serial backend and some other host parallel
 // backend are enabled
 template void hostspace_parallel_deepcopy_async<Kokkos::Serial>(
     const Kokkos::Serial&, void*, const void*, ptrdiff_t);

--- a/core/src/impl/Kokkos_HostSpace_deepcopy.hpp
+++ b/core/src/impl/Kokkos_HostSpace_deepcopy.hpp
@@ -28,9 +28,9 @@ void hostspace_fence(const DefaultHostExecutionSpace& exec);
 void hostspace_parallel_deepcopy(void* dst, const void* src, ptrdiff_t n);
 // DeepCopy called with an execution space that can't access HostSpace
 void hostspace_parallel_deepcopy_async(void* dst, const void* src, ptrdiff_t n);
-void hostspace_parallel_deepcopy_async(const DefaultHostExecutionSpace& exec,
-                                       void* dst, const void* src, ptrdiff_t n);
-
+template <typename ExecutionSpace>
+void hostspace_parallel_deepcopy_async(const ExecutionSpace& exec, void* dst,
+                                       const void* src, ptrdiff_t n);
 }  // namespace Impl
 
 }  // namespace Kokkos


### PR DESCRIPTION
Fixes #7241 

This PR aims at using the correct execution space for the `deep_copy` when both the Serial backend and some other host parallel backends are enabled. 