### PR TITLE
Rework event-based tool testing facility to not rely on RTTI

### DIFF
--- a/core/unit_test/tools/TestEventCorrectness.hpp
+++ b/core/unit_test/tools/TestEventCorrectness.hpp
@@ -739,8 +739,7 @@ TEST(kokkosp, get_events) {
     Kokkos::Tools::popRegion();
   });
   for (const auto& ptr : event_vector) {
-    auto ptr_as_begin = std::dynamic_pointer_cast<BeginParallelForEvent>(ptr);
-    ASSERT_EQ(ptr_as_begin, nullptr);
+    ASSERT_FALSE(is_a<BeginParallelForEvent>(ptr));
   }
 }
 }  // namespace Test

--- a/core/unit_test/tools/include/ToolTestingUtilities.hpp
+++ b/core/unit_test/tools/include/ToolTestingUtilities.hpp
@@ -64,6 +64,27 @@ struct EventBase;  // forward declaration
 using EventBasePtr = std::shared_ptr<EventBase>;
 using event_vector = std::vector<EventBasePtr>;
 
+// unique identifier for derived event classes
+template <class EventDerived,
+          std::enable_if_t<std::is_base_of_v<EventBase, EventDerived> &&
+                           std::is_final_v<EventDerived>>* = nullptr>
+uintptr_t event_type_uid() {
+  static char x{};
+  return reinterpret_cast<uintptr_t>(&x);
+}
+
+// runtime check to determine if an event object of EventBase class is in fact
+// of a particular EventDerived class in which case it is safe to downcast
+// (essentially some hand-rolled form of dynamic pointer casting w/o using RTTI)
+template <
+    class EventDerived, class SomeEventBasePtr,
+    std::enable_if_t<std::is_base_of_v<EventBase, EventDerived> &&
+                     std::is_final_v<EventDerived> &&
+                     std::is_same_v<SomeEventBasePtr, EventBasePtr>>* = nullptr>
+bool is_a(SomeEventBasePtr const& e) {
+  return e->kind() == event_type_uid<EventDerived>();
+}
+
 /**
  * @brief In order to call some arbitrary set of lambdas representing matchers,
  * we need the ability to look at a lambda, and deduce its arguments.
@@ -103,10 +124,10 @@ struct function_traits<R (*)(A...)> {
   constexpr static int num_arguments = sizeof...(A);
   template <class Call, class... Args>
   static auto invoke_as(const Call& call, Args&&... args) {
-    if (!(std::dynamic_pointer_cast<A>(std::forward<Args>(args)) && ...)) {
+    if (!(is_a<A>(std::forward<Args>(args)) && ...)) {
       return MatchDiagnostic{false, {"Types didn't match on arguments"}};
     }
-    return call(*std::dynamic_pointer_cast<A>(std::forward<Args>(args))...);
+    return call(*std::static_pointer_cast<A>(std::forward<Args>(args))...);
   }
 };
 
@@ -127,10 +148,10 @@ struct function_traits<R (C::*)(A...)> {
   constexpr static int num_arguments = sizeof...(A);
   template <class Call, class... Args>
   static auto invoke_as(const Call& call, Args&&... args) {
-    if (!(std::dynamic_pointer_cast<A>(std::forward<Args>(args)) && ...)) {
+    if (!(is_a<A>(std::forward<Args>(args)) && ...)) {
       return MatchDiagnostic{false, {"Types didn't match on arguments"}};
     }
-    return call(*std::dynamic_pointer_cast<A>(std::forward<Args>(args))...);
+    return call(*std::static_pointer_cast<A>(std::forward<Args>(args))...);
   }
 };
 
@@ -152,10 +173,10 @@ struct function_traits<R (C::*)(A...) const>  // const
   constexpr static int num_arguments = sizeof...(A);
   template <class Call, class... Args>
   static auto invoke_as(const Call& call, Args&&... args) {
-    if (!(std::dynamic_pointer_cast<A>(std::forward<Args>(args)) && ...)) {
+    if (!(is_a<A>(std::forward<Args>(args)) && ...)) {
       return MatchDiagnostic{false, {"Types didn't match on arguments"}};
     }
-    return call(*std::dynamic_pointer_cast<A>(std::forward<Args>(args))...);
+    return call(*std::static_pointer_cast<A>(std::forward<Args>(args))...);
   }
 };
 
@@ -168,7 +189,7 @@ struct function_traits<R (C::*)(A...) const>  // const
  * @tparam T The functor type
  */
 template <typename T>
