### PR TITLE
Failure to parse CTest resource allocation not recoverable

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -271,7 +271,7 @@ int Kokkos::Impl::get_ctest_gpu(int local_rank) {
     ss << "Error: local rank " << local_rank
        << " is outside the bounds of resource groups provided by CTest. Raised"
        << " by Kokkos::Impl::get_ctest_gpu().";
-    throw_runtime_exception(ss.str());
+    abort(ss.str().c_str());
   }
 
   // Get the resource types allocated to this resource group
@@ -284,7 +284,7 @@ int Kokkos::Impl::get_ctest_gpu(int local_rank) {
     std::ostringstream ss;
     ss << "Error: " << ctest_resource_group_name << " is not specified. Raised"
        << " by Kokkos::Impl::get_ctest_gpu().";
-    throw_runtime_exception(ss.str());
+    abort(ss.str().c_str());
   }
 
   // Look for the device type specified in CTEST_KOKKOS_DEVICE_TYPE
@@ -308,7 +308,7 @@ int Kokkos::Impl::get_ctest_gpu(int local_rank) {
     ss << "Error: device type '" << ctest_kokkos_device_type
        << "' not included in " << ctest_resource_group_name
        << ". Raised by Kokkos::Impl::get_ctest_gpu().";
-    throw_runtime_exception(ss.str());
+    abort(ss.str().c_str());
   }
 
   // Get the device ID
@@ -324,7 +324,7 @@ int Kokkos::Impl::get_ctest_gpu(int local_rank) {
     std::ostringstream ss;
     ss << "Error: " << ctest_resource_group_id_name
        << " is not specified. Raised by Kokkos::Impl::get_ctest_gpu().";
-    throw_runtime_exception(ss.str());
+    abort(ss.str().c_str());
   }
 
   auto const* comma = std::strchr(resource_str, ',');
@@ -332,7 +332,7 @@ int Kokkos::Impl::get_ctest_gpu(int local_rank) {
     std::ostringstream ss;
     ss << "Error: invalid value of " << ctest_resource_group_id_name << ": '"
        << resource_str << "'. Raised by Kokkos::Impl::get_ctest_gpu().";
-    throw_runtime_exception(ss.str());
+    abort(ss.str().c_str());
   }
 
   std::string id(resource_str + 3, comma - resource_str - 3);

--- a/core/unit_test/TestCTestDevice.cpp
+++ b/core/unit_test/TestCTestDevice.cpp
@@ -87,33 +87,33 @@ TEST_F(ctest_environment_DeathTest, invalid_rank) {
 TEST_F(ctest_environment_DeathTest, no_type_str) {
   EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(0),
                "Error: CTEST_RESOURCE_GROUP_0 is not specified. Raised by "
-               "Kokkos::Impl::get_ctest_gpu().");
+               "Kokkos::Impl::get_ctest_gpu\\(\\).");
 }
 
 TEST_F(ctest_environment_DeathTest, missing_type) {
   EXPECT_DEATH(
       Kokkos::Impl::get_ctest_gpu(1),
       "Error: device type 'gpus' not included in CTEST_RESOURCE_GROUP_1. "
-      "Raised by Kokkos::Impl::get_ctest_gpu().");
+      "Raised by Kokkos::Impl::get_ctest_gpu\\(\\).");
   EXPECT_DEATH(
       Kokkos::Impl::get_ctest_gpu(2),
       "Error: device type 'gpus' not included in CTEST_RESOURCE_GROUP_2. "
-      "Raised by Kokkos::Impl::get_ctest_gpu().");
+      "Raised by Kokkos::Impl::get_ctest_gpu\\(\\).");
 }
 
 TEST_F(ctest_environment_DeathTest, no_id_str) {
   EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(3),
                "Error: CTEST_RESOURCE_GROUP_3_GPUS is not specified. Raised by "
-               "Kokkos::Impl::get_ctest_gpu().");
+               "Kokkos::Impl::get_ctest_gpu\\(\\).");
 }
 
 TEST_F(ctest_environment_DeathTest, invalid_id_str) {
   EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(4),
                "Error: invalid value of CTEST_RESOURCE_GROUP_4_GPUS: 'id:2'. "
-               "Raised by Kokkos::Impl::get_ctest_gpu().");
+               "Raised by Kokkos::Impl::get_ctest_gpu\\(\\).");
   EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(5),
                "Error: invalid value of CTEST_RESOURCE_GROUP_5_GPUS: "
