### PR TITLE
Do not showcase using facility from `Impl::` in examples

### DIFF
--- a/example/tutorial/Advanced_Views/04_dualviews/dual_view.cpp
+++ b/example/tutorial/Advanced_Views/04_dualviews/dual_view.cpp
@@ -48,9 +48,9 @@ struct localsum {
   // overrides Kokkos' default execution space.
   using execution_space = ExecutionSpace;
 
-  using memory_space = typename Kokkos::Impl::if_c<
+  using memory_space = std::conditional_t<
       std::is_same_v<ExecutionSpace, Kokkos::DefaultExecutionSpace>,
-      idx_type::memory_space, idx_type::host_mirror_space>::type;
+      idx_type::memory_space, idx_type::host_mirror_space>;
 
   // Get the view types on the particular device for which the functor
   // is instantiated.


### PR DESCRIPTION
Prefer `std::conditional_t` to `Impl::if_c`, even more so when it is an example

This is the only instance I could find in our examples and benchmarks