### PR TITLE
Reduce visibility of `g_openmp_hardware_max_threads` symbol to avoid trouble with shared libabries

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -113,6 +113,7 @@ jobs:
           cmake -B builddir \
             -DCMAKE_INSTALL_PREFIX=/usr \
             ${{ matrix.clang-tidy }} \
+            -DBUILD_SHARED_LIBS=ON \
             -Ddesul_ROOT=/usr/desul-install/ \
             -DKokkos_ENABLE_DESUL_ATOMICS_EXTERNAL=ON \
             -DKokkos_ENABLE_HWLOC=ON \

--- a/.jenkins
+++ b/.jenkins
@@ -462,6 +462,7 @@ pipeline {
                                 -DKokkos_ENABLE_CUDA=ON \
                                 -DKokkos_ENABLE_CUDA_LAMBDA=ON \
                                 -DKokkos_ENABLE_LIBDL=OFF \
+                                -DKokkos_ENABLE_OPENMP=ON \
                                 -DKokkos_ENABLE_IMPL_MDSPAN=OFF \
                                 -DKokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=OFF \
                               .. && \

--- a/core/src/OpenMP/Kokkos_OpenMP.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.cpp
@@ -113,7 +113,7 @@ int OpenMP::impl_thread_pool_size() const noexcept {
 }
 
 int OpenMP::impl_max_hardware_threads() noexcept {
-  return Impl::g_openmp_hardware_max_threads;
+  return Impl::OpenMPInternal::max_hardware_threads();
 }
 
 namespace Impl {

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -31,11 +31,19 @@
 #include <sstream>
 #include <thread>
 
+namespace {
+int g_openmp_hardware_max_threads = 1;
+}
+
 namespace Kokkos {
 namespace Impl {
 
 std::vector<OpenMPInternal *> OpenMPInternal::all_instances;
 std::mutex OpenMPInternal::all_instances_mutex;
+
+int OpenMPInternal::max_hardware_threads() noexcept {
+  return g_openmp_hardware_max_threads;
+}
 
 void OpenMPInternal::clear_thread_data() {
   const size_t member_bytes =
@@ -188,9 +196,9 @@ void OpenMPInternal::initialize(int thread_count) {
     // Before any other call to OMP query the maximum number of threads
     // and save the value for re-initialization unit testing.
 
-    Impl::g_openmp_hardware_max_threads = get_current_max_threads();
+    g_openmp_hardware_max_threads = get_current_max_threads();
 
-    int process_num_threads = Impl::g_openmp_hardware_max_threads;
+    int process_num_threads = g_openmp_hardware_max_threads;
 
     if (Kokkos::hwloc::available()) {
       process_num_threads = Kokkos::hwloc::get_available_numa_count() *
@@ -203,11 +211,11 @@ void OpenMPInternal::initialize(int thread_count) {
     // process_num_threads if thread_count  > 0, set
     // g_openmp_hardware_max_threads to thread_count
     if (thread_count < 0) {
-      thread_count = Impl::g_openmp_hardware_max_threads;
+      thread_count = g_openmp_hardware_max_threads;
     } else if (thread_count == 0) {
-      if (Impl::g_openmp_hardware_max_threads != process_num_threads) {
-        Impl::g_openmp_hardware_max_threads = process_num_threads;
-        omp_set_num_threads(Impl::g_openmp_hardware_max_threads);
+      if (g_openmp_hardware_max_threads != process_num_threads) {
+        g_openmp_hardware_max_threads = process_num_threads;
+        omp_set_num_threads(g_openmp_hardware_max_threads);
       }
     } else {
       if (Kokkos::show_warnings() && thread_count > process_num_threads) {
@@ -218,16 +226,16 @@ void OpenMPInternal::initialize(int thread_count) {
                   << ",  requested thread : " << std::setw(3) << thread_count
                   << std::endl;
       }
-      Impl::g_openmp_hardware_max_threads = thread_count;
-      omp_set_num_threads(Impl::g_openmp_hardware_max_threads);
+      g_openmp_hardware_max_threads = thread_count;
+      omp_set_num_threads(g_openmp_hardware_max_threads);
     }
 
 // setup thread local
-#pragma omp parallel num_threads(Impl::g_openmp_hardware_max_threads)
+#pragma omp parallel num_threads(g_openmp_hardware_max_threads)
     { Impl::SharedAllocationRecord<void, void>::tracking_enable(); }
 
     auto &instance       = OpenMPInternal::singleton();
-    instance.m_pool_size = Impl::g_openmp_hardware_max_threads;
+    instance.m_pool_size = g_openmp_hardware_max_threads;
 
     // New, unified host thread team data:
     {
@@ -272,10 +280,9 @@ void OpenMPInternal::finalize() {
   if (this == &singleton()) {
     auto const &instance = singleton();
     // Silence Cuda Warning
-    const int nthreads =
-        instance.m_pool_size <= Impl::g_openmp_hardware_max_threads
-            ? Impl::g_openmp_hardware_max_threads
-            : instance.m_pool_size;
+    const int nthreads = instance.m_pool_size <= g_openmp_hardware_max_threads
+                             ? g_openmp_hardware_max_threads
+                             : instance.m_pool_size;
     (void)nthreads;
 
 #pragma omp parallel num_threads(nthreads)
@@ -284,7 +291,7 @@ void OpenMPInternal::finalize() {
     // allow main thread to track
     Impl::SharedAllocationRecord<void, void>::tracking_enable();
 
-    Impl::g_openmp_hardware_max_threads = 1;
+    g_openmp_hardware_max_threads = 1;
   }
 
   m_initialized = false;
@@ -307,7 +314,7 @@ void OpenMPInternal::print_configuration(std::ostream &s) const {
 
   if (m_initialized) {
     const int numa_count      = 1;
-    const int core_per_numa   = Impl::g_openmp_hardware_max_threads;
+    const int core_per_numa   = g_openmp_hardware_max_threads;
     const int thread_per_core = 1;
 
     s << " thread_pool_topology[ " << numa_count << " x " << core_per_numa

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -47,8 +47,6 @@ namespace Impl {
 
 class OpenMPInternal;
 
-inline int g_openmp_hardware_max_threads = 1;
-
 struct OpenMPTraits {
   static constexpr int MAX_THREAD_COUNT = 512;
 };
@@ -85,6 +83,8 @@ class OpenMPInternal {
   void finalize();
 
   void clear_thread_data();
+
+  static int max_hardware_threads() noexcept;
 
   int thread_pool_size() const { return m_pool_size; }
 

--- a/core/src/OpenMP/Kokkos_OpenMP_UniqueToken.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_UniqueToken.hpp
@@ -105,7 +105,8 @@ class UniqueToken<OpenMP, UniqueTokenScope::Global> {
   /// \brief upper bound for acquired values, i.e. 0 <= value < size()
   KOKKOS_INLINE_FUNCTION
   int size() const noexcept {
-    KOKKOS_IF_ON_HOST((return Kokkos::Impl::g_openmp_hardware_max_threads;))
+    KOKKOS_IF_ON_HOST(
+        (return Kokkos::Impl::OpenMPInternal::max_hardware_threads();))
 
     KOKKOS_IF_ON_DEVICE((return 0;))
   }


### PR DESCRIPTION
Fix #7283 (not tested)