### PR TITLE
Fixup View constructor death tests

### DIFF
--- a/core/unit_test/TestViewCtorDimMatch.hpp
+++ b/core/unit_test/TestViewCtorDimMatch.hpp
@@ -93,6 +93,9 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_dyn) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECKS
+  GTEST_SKIP() << "only enforced when debug bound checks is enabled";
+#endif
+
   test_matching_arguments_rank<0, 0, DynamicRank>();  // dim = 0, dynamic = 0
   test_matching_arguments_rank<1, 1, DynamicRank>();  // dim = 1, dynamic = 1
   test_matching_arguments_rank<2, 2, DynamicRank>();  // dim = 2, dynamic = 2
@@ -102,7 +105,6 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_dyn) {
   test_matching_arguments_rank<6, 6, DynamicRank>();  // dim = 6, dynamic = 6
   test_matching_arguments_rank<7, 7, DynamicRank>();  // dim = 7, dynamic = 7
   test_matching_arguments_rank<8, 8, DynamicRank>();  // dim = 8, dynamic = 8
-#endif
 }
 
 template <int rank>
@@ -119,6 +121,9 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_stat) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECKS
+  GTEST_SKIP() << "only enforced when debug bound checks is enabled";
+#endif
+
   test_matching_arguments_rank<0, 0, StaticRank>();  // dim = 0, dynamic = 0
   test_matching_arguments_rank<1, 0, StaticRank>();  // dim = 1, dynamic = 0
   test_matching_arguments_rank<2, 0, StaticRank>();  // dim = 2, dynamic = 0
@@ -128,7 +133,6 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_stat) {
   test_matching_arguments_rank<6, 0, StaticRank>();  // dim = 6, dynamic = 0
   test_matching_arguments_rank<7, 0, StaticRank>();  // dim = 7, dynamic = 0
   test_matching_arguments_rank<8, 0, StaticRank>();  // dim = 8, dynamic = 0
-#endif
 }
 
 template <int rank>
@@ -145,6 +149,9 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_mix) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECKS
+  GTEST_SKIP() << "only enforced when debug bound checks is enabled";
+#endif
+
   test_matching_arguments_rank<0, 0, MixedRank>();  // dim = 0, dynamic = 0
   test_matching_arguments_rank<1, 0, MixedRank>();  // dim = 1, dynamic = 0
   test_matching_arguments_rank<2, 1, MixedRank>();  // dim = 2, dynamic = 1
@@ -154,7 +161,6 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_mix) {
   test_matching_arguments_rank<6, 5, MixedRank>();  // dim = 6, dynamic = 5
   test_matching_arguments_rank<7, 6, MixedRank>();  // dim = 7, dynamic = 6
   test_matching_arguments_rank<8, 7, MixedRank>();  // dim = 8, dynamic = 7
-#endif
 }
 
 #define CHECK_DEATH(EXPR)                                                     \
@@ -174,6 +180,9 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_static_extents) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECKS
+  GTEST_SKIP() << "only enforced when debug bound checks is enabled";
+#endif
+
   // clang-format off
   CHECK_DEATH({ Kokkos::View<int[1]>                      v("v", 2); });
   CHECK_DEATH({ Kokkos::View<int[1][1]>                   v("v", 2, 1); });
@@ -193,7 +202,6 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_static_extents) {
   CHECK_DEATH_UNMANAGED({ Kokkos::View<int[1][1][1][1][1][1][1]>    v(nullptr, 2, 1, 1, 1, 1, 1, 1); });
   CHECK_DEATH_UNMANAGED({ Kokkos::View<int[1][1][1][1][1][1][1][1]> v(nullptr, 2, 1, 1, 1, 1, 1, 1, 1); });
   // clang-format on
-#endif
 }
 
 #undef CHECK_DEATH

--- a/core/unit_test/TestViewCtorDimMatch.hpp
+++ b/core/unit_test/TestViewCtorDimMatch.hpp
@@ -92,7 +92,7 @@ struct DynamicRank<0> {
 TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_dyn) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
-#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECKS
+#ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECKS
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
 #endif
 
@@ -120,7 +120,7 @@ struct StaticRank<0> {
 TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_stat) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
-#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECKS
+#ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECKS
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
 #endif
 
@@ -148,7 +148,7 @@ struct MixedRank<0> {
 TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_mix) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
-#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECKS
+#ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECKS
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
 #endif
 
@@ -179,7 +179,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_mix) {
 TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_static_extents) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
-#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECKS
+#ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECKS
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
 #endif
 

--- a/core/unit_test/TestViewCtorDimMatch.hpp
+++ b/core/unit_test/TestViewCtorDimMatch.hpp
@@ -205,5 +205,6 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_static_extents) {
 }
 
 #undef CHECK_DEATH
+#undef CHECK_DEATH_UNMANAGED
 #endif  // KOKKOS_ENABLE_OPENMPTARGET
 }  // namespace Test

--- a/core/unit_test/TestViewCtorDimMatch.hpp
+++ b/core/unit_test/TestViewCtorDimMatch.hpp
@@ -86,6 +86,12 @@ struct DynamicRank<0> {
   using type = int;
 };
 
+#ifdef KOKKOS_COMPILER_NVHPC
+#define VIEW_CTOR_TEST_UNREACHABLE() __builtin_unreachable()
+#else
+#define VIEW_CTOR_TEST_UNREACHABLE() static_assert(true)
+#endif
+
 // Skip test execution when KOKKOS_ENABLE_OPENMPTARGET is enabled until
 // Kokkos::abort() aborts properly on that backend
 #ifndef KOKKOS_ENABLE_OPENMPTARGET
@@ -94,6 +100,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_dyn) {
 
 #ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECKS
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
+  VIEW_CTOR_TEST_UNREACHABLE();
 #endif
 
   test_matching_arguments_rank<0, 0, DynamicRank>();  // dim = 0, dynamic = 0
@@ -122,6 +129,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_stat) {
 
 #ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECKS
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
+  VIEW_CTOR_TEST_UNREACHABLE();
 #endif
 
   test_matching_arguments_rank<0, 0, StaticRank>();  // dim = 0, dynamic = 0
@@ -150,6 +158,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_mix) {
 
 #ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECKS
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
+  VIEW_CTOR_TEST_UNREACHABLE();
 #endif
 
   test_matching_arguments_rank<0, 0, MixedRank>();  // dim = 0, dynamic = 0
@@ -181,6 +190,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_static_extents) {
 
 #ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECKS
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
+  VIEW_CTOR_TEST_UNREACHABLE();
 #endif
 
   // clang-format off
@@ -207,4 +217,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_static_extents) {
 #undef CHECK_DEATH
 #undef CHECK_DEATH_UNMANAGED
 #endif  // KOKKOS_ENABLE_OPENMPTARGET
+
+#undef VIEW_CTOR_TEST_UNREACHABLE
+
 }  // namespace Test


### PR DESCRIPTION
Instead of guarding the content of the test and give the false impression that the tests ran, use GTest native support to signify that the tests are not run