### PR TITLE
Cleanup/improve C style memory management tests

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -981,7 +981,6 @@ if ((KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_OPENACC) AND KOKKOS_CXX_COMPILE
     default/TestDefaultDeviceType_a3.cpp
     default/TestDefaultDeviceType_b3.cpp
     default/TestDefaultDeviceType_c3.cpp
-    default/TestDefaultDeviceType_d.cpp
     default/TestDefaultDeviceTypeResize.cpp
     default/TestDefaultDeviceTypeViewAPI.cpp
   )
@@ -999,7 +998,6 @@ if (KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
     default/TestDefaultDeviceType_a3.cpp
     default/TestDefaultDeviceType_b3.cpp
     default/TestDefaultDeviceType_c3.cpp
-    default/TestDefaultDeviceType_d.cpp
     default/TestDefaultDeviceTypeResize.cpp
     default/TestDefaultDeviceTypeViewAPI.cpp
   )

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -940,6 +940,7 @@ endif()
 
 SET(DEFAULT_DEVICE_SOURCES
   UnitTestMainInit.cpp
+  TestCStyleMemoryManagement.cpp
   TestInitializationSettings.cpp
   TestParseCmdLineArgsAndEnvVars.cpp
   TestSharedSpace.cpp
@@ -955,7 +956,6 @@ SET(DEFAULT_DEVICE_SOURCES
   default/TestDefaultDeviceType_a3.cpp
   default/TestDefaultDeviceType_b3.cpp
   default/TestDefaultDeviceType_c3.cpp
-  default/TestDefaultDeviceType_d.cpp
   default/TestDefaultDeviceTypeResize.cpp
   default/TestDefaultDeviceTypeViewAPI.cpp
 )

--- a/core/unit_test/Makefile
+++ b/core/unit_test/Makefile
@@ -392,7 +392,6 @@ ifneq ($(KOKKOS_INTERNAL_COMPILER_HCC), 1)
   OBJ_DEFAULT += TestDefaultDeviceType_a1.o TestDefaultDeviceType_b1.o TestDefaultDeviceType_c1.o
   OBJ_DEFAULT += TestDefaultDeviceType_a2.o TestDefaultDeviceType_b2.o TestDefaultDeviceType_c2.o
   OBJ_DEFAULT += TestDefaultDeviceType_a3.o TestDefaultDeviceType_b3.o TestDefaultDeviceType_c3.o
-  OBJ_DEFAULT += TestDefaultDeviceType_d.o
 endif
 endif
 

--- a/core/unit_test/TestCStyleMemoryManagement.cpp
+++ b/core/unit_test/TestCStyleMemoryManagement.cpp
@@ -14,28 +14,29 @@
 //
 //@HEADER
 
-#include <gtest/gtest.h>
-
 #include <Kokkos_Core.hpp>
 
-#if !defined(KOKKOS_ENABLE_CUDA) || defined(__CUDACC__)
-
 #include <TestDefaultDeviceType_Category.hpp>
-#include <TestUtilities.hpp>
 
-namespace Test {
+#include <gtest/gtest.h>
 
-TEST(defaultdevicetype, malloc) {
+namespace {
+
+TEST(defaultdevicetype, c_style_memory_management_malloc_realloc_and_free) {
   int* data = static_cast<int*>(Kokkos::kokkos_malloc(100 * sizeof(int)));
-  ASSERT_NO_THROW(data = static_cast<int*>(
-                      Kokkos::kokkos_realloc(data, 120 * sizeof(int))));
-  Kokkos::kokkos_free(data);
+  ASSERT_NE(data, nullptr);
 
+  data = static_cast<int*>(Kokkos::kokkos_realloc(data, 120 * sizeof(int)));
+  ASSERT_NE(data, nullptr);
+
+  Kokkos::kokkos_free(data);
+}
+
+TEST(defaultdevicetype, c_style_memory_management_malloc_zero_byte_and_free) {
   int* data2 = static_cast<int*>(Kokkos::kokkos_malloc(0));
   ASSERT_EQ(data2, nullptr);
+
   Kokkos::kokkos_free(data2);
 }
 
-}  // namespace Test
-
-#endif
+}  // namespace


### PR DESCRIPTION
Tidying things up in the process of revisiting all *_NO_THROW assertions