### PR TITLE
Fix nvc++ warning set_but_not_used in Array tests

### DIFF
--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -250,28 +250,28 @@ constexpr bool test_begin_end() {
   static_assert(begin(a1) == &a1[0]);
   static_assert(end(a1) == &a1[0] + a1.size());
 
-  Kokkos::Array<double, 0> n0{};
+  [[maybe_unused]] Kokkos::Array<double, 0> n0{};
   static_assert(std::is_same_v<decltype(begin(n0)), double*>);
   static_assert(std::is_same_v<decltype(end(n0)), double*>);
   static_assert(std::is_same_v<double*, decltype(n0)::pointer>);
   static_assert(noexcept(begin(n0)));
   static_assert(noexcept(end(n0)));
 
-  Kokkos::Array<double, 0> const c0{};
+  [[maybe_unused]] Kokkos::Array<double, 0> const c0{};
   static_assert(std::is_same_v<decltype(begin(c0)), double const*>);
   static_assert(std::is_same_v<decltype(end(c0)), double const*>);
   static_assert(std::is_same_v<double const*, decltype(c0)::const_pointer>);
   static_assert(noexcept(begin(c0)));
   static_assert(noexcept(end(c0)));
 
-  Kokkos::Array<double, 1> n1{};
+  [[maybe_unused]] Kokkos::Array<double, 1> n1{};
   static_assert(std::is_same_v<decltype(begin(n1)), double*>);
   static_assert(std::is_same_v<decltype(end(n1)), double*>);
   static_assert(std::is_same_v<double*, decltype(n1)::pointer>);
   static_assert(noexcept(begin(n1)));
   static_assert(noexcept(end(n1)));
 
-  Kokkos::Array<double, 1> const c1{};
+  [[maybe_unused]] Kokkos::Array<double, 1> const c1{};
   static_assert(std::is_same_v<decltype(begin(c1)), double const*>);
   static_assert(std::is_same_v<decltype(end(c1)), double const*>);
   static_assert(std::is_same_v<double const*, decltype(c1)::const_pointer>);


### PR DESCRIPTION
Fixup for #7293

Attempting to fix
```
"/var/jenkins/workspace/Kokkos_PR-7297/core/unit_test/TestArray.cpp", line 253: error: variable "n0" was set but never used [set_but_not_used]
    Kokkos::Array<double, 0> n0{};
                             ^

Remark: individual warnings can be suppressed with "--diag_suppress <warning-name>"

"/var/jenkins/workspace/Kokkos_PR-7297/core/unit_test/TestArray.cpp", line 267: error: variable "n1" was set but never used [set_but_not_used]
    Kokkos::Array<double, 1> n1{};
                             ^

2 errors detected in the compilation of "/var/jenkins/workspace/Kokkos_PR-7297/core/unit_test/TestArray.cpp".