### PR TITLE
Cleanup atomics test

### DIFF
--- a/core/unit_test/TestAtomicOperations.hpp
+++ b/core/unit_test/TestAtomicOperations.hpp
@@ -16,6 +16,7 @@
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Pair.hpp>
+#include <iostream>
 
 namespace TestAtomicOperations {
 
@@ -351,19 +352,22 @@ bool atomic_op_test(T old_val, T update) {
       },
       result);
   if ((result & 1) != 0)
-    printf("atomic_%s failed with type %s\n", Op::name(), typeid(T).name());
+    std::cerr << "atomic_" << Op::name() << " failed with type "
+              << typeid(T).name() << '\n';
   if ((result & 2) != 0)
-    printf("atomic_fetch_%s failed with type %s\n", Op::name(),
-           typeid(T).name());
+    std::cerr << "atomic_fetch_" << Op::name() << " failed with type "
+              << typeid(T).name() << '\n';
   if ((result & 4) != 0)
-    printf("atomic_%s_fetch failed with type %s\n", Op::name(),
-           typeid(T).name());
+    std::cerr << "atomic_" << Op::name() << "_fetch failed with type "
+              << typeid(T).name() << '\n';
   if ((result & 8) != 0)
-    printf("atomic_fetch_%s did not return old value with type %s\n",
-           Op::name(), typeid(T).name());
+    std::cerr << "atomic_fetch_" << Op::name()
+              << " did not return old value with type " << typeid(T).name()
+              << '\n';
   if ((result & 16) != 0)
-    printf("atomic_%s_fetch did not return updated value with type %s\n",
-           Op::name(), typeid(T).name());
+    std::cerr << "atomic_" << Op::name() << "_fetch"
+              << " did not return updated value with type " << typeid(T).name()
+              << '\n';
 
   return result == 0;
 }
@@ -408,19 +412,22 @@ bool atomic_op_test_rel(T old_val, T update) {
       },
       result);
   if ((result & 1) != 0)
-    printf("atomic_%s failed with type %s\n", Op::name(), typeid(T).name());
+    std::cerr << "atomic_" << Op::name() << " failed with type "
+              << typeid(T).name() << '\n';
   if ((result & 2) != 0)
-    printf("atomic_fetch_%s failed with type %s\n", Op::name(),
-           typeid(T).name());
+    std::cerr << "atomic_fetch_" << Op::name() << " failed with type "
+              << typeid(T).name() << '\n';
   if ((result & 4) != 0)
-    printf("atomic_%s_fetch failed with type %s\n", Op::name(),
-           typeid(T).name());
+    std::cerr << "atomic_" << Op::name() << "_fetch failed with type "
+              << typeid(T).name() << '\n';
   if ((result & 8) != 0)
-    printf("atomic_fetch_%s did not return old value with type %s\n",
-           Op::name(), typeid(T).name());
+    std::cerr << "atomic_fetch_" << Op::name()
+              << " did not return old value with type " << typeid(T).name()
+              << '\n';
   if ((result & 16) != 0)
-    printf("atomic_%s_fetch did not return updated value with type %s\n",
-           Op::name(), typeid(T).name());
+    std::cerr << "atomic_" << Op::name() << "_fetch"
+              << " did not return updated value with type " << typeid(T).name()
+              << '\n';
 
   return result == 0;
 }

--- a/core/unit_test/TestAtomicViews.hpp
+++ b/core/unit_test/TestAtomicViews.hpp
@@ -16,7 +16,7 @@
 
 #include <Kokkos_Core.hpp>
 
