### PR TITLE
Move Kokkos_View.hpp in prep for mdspan overhaul

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1,0 +1,27 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+#include <Kokkos_Macros.hpp>
+static_assert(false,
+              "Including non-public Kokkos header files is not allowed.");
+#endif
+#ifndef KOKKOS_VIEW_HPP
+#define KOKKOS_VIEW_HPP
+
+#include <View/Kokkos_ViewLegacy.hpp>
+
+#endif /* KOKKOS_VIEW_HPP */

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -19,8 +19,8 @@
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");
 #endif
-#ifndef KOKKOS_VIEW_HPP
-#define KOKKOS_VIEW_HPP
+#ifndef KOKKOS_VIEWLEGACY_HPP
+#define KOKKOS_VIEWLEGACY_HPP
 
 #include <type_traits>
 #include <string>
@@ -2033,4 +2033,4 @@ KOKKOS_INLINE_FUNCTION DeducedCommonPropsType<Views...> common_view_alloc_prop(
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-#endif /* #ifndef KOKKOS_VIEW_HPP */
+#endif /* #ifndef KOKKOS_VIEWLEGACY_HPP */


### PR DESCRIPTION
We will have an option for some time to switch between the legacy and the new implementation (based on mdspan). Switching between them will largely just change which implementation is visible, with the legacy implementation isolated to the existing file. The new implementation will go into the Kokkos_View.hpp then. 

I.e.: 
```c++
#define KOKKOS_VIEW_HPP

#ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
#include <View/Kokkos_ViewLegacy.hpp>
#else

....

#endif /* KOKKOS_ENABLE_IMPL_VIEW_LEGACY */
#endif /* KOKKOS_VIEW_HPP */
```