### PR TITLE
DynamicView: diagnose incompatible deep_copy() at compile time

### DIFF
--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -835,21 +835,17 @@ inline void deep_copy(const View<T, DP...>& dst,
   using dst_execution_space = typename ViewTraits<T, DP...>::execution_space;
   using src_memory_space    = typename ViewTraits<T, SP...>::memory_space;
 
-  enum {
-    DstExecCanAccessSrc =
-        Kokkos::SpaceAccessibility<dst_execution_space,
-                                   src_memory_space>::accessible
-  };
+  constexpr bool DstExecCanAccessSrc =
+      Kokkos::SpaceAccessibility<dst_execution_space,
+                                 src_memory_space>::accessible;
+  static_assert(
+      DstExecCanAccessSrc,
+      "deep_copy given views that would require a temporary allocation");
 
-  if (DstExecCanAccessSrc) {
-    // Copying data between views in accessible memory spaces and either
-    // non-contiguous or incompatible shape.
-    Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
-    Kokkos::fence("Kokkos::deep_copy(DynamicView)");
-  } else {
-    Kokkos::Impl::throw_runtime_exception(
-        "deep_copy given views that would require a temporary allocation");
-  }
+  // Copying data between views in accessible memory spaces and either
+  // non-contiguous or incompatible shape.
+  Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
+  Kokkos::fence("Kokkos::deep_copy(DynamicView)");
 }
 
 template <class T, class... DP, class... SP>
@@ -861,21 +857,17 @@ inline void deep_copy(const Kokkos::Experimental::DynamicView<T, DP...>& dst,
   using dst_execution_space = typename ViewTraits<T, DP...>::execution_space;
   using src_memory_space    = typename ViewTraits<T, SP...>::memory_space;
 
-  enum {
-    DstExecCanAccessSrc =
-        Kokkos::SpaceAccessibility<dst_execution_space,
-                                   src_memory_space>::accessible
-  };
+  constexpr bool DstExecCanAccessSrc =
+      Kokkos::SpaceAccessibility<dst_execution_space,
+                                 src_memory_space>::accessible;
+  static_assert(
+      DstExecCanAccessSrc,
+      "deep_copy given views that would require a temporary allocation");
 
-  if (DstExecCanAccessSrc) {
-    // Copying data between views in accessible memory spaces and either
-    // non-contiguous or incompatible shape.
-    Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
-    Kokkos::fence("Kokkos::deep_copy(DynamicView)");
-  } else {
-    Kokkos::Impl::throw_runtime_exception(
-        "deep_copy given views that would require a temporary allocation");
-  }
+  // Copying data between views in accessible memory spaces and either
+  // non-contiguous or incompatible shape.
+  Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
+  Kokkos::fence("Kokkos::deep_copy(DynamicView)");
 }
 
 namespace Impl {

--- a/containers/unit_tests/TestDynamicView.hpp
+++ b/containers/unit_tests/TestDynamicView.hpp
@@ -251,20 +251,6 @@ struct TestDynamicView {
           new_result_sum);
 
       ASSERT_EQ(new_result_sum, (value_type)(da_size * (da_size - 1) / 2));
-
-      // Try to deep_copy device_dynamic_view directly to/from host.
-      // host-to-device currently fails to compile because DP and SP are
-      // swapped in the deep_copy implementation.
-      // Once that's fixed, both deep_copy's will fail at runtime because the
-      // destination execution space cannot access the source memory space.
-      // Check if the memory spaces are different before testing the deep_copy.
-      if (!Kokkos::SpaceAccessibility<Kokkos::HostSpace,
-                                      memory_space>::accessible) {
-        ASSERT_THROW(Kokkos::deep_copy(host_view, device_dynamic_view),
-                     std::runtime_error);
-        ASSERT_THROW(Kokkos::deep_copy(device_dynamic_view, host_view),
-                     std::runtime_error);
-      }
     }
   }
 };


### PR DESCRIPTION
My motivation for changing that code is related to support for no exceptions #7037
I needed the `ASSERT_THROW` to go and when looking into this I got somewhat surprised that we deferred to runtime to diagnose something we could tell at compile time.

I am not familiar with `DynamicView` (which I plan to propose to deprecate in a follow up) and could not find any usage in Trilinos, ArborX, Cabana, nor LAMMPS.