### PR TITLE
Add range-based for loop support for `Array<T, N>`

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -439,7 +439,7 @@ KOKKOS_FUNCTION constexpr T const&& get(Array<T, N> const&& a) noexcept {
 namespace Kokkos {
 
 template <class T, std::size_t N>
-KOKKOS_FUNCTION constexpr T const* begin(Array<T, N> const& a) {
+KOKKOS_FUNCTION constexpr T const* begin(Array<T, N> const& a) noexcept {
   if constexpr (N == 0)
     return nullptr;
   else
@@ -447,7 +447,7 @@ KOKKOS_FUNCTION constexpr T const* begin(Array<T, N> const& a) {
 }
 
 template <class T, std::size_t N>
-KOKKOS_FUNCTION constexpr T* begin(Array<T, N>& a) {
+KOKKOS_FUNCTION constexpr T* begin(Array<T, N>& a) noexcept {
   if constexpr (N == 0)
     return nullptr;
   else
@@ -455,7 +455,7 @@ KOKKOS_FUNCTION constexpr T* begin(Array<T, N>& a) {
 }
 
 template <class T, std::size_t N>
-KOKKOS_FUNCTION constexpr T const* end(Array<T, N> const& a) {
+KOKKOS_FUNCTION constexpr T const* end(Array<T, N> const& a) noexcept {
   if constexpr (N == 0)
     return nullptr;
   else
@@ -463,7 +463,7 @@ KOKKOS_FUNCTION constexpr T const* end(Array<T, N> const& a) {
 }
 
 template <class T, std::size_t N>
-KOKKOS_FUNCTION constexpr T* end(Array<T, N>& a) {
+KOKKOS_FUNCTION constexpr T* end(Array<T, N>& a) noexcept {
   if constexpr (N == 0)
     return nullptr;
   else

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -195,8 +195,10 @@ struct Array<T, 0> {
     return *reinterpret_cast<const_pointer>(-1);
   }
 
-  KOKKOS_INLINE_FUNCTION pointer data() { return nullptr; }
-  KOKKOS_INLINE_FUNCTION const_pointer data() const { return nullptr; }
+  KOKKOS_INLINE_FUNCTION constexpr pointer data() { return nullptr; }
+  KOKKOS_INLINE_FUNCTION constexpr const_pointer data() const {
+    return nullptr;
+  }
 
   friend KOKKOS_FUNCTION constexpr bool operator==(Array const&,
                                                    Array const&) noexcept {
@@ -439,37 +441,23 @@ KOKKOS_FUNCTION constexpr T const&& get(Array<T, N> const&& a) noexcept {
 namespace Kokkos {
 
 template <class T, std::size_t N>
-KOKKOS_FUNCTION constexpr T const* begin(
-    [[maybe_unused]] Array<T, N> const& a) noexcept {
-  if constexpr (N == 0)
-    return nullptr;
-  else
-    return &a[0];
+KOKKOS_FUNCTION constexpr T const* begin(Array<T, N> const& a) noexcept {
+  return a.data();
 }
 
 template <class T, std::size_t N>
-KOKKOS_FUNCTION constexpr T* begin([[maybe_unused]] Array<T, N>& a) noexcept {
-  if constexpr (N == 0)
-    return nullptr;
-  else
-    return &a[0];
+KOKKOS_FUNCTION constexpr T* begin(Array<T, N>& a) noexcept {
+  return a.data();
 }
 
 template <class T, std::size_t N>
-KOKKOS_FUNCTION constexpr T const* end(
-    [[maybe_unused]] Array<T, N> const& a) noexcept {
-  if constexpr (N == 0)
-    return nullptr;
-  else
-    return &a[0] + N;
+KOKKOS_FUNCTION constexpr T const* end(Array<T, N> const& a) noexcept {
+  return a.data() + a.size();
 }
 
 template <class T, std::size_t N>
-KOKKOS_FUNCTION constexpr T* end([[maybe_unused]] Array<T, N>& a) noexcept {
-  if constexpr (N == 0)
-    return nullptr;
-  else
-    return &a[0] + N;
+KOKKOS_FUNCTION constexpr T* end(Array<T, N>& a) noexcept {
+  return a.data() + a.size();
 }
 
 }  // namespace Kokkos

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -439,7 +439,8 @@ KOKKOS_FUNCTION constexpr T const&& get(Array<T, N> const&& a) noexcept {
 namespace Kokkos {
 
 template <class T, std::size_t N>
-KOKKOS_FUNCTION constexpr T const* begin(Array<T, N> const& a) noexcept {
+KOKKOS_FUNCTION constexpr T const* begin(
+    [[maybe_unused]] Array<T, N> const& a) noexcept {
   if constexpr (N == 0)
     return nullptr;
   else
@@ -447,7 +448,7 @@ KOKKOS_FUNCTION constexpr T const* begin(Array<T, N> const& a) noexcept {
 }
 
 template <class T, std::size_t N>
-KOKKOS_FUNCTION constexpr T* begin(Array<T, N>& a) noexcept {
+KOKKOS_FUNCTION constexpr T* begin([[maybe_unused]] Array<T, N>& a) noexcept {
   if constexpr (N == 0)
     return nullptr;
   else
@@ -455,7 +456,8 @@ KOKKOS_FUNCTION constexpr T* begin(Array<T, N>& a) noexcept {
 }
 
 template <class T, std::size_t N>
-KOKKOS_FUNCTION constexpr T const* end(Array<T, N> const& a) noexcept {
+KOKKOS_FUNCTION constexpr T const* end(
+    [[maybe_unused]] Array<T, N> const& a) noexcept {
   if constexpr (N == 0)
     return nullptr;
   else
@@ -463,7 +465,7 @@ KOKKOS_FUNCTION constexpr T const* end(Array<T, N> const& a) noexcept {
 }
 
 template <class T, std::size_t N>
-KOKKOS_FUNCTION constexpr T* end(Array<T, N>& a) noexcept {
+KOKKOS_FUNCTION constexpr T* end([[maybe_unused]] Array<T, N>& a) noexcept {
   if constexpr (N == 0)
     return nullptr;
   else

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -435,6 +435,44 @@ KOKKOS_FUNCTION constexpr T const&& get(Array<T, N> const&& a) noexcept {
 }  // namespace Kokkos
 //</editor-fold>
 
+//<editor-fold desc="Support for range-based for loop">
+namespace Kokkos {
+
+template <class T, std::size_t N>
+constexpr T const* begin(Array<T, N> const& a) {
+  if constexpr (N == 0)
+    return nullptr;
+  else
+    return &a[0];
+}
+
+template <class T, std::size_t N>
+constexpr T* begin(Array<T, N>& a) {
+  if constexpr (N == 0)
+    return nullptr;
+  else
+    return &a[0];
+}
+
+template <class T, std::size_t N>
+constexpr T const* end(Array<T, N> const& a) {
+  if constexpr (N == 0)
+    return nullptr;
+  else
+    return &a[0] + N;
+}
+
+template <class T, std::size_t N>
+constexpr T* end(Array<T, N>& a) {
+  if constexpr (N == 0)
+    return nullptr;
+  else
+    return &a[0] + N;
+}
+
+}  // namespace Kokkos
+//</editor-fold>
+
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_ARRAY
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_ARRAY

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -439,7 +439,7 @@ KOKKOS_FUNCTION constexpr T const&& get(Array<T, N> const&& a) noexcept {
 namespace Kokkos {
 
 template <class T, std::size_t N>
-constexpr T const* begin(Array<T, N> const& a) {
+KOKKOS_FUNCTION constexpr T const* begin(Array<T, N> const& a) {
   if constexpr (N == 0)
     return nullptr;
   else
@@ -447,7 +447,7 @@ constexpr T const* begin(Array<T, N> const& a) {
 }
 
 template <class T, std::size_t N>
-constexpr T* begin(Array<T, N>& a) {
+KOKKOS_FUNCTION constexpr T* begin(Array<T, N>& a) {
   if constexpr (N == 0)
     return nullptr;
   else
@@ -455,7 +455,7 @@ constexpr T* begin(Array<T, N>& a) {
 }
 
 template <class T, std::size_t N>
-constexpr T const* end(Array<T, N> const& a) {
+KOKKOS_FUNCTION constexpr T const* end(Array<T, N> const& a) {
   if constexpr (N == 0)
     return nullptr;
   else
@@ -463,7 +463,7 @@ constexpr T const* end(Array<T, N> const& a) {
 }
 
 template <class T, std::size_t N>
-constexpr T* end(Array<T, N>& a) {
+KOKKOS_FUNCTION constexpr T* end(Array<T, N>& a) {
   if constexpr (N == 0)
     return nullptr;
   else

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -241,6 +241,40 @@ constexpr bool test_range_based_for_loop() {
 
 static_assert(test_range_based_for_loop());
 
+constexpr bool test_begin_end() {
+  constexpr Kokkos::Array<float, 0> a0{};
+  static_assert(begin(a0) == nullptr);
+  static_assert(end(a0) == nullptr);
+
+  constexpr Kokkos::Array<float, 1> a1{};
+  static_assert(begin(a1) == &a1[0]);
+  static_assert(end(a1) == &a1[0] + a1.size());
+
+  Kokkos::Array<double, 0> n0{};
+  static_assert(std::is_same_v<decltype(begin(n0)), double*>);
+  static_assert(std::is_same_v<decltype(end(n0)), double*>);
+  static_assert(std::is_same_v<double*, decltype(n0)::pointer>);
+
+  Kokkos::Array<double, 0> const c0{};
+  static_assert(std::is_same_v<decltype(begin(c0)), double const*>);
+  static_assert(std::is_same_v<decltype(end(c0)), double const*>);
+  static_assert(std::is_same_v<double const*, decltype(c0)::const_pointer>);
+
+  Kokkos::Array<double, 1> n1{};
+  static_assert(std::is_same_v<decltype(begin(n1)), double*>);
+  static_assert(std::is_same_v<decltype(end(n1)), double*>);
+  static_assert(std::is_same_v<double*, decltype(n1)::pointer>);
+
+  Kokkos::Array<double, 1> const c1{};
+  static_assert(std::is_same_v<decltype(begin(c1)), double const*>);
+  static_assert(std::is_same_v<decltype(end(c1)), double const*>);
+  static_assert(std::is_same_v<double const*, decltype(c1)::const_pointer>);
+
+  return true;
+}
+
+static_assert(test_begin_end());
+
 constexpr bool test_array_equality_comparable() {
   using C0 = Kokkos::Array<char, 0>;
   using C2 = Kokkos::Array<char, 2>;

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -254,21 +254,29 @@ constexpr bool test_begin_end() {
   static_assert(std::is_same_v<decltype(begin(n0)), double*>);
   static_assert(std::is_same_v<decltype(end(n0)), double*>);
   static_assert(std::is_same_v<double*, decltype(n0)::pointer>);
+  static_assert(noexcept(begin(n0)));
+  static_assert(noexcept(end(n0)));
 
   Kokkos::Array<double, 0> const c0{};
   static_assert(std::is_same_v<decltype(begin(c0)), double const*>);
   static_assert(std::is_same_v<decltype(end(c0)), double const*>);
   static_assert(std::is_same_v<double const*, decltype(c0)::const_pointer>);
+  static_assert(noexcept(begin(c0)));
+  static_assert(noexcept(end(c0)));
 
   Kokkos::Array<double, 1> n1{};
   static_assert(std::is_same_v<decltype(begin(n1)), double*>);
   static_assert(std::is_same_v<decltype(end(n1)), double*>);
   static_assert(std::is_same_v<double*, decltype(n1)::pointer>);
+  static_assert(noexcept(begin(n1)));
+  static_assert(noexcept(end(n1)));
 
   Kokkos::Array<double, 1> const c1{};
   static_assert(std::is_same_v<decltype(begin(c1)), double const*>);
   static_assert(std::is_same_v<decltype(end(c1)), double const*>);
   static_assert(std::is_same_v<double const*, decltype(c1)::const_pointer>);
+  static_assert(noexcept(begin(c1)));
+  static_assert(noexcept(end(c1)));
 
   return true;
 }

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -187,6 +187,60 @@ constexpr bool test_to_array() {
 
 static_assert(test_to_array());
 
+// making sure we cover both const and non-const cases by having a function that
+// writes to an array and another one that reads from it
+// also checking that it supports host device annotations
+template <class T, size_t N>
+KOKKOS_FUNCTION constexpr void iota(Kokkos::Array<T, N>& a, T value) {
+  for (auto& e : a) {
+    e = value++;
+  }
+}
+
+template <class T, size_t N>
+KOKKOS_FUNCTION constexpr T accumulate(Kokkos::Array<T, N> const& a, T init) {
+  T acc = init;
+  for (auto const& e : a) {
+    acc = acc + e;
+  }
+  return acc;
+}
+
+constexpr bool test_range_based_for_loop() {
+  // making sure zero-sized arrays are supported
+  constexpr Kokkos::Array<int, 0> a0 = [] {
+    Kokkos::Array<int, 0> a{};
+    iota(a, 1);
+    return a;
+  }();
+  static_assert(accumulate(a0, 0) == 0);
+
+  constexpr Kokkos::Array<int, 1> a1 = [] {
+    Kokkos::Array<int, 1> a{};
+    iota(a, 1);
+    return a;
+  }();
+  static_assert(accumulate(a1, 0) == 1);
+
+  constexpr Kokkos::Array<int, 2> a2 = [] {
+    Kokkos::Array<int, 2> a{};
+    iota(a, 1);
+    return a;
+  }();
+  static_assert(accumulate(a2, 0) == 3);
+
+  constexpr Kokkos::Array<int, 3> a3 = [] {
+    Kokkos::Array<int, 3> a{};
+    iota(a, 1);
+    return a;
+  }();
+  static_assert(accumulate(a3, 0) == 6);
+
+  return true;
+}
+
+static_assert(test_range_based_for_loop());
+
 constexpr bool test_array_equality_comparable() {
   using C0 = Kokkos::Array<char, 0>;
   using C2 = Kokkos::Array<char, 2>;


### PR DESCRIPTION
This is enabled by introducing `begin()` and `end()` free functions that take const and non-const  `Array` and return pointers to elements.

Whether or not to introduce them as member function can be decided elsewhere.
We would still need the free functions as the `std::` functions would lack the `__host__ __device__` annotations.