### PR TITLE
SYCL: Fix configuring without architecture flags

### DIFF
--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -928,10 +928,8 @@ IF (KOKKOS_ENABLE_SYCL)
     COMPILER_SPECIFIC_FLAGS(
       DEFAULT -fsycl-targets=spir64
     )
-  ELSE()
-    IF(KOKKOS_ARCH_INTEL_GPU)
-      SET(SYCL_TARGET_FLAG -fsycl-targets=spir64_gen)
-    ENDIF()
+  ELSEIF(KOKKOS_ARCH_INTEL_GPU)
+    SET(SYCL_TARGET_FLAG -fsycl-targets=spir64_gen)
 
     IF(KOKKOS_ARCH_INTEL_GEN9)
      SET(SYCL_TARGET_BACKEND_FLAG -Xsycl-target-backend "-device gen9")

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -929,7 +929,9 @@ IF (KOKKOS_ENABLE_SYCL)
       DEFAULT -fsycl-targets=spir64
     )
   ELSE()
-    SET(SYCL_TARGET_FLAG -fsycl-targets=spir64_gen)
+    IF(KOKKOS_ARCH_INTEL_GPU)
+      SET(SYCL_TARGET_FLAG -fsycl-targets=spir64_gen)
+    ENDIF()
 
     IF(KOKKOS_ARCH_INTEL_GEN9)
      SET(SYCL_TARGET_BACKEND_FLAG -Xsycl-target-backend "-device gen9")


### PR DESCRIPTION
Compiling without architceture flags currently fails because we are indicating a AOT for Intel GPU build when we shoudln't provide any flag at all. We broke this in https://github.com/kokkos/kokkos/pull/5705.