### PR TITLE
Add proper testing for kernel names passed to the tools interface

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -1082,6 +1082,7 @@ endif()
     UnitTestMainInit.cpp
     tools/TestEventCorrectness.cpp
     tools/TestWithoutInitializing.cpp
+    tools/TestKernelNames.cpp
     tools/TestProfilingSection.cpp
     tools/TestScopedRegion.cpp
     )

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -1081,10 +1081,10 @@ endif()
   SET(KOKKOSP_SOURCES
     UnitTestMainInit.cpp
     tools/TestEventCorrectness.cpp
-    tools/TestWithoutInitializing.cpp
     tools/TestKernelNames.cpp
     tools/TestProfilingSection.cpp
     tools/TestScopedRegion.cpp
+    tools/TestWithoutInitializing.cpp
     )
 
   # FIXME_OPENMPTARGET This test causes internal compiler errors as of 09/01/22

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -60,32 +60,9 @@ struct TestRange {
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, ScheduleType>(0, N),
                          *this);
 
-    {
-      using ThisType = TestRange<ExecSpace, ScheduleType>;
-      std::string label("parallel_for");
-      Kokkos::Impl::ParallelConstructName<ThisType, void> pcn(label);
-      ASSERT_EQ(pcn.get(), label);
-      std::string empty_label("");
-      Kokkos::Impl::ParallelConstructName<ThisType, void> empty_pcn(
-          empty_label);
-      ASSERT_EQ(empty_pcn.get(), typeid(ThisType).name());
-    }
-
     Kokkos::parallel_for(
         Kokkos::RangePolicy<ExecSpace, ScheduleType, VerifyInitTag>(0, N),
         *this);
-
-    {
-      using ThisType = TestRange<ExecSpace, ScheduleType>;
-      std::string label("parallel_for");
-      Kokkos::Impl::ParallelConstructName<ThisType, VerifyInitTag> pcn(label);
-      ASSERT_EQ(pcn.get(), label);
-      std::string empty_label("");
-      Kokkos::Impl::ParallelConstructName<ThisType, VerifyInitTag> empty_pcn(
-          empty_label);
-      ASSERT_EQ(empty_pcn.get(), std::string(typeid(ThisType).name()) + "/" +
-                                     typeid(VerifyInitTag).name());
-    }
 
     Kokkos::deep_copy(host_flags, m_flags);
 

--- a/core/unit_test/TestRangePolicyRequire.hpp
+++ b/core/unit_test/TestRangePolicyRequire.hpp
@@ -55,34 +55,11 @@ struct TestRangeRequire {
             Kokkos::RangePolicy<ExecSpace, ScheduleType>(0, N), Property()),
         *this);
 
-    {
-      using ThisType = TestRangeRequire<ExecSpace, ScheduleType, Property>;
-      std::string label("parallel_for");
-      Kokkos::Impl::ParallelConstructName<ThisType, void> pcn(label);
-      ASSERT_EQ(pcn.get(), label);
-      std::string empty_label("");
-      Kokkos::Impl::ParallelConstructName<ThisType, void> empty_pcn(
-          empty_label);
-      ASSERT_EQ(empty_pcn.get(), typeid(ThisType).name());
-    }
-
     Kokkos::parallel_for(
         Kokkos::Experimental::require(
             Kokkos::RangePolicy<ExecSpace, ScheduleType, VerifyInitTag>(0, N),
             Property()),
         *this);
-
-    {
-      using ThisType = TestRangeRequire<ExecSpace, ScheduleType, Property>;
-      std::string label("parallel_for");
-      Kokkos::Impl::ParallelConstructName<ThisType, VerifyInitTag> pcn(label);
-      ASSERT_EQ(pcn.get(), label);
-      std::string empty_label("");
-      Kokkos::Impl::ParallelConstructName<ThisType, VerifyInitTag> empty_pcn(
-          empty_label);
-      ASSERT_EQ(empty_pcn.get(), std::string(typeid(ThisType).name()) + "/" +
-                                     typeid(VerifyInitTag).name());
-    }
 
     Kokkos::deep_copy(host_flags, m_flags);
 

