### PR TITLE
Refactor: Add missing `inline`s and `auto`s for `create_mirror*`

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1990,7 +1990,8 @@ template <class Space, class T, class... P,
           class Enable = std::enable_if_t<
               Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
-auto create_mirror(const Space&, const Kokkos::DynRankView<T, P...>& src) {
+inline auto create_mirror(const Space&,
+                          const Kokkos::DynRankView<T, P...>& src) {
   return Impl::create_mirror(
       src, Kokkos::view_alloc(typename Space::memory_space{}));
 }
@@ -2000,8 +2001,8 @@ template <class Space, class T, class... P,
           class Enable = std::enable_if_t<
               Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
-auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
-                   const Kokkos::DynRankView<T, P...>& src) {
+inline auto create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
+                          const Kokkos::DynRankView<T, P...>& src) {
   return Impl::create_mirror(
       src, Kokkos::view_alloc(wi, typename Space::memory_space{}));
 }

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -665,9 +665,9 @@ template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<
               Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
-typename Kokkos::Impl::MirrorDynamicViewType<Space, T, P...>::view_type
-create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
-              const Kokkos::Experimental::DynamicView<T, P...>& src) {
+inline auto create_mirror(
+    Kokkos::Impl::WithoutInitializing_t wi, const Space&,
+    const Kokkos::Experimental::DynamicView<T, P...>& src) {
   return Impl::create_mirror(
       src, Kokkos::view_alloc(wi, typename Space::memory_space{}));
 }

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1874,9 +1874,9 @@ template <class Space, class T, class... P,
           typename Enable = std::enable_if_t<
               Kokkos::is_space<Space>::value &&
               std::is_void_v<typename ViewTraits<T, P...>::specialize>>>
-typename Kokkos::Impl::MirrorOffsetType<Space, T, P...>::view_type
-create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space&,
-              const Kokkos::Experimental::OffsetView<T, P...>& src) {
+inline auto create_mirror(
+    Kokkos::Impl::WithoutInitializing_t wi, const Space&,
+    const Kokkos::Experimental::OffsetView<T, P...>& src) {
   return Impl::create_mirror(
       src, Kokkos::view_alloc(typename Space::memory_space{}, wi));
 }


### PR DESCRIPTION
This refactor PR is a left-over of #6955.

In the simplifications of the aforementioned PR, some `inline`s and `auto`s were forgotten for `DynRankView`, `DynamicView`, and `OffsetView`. Those were added for consistency.