### PR TITLE
Disable thread safety tests on the host backends as well when OpenACC is enabled

### DIFF
--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -19,6 +19,12 @@
 
 namespace {
 
+#ifdef KOKKOS_COMPILER_NVHPC
+#define THREAD_SAFETY_TEST_UNREACHABLE() __builtin_unreachable()
+#else
+#define THREAD_SAFETY_TEST_UNREACHABLE() static_assert(true)
+#endif
+
 #ifdef KOKKOS_ENABLE_OPENMP
 template <class Lambda1, class Lambda2>
 void run_threaded_test(const Lambda1 l1, const Lambda2 l2) {
@@ -81,6 +87,7 @@ TEST(TEST_CATEGORY, exec_space_thread_safety_range) {
   GTEST_SKIP()
       << "skipping OpenACC test since unsupported host-side atomics cause "
          "race conditions during shared allocation reference counting";
+  THREAD_SAFETY_TEST_UNREACHABLE();
 #endif
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
@@ -123,6 +130,7 @@ TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange) {
   GTEST_SKIP()
       << "skipping OpenACC test since unsupported host-side atomics cause "
          "race conditions during shared allocation reference counting";
+  THREAD_SAFETY_TEST_UNREACHABLE();
 #endif
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
@@ -167,6 +175,7 @@ TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy) {
   GTEST_SKIP()
       << "skipping OpenACC test since unsupported host-side atomics cause "
          "race conditions during shared allocation reference counting";
+  THREAD_SAFETY_TEST_UNREACHABLE();
 #endif
 // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
@@ -211,6 +220,7 @@ TEST(TEST_CATEGORY, exec_space_thread_safety_range_reduce) {
   GTEST_SKIP()
       << "skipping OpenACC test since unsupported host-side atomics cause "
          "race conditions during shared allocation reference counting";
+  THREAD_SAFETY_TEST_UNREACHABLE();
 #endif
   run_exec_space_thread_safety_range_reduce();
 }
@@ -250,6 +260,7 @@ TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange_reduce) {
   GTEST_SKIP()
       << "skipping OpenACC test since unsupported host-side atomics cause "
          "race conditions during shared allocation reference counting";
+  THREAD_SAFETY_TEST_UNREACHABLE();
 #endif
 // FIXME_INTEL
 #if defined(KOKKOS_COMPILER_INTEL) && defined(KOKKOS_ENABLE_OPENMP)
@@ -296,6 +307,7 @@ TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy_reduce) {
   GTEST_SKIP()
       << "skipping OpenACC test since unsupported host-side atomics cause "
          "race conditions during shared allocation reference counting";
+  THREAD_SAFETY_TEST_UNREACHABLE();
 #endif
 // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
@@ -347,6 +359,7 @@ TEST(TEST_CATEGORY, exec_space_thread_safety_range_scan) {
   GTEST_SKIP()
       << "skipping OpenACC test since unsupported host-side atomics cause "
          "race conditions during shared allocation reference counting";
+  THREAD_SAFETY_TEST_UNREACHABLE();
 #endif
   run_exec_space_thread_safety_range_scan();
 }

--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -78,10 +78,9 @@ void run_exec_space_thread_safety_range() {
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_range) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP()
-        << "skipping OpenACC test since unsupported host-side atomics cause "
-           "race conditions during shared allocation reference counting";
+  GTEST_SKIP()
+      << "skipping OpenACC test since unsupported host-side atomics cause "
+         "race conditions during shared allocation reference counting";
 #endif
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
@@ -121,10 +120,9 @@ void run_exec_space_thread_safety_mdrange() {
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP()
-        << "skipping OpenACC test since unsupported host-side atomics cause "
-           "race conditions during shared allocation reference counting";
+  GTEST_SKIP()
+      << "skipping OpenACC test since unsupported host-side atomics cause "
+         "race conditions during shared allocation reference counting";
 #endif
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
@@ -166,10 +164,9 @@ void run_exec_space_thread_safety_team_policy() {
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP()
-        << "skipping OpenACC test since unsupported host-side atomics cause "
-           "race conditions during shared allocation reference counting";
+  GTEST_SKIP()
+      << "skipping OpenACC test since unsupported host-side atomics cause "
+         "race conditions during shared allocation reference counting";
 #endif
 // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
@@ -211,10 +208,9 @@ void run_exec_space_thread_safety_range_reduce() {
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_range_reduce) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP()
-        << "skipping OpenACC test since unsupported host-side atomics cause "
-           "race conditions during shared allocation reference counting";
+  GTEST_SKIP()
+      << "skipping OpenACC test since unsupported host-side atomics cause "
+         "race conditions during shared allocation reference counting";
 #endif
   run_exec_space_thread_safety_range_reduce();
 }
@@ -251,10 +247,9 @@ void run_exec_space_thread_safety_mdrange_reduce() {
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange_reduce) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP()
-        << "skipping OpenACC test since unsupported host-side atomics cause "
-           "race conditions during shared allocation reference counting";
+  GTEST_SKIP()
+      << "skipping OpenACC test since unsupported host-side atomics cause "
+         "race conditions during shared allocation reference counting";
 #endif
 // FIXME_INTEL
 #if defined(KOKKOS_COMPILER_INTEL) && defined(KOKKOS_ENABLE_OPENMP)
@@ -298,10 +293,9 @@ void run_exec_space_thread_safety_team_policy_reduce() {
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy_reduce) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP()
-        << "skipping OpenACC test since unsupported host-side atomics cause "
-           "race conditions during shared allocation reference counting";
+  GTEST_SKIP()
+      << "skipping OpenACC test since unsupported host-side atomics cause "
+         "race conditions during shared allocation reference counting";
 #endif
 // FIXME_OPENMPTARGET
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
@@ -350,10 +344,9 @@ void run_exec_space_thread_safety_range_scan() {
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_range_scan) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
-    GTEST_SKIP()
-        << "skipping OpenACC test since unsupported host-side atomics cause "
-           "race conditions during shared allocation reference counting";
+  GTEST_SKIP()
+      << "skipping OpenACC test since unsupported host-side atomics cause "
+         "race conditions during shared allocation reference counting";
 #endif
   run_exec_space_thread_safety_range_scan();
 }


### PR DESCRIPTION
Fixup for #7306

Need do skip for all exec spaces because host-side atomics have issues which is affecting the shared allocation reference counting