### PR TITLE
View-refactor: Use stride in layout instance

### DIFF
--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -52,11 +52,9 @@ struct LayoutLeft {
   using array_layout = LayoutLeft;
 
   size_t dimension[ARRAY_LAYOUT_MAX_RANK];
-  // we don't have a constructor to set this directly
+  // we don't have a constructor to set the stride directly
   // but we will deprecate the class anyway (or at least using an instance of
-  // this class) so I believe its acceptable to not introduce a new ctor and
-  // simply set this value directly in the internal functions where we construct
-  // instances of LayoutLeft
+  // this class) when switching the internal implementation to use mdspan
   size_t stride;
 
   enum : bool { is_extent_constructible = true };
@@ -108,11 +106,9 @@ struct LayoutRight {
   using array_layout = LayoutRight;
 
   size_t dimension[ARRAY_LAYOUT_MAX_RANK];
-  // we don't have a constructor to set this directly
+  // we don't have a constructor to set the stride directly
   // but we will deprecate the class anyway (or at least using an instance of
-  // this class) so I believe its acceptable to not introduce a new ctor and
-  // simply set this value directly in the internal functions where we construct
-  // instances of LayoutLeft
+  // this class) when switching the internal implementation to use mdspan
   size_t stride;
 
   enum : bool { is_extent_constructible = true };

--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -52,6 +52,12 @@ struct LayoutLeft {
   using array_layout = LayoutLeft;
 
   size_t dimension[ARRAY_LAYOUT_MAX_RANK];
+  // we don't have a constructor to set this directly
+  // but we will deprecate the class anyway (or at least using an instance of
+  // this class) so I believe its acceptable to not introduce a new ctor and
+  // simply set this value directly in the internal functions where we construct
+  // instances of LayoutLeft
+  size_t stride;
 
   enum : bool { is_extent_constructible = true };
 
@@ -69,7 +75,8 @@ struct LayoutLeft {
                                 size_t N5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                                 size_t N6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                                 size_t N7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
-      : dimension{N0, N1, N2, N3, N4, N5, N6, N7} {}
+      : dimension{N0, N1, N2, N3, N4, N5, N6, N7},
+        stride(KOKKOS_IMPL_CTOR_DEFAULT_ARG) {}
 
   friend bool operator==(const LayoutLeft& left, const LayoutLeft& right) {
     for (unsigned int rank = 0; rank < ARRAY_LAYOUT_MAX_RANK; ++rank)
@@ -101,6 +108,12 @@ struct LayoutRight {
   using array_layout = LayoutRight;
 
   size_t dimension[ARRAY_LAYOUT_MAX_RANK];
+  // we don't have a constructor to set this directly
+  // but we will deprecate the class anyway (or at least using an instance of
+  // this class) so I believe its acceptable to not introduce a new ctor and
+  // simply set this value directly in the internal functions where we construct
+  // instances of LayoutLeft
+  size_t stride;
 
   enum : bool { is_extent_constructible = true };
 
@@ -118,7 +131,8 @@ struct LayoutRight {
                                  size_t N5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                                  size_t N6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                                  size_t N7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
-      : dimension{N0, N1, N2, N3, N4, N5, N6, N7} {}
+      : dimension{N0, N1, N2, N3, N4, N5, N6, N7},
+        stride{KOKKOS_IMPL_CTOR_DEFAULT_ARG} {}
 
   friend bool operator==(const LayoutRight& left, const LayoutRight& right) {
     for (unsigned int rank = 0; rank < ARRAY_LAYOUT_MAX_RANK; ++rank)

--- a/core/src/View/Kokkos_ViewMapping.hpp
+++ b/core/src/View/Kokkos_ViewMapping.hpp
@@ -1762,6 +1762,43 @@ struct ViewOffset<
 
   /* Enable padding for trivial scalar types with non-zero trivial scalar size.
    */
+
+  template <unsigned TrivialScalarSize>
+  constexpr size_type compute_stride(const Kokkos::LayoutRight& arg_layout) {
+    return arg_layout.stride != KOKKOS_IMPL_CTOR_DEFAULT_ARG
+               ? arg_layout.stride
+               : Padding<TrivialScalarSize>::
+                     stride(/* 2 <= rank */
+                            m_dim.N1 *
+                            (dimension_type::rank == 2
+                                 ? size_t(1)
+                                 : m_dim.N2 *
+                                       (dimension_type::rank == 3
+                                            ? size_t(1)
+                                            : m_dim.N3 *
+                                                  (dimension_type::rank == 4
+                                                       ? size_t(1)
+                                                       : m_dim.N4 *
+                                                             (dimension_type::
+                                                                          rank ==
+                                                                      5
+                                                                  ? size_t(1)
+                                                                  : m_dim.N5 *
+                                                                        (dimension_type::
+                                                                                     rank ==
+                                                                                 6
+                                                                             ? size_t(
+                                                                                   1)
+                                                                             : m_dim.N6 *
+                                                                                   (dimension_type::
+                                                                                                rank ==
+                                                                                            7
+                                                                                        ? size_t(
+                                                                                              1)
+                                                                                        : m_dim
+                                                                                              .N7)))))));
+  }
+
   template <unsigned TrivialScalarSize>
   KOKKOS_INLINE_FUNCTION constexpr ViewOffset(
       std::integral_constant<unsigned, TrivialScalarSize> const&,
@@ -1770,40 +1807,7 @@ struct ViewOffset<
               arg_layout.dimension[2], arg_layout.dimension[3],
               arg_layout.dimension[4], arg_layout.dimension[5],
               arg_layout.dimension[6], arg_layout.dimension[7]),
-        m_stride(
-            arg_layout.stride != KOKKOS_IMPL_CTOR_DEFAULT_ARG
-                ? arg_layout.stride
-                : Padding<TrivialScalarSize>::
-                      stride(/* 2 <= rank */
-                             m_dim.N1 *
-                             (dimension_type::rank == 2
-                                  ? size_t(1)
-                                  : m_dim.N2 *
-                                        (dimension_type::rank == 3
-                                             ? size_t(1)
-                                             : m_dim.N3 *
-                                                   (dimension_type::rank == 4
-                                                        ? size_t(1)
-                                                        : m_dim.N4 *
-                                                              (dimension_type::
-                                                                           rank ==
-                                                                       5
-                                                                   ? size_t(1)
-                                                                   : m_dim.N5 *
-                                                                         (dimension_type::
-                                                                                      rank ==
-                                                                                  6
-                                                                              ? size_t(
-                                                                                    1)
-                                                                              : m_dim.N6 *
-                                                                                    (dimension_type::
-                                                                                                 rank ==
-                                                                                             7
-                                                                                         ? size_t(
-                                                                                               1)
-                                                                                         : m_dim
-                                                                                               .N7)))))))) {
-  }
+        m_stride(compute_stride<TrivialScalarSize>(arg_layout)) {}
 
   template <class DimRHS>
   KOKKOS_INLINE_FUNCTION constexpr ViewOffset(

--- a/core/src/View/Kokkos_ViewMapping.hpp
+++ b/core/src/View/Kokkos_ViewMapping.hpp
@@ -883,14 +883,16 @@ struct ViewOffset<
   KOKKOS_INLINE_FUNCTION
   constexpr array_layout layout() const {
     constexpr auto r = dimension_type::rank;
-    return array_layout((r > 0 ? m_dim.N0 : KOKKOS_INVALID_INDEX),
-                        (r > 1 ? m_dim.N1 : KOKKOS_INVALID_INDEX),
-                        (r > 2 ? m_dim.N2 : KOKKOS_INVALID_INDEX),
-                        (r > 3 ? m_dim.N3 : KOKKOS_INVALID_INDEX),
-                        (r > 4 ? m_dim.N4 : KOKKOS_INVALID_INDEX),
-                        (r > 5 ? m_dim.N5 : KOKKOS_INVALID_INDEX),
-                        (r > 6 ? m_dim.N6 : KOKKOS_INVALID_INDEX),
-                        (r > 7 ? m_dim.N7 : KOKKOS_INVALID_INDEX));
+    array_layout l((r > 0 ? m_dim.N0 : KOKKOS_INVALID_INDEX),
+                   (r > 1 ? m_dim.N1 : KOKKOS_INVALID_INDEX),
+                   (r > 2 ? m_dim.N2 : KOKKOS_INVALID_INDEX),
+                   (r > 3 ? m_dim.N3 : KOKKOS_INVALID_INDEX),
+                   (r > 4 ? m_dim.N4 : KOKKOS_INVALID_INDEX),
+                   (r > 5 ? m_dim.N5 : KOKKOS_INVALID_INDEX),
+                   (r > 6 ? m_dim.N6 : KOKKOS_INVALID_INDEX),
+                   (r > 7 ? m_dim.N7 : KOKKOS_INVALID_INDEX));
+    l.stride = m_stride;
+    return l;
   }
 
   KOKKOS_INLINE_FUNCTION constexpr size_type dimension_0() const {
@@ -1084,7 +1086,11 @@ struct ViewOffset<
               arg_layout.dimension[2], arg_layout.dimension[3],
               arg_layout.dimension[4], arg_layout.dimension[5],
               arg_layout.dimension[6], arg_layout.dimension[7]),
-        m_stride(Padding<TrivialScalarSize>::stride(arg_layout.dimension[0])) {}
+        m_stride(
+            arg_layout.stride != KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                ? arg_layout.stride
+                : Padding<TrivialScalarSize>::stride(arg_layout.dimension[0])) {
+  }
 
   template <class DimRHS>
   KOKKOS_INLINE_FUNCTION constexpr ViewOffset(
@@ -1563,14 +1569,16 @@ struct ViewOffset<
   KOKKOS_INLINE_FUNCTION
   constexpr array_layout layout() const {
     constexpr auto r = dimension_type::rank;
-    return array_layout((r > 0 ? m_dim.N0 : KOKKOS_INVALID_INDEX),
-                        (r > 1 ? m_dim.N1 : KOKKOS_INVALID_INDEX),
-                        (r > 2 ? m_dim.N2 : KOKKOS_INVALID_INDEX),
-                        (r > 3 ? m_dim.N3 : KOKKOS_INVALID_INDEX),
-                        (r > 4 ? m_dim.N4 : KOKKOS_INVALID_INDEX),
-                        (r > 5 ? m_dim.N5 : KOKKOS_INVALID_INDEX),
-                        (r > 6 ? m_dim.N6 : KOKKOS_INVALID_INDEX),
-                        (r > 7 ? m_dim.N7 : KOKKOS_INVALID_INDEX));
+    array_layout l((r > 0 ? m_dim.N0 : KOKKOS_INVALID_INDEX),
+                   (r > 1 ? m_dim.N1 : KOKKOS_INVALID_INDEX),
+                   (r > 2 ? m_dim.N2 : KOKKOS_INVALID_INDEX),
+                   (r > 3 ? m_dim.N3 : KOKKOS_INVALID_INDEX),
+                   (r > 4 ? m_dim.N4 : KOKKOS_INVALID_INDEX),
+                   (r > 5 ? m_dim.N5 : KOKKOS_INVALID_INDEX),
+                   (r > 6 ? m_dim.N6 : KOKKOS_INVALID_INDEX),
+                   (r > 7 ? m_dim.N7 : KOKKOS_INVALID_INDEX));
+    l.stride = m_stride;
+    return l;
   }
 
   KOKKOS_INLINE_FUNCTION constexpr size_type dimension_0() const {
@@ -1763,35 +1771,38 @@ struct ViewOffset<
               arg_layout.dimension[4], arg_layout.dimension[5],
               arg_layout.dimension[6], arg_layout.dimension[7]),
         m_stride(
-            Padding<TrivialScalarSize>::
-                stride(/* 2 <= rank */
-                       m_dim.N1 *
-                       (dimension_type::rank == 2
-                            ? size_t(1)
-                            : m_dim.N2 *
-                                  (dimension_type::rank == 3
-                                       ? size_t(1)
-                                       : m_dim.N3 *
-                                             (dimension_type::rank == 4
-                                                  ? size_t(1)
-                                                  : m_dim.N4 *
-                                                        (dimension_type::rank ==
-                                                                 5
-                                                             ? size_t(1)
-                                                             : m_dim.N5 *
-                                                                   (dimension_type::
-                                                                                rank ==
-                                                                            6
-                                                                        ? size_t(
-                                                                              1)
-                                                                        : m_dim.N6 *
-                                                                              (dimension_type::
-                                                                                           rank ==
-                                                                                       7
-                                                                                   ? size_t(
-                                                                                         1)
-                                                                                   : m_dim
-                                                                                         .N7)))))))) {
+            arg_layout.stride != KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                ? arg_layout.stride
+                : Padding<TrivialScalarSize>::
+                      stride(/* 2 <= rank */
+                             m_dim.N1 *
+                             (dimension_type::rank == 2
+                                  ? size_t(1)
+                                  : m_dim.N2 *
+                                        (dimension_type::rank == 3
+                                             ? size_t(1)
+                                             : m_dim.N3 *
+                                                   (dimension_type::rank == 4
+                                                        ? size_t(1)
+                                                        : m_dim.N4 *
+                                                              (dimension_type::
+                                                                           rank ==
+                                                                       5
+                                                                   ? size_t(1)
+                                                                   : m_dim.N5 *
+                                                                         (dimension_type::
+                                                                                      rank ==
+                                                                                  6
+                                                                              ? size_t(
+                                                                                    1)
+                                                                              : m_dim.N6 *
+                                                                                    (dimension_type::
+                                                                                                 rank ==
+                                                                                             7
+                                                                                         ? size_t(
+                                                                                               1)
+                                                                                         : m_dim
+                                                                                               .N7)))))))) {
   }
 
   template <class DimRHS>

--- a/core/src/View/Kokkos_ViewMapping.hpp
+++ b/core/src/View/Kokkos_ViewMapping.hpp
@@ -1763,42 +1763,23 @@ struct ViewOffset<
   /* Enable padding for trivial scalar types with non-zero trivial scalar size.
    */
 
+ private:
   template <unsigned TrivialScalarSize>
-  constexpr size_type compute_stride(const Kokkos::LayoutRight& arg_layout) {
-    return arg_layout.stride != KOKKOS_IMPL_CTOR_DEFAULT_ARG
-               ? arg_layout.stride
-               : Padding<TrivialScalarSize>::
-                     stride(/* 2 <= rank */
-                            m_dim.N1 *
-                            (dimension_type::rank == 2
-                                 ? size_t(1)
-                                 : m_dim.N2 *
-                                       (dimension_type::rank == 3
-                                            ? size_t(1)
-                                            : m_dim.N3 *
-                                                  (dimension_type::rank == 4
-                                                       ? size_t(1)
-                                                       : m_dim.N4 *
-                                                             (dimension_type::
-                                                                          rank ==
-                                                                      5
-                                                                  ? size_t(1)
-                                                                  : m_dim.N5 *
-                                                                        (dimension_type::
-                                                                                     rank ==
-                                                                                 6
-                                                                             ? size_t(
-                                                                                   1)
-                                                                             : m_dim.N6 *
-                                                                                   (dimension_type::
-                                                                                                rank ==
-                                                                                            7
-                                                                                        ? size_t(
-                                                                                              1)
-                                                                                        : m_dim
-                                                                                              .N7)))))));
+  KOKKOS_FUNCTION constexpr size_type compute_stride(
+      const Kokkos::LayoutRight& arg_layout) {
+    if (arg_layout.stride != KOKKOS_IMPL_CTOR_DEFAULT_ARG)
+      return arg_layout.stride;
+    size_type value = m_dim.N1;
+    if constexpr (dimension_type::rank > 2) value *= m_dim.N2;
+    if constexpr (dimension_type::rank > 3) value *= m_dim.N3;
+    if constexpr (dimension_type::rank > 4) value *= m_dim.N4;
+    if constexpr (dimension_type::rank > 5) value *= m_dim.N5;
+    if constexpr (dimension_type::rank > 6) value *= m_dim.N6;
+    if constexpr (dimension_type::rank > 7) value *= m_dim.N7;
+    return Padding<TrivialScalarSize>::stride(value);
   }
 
+ public:
   template <unsigned TrivialScalarSize>
   KOKKOS_INLINE_FUNCTION constexpr ViewOffset(
       std::integral_constant<unsigned, TrivialScalarSize> const&,

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
@@ -25,6 +25,10 @@ static_assert(false,
 #include "Kokkos_MDSpan_Extents.hpp"
 #include <View/Kokkos_ViewDataAnalysis.hpp>
 
+// The difference between a legacy Kokkos array layout and an
+// mdspan layout is that the array layouts can have state, but don't have the
+// nested mapping. This file provides interoperability helpers.
+
 namespace Kokkos::Impl {
 
 template <class ArrayLayout>
@@ -77,32 +81,7 @@ KOKKOS_INLINE_FUNCTION auto array_layout_from_mapping(
         rank > 7 ? mapping.stride(7) : 0,
     };
   } else {
-    // FIXME: Kokkos Layouts don't store stride (it's in the mapping)
-    // We could conceivably fix this by adding an extra ViewCtorProp for
-    // an abritrary padding. For now we will check for this.
-    if constexpr (rank > 1 &&
-                  (std::is_same_v<typename mapping_type::layout_type,
-                                  Kokkos::Experimental::layout_left_padded<
-                                      dynamic_extent>> ||
-                   std::is_same_v<typename mapping_type::layout_type,
-                                  Kokkos::Experimental::layout_right_padded<
-                                      dynamic_extent>>)) {
-      [[maybe_unused]] constexpr size_t strided_index =
-          std::is_same_v<
-              typename mapping_type::layout_type,
-              Kokkos::Experimental::layout_left_padded<dynamic_extent>>
-              ? 1
-              : rank - 2;
-      [[maybe_unused]] constexpr size_t extent_index =
-          std::is_same_v<
-              typename mapping_type::layout_type,
-              Kokkos::Experimental::layout_left_padded<dynamic_extent>>
-              ? 0
-              : rank - 1;
-      KOKKOS_ASSERT(mapping.stride(strided_index) == ext.extent(extent_index));
-    }
-
-    return ArrayLayout{rank > 0 ? ext.extent(0) : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+    ArrayLayout layout{rank > 0 ? ext.extent(0) : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                        rank > 1 ? ext.extent(1) : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                        rank > 2 ? ext.extent(2) : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                        rank > 3 ? ext.extent(3) : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
@@ -110,10 +89,96 @@ KOKKOS_INLINE_FUNCTION auto array_layout_from_mapping(
                        rank > 5 ? ext.extent(5) : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                        rank > 6 ? ext.extent(6) : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                        rank > 7 ? ext.extent(7) : KOKKOS_IMPL_CTOR_DEFAULT_ARG};
+
+    if constexpr (rank > 1 &&
+                  std::is_same_v<typename mapping_type::layout_type,
+                                 Kokkos::Experimental::layout_left_padded<
+                                     dynamic_extent>>) {
+      layout.stride = mapping.stride(1);
+    }
+    if constexpr (std::is_same_v<typename mapping_type::layout_type,
+                                 Kokkos::Experimental::layout_right_padded<
+                                     dynamic_extent>>) {
+      if constexpr (rank == 2) {
+        layout.stride = mapping.stride(0);
+      }
+      if constexpr (rank > 2) {
+        if (mapping.stride(rank - 2) != mapping.extents().extent(rank - 1))
+          Kokkos::abort(
+              "Invalid conversion from layout_right_padded to LayoutRight");
+      }
+    }
+    return layout;
   }
 #ifdef KOKKOS_COMPILER_INTEL
   __builtin_unreachable();
 #endif
+}
+
+template <class MappingType, class ArrayLayout, size_t... Idx>
+KOKKOS_INLINE_FUNCTION auto mapping_from_array_layout_impl(
+    ArrayLayout layout, std::index_sequence<Idx...>) {
+  using index_type   = typename MappingType::index_type;
+  using extents_type = typename MappingType::extents_type;
+  if constexpr (std::is_same_v<typename MappingType::layout_type,
+                               layout_left> ||
+                std::is_same_v<typename MappingType::layout_type,
+                               layout_right>) {
+    return MappingType{
+        extents_type{dextents<index_type, MappingType::extents_type::rank()>{
+            layout.dimension[Idx]...}}};
+  } else {
+    if (layout.stride == KOKKOS_IMPL_CTOR_DEFAULT_ARG ||
+        extents_type::rank() < 2) {
+      return MappingType{
+          extents_type{dextents<index_type, MappingType::extents_type::rank()>{
+              layout.dimension[Idx]...}}};
+    } else {
+      if constexpr (std::is_same_v<ArrayLayout, LayoutRight> &&
+                    extents_type::rank() > 2) {
+        size_t product_of_dimensions = 1;
+        for (size_t r = 1; r < extents_type::rank(); r++)
+          product_of_dimensions *= layout.dimension[r];
+        if (product_of_dimensions != layout.stride)
+          Kokkos::abort(
+              "Invalid conversion from LayoutRight to layout_right_padded");
+      } else {
+        return MappingType{
+            extents_type{
+                dextents<index_type, MappingType::extents_type::rank()>{
+                    layout.dimension[Idx]...}},
+            layout.stride};
+      }
+    }
+  }
+}
+template <class MappingType, size_t... Idx>
+KOKKOS_INLINE_FUNCTION auto mapping_from_array_layout_impl(
+    LayoutStride layout, std::index_sequence<Idx...>) {
+  static_assert(
+      std::is_same_v<typename MappingType::layout_type, layout_stride>);
+  using index_type = typename MappingType::index_type;
+  index_type strides[MappingType::extents_type::rank()] = {
+      layout.stride[Idx]...};
+  return MappingType{
+      mdspan_non_standard_tag(),
+      static_cast<typename MappingType::extents_type>(
+          dextents<index_type, MappingType::extents_type::rank()>{
+              layout.dimension[Idx]...}),
+      strides};
+}
+
+// specialization for rank 0 to avoid empty array
+template <class MappingType>
+KOKKOS_INLINE_FUNCTION auto mapping_from_array_layout_impl(
+    LayoutStride, std::index_sequence<>) {
+  return MappingType{};
+}
+
+template <class MappingType, class ArrayLayout>
+KOKKOS_INLINE_FUNCTION auto mapping_from_array_layout(ArrayLayout layout) {
+  return mapping_from_array_layout_impl<MappingType>(
+      layout, std::make_index_sequence<MappingType::extents_type::rank()>());
 }
 
 template <class MDSpanType, class VM>

--- a/core/unit_test/TestMDSpanConversion.hpp
+++ b/core/unit_test/TestMDSpanConversion.hpp
@@ -513,46 +513,46 @@ TEST(TEST_CATEGORY, view_mdspan_conversion_with_stride) {
                                    Kokkos::pair{2, 38});
     auto sub_mds = sub_v.to_mdspan();
     Kokkos::View<int ***, Kokkos::LayoutLeft> sub_v2(sub_mds);
-    ASSERT_EQ(sub_v.extent(0), 10);
-    ASSERT_EQ(sub_v.extent(1), 40);
-    ASSERT_EQ(sub_v.extent(2), 36);
-    ASSERT_EQ(sub_v.stride(0), 1);
-    ASSERT_EQ(sub_v.stride(1), 20);
-    ASSERT_EQ(sub_v.stride(2), 800);
-    ASSERT_EQ(sub_mds.extent(0), 10);
-    ASSERT_EQ(sub_mds.extent(1), 40);
-    ASSERT_EQ(sub_mds.extent(2), 36);
-    ASSERT_EQ(sub_mds.stride(0), 1);
-    ASSERT_EQ(sub_mds.stride(1), 20);
-    ASSERT_EQ(sub_mds.stride(2), 800);
-    ASSERT_EQ(sub_v2.extent(0), 10);
-    ASSERT_EQ(sub_v2.extent(1), 40);
-    ASSERT_EQ(sub_v2.extent(2), 36);
-    ASSERT_EQ(sub_v2.stride(0), 1);
-    ASSERT_EQ(sub_v2.stride(1), 20);
-    ASSERT_EQ(sub_v2.stride(2), 800);
+    ASSERT_EQ(static_cast<int>(sub_v.extent(0)), 10);
+    ASSERT_EQ(static_cast<int>(sub_v.extent(1)), 40);
+    ASSERT_EQ(static_cast<int>(sub_v.extent(2)), 36);
+    ASSERT_EQ(static_cast<int>(sub_v.stride(0)), 1);
+    ASSERT_EQ(static_cast<int>(sub_v.stride(1)), 20);
+    ASSERT_EQ(static_cast<int>(sub_v.stride(2)), 800);
+    ASSERT_EQ(static_cast<int>(sub_mds.extent(0)), 10);
+    ASSERT_EQ(static_cast<int>(sub_mds.extent(1)), 40);
+    ASSERT_EQ(static_cast<int>(sub_mds.extent(2)), 36);
+    ASSERT_EQ(static_cast<int>(sub_mds.stride(0)), 1);
+    ASSERT_EQ(static_cast<int>(sub_mds.stride(1)), 20);
+    ASSERT_EQ(static_cast<int>(sub_mds.stride(2)), 800);
+    ASSERT_EQ(static_cast<int>(sub_v2.extent(0)), 10);
+    ASSERT_EQ(static_cast<int>(sub_v2.extent(1)), 40);
+    ASSERT_EQ(static_cast<int>(sub_v2.extent(2)), 36);
+    ASSERT_EQ(static_cast<int>(sub_v2.stride(0)), 1);
+    ASSERT_EQ(static_cast<int>(sub_v2.stride(1)), 20);
+    ASSERT_EQ(static_cast<int>(sub_v2.stride(2)), 800);
   }
   {
     // layout_right_padded<dynamic_extent> has a custom stride for
     // stride(rank-2) LayoutRight has a custom stride for stride(0) That means
-    // the "padding" only mateches up for Rank-2 Views
+    // the "padding" only matches up for Rank-2 Views
     Kokkos::View<int **, Kokkos::LayoutRight> source("S", 20, 40);
     auto sub_v =
         Kokkos::subview(source, Kokkos::pair{5, 15}, Kokkos::pair{2, 38});
     auto sub_mds = sub_v.to_mdspan();
     Kokkos::View<int **, Kokkos::LayoutRight> sub_v2(sub_mds);
-    ASSERT_EQ(sub_v.extent(0), 10);
-    ASSERT_EQ(sub_v.extent(1), 36);
-    ASSERT_EQ(sub_v.stride(0), 40);
-    ASSERT_EQ(sub_v.stride(1), 1);
-    ASSERT_EQ(sub_mds.extent(0), 10);
-    ASSERT_EQ(sub_mds.extent(1), 36);
-    ASSERT_EQ(sub_mds.stride(0), 40);
-    ASSERT_EQ(sub_mds.stride(1), 1);
-    ASSERT_EQ(sub_v2.extent(0), 10);
-    ASSERT_EQ(sub_v2.extent(1), 36);
-    ASSERT_EQ(sub_v2.stride(0), 40);
-    ASSERT_EQ(sub_v2.stride(1), 1);
+    ASSERT_EQ(static_cast<int>(sub_v.extent(0)), 10);
+    ASSERT_EQ(static_cast<int>(sub_v.extent(1)), 36);
+    ASSERT_EQ(static_cast<int>(sub_v.stride(0)), 40);
+    ASSERT_EQ(static_cast<int>(sub_v.stride(1)), 1);
+    ASSERT_EQ(static_cast<int>(sub_mds.extent(0)), 10);
+    ASSERT_EQ(static_cast<int>(sub_mds.extent(1)), 36);
+    ASSERT_EQ(static_cast<int>(sub_mds.stride(0)), 40);
+    ASSERT_EQ(static_cast<int>(sub_mds.stride(1)), 1);
+    ASSERT_EQ(static_cast<int>(sub_v2.extent(0)), 10);
+    ASSERT_EQ(static_cast<int>(sub_v2.extent(1)), 36);
+    ASSERT_EQ(static_cast<int>(sub_v2.stride(0)), 40);
+    ASSERT_EQ(static_cast<int>(sub_v2.stride(1)), 1);
   }
 }
 }  // namespace

--- a/core/unit_test/TestMDSpanConversion.hpp
+++ b/core/unit_test/TestMDSpanConversion.hpp
@@ -81,6 +81,8 @@ struct TestViewMDSpanConversion {
     for (std::size_t r = 0; r < mdspan_type::rank(); ++r) {
       ASSERT_EQ(test_view.extent(r), ref.extent(r));
       ASSERT_EQ(test_view.extent(r), exts.extent(r));
+      ASSERT_EQ(test_view.stride(r), ref.stride(r));
+      ASSERT_EQ(test_view.stride(r), mapping.stride(r));
     }
   }
 
@@ -504,4 +506,53 @@ TEST(TEST_CATEGORY, view_mdspan_conversion) {
   TestViewMDSpanConversion<int, TEST_EXECSPACE>::run_test();
 }
 
+TEST(TEST_CATEGORY, view_mdspan_conversion_with_stride) {
+  {
+    Kokkos::View<int ***, Kokkos::LayoutLeft> source("S", 20, 40, 70);
+    auto sub_v   = Kokkos::subview(source, Kokkos::pair{5, 15}, Kokkos::ALL(),
+                                   Kokkos::pair{2, 38});
+    auto sub_mds = sub_v.to_mdspan();
+    Kokkos::View<int ***, Kokkos::LayoutLeft> sub_v2(sub_mds);
+    ASSERT_EQ(sub_v.extent(0), 10);
+    ASSERT_EQ(sub_v.extent(1), 40);
+    ASSERT_EQ(sub_v.extent(2), 36);
+    ASSERT_EQ(sub_v.stride(0), 1);
+    ASSERT_EQ(sub_v.stride(1), 20);
+    ASSERT_EQ(sub_v.stride(2), 800);
+    ASSERT_EQ(sub_mds.extent(0), 10);
+    ASSERT_EQ(sub_mds.extent(1), 40);
+    ASSERT_EQ(sub_mds.extent(2), 36);
+    ASSERT_EQ(sub_mds.stride(0), 1);
+    ASSERT_EQ(sub_mds.stride(1), 20);
+    ASSERT_EQ(sub_mds.stride(2), 800);
+    ASSERT_EQ(sub_v2.extent(0), 10);
+    ASSERT_EQ(sub_v2.extent(1), 40);
+    ASSERT_EQ(sub_v2.extent(2), 36);
+    ASSERT_EQ(sub_v2.stride(0), 1);
+    ASSERT_EQ(sub_v2.stride(1), 20);
+    ASSERT_EQ(sub_v2.stride(2), 800);
+  }
+  {
+    // layout_right_padded<dynamic_extent> has a custom stride for
+    // stride(rank-2) LayoutRight has a custom stride for stride(0) That means
+    // the "padding" only mateches up for Rank-2 Views
+    Kokkos::View<int **, Kokkos::LayoutRight> source("S", 20, 40);
+    auto sub_v =
+        Kokkos::subview(source, Kokkos::pair{5, 15}, Kokkos::pair{2, 38});
+    auto sub_mds = sub_v.to_mdspan();
+    Kokkos::View<int **, Kokkos::LayoutRight> sub_v2(sub_mds);
+    ASSERT_EQ(sub_v.extent(0), 10);
+    ASSERT_EQ(sub_v.extent(1), 36);
+    ASSERT_EQ(sub_v.stride(0), 40);
+    ASSERT_EQ(sub_v.stride(1), 1);
+    ASSERT_EQ(sub_mds.extent(0), 10);
+    ASSERT_EQ(sub_mds.extent(1), 36);
+    ASSERT_EQ(sub_mds.stride(0), 40);
+    ASSERT_EQ(sub_mds.stride(1), 1);
+    ASSERT_EQ(sub_v2.extent(0), 10);
+    ASSERT_EQ(sub_v2.extent(1), 36);
+    ASSERT_EQ(sub_v2.stride(0), 40);
+    ASSERT_EQ(sub_v2.stride(1), 1);
+  }
+}
 }  // namespace

--- a/core/unit_test/TestViewAPI_b.hpp
+++ b/core/unit_test/TestViewAPI_b.hpp
@@ -22,30 +22,30 @@ TEST(TEST_CATEGORY, view_layout_left_with_stride) {
   Kokkos::LayoutLeft ll(10, 20);
   ll.stride = 15;
   Kokkos::View<int**, Kokkos::LayoutLeft> a("A", ll);
-  ASSERT_EQ(a.extent(0), 10);
-  ASSERT_EQ(a.extent(1), 20);
-  ASSERT_EQ(a.stride(0), 1);
-  ASSERT_EQ(a.stride(1), 15);
+  ASSERT_EQ(static_cast<int>(a.extent(0)), 10);
+  ASSERT_EQ(static_cast<int>(a.extent(1)), 20);
+  ASSERT_EQ(static_cast<int>(a.stride(0)), 1);
+  ASSERT_EQ(static_cast<int>(a.stride(1)), 15);
 
   auto ll2 = a.layout();
-  ASSERT_EQ(ll2.dimension[0], 10);
-  ASSERT_EQ(ll2.dimension[1], 20);
-  ASSERT_EQ(ll2.stride, 15);
+  ASSERT_EQ(static_cast<int>(ll2.dimension[0]), 10);
+  ASSERT_EQ(static_cast<int>(ll2.dimension[1]), 20);
+  ASSERT_EQ(static_cast<int>(ll2.stride), 15);
 }
 
 TEST(TEST_CATEGORY, view_layout_right_with_stride) {
   Kokkos::LayoutRight lr(10, 20);
   lr.stride = 25;
   Kokkos::View<int**, Kokkos::LayoutRight> a("A", lr);
-  ASSERT_EQ(a.extent(0), 10);
-  ASSERT_EQ(a.extent(1), 20);
-  ASSERT_EQ(a.stride(0), 25);
-  ASSERT_EQ(a.stride(1), 1);
+  ASSERT_EQ(static_cast<int>(a.extent(0)), 10);
+  ASSERT_EQ(static_cast<int>(a.extent(1)), 20);
+  ASSERT_EQ(static_cast<int>(a.stride(0)), 25);
+  ASSERT_EQ(static_cast<int>(a.stride(1)), 1);
 
   auto lr2 = a.layout();
-  ASSERT_EQ(lr2.dimension[0], 10);
-  ASSERT_EQ(lr2.dimension[1], 20);
-  ASSERT_EQ(lr2.stride, 25);
+  ASSERT_EQ(static_cast<int>(lr2.dimension[0]), 10);
+  ASSERT_EQ(static_cast<int>(lr2.dimension[1]), 20);
+  ASSERT_EQ(static_cast<int>(lr2.stride), 25);
 }
 
 TEST(TEST_CATEGORY, view_api_b) {

--- a/core/unit_test/TestViewAPI_b.hpp
+++ b/core/unit_test/TestViewAPI_b.hpp
@@ -18,6 +18,36 @@
 
 namespace Test {
 
+TEST(TEST_CATEGORY, view_layout_left_with_stride) {
+  Kokkos::LayoutLeft ll(10, 20);
+  ll.stride = 15;
+  Kokkos::View<int**, Kokkos::LayoutLeft> a("A", ll);
+  ASSERT_EQ(a.extent(0), 10);
+  ASSERT_EQ(a.extent(1), 20);
+  ASSERT_EQ(a.stride(0), 1);
+  ASSERT_EQ(a.stride(1), 15);
+
+  auto ll2 = a.layout();
+  ASSERT_EQ(ll2.dimension[0], 10);
+  ASSERT_EQ(ll2.dimension[1], 20);
+  ASSERT_EQ(ll2.stride, 15);
+}
+
+TEST(TEST_CATEGORY, view_layout_right_with_stride) {
+  Kokkos::LayoutRight lr(10, 20);
+  lr.stride = 25;
+  Kokkos::View<int**, Kokkos::LayoutRight> a("A", lr);
+  ASSERT_EQ(a.extent(0), 10);
+  ASSERT_EQ(a.extent(1), 20);
+  ASSERT_EQ(a.stride(0), 25);
+  ASSERT_EQ(a.stride(1), 1);
+
+  auto lr2 = a.layout();
+  ASSERT_EQ(lr2.dimension[0], 10);
+  ASSERT_EQ(lr2.dimension[1], 20);
+  ASSERT_EQ(lr2.stride, 25);
+}
+
 TEST(TEST_CATEGORY, view_api_b) {
   TestViewAPI<double, TEST_EXECSPACE>::run_test_view_operator_a();
   TestViewAPI<double, TEST_EXECSPACE>::run_test_mirror();


### PR DESCRIPTION
This lets instances of LayoutRight and LayoutLeft carry stride information, and also use that information in LayoutRight/Left to mdspan mapping conversions. 

One issue this resolves is that the following code would actually not be valid:

```c++
using view_t = Kokkos::View<int**, Kokkos::LayoutLeft>;
view_t a("A", 20, 30);
view_t sub = Kokkos::subview(a, Kokkos::pair{5,15}, Kokkos::pair{5,25});
view_t sub2(sub.data(), sub.layout());
```

`sub2` will have lost the stride information, i.e. `sub` and `sub2` do not view the same data because `sub2` won't have the same stride as `sub`. https://godbolt.org/z/WEhxWTWE3

Note that `LayoutRight` to `layout_right_padded` is complicated by the fact that they are in-fact not the same Layout for Rank>2. `LayoutRight` has its custom stride for `stride(0)`; `layout_right_padded` has its custom stride for `stride(rank-2)`.

For a Rank-3 `View`/`mdspan` that means with `LayoutRight` the stride of dimension 0 is custom for `layout_right_padded` its the stride for dimension 1. We overlooked this for the longest time. Note that this property of `LayoutRight` is not getting exploited, by much in Kokkos. Specifically `subview` does not leverage that stride capability. 

Say you have a 3-D View and you take different types of subviews, either using a `pair` on the first, second or third dimension and otherwise use `ALL`
```c++
Kokkos::View<int***, LayoutLeft> a("A",N,M,K);
// returns LayoutLeft
auto sub_a = Kokkos::subview(a, Kokkos::pair{1,3}, Kokkos::ALL(), Kokkos::ALL());
// returns LayoutStride
auto sub_b = Kokkos::subview(a, Kokkos::ALL(), Kokkos::pair{1,3}, Kokkos::ALL());
// returns LayoutLeft
auto sub_c = Kokkos::subview(a, Kokkos::ALL(), Kokkos::ALL(), Kokkos::pair{1,3});

Kokkos::View<int***, LayoutRight> a("A",N,M,K);
// returns LayoutRight
auto sub_a = Kokkos::subview(a, Kokkos::pair{1,3}, Kokkos::ALL(), Kokkos::ALL());
// returns LayoutStride but LayoutRight would be possible
auto sub_b = Kokkos::subview(a, Kokkos::ALL(), Kokkos::pair{1,3}, Kokkos::ALL());
// returns LayoutStride but with layout_right_padded this could return layout_right_padded
auto sub_c = Kokkos::subview(a, Kokkos::ALL(), Kokkos::ALL(), Kokkos::pair{1,3});
```

So the only way you can get into the situation where you have an incompatible `LayoutRight` to `layout_right_padded` conversion is if you asked for padding during construction of a `Kokkos::View` of Rank-3 or larger.

We don't even allow this stride thing in a LayoutStride -> LayoutRight conversion right now. 

Fixes https://github.com/kokkos/kokkos/issues/6974.