### PR TITLE
Disable all thread safety tests for the OpenACC backend

### DIFF
--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -79,7 +79,9 @@ void run_exec_space_thread_safety_range() {
 TEST(TEST_CATEGORY, exec_space_thread_safety_range) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
+    GTEST_SKIP()
+        << "skipping OpenACC test since unsupported host-side atomics cause "
+           "race conditions during shared allocation reference counting";
 #endif
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
@@ -120,7 +122,9 @@ void run_exec_space_thread_safety_mdrange() {
 TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
+    GTEST_SKIP()
+        << "skipping OpenACC test since unsupported host-side atomics cause "
+           "race conditions during shared allocation reference counting";
 #endif
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
@@ -163,7 +167,9 @@ void run_exec_space_thread_safety_team_policy() {
 TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
+    GTEST_SKIP()
+        << "skipping OpenACC test since unsupported host-side atomics cause "
+           "race conditions during shared allocation reference counting";
 #endif
 // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
@@ -206,7 +212,9 @@ void run_exec_space_thread_safety_range_reduce() {
 TEST(TEST_CATEGORY, exec_space_thread_safety_range_reduce) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
+    GTEST_SKIP()
+        << "skipping OpenACC test since unsupported host-side atomics cause "
+           "race conditions during shared allocation reference counting";
 #endif
   run_exec_space_thread_safety_range_reduce();
 }
@@ -244,7 +252,9 @@ void run_exec_space_thread_safety_mdrange_reduce() {
 TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange_reduce) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
+    GTEST_SKIP()
+        << "skipping OpenACC test since unsupported host-side atomics cause "
+           "race conditions during shared allocation reference counting";
 #endif
 // FIXME_INTEL
 #if defined(KOKKOS_COMPILER_INTEL) && defined(KOKKOS_ENABLE_OPENMP)
@@ -289,7 +299,9 @@ void run_exec_space_thread_safety_team_policy_reduce() {
 TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy_reduce) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
+    GTEST_SKIP()
+        << "skipping OpenACC test since unsupported host-side atomics cause "
+           "race conditions during shared allocation reference counting";
 #endif
 // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
@@ -339,7 +351,9 @@ void run_exec_space_thread_safety_range_scan() {
 TEST(TEST_CATEGORY, exec_space_thread_safety_range_scan) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
+    GTEST_SKIP()
+        << "skipping OpenACC test since unsupported host-side atomics cause "
+           "race conditions during shared allocation reference counting";
 #endif
   run_exec_space_thread_safety_range_scan();
 }

--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -78,10 +78,8 @@ void run_exec_space_thread_safety_range() {
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_range) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-#ifdef KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
     GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
-#endif
 #endif
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
@@ -121,10 +119,8 @@ void run_exec_space_thread_safety_mdrange() {
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-#ifdef KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
     GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
-#endif
 #endif
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
@@ -166,10 +162,8 @@ void run_exec_space_thread_safety_team_policy() {
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-#ifdef KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
     GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
-#endif
 #endif
 // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
@@ -211,10 +205,8 @@ void run_exec_space_thread_safety_range_reduce() {
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_range_reduce) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-#ifdef KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
     GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
-#endif
 #endif
   run_exec_space_thread_safety_range_reduce();
 }
@@ -251,10 +243,8 @@ void run_exec_space_thread_safety_mdrange_reduce() {
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange_reduce) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-#ifdef KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
     GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
-#endif
 #endif
 // FIXME_INTEL
 #if defined(KOKKOS_COMPILER_INTEL) && defined(KOKKOS_ENABLE_OPENMP)
@@ -298,10 +288,8 @@ void run_exec_space_thread_safety_team_policy_reduce() {
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy_reduce) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-#ifdef KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
     GTEST_SKIP() << "skipping since test is known to fail with OpenACC";
-#endif
 #endif
 // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET


### PR DESCRIPTION
Temporarily disable all thread safety tests for the OpenACC backend until the thread safety issue is fixed.