### PR TITLE
Prefer `ExecSpace::name()` to `typeid(ExecSpace).name()` in `print_configuration()`

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -613,7 +613,7 @@ void pre_initialize_internal(const Kokkos::InitializationSettings& settings) {
 #endif
 
   declare_configuration_metadata("architecture", "Default Device",
-                                 typeid(Kokkos::DefaultExecutionSpace).name());
+                                 Kokkos::DefaultExecutionSpace::name());
 
 #if defined(KOKKOS_ARCH_A64FX)
   declare_configuration_metadata("architecture", "CPU architecture", "A64FX");


### PR DESCRIPTION
Take advantage of the execution space static member function that returns their name when printing the configuration and avoid outputting mangled information.

On my local setup:
```diff
--- before
+++ after
@@ -3,7 +3,7 @@
   KOKKOS_COMPILER_APPLECC: 6000
 Architecture:
   CPU architecture: none
-  Default Device: N6Kokkos7ThreadsE
+  Default Device: Threads
   GPU architecture: none
   platform: 64bit
 Atomics: