### PR TITLE
View-refactor: update View Typedefs: add some from mdspan and fix uniform const types 

### DIFF
--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -296,7 +296,8 @@ class View : public ViewTraits<DataType, Properties...> {
 
   // Typedefs from mdspan
   // using extents_type -> not applicable
-  using layout_type = typename traits::array_layout;
+  // Defining layout_type here made MSVC+CUDA fail
+  // using layout_type = typename traits::array_layout;
   // using accessor_type -> not applicable
   // using mapping_type -> not applicable
   using element_type = typename traits::value_type;

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -291,6 +291,23 @@ class View : public ViewTraits<DataType, Properties...> {
   using uniform_runtime_const_nomemspace_type =
       typename Impl::ViewUniformType<View, 0>::runtime_const_nomemspace_type;
 
+  using reference_type = typename map_type::reference_type;
+  using pointer_type   = typename map_type::pointer_type;
+
+  // Typedefs from mdspan
+  // using extents_type -> not applicable
+  using layout_type = typename traits::array_layout;
+  // using accessor_type -> not applicable
+  // using mapping_type -> not applicable
+  using element_type = typename traits::value_type;
+  // using value_type -> conflicts with traits::value_type
+  using index_type = typename traits::memory_space::size_type;
+  // using size_type -> already from traits::size_type; where it is
+  // memory_space::size_type
+  using rank_type        = size_t;
+  using data_handle_type = pointer_type;
+  using reference        = reference_type;
+
   //----------------------------------------
   // Domain rank and extents
 
@@ -393,9 +410,6 @@ class View : public ViewTraits<DataType, Properties...> {
 
   //----------------------------------------
   // Range span is the span which contains all members.
-
-  using reference_type = typename map_type::reference_type;
-  using pointer_type   = typename map_type::pointer_type;
 
   enum {
     reference_type_is_lvalue_reference =

--- a/core/src/View/Kokkos_ViewUniformType.hpp
+++ b/core/src/View/Kokkos_ViewUniformType.hpp
@@ -24,11 +24,14 @@ namespace Impl {
 template <class ScalarType, int Rank>
 struct ViewScalarToDataType {
   using type = typename ViewScalarToDataType<ScalarType, Rank - 1>::type *;
+  using const_type =
+      typename ViewScalarToDataType<ScalarType, Rank - 1>::const_type *;
 };
 
 template <class ScalarType>
 struct ViewScalarToDataType<ScalarType, 0> {
-  using type = ScalarType;
+  using type       = ScalarType;
+  using const_type = const ScalarType;
 };
 
 template <class LayoutType, int Rank>
@@ -49,12 +52,13 @@ struct ViewUniformLayout<Kokkos::LayoutRight, 1> {
 template <class ViewType, int Traits>
 struct ViewUniformType {
   using data_type       = typename ViewType::data_type;
-  using const_data_type = std::add_const_t<typename ViewType::data_type>;
+  using const_data_type = typename ViewType::const_data_type;
   using runtime_data_type =
       typename ViewScalarToDataType<typename ViewType::value_type,
                                     ViewType::rank>::type;
-  using runtime_const_data_type = typename ViewScalarToDataType<
-      std::add_const_t<typename ViewType::value_type>, ViewType::rank>::type;
+  using runtime_const_data_type =
+      typename ViewScalarToDataType<typename ViewType::value_type,
+                                    ViewType::rank>::const_type;
 
   using array_layout =
       typename ViewUniformLayout<typename ViewType::array_layout,

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -91,6 +91,7 @@ SET(COMPILE_ONLY_SOURCES
   TestVersionMacros.cpp
   TestViewRank.cpp
   TestViewTypeTraits.cpp
+  TestViewTypedefs.cpp
   TestTypeInfo.cpp
   TestTypeList.cpp
   TestMDRangePolicyCTAD.cpp

--- a/core/unit_test/TestViewTypedefs.cpp
+++ b/core/unit_test/TestViewTypedefs.cpp
@@ -1,0 +1,224 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+namespace {
+
+// clang-format off
+template<class DataType>
+struct data_analysis {
+  using data_type = DataType;
+  using const_data_type = const DataType;
+  using runtime_data_type = DataType;
+  using runtime_const_data_type = const DataType;
+  using non_const_data_type = std::remove_const_t<DataType>;
+};
+
+template<class DataType>
+struct data_analysis<DataType*> {
+  using data_type = typename data_analysis<DataType>::data_type*;
+  using const_data_type = typename data_analysis<DataType>::const_data_type*;
+  using runtime_data_type = typename data_analysis<DataType>::runtime_data_type*;
+  using runtime_const_data_type = typename data_analysis<DataType>::runtime_const_data_type*;
+  using non_const_data_type = typename data_analysis<DataType>::non_const_data_type*;
+};
+
+template<class DataType, size_t N>
+struct data_analysis<DataType[N]> {
+  using data_type = typename data_analysis<DataType>::data_type[N];
+  using const_data_type = typename data_analysis<DataType>::const_data_type[N];
+  using runtime_data_type = typename data_analysis<DataType>::runtime_data_type*;
+  using runtime_const_data_type = typename data_analysis<DataType>::runtime_const_data_type*;
+  using non_const_data_type = typename data_analysis<DataType>::non_const_data_type[N];
+};
+
+template<class ViewType, class ViewTraitsType, class DataType, class Layout, class Space, class MemoryTraitsType,
+         class HostMirrorSpace, class ValueType, class ReferenceType>
+constexpr bool test_view_typedefs_impl() {
+  // ========================
+  // inherited from ViewTraits
+  // ========================
+  static_assert(std::is_same_v<typename ViewType::data_type, DataType>);
+  static_assert(std::is_same_v<typename ViewType::const_data_type, typename data_analysis<DataType>::const_data_type>);
+  static_assert(std::is_same_v<typename ViewType::non_const_data_type, typename data_analysis<DataType>::non_const_data_type>);
+  
+  // these should be deprecated and for proper testing (I.e. where this is different from data_type)
+  // we would need ensemble types which use the hidden View dimension facility of View (i.e. which make
+  // "specialize" not void)
+  static_assert(std::is_same_v<typename ViewType::scalar_array_type, DataType>);
+  static_assert(std::is_same_v<typename ViewType::const_scalar_array_type, typename data_analysis<DataType>::const_data_type>);
+  static_assert(std::is_same_v<typename ViewType::non_const_scalar_array_type, typename data_analysis<DataType>::non_const_data_type>);
+  static_assert(std::is_same_v<typename ViewType::specialize, void>);
+
+  // value_type definition conflicts with mdspan value_type
+  static_assert(std::is_same_v<typename ViewType::value_type, ValueType>);
+  static_assert(std::is_same_v<typename ViewType::const_value_type, const ValueType>);
+  static_assert(std::is_same_v<typename ViewType::non_const_value_type, std::remove_const_t<ValueType>>);
+
+  // should maybe be deprecated
+  static_assert(std::is_same_v<typename ViewType::array_layout, Layout>);
+
+  // should be deprecated and is some complicated impl type
+  static_assert(!std::is_void_v<typename ViewType::dimension>);
+
+  static_assert(std::is_same_v<typename ViewType::execution_space, typename Space::execution_space>);
+  static_assert(std::is_same_v<typename ViewType::memory_space, typename Space::memory_space>);
+  static_assert(std::is_same_v<typename ViewType::device_type, Kokkos::Device<typename ViewType::execution_space, typename ViewType::memory_space>>);
+  static_assert(std::is_same_v<typename ViewType::memory_traits, MemoryTraitsType>);
+  static_assert(std::is_same_v<typename ViewType::host_mirror_space, HostMirrorSpace>);
+  static_assert(std::is_same_v<typename ViewType::size_type, typename ViewType::memory_space::size_type>);
+ 
+  // should be deprecated in favor of reference
+  static_assert(std::is_same_v<typename ViewType::reference_type, ReferenceType>);
+  // should be deprecated in favor of data_handle_type
+  static_assert(std::is_same_v<typename ViewType::pointer_type, ValueType*>);
+ 
+  // =========================================
+  // in Legacy View: some helper View variants
+  // =========================================
+  static_assert(std::is_same_v<typename ViewType::traits, ViewTraitsType>);
+  static_assert(std::is_same_v<typename ViewType::array_type,
+                               Kokkos::View<typename ViewType::scalar_array_type, typename ViewType::array_layout,
+                                            typename ViewType::device_type, typename ViewTraitsType::hooks_policy,
+                                            typename ViewType::memory_traits>>);
+  static_assert(std::is_same_v<typename ViewType::const_type,
+                               Kokkos::View<typename ViewType::const_data_type, typename ViewType::array_layout,
+                                            typename ViewType::device_type, typename ViewTraitsType::hooks_policy,
+                                            typename ViewType::memory_traits>>);
+  static_assert(std::is_same_v<typename ViewType::non_const_type,
+                               Kokkos::View<typename ViewType::non_const_data_type, typename ViewType::array_layout,
+                                            typename ViewType::device_type, typename ViewTraitsType::hooks_policy,
+                                            typename ViewType::memory_traits>>);
+  static_assert(std::is_same_v<typename ViewType::host_mirror_type,
+                               Kokkos::View<typename ViewType::non_const_data_type, typename ViewType::array_layout,
+                                            Kokkos::Device<Kokkos::DefaultHostExecutionSpace,
+                                                           typename ViewType::host_mirror_space::memory_space>,
+                                            typename ViewTraitsType::hooks_policy>>);
+
+  using uniform_layout_type = std::conditional_t<ViewType::rank()==0 || (ViewType::rank()==0 &&
+                                                 std::is_same_v<Layout, Kokkos::LayoutRight>),
+                                                 Kokkos::LayoutLeft, Layout>;
+
+  // Uhm uniformtype removes all memorytraits?
+  static_assert(std::is_same_v<typename ViewType::uniform_type,
+                               Kokkos::View<typename ViewType::data_type, uniform_layout_type,
+                                            typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
+  static_assert(std::is_same_v<typename ViewType::uniform_const_type,
+                               Kokkos::View<typename ViewType::const_data_type, uniform_layout_type,
+                                            typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
+  static_assert(std::is_same_v<typename ViewType::uniform_runtime_type,
+                               Kokkos::View<typename data_analysis<DataType>::runtime_data_type, uniform_layout_type,
+                                            typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
+  static_assert(std::is_same_v<typename ViewType::uniform_runtime_const_type,
+                               Kokkos::View<typename data_analysis<DataType>::runtime_const_data_type, uniform_layout_type,
+                                            typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
+
+  using anonymous_device_type = Kokkos::Device<typename ViewType::execution_space, Kokkos::AnonymousSpace>;
+  static_assert(std::is_same_v<typename ViewType::uniform_nomemspace_type,
+                               Kokkos::View<typename ViewType::data_type, uniform_layout_type,
+                                            anonymous_device_type, Kokkos::MemoryTraits<0>>>);
+  static_assert(std::is_same_v<typename ViewType::uniform_const_nomemspace_type,
+                               Kokkos::View<typename ViewType::const_data_type, uniform_layout_type,
+                                            anonymous_device_type, Kokkos::MemoryTraits<0>>>);
+  static_assert(std::is_same_v<typename ViewType::uniform_runtime_nomemspace_type,
+                               Kokkos::View<typename data_analysis<DataType>::runtime_data_type, uniform_layout_type,
+                                            anonymous_device_type, Kokkos::MemoryTraits<0>>>);
+  static_assert(std::is_same_v<typename ViewType::uniform_runtime_const_nomemspace_type,
+                               Kokkos::View<typename data_analysis<DataType>::runtime_const_data_type, uniform_layout_type,
+                                            anonymous_device_type, Kokkos::MemoryTraits<0>>>);
+
+
+  // ==================================
+  // mdspan compatibility
+  // ==================================
+
+  // This typedef caused some weird issue with MSVC+NVCC
+  // static_assert(std::is_same_v<typename ViewType::layout_type, Layout>);
+  // Not supported yet
+  // static_assert(std::is_same_v<typename ViewType::extents_type, >);
+  // static_assert(std::is_same_v<typename ViewType::mapping_type, >);
+  // static_assert(std::is_same_v<typename ViewType::accessor_type, >);
+
+  static_assert(std::is_same_v<typename ViewType::element_type, ValueType>);
+  // should be remove_const_t<element_type>
+  static_assert(std::is_same_v<typename ViewType::value_type, ValueType>);
+  // should be extents_type::index_type
+  static_assert(std::is_same_v<typename ViewType::index_type, typename Space::memory_space::size_type>);
+  static_assert(std::is_same_v<typename ViewType::size_type, std::make_unsigned_t<typename ViewType::index_type>>);
+  static_assert(std::is_same_v<typename ViewType::rank_type, size_t>);
+
+  // should come from accessor_type
+  static_assert(std::is_same_v<typename ViewType::data_handle_type, typename ViewType::pointer_type>);
+  static_assert(std::is_same_v<typename ViewType::reference, typename ViewType::reference_type>);
+  return true;
+};
+
+template<class T, class ... ViewArgs>
+struct ViewParams {};
+
+template<class L, class S, class M, class HostMirrorSpace, class ValueType, class ReferenceType, class T, class ... ViewArgs>
+constexpr bool test_view_typedefs(ViewParams<T, ViewArgs...>) {
+  return test_view_typedefs_impl<Kokkos::View<T, ViewArgs...>, Kokkos::ViewTraits<T, ViewArgs...>,
+                            T, L, S, M, HostMirrorSpace, ValueType, ReferenceType>();
+}
+
+
+constexpr bool is_host_exec = Kokkos::Impl::MemorySpaceAccess<
+        Kokkos::DefaultExecutionSpace::memory_space,
+        Kokkos::HostSpace>::accessible;
+
+// These test take explicit template arguments for: LayoutType, Space, MemoryTraits, HostMirrorSpace, ValueType, ReferenceType
+// The ViewParams is just a type pack for the View template arguments
+static_assert(test_view_typedefs<
+                  Kokkos::DefaultExecutionSpace::array_layout,
+                  Kokkos::DefaultExecutionSpace, Kokkos::MemoryTraits<0>,
+                  std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace, Kokkos::HostSpace>,
+                  int, int&>
+                  (ViewParams<int>{}));
+// WTF: HostMirrorSpace is different from the first one ....
+static_assert(test_view_typedefs<
+                  Kokkos::DefaultExecutionSpace::array_layout,
+                  Kokkos::DefaultExecutionSpace, Kokkos::MemoryTraits<0>,
+                  std::conditional_t<is_host_exec, Kokkos::HostSpace, Kokkos::HostSpace>,
+                  int, int&>
+                  (ViewParams<int, Kokkos::DefaultExecutionSpace>{}));
+static_assert(test_view_typedefs<
+                  Kokkos::LayoutRight,
+                  Kokkos::HostSpace, Kokkos::MemoryTraits<0>,
+                  Kokkos::HostSpace,
+                  float, float&>
+                  (ViewParams<float**, Kokkos::HostSpace>{}));
+static_assert(test_view_typedefs<
+                  Kokkos::LayoutLeft,
+                  Kokkos::DefaultExecutionSpace, Kokkos::MemoryTraits<0>,
+                  std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace, Kokkos::HostSpace>,
+                  float, float&>
+                  (ViewParams<float*[3], Kokkos::LayoutLeft>{}));
+static_assert(test_view_typedefs<
+                  Kokkos::LayoutRight,
+                  Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, Kokkos::MemoryTraits<0>,
+                  Kokkos::HostSpace,
+                  float, float&>
+                  (ViewParams<float[2][3], Kokkos::LayoutRight, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>>{}));
+static_assert(test_view_typedefs<
+                  Kokkos::DefaultExecutionSpace::array_layout,
+                  Kokkos::DefaultExecutionSpace, Kokkos::MemoryTraits<Kokkos::Atomic>,
+                  std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace, Kokkos::HostSpace>,
+                  int, Kokkos::Impl::AtomicDataElement<Kokkos::ViewTraits<int, Kokkos::MemoryTraits<Kokkos::Atomic>>>>
+                  (ViewParams<int, Kokkos::MemoryTraits<Kokkos::Atomic>>{}));
+// clang-format on
+}  // namespace


### PR DESCRIPTION
Implementing DynRankView in a way that it is compatible with the current and the next impl of View gets a bit smoother by already introducing some of the mdspan typedefs (the ones which make trivially sense for now). In the process I implemented a test for all the View member typedefs and found that the const versions of the uniform typedefs are broken. So the last commit fixes that. 

Before `uniform_const_type` was effectively something like `View<T* const, ...>` instead of `View<const T*>` ...