-namespace TestAtomicViews {
+namespace {
 
 //-------------------------------------------------
 //-----------atomic view api tests-----------------
@@ -415,21 +415,12 @@ T PlusEqualAtomicViewCheck(const int64_t input_length) {
 }
 
 template <class T, class DeviceType>
-bool PlusEqualAtomicViewTest(int64_t input_length) {
+void PlusEqualAtomicViewTest(int64_t input_length) {
   T res       = PlusEqualAtomicView<T, DeviceType>(input_length);
   T resSerial = PlusEqualAtomicViewCheck<T>(input_length);
 
-  bool passed = true;
-
-  if (resSerial != res) {
-    passed = false;
-
-    std::cout << "Loop<" << typeid(T).name()
-              << ">( test = PlusEqualAtomicViewTest"
-              << " FAILED : " << resSerial << " != " << res << std::endl;
-  }
-
-  return passed;
+  ASSERT_EQ(res, resSerial) << "PlusEqualAtomicViewTest<" << typeid(T).name()
+                            << ">(length=" << input_length << ")";
 }
 
 //---------------------------------------------------
@@ -512,21 +503,12 @@ T MinusEqualAtomicViewCheck(const int64_t input_length) {
 }
 
 template <class T, class DeviceType>
-bool MinusEqualAtomicViewTest(int64_t input_length) {
+void MinusEqualAtomicViewTest(int64_t input_length) {
   T res       = MinusEqualAtomicView<T, DeviceType>(input_length);
   T resSerial = MinusEqualAtomicViewCheck<T>(input_length);
 
-  bool passed = true;
-
-  if (resSerial != res) {
-    passed = false;
-
-    std::cout << "Loop<" << typeid(T).name()
-              << ">( test = MinusEqualAtomicViewTest"
-              << " FAILED : " << resSerial << " != " << res << std::endl;
-  }
-
-  return passed;
+  ASSERT_EQ(res, resSerial) << "MinusEqualAtomicViewTest<" << typeid(T).name()
+                            << ">(length=" << input_length << ")";
 }
 
 //---------------------------------------------------
@@ -601,22 +583,13 @@ T TimesEqualAtomicViewCheck(const int64_t input_length,
 }
 
 template <class T, class DeviceType>
-bool TimesEqualAtomicViewTest(const int64_t input_length) {
+void TimesEqualAtomicViewTest(const int64_t input_length) {
   const int64_t remainder = 23;
   T res       = TimesEqualAtomicView<T, DeviceType>(input_length, remainder);
   T resSerial = TimesEqualAtomicViewCheck<T>(input_length, remainder);
 
-  bool passed = true;
-
-  if (resSerial != res) {
-    passed = false;
-
-    std::cout << "Loop<" << typeid(T).name()
-              << ">( test = TimesEqualAtomicViewTest"
-              << " FAILED : " << resSerial << " != " << res << std::endl;
-  }
-
-  return passed;
+  ASSERT_EQ(res, resSerial) << "TimesEqualAtomicViewTest<" << typeid(T).name()
+                            << ">(length=" << input_length << ")";
 }
 
 //---------------------------------------------------
@@ -690,23 +663,15 @@ T DivEqualAtomicViewCheck(const int64_t input_length, const int64_t remainder) {
 }
 
 template <class T, class DeviceType>
-bool DivEqualAtomicViewTest(const int64_t input_length) {
+void DivEqualAtomicViewTest(const int64_t input_length) {
   const int64_t remainder = 23;
 
   T res       = DivEqualAtomicView<T, DeviceType>(input_length, remainder);
   T resSerial = DivEqualAtomicViewCheck<T>(input_length, remainder);
 
-  bool passed = true;
-
-  if (resSerial != res) {
-    passed = false;
-
-    std::cout << "Loop<" << typeid(T).name()
-              << ">( test = DivEqualAtomicViewTest"
-              << " FAILED : " << resSerial << " != " << res << std::endl;
-  }
-
-  return passed;
+  ASSERT_EQ(res, resSerial)
+      << "DivEqualAtomicViewTest<" << typeid(T).name()
+      << ">(length=" << input_length << ",remainder=" << remainder << ")";
 }
 
 //---------------------------------------------------
@@ -780,7 +745,7 @@ T ModEqualAtomicViewCheck(const int64_t input_length, const int64_t remainder) {
 }
 
 template <class T, class DeviceType>
-bool ModEqualAtomicViewTest(const int64_t input_length) {
+void ModEqualAtomicViewTest(const int64_t input_length) {
   static_assert(std::is_integral_v<T>,
                 "ModEqualAtomicView Error: Type must be integral type for this "
                 "unit test");
@@ -790,17 +755,9 @@ bool ModEqualAtomicViewTest(const int64_t input_length) {
   T res       = ModEqualAtomicView<T, DeviceType>(input_length, remainder);
   T resSerial = ModEqualAtomicViewCheck<T>(input_length, remainder);
 
-  bool passed = true;
-
-  if (resSerial != res) {
-    passed = false;
-
-    std::cout << "Loop<" << typeid(T).name()
-              << ">( test = ModEqualAtomicViewTest"
-              << " FAILED : " << resSerial << " != " << res << std::endl;
-  }
-
-  return passed;
+  ASSERT_EQ(res, resSerial)
+      << "ModEqualAtomicViewTest<" << typeid(T).name()
+      << ">(length=" << input_length << ",remainder=" << remainder << ")";
 }
 
 //---------------------------------------------------
@@ -908,7 +865,7 @@ T RSEqualAtomicViewCheck(const int64_t input_length, const int64_t value,
 }
 
 template <class T, class DeviceType>
-bool RSEqualAtomicViewTest(const int64_t input_length) {
+void RSEqualAtomicViewTest(const int64_t input_length) {
   static_assert(std::is_integral_v<T>,
                 "RSEqualAtomicViewTest: Must be integral type for test");
 
@@ -917,17 +874,9 @@ bool RSEqualAtomicViewTest(const int64_t input_length) {
   T res = RSEqualAtomicView<T, DeviceType>(input_length, value, remainder);
   T resSerial = RSEqualAtomicViewCheck<T>(input_length, value, remainder);
 
-  bool passed = true;
-
-  if (resSerial != res) {
-    passed = false;
-
-    std::cout << "Loop<" << typeid(T).name()
-              << ">( test = RSEqualAtomicViewTest"
-              << " FAILED : " << resSerial << " != " << res << std::endl;
-  }
-
-  return passed;
+  ASSERT_EQ(res, resSerial) << "RSEqualAtomicViewTest<" << typeid(T).name()
+                            << ">(length=" << input_length << ",value=" << value
+                            << ",remainder=" << remainder << ")";
 }
 
 //---------------------------------------------------
@@ -1035,7 +984,7 @@ T LSEqualAtomicViewCheck(const int64_t input_length, const int64_t value,
 }
 
 template <class T, class DeviceType>
-bool LSEqualAtomicViewTest(const int64_t input_length) {
+void LSEqualAtomicViewTest(const int64_t input_length) {
   static_assert(std::is_integral_v<T>,
                 "LSEqualAtomicViewTest: Must be integral type for test");
 
@@ -1044,17 +993,9 @@ bool LSEqualAtomicViewTest(const int64_t input_length) {
   T res = LSEqualAtomicView<T, DeviceType>(input_length, value, remainder);
   T resSerial = LSEqualAtomicViewCheck<T>(input_length, value, remainder);
 
-  bool passed = true;
-
-  if (resSerial != res) {
-    passed = false;
-
-    std::cout << "Loop<" << typeid(T).name()
-              << ">( test = RSEqualAtomicViewTest"
-              << " FAILED : " << resSerial << " != " << res << std::endl;
-  }
-
-  return passed;
+  ASSERT_EQ(res, resSerial) << "LSEqualAtomicViewTest<" << typeid(T).name()
+                            << ">(length=" << input_length << ",value=" << value
+                            << ",remainder=" << remainder << ")";
 }
 
 //---------------------------------------------------
@@ -1130,24 +1071,15 @@ T AndEqualAtomicViewCheck(const int64_t input_length) {
 }
 
 template <class T, class DeviceType>
-bool AndEqualAtomicViewTest(int64_t input_length) {
+void AndEqualAtomicViewTest(int64_t input_length) {
   static_assert(std::is_integral_v<T>,
                 "AndEqualAtomicViewTest: Must be integral type for test");
 
   T res       = AndEqualAtomicView<T, DeviceType>(input_length);
   T resSerial = AndEqualAtomicViewCheck<T>(input_length);
 
-  bool passed = true;
-
-  if (resSerial != res) {
-    passed = false;
-
-    std::cout << "Loop<" << typeid(T).name()
-              << ">( test = AndEqualAtomicViewTest"
-              << " FAILED : " << resSerial << " != " << res << std::endl;
-  }
-
-  return passed;
+  ASSERT_EQ(res, resSerial) << "AndEqualAtomicViewTest<" << typeid(T).name()
+                            << ">(length=" << input_length << ")";
 }
 
 //---------------------------------------------------
@@ -1222,24 +1154,15 @@ T OrEqualAtomicViewCheck(const int64_t input_length) {
 }
 
 template <class T, class DeviceType>
-bool OrEqualAtomicViewTest(int64_t input_length) {
+void OrEqualAtomicViewTest(int64_t input_length) {
   static_assert(std::is_integral_v<T>,
                 "OrEqualAtomicViewTest: Must be integral type for test");
 
   T res       = OrEqualAtomicView<T, DeviceType>(input_length);
   T resSerial = OrEqualAtomicViewCheck<T>(input_length);
 
-  bool passed = true;
-
-  if (resSerial != res) {
-    passed = false;
-
-    std::cout << "Loop<" << typeid(T).name()
-              << ">( test = OrEqualAtomicViewTest"
-              << " FAILED : " << resSerial << " != " << res << std::endl;
-  }
-
-  return passed;
+  ASSERT_EQ(res, resSerial) << "OrEqualAtomicViewTest<" << typeid(T).name()
+                            << ">(length=" << input_length << ")";
 }
 
 //---------------------------------------------------
@@ -1314,119 +1237,41 @@ T XOrEqualAtomicViewCheck(const int64_t input_length) {
 }
 
 template <class T, class DeviceType>
-bool XOrEqualAtomicViewTest(int64_t input_length) {
+void XOrEqualAtomicViewTest(int64_t input_length) {
   static_assert(std::is_integral_v<T>,
                 "XOrEqualAtomicViewTest: Must be integral type for test");
 
   T res       = XOrEqualAtomicView<T, DeviceType>(input_length);
   T resSerial = XOrEqualAtomicViewCheck<T>(input_length);
 
-  bool passed = true;
-
-  if (resSerial != res) {
-    passed = false;
-
-    std::cout << "Loop<" << typeid(T).name()
-              << ">( test = XOrEqualAtomicViewTest"
-              << " FAILED : " << resSerial << " != " << res << std::endl;
-  }
-
-  return passed;
+  ASSERT_EQ(res, resSerial) << "XOrEqualAtomicViewTest<" << typeid(T).name()
+                            << ">(length=" << input_length << ")";
 }
 
 // inc/dec?
 
-//---------------------------------------------------
-//--------------atomic_test_control------------------
-//---------------------------------------------------
-
-template <class T, class DeviceType>
-bool AtomicViewsTestIntegralType(const int length, int test) {
-  static_assert(std::is_integral_v<T>,
-                "TestAtomicViews Error: Non-integral type passed into "
-                "IntegralType tests");
-
-  switch (test) {
-    case 1: return PlusEqualAtomicViewTest<T, DeviceType>(length);
-    case 2: return MinusEqualAtomicViewTest<T, DeviceType>(length);
-    case 3: return RSEqualAtomicViewTest<T, DeviceType>(length);
-    case 4: return LSEqualAtomicViewTest<T, DeviceType>(length);
-    case 5: return ModEqualAtomicViewTest<T, DeviceType>(length);
-    case 6: return AndEqualAtomicViewTest<T, DeviceType>(length);
-    case 7: return OrEqualAtomicViewTest<T, DeviceType>(length);
-    case 8: return XOrEqualAtomicViewTest<T, DeviceType>(length);
-  }
-
-  return 0;
-}
-
-template <class T, class DeviceType>
-bool AtomicViewsTestNonIntegralType(const int length, int test) {
-  switch (test) {
-    case 1: return PlusEqualAtomicViewTest<T, DeviceType>(length);
-    case 2: return MinusEqualAtomicViewTest<T, DeviceType>(length);
-    case 3: return TimesEqualAtomicViewTest<T, DeviceType>(length);
-    case 4: return DivEqualAtomicViewTest<T, DeviceType>(length);
-  }
-
-  return 0;
-}
-
-}  // namespace TestAtomicViews
-
-namespace Test {
-
 TEST(TEST_CATEGORY, atomic_views_integral) {
   const int64_t length = 1000000;
-  {
-    // Integral Types.
-    ASSERT_TRUE(
-        (TestAtomicViews::AtomicViewsTestIntegralType<int64_t, TEST_EXECSPACE>(
-            length, 1)));
-    ASSERT_TRUE(
-        (TestAtomicViews::AtomicViewsTestIntegralType<int64_t, TEST_EXECSPACE>(
-            length, 2)));
-    ASSERT_TRUE(
-        (TestAtomicViews::AtomicViewsTestIntegralType<int64_t, TEST_EXECSPACE>(
-            length, 3)));
-    ASSERT_TRUE(
-        (TestAtomicViews::AtomicViewsTestIntegralType<int64_t, TEST_EXECSPACE>(
-            length, 4)));
-    ASSERT_TRUE(
-        (TestAtomicViews::AtomicViewsTestIntegralType<int64_t, TEST_EXECSPACE>(
-            length, 5)));
-    ASSERT_TRUE(
-        (TestAtomicViews::AtomicViewsTestIntegralType<int64_t, TEST_EXECSPACE>(
-            length, 6)));
-    ASSERT_TRUE(
-        (TestAtomicViews::AtomicViewsTestIntegralType<int64_t, TEST_EXECSPACE>(
-            length, 7)));
-    ASSERT_TRUE(
-        (TestAtomicViews::AtomicViewsTestIntegralType<int64_t, TEST_EXECSPACE>(
-            length, 8)));
-  }
+  PlusEqualAtomicViewTest<int64_t, TEST_EXECSPACE>(length);
+  MinusEqualAtomicViewTest<int64_t, TEST_EXECSPACE>(length);
+  RSEqualAtomicViewTest<int64_t, TEST_EXECSPACE>(length);
+  LSEqualAtomicViewTest<int64_t, TEST_EXECSPACE>(length);
+  ModEqualAtomicViewTest<int64_t, TEST_EXECSPACE>(length);
+  AndEqualAtomicViewTest<int64_t, TEST_EXECSPACE>(length);
+  OrEqualAtomicViewTest<int64_t, TEST_EXECSPACE>(length);
+  XOrEqualAtomicViewTest<int64_t, TEST_EXECSPACE>(length);
 }
 
 TEST(TEST_CATEGORY, atomic_views_nonintegral) {
   const int64_t length = 1000000;
-  {
-    // Non-Integral Types.
-    ASSERT_TRUE((
-        TestAtomicViews::AtomicViewsTestNonIntegralType<double, TEST_EXECSPACE>(
-            length, 1)));
-    ASSERT_TRUE((
-        TestAtomicViews::AtomicViewsTestNonIntegralType<double, TEST_EXECSPACE>(
-            length, 2)));
-    ASSERT_TRUE((
-        TestAtomicViews::AtomicViewsTestNonIntegralType<double, TEST_EXECSPACE>(
-            length, 3)));
-    ASSERT_TRUE((
-        TestAtomicViews::AtomicViewsTestNonIntegralType<double, TEST_EXECSPACE>(
-            length, 4)));
-  }
+  PlusEqualAtomicViewTest<double, TEST_EXECSPACE>(length);
+  MinusEqualAtomicViewTest<double, TEST_EXECSPACE>(length);
+  TimesEqualAtomicViewTest<double, TEST_EXECSPACE>(length);
+  DivEqualAtomicViewTest<double, TEST_EXECSPACE>(length);
 }
 
 TEST(TEST_CATEGORY, atomic_view_api) {
-  TestAtomicViews::TestAtomicViewAPI<int, TEST_EXECSPACE>();
+  TestAtomicViewAPI<int, TEST_EXECSPACE>();
 }
-}  // namespace Test
+
+}  // namespace

--- a/core/unit_test/TestAtomics.hpp
+++ b/core/unit_test/TestAtomics.hpp
@@ -16,7 +16,7 @@
 
 #include <Kokkos_Core.hpp>
 
-namespace TestAtomic {
+namespace {
 
 // Struct for testing arbitrary size atomics.
 
@@ -444,73 +444,55 @@ T LoopVariantSerial(int loop, int test) {
 }
 
 template <class T, class DeviceType>
-bool Loop(int loop, int test) {
+void Loop(int loop, int test) {
   T res       = LoopVariant<T, DeviceType>(loop, test);
   T resSerial = LoopVariantSerial<T>(loop, test);
 
-  bool passed = true;
-
-  if (resSerial != res) {
-    passed = false;
-
-    std::cout << "Loop<" << typeid(T).name() << ">( test = " << test
-              << " FAILED : " << resSerial << " != " << res << std::endl;
-  }
-
-  return passed;
+  ASSERT_EQ(res, resSerial) << "Loop<" << typeid(T).name() << ">(loop=" << loop
+                            << ",test=" << test << ")";
 }
-
-}  // namespace TestAtomic
-
-namespace Test {
 
 TEST(TEST_CATEGORY, atomics) {
   const int loop_count = 1e4;
 
-  ASSERT_TRUE((TestAtomic::Loop<int, TEST_EXECSPACE>(loop_count, 1)));
-  ASSERT_TRUE((TestAtomic::Loop<int, TEST_EXECSPACE>(loop_count, 2)));
-  ASSERT_TRUE((TestAtomic::Loop<int, TEST_EXECSPACE>(loop_count, 3)));
+  Loop<int, TEST_EXECSPACE>(loop_count, 1);
+  Loop<int, TEST_EXECSPACE>(loop_count, 2);
+  Loop<int, TEST_EXECSPACE>(loop_count, 3);
 
-  ASSERT_TRUE((TestAtomic::Loop<unsigned int, TEST_EXECSPACE>(loop_count, 1)));
-  ASSERT_TRUE((TestAtomic::Loop<unsigned int, TEST_EXECSPACE>(loop_count, 2)));
-  ASSERT_TRUE((TestAtomic::Loop<unsigned int, TEST_EXECSPACE>(loop_count, 3)));
+  Loop<unsigned int, TEST_EXECSPACE>(loop_count, 1);
+  Loop<unsigned int, TEST_EXECSPACE>(loop_count, 2);
+  Loop<unsigned int, TEST_EXECSPACE>(loop_count, 3);
 
-  ASSERT_TRUE((TestAtomic::Loop<long int, TEST_EXECSPACE>(loop_count, 1)));
-  ASSERT_TRUE((TestAtomic::Loop<long int, TEST_EXECSPACE>(loop_count, 2)));
-  ASSERT_TRUE((TestAtomic::Loop<long int, TEST_EXECSPACE>(loop_count, 3)));
+  Loop<long int, TEST_EXECSPACE>(loop_count, 1);
+  Loop<long int, TEST_EXECSPACE>(loop_count, 2);
+  Loop<long int, TEST_EXECSPACE>(loop_count, 3);
 
-  ASSERT_TRUE(
-      (TestAtomic::Loop<unsigned long int, TEST_EXECSPACE>(loop_count, 1)));
-  ASSERT_TRUE(
-      (TestAtomic::Loop<unsigned long int, TEST_EXECSPACE>(loop_count, 2)));
-  ASSERT_TRUE(
-      (TestAtomic::Loop<unsigned long int, TEST_EXECSPACE>(loop_count, 3)));
+  Loop<unsigned long int, TEST_EXECSPACE>(loop_count, 1);
+  Loop<unsigned long int, TEST_EXECSPACE>(loop_count, 2);
+  Loop<unsigned long int, TEST_EXECSPACE>(loop_count, 3);
 
-  ASSERT_TRUE((TestAtomic::Loop<long long int, TEST_EXECSPACE>(loop_count, 1)));
-  ASSERT_TRUE((TestAtomic::Loop<long long int, TEST_EXECSPACE>(loop_count, 2)));
-  ASSERT_TRUE((TestAtomic::Loop<long long int, TEST_EXECSPACE>(loop_count, 3)));
+  Loop<long long int, TEST_EXECSPACE>(loop_count, 1);
+  Loop<long long int, TEST_EXECSPACE>(loop_count, 2);
+  Loop<long long int, TEST_EXECSPACE>(loop_count, 3);
 
-  ASSERT_TRUE((TestAtomic::Loop<double, TEST_EXECSPACE>(loop_count, 1)));
-  ASSERT_TRUE((TestAtomic::Loop<double, TEST_EXECSPACE>(loop_count, 2)));
-  ASSERT_TRUE((TestAtomic::Loop<double, TEST_EXECSPACE>(loop_count, 3)));
+  Loop<double, TEST_EXECSPACE>(loop_count, 1);
+  Loop<double, TEST_EXECSPACE>(loop_count, 2);
+  Loop<double, TEST_EXECSPACE>(loop_count, 3);
 
-  ASSERT_TRUE((TestAtomic::Loop<float, TEST_EXECSPACE>(100, 1)));
-  ASSERT_TRUE((TestAtomic::Loop<float, TEST_EXECSPACE>(100, 2)));
-  ASSERT_TRUE((TestAtomic::Loop<float, TEST_EXECSPACE>(100, 3)));
+  Loop<float, TEST_EXECSPACE>(100, 1);
+  Loop<float, TEST_EXECSPACE>(100, 2);
+  Loop<float, TEST_EXECSPACE>(100, 3);
 
   // FIXME_OPENMPTARGET
   // FIXME_OPENACC: atomic operations on composite types are not supported.
 #if !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(KOKKOS_ENABLE_OPENACC)
-  ASSERT_TRUE((TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(1, 1)));
-  ASSERT_TRUE((TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(1, 2)));
-  ASSERT_TRUE((TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(1, 3)));
+  Loop<Kokkos::complex<float>, TEST_EXECSPACE>(1, 1);
+  Loop<Kokkos::complex<float>, TEST_EXECSPACE>(1, 2);
+  Loop<Kokkos::complex<float>, TEST_EXECSPACE>(1, 3);
 
-  ASSERT_TRUE(
-      (TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(100, 1)));
-  ASSERT_TRUE(
-      (TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(100, 2)));
-  ASSERT_TRUE(
-      (TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(100, 3)));
+  Loop<Kokkos::complex<float>, TEST_EXECSPACE>(100, 1);
+  Loop<Kokkos::complex<float>, TEST_EXECSPACE>(100, 2);
+  Loop<Kokkos::complex<float>, TEST_EXECSPACE>(100, 3);
 
 // FIXME_SYCL Replace macro by SYCL_EXT_ONEAPI_DEVICE_GLOBAL or remove
 // condition alltogether when possible.
@@ -518,28 +500,19 @@ TEST(TEST_CATEGORY, atomics) {
     !defined(KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED)
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::SYCL>) return;
 #endif
-  ASSERT_TRUE(
-      (TestAtomic::Loop<Kokkos::complex<double>, TEST_EXECSPACE>(1, 1)));
-  ASSERT_TRUE(
-      (TestAtomic::Loop<Kokkos::complex<double>, TEST_EXECSPACE>(1, 2)));
-  ASSERT_TRUE(
-      (TestAtomic::Loop<Kokkos::complex<double>, TEST_EXECSPACE>(1, 3)));
+  Loop<Kokkos::complex<double>, TEST_EXECSPACE>(1, 1);
+  Loop<Kokkos::complex<double>, TEST_EXECSPACE>(1, 2);
+  Loop<Kokkos::complex<double>, TEST_EXECSPACE>(1, 3);
 
-  ASSERT_TRUE(
-      (TestAtomic::Loop<Kokkos::complex<double>, TEST_EXECSPACE>(100, 1)));
-  ASSERT_TRUE(
-      (TestAtomic::Loop<Kokkos::complex<double>, TEST_EXECSPACE>(100, 2)));
-  ASSERT_TRUE(
-      (TestAtomic::Loop<Kokkos::complex<double>, TEST_EXECSPACE>(100, 3)));
+  Loop<Kokkos::complex<double>, TEST_EXECSPACE>(100, 1);
+  Loop<Kokkos::complex<double>, TEST_EXECSPACE>(100, 2);
+  Loop<Kokkos::complex<double>, TEST_EXECSPACE>(100, 3);
 
 // WORKAROUND MSVC
 #ifndef _WIN32
-  ASSERT_TRUE(
-      (TestAtomic::Loop<TestAtomic::SuperScalar<4>, TEST_EXECSPACE>(100, 1)));
-  ASSERT_TRUE(
-      (TestAtomic::Loop<TestAtomic::SuperScalar<4>, TEST_EXECSPACE>(100, 2)));
-  ASSERT_TRUE(
-      (TestAtomic::Loop<TestAtomic::SuperScalar<4>, TEST_EXECSPACE>(100, 3)));
+  Loop<SuperScalar<4>, TEST_EXECSPACE>(100, 1);
+  Loop<SuperScalar<4>, TEST_EXECSPACE>(100, 2);
+  Loop<SuperScalar<4>, TEST_EXECSPACE>(100, 3);
 #endif
 #endif
 }
@@ -587,4 +560,4 @@ struct TpetraUseCase {
 
 TEST(TEST_CATEGORY, atomics_tpetra_max_abs) { TpetraUseCase().check(); }
 
-}  // namespace Test
+}  // namespace

--- a/core/unit_test/TestAtomics.hpp
+++ b/core/unit_test/TestAtomics.hpp
@@ -429,6 +429,7 @@ T LoopVariant(int loop, int test) {
     case 3: return ExchLoop<T, DeviceType>(loop);
   }
 
+  Kokkos::abort("unreachable");
   return 0;
 }
 
@@ -440,6 +441,7 @@ T LoopVariantSerial(int loop, int test) {
     case 3: return ExchLoopSerial<T>(loop);
   }
 
+  Kokkos::abort("unreachable");
   return 0;
 }
 


### PR DESCRIPTION
In anticipation of upcoming changes where we avoid using the `typeid` operator, we revisit the test failure reporting in atomic tests and prefer native gtest mechanism to log additional information on failure. 