-struct function_traits<T, std::void_t<decltype(&T::operator())> >
+struct function_traits<T, std::void_t<decltype(&T::operator())>>
     : public function_traits<decltype(&T::operator())> {};
 
 /**
@@ -284,6 +305,12 @@ struct EventBase {
   using PtrHandle                        = const void* const;
   virtual ~EventBase()                   = default;
   virtual std::string descriptor() const = 0;
+  virtual uintptr_t kind() const         = 0;
+};
+
+template <class Derived>
+struct UniquelyIdentifiableEventType : public EventBase {
+  uintptr_t kind() const { return event_type_uid<Derived>(); }
 };
 
 /**
@@ -293,7 +320,7 @@ struct EventBase {
  * @tparam Derived CRTP, intended for use with dynamic_casts
  */
 template <class Derived>
-struct BeginOperation : public EventBase {
+struct BeginOperation : public UniquelyIdentifiableEventType<Derived> {
   const std::string name;
   const uint32_t deviceID;
   uint64_t kID;
@@ -317,7 +344,7 @@ struct BeginOperation : public EventBase {
  * same type
  */
 template <class Derived>
-struct EndOperation : public EventBase {
+struct EndOperation : public UniquelyIdentifiableEventType<Derived> {
   uint64_t kID;
   EndOperation(uint64_t k) : kID(k) {}
 
@@ -336,7 +363,8 @@ struct EndOperation : public EventBase {
  * type. So the different type names here are meaningful, even though the
  * classes are empty
  */
-struct BeginParallelForEvent : public BeginOperation<BeginParallelForEvent> {
+struct BeginParallelForEvent final
+    : public BeginOperation<BeginParallelForEvent> {
   static const std::string& begin_op_name() {
     static std::string value = "BeginParallelFor";
     return value;
@@ -344,7 +372,7 @@ struct BeginParallelForEvent : public BeginOperation<BeginParallelForEvent> {
   BeginParallelForEvent(std::string n, const uint32_t devID, uint64_t k)
       : BeginOperation<BeginParallelForEvent>(n, devID, k) {}
 };
-struct BeginParallelReduceEvent
+struct BeginParallelReduceEvent final
     : public BeginOperation<BeginParallelReduceEvent> {
   static const std::string& begin_op_name() {
     static std::string value = "BeginParallelReduce";
@@ -354,7 +382,8 @@ struct BeginParallelReduceEvent
   BeginParallelReduceEvent(std::string n, const uint32_t devID, uint64_t k)
       : BeginOperation<BeginParallelReduceEvent>(n, devID, k) {}
 };
-struct BeginParallelScanEvent : public BeginOperation<BeginParallelScanEvent> {
+struct BeginParallelScanEvent final
+    : public BeginOperation<BeginParallelScanEvent> {
   static const std::string& begin_op_name() {
     static std::string value = "BeginParallelScan";
     return value;
@@ -363,7 +392,7 @@ struct BeginParallelScanEvent : public BeginOperation<BeginParallelScanEvent> {
   BeginParallelScanEvent(std::string n, const uint32_t devID, uint64_t k)
       : BeginOperation<BeginParallelScanEvent>(n, devID, k) {}
 };
-struct BeginFenceEvent : public BeginOperation<BeginFenceEvent> {
+struct BeginFenceEvent final : public BeginOperation<BeginFenceEvent> {
   static const std::string& begin_op_name() {
     static std::string value = "BeginFence";
     return value;
@@ -373,7 +402,7 @@ struct BeginFenceEvent : public BeginOperation<BeginFenceEvent> {
       : BeginOperation<BeginFenceEvent>(n, devID, k) {}
 };
 
-struct EndParallelForEvent : public EndOperation<EndParallelForEvent> {
+struct EndParallelForEvent final : public EndOperation<EndParallelForEvent> {
   static const std::string& end_op_name() {
     static std::string value = "EndParallelFor";
     return value;
@@ -381,7 +410,8 @@ struct EndParallelForEvent : public EndOperation<EndParallelForEvent> {
 
   EndParallelForEvent(uint64_t k) : EndOperation<EndParallelForEvent>(k) {}
 };
-struct EndParallelReduceEvent : public EndOperation<EndParallelReduceEvent> {
+struct EndParallelReduceEvent final
+    : public EndOperation<EndParallelReduceEvent> {
   static const std::string& end_op_name() {
     static std::string value = "EndParallelReduce";
     return value;
@@ -390,7 +420,7 @@ struct EndParallelReduceEvent : public EndOperation<EndParallelReduceEvent> {
   EndParallelReduceEvent(uint64_t k)
       : EndOperation<EndParallelReduceEvent>(k) {}
 };
-struct EndParallelScanEvent : public EndOperation<EndParallelScanEvent> {
+struct EndParallelScanEvent final : public EndOperation<EndParallelScanEvent> {
   static const std::string& end_op_name() {
     static std::string value = "EndParallelScan";
     return value;
@@ -398,7 +428,7 @@ struct EndParallelScanEvent : public EndOperation<EndParallelScanEvent> {
 
   EndParallelScanEvent(uint64_t k) : EndOperation<EndParallelScanEvent>(k) {}
 };
-struct EndFenceEvent : public EndOperation<EndFenceEvent> {
+struct EndFenceEvent final : public EndOperation<EndFenceEvent> {
   static const std::string& end_op_name() {
     static std::string value = "EndFence";
     return value;
@@ -407,7 +437,7 @@ struct EndFenceEvent : public EndOperation<EndFenceEvent> {
   EndFenceEvent(uint64_t k) : EndOperation<EndFenceEvent>(k) {}
 };
 
-struct InitEvent : public EventBase {
+struct InitEvent final : public UniquelyIdentifiableEventType<InitEvent> {
   int load_sequence;
   uint64_t version_number;
   uint32_t num_device_infos;
@@ -425,11 +455,13 @@ struct InitEvent : public EventBase {
         num_device_infos(n_d_i),
         device_infos(d_i) {}
 };
-struct FinalizeEvent : public EventBase {
+struct FinalizeEvent final
+    : public UniquelyIdentifiableEventType<FinalizeEvent> {
   std::string descriptor() const override { return "FinalizeEvent{}"; }
 };
 
-struct ParseArgsEvent : public EventBase {
+struct ParseArgsEvent final
+    : public UniquelyIdentifiableEventType<ParseArgsEvent> {
   int num_args;
   char** args;
 
@@ -444,26 +476,29 @@ struct ParseArgsEvent : public EventBase {
   }
   ParseArgsEvent(int n_a, char** a) : num_args(n_a), args(a) {}
 };
-struct PrintHelpEvent : public EventBase {
+struct PrintHelpEvent final
+    : public UniquelyIdentifiableEventType<PrintHelpEvent> {
   char* prog_name;
   std::string descriptor() const override {
     return "PrintHelpEvent { Program Name: \"" + std::string(prog_name) + "\"}";
   }
   PrintHelpEvent(char* p_n) : prog_name(p_n) {}
 };
-struct PushRegionEvent : public EventBase {
+struct PushRegionEvent final
+    : public UniquelyIdentifiableEventType<PushRegionEvent> {
   std::string name;
   std::string descriptor() const override {
     return "PushRegionEvent { Region Name: \"" + name + "\" }";
   }
   PushRegionEvent(std::string n) : name(n) {}
 };
-struct PopRegionEvent : public EventBase {
+struct PopRegionEvent final
+    : public UniquelyIdentifiableEventType<PopRegionEvent> {
   std::string descriptor() const override { return "PopRegionEvent{}"; }
 };
 
 template <class Derived>
-struct DataEvent : public EventBase {
+struct DataEvent : public UniquelyIdentifiableEventType<Derived> {
   using SpaceHandleType = Kokkos::Profiling::SpaceHandle;
   SpaceHandleType handle;
   std::string name;
@@ -482,20 +517,21 @@ struct DataEvent : public EventBase {
       : handle(h), name(n), ptr(p), size(s) {}
 };
 
-struct AllocateDataEvent : public DataEvent<AllocateDataEvent> {
+struct AllocateDataEvent final : public DataEvent<AllocateDataEvent> {
   static std::string event_name() { return "AllocateDataEvent"; }
   AllocateDataEvent(DataEvent::SpaceHandleType h, std::string n,
                     EventBase::PtrHandle p, uint64_t s)
       : DataEvent<AllocateDataEvent>(h, n, p, s) {}
 };
-struct DeallocateDataEvent : public DataEvent<DeallocateDataEvent> {
+struct DeallocateDataEvent final : public DataEvent<DeallocateDataEvent> {
   static std::string event_name() { return "DeallocateDataEvent"; }
   DeallocateDataEvent(DataEvent::SpaceHandleType h, std::string n,
                       EventBase::PtrHandle p, uint64_t s)
       : DataEvent<DeallocateDataEvent>(h, n, p, s) {}
 };
 
-struct CreateProfileSectionEvent : public EventBase {
+struct CreateProfileSectionEvent final
+    : public UniquelyIdentifiableEventType<CreateProfileSectionEvent> {
   std::string name;
   uint32_t id;
   std::string descriptor() const override {
@@ -506,7 +542,8 @@ struct CreateProfileSectionEvent : public EventBase {
 };
 
 template <class Derived>
-struct ProfileSectionManipulationEvent : public EventBase {
+struct ProfileSectionManipulationEvent
+    : public UniquelyIdentifiableEventType<Derived> {
   uint32_t id;
   std::string descriptor() const override {
     std::stringstream s;
@@ -516,26 +553,26 @@ struct ProfileSectionManipulationEvent : public EventBase {
   ProfileSectionManipulationEvent(uint32_t d_i) : id(d_i){};
 };
 
-struct StartProfileSectionEvent
+struct StartProfileSectionEvent final
     : public ProfileSectionManipulationEvent<StartProfileSectionEvent> {
   static std::string event_name() { return "StartProfileSectionEvent"; }
   StartProfileSectionEvent(uint32_t d_i)
       : ProfileSectionManipulationEvent<StartProfileSectionEvent>(d_i){};
 };
-struct StopProfileSectionEvent
+struct StopProfileSectionEvent final
     : public ProfileSectionManipulationEvent<StopProfileSectionEvent> {
   static std::string event_name() { return "StopProfileSectionEvent"; }
   StopProfileSectionEvent(uint32_t d_i)
       : ProfileSectionManipulationEvent<StopProfileSectionEvent>(d_i){};
 };
-struct DestroyProfileSectionEvent
+struct DestroyProfileSectionEvent final
     : public ProfileSectionManipulationEvent<DestroyProfileSectionEvent> {
   static std::string event_name() { return "DestroyProfileSectionEvent"; }
   DestroyProfileSectionEvent(uint32_t d_i)
       : ProfileSectionManipulationEvent<DestroyProfileSectionEvent>(d_i){};
 };
 
-struct ProfileEvent : public EventBase {
+struct ProfileEvent final : public UniquelyIdentifiableEventType<ProfileEvent> {
   std::string name;
   std::string descriptor() const override {
     return "ProfileEvent {\"" + name + "\"}";
@@ -543,7 +580,8 @@ struct ProfileEvent : public EventBase {
   ProfileEvent(std::string n) : name(n) {}
 };
 
-struct BeginDeepCopyEvent : public EventBase {
+struct BeginDeepCopyEvent final
+    : public UniquelyIdentifiableEventType<BeginDeepCopyEvent> {
   using SpaceHandleType = Kokkos::Profiling::SpaceHandle;
   SpaceHandleType src_handle;
   std::string src_name;
@@ -573,12 +611,13 @@ struct BeginDeepCopyEvent : public EventBase {
         dst_ptr(d_p),
         size(s) {}
 };
-struct EndDeepCopyEvent : public EventBase {
+struct EndDeepCopyEvent final
+    : public UniquelyIdentifiableEventType<EndDeepCopyEvent> {
   std::string descriptor() const override { return "EndDeepCopyEvent{}"; }
 };
 
 template <class Derived>
-struct DualViewEvent : public EventBase {
+struct DualViewEvent : public UniquelyIdentifiableEventType<Derived> {
   std::string name;
   EventBase::PtrHandle ptr;
   bool is_device;
@@ -591,18 +630,19 @@ struct DualViewEvent : public EventBase {
     return s.str();
   }
 };
-struct DualViewModifyEvent : public DualViewEvent<DualViewModifyEvent> {
+struct DualViewModifyEvent final : public DualViewEvent<DualViewModifyEvent> {
   static std::string event_name() { return "DualViewModifyEvent"; }
   DualViewModifyEvent(std::string n, EventBase::PtrHandle p, bool i_d)
       : DualViewEvent(n, p, i_d) {}
 };
-struct DualViewSyncEvent : public DualViewEvent<DualViewSyncEvent> {
+struct DualViewSyncEvent final : public DualViewEvent<DualViewSyncEvent> {
   static std::string event_name() { return "DualViewSyncEvent"; }
   DualViewSyncEvent(std::string n, EventBase::PtrHandle p, bool i_d)
       : DualViewEvent(n, p, i_d) {}
 };
 
-struct DeclareMetadataEvent : public EventBase {
+struct DeclareMetadataEvent final
+    : public UniquelyIdentifiableEventType<DeclareMetadataEvent> {
   std::string key;
   std::string value;
   std::string descriptor() const override {
@@ -611,7 +651,9 @@ struct DeclareMetadataEvent : public EventBase {
   DeclareMetadataEvent(std::string k, std::string v) : key(k), value(v) {}
 };
 
-struct ProvideToolProgrammingInterfaceEvent : public EventBase {
+struct ProvideToolProgrammingInterfaceEvent final
+    : public UniquelyIdentifiableEventType<
+          ProvideToolProgrammingInterfaceEvent> {
   using Interface = Kokkos::Tools::Experimental::ToolProgrammingInterface;
 
   uint32_t num_functions;
@@ -623,7 +665,8 @@ struct ProvideToolProgrammingInterfaceEvent : public EventBase {
            std::to_string(num_functions) + "}";
   }
 };
-struct RequestToolSettingsEvent : public EventBase {
+struct RequestToolSettingsEvent final
+    : public UniquelyIdentifiableEventType<RequestToolSettingsEvent> {
   using Settings = Kokkos::Tools::Experimental::ToolSettings;
 
   uint32_t num_settings;
@@ -636,7 +679,7 @@ struct RequestToolSettingsEvent : public EventBase {
 };
 
 template <class Derived>
-struct TypeDeclarationEvent : public EventBase {
+struct TypeDeclarationEvent : public UniquelyIdentifiableEventType<Derived> {
   std::string name;
   size_t variable_id;
   Kokkos::Tools::Experimental::VariableInfo info;
@@ -648,14 +691,14 @@ struct TypeDeclarationEvent : public EventBase {
                        Kokkos::Tools::Experimental::VariableInfo i)
       : name(n), variable_id(v_i), info(i) {}
 };
-struct DeclareOutputTypeEvent
+struct DeclareOutputTypeEvent final
     : public TypeDeclarationEvent<DeclareOutputTypeEvent> {
   static std::string event_name() { return "DeclarateOutputTypeEvent"; }
   DeclareOutputTypeEvent(std::string n, size_t v_i,
                          Kokkos::Tools::Experimental::VariableInfo i)
       : TypeDeclarationEvent(n, v_i, i) {}
 };
-struct DeclareInputTypeEvent
+struct DeclareInputTypeEvent final
     : public TypeDeclarationEvent<DeclareInputTypeEvent> {
   static std::string event_name() { return "DeclareInputTypeEvent"; }
   DeclareInputTypeEvent(std::string n, size_t v_i,
@@ -663,7 +706,8 @@ struct DeclareInputTypeEvent
       : TypeDeclarationEvent(n, v_i, i) {}
 };
 
-struct RequestOutputValuesEvent : public EventBase {
+struct RequestOutputValuesEvent final
+    : public UniquelyIdentifiableEventType<RequestOutputValuesEvent> {
   size_t context;
   size_t num_inputs;
   std::vector<Kokkos::Tools::Experimental::VariableValue> inputs;
@@ -683,14 +727,16 @@ struct RequestOutputValuesEvent : public EventBase {
       : context(c), num_inputs(n_i), inputs(i), num_outputs(n_o), outputs(o) {}
 };
 
-struct BeginContextEvent : public EventBase {
+struct BeginContextEvent final
+    : public UniquelyIdentifiableEventType<BeginContextEvent> {
   size_t context;
   std::string descriptor() const override {
     return "ContextBeginEvent{ " + std::to_string(context) + "}";
   }
   BeginContextEvent(size_t c) : context(c) {}
 };
-struct EndContextEvent : public EventBase {
+struct EndContextEvent final
+    : public UniquelyIdentifiableEventType<EndContextEvent> {
   size_t context;
   Kokkos::Tools::Experimental::VariableValue value;
   std::string descriptor() const override {
@@ -700,7 +746,8 @@ struct EndContextEvent : public EventBase {
       : context(c), value(v) {}
 };
 
-struct OptimizationGoalDeclarationEvent : public EventBase {
+struct OptimizationGoalDeclarationEvent final
+    : public UniquelyIdentifiableEventType<OptimizationGoalDeclarationEvent> {
   size_t context;
   Kokkos::Tools::Experimental::OptimizationGoal goal;
   std::string descriptor() const override {


### PR DESCRIPTION
Partial fix for #7037 

Together with #7043 enables building with `-fno-rtti`

Implements some hand-rolled form of RTTI to avoid doing dynamic pointer cast to determine if an object of EventBase class is indeed of EventDerived class.  The UID values are meaningless but they get the job done.  The alternative would be to define some sort of enum that knows all the set of derived classes which is quite cumbersome.
