### PR TITLE
View-Refactor: mdspan implementation updates

### DIFF
--- a/tpls/mdspan/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/tpls/mdspan/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <tuple>
+#include <complex>
 
 #include "strided_slice.hpp"
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
@@ -52,6 +53,33 @@ template <class OffsetType, class ExtentType, class StrideType>
 struct is_strided_slice<
     strided_slice<OffsetType, ExtentType, StrideType>> : std::true_type {};
 
+// Helper for identifying valid pair like things
+template <class T, class IndexType> struct index_pair_like : std::false_type {};
+
+template <class IdxT1, class IdxT2, class IndexType>
+struct index_pair_like<std::pair<IdxT1, IdxT2>, IndexType> {
+  static constexpr bool value = std::is_convertible_v<IdxT1, IndexType> &&
+                                std::is_convertible_v<IdxT2, IndexType>;
+};
+
+template <class IdxT1, class IdxT2, class IndexType>
+struct index_pair_like<std::tuple<IdxT1, IdxT2>, IndexType> {
+  static constexpr bool value = std::is_convertible_v<IdxT1, IndexType> &&
+                                std::is_convertible_v<IdxT2, IndexType>;
+};
+
+template <class IdxT, class IndexType>
+struct index_pair_like<std::complex<IdxT>, IndexType> {
+  static constexpr bool value = std::is_convertible_v<IdxT, IndexType>;
+};
+
+template <class IdxT, class IndexType>
+struct index_pair_like<std::array<IdxT, 2>, IndexType> {
+  static constexpr bool value = std::is_convertible_v<IdxT, IndexType>;
+};
+
+// FIXME: we actually need to pass IndexType into all of these
+
 // first_of(slice): getting begin of slice specifier range
 MDSPAN_TEMPLATE_REQUIRES(
   class Integral,
@@ -70,7 +98,7 @@ first_of(const ::MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent_t &) {
 
 MDSPAN_TEMPLATE_REQUIRES(
   class Slice,
-  /* requires */(std::is_convertible_v<Slice, std::tuple<size_t, size_t>>)
+  /* requires */(index_pair_like<Slice, size_t>::value)
 )
 MDSPAN_INLINE_FUNCTION
 constexpr auto first_of(const Slice &i) {
@@ -100,7 +128,7 @@ constexpr Integral
 
 MDSPAN_TEMPLATE_REQUIRES(
   size_t k, class Extents, class Slice,
-  /* requires */(std::is_convertible_v<Slice, std::tuple<size_t, size_t>>)
+  /* requires */(index_pair_like<Slice, size_t>::value)
 )
 MDSPAN_INLINE_FUNCTION
 constexpr auto last_of(std::integral_constant<size_t, k>, const Extents &,

--- a/tpls/mdspan/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/tpls/mdspan/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -78,8 +78,6 @@ struct index_pair_like<std::array<IdxT, 2>, IndexType> {
   static constexpr bool value = std::is_convertible_v<IdxT, IndexType>;
 };
 
-// FIXME: we actually need to pass IndexType into all of these
-
 // first_of(slice): getting begin of slice specifier range
 MDSPAN_TEMPLATE_REQUIRES(
   class Integral,

--- a/tpls/mdspan/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/tpls/mdspan/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -105,6 +105,12 @@ constexpr auto first_of(const Slice &i) {
   return std::get<0>(i);
 }
 
+template<class T>
+MDSPAN_INLINE_FUNCTION
+constexpr auto first_of(const std::complex<T> &i) {
+  return i.real();
+}
+
 template <class OffsetType, class ExtentType, class StrideType>
 MDSPAN_INLINE_FUNCTION
 constexpr OffsetType
@@ -134,6 +140,12 @@ MDSPAN_INLINE_FUNCTION
 constexpr auto last_of(std::integral_constant<size_t, k>, const Extents &,
                        const Slice &i) {
   return std::get<1>(i);
+}
+
+template<size_t k, class Extents, class T>
+MDSPAN_INLINE_FUNCTION
+constexpr auto last_of(std::integral_constant<size_t, k>, const Extents &, const std::complex<T> &i) {
+  return i.imag();
 }
 
 // Suppress spurious warning with NVCC about no return statement.

--- a/tpls/mdspan/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/tpls/mdspan/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -98,8 +98,7 @@ template<class SliceSpecifier, class IndexType>
 struct is_range_slice {
   constexpr static bool value =
     std::is_same_v<SliceSpecifier, full_extent_t> ||
-    std::is_convertible_v<SliceSpecifier,
-                          std::tuple<IndexType, IndexType>>;
+    index_pair_like<SliceSpecifier, IndexType>::value;
 };
 
 template<class SliceSpecifier, class IndexType>

--- a/tpls/mdspan/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/tpls/mdspan/include/experimental/__p2642_bits/layout_padded.hpp
@@ -347,7 +347,7 @@ public:
   MDSPAN_INLINE_FUNCTION
   constexpr mapping(const _Mapping &other_mapping) noexcept
       : padded_stride(padded_stride_type::init_padding(
-            other_mapping.extents(),
+            static_cast<extents_type>(other_mapping.extents()),
             other_mapping.extents().extent(extent_to_pad_idx))),
         exts(other_mapping.extents()) {}
 
@@ -707,7 +707,7 @@ public:
   MDSPAN_INLINE_FUNCTION
   constexpr mapping(const _Mapping &other_mapping) noexcept
       : padded_stride(padded_stride_type::init_padding(
-            other_mapping.extents(),
+            static_cast<extents_type>(other_mapping.extents()),
             other_mapping.extents().extent(extent_to_pad_idx))),
         exts(other_mapping.extents()) {}
 

--- a/tpls/mdspan/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/tpls/mdspan/include/experimental/__p2642_bits/layout_padded.hpp
@@ -95,6 +95,7 @@ struct padded_extent {
   using static_array_type = typename static_array_type_for_padded_extent<
       padding_value, _Extents, _ExtentToPadIdx, _Extents::rank()>::type;
 
+  MDSPAN_INLINE_FUNCTION
   static constexpr auto static_value() { return static_array_type::static_value(0); }
 
   MDSPAN_INLINE_FUNCTION
@@ -203,7 +204,7 @@ private:
   }
 
 public:
-#if !MDSPAN_HAS_CXX_20
+#if !MDSPAN_HAS_CXX_20 || defined(__NVCC__)
   MDSPAN_INLINE_FUNCTION_DEFAULTED
   constexpr mapping()
       : mapping(extents_type{})
@@ -566,7 +567,7 @@ public:
   }
 
 public:
-#if !MDSPAN_HAS_CXX_20
+#if !MDSPAN_HAS_CXX_20 || defined(__NVCC__)
   MDSPAN_INLINE_FUNCTION_DEFAULTED
       constexpr mapping()
       : mapping(extents_type{})


### PR DESCRIPTION
This is a piece of #7286 fixing a few small mdspan things. I will open a PR on the mdspan implementation shortly also attempting to write a test for one of the conversion issues exposed and fixed here. (`padded_stride_type::init_padding` takes an `extents_type` as argument, which previously would have required `other_mapping.extents()` to be convertible to `extents_type`. The function constraint is only "is_constructible" though, so we need to explicitly cast before calling the helper. 

MDSpan PR here: https://github.com/kokkos/mdspan/pull/358