### PR TITLE
update `Random_UniqueIndexget_state_idx to take locks_view_type by reference

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -615,7 +615,7 @@ template <class DeviceType>
 struct Random_UniqueIndex {
   using locks_view_type = View<int**, DeviceType>;
   KOKKOS_FUNCTION
-  static int get_state_idx(const locks_view_type) {
+  static int get_state_idx(const locks_view_type&) {
     KOKKOS_IF_ON_HOST(
         (return DeviceType::execution_space::impl_hardware_thread_id();))
 


### PR DESCRIPTION
Since the `lockview` type was not passed by reference this was causing a construction and destruction of 