### PR TITLE
core(graph): allow submission onto an arbitrary exec space instance

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -160,13 +160,13 @@ struct GraphImpl<Kokkos::Cuda> {
                                                    &cuda_node, 1)));
   }
 
-  void submit() {
+  void submit(const execution_space& exec) {
     if (!bool(m_graph_exec)) {
       instantiate();
     }
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (m_execution_space.impl_internal_space_instance()
-             ->cuda_graph_launch_wrapper(m_graph_exec)));
+        (exec.impl_internal_space_instance()->cuda_graph_launch_wrapper(
+            m_graph_exec)));
   }
 
   execution_space const& get_execution_space() const noexcept {

--- a/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
@@ -60,7 +60,7 @@ class GraphImpl<Kokkos::HIP> {
   template <class NodeImplPtr, class PredecessorRef>
   void add_predecessor(NodeImplPtr arg_node_ptr, PredecessorRef arg_pred_ref);
 
-  void submit();
+  void submit(const Kokkos::HIP& exec);
 
   Kokkos::HIP const& get_execution_space() const noexcept;
 
@@ -147,12 +147,11 @@ inline void GraphImpl<Kokkos::HIP>::add_predecessor(
       hipGraphAddDependencies(m_graph, &pred_node, &node, 1));
 }
 
-inline void GraphImpl<Kokkos::HIP>::submit() {
+inline void GraphImpl<Kokkos::HIP>::submit(const Kokkos::HIP& exec) {
   if (!m_graph_exec) {
     instantiate();
   }
-  KOKKOS_IMPL_HIP_SAFE_CALL(
-      hipGraphLaunch(m_graph_exec, m_execution_space.hip_stream()));
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphLaunch(m_graph_exec, exec.hip_stream()));
 }
 
 inline Kokkos::HIP const& GraphImpl<Kokkos::HIP>::get_execution_space()

--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -91,10 +91,12 @@ struct [[nodiscard]] Graph {
     (*m_impl_ptr).instantiate();
   }
 
-  void submit() const {
+  void submit(const execution_space& exec) const {
     KOKKOS_EXPECTS(bool(m_impl_ptr))
-    (*m_impl_ptr).submit();
+    (*m_impl_ptr).submit(exec);
   }
+
+  void submit() const { submit(get_execution_space()); }
 };
 
 // </editor-fold> end Graph }}}1

--- a/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
@@ -62,7 +62,7 @@ class GraphImpl<Kokkos::SYCL> {
   template <class NodeImplPtr, class PredecessorRef>
   void add_predecessor(NodeImplPtr arg_node_ptr, PredecessorRef arg_pred_ref);
 
-  void submit();
+  void submit(const Kokkos::SYCL& exec);
 
   Kokkos::SYCL const& get_execution_space() const noexcept;
 
@@ -138,11 +138,11 @@ inline void GraphImpl<Kokkos::SYCL>::add_predecessor(
   m_graph.make_edge(*pred_node, *node);
 }
 
-inline void GraphImpl<Kokkos::SYCL>::submit() {
+inline void GraphImpl<Kokkos::SYCL>::submit(const Kokkos::SYCL& exec) {
   if (!m_graph_exec) {
     instantiate();
   }
-  m_execution_space.sycl_queue().ext_oneapi_graph(*m_graph_exec);
+  exec.sycl_queue().ext_oneapi_graph(*m_graph_exec);
 }
 
 inline Kokkos::SYCL const& GraphImpl<Kokkos::SYCL>::get_execution_space()

--- a/core/src/impl/Kokkos_Default_Graph_Impl.hpp
+++ b/core/src/impl/Kokkos_Default_Graph_Impl.hpp
@@ -141,7 +141,8 @@ struct GraphImpl : private ExecutionSpaceInstanceStorage<ExecutionSpace> {
     m_has_been_instantiated = true;
   }
 
-  void submit() {
+  // FIXME The execution space instance should be passed to the nodes.
+  void submit(const ExecutionSpace& /* exec */) {
     if (!m_has_been_instantiated) instantiate();
     // This reset is gross, but for the purposes of our simple host
     // implementation...


### PR DESCRIPTION
From a semantic standpoint, `Kokkos::Graph` must be used in a three-phases way.

1. :books: *definition* (add nodes and edges according to a DAG graph to create a *topological* graph)
2. :hotsprings: *instantiation* (check DAG for flaws and prepare the *executable* graph)
3. :fire: *submission* (launch the *executable* graph)

The submission can be viewed as throwing a bunch of kernels to the device, and as such must orchestrate them in some queue. Therefore, `submit` should accept an execution space instance.

### Going further

- [x] For some backends, adding nodes to the graph effectively triggers some asynchronous copies to devices under some circumstances (*e.g.* for `Cuda` we would async copy the driver to the global memory while creating the `Cuda` graph node). Proper fencing is therefore required before submission.
- [x] I still need to check that this makes sense with [P2300](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html).