--- a/core/unit_test/tools/TestKernelNames.cpp
+++ b/core/unit_test/tools/TestKernelNames.cpp
@@ -158,4 +158,26 @@ TEST(kokkosp, kernel_name_parallel_reduce) {
 
 TEST(kokkosp, kernel_name_parallel_scan) { test_kernel_name_parallel_scan(); }
 
+TEST(kokkosp, kernel_name_internal) {
+  struct ThisType {};
+  {
+    std::string const label("my_label");
+    Kokkos::Impl::ParallelConstructName<ThisType, void> pcn(label);
+    ASSERT_EQ(pcn.get(), label);
+    std::string const empty_label("");
+    Kokkos::Impl::ParallelConstructName<ThisType, void> empty_pcn(empty_label);
+    ASSERT_EQ(empty_pcn.get(), typeid(ThisType).name());
+  }
+  {
+    std::string const label("my_label");
+    Kokkos::Impl::ParallelConstructName<ThisType, WorkTag> pcn(label);
+    ASSERT_EQ(pcn.get(), label);
+    std::string const empty_label("");
+    Kokkos::Impl::ParallelConstructName<ThisType, WorkTag> empty_pcn(
+        empty_label);
+    ASSERT_EQ(empty_pcn.get(), std::string(typeid(ThisType).name()) + "/" +
+                                   typeid(WorkTag).name());
+  }
+}
+
 }  // namespace

--- a/core/unit_test/tools/TestKernelNames.cpp
+++ b/core/unit_test/tools/TestKernelNames.cpp
@@ -93,11 +93,13 @@ void test_kernel_name_parallel_reduce() {
 
     Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecutionSpace>(0, 1),
                             my_lambda, my_result);
-    ASSERT_NE(
-        last_parallel_reduce.find(typeid(my_lambda).name()),
-        std::string::npos);  // internally using
-                             // Impl::CombinedFunctorReducer but the name should
-                             // still include the lambda as template parameter
+    ASSERT_NE(last_parallel_reduce.find(typeid(my_lambda).name()),
+              std::string::npos)
+        << last_parallel_reduce << " does not contain "
+        << typeid(my_lambda)
+               .name();  // internally using
+                         // Impl::CombinedFunctorReducer but the name should
+                         // still include the lambda as template parameter
 
     auto my_lambda_with_tag = KOKKOS_LAMBDA(WorkTag, int, float&){};
     Kokkos::parallel_reduce(my_label,
@@ -108,8 +110,10 @@ void test_kernel_name_parallel_reduce() {
     Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
                             my_lambda_with_tag, my_result);
     ASSERT_NE(last_parallel_reduce.find(typeid(my_lambda_with_tag).name()),
-              std::string::npos);  // ditto and below check that it ends with
-                                   // the WorkTag
+              std::string::npos)
+        << last_parallel_reduce << " does not contain "
+        << typeid(my_lambda_with_tag).name();  // ditto and below check that it
+                                               // ends with the WorkTag
     auto suffix = std::string("/") + typeid(WorkTag).name();
     ASSERT_EQ(last_parallel_reduce.find(suffix),
               last_parallel_reduce.length() - suffix.length());

