### PR TITLE
View-refactor: Updating Offsetview to use public APIs of View. 

### DIFF
--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -489,14 +489,22 @@ class OffsetView : public View<DataType, Properties...> {
                              const E& ends_, subtraction_failure)
       : base_t(Kokkos::view_wrap(p),
                typename traits::array_layout(
-                   base_t::rank() > 0 ? at(ends_, 0) - at(begins_, 0) : 0,
-                   base_t::rank() > 1 ? at(ends_, 1) - at(begins_, 1) : 0,
-                   base_t::rank() > 2 ? at(ends_, 2) - at(begins_, 2) : 0,
-                   base_t::rank() > 3 ? at(ends_, 3) - at(begins_, 3) : 0,
-                   base_t::rank() > 4 ? at(ends_, 4) - at(begins_, 4) : 0,
-                   base_t::rank() > 5 ? at(ends_, 5) - at(begins_, 5) : 0,
-                   base_t::rank() > 6 ? at(ends_, 6) - at(begins_, 6) : 0,
-                   base_t::rank() > 7 ? at(ends_, 7) - at(begins_, 7) : 0)) {
+                   base_t::rank() > 0 ? at(ends_, 0) - at(begins_, 0)
+                                      : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                   base_t::rank() > 1 ? at(ends_, 1) - at(begins_, 1)
+                                      : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                   base_t::rank() > 2 ? at(ends_, 2) - at(begins_, 2)
+                                      : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                   base_t::rank() > 3 ? at(ends_, 3) - at(begins_, 3)
+                                      : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                   base_t::rank() > 4 ? at(ends_, 4) - at(begins_, 4)
+                                      : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                   base_t::rank() > 5 ? at(ends_, 5) - at(begins_, 5)
+                                      : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                   base_t::rank() > 6 ? at(ends_, 6) - at(begins_, 6)
+                                      : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                   base_t::rank() > 7 ? at(ends_, 7) - at(begins_, 7)
+                                      : KOKKOS_IMPL_CTOR_DEFAULT_ARG)) {
     for (size_t i = 0; i != m_begins.size(); ++i) {
       m_begins[i] = at(begins_, i);
     };
@@ -551,18 +559,34 @@ class OffsetView : public View<DataType, Properties...> {
       const std::pair<int64_t, int64_t> range7 = KOKKOS_INVALID_INDEX_RANGE
 
       )
-      : OffsetView(
-            Kokkos::Impl::ViewCtorProp<std::string>(arg_label),
-            typename traits::array_layout(range0.second - range0.first + 1,
-                                          range1.second - range1.first + 1,
-                                          range2.second - range2.first + 1,
-                                          range3.second - range3.first + 1,
-                                          range4.second - range4.first + 1,
-                                          range5.second - range5.first + 1,
-                                          range6.second - range6.first + 1,
-                                          range7.second - range7.first + 1),
-            {range0.first, range1.first, range2.first, range3.first,
-             range4.first, range5.first, range6.first, range7.first}) {}
+      : OffsetView(Kokkos::Impl::ViewCtorProp<std::string>(arg_label),
+                   typename traits::array_layout(
+                       range0.first == KOKKOS_INVALID_OFFSET
+                           ? KOKKOS_IMPL_CTOR_DEFAULT_ARG - 1
+                           : range0.second - range0.first + 1,
+                       range1.first == KOKKOS_INVALID_OFFSET
+                           ? KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                           : range1.second - range1.first + 1,
+                       range2.first == KOKKOS_INVALID_OFFSET
+                           ? KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                           : range2.second - range2.first + 1,
+                       range3.first == KOKKOS_INVALID_OFFSET
+                           ? KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                           : range3.second - range3.first + 1,
+                       range4.first == KOKKOS_INVALID_OFFSET
+                           ? KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                           : range4.second - range4.first + 1,
+                       range5.first == KOKKOS_INVALID_OFFSET
+                           ? KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                           : range5.second - range5.first + 1,
+                       range6.first == KOKKOS_INVALID_OFFSET
+                           ? KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                           : range6.second - range6.first + 1,
+                       range7.first == KOKKOS_INVALID_OFFSET
+                           ? KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                           : range7.second - range7.first + 1),
+                   {range0.first, range1.first, range2.first, range3.first,
+                    range4.first, range5.first, range6.first, range7.first}) {}
 
   template <class... P>
   explicit OffsetView(
@@ -575,18 +599,34 @@ class OffsetView : public View<DataType, Properties...> {
       const std::pair<int64_t, int64_t> range5 = KOKKOS_INVALID_INDEX_RANGE,
       const std::pair<int64_t, int64_t> range6 = KOKKOS_INVALID_INDEX_RANGE,
       const std::pair<int64_t, int64_t> range7 = KOKKOS_INVALID_INDEX_RANGE)
-      : OffsetView(
-            arg_prop,
-            typename traits::array_layout(range0.second - range0.first + 1,
-                                          range1.second - range1.first + 1,
-                                          range2.second - range2.first + 1,
-                                          range3.second - range3.first + 1,
-                                          range4.second - range4.first + 1,
-                                          range5.second - range5.first + 1,
-                                          range6.second - range6.first + 1,
-                                          range7.second - range7.first + 1),
-            {range0.first, range1.first, range2.first, range3.first,
-             range4.first, range5.first, range6.first, range7.first}) {}
+      : OffsetView(arg_prop,
+                   typename traits::array_layout(
+                       range0.first == KOKKOS_INVALID_OFFSET
+                           ? KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                           : range0.second - range0.first + 1,
+                       range1.first == KOKKOS_INVALID_OFFSET
+                           ? KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                           : range1.second - range1.first + 1,
+                       range2.first == KOKKOS_INVALID_OFFSET
+                           ? KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                           : range2.second - range2.first + 1,
+                       range3.first == KOKKOS_INVALID_OFFSET
+                           ? KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                           : range3.second - range3.first + 1,
+                       range4.first == KOKKOS_INVALID_OFFSET
+                           ? KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                           : range4.second - range4.first + 1,
+                       range5.first == KOKKOS_INVALID_OFFSET
+                           ? KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                           : range5.second - range5.first + 1,
+                       range6.first == KOKKOS_INVALID_OFFSET
+                           ? KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                           : range6.second - range6.first + 1,
+                       range7.first == KOKKOS_INVALID_OFFSET
+                           ? KOKKOS_IMPL_CTOR_DEFAULT_ARG
+                           : range7.second - range7.first + 1),
+                   {range0.first, range1.first, range2.first, range3.first,
+                    range4.first, range5.first, range6.first, range7.first}) {}
 
   template <class... P>
   explicit KOKKOS_FUNCTION OffsetView(

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -281,6 +281,11 @@ class OffsetView : public View<DataType, Properties...> {
     return offset_operator(std::make_index_sequence<base_t::rank()>(),
                            indices...);
   }
+
+  template <class... OtherIndexTypes>
+  KOKKOS_FUNCTION constexpr typename base_t::reference_type access(
+      OtherIndexTypes... args) const = delete;
+
   //----------------------------------------
 
   //----------------------------------------

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -180,30 +180,28 @@ void runtime_check_rank_device(const size_t rank_dynamic, const size_t rank,
 }  // namespace Impl
 
 template <class DataType, class... Properties>
-class OffsetView : public ViewTraits<DataType, Properties...> {
- public:
-  using traits = ViewTraits<DataType, Properties...>;
-
+class OffsetView : public View<DataType, Properties...> {
  private:
   template <class, class...>
   friend class OffsetView;
-  template <class, class...>
-  friend class View;  // FIXME delete this line
-  template <class, class...>
-  friend class Kokkos::Impl::ViewMapping;
 
-  using map_type   = Kokkos::Impl::ViewMapping<traits, void>;
-  using track_type = Kokkos::Impl::SharedAllocationTracker;
+  using base_t = View<DataType, Properties...>;
 
  public:
-  enum { Rank = map_type::Rank };
-  using begins_type = Kokkos::Array<int64_t, Rank>;
+  // typedefs to reduce typing base_t:: further down
+  using traits = typename base_t::traits;
+  // FIXME: should be base_t::index_type after refactor
+  using index_type   = typename base_t::memory_space::size_type;
+  using pointer_type = typename base_t::pointer_type;
+
+  using begins_type = Kokkos::Array<int64_t, base_t::rank()>;
 
   template <typename iType,
             std::enable_if_t<std::is_integral_v<iType>, iType> = 0>
   KOKKOS_FUNCTION int64_t begin(const iType local_dimension) const {
-    return local_dimension < Rank ? m_begins[local_dimension]
-                                  : KOKKOS_INVALID_OFFSET;
+    return static_cast<size_t>(local_dimension) < base_t::rank()
+               ? m_begins[local_dimension]
+               : KOKKOS_INVALID_OFFSET;
   }
 
   KOKKOS_FUNCTION
@@ -212,12 +210,10 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
   template <typename iType,
             std::enable_if_t<std::is_integral_v<iType>, iType> = 0>
   KOKKOS_FUNCTION int64_t end(const iType local_dimension) const {
-    return begin(local_dimension) + m_map.extent(local_dimension);
+    return begin(local_dimension) + base_t::extent(local_dimension);
   }
 
  private:
-  track_type m_track;
-  map_type m_map;
   begins_type m_begins;
 
  public:
@@ -245,526 +241,55 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
                                 typename traits::array_layout,
                                 typename traits::host_mirror_space>;
 
-  //----------------------------------------
-  // Domain rank and extents
-
-  /** \brief rank() to be implemented
-   */
-  // KOKKOS_FUNCTION
-  // static
-  // constexpr unsigned rank() { return map_type::Rank; }
-
-  template <typename iType>
-  KOKKOS_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>, size_t>
-  extent(const iType& r) const {
-    return m_map.extent(r);
+  template <size_t... I, class... OtherIndexTypes>
+  KOKKOS_FUNCTION typename base_t::reference_type offset_operator(
+      std::integer_sequence<size_t, I...>, OtherIndexTypes... indices) const {
+    return base_t::operator()((indices - m_begins[I])...);
   }
 
-  template <typename iType>
-  KOKKOS_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>, int>
-  extent_int(const iType& r) const {
-    return static_cast<int>(m_map.extent(r));
-  }
-
-  KOKKOS_FUNCTION constexpr typename traits::array_layout layout() const {
-    return m_map.layout();
-  }
-
-  KOKKOS_FUNCTION constexpr size_t size() const {
-    return m_map.dimension_0() * m_map.dimension_1() * m_map.dimension_2() *
-           m_map.dimension_3() * m_map.dimension_4() * m_map.dimension_5() *
-           m_map.dimension_6() * m_map.dimension_7();
-  }
-
-  KOKKOS_FUNCTION constexpr size_t stride_0() const { return m_map.stride_0(); }
-  KOKKOS_FUNCTION constexpr size_t stride_1() const { return m_map.stride_1(); }
-  KOKKOS_FUNCTION constexpr size_t stride_2() const { return m_map.stride_2(); }
-  KOKKOS_FUNCTION constexpr size_t stride_3() const { return m_map.stride_3(); }
-  KOKKOS_FUNCTION constexpr size_t stride_4() const { return m_map.stride_4(); }
-  KOKKOS_FUNCTION constexpr size_t stride_5() const { return m_map.stride_5(); }
-  KOKKOS_FUNCTION constexpr size_t stride_6() const { return m_map.stride_6(); }
-  KOKKOS_FUNCTION constexpr size_t stride_7() const { return m_map.stride_7(); }
-
-  template <typename iType>
-  KOKKOS_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>, size_t>
-  stride(iType r) const {
-    return (
-        r == 0
-            ? m_map.stride_0()
-            : (r == 1
-                   ? m_map.stride_1()
-                   : (r == 2
-                          ? m_map.stride_2()
-                          : (r == 3
-                                 ? m_map.stride_3()
-                                 : (r == 4
-                                        ? m_map.stride_4()
-                                        : (r == 5
-                                               ? m_map.stride_5()
-                                               : (r == 6
-                                                      ? m_map.stride_6()
-                                                      : m_map.stride_7())))))));
-  }
-
-  template <typename iType>
-  KOKKOS_FUNCTION void stride(iType* const s) const {
-    m_map.stride(s);
-  }
-
-  //----------------------------------------
-  // Range span is the span which contains all members.
-
-  using reference_type = typename map_type::reference_type;
-  using pointer_type   = typename map_type::pointer_type;
-
-  enum {
-    reference_type_is_lvalue_reference =
-        std::is_lvalue_reference_v<reference_type>
-  };
-
-  KOKKOS_FUNCTION constexpr size_t span() const { return m_map.span(); }
-  KOKKOS_FUNCTION bool span_is_contiguous() const {
-    return m_map.span_is_contiguous();
-  }
-  KOKKOS_FUNCTION constexpr bool is_allocated() const {
-    return m_map.data() != nullptr;
-  }
-  KOKKOS_FUNCTION constexpr pointer_type data() const { return m_map.data(); }
-
-  //----------------------------------------
-  // Allow specializations to query their specialized map
-
-  KOKKOS_FUNCTION
-  const Kokkos::Impl::ViewMapping<traits, void>& implementation_map() const {
-    return m_map;
-  }
-
-  //----------------------------------------
-
- private:
-  static constexpr bool is_layout_left =
-      std::is_same_v<typename traits::array_layout, Kokkos::LayoutLeft>;
-
-  static constexpr bool is_layout_right =
-      std::is_same_v<typename traits::array_layout, Kokkos::LayoutRight>;
-
-  static constexpr bool is_layout_stride =
-      std::is_same_v<typename traits::array_layout, Kokkos::LayoutStride>;
-
-  static constexpr bool is_default_map =
-      std::is_void_v<typename traits::specialize> &&
-      (is_layout_left || is_layout_right || is_layout_stride);
-
-#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-
-#define KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY(ARG)                      \
-  Kokkos::Impl::runtime_check_memory_access_violation<                   \
-      typename traits::memory_space>(                                    \
-      "Kokkos::OffsetView ERROR: attempt to access inaccessible memory " \
-      "space");                                                          \
-  Kokkos::Experimental::Impl::offsetview_verify_operator_bounds<         \
-      typename traits::memory_space>                                     \
-      ARG;
-
-#else
-
-#define KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY(ARG)                      \
-  Kokkos::Impl::runtime_check_memory_access_violation<                   \
-      typename traits::memory_space>(                                    \
-      "Kokkos::OffsetView ERROR: attempt to access inaccessible memory " \
-      "space");
-
+  template <class OtherIndexType>
+#ifndef KOKKOS_ENABLE_CXX17
+    requires(std::is_convertible_v<OtherIndexType, index_type> &&
+             std::is_nothrow_constructible_v<index_type, OtherIndexType> &&
+             (base_t::rank() == 1))
 #endif
- public:
-  //------------------------------
-  // Rank 0 operator()
-
-  KOKKOS_FORCEINLINE_FUNCTION
-  reference_type operator()() const { return m_map.reference(); }
-  //------------------------------
-  // Rank 1 operator()
-
-  template <typename I0>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::are_integral<I0>::value && (1 == Rank) && !is_default_map),
-      reference_type>
-  operator()(const I0& i0) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY((m_track, m_map, m_begins, i0))
-    const size_t j0 = i0 - m_begins[0];
-    return m_map.reference(j0);
-  }
-
-  template <typename I0>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(Kokkos::Impl::are_integral<I0>::value && (1 == Rank) &&
-                        is_default_map && !is_layout_stride),
-                       reference_type>
-      operator()(const I0& i0) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY((m_track, m_map, m_begins, i0))
-    const size_t j0 = i0 - m_begins[0];
-    return m_map.m_impl_handle[j0];
-  }
-
-  template <typename I0>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(Kokkos::Impl::are_integral<I0>::value && (1 == Rank) &&
-                        is_default_map && is_layout_stride),
-                       reference_type>
-      operator()(const I0& i0) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY((m_track, m_map, m_begins, i0))
-    const size_t j0 = i0 - m_begins[0];
-    return m_map.m_impl_handle[m_map.m_impl_offset.m_stride.S0 * j0];
-  }
-  //------------------------------
-  // Rank 1 operator[]
-
-  template <typename I0>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::are_integral<I0>::value && (1 == Rank) && !is_default_map),
-      reference_type>
-  operator[](const I0& i0) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY((m_track, m_map, m_begins, i0))
-    const size_t j0 = i0 - m_begins[0];
-    return m_map.reference(j0);
-  }
-
-  template <typename I0>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(Kokkos::Impl::are_integral<I0>::value && (1 == Rank) &&
-                        is_default_map && !is_layout_stride),
-                       reference_type>
-      operator[](const I0& i0) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY((m_track, m_map, m_begins, i0))
-    const size_t j0 = i0 - m_begins[0];
-    return m_map.m_impl_handle[j0];
-  }
-
-  template <typename I0>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(Kokkos::Impl::are_integral<I0>::value && (1 == Rank) &&
-                        is_default_map && is_layout_stride),
-                       reference_type>
-      operator[](const I0& i0) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY((m_track, m_map, m_begins, i0))
-    const size_t j0 = i0 - m_begins[0];
-    return m_map.m_impl_handle[m_map.m_impl_offset.m_stride.S0 * j0];
-  }
-
-  //------------------------------
-  // Rank 2
-
-  template <typename I0, typename I1>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(Kokkos::Impl::are_integral<I0, I1>::value &&
-                        (2 == Rank) && !is_default_map),
-                       reference_type>
-      operator()(const I0& i0, const I1& i1) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY((m_track, m_map, m_begins, i0, i1))
-    const size_t j0 = i0 - m_begins[0];
-    const size_t j1 = i1 - m_begins[1];
-    return m_map.reference(j0, j1);
-  }
-
-  template <typename I0, typename I1>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::are_integral<I0, I1>::value && (2 == Rank) &&
-       is_default_map &&
-       (is_layout_left || is_layout_right || is_layout_stride)),
-      reference_type>
-  operator()(const I0& i0, const I1& i1) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY((m_track, m_map, m_begins, i0, i1))
-    const size_t j0 = i0 - m_begins[0];
-    const size_t j1 = i1 - m_begins[1];
-    if constexpr (is_layout_left) {
-      if constexpr (traits::rank_dynamic == 0)
-        return m_map.m_impl_handle[j0 + m_map.m_impl_offset.m_dim.N0 * j1];
-      else
-        return m_map.m_impl_handle[j0 + m_map.m_impl_offset.m_stride * j1];
-    } else if constexpr (is_layout_right) {
-      if constexpr (traits::rank_dynamic == 0)
-        return m_map.m_impl_handle[j1 + m_map.m_impl_offset.m_dim.N1 * j0];
-      else
-        return m_map.m_impl_handle[j1 + m_map.m_impl_offset.m_stride * j0];
-    } else {
-      static_assert(is_layout_stride);
-      return m_map.m_impl_handle[j0 * m_map.m_impl_offset.m_stride.S0 +
-                                 j1 * m_map.m_impl_offset.m_stride.S1];
-    }
-#if defined(KOKKOS_COMPILER_INTEL)
-    __builtin_unreachable();
+  KOKKOS_FUNCTION constexpr typename base_t::reference_type operator[](
+      const OtherIndexType& idx) const {
+#ifdef KOKKOS_ENABLE_CXX17
+    static_assert(std::is_convertible_v<OtherIndexType, index_type> &&
+                  std::is_nothrow_constructible_v<index_type, OtherIndexType> &&
+                  (base_t::rank() == 1));
 #endif
+    return base_t::operator[](idx - m_begins[0]);
   }
 
