### PR TITLE
core(hpx): overload for `partition_space`

### DIFF
--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -447,6 +447,20 @@ class HPX {
   }
 };
 
+template <typename... Args>
+std::vector<HPX> partition_space(HPX const &, Args... args) {
+  std::vector<HPX> instances(sizeof...(args));
+  for (auto &in : instances) in = HPX(HPX::instance_mode::independent);
+  return instances;
+}
+
+template <typename T>
+std::vector<HPX> partition_space(HPX const &, std::vector<T> const &weights) {
+  std::vector<HPX> instances(weights.size());
+  for (auto &in : instances) in = HPX(HPX::instance_mode::independent);
+  return instances;
+}
+
 extern template void HPX::impl_bulk_plain_erased<int>(
     bool, bool, std::function<void(int)> &&, int const,
     hpx::threads::thread_stacksize stacksize) const;

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -68,6 +68,11 @@ void check_distinctive([[maybe_unused]] ExecSpace exec1,
               *exec2.impl_internal_space_instance()->m_queue);
   }
 #endif
+#ifdef KOKKOS_ENABLE_HPX
+  if constexpr (std::is_same_v<ExecSpace, Kokkos::Experimental::HPX>) {
+    ASSERT_NE(exec1.impl_instance_id(), exec2.impl_instance_id());
+  }
+#endif
 }
 }  // namespace
 


### PR DESCRIPTION
This PR adds an overload of `Kokkos::Experimental::partition_space` for `HPX`.

It creates new instances in "independent" mode.