### PR TITLE
Prefer `std::conditional_t<T>` to `typename Impl::if_c<T>::type`

### DIFF
--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -143,8 +143,8 @@ class ThreadsExecTeamMember {
 
     KOKKOS_IF_ON_HOST((
         // Make sure there is enough scratch space:
-        using type = typename if_c<sizeof(ValueType) < TEAM_REDUCE_SIZE,
-                                   ValueType, void>::type;
+        using type = std::conditional_t<sizeof(ValueType) < TEAM_REDUCE_SIZE,
+                                        ValueType, void>;
 
         if (m_team_base) {
           type* const local_value = ((type*)m_team_base[0]->scratch_memory());
@@ -164,8 +164,8 @@ class ThreadsExecTeamMember {
 
     KOKKOS_IF_ON_HOST((
         // Make sure there is enough scratch space:
-        using type = typename if_c<sizeof(ValueType) < TEAM_REDUCE_SIZE,
-                                   ValueType, void>::type;
+        using type = std::conditional_t<sizeof(ValueType) < TEAM_REDUCE_SIZE,
+                                        ValueType, void>;
         f(value); if (m_team_base) {
           type* const local_value = ((type*)m_team_base[0]->scratch_memory());
           memory_fence();
@@ -186,7 +186,7 @@ class ThreadsExecTeamMember {
     KOKKOS_IF_ON_HOST((
         // Make sure there is enough scratch space:
         using type =
-            typename if_c<sizeof(Type) < TEAM_REDUCE_SIZE, Type, void>::type;
+            std::conditional_t<sizeof(Type) < TEAM_REDUCE_SIZE, Type, void>;
 
         if (team_rank() != team_size() - 1) *
             ((volatile type*)m_instance->scratch_memory()) = value;
@@ -224,8 +224,8 @@ class ThreadsExecTeamMember {
     KOKKOS_IF_ON_HOST((
         using value_type = typename ReducerType::value_type;
         // Make sure there is enough scratch space:
-        using type = typename if_c<sizeof(value_type) < TEAM_REDUCE_SIZE,
-                                   value_type, void>::type;
+        using type = std::conditional_t<sizeof(value_type) < TEAM_REDUCE_SIZE,
+                                        value_type, void>;
 
         type* const local_value = ((type*)m_instance->scratch_memory());
 
@@ -278,8 +278,8 @@ class ThreadsExecTeamMember {
     KOKKOS_IF_ON_DEVICE(((void)global_accum; return value;))
 
     KOKKOS_IF_ON_HOST((  // Make sure there is enough scratch space:
-        using type = typename if_c<sizeof(ArgType) < TEAM_REDUCE_SIZE, ArgType,
-                                   void>::type;
+        using type = std::conditional_t<sizeof(ArgType) < TEAM_REDUCE_SIZE,
+                                        ArgType, void>;
 
         volatile type* const work_value = ((type*)m_instance->scratch_memory());
 


### PR DESCRIPTION
Prefer standard facility to homegrown solution that it would be nice to get rid of.
We are left with two use cases that use a different functionality of `Impl::if_c` that need more thought to refactor.
```
core/src/Kokkos_GraphNode.hpp:380:    using reducer_selector = Kokkos::Impl::if_c<
core/src/Kokkos_Parallel_Reduce.hpp:1501:        Kokkos::Impl::if_c<std::is_same_v<InvalidType, PassedReducerType>,