### PR TITLE
Set GTest death_test_style to "threadsafe"

### DIFF
--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -170,6 +170,7 @@ struct TEST_CATEGORY_FIXTURE_DEATH(graph)
 //      checks that submission instantiates if need be).
 //   2. Instantiating twice in a row is invalid.
 TEST_F(TEST_CATEGORY_FIXTURE_DEATH(graph), can_instantiate_only_once) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   {
     bool checked_assertions = false;
     KOKKOS_ASSERT(checked_assertions = true);

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -121,6 +121,7 @@ TEST(TEST_CATEGORY_DEATH, policy_invalid_bounds) {
   // escape the parentheses in the regex to match the error message
   msg1 = std::regex_replace(msg1, std::regex("\\(|\\)"), "\\$&");
   (void)msg2;
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_DEATH({ (void)Policy({100, 100}, {90, 90}); }, msg1);
 #else
   if (!Kokkos::show_warnings()) {

--- a/core/unit_test/TestStackTrace.hpp
+++ b/core/unit_test/TestStackTrace.hpp
@@ -136,11 +136,13 @@ void test_stacktrace(bool bTerminate, bool bCustom = true) {
 TEST(defaultdevicetype, stacktrace_normal) { test_stacktrace(false); }
 
 TEST(defaultdevicetype_DeathTest, stacktrace_terminate) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_DEATH({ test_stacktrace(true); },
                "I am the custom std::terminate handler.");
 }
 
 TEST(defaultdevicetype_DeathTest, stacktrace_generic_term) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_DEATH({ test_stacktrace(true, false); },
                "Kokkos observes that std::terminate has been called");
 }


### PR DESCRIPTION
Spotted the following warning in our test logs
```
[----------] 1 test from hpx_graph_DeathTest
[ RUN      ] hpx_graph_DeathTest.can_instantiate_only_once

Warning:  /home/runner/work/kokkos/kokkos/kokkos/tpls/gtest/gtest/gtest-all.cc:9326:: Death tests use fork(), which is unsafe particularly in a threaded context. For this test, Google Test detected 7 threads. See https://github.com/google/googletest/blob/master/docs/advanced.md#death-tests-and-threads for more explanation and suggested solutions, especially if this is the last message you see before your test times out.

Warning:  /home/runner/work/kokkos/kokkos/kokkos/tpls/gtest/gtest/gtest-all.cc:9326:: Death tests use fork(), which is unsafe particularly in a threaded context. For this test, Google Test detected 7 threads. See https://github.com/google/googletest/blob/master/docs/advanced.md#death-tests-and-threads for more explanation and suggested solutions, especially if this is the last message you see before your test times out.
[       OK ] hpx_graph_DeathTest.can_instantiate_only_once (40 ms)
[----------] 1 test from hpx_graph_DeathTest (40 ms total)
```