### PR TITLE
OpenMP/HPX: Deprecate is_asynchronous

### DIFF
--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -249,13 +249,15 @@ class HPX {
     impl_instance_fence(name);
   }
 
-  static bool is_asynchronous(HPX const & = HPX()) noexcept {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED static bool is_asynchronous(HPX const & = HPX()) noexcept {
 #if defined(KOKKOS_ENABLE_IMPL_HPX_ASYNC_DISPATCH)
     return true;
 #else
     return false;
 #endif
   }
+#endif
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static int concurrency();

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -93,11 +93,14 @@ class OpenMP {
   void fence(std::string const& name =
                  "Kokkos::OpenMP::fence: Unnamed Instance Fence") const;
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   /// \brief Does the given instance return immediately after launching
   /// a parallel algorithm
   ///
   /// This always returns false on OpenMP
-  inline static bool is_asynchronous(OpenMP const& = OpenMP()) noexcept;
+  KOKKOS_DEPRECATED inline static bool is_asynchronous(
+      OpenMP const& = OpenMP()) noexcept;
+#endif
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static int concurrency(OpenMP const& = OpenMP());
@@ -154,9 +157,11 @@ inline int OpenMP::impl_thread_pool_rank() noexcept {
   KOKKOS_IF_ON_DEVICE((return -1;))
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 inline bool OpenMP::is_asynchronous(OpenMP const& /*instance*/) noexcept {
   return false;
 }
+#endif
 
 inline int OpenMP::impl_thread_pool_size(int depth) const {
   return depth < 2 ? impl_thread_pool_size() : 1;

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -99,7 +99,9 @@ class OpenMP {
   ///
   /// This always returns false on OpenMP
   KOKKOS_DEPRECATED inline static bool is_asynchronous(
-      OpenMP const& = OpenMP()) noexcept;
+      OpenMP const& = OpenMP()) noexcept {
+    return false;
+  }
 #endif
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -156,12 +158,6 @@ inline int OpenMP::impl_thread_pool_rank() noexcept {
 
   KOKKOS_IF_ON_DEVICE((return -1;))
 }
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-inline bool OpenMP::is_asynchronous(OpenMP const& /*instance*/) noexcept {
-  return false;
-}
-#endif
 
 inline int OpenMP::impl_thread_pool_size(int depth) const {
   return depth < 2 ? impl_thread_pool_size() : 1;


### PR DESCRIPTION
This member function only exists for `OpenMP` and `HPX` and is unused.
Related to  #7319.