-               "'slots:1,id:2'. Raised by Kokkos::Impl::get_ctest_gpu().");
+               "'slots:1,id:2'. Raised by Kokkos::Impl::get_ctest_gpu\\(\\).");
 }
 
 TEST_F(ctest_environment, good) {

--- a/core/unit_test/TestCTestDevice.cpp
+++ b/core/unit_test/TestCTestDevice.cpp
@@ -79,18 +79,21 @@ TEST_F(ctest_environment, no_process_count) {
 }
 
 TEST_F(ctest_environment_DeathTest, invalid_rank) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(10),
                "Error: local rank 10 is outside the bounds of resource groups "
                "provided by CTest.");
 }
 
 TEST_F(ctest_environment_DeathTest, no_type_str) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(0),
                "Error: CTEST_RESOURCE_GROUP_0 is not specified. Raised by "
                "Kokkos::Impl::get_ctest_gpu\\(\\).");
 }
 
 TEST_F(ctest_environment_DeathTest, missing_type) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(
       Kokkos::Impl::get_ctest_gpu(1),
       "Error: device type 'gpus' not included in CTEST_RESOURCE_GROUP_1. "
@@ -102,12 +105,14 @@ TEST_F(ctest_environment_DeathTest, missing_type) {
 }
 
 TEST_F(ctest_environment_DeathTest, no_id_str) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(3),
                "Error: CTEST_RESOURCE_GROUP_3_GPUS is not specified. Raised by "
                "Kokkos::Impl::get_ctest_gpu\\(\\).");
 }
 
 TEST_F(ctest_environment_DeathTest, invalid_id_str) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(4),
                "Error: invalid value of CTEST_RESOURCE_GROUP_4_GPUS: 'id:2'. "
                "Raised by Kokkos::Impl::get_ctest_gpu\\(\\).");

