### PR TITLE
graph(fix): defaulted graph submit control flow

### DIFF
--- a/core/src/impl/Kokkos_Default_GraphNode_Impl.hpp
+++ b/core/src/impl/Kokkos_Default_GraphNode_Impl.hpp
@@ -92,6 +92,18 @@ struct GraphNodeBackendSpecificDetails {
     m_is_aggregate = true;
   }
 
+  // A node is awaitable if it can execute a kernel.
+  // A root node or an aggregate node cannot be waited for, because it does
+  // not launch anything.
+  bool awaitable() const { return (!m_is_root) && (!m_is_aggregate); }
+
+  // Retrieve the execution space instance that has been passed to
+  // the kernel at construction phase.
+  const ExecutionSpace& get_execution_space() const {
+    KOKKOS_EXPECTS(m_kernel_ptr != nullptr)
+    return m_kernel_ptr->m_execution_space;
+  }
+
   void set_predecessor(
       std::shared_ptr<GraphNodeBackendSpecificDetails<ExecutionSpace>>
           arg_pred_impl) {
@@ -104,7 +116,7 @@ struct GraphNodeBackendSpecificDetails {
     m_predecessors.push_back(std::move(arg_pred_impl));
   }
 
-  void execute_node() {
+  void execute_node(const ExecutionSpace& exec) {
     // This node could have already been executed as the predecessor of some
     // other
     KOKKOS_EXPECTS(bool(m_kernel_ptr) || m_has_executed)
@@ -115,8 +127,18 @@ struct GraphNodeBackendSpecificDetails {
       // supported semantics, but instinct I have feels like it should be...
       m_has_executed = true;
       for (auto const& predecessor : m_predecessors) {
-        predecessor->execute_node();
+        predecessor->execute_node(exec);
       }
+
+      // Before executing the kernel, be sure to fence the execution space
+      // instance of predecessors.
+      for (const auto& predecessor : m_predecessors) {
+        if (predecessor->awaitable() &&
+            predecessor->get_execution_space() != this->get_execution_space())
+          predecessor->get_execution_space().fence(
+              "Kokkos::DefaultGraphNode::execute_node: sync with predecessors");
+      }
+
       m_kernel_ptr->execute_kernel();
     }
     KOKKOS_ENSURES(m_has_executed)

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -379,11 +379,7 @@ struct FetchValuesAndContribute {
 
   template <typename T>
   KOKKOS_FUNCTION void operator()(const T) const {
-    if constexpr (NumIndices > 0) {
-      /// FIXME @c Kokkos::Array should work with range-based for loop.
-      for (size_t index = 0; index < indices.size(); ++index)
-        data(TargetIndex) += data(indices[index]);
-    }
+    for (const auto index : indices) data(TargetIndex) += data(index);
     data(TargetIndex) += value;
   }
 };


### PR DESCRIPTION
This PR fixes the defaulted graph implementation `submit` control flow by ensuring that:
1. `submit` fences the received execution space instance right away before launching any work.
2. Nodes wait for their predecessors to finish (`awaitable` concept needed to make things readable).
3. `submit` waits for completion of all sinks before returning control flow to user.

This should solve:
1. The problem with `HIP 5.2` detected in #7249.
2. The problem with `HPX` backend (hopefully).