### PR TITLE
Fix bogus icpc -Werror

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -441,6 +441,9 @@ class DualView : public ViewTraits<DataType, Properties...> {
         }
       }
     }
+#ifdef KOKKOS_COMPILER_INTEL
+    __builtin_unreachable();
+#endif
   }
 
   KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
Workaround error #1011: missing return statement at end of non-void function