-  //------------------------------
-  // Rank 3
-
-  template <typename I0, typename I1, typename I2>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(Kokkos::Impl::are_integral<I0, I1, I2>::value &&
-                        (3 == Rank) && is_default_map),
-                       reference_type>
-      operator()(const I0& i0, const I1& i1, const I2& i2) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY(
-        (m_track, m_map, m_begins, i0, i1, i2))
-    const size_t j0 = i0 - m_begins[0];
-    const size_t j1 = i1 - m_begins[1];
-    const size_t j2 = i2 - m_begins[2];
-    return m_map.m_impl_handle[m_map.m_impl_offset(j0, j1, j2)];
+  template <class... OtherIndexTypes>
+#ifndef KOKKOS_ENABLE_CXX17
+    requires((std::is_convertible_v<OtherIndexTypes, index_type> && ...) &&
+             (std::is_nothrow_constructible_v<index_type, OtherIndexTypes> &&
+              ...) &&
+             (sizeof...(OtherIndexTypes) == base_t::rank()))
+#endif
+  KOKKOS_FUNCTION constexpr typename base_t::reference_type operator()(
+      OtherIndexTypes... indices) const {
+#ifdef KOKKOS_ENABLE_CXX17
+    static_assert(
+        (std::is_convertible_v<OtherIndexTypes, index_type> && ...) &&
+        (std::is_nothrow_constructible_v<index_type, OtherIndexTypes> && ...) &&
+        (sizeof...(OtherIndexTypes) == base_t::rank()));
+#endif
+    return offset_operator(std::make_index_sequence<base_t::rank()>(),
+                           indices...);
   }
