### PR TITLE
Update nightly CI from ROCm 6.1 to ROCm 6.2

### DIFF
--- a/.jenkins_nightly
+++ b/.jenkins_nightly
@@ -100,12 +100,12 @@ pipeline {
                           '''
                     }
                 }
-                stage('HIP-ROCM-6.1') {
+                stage('HIP-ROCM-6.2') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.hipcc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-22.04:6.1.2-complete'
+                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-22.04:6.2-complete'
                             label 'rocm-docker && AMD_Radeon_Instinct_MI210'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
                         }


### PR DESCRIPTION
Update the nightly to use the latest version of ROCm