### PR TITLE
 SYCL: Avoid creating backend events 

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -670,7 +670,11 @@ struct Random_UniqueIndex<Kokkos::Device<Kokkos::SYCL, MemorySpace>> {
       View<int**, Kokkos::Device<Kokkos::SYCL, MemorySpace>>;
   KOKKOS_FUNCTION
   static int get_state_idx(const locks_view_type& locks_) {
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER >= 20250000
+    auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
+#else
     auto item = sycl::ext::oneapi::experimental::this_nd_item<3>();
+#endif
     std::size_t threadIdx[3] = {item.get_local_id(2), item.get_local_id(1),
                                 item.get_local_id(0)};
     std::size_t blockIdx[3]  = {item.get_group(2), item.get_group(1),

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -137,7 +137,13 @@ class SYCLInternal {
       if constexpr (sycl::usm::alloc::device == Kind) {
         std::memcpy(static_cast<void*>(m_staging.get()), std::addressof(t),
                     sizeof(T));
+#if defined(SYCL_EXT_ONEAPI_ENQUEUE_FUNCTIONS) && \
+    defined(KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES)
+        sycl::ext::oneapi::experimental::memcpy(*m_q, m_data, m_staging.get(),
+                                                sizeof(T));
+#else
         m_copy_event = m_q->memcpy(m_data, m_staging.get(), sizeof(T));
+#endif
       } else
         std::memcpy(m_data, std::addressof(t), sizeof(T));
       return *reinterpret_cast<T*>(m_data);

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -162,12 +162,18 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     } else
 #endif
     {
+#if defined(SYCL_EXT_ONEAPI_ENQUEUE_FUNCTIONS) && \
+    defined(KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES)
+      sycl::ext::oneapi::experimental::submit(q, cgh_lambda);
+      return {};
+#else
       auto parallel_for_event = q.submit(cgh_lambda);
 
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
       q.ext_oneapi_submit_barrier(std::vector<sycl::event>{parallel_for_event});
 #endif
       return parallel_for_event;
+#endif
     }
   }
 

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Range.hpp
@@ -145,12 +145,18 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
     } else
 #endif
     {
+#if defined(SYCL_EXT_ONEAPI_ENQUEUE_FUNCTIONS) && \
+    defined(KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES)
+      sycl::ext::oneapi::experimental::submit(q, cgh_lambda);
+      return {};
+#else
       auto parallel_for_event = q.submit(cgh_lambda);
 
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
       q.ext_oneapi_submit_barrier(std::vector<sycl::event>{parallel_for_event});
 #endif
       return parallel_for_event;
+#endif
     }
   }
 

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
@@ -118,12 +118,18 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     } else
 #endif
     {
+#if defined(SYCL_EXT_ONEAPI_ENQUEUE_FUNCTIONS) && \
+    defined(KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES)
+      sycl::ext::oneapi::experimental::submit(q, cgh_lambda);
+      return {};
+#else
       auto parallel_for_event = q.submit(cgh_lambda);
 
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
       q.ext_oneapi_submit_barrier(std::vector<sycl::event>{parallel_for_event});
 #endif
       return parallel_for_event;
+#endif
     }
   }
 

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
@@ -135,10 +135,15 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
       } else
 #endif
       {
+#if defined(SYCL_EXT_ONEAPI_ENQUEUE_FUNCTIONS) && \
+    defined(KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES)
+        sycl::ext::oneapi::experimental::submit(q, cgh_lambda);
+#else
         last_reduction_event = q.submit(cgh_lambda);
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
         q.ext_oneapi_submit_barrier(
             std::vector<sycl::event>{last_reduction_event});
+#endif
 #endif
       }
     } else {
@@ -311,10 +316,15 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
       } else
 #endif
       {
+#if defined(SYCL_EXT_ONEAPI_ENQUEUE_FUNCTIONS) && \
+    defined(KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES)
+        sycl::ext::oneapi::experimental::submit(q, cgh_lambda);
+#else
         last_reduction_event = q.submit(cgh_lambda);
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
         q.ext_oneapi_submit_barrier(
             std::vector<sycl::event>{last_reduction_event});
+#endif
 #endif
       }
     }

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
@@ -119,7 +119,12 @@ class Kokkos::Impl::ParallelReduce<
       } else
 #endif
       {
+#if defined(SYCL_EXT_ONEAPI_ENQUEUE_FUNCTIONS) && \
+    defined(KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES)
+        sycl::ext::oneapi::experimental::submit(q, cgh_lambda);
+#else
         last_reduction_event = q.submit(cgh_lambda);
+#endif
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
         q.ext_oneapi_submit_barrier(
             std::vector<sycl::event>{last_reduction_event});
@@ -333,10 +338,15 @@ class Kokkos::Impl::ParallelReduce<
       } else
 #endif
       {
+#if defined(SYCL_EXT_ONEAPI_ENQUEUE_FUNCTIONS) && \
+    defined(KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES)
+        sycl::ext::oneapi::experimental::submit(q, cgh_lambda);
+#else
         last_reduction_event = q.submit(cgh_lambda);
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
         q.ext_oneapi_submit_barrier(
             std::vector<sycl::event>{last_reduction_event});
+#endif
 #endif
       }
     }

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -145,10 +145,15 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
       } else
 #endif
       {
+#if defined(SYCL_EXT_ONEAPI_ENQUEUE_FUNCTIONS) && \
+    defined(KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES)
+        sycl::ext::oneapi::experimental::submit(q, cgh_lambda);
+#else
         last_reduction_event = q.submit(cgh_lambda);
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
         q.ext_oneapi_submit_barrier(
             std::vector<sycl::event>{last_reduction_event});
+#endif
 #endif
       }
     } else {
@@ -366,10 +371,15 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
       } else
 #endif
       {
+#if defined(SYCL_EXT_ONEAPI_ENQUEUE_FUNCTIONS) && \
+    defined(KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES)
+        sycl::ext::oneapi::experimental::submit(q, cgh_lambda);
+#else
         last_reduction_event = q.submit(cgh_lambda);
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
         q.ext_oneapi_submit_barrier(
             std::vector<sycl::event>{last_reduction_event});
+#endif
 #endif
       }
     }

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -33,20 +33,37 @@ namespace Kokkos {
 namespace Impl {
 
 void DeepCopySYCL(void* dst, const void* src, size_t n) {
+#if defined(SYCL_EXT_ONEAPI_ENQUEUE_FUNCTIONS) && \
+    defined(KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES)
+  sycl::ext::oneapi::experimental::memcpy(
+      *Impl::SYCLInternal::singleton().m_queue, dst, src, n);
+#else
   Impl::SYCLInternal::singleton().m_queue->memcpy(dst, src, n);
+#endif
 }
 
 void DeepCopyAsyncSYCL(const Kokkos::SYCL& instance, void* dst, const void* src,
                        size_t n) {
   sycl::queue& q = *instance.impl_internal_space_instance()->m_queue;
-  auto event     = q.memcpy(dst, src, n);
+#if defined(SYCL_EXT_ONEAPI_ENQUEUE_FUNCTIONS) && \
+    defined(KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES)
+  sycl::ext::oneapi::experimental::memcpy(q, dst, src, n);
+#else
+  auto event = q.memcpy(dst, src, n);
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
   q.ext_oneapi_submit_barrier(std::vector<sycl::event>{event});
+#endif
 #endif
 }
 
 void DeepCopyAsyncSYCL(void* dst, const void* src, size_t n) {
+#if defined(SYCL_EXT_ONEAPI_ENQUEUE_FUNCTIONS) && \
+    defined(KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES)
+  sycl::ext::oneapi::experimental::memcpy(
+      *Impl::SYCLInternal::singleton().m_queue, dst, src, n);
+#else
   Impl::SYCLInternal::singleton().m_queue->memcpy(dst, src, n);
+#endif
   SYCL().fence("Kokkos::Impl::DeepCopyAsyncSYCL: fence after memcpy");
 }
 

--- a/tpls/desul/include/desul/atomics/Lock_Array_SYCL.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Array_SYCL.hpp
@@ -158,16 +158,32 @@ inline static
     copy_sycl_lock_arrays_to_device(sycl::queue q) {
   static bool once = [&q]() {
 #ifdef SYCL_EXT_ONEAPI_DEVICE_GLOBAL
+#ifdef SYCL_EXT_ONEAPI_ENQUEUE_FUNCTIONS
+      sycl::ext::oneapi::experimental::memcpy(
+q, SYCL_SPACE_ATOMIC_LOCKS_DEVICE,
+             &SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h,
+             sizeof(int32_t*));
+            sycl::ext::oneapi::experimental::memcpy(
+    q, SYCL_SPACE_ATOMIC_LOCKS_NODE,
+             &SYCL_SPACE_ATOMIC_LOCKS_NODE_h,
+             sizeof(int32_t*));
+#else
     q.memcpy(SYCL_SPACE_ATOMIC_LOCKS_DEVICE,
              &SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h,
              sizeof(int32_t*));
     q.memcpy(SYCL_SPACE_ATOMIC_LOCKS_NODE,
              &SYCL_SPACE_ATOMIC_LOCKS_NODE_h,
              sizeof(int32_t*));
+#endif
 #else
     auto device_ptr = SYCL_SPACE_ATOMIC_LOCKS_DEVICE_h;
     auto node_ptr = SYCL_SPACE_ATOMIC_LOCKS_NODE_h;
-    q.single_task([=] {
+#ifdef SYCL_EXT_ONEAPI_ENQUEUE_FUNCTIONS
+      sycl::ext::oneapi::experimental::single_task(q,
+#else
+    q.single_task(
+#endif
+	    [=] {
       SYCL_SPACE_ATOMIC_LOCKS_DEVICE.get() = device_ptr;
       SYCL_SPACE_ATOMIC_LOCKS_NODE.get() = node_ptr;
     });


### PR DESCRIPTION
This requires https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_enqueue_functions.asciidoc.
With the new syntax, we avoid creating backend events that we aren't using anyway when we are using in-order `sycl::queue`s.