-
-  template <typename I0, typename I1, typename I2>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(Kokkos::Impl::are_integral<I0, I1, I2>::value &&
-                        (3 == Rank) && !is_default_map),
-                       reference_type>
-      operator()(const I0& i0, const I1& i1, const I2& i2) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY(
-        (m_track, m_map, m_begins, i0, i1, i2))
-    const size_t j0 = i0 - m_begins[0];
-    const size_t j1 = i1 - m_begins[1];
-    const size_t j2 = i2 - m_begins[2];
-    return m_map.reference(j0, j1, j2);
-  }
-
-  //------------------------------
-  // Rank 4
-
-  template <typename I0, typename I1, typename I2, typename I3>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(Kokkos::Impl::are_integral<I0, I1, I2, I3>::value &&
-                        (4 == Rank) && is_default_map),
-                       reference_type>
-      operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY(
-        (m_track, m_map, m_begins, i0, i1, i2, i3))
-    const size_t j0 = i0 - m_begins[0];
-    const size_t j1 = i1 - m_begins[1];
-    const size_t j2 = i2 - m_begins[2];
-    const size_t j3 = i3 - m_begins[3];
-    return m_map.m_impl_handle[m_map.m_impl_offset(j0, j1, j2, j3)];
-  }
-
-  template <typename I0, typename I1, typename I2, typename I3>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(Kokkos::Impl::are_integral<I0, I1, I2, I3>::value &&
-                        (4 == Rank) && !is_default_map),
-                       reference_type>
-      operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY(
-        (m_track, m_map, m_begins, i0, i1, i2, i3))
-    const size_t j0 = i0 - m_begins[0];
-    const size_t j1 = i1 - m_begins[1];
-    const size_t j2 = i2 - m_begins[2];
-    const size_t j3 = i3 - m_begins[3];
-    return m_map.reference(j0, j1, j2, j3);
-  }
-
-  //------------------------------
-  // Rank 5
-
-  template <typename I0, typename I1, typename I2, typename I3, typename I4>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(Kokkos::Impl::are_integral<I0, I1, I2, I3, I4>::value &&
-                        (5 == Rank) && is_default_map),
-                       reference_type>
-      operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3,
-                 const I4& i4) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY(
-        (m_track, m_map, m_begins, i0, i1, i2, i3, i4))
-    const size_t j0 = i0 - m_begins[0];
-    const size_t j1 = i1 - m_begins[1];
-    const size_t j2 = i2 - m_begins[2];
-    const size_t j3 = i3 - m_begins[3];
-    const size_t j4 = i4 - m_begins[4];
-    return m_map.m_impl_handle[m_map.m_impl_offset(j0, j1, j2, j3, j4)];
-  }
-
-  template <typename I0, typename I1, typename I2, typename I3, typename I4>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(Kokkos::Impl::are_integral<I0, I1, I2, I3, I4>::value &&
-                        (5 == Rank) && !is_default_map),
-                       reference_type>
-      operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3,
-                 const I4& i4) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY(
-        (m_track, m_map, m_begins, i0, i1, i2, i3, i4))
-    const size_t j0 = i0 - m_begins[0];
-    const size_t j1 = i1 - m_begins[1];
-    const size_t j2 = i2 - m_begins[2];
-    const size_t j3 = i3 - m_begins[3];
-    const size_t j4 = i4 - m_begins[4];
-    return m_map.reference(j0, j1, j2, j3, j4);
-  }
-
-  //------------------------------
-  // Rank 6
-
-  template <typename I0, typename I1, typename I2, typename I3, typename I4,
-            typename I5>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::are_integral<I0, I1, I2, I3, I4, I5>::value &&
-       (6 == Rank) && is_default_map),
-      reference_type>
-  operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3,
-             const I4& i4, const I5& i5) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY(
-        (m_track, m_map, m_begins, i0, i1, i2, i3, i4, i5))
-    const size_t j0 = i0 - m_begins[0];
-    const size_t j1 = i1 - m_begins[1];
-    const size_t j2 = i2 - m_begins[2];
-    const size_t j3 = i3 - m_begins[3];
-    const size_t j4 = i4 - m_begins[4];
-    const size_t j5 = i5 - m_begins[5];
-    return m_map.m_impl_handle[m_map.m_impl_offset(j0, j1, j2, j3, j4, j5)];
-  }
-
-  template <typename I0, typename I1, typename I2, typename I3, typename I4,
-            typename I5>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::are_integral<I0, I1, I2, I3, I4, I5>::value &&
-       (6 == Rank) && !is_default_map),
-      reference_type>
-  operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3,
-             const I4& i4, const I5& i5) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY(
-        (m_track, m_map, m_begins, i0, i1, i2, i3, i4, i5))
-    const size_t j0 = i0 - m_begins[0];
-    const size_t j1 = i1 - m_begins[1];
-    const size_t j2 = i2 - m_begins[2];
-    const size_t j3 = i3 - m_begins[3];
-    const size_t j4 = i4 - m_begins[4];
-    const size_t j5 = i5 - m_begins[5];
-    return m_map.reference(j0, j1, j2, j3, j4, j5);
-  }
-
-  //------------------------------
-  // Rank 7
-
-  template <typename I0, typename I1, typename I2, typename I3, typename I4,
-            typename I5, typename I6>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::are_integral<I0, I1, I2, I3, I4, I5, I6>::value &&
-       (7 == Rank) && is_default_map),
-      reference_type>
-  operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3,
-             const I4& i4, const I5& i5, const I6& i6) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY(
-        (m_track, m_map, m_begins, i0, i1, i2, i3, i4, i5, i6))
-    const size_t j0 = i0 - m_begins[0];
-    const size_t j1 = i1 - m_begins[1];
-    const size_t j2 = i2 - m_begins[2];
-    const size_t j3 = i3 - m_begins[3];
-    const size_t j4 = i4 - m_begins[4];
-    const size_t j5 = i5 - m_begins[5];
-    const size_t j6 = i6 - m_begins[6];
-    return m_map.m_impl_handle[m_map.m_impl_offset(j0, j1, j2, j3, j4, j5, j6)];
-  }
-
-  template <typename I0, typename I1, typename I2, typename I3, typename I4,
-            typename I5, typename I6>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::are_integral<I0, I1, I2, I3, I4, I5, I6>::value &&
-       (7 == Rank) && !is_default_map),
-      reference_type>
-  operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3,
-             const I4& i4, const I5& i5, const I6& i6) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY(
-        (m_track, m_map, m_begins, i0, i1, i2, i3, i4, i5, i6))
-    const size_t j0 = i0 - m_begins[0];
-    const size_t j1 = i1 - m_begins[1];
-    const size_t j2 = i2 - m_begins[2];
-    const size_t j3 = i3 - m_begins[3];
-    const size_t j4 = i4 - m_begins[4];
-    const size_t j5 = i5 - m_begins[5];
-    const size_t j6 = i6 - m_begins[6];
-    return m_map.reference(j0, j1, j2, j3, j4, j5, j6);
-  }
-
-  //------------------------------
-  // Rank 8
-
-  template <typename I0, typename I1, typename I2, typename I3, typename I4,
-            typename I5, typename I6, typename I7>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::are_integral<I0, I1, I2, I3, I4, I5, I6, I7>::value &&
-       (8 == Rank) && is_default_map),
-      reference_type>
-  operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3,
-             const I4& i4, const I5& i5, const I6& i6, const I7& i7) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY(
-        (m_track, m_map, m_begins, i0, i1, i2, i3, i4, i5, i6, i7))
-    const size_t j0 = i0 - m_begins[0];
-    const size_t j1 = i1 - m_begins[1];
-    const size_t j2 = i2 - m_begins[2];
-    const size_t j3 = i3 - m_begins[3];
-    const size_t j4 = i4 - m_begins[4];
-    const size_t j5 = i5 - m_begins[5];
-    const size_t j6 = i6 - m_begins[6];
-    const size_t j7 = i7 - m_begins[7];
-    return m_map
-        .m_impl_handle[m_map.m_impl_offset(j0, j1, j2, j3, j4, j5, j6, j7)];
-  }
-
-  template <typename I0, typename I1, typename I2, typename I3, typename I4,
-            typename I5, typename I6, typename I7>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::are_integral<I0, I1, I2, I3, I4, I5, I6, I7>::value &&
-       (8 == Rank) && !is_default_map),
-      reference_type>
-  operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3,
-             const I4& i4, const I5& i5, const I6& i6, const I7& i7) const {
-    KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY(
-        (m_track, m_map, m_begins, i0, i1, i2, i3, i4, i5, i6, i7))
-    const size_t j0 = i0 - m_begins[0];
-    const size_t j1 = i1 - m_begins[1];
-    const size_t j2 = i2 - m_begins[2];
-    const size_t j3 = i3 - m_begins[3];
-    const size_t j4 = i4 - m_begins[4];
-    const size_t j5 = i5 - m_begins[5];
-    const size_t j6 = i6 - m_begins[6];
-    const size_t j7 = i7 - m_begins[7];
-    return m_map.reference(j0, j1, j2, j3, j4, j5, j6, j7);
-  }
-
-#undef KOKKOS_IMPL_OFFSETVIEW_OPERATOR_VERIFY
+  //----------------------------------------
 
   //----------------------------------------
   // Standard destructor, constructors, and assignment operators
 
