### PR TITLE
graph(tests): fix for gcc 10.1 CTAD bug

### DIFF
--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -564,10 +564,16 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), end_of_submit_control_flow) {
   //      their policy if the defaulted graph implementation is used.
   graph.submit(exec_3);
 
+  // clang-format off
   Kokkos::parallel_for(
       policy_t(exec_3, 0, 1),
+#if defined(KOKKOS_COMPILER_GNU) && (1010 == KOKKOS_COMPILER_GNU)
+      // Workaround CTAD bug, see 7316.
+      FetchValuesAndContribute<decltype(data), index_F, 2>(data, {index_D(), index_E()}, index_F, value_F));
+#else
       FetchValuesAndContribute(data, {index_D(), index_E()}, index_F, value_F));
-
+#endif
+  // clang-format on
   view_h_t data_host(
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "data - host"), 6);
 


### PR DESCRIPTION
This fixes #7316.