--- a/core/unit_test/tools/TestKernelNames.cpp
+++ b/core/unit_test/tools/TestKernelNames.cpp
@@ -1,0 +1,167 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+std::string last_parallel_for;
+std::string last_parallel_reduce;
+std::string last_parallel_scan;
+
+void get_parallel_for_kernel_name(char const* kernelName, uint32_t /*deviceID*/,
+                                  uint64_t* /*kernelID*/) {
+  last_parallel_for = kernelName;
+}
+
+void get_parallel_reduce_kernel_name(char const* kernelName,
+                                     uint32_t /*deviceID*/,
+                                     uint64_t* /*kernelID*/) {
+  last_parallel_reduce = kernelName;
+}
+
+void get_parallel_scan_kernel_name(char const* kernelName,
+                                   uint32_t /*deviceID*/,
+                                   uint64_t* /*kernelID*/) {
+  last_parallel_scan = kernelName;
+}
+
+void test_kernel_name_parallel_for() {
+  Kokkos::Tools::Experimental::set_begin_parallel_for_callback(
+      get_parallel_for_kernel_name);
+
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+  struct WorkTag {};
+
+  {
+    std::string my_label = "my_parallel_for_range_policy";
+
+    auto my_lambda = KOKKOS_LAMBDA(int){};
+    Kokkos::parallel_for(my_label, Kokkos::RangePolicy<ExecutionSpace>(0, 1),
+                         my_lambda);
+    ASSERT_EQ(last_parallel_for, my_label);
+
+    Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, 1), my_lambda);
+    ASSERT_EQ(last_parallel_for, typeid(my_lambda).name());
+
+    auto my_lambda_with_tag = KOKKOS_LAMBDA(WorkTag, int){};
+    Kokkos::parallel_for(my_label,
+                         Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
+                         my_lambda_with_tag);
+    ASSERT_EQ(last_parallel_for, my_label);
+
+    Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
+                         my_lambda_with_tag);
+    ASSERT_EQ(last_parallel_for,
+              std::string(typeid(my_lambda_with_tag).name()) + "/" +
+                  typeid(WorkTag).name());
+  }
+
+  Kokkos::Tools::Experimental::set_begin_parallel_for_callback(nullptr);
+}
+
+void test_kernel_name_parallel_reduce() {
+  Kokkos::Tools::Experimental::set_begin_parallel_reduce_callback(
+      get_parallel_reduce_kernel_name);
+
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+  struct WorkTag {};
+
+  {
+    std::string my_label = "my_parallel_reduce_range_policy";
+    float my_result;
+
+    auto my_lambda = KOKKOS_LAMBDA(int, float&){};
+    Kokkos::parallel_reduce(my_label, Kokkos::RangePolicy<ExecutionSpace>(0, 1),
+                            my_lambda, my_result);
+    ASSERT_EQ(last_parallel_reduce, my_label);
+
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecutionSpace>(0, 1),
+                            my_lambda, my_result);
+    ASSERT_NE(
+        last_parallel_reduce.find(typeid(my_lambda).name()),
+        std::string::npos);  // internally using
+                             // Impl::CombinedFunctorReducer but the name should
+                             // still include the lambda as template parameter
+
+    auto my_lambda_with_tag = KOKKOS_LAMBDA(WorkTag, int, float&){};
+    Kokkos::parallel_reduce(my_label,
+                            Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
+                            my_lambda_with_tag, my_result);
+    ASSERT_EQ(last_parallel_reduce, my_label);
+
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
+                            my_lambda_with_tag, my_result);
+    ASSERT_NE(last_parallel_reduce.find(typeid(my_lambda_with_tag).name()),
+              std::string::npos);  // ditto and below check that it ends with
+                                   // the WorkTag
+    auto suffix = std::string("/") + typeid(WorkTag).name();
+    ASSERT_EQ(last_parallel_reduce.find(suffix),
+              last_parallel_reduce.length() - suffix.length());
+  }
+
+  Kokkos::Tools::Experimental::set_begin_parallel_reduce_callback(nullptr);
+}
+
+void test_kernel_name_parallel_scan() {
+  Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(
+      get_parallel_scan_kernel_name);
+
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+  struct WorkTag {};
+
+  {
+    std::string my_label = "my_parallel_scan_range_policy";
+
+    auto my_lambda = KOKKOS_LAMBDA(int, float&, bool){};
+    Kokkos::parallel_scan(my_label, Kokkos::RangePolicy<ExecutionSpace>(0, 1),
+                          my_lambda);
+    ASSERT_EQ(last_parallel_scan, my_label);
+
+    Kokkos::parallel_scan(Kokkos::RangePolicy<ExecutionSpace>(0, 1), my_lambda);
+    ASSERT_EQ(last_parallel_scan, typeid(my_lambda).name());
+
+    auto my_lambda_with_tag = KOKKOS_LAMBDA(WorkTag, int, float&, bool){};
+    Kokkos::parallel_scan(my_label,
+                          Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
+                          my_lambda_with_tag);
+    ASSERT_EQ(last_parallel_scan, my_label);
+
+    Kokkos::parallel_scan(Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
+                          my_lambda_with_tag);
+    ASSERT_EQ(last_parallel_scan,
+              std::string(typeid(my_lambda_with_tag).name()) + "/" +
+                  typeid(WorkTag).name());
+  }
+
+  Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(nullptr);
+}
+
+TEST(defaultdevicetype, kernel_name_parallel_for) {
+  test_kernel_name_parallel_for();
+}
+
+TEST(defaultdevicetype, kernel_name_parallel_reduce) {
+  test_kernel_name_parallel_reduce();
+}
+
+TEST(defaultdevicetype, kernel_name_parallel_scan) {
+  test_kernel_name_parallel_scan();
+}
+
+}  // namespace