--- a/core/unit_test/TestCTestDevice.cpp
+++ b/core/unit_test/TestCTestDevice.cpp
@@ -32,16 +32,6 @@ int setenv(const char *name, const char *value, int overwrite) {
 int unsetenv(const char *name) { return _putenv_s(name, ""); }
 #endif
 
-// Needed because https://github.com/google/googletest/issues/952 has not been
-// resolved
-#define EXPECT_THROW_WITH_MESSAGE(stmt, etype, whatstring)      \
-  EXPECT_THROW(                                                 \
-      try { stmt; } catch (const etype &ex) {                   \
-        EXPECT_EQ(std::string(ex.what()).find(whatstring), 0u); \
-        throw;                                                  \
-      },                                                        \
-      etype)
-
 class ctest_environment : public ::testing::Test {
  protected:
   void SetUp();
@@ -76,6 +66,8 @@ void ctest_environment::SetUp() {
   setenv("CTEST_RESOURCE_GROUP_9_GPUS", "id:4,slots:1", 1);
 }
 
+struct ctest_environment_DeathTest : public ctest_environment {};
+
 TEST_F(ctest_environment, no_device_type) {
   unsetenv("CTEST_KOKKOS_DEVICE_TYPE");
   EXPECT_EQ(Kokkos::Impl::get_ctest_gpu(0), 0);
@@ -86,47 +78,42 @@ TEST_F(ctest_environment, no_process_count) {
   EXPECT_EQ(Kokkos::Impl::get_ctest_gpu(0), 0);
 }
 
-TEST_F(ctest_environment, invalid_rank) {
-  EXPECT_THROW_WITH_MESSAGE(
-      Kokkos::Impl::get_ctest_gpu(10), std::runtime_error,
-      "Error: local rank 10 is outside the bounds of resource groups provided "
-      "by CTest.");
+TEST_F(ctest_environment_DeathTest, invalid_rank) {
+  EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(10),
+               "Error: local rank 10 is outside the bounds of resource groups "
+               "provided by CTest.");
 }
 
-TEST_F(ctest_environment, no_type_str) {
-  EXPECT_THROW_WITH_MESSAGE(
-      Kokkos::Impl::get_ctest_gpu(0), std::runtime_error,
-      "Error: CTEST_RESOURCE_GROUP_0 is not specified. Raised by "
-      "Kokkos::Impl::get_ctest_gpu().");
+TEST_F(ctest_environment_DeathTest, no_type_str) {
+  EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(0),
+               "Error: CTEST_RESOURCE_GROUP_0 is not specified. Raised by "
+               "Kokkos::Impl::get_ctest_gpu().");
 }
 
-TEST_F(ctest_environment, missing_type) {
-  EXPECT_THROW_WITH_MESSAGE(
-      Kokkos::Impl::get_ctest_gpu(1), std::runtime_error,
+TEST_F(ctest_environment_DeathTest, missing_type) {
+  EXPECT_DEATH(
+      Kokkos::Impl::get_ctest_gpu(1),
       "Error: device type 'gpus' not included in CTEST_RESOURCE_GROUP_1. "
       "Raised by Kokkos::Impl::get_ctest_gpu().");
-  EXPECT_THROW_WITH_MESSAGE(
-      Kokkos::Impl::get_ctest_gpu(2), std::runtime_error,
+  EXPECT_DEATH(
+      Kokkos::Impl::get_ctest_gpu(2),
       "Error: device type 'gpus' not included in CTEST_RESOURCE_GROUP_2. "
       "Raised by Kokkos::Impl::get_ctest_gpu().");
 }
 
-TEST_F(ctest_environment, no_id_str) {
-  EXPECT_THROW_WITH_MESSAGE(
-      Kokkos::Impl::get_ctest_gpu(3), std::runtime_error,
-      "Error: CTEST_RESOURCE_GROUP_3_GPUS is not specified. Raised by "
-      "Kokkos::Impl::get_ctest_gpu().");
+TEST_F(ctest_environment_DeathTest, no_id_str) {
+  EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(3),
+               "Error: CTEST_RESOURCE_GROUP_3_GPUS is not specified. Raised by "
+               "Kokkos::Impl::get_ctest_gpu().");
 }
 
-TEST_F(ctest_environment, invalid_id_str) {
-  EXPECT_THROW_WITH_MESSAGE(
-      Kokkos::Impl::get_ctest_gpu(4), std::runtime_error,
-      "Error: invalid value of CTEST_RESOURCE_GROUP_4_GPUS: 'id:2'. Raised by "
-      "Kokkos::Impl::get_ctest_gpu().");
-  EXPECT_THROW_WITH_MESSAGE(
-      Kokkos::Impl::get_ctest_gpu(5), std::runtime_error,
-      "Error: invalid value of CTEST_RESOURCE_GROUP_5_GPUS: 'slots:1,id:2'. "
-      "Raised by Kokkos::Impl::get_ctest_gpu().");
+TEST_F(ctest_environment_DeathTest, invalid_id_str) {
+  EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(4),
+               "Error: invalid value of CTEST_RESOURCE_GROUP_4_GPUS: 'id:2'. "
+               "Raised by Kokkos::Impl::get_ctest_gpu().");
+  EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(5),
+               "Error: invalid value of CTEST_RESOURCE_GROUP_5_GPUS: "
+               "'slots:1,id:2'. Raised by Kokkos::Impl::get_ctest_gpu().");
 }
 
 TEST_F(ctest_environment, good) {


### PR DESCRIPTION
Proposing to call abort instead of throwing an exception to report errors in CTest resource allocation parsing