-  KOKKOS_DEFAULTED_FUNCTION
-  ~OffsetView() = default;
-
   KOKKOS_FUNCTION
-  OffsetView() : m_track(), m_map() {
-    for (size_t i = 0; i < Rank; ++i) m_begins[i] = KOKKOS_INVALID_OFFSET;
-  }
-
-  KOKKOS_FUNCTION
-  OffsetView(const OffsetView& rhs)
-      : m_track(rhs.m_track, traits::is_managed),
-        m_map(rhs.m_map),
-        m_begins(rhs.m_begins) {}
-
-  KOKKOS_FUNCTION
-  OffsetView(OffsetView&& rhs)
-      : m_track(std::move(rhs.m_track)),
-        m_map(std::move(rhs.m_map)),
-        m_begins(std::move(rhs.m_begins)) {}
-
-  KOKKOS_FUNCTION
-  OffsetView& operator=(const OffsetView& rhs) {
-    m_track  = rhs.m_track;
-    m_map    = rhs.m_map;
-    m_begins = rhs.m_begins;
-    return *this;
-  }
-
-  KOKKOS_FUNCTION
-  OffsetView& operator=(OffsetView&& rhs) {
-    m_track  = std::move(rhs.m_track);
-    m_map    = std::move(rhs.m_map);
-    m_begins = std::move(rhs.m_begins);
-    return *this;
+  OffsetView() : base_t() {
+    for (size_t i = 0; i < base_t::rank(); ++i)
+      m_begins[i] = KOKKOS_INVALID_OFFSET;
   }
 
   // interoperability with View
@@ -775,20 +300,10 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
 
  public:
   KOKKOS_FUNCTION
-  view_type view() const {
-    view_type v(m_track, m_map);
-    return v;
-  }
+  view_type view() const { return *this; }
 
   template <class RT, class... RP>
-  KOKKOS_FUNCTION OffsetView(const View<RT, RP...>& aview)
-      : m_track(aview.impl_track()), m_map() {
-    using SrcTraits = typename OffsetView<RT, RP...>::traits;
-    using Mapping   = Kokkos::Impl::ViewMapping<traits, SrcTraits, void>;
-    static_assert(Mapping::is_assignable,
-                  "Incompatible OffsetView copy construction");
-    Mapping::assign(m_map, aview.impl_map(), m_track);
-
+  KOKKOS_FUNCTION OffsetView(const View<RT, RP...>& aview) : base_t(aview) {
     for (size_t i = 0; i < View<RT, RP...>::rank(); ++i) {
       m_begins[i] = 0;
     }
@@ -797,19 +312,14 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
   template <class RT, class... RP>
   KOKKOS_FUNCTION OffsetView(const View<RT, RP...>& aview,
                              const index_list_type& minIndices)
-      : m_track(aview.impl_track()), m_map() {
-    using SrcTraits = typename OffsetView<RT, RP...>::traits;
-    using Mapping   = Kokkos::Impl::ViewMapping<traits, SrcTraits, void>;
-    static_assert(Mapping::is_assignable,
-                  "Incompatible OffsetView copy construction");
-    Mapping::assign(m_map, aview.impl_map(), m_track);
+      : base_t(aview) {
+    KOKKOS_IF_ON_HOST(
+        (Kokkos::Experimental::Impl::runtime_check_rank_host(
+             traits::rank_dynamic, base_t::rank(), minIndices, aview.label());))
 
-    KOKKOS_IF_ON_HOST((Kokkos::Experimental::Impl::runtime_check_rank_host(
-                           traits::rank_dynamic, Rank, minIndices, label());))
-
-    KOKKOS_IF_ON_DEVICE((Kokkos::Experimental::Impl::runtime_check_rank_device(
-                             traits::rank_dynamic, Rank, minIndices);))
-
+    KOKKOS_IF_ON_DEVICE(
+        (Kokkos::Experimental::Impl::runtime_check_rank_device(
+             traits::rank_dynamic, base_t::rank(), minIndices);))
     for (size_t i = 0; i < minIndices.size(); ++i) {
       m_begins[i] = minIndices.begin()[i];
     }
@@ -817,27 +327,13 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
   template <class RT, class... RP>
   KOKKOS_FUNCTION OffsetView(const View<RT, RP...>& aview,
                              const begins_type& beg)
-      : m_track(aview.impl_track()), m_map(), m_begins(beg) {
-    using SrcTraits = typename OffsetView<RT, RP...>::traits;
-    using Mapping   = Kokkos::Impl::ViewMapping<traits, SrcTraits, void>;
-    static_assert(Mapping::is_assignable,
-                  "Incompatible OffsetView copy construction");
-    Mapping::assign(m_map, aview.impl_map(), m_track);
-  }
+      : base_t(aview), m_begins(beg) {}
 
   // may assign unmanaged from managed.
 
   template <class RT, class... RP>
   KOKKOS_FUNCTION OffsetView(const OffsetView<RT, RP...>& rhs)
-      : m_track(rhs.m_track, traits::is_managed),
-        m_map(),
-        m_begins(rhs.m_begins) {
-    using SrcTraits = typename OffsetView<RT, RP...>::traits;
-    using Mapping   = Kokkos::Impl::ViewMapping<traits, SrcTraits, void>;
-    static_assert(Mapping::is_assignable,
-                  "Incompatible OffsetView copy construction");
-    Mapping::assign(m_map, rhs.m_map, rhs.m_track);  // swb what about assign?
-  }
+      : base_t(rhs.view()), m_begins(rhs.m_begins) {}
 
  private:
   enum class subtraction_failure {
@@ -876,7 +372,7 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
   static subtraction_failure runtime_check_begins_ends_host(const B& begins,
                                                             const E& ends) {
     std::string message;
-    if (begins.size() != Rank)
+    if (begins.size() != base_t::rank())
       message +=
           "begins.size() "
           "(" +
@@ -884,11 +380,11 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
           ")"
           " != Rank "
           "(" +
-          std::to_string(Rank) +
+          std::to_string(base_t::rank()) +
           ")"
           "\n";
 
-    if (ends.size() != Rank)
+    if (ends.size() != base_t::rank())
       message +=
           "ends.size() "
           "(" +
@@ -896,7 +392,7 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
           ")"
           " != Rank "
           "(" +
-          std::to_string(Rank) +
+          std::to_string(base_t::rank()) +
           ")"
           "\n";
 
@@ -948,11 +444,11 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
   template <typename B, typename E>
   KOKKOS_FUNCTION static subtraction_failure runtime_check_begins_ends_device(
       const B& begins, const E& ends) {
-    if (begins.size() != Rank)
+    if (begins.size() != base_t::rank())
       Kokkos::abort(
           "Kokkos::Experimental::OffsetView ERROR: for unmanaged "
           "OffsetView: begins has bad Rank");
-    if (ends.size() != Rank)
+    if (ends.size() != base_t::rank())
       Kokkos::abort(
           "Kokkos::Experimental::OffsetView ERROR: for unmanaged "
           "OffsetView: ends has bad Rank");
@@ -990,20 +486,17 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
   // Precondition: begins.size() == ends.size() == m_begins.size() == Rank
   template <typename B, typename E>
   KOKKOS_FUNCTION OffsetView(const pointer_type& p, const B& begins_,
-                             const E& ends_,
-                             subtraction_failure)
-      : m_track()  // no tracking
-        ,
-        m_map(Kokkos::Impl::ViewCtorProp<pointer_type>(p),
-              typename traits::array_layout(
-                  Rank > 0 ? at(ends_, 0) - at(begins_, 0) : 0,
-                  Rank > 1 ? at(ends_, 1) - at(begins_, 1) : 0,
-                  Rank > 2 ? at(ends_, 2) - at(begins_, 2) : 0,
-                  Rank > 3 ? at(ends_, 3) - at(begins_, 3) : 0,
-                  Rank > 4 ? at(ends_, 4) - at(begins_, 4) : 0,
-                  Rank > 5 ? at(ends_, 5) - at(begins_, 5) : 0,
-                  Rank > 6 ? at(ends_, 6) - at(begins_, 6) : 0,
-                  Rank > 7 ? at(ends_, 7) - at(begins_, 7) : 0)) {
+                             const E& ends_, subtraction_failure)
+      : base_t(Kokkos::view_wrap(p),
+               typename traits::array_layout(
+                   base_t::rank() > 0 ? at(ends_, 0) - at(begins_, 0) : 0,
+                   base_t::rank() > 1 ? at(ends_, 1) - at(begins_, 1) : 0,
+                   base_t::rank() > 2 ? at(ends_, 2) - at(begins_, 2) : 0,
+                   base_t::rank() > 3 ? at(ends_, 3) - at(begins_, 3) : 0,
+                   base_t::rank() > 4 ? at(ends_, 4) - at(begins_, 4) : 0,
+                   base_t::rank() > 5 ? at(ends_, 5) - at(begins_, 5) : 0,
+                   base_t::rank() > 6 ? at(ends_, 6) - at(begins_, 6) : 0,
+                   base_t::rank() > 7 ? at(ends_, 7) - at(begins_, 7) : 0)) {
     for (size_t i = 0; i != m_begins.size(); ++i) {
       m_begins[i] = at(begins_, i);
     };
@@ -1036,15 +529,6 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
              index_list_type ends_)
       : OffsetView(p, begins_, ends_,
                    runtime_check_begins_ends(begins_, ends_)) {}
-
-  //----------------------------------------
-  // Allocation tracking properties
-  KOKKOS_FUNCTION
-  int use_count() const { return m_track.use_count(); }
-
-  const std::string label() const {
-    return m_track.template get_label<typename traits::memory_space>();
-  }
 
   // Choosing std::pair as type for the arguments allows constructing an
   // OffsetView using list initialization syntax, e.g.,
@@ -1110,9 +594,14 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
       std::enable_if_t<Kokkos::Impl::ViewCtorProp<P...>::has_pointer,
                        typename traits::array_layout> const& arg_layout,
       const index_list_type minIndices)
-      : m_track()  // No memory tracking
-        ,
-        m_map(arg_prop, arg_layout) {
+      : base_t(arg_prop, arg_layout) {
+    KOKKOS_IF_ON_HOST((Kokkos::Experimental::Impl::runtime_check_rank_host(
+                           traits::rank_dynamic, base_t::rank(), minIndices,
+                           base_t::label());))
+
+    KOKKOS_IF_ON_DEVICE(
+        (Kokkos::Experimental::Impl::runtime_check_rank_device(
+             traits::rank_dynamic, base_t::rank(), minIndices);))
     for (size_t i = 0; i < minIndices.size(); ++i) {
       m_begins[i] = minIndices.begin()[i];
     }
@@ -1129,42 +618,9 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
       std::enable_if_t<!Kokkos::Impl::ViewCtorProp<P...>::has_pointer,
                        typename traits::array_layout> const& arg_layout,
       const index_list_type minIndices)
-      : m_track(),
-        m_map()
-
-  {
-    for (size_t i = 0; i < Rank; ++i) m_begins[i] = minIndices.begin()[i];
-
-    // Copy the input allocation properties with possibly defaulted properties
-    auto prop_copy = Kokkos::Impl::with_properties_if_unset(
-        arg_prop, std::string{}, typename traits::device_type::memory_space{},
-        typename traits::device_type::execution_space{});
-    using alloc_prop = decltype(prop_copy);
-
-    static_assert(traits::is_managed,
-                  "OffsetView allocation constructor requires managed memory");
-
-    if (alloc_prop::initialize &&
-        !alloc_prop::execution_space::impl_is_initialized()) {
-      // If initializing view data then
-      // the execution space must be initialized.
-      Kokkos::Impl::throw_runtime_exception(
-          "Constructing OffsetView and initializing data with uninitialized "
-          "execution space");
-    }
-
-    Kokkos::Impl::SharedAllocationRecord<>* record = m_map.allocate_shared(
-        prop_copy, arg_layout,
-        Kokkos::Impl::ViewCtorProp<P...>::has_execution_space);
-
-    // Setup and initialization complete, start tracking
-    m_track.assign_allocated_record_to_uninitialized(record);
-
-    KOKKOS_IF_ON_HOST((Kokkos::Experimental::Impl::runtime_check_rank_host(
-                           traits::rank_dynamic, Rank, minIndices, label());))
-
-    KOKKOS_IF_ON_DEVICE((Kokkos::Experimental::Impl::runtime_check_rank_device(
-                             traits::rank_dynamic, Rank, minIndices);))
+      : base_t(arg_prop, arg_layout) {
+    for (size_t i = 0; i < base_t::rank(); ++i)
+      m_begins[i] = minIndices.begin()[i];
   }
 };
 
@@ -1174,7 +630,7 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
  */
 template <typename D, class... P>
 KOKKOS_INLINE_FUNCTION constexpr unsigned rank(const OffsetView<D, P...>& V) {
-  return V.Rank;
+  return V.rank();
 }  // Temporary until added to view
 
 //----------------------------------------------------------------------------
@@ -1618,7 +1074,7 @@ KOKKOS_INLINE_FUNCTION
             ViewTraits<D, P...>, Args...>::type>::type
     subview(const OffsetView<D, P...>& src, Args... args) {
   static_assert(
-      OffsetView<D, P...>::Rank == sizeof...(Args),
+      OffsetView<D, P...>::rank() == sizeof...(Args),
       "subview requires one argument for each source OffsetView rank");
 
   return Kokkos::Experimental::Impl::subview_offset(src, args...);

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -56,7 +56,14 @@ void test_offsetview_construction() {
   offset_view_type ov("firstOV", range0, range1);
 
   ASSERT_EQ("firstOV", ov.label());
-  ASSERT_EQ(2, ov.Rank);
+
+  KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  ASSERT_EQ(2u, ov.Rank);
+#endif
+  KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+
+  ASSERT_EQ(2u, ov.rank());
 
   ASSERT_EQ(ov.begin(0), -1);
   ASSERT_EQ(ov.end(0), 4);
@@ -377,8 +384,8 @@ void test_offsetview_subview() {
     Kokkos::Experimental::OffsetView<Scalar*, Device> sliceMe("offsetToSlice",
                                                               {-10, 20});
     {
-      auto offsetSubviewa = Kokkos::Experimental::subview(sliceMe, 0);
-      ASSERT_EQ(offsetSubviewa.Rank, 0) << "subview of offset is broken.";
+      auto offsetSubview = Kokkos::Experimental::subview(sliceMe, 0);
+      ASSERT_EQ(offsetSubview.rank(), 0u) << "subview of offset is broken.";
     }
   }
   {  // test subview 2
@@ -387,13 +394,13 @@ void test_offsetview_subview() {
     {
       auto offsetSubview =
           Kokkos::Experimental::subview(sliceMe, Kokkos::ALL(), -2);
-      ASSERT_EQ(offsetSubview.Rank, 1) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
 
     {
       auto offsetSubview =
           Kokkos::Experimental::subview(sliceMe, 0, Kokkos::ALL());
-      ASSERT_EQ(offsetSubview.Rank, 1) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
   }
 
@@ -406,23 +413,23 @@ void test_offsetview_subview() {
     {
       auto offsetSubview = Kokkos::Experimental::subview(sliceMe, Kokkos::ALL(),
                                                          Kokkos::ALL(), 0);
-      ASSERT_EQ(offsetSubview.Rank, 2) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 2u) << "subview of offset is broken.";
     }
     {
       auto offsetSubview = Kokkos::Experimental::subview(sliceMe, Kokkos::ALL(),
                                                          0, Kokkos::ALL());
-      ASSERT_EQ(offsetSubview.Rank, 2) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 2u) << "subview of offset is broken.";
     }
 
     {
       auto offsetSubview = Kokkos::Experimental::subview(
           sliceMe, 0, Kokkos::ALL(), Kokkos::ALL());
-      ASSERT_EQ(offsetSubview.Rank, 2) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 2u) << "subview of offset is broken.";
     }
     {
       auto offsetSubview = Kokkos::Experimental::subview(
           sliceMe, 0, Kokkos::ALL(), Kokkos::make_pair(-30, -21));
-      ASSERT_EQ(offsetSubview.Rank, 2) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 2u) << "subview of offset is broken.";
 
       ASSERT_EQ(offsetSubview.begin(0), -20);
       ASSERT_EQ(offsetSubview.end(0), 31);
@@ -462,18 +469,18 @@ void test_offsetview_subview() {
     {
       auto offsetSubview =
           Kokkos::Experimental::subview(sliceMe, Kokkos::ALL(), 0, 0);
-      ASSERT_EQ(offsetSubview.Rank, 1) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
     {
       auto offsetSubview =
           Kokkos::Experimental::subview(sliceMe, 0, 0, Kokkos::ALL());
-      ASSERT_EQ(offsetSubview.Rank, 1) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
 
     {
       auto offsetSubview =
           Kokkos::Experimental::subview(sliceMe, 0, Kokkos::ALL(), 0);
-      ASSERT_EQ(offsetSubview.Rank, 1) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
   }
 
@@ -486,68 +493,68 @@ void test_offsetview_subview() {
     {
       auto offsetSubview = Kokkos::Experimental::subview(
           sliceMe, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), 0);
-      ASSERT_EQ(offsetSubview.Rank, 3) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 3u) << "subview of offset is broken.";
     }
     {
       auto offsetSubview = Kokkos::Experimental::subview(
           sliceMe, Kokkos::ALL(), Kokkos::ALL(), 0, Kokkos::ALL());
-      ASSERT_EQ(offsetSubview.Rank, 3) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 3u) << "subview of offset is broken.";
     }
     {
       auto offsetSubview = Kokkos::Experimental::subview(
           sliceMe, Kokkos::ALL(), 0, Kokkos::ALL(), Kokkos::ALL());
-      ASSERT_EQ(offsetSubview.Rank, 3) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 3u) << "subview of offset is broken.";
     }
     {
       auto offsetSubview = Kokkos::Experimental::subview(
           sliceMe, 0, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-      ASSERT_EQ(offsetSubview.Rank, 3) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 3u) << "subview of offset is broken.";
     }
 
     // slice 2
     auto offsetSubview2a = Kokkos::Experimental::subview(sliceMe, Kokkos::ALL(),
                                                          Kokkos::ALL(), 0, 0);
-    ASSERT_EQ(offsetSubview2a.Rank, 2) << "subview of offset is broken.";
+    ASSERT_EQ(offsetSubview2a.rank(), 2u) << "subview of offset is broken.";
     {
       auto offsetSubview2b = Kokkos::Experimental::subview(
           sliceMe, Kokkos::ALL(), 0, Kokkos::ALL(), 0);
-      ASSERT_EQ(offsetSubview2b.Rank, 2) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview2b.rank(), 2u) << "subview of offset is broken.";
     }
     {
       auto offsetSubview2b = Kokkos::Experimental::subview(
           sliceMe, Kokkos::ALL(), 0, 0, Kokkos::ALL());
-      ASSERT_EQ(offsetSubview2b.Rank, 2) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview2b.rank(), 2u) << "subview of offset is broken.";
     }
     {
       auto offsetSubview2b = Kokkos::Experimental::subview(
           sliceMe, 0, Kokkos::ALL(), 0, Kokkos::ALL());
-      ASSERT_EQ(offsetSubview2b.Rank, 2) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview2b.rank(), 2u) << "subview of offset is broken.";
     }
     {
       auto offsetSubview2b = Kokkos::Experimental::subview(
           sliceMe, 0, 0, Kokkos::ALL(), Kokkos::ALL());
-      ASSERT_EQ(offsetSubview2b.Rank, 2) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview2b.rank(), 2u) << "subview of offset is broken.";
     }
     // slice 3
     {
       auto offsetSubview =
           Kokkos::Experimental::subview(sliceMe, Kokkos::ALL(), 0, 0, 0);
-      ASSERT_EQ(offsetSubview.Rank, 1) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
     {
       auto offsetSubview =
           Kokkos::Experimental::subview(sliceMe, 0, Kokkos::ALL(), 0, 0);
-      ASSERT_EQ(offsetSubview.Rank, 1) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
     {
       auto offsetSubview =
           Kokkos::Experimental::subview(sliceMe, 0, 0, Kokkos::ALL(), 0);
-      ASSERT_EQ(offsetSubview.Rank, 1) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
     {
       auto offsetSubview =
           Kokkos::Experimental::subview(sliceMe, 0, 0, 0, Kokkos::ALL());
-      ASSERT_EQ(offsetSubview.Rank, 1) << "subview of offset is broken.";
+      ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
   }
 }
@@ -586,6 +593,7 @@ void test_offsetview_offsets_rank1() {
       KOKKOS_LAMBDA(const int ii, int& lerrors) {
         offset_view_type ov(v, {ii});
         lerrors += (ov(3) != element({3 - ii}));
+        lerrors += (ov[3] != element({3 - ii}));
       },
       errors);
 


### PR DESCRIPTION
I am changing OffsetView to inherit publicly from View. Many functions such as as `extent()`, `rank()`, and what not are the same as for `View`. It really is just the additional stuff around the offsets (i.e. ctors and `operator()`) that are different.   