### PR TITLE
Fix some more clang-tidy complains

### DIFF
--- a/core/src/impl/Kokkos_Tools_Generic.hpp
+++ b/core/src/impl/Kokkos_Tools_Generic.hpp
@@ -169,9 +169,8 @@ auto generic_tune_policy(const std::string& label_in, Map& map,
   if (should_tune(policy)) {
     std::string label = label_in;
     if (label_in.empty()) {
-      using policy_type =
-          typename std::remove_reference<decltype(policy)>::type;
-      using work_tag = typename policy_type::work_tag;
+      using policy_type = std::remove_reference_t<decltype(policy)>;
+      using work_tag    = typename policy_type::work_tag;
       Kokkos::Impl::ParallelConstructName<Functor, work_tag> name(label);
       label = name.get();
     }
@@ -197,9 +196,8 @@ auto generic_tune_policy(const std::string& label_in, Map& map,
   if (should_tune(policy)) {
     std::string label = label_in;
     if (label_in.empty()) {
-      using policy_type =
-          typename std::remove_reference<decltype(policy)>::type;
-      using work_tag = typename policy_type::work_tag;
+      using policy_type = std::remove_reference_t<decltype(policy)>;
+      using work_tag    = typename policy_type::work_tag;
       Kokkos::Impl::ParallelConstructName<Functor, work_tag> name(label);
       label = name.get();
     }
@@ -390,9 +388,8 @@ void generic_report_results(const std::string& label_in, Map& map,
   if (should_tune(policy)) {
     std::string label = label_in;
     if (label_in.empty()) {
-      using policy_type =
-          typename std::remove_reference<decltype(policy)>::type;
-      using work_tag = typename policy_type::work_tag;
+      using policy_type = std::remove_reference_t<decltype(policy)>;
+      using work_tag    = typename policy_type::work_tag;
       Kokkos::Impl::ParallelConstructName<Functor, work_tag> name(label);
       label = name.get();
     }

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -1434,10 +1434,10 @@ struct TestTeamBroadcast<ExecSpace, ScheduleType, T,
   }
 
   template <class ScalarType>
-  static inline std::enable_if_t<!std::is_integral<ScalarType>::value, void>
+  static inline std::enable_if_t<!std::is_integral_v<ScalarType>, void>
   compare_test(ScalarType A, ScalarType B, double epsilon_factor) {
-    if (std::is_same<ScalarType, double>::value ||
-        std::is_same<ScalarType, float>::value) {
+    if (std::is_same_v<ScalarType, double> ||
+        std::is_same_v<ScalarType, float>) {
       ASSERT_NEAR((double)A, (double)B,
                   epsilon_factor * std::abs(A) *
                       std::numeric_limits<ScalarType>::epsilon());
@@ -1447,7 +1447,7 @@ struct TestTeamBroadcast<ExecSpace, ScheduleType, T,
   }
 
   template <class ScalarType>
-  static inline std::enable_if_t<std::is_integral<ScalarType>::value, void>
+  static inline std::enable_if_t<std::is_integral_v<ScalarType>, void>
   compare_test(ScalarType A, ScalarType B, double) {
     ASSERT_EQ(A, B);
   }

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -280,7 +280,7 @@ namespace Test {
 
 // Test for non-arithmetic type
 TEST(TEST_CATEGORY, team_broadcast_long_wrapper) {
-  static_assert(!std::is_arithmetic<long_wrapper>::value);
+  static_assert(!std::is_arithmetic_v<long_wrapper>);
 
   TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
                     long_wrapper>::test_teambroadcast(0, 1);

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -741,8 +741,7 @@ struct TestViewMirror {
     int equal_ptr_h2_d = a_h2.data() == a_d.data() ? 1 : 0;
 
     int is_same_memspace =
-        std::is_same<Kokkos::HostSpace,
-                     typename DeviceType::memory_space>::value
+        std::is_same_v<Kokkos::HostSpace, typename DeviceType::memory_space>
             ? 1
             : 0;
     ASSERT_EQ(equal_ptr_h_h2, 1);
@@ -768,8 +767,7 @@ struct TestViewMirror {
     int equal_ptr_h3_d = a_h3.data() == a_d.data() ? 1 : 0;
 
     int is_same_memspace =
-        std::is_same<Kokkos::HostSpace,
-                     typename DeviceType::memory_space>::value
+        std::is_same_v<Kokkos::HostSpace, typename DeviceType::memory_space>
             ? 1
             : 0;
     ASSERT_EQ(equal_ptr_h_h2, 1);
@@ -863,8 +861,7 @@ struct TestViewMirror {
 
     int equal_ptr_h_d = (a_h.data() == a_d.data()) ? 1 : 0;
     constexpr int is_same_memspace =
-        std::is_same<Kokkos::HostSpace,
-                     typename DeviceType::memory_space>::value
+        std::is_same_v<Kokkos::HostSpace, typename DeviceType::memory_space>
             ? 1
             : 0;
 
@@ -958,8 +955,8 @@ class TestViewAPI {
     static_assert(std::is_same_v<typename view_type::HostMirror,
                                  typename view_type::host_mirror_type>);
 
-    static_assert(std::is_same<typename view_type::memory_space,
-                               typename mirror_type::memory_space>::value);
+    static_assert(std::is_same_v<typename view_type::memory_space,
+                                 typename mirror_type::memory_space>);
 
     view_type a("a");
     mirror_type am = Kokkos::create_mirror_view(a);

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -539,16 +539,15 @@ void test_view_mapping() {
     static_assert(a_int_r5::dimension::ArgN5 == 1);
 
     static_assert(
-        std::is_same<typename a_int_r1::dimension, ViewDimension<0> >::value);
-    static_assert(
-        std::is_same<typename a_int_r1::non_const_value_type, int>::value);
+        std::is_same_v<typename a_int_r1::dimension, ViewDimension<0> >);
+    static_assert(std::is_same_v<typename a_int_r1::non_const_value_type, int>);
 
     static_assert(a_const_int_r1::dimension::rank == 1);
     static_assert(a_const_int_r1::dimension::rank_dynamic == 1);
-    static_assert(std::is_same<typename a_const_int_r1::dimension,
-                               ViewDimension<0> >::value);
-    static_assert(std::is_same<typename a_const_int_r1::non_const_value_type,
-                               int>::value);
+    static_assert(
+        std::is_same_v<typename a_const_int_r1::dimension, ViewDimension<0> >);
+    static_assert(
+        std::is_same_v<typename a_const_int_r1::non_const_value_type, int>);
 
     static_assert(a_const_int_r5::dimension::rank == 5);
     static_assert(a_const_int_r5::dimension::rank_dynamic == 2);
@@ -560,17 +559,16 @@ void test_view_mapping() {
     static_assert(a_const_int_r5::dimension::ArgN4 == 6);
     static_assert(a_const_int_r5::dimension::ArgN5 == 1);
 
-    static_assert(std::is_same<typename a_const_int_r5::dimension,
-                               ViewDimension<0, 0, 4, 5, 6> >::value);
-    static_assert(std::is_same<typename a_const_int_r5::non_const_value_type,
-                               int>::value);
+    static_assert(std::is_same_v<typename a_const_int_r5::dimension,
+                                 ViewDimension<0, 0, 4, 5, 6> >);
+    static_assert(
+        std::is_same_v<typename a_const_int_r5::non_const_value_type, int>);
 
     static_assert(a_int_r5::dimension::rank == 5);
     static_assert(a_int_r5::dimension::rank_dynamic == 2);
-    static_assert(std::is_same<typename a_int_r5::dimension,
-                               ViewDimension<0, 0, 4, 5, 6> >::value);
-    static_assert(
-        std::is_same<typename a_int_r5::non_const_value_type, int>::value);
+    static_assert(std::is_same_v<typename a_int_r5::dimension,
+                                 ViewDimension<0, 0, 4, 5, 6> >);
+    static_assert(std::is_same_v<typename a_int_r5::non_const_value_type, int>);
   }
 
   {
@@ -588,8 +586,7 @@ void test_view_mapping() {
     static_assert(a_int_r5::dimension::ArgN2 == 0);
     static_assert(a_int_r5::dimension::ArgN3 == 3);
     static_assert(a_int_r5::dimension::ArgN4 == 4);
-    static_assert(
-        std::is_same<typename a_int_r5::non_const_value_type, int>::value);
+    static_assert(std::is_same_v<typename a_int_r5::non_const_value_type, int>);
   }
 
   {
@@ -597,54 +594,55 @@ void test_view_mapping() {
 
     using a_const_int_r1 = ViewDataAnalysis<const int[], void>;
 
-    static_assert(std::is_void<typename a_const_int_r1::specialize>::value);
-    static_assert(std::is_same<typename a_const_int_r1::dimension,
-                               Kokkos::Impl::ViewDimension<0> >::value);
+    static_assert(std::is_void_v<typename a_const_int_r1::specialize>);
+    static_assert(std::is_same_v<typename a_const_int_r1::dimension,
+                                 Kokkos::Impl::ViewDimension<0> >);
+
+    static_assert(std::is_same_v<typename a_const_int_r1::type, const int*>);
+    static_assert(
+        std::is_same_v<typename a_const_int_r1::value_type, const int>);
 
     static_assert(
-        std::is_same<typename a_const_int_r1::type, const int*>::value);
+        std::is_same_v<typename a_const_int_r1::scalar_array_type, const int*>);
     static_assert(
-        std::is_same<typename a_const_int_r1::value_type, const int>::value);
-
-    static_assert(std::is_same<typename a_const_int_r1::scalar_array_type,
-                               const int*>::value);
+        std::is_same_v<typename a_const_int_r1::const_type, const int*>);
     static_assert(
-        std::is_same<typename a_const_int_r1::const_type, const int*>::value);
-    static_assert(std::is_same<typename a_const_int_r1::const_value_type,
-                               const int>::value);
-    static_assert(std::is_same<typename a_const_int_r1::const_scalar_array_type,
-                               const int*>::value);
+        std::is_same_v<typename a_const_int_r1::const_value_type, const int>);
     static_assert(
-        std::is_same<typename a_const_int_r1::non_const_type, int*>::value);
-    static_assert(std::is_same<typename a_const_int_r1::non_const_value_type,
-                               int>::value);
+        std::is_same_v<typename a_const_int_r1::const_scalar_array_type,
+                       const int*>);
+    static_assert(
+        std::is_same_v<typename a_const_int_r1::non_const_type, int*>);
+    static_assert(
+        std::is_same_v<typename a_const_int_r1::non_const_value_type, int>);
 
     using a_const_int_r3 = ViewDataAnalysis<const int** [4], void>;
 
-    static_assert(std::is_void<typename a_const_int_r3::specialize>::value);
+    static_assert(std::is_void_v<typename a_const_int_r3::specialize>);
 
-    static_assert(std::is_same<typename a_const_int_r3::dimension,
-                               Kokkos::Impl::ViewDimension<0, 0, 4> >::value);
+    static_assert(std::is_same_v<typename a_const_int_r3::dimension,
+                                 Kokkos::Impl::ViewDimension<0, 0, 4> >);
 
     static_assert(
-        std::is_same<typename a_const_int_r3::type, const int** [4]>::value);
+        std::is_same_v<typename a_const_int_r3::type, const int** [4]>);
     static_assert(
-        std::is_same<typename a_const_int_r3::value_type, const int>::value);
-    static_assert(std::is_same<typename a_const_int_r3::scalar_array_type,
-                               const int** [4]>::value);
-    static_assert(std::is_same<typename a_const_int_r3::const_type,
-                               const int** [4]>::value);
-    static_assert(std::is_same<typename a_const_int_r3::const_value_type,
-                               const int>::value);
-    static_assert(std::is_same<typename a_const_int_r3::const_scalar_array_type,
-                               const int** [4]>::value);
-    static_assert(std::is_same<typename a_const_int_r3::non_const_type,
-                               int** [4]>::value);
-    static_assert(std::is_same<typename a_const_int_r3::non_const_value_type,
-                               int>::value);
+        std::is_same_v<typename a_const_int_r3::value_type, const int>);
+    static_assert(std::is_same_v<typename a_const_int_r3::scalar_array_type,
+                                 const int** [4]>);
     static_assert(
-        std::is_same<typename a_const_int_r3::non_const_scalar_array_type,
-                     int** [4]>::value);
+        std::is_same_v<typename a_const_int_r3::const_type, const int** [4]>);
+    static_assert(
+        std::is_same_v<typename a_const_int_r3::const_value_type, const int>);
+    static_assert(
+        std::is_same_v<typename a_const_int_r3::const_scalar_array_type,
+                       const int** [4]>);
+    static_assert(
+        std::is_same_v<typename a_const_int_r3::non_const_type, int** [4]>);
+    static_assert(
+        std::is_same_v<typename a_const_int_r3::non_const_value_type, int>);
+    static_assert(
+        std::is_same_v<typename a_const_int_r3::non_const_scalar_array_type,
+                       int** [4]>);
 
     // std::cout << "typeid( const int**[4] ).name() = " << typeid( const
     // int**[4] ).name() << std::endl;
@@ -672,44 +670,43 @@ void test_view_mapping() {
     ASSERT_EQ(vr1.data(), &data[0]);
     ASSERT_EQ(cr1.data(), &data[0]);
 
-    ASSERT_TRUE((std::is_same<typename T::data_type, int*>::value));
-    ASSERT_TRUE((std::is_same<typename T::const_data_type, const int*>::value));
-    ASSERT_TRUE((std::is_same<typename T::non_const_data_type, int*>::value));
+    ASSERT_TRUE((std::is_same_v<typename T::data_type, int*>));
+    ASSERT_TRUE((std::is_same_v<typename T::const_data_type, const int*>));
+    ASSERT_TRUE((std::is_same_v<typename T::non_const_data_type, int*>));
 
-    ASSERT_TRUE((std::is_same<typename T::scalar_array_type, int*>::value));
+    ASSERT_TRUE((std::is_same_v<typename T::scalar_array_type, int*>));
     ASSERT_TRUE(
-        (std::is_same<typename T::const_scalar_array_type, const int*>::value));
+        (std::is_same_v<typename T::const_scalar_array_type, const int*>));
     ASSERT_TRUE(
-        (std::is_same<typename T::non_const_scalar_array_type, int*>::value));
+        (std::is_same_v<typename T::non_const_scalar_array_type, int*>));
 
-    ASSERT_TRUE((std::is_same<typename T::value_type, int>::value));
-    ASSERT_TRUE((std::is_same<typename T::const_value_type, const int>::value));
-    ASSERT_TRUE((std::is_same<typename T::non_const_value_type, int>::value));
+    ASSERT_TRUE((std::is_same_v<typename T::value_type, int>));
+    ASSERT_TRUE((std::is_same_v<typename T::const_value_type, const int>));
+    ASSERT_TRUE((std::is_same_v<typename T::non_const_value_type, int>));
 
-    ASSERT_TRUE((std::is_same<typename T::memory_space,
-                              typename Space::memory_space>::value));
-    ASSERT_TRUE((std::is_same<typename T::reference_type, int&>::value));
+    ASSERT_TRUE((std::is_same_v<typename T::memory_space,
+                                typename Space::memory_space>));
+    ASSERT_TRUE((std::is_same_v<typename T::reference_type, int&>));
 
     ASSERT_EQ(T::rank, size_t(1));
 
-    ASSERT_TRUE((std::is_same<typename C::data_type, const int*>::value));
-    ASSERT_TRUE((std::is_same<typename C::const_data_type, const int*>::value));
-    ASSERT_TRUE((std::is_same<typename C::non_const_data_type, int*>::value));
+    ASSERT_TRUE((std::is_same_v<typename C::data_type, const int*>));
+    ASSERT_TRUE((std::is_same_v<typename C::const_data_type, const int*>));
+    ASSERT_TRUE((std::is_same_v<typename C::non_const_data_type, int*>));
 
+    ASSERT_TRUE((std::is_same_v<typename C::scalar_array_type, const int*>));
     ASSERT_TRUE(
-        (std::is_same<typename C::scalar_array_type, const int*>::value));
+        (std::is_same_v<typename C::const_scalar_array_type, const int*>));
     ASSERT_TRUE(
-        (std::is_same<typename C::const_scalar_array_type, const int*>::value));
-    ASSERT_TRUE(
-        (std::is_same<typename C::non_const_scalar_array_type, int*>::value));
+        (std::is_same_v<typename C::non_const_scalar_array_type, int*>));
 
-    ASSERT_TRUE((std::is_same<typename C::value_type, const int>::value));
-    ASSERT_TRUE((std::is_same<typename C::const_value_type, const int>::value));
-    ASSERT_TRUE((std::is_same<typename C::non_const_value_type, int>::value));
+    ASSERT_TRUE((std::is_same_v<typename C::value_type, const int>));
+    ASSERT_TRUE((std::is_same_v<typename C::const_value_type, const int>));
+    ASSERT_TRUE((std::is_same_v<typename C::non_const_value_type, int>));
 
-    ASSERT_TRUE((std::is_same<typename C::memory_space,
-                              typename Space::memory_space>::value));
-    ASSERT_TRUE((std::is_same<typename C::reference_type, const int&>::value));
+    ASSERT_TRUE((std::is_same_v<typename C::memory_space,
+                                typename Space::memory_space>));
+    ASSERT_TRUE((std::is_same_v<typename C::reference_type, const int&>));
 
     ASSERT_EQ(C::rank, size_t(1));
 
@@ -741,23 +738,23 @@ void test_view_mapping() {
     T vr1("vr1", N);
     C cr1(vr1);
 
-    ASSERT_TRUE((std::is_same<typename T::data_type, int*>::value));
-    ASSERT_TRUE((std::is_same<typename T::const_data_type, const int*>::value));
-    ASSERT_TRUE((std::is_same<typename T::non_const_data_type, int*>::value));
+    ASSERT_TRUE((std::is_same_v<typename T::data_type, int*>));
+    ASSERT_TRUE((std::is_same_v<typename T::const_data_type, const int*>));
+    ASSERT_TRUE((std::is_same_v<typename T::non_const_data_type, int*>));
 
-    ASSERT_TRUE((std::is_same<typename T::scalar_array_type, int*>::value));
+    ASSERT_TRUE((std::is_same_v<typename T::scalar_array_type, int*>));
     ASSERT_TRUE(
-        (std::is_same<typename T::const_scalar_array_type, const int*>::value));
+        (std::is_same_v<typename T::const_scalar_array_type, const int*>));
     ASSERT_TRUE(
-        (std::is_same<typename T::non_const_scalar_array_type, int*>::value));
+        (std::is_same_v<typename T::non_const_scalar_array_type, int*>));
 
-    ASSERT_TRUE((std::is_same<typename T::value_type, int>::value));
-    ASSERT_TRUE((std::is_same<typename T::const_value_type, const int>::value));
-    ASSERT_TRUE((std::is_same<typename T::non_const_value_type, int>::value));
+    ASSERT_TRUE((std::is_same_v<typename T::value_type, int>));
+    ASSERT_TRUE((std::is_same_v<typename T::const_value_type, const int>));
+    ASSERT_TRUE((std::is_same_v<typename T::non_const_value_type, int>));
 
-    ASSERT_TRUE((std::is_same<typename T::memory_space,
-                              typename Space::memory_space>::value));
-    ASSERT_TRUE((std::is_same<typename T::reference_type, int&>::value));
+    ASSERT_TRUE((std::is_same_v<typename T::memory_space,
+                                typename Space::memory_space>));
+    ASSERT_TRUE((std::is_same_v<typename T::reference_type, int&>));
     ASSERT_EQ(T::rank, size_t(1));
 
     ASSERT_EQ(vr1.extent(0), size_t(N));
@@ -795,8 +792,8 @@ void test_view_mapping() {
   // Testing using space instance for allocation.
   // The execution space of the memory space must be available for view data
   // initialization.
-  if (std::is_same<ExecSpace,
-                   typename ExecSpace::memory_space::execution_space>::value) {
+  if (std::is_same_v<ExecSpace,
+                     typename ExecSpace::memory_space::execution_space>) {
     using namespace Kokkos;
 
     using memory_space = typename ExecSpace::memory_space;


### PR DESCRIPTION
It seems we merged some changes between the last rebase of the "modernize type-traits" that were not fixed.