### PR TITLE
Change RandomAccessIterator to avoid storing a view

### DIFF
--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -53,13 +53,9 @@ void sort(const ExecutionSpace& exec,
 
   if constexpr (Impl::better_off_calling_std_sort_v<ExecutionSpace>) {
     exec.fence("Kokkos::sort without comparator use std::sort");
-    if (view.span_is_contiguous()) {
-      std::sort(view.data(), view.data() + view.size());
-    } else {
-      auto first = ::Kokkos::Experimental::begin(view);
-      auto last  = ::Kokkos::Experimental::end(view);
-      std::sort(first, last);
-    }
+    auto first = ::Kokkos::Experimental::begin(view);
+    auto last  = ::Kokkos::Experimental::end(view);
+    std::sort(first, last);
   } else {
     Impl::sort_device_view_without_comparator(exec, view);
   }
@@ -111,13 +107,9 @@ void sort(const ExecutionSpace& exec,
 
   if constexpr (Impl::better_off_calling_std_sort_v<ExecutionSpace>) {
     exec.fence("Kokkos::sort with comparator use std::sort");
-    if (view.span_is_contiguous()) {
-      std::sort(view.data(), view.data() + view.size(), comparator);
-    } else {
-      auto first = ::Kokkos::Experimental::begin(view);
-      auto last  = ::Kokkos::Experimental::end(view);
-      std::sort(first, last, comparator);
-    }
+    auto first = ::Kokkos::Experimental::begin(view);
+    auto last  = ::Kokkos::Experimental::end(view);
+    std::sort(first, last, comparator);
   } else {
     Impl::sort_device_view_with_comparator(exec, view, comparator);
   }

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -268,29 +268,19 @@ void copy_to_host_run_stdsort_copy_back(
     KE::copy(exec, view, view_dc);
 
     // run sort on the mirror of view_dc
-    auto mv_h = create_mirror_view_and_copy(Kokkos::HostSpace(), view_dc);
-    if (view.span_is_contiguous()) {
-      std::sort(mv_h.data(), mv_h.data() + mv_h.size(),
-                std::forward<MaybeComparator>(maybeComparator)...);
-    } else {
-      auto first = KE::begin(mv_h);
-      auto last  = KE::end(mv_h);
-      std::sort(first, last, std::forward<MaybeComparator>(maybeComparator)...);
-    }
+    auto mv_h  = create_mirror_view_and_copy(Kokkos::HostSpace(), view_dc);
+    auto first = KE::begin(mv_h);
+    auto last  = KE::end(mv_h);
+    std::sort(first, last, std::forward<MaybeComparator>(maybeComparator)...);
     Kokkos::deep_copy(exec, view_dc, mv_h);
 
     // copy back to argument view
     KE::copy(exec, KE::cbegin(view_dc), KE::cend(view_dc), KE::begin(view));
   } else {
     auto view_h = create_mirror_view_and_copy(Kokkos::HostSpace(), view);
-    if (view.span_is_contiguous()) {
-      std::sort(view_h.data(), view_h.data() + view_h.size(),
-                std::forward<MaybeComparator>(maybeComparator)...);
-    } else {
-      auto first = KE::begin(view_h);
-      auto last  = KE::end(view_h);
-      std::sort(first, last, std::forward<MaybeComparator>(maybeComparator)...);
-    }
+    auto first  = KE::begin(view_h);
+    auto last   = KE::end(view_h);
+    std::sort(first, last, std::forward<MaybeComparator>(maybeComparator)...);
     Kokkos::deep_copy(exec, view, view_h);
   }
 }

--- a/algorithms/src/std_algorithms/impl/Kokkos_Constraints.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Constraints.hpp
@@ -238,12 +238,9 @@ KOKKOS_INLINE_FUNCTION void expect_no_overlap(
     [[maybe_unused]] IteratorType2 s_first) {
   if constexpr (is_kokkos_iterator_v<IteratorType1> &&
                 is_kokkos_iterator_v<IteratorType2>) {
-    auto const view1 = first.view();
-    auto const view2 = s_first.view();
-
-    std::size_t stride1  = view1.stride(0);
-    std::size_t stride2  = view2.stride(0);
-    ptrdiff_t first_diff = view1.data() - view2.data();
+    std::size_t stride1  = first.stride();
+    std::size_t stride2  = s_first.stride();
+    ptrdiff_t first_diff = first.data() - s_first.data();
 
     // FIXME If strides are not identical, checks may not be made
     // with the cost of O(1)
@@ -251,8 +248,8 @@ KOKKOS_INLINE_FUNCTION void expect_no_overlap(
     // If first_diff == 0, there is already an overlap
     if (stride1 == stride2 || first_diff == 0) {
       [[maybe_unused]] bool is_no_overlap  = (first_diff % stride1);
-      auto* first_pointer1                 = view1.data();
-      auto* first_pointer2                 = view2.data();
+      auto* first_pointer1                 = first.data();
+      auto* first_pointer2                 = s_first.data();
       [[maybe_unused]] auto* last_pointer1 = first_pointer1 + (last - first);
       [[maybe_unused]] auto* last_pointer2 = first_pointer2 + (last - first);
       KOKKOS_EXPECTS(first_pointer1 >= last_pointer2 ||

--- a/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_RANDOM_ACCESS_ITERATOR_IMPL_HPP
 
 #include <iterator>
+#include <utility>  // declval
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_View.hpp>
 #include "Kokkos_Constraints.hpp"
@@ -29,8 +30,29 @@ namespace Impl {
 template <class T>
 class RandomAccessIterator;
 
+namespace {
+
+template <typename ViewType>
+struct is_always_strided {
+  static_assert(is_view_v<ViewType>);
+
+  constexpr static bool value =
+#ifdef KOKKOS_ENABLE_IMPL_MDSPAN
+      decltype(std::declval<ViewType>().to_mdspan())::is_always_strided();
+#else
+      (std::is_same_v<typename ViewType::traits::array_layout,
+                      Kokkos::LayoutLeft> ||
+       std::is_same_v<typename ViewType::traits::array_layout,
+                      Kokkos::LayoutRight> ||
+       std::is_same_v<typename ViewType::traits::array_layout,
+                      Kokkos::LayoutStride>);
+#endif
+};
+
+}  // namespace
+
 template <class DataType, class... Args>
-class RandomAccessIterator< ::Kokkos::View<DataType, Args...> > {
+class RandomAccessIterator<::Kokkos::View<DataType, Args...>> {
  public:
   using view_type     = ::Kokkos::View<DataType, Args...>;
   using iterator_type = RandomAccessIterator<view_type>;
@@ -42,29 +64,23 @@ class RandomAccessIterator< ::Kokkos::View<DataType, Args...> > {
   using reference         = typename view_type::reference_type;
 
   static_assert(view_type::rank == 1 &&
-                    (std::is_same_v<typename view_type::traits::array_layout,
-                                    Kokkos::LayoutLeft> ||
-                     std::is_same_v<typename view_type::traits::array_layout,
-                                    Kokkos::LayoutRight> ||
-                     std::is_same_v<typename view_type::traits::array_layout,
-                                    Kokkos::LayoutStride>),
-                "RandomAccessIterator only supports 1D Views with LayoutLeft, "
-                "LayoutRight, LayoutStride.");
+                is_always_strided<::Kokkos::View<DataType, Args...>>::value);
 
   KOKKOS_DEFAULTED_FUNCTION RandomAccessIterator() = default;
 
   explicit KOKKOS_FUNCTION RandomAccessIterator(const view_type view)
-      : m_view(view) {}
+      : m_data(view.data()), m_stride(view.stride_0()) {}
   explicit KOKKOS_FUNCTION RandomAccessIterator(const view_type view,
                                                 ptrdiff_t current_index)
-      : m_view(view), m_current_index(current_index) {}
+      : m_data(view.data() + current_index * view.stride_0()),
+        m_stride(view.stride_0()) {}
 
 #ifndef KOKKOS_ENABLE_CXX17  // C++20 and beyond
   template <class OtherViewType>
     requires(std::is_constructible_v<view_type, OtherViewType>)
   KOKKOS_FUNCTION explicit(!std::is_convertible_v<OtherViewType, view_type>)
       RandomAccessIterator(const RandomAccessIterator<OtherViewType>& other)
-      : m_view(other.m_view), m_current_index(other.m_current_index) {}
+      : m_data(other.m_data), m_stride(other.m_stride) {}
 #else
   template <
       class OtherViewType,
@@ -73,19 +89,22 @@ class RandomAccessIterator< ::Kokkos::View<DataType, Args...> > {
                        int> = 0>
   KOKKOS_FUNCTION explicit RandomAccessIterator(
       const RandomAccessIterator<OtherViewType>& other)
-      : m_view(other.m_view), m_current_index(other.m_current_index) {}
+      : m_data(other.m_data), m_stride(other.m_stride) {}
 
   template <class OtherViewType,
             std::enable_if_t<std::is_convertible_v<OtherViewType, view_type>,
                              int> = 0>
   KOKKOS_FUNCTION RandomAccessIterator(
       const RandomAccessIterator<OtherViewType>& other)
-      : m_view(other.m_view), m_current_index(other.m_current_index) {}
+      : m_data(other.m_data), m_stride(other.m_stride) {}
 #endif
 
   KOKKOS_FUNCTION
   iterator_type& operator++() {
-    ++m_current_index;
+    if constexpr (is_always_contiguous)
+      m_data++;
+    else
+      m_data += m_stride;
     return *this;
   }
 
@@ -98,7 +117,10 @@ class RandomAccessIterator< ::Kokkos::View<DataType, Args...> > {
 
   KOKKOS_FUNCTION
   iterator_type& operator--() {
-    --m_current_index;
+    if constexpr (is_always_contiguous)
+      m_data--;
+    else
+      m_data -= m_stride;
     return *this;
   }
 
@@ -111,77 +133,91 @@ class RandomAccessIterator< ::Kokkos::View<DataType, Args...> > {
 
   KOKKOS_FUNCTION
   reference operator[](difference_type n) const {
-    return m_view(m_current_index + n);
+    if constexpr (is_always_contiguous)
+      return *(m_data + n);
+    else
+      return *(m_data + n * m_stride);
   }
 
   KOKKOS_FUNCTION
   iterator_type& operator+=(difference_type n) {
-    m_current_index += n;
+    if constexpr (is_always_contiguous)
+      m_data += n;
+    else
+      m_data += n * m_stride;
     return *this;
   }
 
   KOKKOS_FUNCTION
   iterator_type& operator-=(difference_type n) {
-    m_current_index -= n;
+    if constexpr (is_always_contiguous)
+      m_data -= n;
+    else
+      m_data -= n * m_stride;
     return *this;
   }
 
   KOKKOS_FUNCTION
   iterator_type operator+(difference_type n) const {
-    return iterator_type(m_view, m_current_index + n);
+    auto it = *this;
+    it += n;
+    return it;
   }
 
   KOKKOS_FUNCTION
   iterator_type operator-(difference_type n) const {
-    return iterator_type(m_view, m_current_index - n);
+    auto it = *this;
+    it -= n;
+    return it;
   }
 
   KOKKOS_FUNCTION
   difference_type operator-(iterator_type it) const {
-    return m_current_index - it.m_current_index;
+    if constexpr (is_always_contiguous)
+      return m_data - it.m_data;
+    else
+      return (m_data - it.m_data) / m_stride;
   }
 
   KOKKOS_FUNCTION
   bool operator==(iterator_type other) const {
-    return m_current_index == other.m_current_index &&
-           m_view.data() == other.m_view.data();
+    return m_data == other.m_data && m_stride == other.m_stride;
   }
 
   KOKKOS_FUNCTION
   bool operator!=(iterator_type other) const {
-    return m_current_index != other.m_current_index ||
-           m_view.data() != other.m_view.data();
+    return m_data != other.m_data || m_stride != other.m_stride;
   }
 
   KOKKOS_FUNCTION
-  bool operator<(iterator_type other) const {
-    return m_current_index < other.m_current_index;
-  }
+  bool operator<(iterator_type other) const { return m_data < other.m_data; }
 
   KOKKOS_FUNCTION
-  bool operator<=(iterator_type other) const {
-    return m_current_index <= other.m_current_index;
-  }
+  bool operator<=(iterator_type other) const { return m_data <= other.m_data; }
 
   KOKKOS_FUNCTION
-  bool operator>(iterator_type other) const {
-    return m_current_index > other.m_current_index;
-  }
+  bool operator>(iterator_type other) const { return m_data > other.m_data; }
 
   KOKKOS_FUNCTION
-  bool operator>=(iterator_type other) const {
-    return m_current_index >= other.m_current_index;
-  }
+  bool operator>=(iterator_type other) const { return m_data >= other.m_data; }
 
   KOKKOS_FUNCTION
-  reference operator*() const { return m_view(m_current_index); }
+  reference operator*() const { return *m_data; }
 
   KOKKOS_FUNCTION
-  view_type view() const { return m_view; }
+  pointer data() const { return m_data; }
+
+  KOKKOS_FUNCTION
+  int stride() const { return m_stride; }
 
  private:
-  view_type m_view;
-  ptrdiff_t m_current_index = 0;
+  pointer m_data;
+  int m_stride;
+  static constexpr bool is_always_contiguous =
+      (std::is_same_v<typename view_type::traits::array_layout,
+                      Kokkos::LayoutLeft> ||
+       std::is_same_v<typename view_type::traits::array_layout,
+                      Kokkos::LayoutRight>);
 
   // Needed for the converting constructor accepting another iterator
   template <class>

--- a/algorithms/unit_tests/TestRandomAccessIterator.cpp
+++ b/algorithms/unit_tests/TestRandomAccessIterator.cpp
@@ -37,12 +37,18 @@ struct random_access_iterator_test : std_algorithms_test {
 
 TEST_F(random_access_iterator_test, constructor) {
   // just tests that constructor works
-  auto it1 = KE::Impl::RandomAccessIterator<static_view_t>(m_static_view);
-  auto it2 = KE::Impl::RandomAccessIterator<dyn_view_t>(m_dynamic_view);
-  auto it3 = KE::Impl::RandomAccessIterator<strided_view_t>(m_strided_view);
-  auto it4 = KE::Impl::RandomAccessIterator<static_view_t>(m_static_view, 3);
-  auto it5 = KE::Impl::RandomAccessIterator<dyn_view_t>(m_dynamic_view, 3);
-  auto it6 = KE::Impl::RandomAccessIterator<strided_view_t>(m_strided_view, 3);
+  [[maybe_unused]] auto it1 =
+      KE::Impl::RandomAccessIterator<static_view_t>(m_static_view);
+  [[maybe_unused]] auto it2 =
+      KE::Impl::RandomAccessIterator<dyn_view_t>(m_dynamic_view);
+  [[maybe_unused]] auto it3 =
+      KE::Impl::RandomAccessIterator<strided_view_t>(m_strided_view);
+  [[maybe_unused]] auto it4 =
+      KE::Impl::RandomAccessIterator<static_view_t>(m_static_view, 3);
+  [[maybe_unused]] auto it5 =
+      KE::Impl::RandomAccessIterator<dyn_view_t>(m_dynamic_view, 3);
+  [[maybe_unused]] auto it6 =
+      KE::Impl::RandomAccessIterator<strided_view_t>(m_strided_view, 3);
   EXPECT_TRUE(true);
 }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsIsSortedUntil.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsIsSortedUntil.cpp
@@ -152,12 +152,13 @@ void run_single_scenario(const InfoType& scenario_info) {
 
 #if !defined KOKKOS_ENABLE_OPENMPTARGET
   CustomLessThanComparator<ValueType, ValueType> comp;
-  auto r5 =
+  [[maybe_unused]] auto r5 =
       KE::is_sorted_until(exespace(), KE::cbegin(view), KE::cend(view), comp);
-  auto r6 = KE::is_sorted_until("label", exespace(), KE::cbegin(view),
-                                KE::cend(view), comp);
-  auto r7 = KE::is_sorted_until(exespace(), view, comp);
-  auto r8 = KE::is_sorted_until("label", exespace(), view, comp);
+  [[maybe_unused]] auto r6 = KE::is_sorted_until(
+      "label", exespace(), KE::cbegin(view), KE::cend(view), comp);
+  [[maybe_unused]] auto r7 = KE::is_sorted_until(exespace(), view, comp);
+  [[maybe_unused]] auto r8 =
+      KE::is_sorted_until("label", exespace(), view, comp);
 #endif
 
   ASSERT_EQ(r1, gold) << name << ", " << view_tag_to_string(Tag{});

--- a/algorithms/unit_tests/TestStdAlgorithmsRotate.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsRotate.cpp
@@ -196,7 +196,7 @@ void run_single_scenario(const InfoType& scenario_info,
     // create host copy BEFORE rotate or view will be modified
     auto view_h = create_host_space_copy(view);
     auto rit    = KE::rotate(exespace(), view, rotation_point);
-    // verify_data(rit, view, view_h, rotation_point);
+    verify_data(rit, view, view_h, rotation_point);
   }
 
   {


### PR DESCRIPTION
#7264 provided a workaround for #7263. However, given that the random access iterators are used throughout the `algorithms`, I think the found performance affects performance of anything in `algorithms/`, so I wanted to see if I can improve the iterators themselves.

I first switched to the `m_data` and `m_stride` instead of storing a view and index. With this change, `RandomAccessIterator` is no longer participating in reference counting as it does not keep the view.

This got pretty close on my MAC, though not exactly the same as `std::sort` (using benchmark from #7263), about 6% slower:

| n         | function      | time        |
| --        | --            | --          |
| 1         | Kokkos::sort: | 2.09e-07
| 1         | std::sort:    | 8.33e-07
| 10        | Kokkos::sort: | 1.25e-06
| 10        | std::sort:    | 4.58e-07
| 100       | Kokkos::sort: | 9.459e-06
| 100       | std::sort:    | 8.25e-06
| 1000      | Kokkos::sort: | 0.000112167
| 1000      | std::sort:    | 0.000102584
| 10000     | Kokkos::sort: | 0.00143758
| 10000     | std::sort:    | 0.00131521
| 100000    | Kokkos::sort: | 0.012805
| 100000    | std::sort:    | 0.00973313
| 1000000   | Kokkos::sort: | 0.0804865
| 1000000   | std::sort:    | 0.0677386
| 10000000  | Kokkos::sort: | 0.837974
| 10000000  | std::sort:    | 0.790265
| 100000000 | Kokkos::sort: | 9.46917
| 100000000 | std::sort:    | 8.91758


After adding a special pathway for `LayoutLeft/LayoutRight`, it recovered it:

| n         | function      | time        |
| --        | --            | --          |
| 1         | Kokkos::sort: | 2.09e-07
| 1         | std::sort:    | 7.08e-07
| 10        | Kokkos::sort: | 1.583e-06
| 10        | std::sort:    | 5.41e-07
| 100       | Kokkos::sort: | 7.958e-06
| 100       | std::sort:    | 8.25e-06
| 1000      | Kokkos::sort: | 0.000104167
| 1000      | std::sort:    | 0.000102584
| 10000     | Kokkos::sort: | 0.00137208
| 10000     | std::sort:    | 0.00138138
| 100000    | Kokkos::sort: | 0.0130026
| 100000    | std::sort:    | 0.00993137
| 1000000   | Kokkos::sort: | 0.0762402
| 1000000   | std::sort:    | 0.0682584
| 10000000  | Kokkos::sort: | 0.789772
| 10000000  | std::sort:    | 0.790647
| 100000000 | Kokkos::sort: | 8.84346
| 100000000 | std::sort:    | 8.87267

The only thing that is slightly different from #7264 is that a strided view that has contiguous storage is not treated as such. If that can be determined at compile time, that could be incorporated.

I was not present during the design of the original `RandomAccessIterator`, so I'm not sure why its design was chosen as it is. So I may be missing something in this refactor.

/cc @fnrizzi