--- a/core/unit_test/tools/TestKernelNames.cpp
+++ b/core/unit_test/tools/TestKernelNames.cpp
@@ -41,12 +41,13 @@ void get_parallel_scan_kernel_name(char const* kernelName,
   last_parallel_scan = kernelName;
 }
 
+struct WorkTag {};
+
 void test_kernel_name_parallel_for() {
   Kokkos::Tools::Experimental::set_begin_parallel_for_callback(
       get_parallel_for_kernel_name);
 
   using ExecutionSpace = Kokkos::DefaultExecutionSpace;
-  struct WorkTag {};
 
   {
     std::string my_label = "my_parallel_for_range_policy";
@@ -80,7 +81,6 @@ void test_kernel_name_parallel_reduce() {
       get_parallel_reduce_kernel_name);
 
   using ExecutionSpace = Kokkos::DefaultExecutionSpace;
-  struct WorkTag {};
 
   {
     std::string my_label = "my_parallel_reduce_range_policy";
@@ -127,7 +127,6 @@ void test_kernel_name_parallel_scan() {
       get_parallel_scan_kernel_name);
 
   using ExecutionSpace = Kokkos::DefaultExecutionSpace;
-  struct WorkTag {};
 
   {
     std::string my_label = "my_parallel_scan_range_policy";

--- a/core/unit_test/tools/TestKernelNames.cpp
+++ b/core/unit_test/tools/TestKernelNames.cpp
@@ -109,11 +109,6 @@ void test_kernel_name_parallel_reduce() {
 
     Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
                             my_lambda_with_tag, my_result);
-    ASSERT_NE(last_parallel_reduce.find(typeid(my_lambda_with_tag).name()),
-              std::string::npos)
-        << last_parallel_reduce << " does not contain "
-        << typeid(my_lambda_with_tag).name();  // ditto and below check that it
-                                               // ends with the WorkTag
     auto suffix = std::string("/") + typeid(WorkTag).name();
     ASSERT_EQ(last_parallel_reduce.find(suffix),
               last_parallel_reduce.length() - suffix.length());

--- a/core/unit_test/tools/TestKernelNames.cpp
+++ b/core/unit_test/tools/TestKernelNames.cpp
@@ -50,9 +50,9 @@ void test_kernel_name_parallel_for() {
   using ExecutionSpace = Kokkos::DefaultExecutionSpace;
 
   {
-    std::string my_label = "my_parallel_for_range_policy";
+    std::string const my_label = "my_parallel_for_range_policy";
 
-    auto my_lambda = KOKKOS_LAMBDA(int){};
+    auto const my_lambda = KOKKOS_LAMBDA(int){};
     Kokkos::parallel_for(my_label, Kokkos::RangePolicy<ExecutionSpace>(0, 1),
                          my_lambda);
     ASSERT_EQ(last_parallel_for, my_label);
@@ -60,7 +60,7 @@ void test_kernel_name_parallel_for() {
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, 1), my_lambda);
     ASSERT_EQ(last_parallel_for, typeid(my_lambda).name());
 
-    auto my_lambda_with_tag = KOKKOS_LAMBDA(WorkTag, int){};
+    auto const my_lambda_with_tag = KOKKOS_LAMBDA(WorkTag, int){};
     Kokkos::parallel_for(my_label,
                          Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
                          my_lambda_with_tag);
@@ -83,10 +83,10 @@ void test_kernel_name_parallel_reduce() {
   using ExecutionSpace = Kokkos::DefaultExecutionSpace;
 
   {
-    std::string my_label = "my_parallel_reduce_range_policy";
+    std::string const my_label = "my_parallel_reduce_range_policy";
     float my_result;
 
-    auto my_lambda = KOKKOS_LAMBDA(int, float&){};
+    auto const my_lambda = KOKKOS_LAMBDA(int, float&){};
     Kokkos::parallel_reduce(my_label, Kokkos::RangePolicy<ExecutionSpace>(0, 1),
                             my_lambda, my_result);
     ASSERT_EQ(last_parallel_reduce, my_label);
@@ -101,7 +101,7 @@ void test_kernel_name_parallel_reduce() {
                          // Impl::CombinedFunctorReducer but the name should
                          // still include the lambda as template parameter
 
-    auto my_lambda_with_tag = KOKKOS_LAMBDA(WorkTag, int, float&){};
+    auto const my_lambda_with_tag = KOKKOS_LAMBDA(WorkTag, int, float&){};
     Kokkos::parallel_reduce(my_label,
                             Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
                             my_lambda_with_tag, my_result);
@@ -109,7 +109,7 @@ void test_kernel_name_parallel_reduce() {
 
     Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
                             my_lambda_with_tag, my_result);
-    auto suffix = std::string("/") + typeid(WorkTag).name();
+    auto const suffix = std::string("/") + typeid(WorkTag).name();
     ASSERT_EQ(last_parallel_reduce.find(suffix),
               last_parallel_reduce.length() - suffix.length());
   }
@@ -124,9 +124,9 @@ void test_kernel_name_parallel_scan() {
   using ExecutionSpace = Kokkos::DefaultExecutionSpace;
 
   {
-    std::string my_label = "my_parallel_scan_range_policy";
+    std::string const my_label = "my_parallel_scan_range_policy";
 
-    auto my_lambda = KOKKOS_LAMBDA(int, float&, bool){};
+    auto const my_lambda = KOKKOS_LAMBDA(int, float&, bool){};
     Kokkos::parallel_scan(my_label, Kokkos::RangePolicy<ExecutionSpace>(0, 1),
                           my_lambda);
     ASSERT_EQ(last_parallel_scan, my_label);
@@ -134,7 +134,7 @@ void test_kernel_name_parallel_scan() {
     Kokkos::parallel_scan(Kokkos::RangePolicy<ExecutionSpace>(0, 1), my_lambda);
     ASSERT_EQ(last_parallel_scan, typeid(my_lambda).name());
 
-    auto my_lambda_with_tag = KOKKOS_LAMBDA(WorkTag, int, float&, bool){};
+    auto const my_lambda_with_tag = KOKKOS_LAMBDA(WorkTag, int, float&, bool){};
     Kokkos::parallel_scan(my_label,
                           Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
                           my_lambda_with_tag);

--- a/core/unit_test/tools/TestKernelNames.cpp
+++ b/core/unit_test/tools/TestKernelNames.cpp
@@ -150,16 +150,12 @@ void test_kernel_name_parallel_scan() {
   Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(nullptr);
 }
 
-TEST(defaultdevicetype, kernel_name_parallel_for) {
-  test_kernel_name_parallel_for();
-}
+TEST(kokkosp, kernel_name_parallel_for) { test_kernel_name_parallel_for(); }
 
-TEST(defaultdevicetype, kernel_name_parallel_reduce) {
+TEST(kokkosp, kernel_name_parallel_reduce) {
   test_kernel_name_parallel_reduce();
 }
 
-TEST(defaultdevicetype, kernel_name_parallel_scan) {
-  test_kernel_name_parallel_scan();
-}
+TEST(kokkosp, kernel_name_parallel_scan) { test_kernel_name_parallel_scan(); }
 
 }  // namespace

--- a/core/unit_test/tools/TestProfilingSection.cpp
+++ b/core/unit_test/tools/TestProfilingSection.cpp
@@ -57,7 +57,7 @@ void kokkosp_test_destroy_section(std::uint32_t id) {
 
 }  // namespace
 
-TEST(defaultdevicetype, profiling_section) {
+TEST(kokkosp, profiling_section) {
   Kokkos::Profiling::Experimental::set_create_profile_section_callback(
       kokkosp_test_create_section);
   Kokkos::Profiling::Experimental::set_destroy_profile_section_callback(

--- a/core/unit_test/tools/TestScopedRegion.cpp
+++ b/core/unit_test/tools/TestScopedRegion.cpp
@@ -31,7 +31,7 @@ void test_push_region(char const *label) { test_region_stack.push(label); }
 
 void test_pop_region() { test_region_stack.pop(); }
 
-TEST(defaultdevicetype, scoped_profile_region) {
+TEST(kokkosp, scoped_profile_region) {
   Kokkos::Tools::Experimental::set_push_region_callback(test_push_region);
   Kokkos::Tools::Experimental::set_pop_region_callback(test_pop_region);
 


### PR DESCRIPTION
Check that, the user-provided label `parallel_{for,reduce,scan}(<label>, ...)` is passed to the tool and that, when it is absent, the default is based on the information from the functor/lambda `typeid`.

This work is a preliminary step towards #7043 that would change that `std::type_info`-based fallback kernel name to something else that does not rely on RTTI (see #7037)