### PR TITLE
View-refactor: DynRankView

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -103,14 +103,17 @@ struct DynRankDimTraits {
        std::is_same_v<Layout, Kokkos::LayoutLeft>),
       Layout>
   createLayout(const Layout& layout) {
-    return Layout(layout.dimension[0] != unspecified ? layout.dimension[0] : 1,
-                  layout.dimension[1] != unspecified ? layout.dimension[1] : 1,
-                  layout.dimension[2] != unspecified ? layout.dimension[2] : 1,
-                  layout.dimension[3] != unspecified ? layout.dimension[3] : 1,
-                  layout.dimension[4] != unspecified ? layout.dimension[4] : 1,
-                  layout.dimension[5] != unspecified ? layout.dimension[5] : 1,
-                  layout.dimension[6] != unspecified ? layout.dimension[6] : 1,
-                  layout.dimension[7] != unspecified ? layout.dimension[7] : 1);
+    Layout new_layout(
+        layout.dimension[0] != unspecified ? layout.dimension[0] : 1,
+        layout.dimension[1] != unspecified ? layout.dimension[1] : 1,
+        layout.dimension[2] != unspecified ? layout.dimension[2] : 1,
+        layout.dimension[3] != unspecified ? layout.dimension[3] : 1,
+        layout.dimension[4] != unspecified ? layout.dimension[4] : 1,
+        layout.dimension[5] != unspecified ? layout.dimension[5] : 1,
+        layout.dimension[6] != unspecified ? layout.dimension[6] : 1,
+        layout.dimension[7] != unspecified ? layout.dimension[7] : 1);
+    new_layout.stride = layout.stride;
+    return new_layout;
   }
 
   // LayoutStride

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -38,10 +38,19 @@ class DynRankView;  // forward declare
 
 namespace Impl {
 
+template <class T, size_t Rank>
+struct ViewDataTypeFromRank {
+  using type = typename ViewDataTypeFromRank<T, Rank - 1>::type*;
+};
+
+template <class T>
+struct ViewDataTypeFromRank<T, 0> {
+  using type = T;
+};
+
 template <unsigned N, typename T, typename... Args>
-KOKKOS_FUNCTION
-    View<typename DataTypeFromExtents<T, dextents<int, N>>::type, Args...>
-    as_view_of_rank_n(DynRankView<T, Args...> v);
+KOKKOS_FUNCTION View<typename ViewDataTypeFromRank<T, N>::type, Args...>
+as_view_of_rank_n(DynRankView<T, Args...> v);
 
 template <typename Specialize>
 struct DynRankDimTraits {
@@ -1061,9 +1070,8 @@ namespace Impl {
    underlying memory, to facilitate implementation of deep_copy() and
    other routines that are defined on View */
 template <unsigned N, typename T, typename... Args>
-KOKKOS_FUNCTION
-    View<typename DataTypeFromExtents<T, dextents<int, N>>::type, Args...>
-    as_view_of_rank_n(DynRankView<T, Args...> v) {
+KOKKOS_FUNCTION View<typename ViewDataTypeFromRank<T, N>::type, Args...>
+as_view_of_rank_n(DynRankView<T, Args...> v) {
   if (v.rank() != N) {
     KOKKOS_IF_ON_HOST(
         const std::string message =

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -785,8 +785,8 @@ class DynRankView : private View<DataType*******, Properties...> {
            (arg_N3 != KOKKOS_INVALID_INDEX ? arg_N3 : 1) *
            (arg_N4 != KOKKOS_INVALID_INDEX ? arg_N4 : 1) *
            (arg_N5 != KOKKOS_INVALID_INDEX ? arg_N5 : 1) *
-           (arg_N6 != KOKKOS_INVALID_INDEX ? arg_N6 : 1);
-    (arg_N7 != KOKKOS_INVALID_INDEX ? arg_N7 : 1);
+           (arg_N6 != KOKKOS_INVALID_INDEX ? arg_N6 : 1) *
+           (arg_N7 != KOKKOS_INVALID_INDEX ? arg_N7 : 1);
   }
 
   explicit KOKKOS_INLINE_FUNCTION DynRankView(

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -438,7 +438,8 @@ class DynRankView : private View<DataType*******, Properties...> {
   using specialize = typename view_type::specialize;
 
   // typedefs in View for mdspan compatibility
-  using layout_type  = typename view_type::layout_type;
+  // cause issues with MSVC+CUDA
+  // using layout_type  = typename view_type::layout_type;
   using index_type   = typename view_type::index_type;
   using element_type = typename view_type::element_type;
   using rank_type    = typename view_type::rank_type;
@@ -875,7 +876,7 @@ KOKKOS_INLINE_FUNCTION auto subdynrankview(
                     (drv.rank() > 4 && !std::is_integral_v<SubArg4> ? 1 : 0) +
                     (drv.rank() > 5 && !std::is_integral_v<SubArg5> ? 1 : 0) +
                     (drv.rank() > 6 && !std::is_integral_v<SubArg6> ? 1 : 0);
-  return DynRankView<typename sub_t::value_type, typename sub_t::layout_type,
+  return DynRankView<typename sub_t::value_type, typename sub_t::array_layout,
                      typename sub_t::device_type,
                      typename sub_t::memory_traits>(sub, new_rank);
 }

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -38,6 +38,11 @@ class DynRankView;  // forward declare
 
 namespace Impl {
 
+template <unsigned N, typename T, typename... Args>
+KOKKOS_FUNCTION
+    View<typename DataTypeFromExtents<T, dextents<int, N>>::type, Args...>
+    as_view_of_rank_n(DynRankView<T, Args...> v);
+
 template <typename Specialize>
 struct DynRankDimTraits {
   enum : size_t { unspecified = KOKKOS_INVALID_INDEX };
@@ -378,7 +383,7 @@ template <class T>
 inline constexpr bool is_dyn_rank_view_v = is_dyn_rank_view<T>::value;
 
 template <typename DataType, class... Properties>
-class DynRankView : public ViewTraits<DataType, Properties...> {
+class DynRankView : public View<DataType*******, Properties...> {
   static_assert(!std::is_array_v<DataType> && !std::is_pointer_v<DataType>,
                 "Cannot template DynRankView with array or pointer datatype - "
                 "must be pod");
@@ -389,25 +394,29 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   template <class, class...>
   friend class Kokkos::Impl::ViewMapping;
 
+  size_t m_rank{};
+
+  using drdtraits = Impl::DynRankDimTraits<void>;
+
  public:
   using drvtraits = ViewTraits<DataType, Properties...>;
 
   using view_type = View<DataType*******, Properties...>;
 
-  using traits = ViewTraits<DataType*******, Properties...>;
+  using traits = typename view_type::traits;
 
- private:
-  using map_type =
-      Kokkos::Impl::ViewMapping<traits, typename traits::specialize>;
-  using track_type = Kokkos::Impl::SharedAllocationTracker;
-
-  track_type m_track;
-  map_type m_map;
-  unsigned m_rank;
+  using data_type           = typename drvtraits::data_type;
+  using const_data_type     = typename drvtraits::const_data_type;
+  using non_const_data_type = typename drvtraits::non_const_data_type;
+  using index_type          = typename view_type::index_type;
+  using reference_type      = typename view_type::reference_type;
 
  public:
   KOKKOS_INLINE_FUNCTION
   view_type& DownCast() const { return (view_type&)(*this); }
+  KOKKOS_FUNCTION
+  view_type to_view() const { return *this; }
+
   KOKKOS_INLINE_FUNCTION
   const view_type& ConstDownCast() const { return (const view_type&)(*this); }
 
@@ -440,92 +449,10 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   //  enum { Rank = map_type::Rank }; //Will be dyn rank of 7 always, keep the
   //  enum?
 
-  template <typename iType>
-  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>,
-                                                    size_t>
-  extent(const iType& r) const {
-    return m_map.extent(r);
-  }
-
-  template <typename iType>
-  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>,
-                                                    int>
-  extent_int(const iType& r) const {
-    return static_cast<int>(m_map.extent(r));
-  }
-
-  KOKKOS_INLINE_FUNCTION constexpr typename traits::array_layout layout() const;
-
   //----------------------------------------
   /*  Deprecate all 'dimension' functions in favor of
    *  ISO/C++ vocabulary 'extent'.
    */
-
-  KOKKOS_INLINE_FUNCTION constexpr size_t size() const {
-    return m_map.extent(0) * m_map.extent(1) * m_map.extent(2) *
-           m_map.extent(3) * m_map.extent(4) * m_map.extent(5) *
-           m_map.extent(6) * m_map.extent(7);
-  }
-
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_0() const {
-    return m_map.stride_0();
-  }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_1() const {
-    return m_map.stride_1();
-  }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_2() const {
-    return m_map.stride_2();
-  }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_3() const {
-    return m_map.stride_3();
-  }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_4() const {
-    return m_map.stride_4();
-  }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_5() const {
-    return m_map.stride_5();
-  }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_6() const {
-    return m_map.stride_6();
-  }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_7() const {
-    return m_map.stride_7();
-  }
-
-  template <typename iType>
-  KOKKOS_INLINE_FUNCTION void stride(iType* const s) const {
-    m_map.stride(s);
-  }
-
-  //----------------------------------------
-  // Range span is the span which contains all members.
-
-  using reference_type = typename map_type::reference_type;
-  using pointer_type   = typename map_type::pointer_type;
-
-  enum {
-    reference_type_is_lvalue_reference =
-        std::is_lvalue_reference_v<reference_type>
-  };
-
-  KOKKOS_INLINE_FUNCTION constexpr size_t span() const { return m_map.span(); }
-  KOKKOS_INLINE_FUNCTION constexpr bool span_is_contiguous() const {
-    return m_map.span_is_contiguous();
-  }
-  KOKKOS_INLINE_FUNCTION constexpr pointer_type data() const {
-    return m_map.data();
-  }
-  KOKKOS_INLINE_FUNCTION constexpr bool is_allocated() const {
-    return (m_map.data() != nullptr);
-  }
-
-  //----------------------------------------
-  // Allow specializations to query their specialized map
-  KOKKOS_INLINE_FUNCTION
-  const Kokkos::Impl::ViewMapping<traits, typename traits::specialize>&
-  impl_map() const {
-    return m_map;
-  }
 
   //----------------------------------------
 
@@ -571,404 +498,21 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   KOKKOS_INLINE_FUNCTION
   constexpr unsigned rank() const { return m_rank; }
 
-  // operators ()
-  // Rank 0
-  KOKKOS_INLINE_FUNCTION
-  reference_type operator()() const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((0, this->rank(), m_track, m_map))
-    return impl_map().reference();
-    // return m_map.reference(0,0,0,0,0,0,0);
+  KOKKOS_FUNCTION reference_type
+  operator()(index_type i0 = 0, index_type i1 = 0, index_type i2 = 0,
+             index_type i3 = 0, index_type i4 = 0, index_type i5 = 0,
+             index_type i6 = 0) const {
+    return view_type::operator()(i0, i1, i2, i3, i4, i5, i6);
   }
-
-  // Rank 1
-  // This assumes a contiguous underlying memory (i.e. no padding, no
-  // striding...)
-  template <typename iType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType> &&
-          std::is_same_v<typename drvtraits::value_type,
-                         typename drvtraits::scalar_array_type>,
-      reference_type>
-  operator[](const iType& i0) const {
-    // Phalanx is violating this, since they use the operator to access ALL
-    // elements in the allocation KOKKOS_IMPL_VIEW_OPERATOR_VERIFY( (1 ,
-    // this->rank(), m_track, m_map) )
-    return data()[i0];
+  KOKKOS_FUNCTION reference_type operator[](index_type i0) const {
+    return view_type::operator()(i0, 0, 0, 0, 0, 0, 0);
   }
-
-  // This assumes a contiguous underlying memory (i.e. no padding, no
-  // striding... AND a Trilinos/Sacado scalar type )
-  template <typename iType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType> &&
-          !std::is_same_v<typename drvtraits::value_type,
-                          typename drvtraits::scalar_array_type>,
-      reference_type>
-  operator[](const iType& i0) const {
-    //      auto map = impl_map();
-    const size_t dim_scalar = m_map.dimension_scalar();
-    const size_t bytes      = this->span() / dim_scalar;
-
-    using tmp_view_type = Kokkos::View<
-        DataType*, typename traits::array_layout, typename traits::device_type,
-        Kokkos::MemoryTraits<traits::memory_traits::is_unmanaged |
-                             traits::memory_traits::is_random_access |
-                             traits::memory_traits::is_atomic>>;
-    tmp_view_type rankone_view(this->data(), bytes, dim_scalar);
-    return rankone_view(i0);
+  KOKKOS_FUNCTION reference_type access(index_type i0 = 0, index_type i1 = 0,
+                                        index_type i2 = 0, index_type i3 = 0,
+                                        index_type i4 = 0, index_type i5 = 0,
+                                        index_type i6 = 0) const {
+    return view_type::operator()(i0, i1, i2, i3, i4, i5, i6);
   }
-
-  // Rank 1 parenthesis
-  template <typename iType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType> && std::is_void_v<typename traits::specialize>,
-      reference_type>
-  operator()(const iType& i0) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((1, this->rank(), m_track, m_map, i0))
-    return m_map.reference(i0);
-  }
-
-  template <typename iType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType> && !std::is_void_v<typename traits::specialize>,
-      reference_type>
-  operator()(const iType& i0) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((1, this->rank(), m_track, m_map, i0))
-    return m_map.reference(i0, 0, 0, 0, 0, 0, 0);
-  }
-
-  // Rank 2
-  template <typename iType0, typename iType1>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_void_v<typename traits::specialize>,
-      reference_type>
-  operator()(const iType0& i0, const iType1& i1) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((2, this->rank(), m_track, m_map, i0, i1))
-    return m_map.reference(i0, i1);
-  }
-
-  template <typename iType0, typename iType1>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          !std::is_void_v<typename drvtraits::specialize>,
-      reference_type>
-  operator()(const iType0& i0, const iType1& i1) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((2, this->rank(), m_track, m_map, i0, i1))
-    return m_map.reference(i0, i1, 0, 0, 0, 0, 0);
-  }
-
-  // Rank 3
-  template <typename iType0, typename iType1, typename iType2>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_integral_v<iType2> &&
-          std::is_void_v<typename traits::specialize>,
-      reference_type>
-  operator()(const iType0& i0, const iType1& i1, const iType2& i2) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (3, this->rank(), m_track, m_map, i0, i1, i2))
-    return m_map.reference(i0, i1, i2);
-  }
-
-  template <typename iType0, typename iType1, typename iType2>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_integral_v<iType2> &&
-          !std::is_void_v<typename drvtraits::specialize>,
-      reference_type>
-  operator()(const iType0& i0, const iType1& i1, const iType2& i2) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (3, this->rank(), m_track, m_map, i0, i1, i2))
-    return m_map.reference(i0, i1, i2, 0, 0, 0, 0);
-  }
-
-  // Rank 4
-  template <typename iType0, typename iType1, typename iType2, typename iType3>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
-          std::is_void_v<typename traits::specialize>,
-      reference_type>
-  operator()(const iType0& i0, const iType1& i1, const iType2& i2,
-             const iType3& i3) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (4, this->rank(), m_track, m_map, i0, i1, i2, i3))
-    return m_map.reference(i0, i1, i2, i3);
-  }
-
-  template <typename iType0, typename iType1, typename iType2, typename iType3>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
-          !std::is_void_v<typename traits::specialize>,
-      reference_type>
-  operator()(const iType0& i0, const iType1& i1, const iType2& i2,
-             const iType3& i3) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (4, this->rank(), m_track, m_map, i0, i1, i2, i3))
-    return m_map.reference(i0, i1, i2, i3, 0, 0, 0);
-  }
-
-  // Rank 5
-  template <typename iType0, typename iType1, typename iType2, typename iType3,
-            typename iType4>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
-          std::is_integral_v<iType4> &&
-          std::is_void_v<typename traits::specialize>,
-      reference_type>
-  operator()(const iType0& i0, const iType1& i1, const iType2& i2,
-             const iType3& i3, const iType4& i4) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (5, this->rank(), m_track, m_map, i0, i1, i2, i3, i4))
-    return m_map.reference(i0, i1, i2, i3, i4);
-  }
-
-  template <typename iType0, typename iType1, typename iType2, typename iType3,
-            typename iType4>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
-          std::is_integral_v<iType4> &&
-          !std::is_void_v<typename traits::specialize>,
-      reference_type>
-  operator()(const iType0& i0, const iType1& i1, const iType2& i2,
-             const iType3& i3, const iType4& i4) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (5, this->rank(), m_track, m_map, i0, i1, i2, i3, i4))
-    return m_map.reference(i0, i1, i2, i3, i4, 0, 0);
-  }
-
-  // Rank 6
-  template <typename iType0, typename iType1, typename iType2, typename iType3,
-            typename iType4, typename iType5>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
-          std::is_integral_v<iType4> && std::is_integral_v<iType5> &&
-          std::is_void_v<typename traits::specialize>,
-      reference_type>
-  operator()(const iType0& i0, const iType1& i1, const iType2& i2,
-             const iType3& i3, const iType4& i4, const iType5& i5) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (6, this->rank(), m_track, m_map, i0, i1, i2, i3, i4, i5))
-    return m_map.reference(i0, i1, i2, i3, i4, i5);
-  }
-
-  template <typename iType0, typename iType1, typename iType2, typename iType3,
-            typename iType4, typename iType5>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
-          std::is_integral_v<iType4> && std::is_integral_v<iType5> &&
-          !std::is_void_v<typename traits::specialize>,
-      reference_type>
-  operator()(const iType0& i0, const iType1& i1, const iType2& i2,
-             const iType3& i3, const iType4& i4, const iType5& i5) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (6, this->rank(), m_track, m_map, i0, i1, i2, i3, i4, i5))
-    return m_map.reference(i0, i1, i2, i3, i4, i5, 0);
-  }
-
-  // Rank 7
-  template <typename iType0, typename iType1, typename iType2, typename iType3,
-            typename iType4, typename iType5, typename iType6>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      (std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-       std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
-       std::is_integral_v<iType4> && std::is_integral_v<iType5> &&
-       std::is_integral_v<iType6>),
-      reference_type>
-  operator()(const iType0& i0, const iType1& i1, const iType2& i2,
-             const iType3& i3, const iType4& i4, const iType5& i5,
-             const iType6& i6) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (7, this->rank(), m_track, m_map, i0, i1, i2, i3, i4, i5, i6))
-    return m_map.reference(i0, i1, i2, i3, i4, i5, i6);
-  }
-
-  // Rank 0
-  KOKKOS_INLINE_FUNCTION
-  reference_type access() const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((0, this->rank(), m_track, m_map))
-    return impl_map().reference();
-    // return m_map.reference(0,0,0,0,0,0,0);
-  }
-
-  // Rank 1
-  // Rank 1 parenthesis
-  template <typename iType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType> && std::is_void_v<typename traits::specialize>,
-      reference_type>
-  access(const iType& i0) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((1, this->rank(), m_track, m_map, i0))
-    return m_map.reference(i0);
-  }
-
-  template <typename iType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType> && !std::is_void_v<typename traits::specialize>,
-      reference_type>
-  access(const iType& i0) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((1, this->rank(), m_track, m_map, i0))
-    return m_map.reference(i0, 0, 0, 0, 0, 0, 0);
-  }
-
-  // Rank 2
-  template <typename iType0, typename iType1>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_void_v<typename traits::specialize>,
-      reference_type>
-  access(const iType0& i0, const iType1& i1) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((2, this->rank(), m_track, m_map, i0, i1))
-    return m_map.reference(i0, i1);
-  }
-
-  template <typename iType0, typename iType1>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          !std::is_void_v<typename traits::specialize>,
-      reference_type>
-  access(const iType0& i0, const iType1& i1) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((2, this->rank(), m_track, m_map, i0, i1))
-    return m_map.reference(i0, i1, 0, 0, 0, 0, 0);
-  }
-
-  // Rank 3
-  template <typename iType0, typename iType1, typename iType2>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_integral_v<iType2> &&
-          std::is_void_v<typename traits::specialize>,
-      reference_type>
-  access(const iType0& i0, const iType1& i1, const iType2& i2) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (3, this->rank(), m_track, m_map, i0, i1, i2))
-    return m_map.reference(i0, i1, i2);
-  }
-
-  template <typename iType0, typename iType1, typename iType2>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_integral_v<iType2> &&
-          !std::is_void_v<typename traits::specialize>,
-      reference_type>
-  access(const iType0& i0, const iType1& i1, const iType2& i2) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (3, this->rank(), m_track, m_map, i0, i1, i2))
-    return m_map.reference(i0, i1, i2, 0, 0, 0, 0);
-  }
-
-  // Rank 4
-  template <typename iType0, typename iType1, typename iType2, typename iType3>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
-          std::is_void_v<typename traits::specialize>,
-      reference_type>
-  access(const iType0& i0, const iType1& i1, const iType2& i2,
-         const iType3& i3) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (4, this->rank(), m_track, m_map, i0, i1, i2, i3))
-    return m_map.reference(i0, i1, i2, i3);
-  }
-
-  template <typename iType0, typename iType1, typename iType2, typename iType3>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
-          !std::is_void_v<typename traits::specialize>,
-      reference_type>
-  access(const iType0& i0, const iType1& i1, const iType2& i2,
-         const iType3& i3) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (4, this->rank(), m_track, m_map, i0, i1, i2, i3))
-    return m_map.reference(i0, i1, i2, i3, 0, 0, 0);
-  }
-
-  // Rank 5
-  template <typename iType0, typename iType1, typename iType2, typename iType3,
-            typename iType4>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
-          std::is_integral_v<iType4> &&
-          std::is_void_v<typename traits::specialize>,
-      reference_type>
-  access(const iType0& i0, const iType1& i1, const iType2& i2, const iType3& i3,
-         const iType4& i4) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (5, this->rank(), m_track, m_map, i0, i1, i2, i3, i4))
-    return m_map.reference(i0, i1, i2, i3, i4);
-  }
-
-  template <typename iType0, typename iType1, typename iType2, typename iType3,
-            typename iType4>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
-          std::is_integral_v<iType4> &&
-          !std::is_void_v<typename traits::specialize>,
-      reference_type>
-  access(const iType0& i0, const iType1& i1, const iType2& i2, const iType3& i3,
-         const iType4& i4) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (5, this->rank(), m_track, m_map, i0, i1, i2, i3, i4))
-    return m_map.reference(i0, i1, i2, i3, i4, 0, 0);
-  }
-
-  // Rank 6
-  template <typename iType0, typename iType1, typename iType2, typename iType3,
-            typename iType4, typename iType5>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
-          std::is_integral_v<iType4> && std::is_integral_v<iType5> &&
-          std::is_void_v<typename traits::specialize>,
-      reference_type>
-  access(const iType0& i0, const iType1& i1, const iType2& i2, const iType3& i3,
-         const iType4& i4, const iType5& i5) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (6, this->rank(), m_track, m_map, i0, i1, i2, i3, i4, i5))
-    return m_map.reference(i0, i1, i2, i3, i4, i5);
-  }
-
-  template <typename iType0, typename iType1, typename iType2, typename iType3,
-            typename iType4, typename iType5>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-          std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
-          std::is_integral_v<iType4> && std::is_integral_v<iType5> &&
-          !std::is_void_v<typename traits::specialize>,
-      reference_type>
-  access(const iType0& i0, const iType1& i1, const iType2& i2, const iType3& i3,
-         const iType4& i4, const iType5& i5) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (6, this->rank(), m_track, m_map, i0, i1, i2, i3, i4, i5))
-    return m_map.reference(i0, i1, i2, i3, i4, i5, 0);
-  }
-
-  // Rank 7
-  template <typename iType0, typename iType1, typename iType2, typename iType3,
-            typename iType4, typename iType5, typename iType6>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<
-      (std::is_integral_v<iType0> && std::is_integral_v<iType1> &&
-       std::is_integral_v<iType2> && std::is_integral_v<iType3> &&
-       std::is_integral_v<iType4> && std::is_integral_v<iType5> &&
-       std::is_integral_v<iType6>),
-      reference_type>
-  access(const iType0& i0, const iType1& i1, const iType2& i2, const iType3& i3,
-         const iType4& i4, const iType5& i5, const iType6& i6) const {
-    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(
-        (7, this->rank(), m_track, m_map, i0, i1, i2, i3, i4, i5, i6))
-    return m_map.reference(i0, i1, i2, i3, i4, i5, i6);
-  }
-
-#undef KOKKOS_IMPL_VIEW_OPERATOR_VERIFY
 
   //----------------------------------------
   // Standard constructor, destructor, and assignment operators...
@@ -976,157 +520,84 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   KOKKOS_DEFAULTED_FUNCTION
   ~DynRankView() = default;
 
-  KOKKOS_INLINE_FUNCTION
-  DynRankView() : m_track(), m_map(), m_rank() {}  // Default ctor
-
-  KOKKOS_INLINE_FUNCTION
-  DynRankView(const DynRankView& rhs)
-      : m_track(rhs.m_track), m_map(rhs.m_map), m_rank(rhs.m_rank) {}
-
-  KOKKOS_INLINE_FUNCTION
-  DynRankView(DynRankView&& rhs)
-      : m_track(rhs.m_track), m_map(rhs.m_map), m_rank(rhs.m_rank) {}
-
-  KOKKOS_INLINE_FUNCTION
-  DynRankView& operator=(const DynRankView& rhs) {
-    m_track = rhs.m_track;
-    m_map   = rhs.m_map;
-    m_rank  = rhs.m_rank;
-    return *this;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  DynRankView& operator=(DynRankView&& rhs) {
-    m_track = rhs.m_track;
-    m_map   = rhs.m_map;
-    m_rank  = rhs.m_rank;
-    return *this;
-  }
+  KOKKOS_DEFAULTED_FUNCTION DynRankView()                   = default;
+  KOKKOS_DEFAULTED_FUNCTION DynRankView(const DynRankView&) = default;
+  KOKKOS_DEFAULTED_FUNCTION DynRankView(DynRankView&&)      = default;
+  KOKKOS_DEFAULTED_FUNCTION DynRankView& operator=(const DynRankView&) =
+      default;
+  KOKKOS_DEFAULTED_FUNCTION DynRankView& operator=(DynRankView&&) = default;
 
   //----------------------------------------
   // Compatible view copy constructor and assignment
   // may assign unmanaged from managed.
+  // Make this conditionally explicit?
   template <class RT, class... RP>
   KOKKOS_INLINE_FUNCTION DynRankView(const DynRankView<RT, RP...>& rhs)
-      : m_track(rhs.m_track, traits::is_managed), m_map(), m_rank(rhs.m_rank) {
-    using SrcTraits = typename DynRankView<RT, RP...>::traits;
-    using Mapping   = Kokkos::Impl::ViewMapping<traits, SrcTraits,
-                                              typename traits::specialize>;
-    static_assert(Mapping::is_assignable,
-                  "Incompatible DynRankView copy construction");
-    Mapping::assign(m_map, rhs.m_map, rhs.m_track);
-  }
+      : view_type(
+            static_cast<typename view_type::data_handle_type>(
+                rhs.data_handle()),
+            static_cast<typename view_type::mapping_type>(rhs.mapping()),
+            static_cast<typename view_type::accessor_type>(rhs.accessor())),
+        m_rank(rhs.m_rank) {}
 
   template <class RT, class... RP>
   KOKKOS_INLINE_FUNCTION DynRankView& operator=(
       const DynRankView<RT, RP...>& rhs) {
-    using SrcTraits = typename DynRankView<RT, RP...>::traits;
-    using Mapping   = Kokkos::Impl::ViewMapping<traits, SrcTraits,
-                                              typename traits::specialize>;
-    static_assert(Mapping::is_assignable,
-                  "Incompatible DynRankView copy construction");
-    Mapping::assign(m_map, rhs.m_map, rhs.m_track);
-    m_track.assign(rhs.m_track, traits::is_managed);
-    m_rank = rhs.rank();
+    view_type::operator=(rhs);
+    m_rank = rhs.m_rank;
     return *this;
   }
 
+ private:
+  template <class Ext>
+  KOKKOS_FUNCTION typename view_type::extents_type create_rank7_extents(
+      const Ext& ext) {
+    return typename view_type::extents_type(
+        ext.rank() > 0 ? ext.extent(0) : 1, ext.rank() > 1 ? ext.extent(1) : 1,
+        ext.rank() > 2 ? ext.extent(2) : 1, ext.rank() > 3 ? ext.extent(3) : 1,
+        ext.rank() > 4 ? ext.extent(4) : 1, ext.rank() > 5 ? ext.extent(5) : 1,
+        ext.rank() > 6 ? ext.extent(6) : 1);
+  }
+
+ public:
   // Copy/Assign View to DynRankView
   template <class RT, class... RP>
   KOKKOS_INLINE_FUNCTION DynRankView(const View<RT, RP...>& rhs)
-      : m_track(), m_map(), m_rank(View<RT, RP...>::rank()) {
-    using SrcTraits = typename View<RT, RP...>::traits;
-    using Mapping =
-        Kokkos::Impl::ViewMapping<traits, SrcTraits,
-                                  Kokkos::Impl::ViewToDynRankViewTag>;
-    static_assert(Mapping::is_assignable,
-                  "Incompatible View to DynRankView copy construction");
-    Mapping::assign(*this, rhs);
+      : view_type(rhs.data_handle(), drdtraits::createLayout(rhs.layout())),
+        m_rank(rhs.rank()) {}
+  template <class RT, class... RP>
+  KOKKOS_INLINE_FUNCTION DynRankView(const View<RT, RP...>& rhs,
+                                     size_t new_rank)
+      : view_type(rhs.data_handle(), drdtraits::createLayout(rhs.layout())),
+        m_rank(new_rank) {
+    if (new_rank > rhs.rank())
+      Kokkos::abort(
+          "Attempting to construct DynRankView from View and new rank, with "
+          "the new rank being too large.");
   }
 
   template <class RT, class... RP>
   KOKKOS_INLINE_FUNCTION DynRankView& operator=(const View<RT, RP...>& rhs) {
-    using SrcTraits = typename View<RT, RP...>::traits;
-    using Mapping =
-        Kokkos::Impl::ViewMapping<traits, SrcTraits,
-                                  Kokkos::Impl::ViewToDynRankViewTag>;
-    static_assert(Mapping::is_assignable,
-                  "Incompatible View to DynRankView copy assignment");
-    Mapping::assign(*this, rhs);
+    view_type::operator=(view_type(
+        rhs.data_handle(),
+        typename view_type::mapping_type(create_rank7_extents(rhs.extents())),
+        rhs.accessor()));
+    m_rank = rhs.rank();
     return *this;
   }
 
   //----------------------------------------
   // Allocation tracking properties
 
-  KOKKOS_INLINE_FUNCTION
-  int use_count() const { return m_track.use_count(); }
-
-  inline const std::string label() const {
-    return m_track.template get_label<typename traits::memory_space>();
-  }
-
   //----------------------------------------
   // Allocation according to allocation properties and array layout
   // unused arg_layout dimensions must be set to KOKKOS_INVALID_INDEX so that
   // rank deduction can properly take place
   template <class... P>
-  explicit inline DynRankView(
-      const Kokkos::Impl::ViewCtorProp<P...>& arg_prop,
-      std::enable_if_t<!Kokkos::Impl::ViewCtorProp<P...>::has_pointer,
-                       typename traits::array_layout> const& arg_layout)
-      : m_track(),
-        m_map(),
-        m_rank(Impl::DynRankDimTraits<typename traits::specialize>::
-                   template computeRank<typename traits::array_layout, P...>(
-                       arg_prop, arg_layout)) {
-    // Copy the input allocation properties with possibly defaulted properties
-    auto prop_copy = Impl::with_properties_if_unset(
-        arg_prop, std::string{}, typename traits::device_type::memory_space{},
-        typename traits::device_type::execution_space{});
-    using alloc_prop = decltype(prop_copy);
-
-    static_assert(traits::is_managed,
-                  "View allocation constructor requires managed memory");
-
-    if (alloc_prop::initialize &&
-        !alloc_prop::execution_space::impl_is_initialized()) {
-      // If initializing view data then
-      // the execution space must be initialized.
-      Kokkos::Impl::throw_runtime_exception(
-          "Constructing DynRankView and initializing data with uninitialized "
-          "execution space");
-    }
-
-    Kokkos::Impl::SharedAllocationRecord<>* record = m_map.allocate_shared(
-        prop_copy,
-        Impl::DynRankDimTraits<typename traits::specialize>::
-            template createLayout<traits, P...>(arg_prop, arg_layout),
-        Impl::ViewCtorProp<P...>::has_execution_space);
-
-    // Setup and initialization complete, start tracking
-    m_track.assign_allocated_record_to_uninitialized(record);
-  }
-
-  // Wrappers
-  template <class... P>
-  explicit KOKKOS_INLINE_FUNCTION DynRankView(
-      const Kokkos::Impl::ViewCtorProp<P...>& arg_prop,
-      std::enable_if_t<Kokkos::Impl::ViewCtorProp<P...>::has_pointer,
-                       typename traits::array_layout> const& arg_layout)
-      : m_track()  // No memory tracking
-        ,
-        m_map(arg_prop,
-              Impl::DynRankDimTraits<typename traits::specialize>::
-                  template createLayout<traits, P...>(arg_prop, arg_layout)),
-        m_rank(Impl::DynRankDimTraits<typename traits::specialize>::
-                   template computeRank<typename traits::array_layout, P...>(
-                       arg_prop, arg_layout)) {
-    static_assert(
-        std::is_same<pointer_type,
-                     typename Impl::ViewCtorProp<P...>::pointer_type>::value,
-        "Constructing DynRankView to wrap user memory must supply matching "
-        "pointer type");
+  explicit inline DynRankView(const Kokkos::Impl::ViewCtorProp<P...>& arg_prop,
+                              typename traits::array_layout const& arg_layout)
+      : DynRankView(view_type(arg_prop, drdtraits::createLayout(arg_layout))) {
+    m_rank = drdtraits::computeRank(arg_layout);
   }
 
   //----------------------------------------
@@ -1134,33 +605,15 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
 
   // Simple dimension-only layout
   template <class... P>
-  explicit inline DynRankView(
-      const Kokkos::Impl::ViewCtorProp<P...>& arg_prop,
-      std::enable_if_t<!Kokkos::Impl::ViewCtorProp<P...>::has_pointer,
-                       size_t> const arg_N0 = KOKKOS_INVALID_INDEX,
-      const size_t arg_N1                   = KOKKOS_INVALID_INDEX,
-      const size_t arg_N2                   = KOKKOS_INVALID_INDEX,
-      const size_t arg_N3                   = KOKKOS_INVALID_INDEX,
-      const size_t arg_N4                   = KOKKOS_INVALID_INDEX,
-      const size_t arg_N5                   = KOKKOS_INVALID_INDEX,
-      const size_t arg_N6                   = KOKKOS_INVALID_INDEX,
-      const size_t arg_N7                   = KOKKOS_INVALID_INDEX)
-      : DynRankView(arg_prop, typename traits::array_layout(
-                                  arg_N0, arg_N1, arg_N2, arg_N3, arg_N4,
-                                  arg_N5, arg_N6, arg_N7)) {}
-
-  template <class... P>
-  explicit KOKKOS_INLINE_FUNCTION DynRankView(
-      const Kokkos::Impl::ViewCtorProp<P...>& arg_prop,
-      std::enable_if_t<Kokkos::Impl::ViewCtorProp<P...>::has_pointer,
-                       size_t> const arg_N0 = KOKKOS_INVALID_INDEX,
-      const size_t arg_N1                   = KOKKOS_INVALID_INDEX,
-      const size_t arg_N2                   = KOKKOS_INVALID_INDEX,
-      const size_t arg_N3                   = KOKKOS_INVALID_INDEX,
-      const size_t arg_N4                   = KOKKOS_INVALID_INDEX,
-      const size_t arg_N5                   = KOKKOS_INVALID_INDEX,
-      const size_t arg_N6                   = KOKKOS_INVALID_INDEX,
-      const size_t arg_N7                   = KOKKOS_INVALID_INDEX)
+  explicit inline DynRankView(const Kokkos::Impl::ViewCtorProp<P...>& arg_prop,
+                              const size_t arg_N0 = KOKKOS_INVALID_INDEX,
+                              const size_t arg_N1 = KOKKOS_INVALID_INDEX,
+                              const size_t arg_N2 = KOKKOS_INVALID_INDEX,
+                              const size_t arg_N3 = KOKKOS_INVALID_INDEX,
+                              const size_t arg_N4 = KOKKOS_INVALID_INDEX,
+                              const size_t arg_N5 = KOKKOS_INVALID_INDEX,
+                              const size_t arg_N6 = KOKKOS_INVALID_INDEX,
+                              const size_t arg_N7 = KOKKOS_INVALID_INDEX)
       : DynRankView(arg_prop, typename traits::array_layout(
                                   arg_N0, arg_N1, arg_N2, arg_N3, arg_N4,
                                   arg_N5, arg_N6, arg_N7)) {}
@@ -1194,16 +647,18 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
 
   //----------------------------------------
   // Memory span required to wrap these dimensions.
-  static constexpr size_t required_allocation_size(
-      const size_t arg_N0 = 0, const size_t arg_N1 = 0, const size_t arg_N2 = 0,
-      const size_t arg_N3 = 0, const size_t arg_N4 = 0, const size_t arg_N5 = 0,
-      const size_t arg_N6 = 0, const size_t arg_N7 = 0) {
-    return map_type::memory_span(typename traits::array_layout(
-        arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7));
-  }
-
+  /*
+    static constexpr size_t required_allocation_size(
+        const size_t arg_N0 = 0, const size_t arg_N1 = 0, const size_t arg_N2 =
+    0, const size_t arg_N3 = 0, const size_t arg_N4 = 0, const size_t arg_N5 =
+    0, const size_t arg_N6 = 0, const size_t arg_N7 = 0) { return
+    map_type::memory_span(typename traits::array_layout( arg_N0, arg_N1, arg_N2,
+    arg_N3, arg_N4, arg_N5, arg_N6, arg_N7));
+    }
+  */
   explicit KOKKOS_INLINE_FUNCTION DynRankView(
-      pointer_type arg_ptr, const size_t arg_N0 = KOKKOS_INVALID_INDEX,
+      typename view_type::pointer_type arg_ptr,
+      const size_t arg_N0 = KOKKOS_INVALID_INDEX,
       const size_t arg_N1 = KOKKOS_INVALID_INDEX,
       const size_t arg_N2 = KOKKOS_INVALID_INDEX,
       const size_t arg_N3 = KOKKOS_INVALID_INDEX,
@@ -1211,13 +666,18 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
       const size_t arg_N5 = KOKKOS_INVALID_INDEX,
       const size_t arg_N6 = KOKKOS_INVALID_INDEX,
       const size_t arg_N7 = KOKKOS_INVALID_INDEX)
-      : DynRankView(Kokkos::Impl::ViewCtorProp<pointer_type>(arg_ptr), arg_N0,
-                    arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7) {}
+      : DynRankView(
+            Kokkos::Impl::ViewCtorProp<typename view_type::pointer_type>(
+                arg_ptr),
+            arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7) {}
 
   explicit KOKKOS_INLINE_FUNCTION DynRankView(
-      pointer_type arg_ptr, typename traits::array_layout& arg_layout)
-      : DynRankView(Kokkos::Impl::ViewCtorProp<pointer_type>(arg_ptr),
-                    arg_layout) {}
+      typename view_type::pointer_type arg_ptr,
+      typename traits::array_layout& arg_layout)
+      : DynRankView(
+            Kokkos::Impl::ViewCtorProp<typename view_type::pointer_type>(
+                arg_ptr),
+            arg_layout) {}
 
   //----------------------------------------
   // Shared scratch memory constructor
@@ -1230,33 +690,25 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
                                   const size_t arg_N5 = KOKKOS_INVALID_INDEX,
                                   const size_t arg_N6 = KOKKOS_INVALID_INDEX,
                                   const size_t arg_N7 = KOKKOS_INVALID_INDEX) {
-    const size_t num_passed_args =
-        (arg_N0 != KOKKOS_INVALID_INDEX) + (arg_N1 != KOKKOS_INVALID_INDEX) +
-        (arg_N2 != KOKKOS_INVALID_INDEX) + (arg_N3 != KOKKOS_INVALID_INDEX) +
-        (arg_N4 != KOKKOS_INVALID_INDEX) + (arg_N5 != KOKKOS_INVALID_INDEX) +
-        (arg_N6 != KOKKOS_INVALID_INDEX) + (arg_N7 != KOKKOS_INVALID_INDEX);
-
-    if (std::is_void_v<typename traits::specialize> &&
-        num_passed_args != traits::rank_dynamic) {
-      Kokkos::abort(
-          "Kokkos::View::shmem_size() rank_dynamic != number of arguments.\n");
-    }
-    {}
-
-    return map_type::memory_span(typename traits::array_layout(
-        arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7));
+    return size_t(1) * (arg_N0 != KOKKOS_INVALID_INDEX ? arg_N0 : 1) *
+           (arg_N1 != KOKKOS_INVALID_INDEX ? arg_N1 : 1) *
+           (arg_N2 != KOKKOS_INVALID_INDEX ? arg_N2 : 1) *
+           (arg_N3 != KOKKOS_INVALID_INDEX ? arg_N3 : 1) *
+           (arg_N4 != KOKKOS_INVALID_INDEX ? arg_N4 : 1) *
+           (arg_N5 != KOKKOS_INVALID_INDEX ? arg_N5 : 1) *
+           (arg_N6 != KOKKOS_INVALID_INDEX ? arg_N6 : 1);
   }
 
   explicit KOKKOS_INLINE_FUNCTION DynRankView(
       const typename traits::execution_space::scratch_memory_space& arg_space,
       const typename traits::array_layout& arg_layout)
       : DynRankView(
-            Kokkos::Impl::ViewCtorProp<pointer_type>(
-                reinterpret_cast<pointer_type>(
-                    arg_space.get_shmem(map_type::memory_span(
-                        Impl::DynRankDimTraits<typename traits::specialize>::
-                            createLayout(arg_layout)  // is this correct?
-                        )))),
+            Kokkos::Impl::ViewCtorProp<typename view_type::pointer_type>(
+                reinterpret_cast<typename view_type::pointer_type>(
+                    // arg_space.get_shmem(map_type::memory_span(
+                    //     Impl::DynRankDimTraits<typename traits::specialize>::
+                    //         createLayout(arg_layout)  // is this correct?
+                    1)),
             arg_layout) {}
 
   explicit KOKKOS_INLINE_FUNCTION DynRankView(
@@ -1271,15 +723,47 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
       const size_t arg_N7 = KOKKOS_INVALID_INDEX)
 
       : DynRankView(
-            Kokkos::Impl::ViewCtorProp<pointer_type>(
-                reinterpret_cast<pointer_type>(
-                    arg_space.get_shmem(map_type::memory_span(
-                        Impl::DynRankDimTraits<typename traits::specialize>::
-                            createLayout(typename traits::array_layout(
-                                arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5,
-                                arg_N6, arg_N7)))))),
+            Kokkos::Impl::ViewCtorProp<
+                typename view_type::
+                    pointer_type>(reinterpret_cast<
+                                  typename view_type::pointer_type>(
+                //                    arg_space.get_shmem(map_type::memory_span(
+                //                        Impl::DynRankDimTraits<typename
+                //                        traits::specialize>::
+                //                            createLayout(typename
+                //                            traits::array_layout(
+                //                                arg_N0, arg_N1, arg_N2,
+                //                                arg_N3, arg_N4, arg_N5,
+                //                                arg_N6, arg_N7))))
+                1)),
             typename traits::array_layout(arg_N0, arg_N1, arg_N2, arg_N3,
                                           arg_N4, arg_N5, arg_N6, arg_N7)) {}
+
+  KOKKOS_INLINE_FUNCTION constexpr auto layout() const {
+    switch (rank()) {
+      case 0: return Impl::as_view_of_rank_n<0>(*this).layout();
+      case 1: return Impl::as_view_of_rank_n<1>(*this).layout();
+      case 2: return Impl::as_view_of_rank_n<2>(*this).layout();
+      case 3: return Impl::as_view_of_rank_n<3>(*this).layout();
+      case 4: return Impl::as_view_of_rank_n<4>(*this).layout();
+      case 5: return Impl::as_view_of_rank_n<5>(*this).layout();
+      case 6: return Impl::as_view_of_rank_n<6>(*this).layout();
+      case 7: return Impl::as_view_of_rank_n<7>(*this).layout();
+      default:
+        KOKKOS_IF_ON_HOST(
+            Kokkos::abort(
+                std::string(
+                    "Calling DynRankView::layout on DRV of unexpected rank " +
+                    std::to_string(rank()))
+                    .c_str());)
+        KOKKOS_IF_ON_DEVICE(
+            Kokkos::abort(
+                "Calling DynRankView::layout on DRV of unexpected rank");)
+    }
+    // control flow should never reach here
+    return view_type::layout();
+    ;
+  }
 };
 
 template <typename D, class... P>
@@ -1299,181 +783,41 @@ struct DynRankSubviewTag {};
 
 }  // namespace Impl
 
-namespace Impl {
-
-template <class SrcTraits, class... Args>
-class ViewMapping<
-    std::enable_if_t<(std::is_void_v<typename SrcTraits::specialize> &&
-                      (std::is_same_v<typename SrcTraits::array_layout,
-                                      Kokkos::LayoutLeft> ||
-                       std::is_same_v<typename SrcTraits::array_layout,
-                                      Kokkos::LayoutRight> ||
-                       std::is_same_v<typename SrcTraits::array_layout,
-                                      Kokkos::LayoutStride>)),
-                     Kokkos::Impl::DynRankSubviewTag>,
-    SrcTraits, Args...> {
- private:
-  enum {
-    RZ = false,
-    R0 = bool(is_integral_extent<0, Args...>::value),
-    R1 = bool(is_integral_extent<1, Args...>::value),
-    R2 = bool(is_integral_extent<2, Args...>::value),
-    R3 = bool(is_integral_extent<3, Args...>::value),
-    R4 = bool(is_integral_extent<4, Args...>::value),
-    R5 = bool(is_integral_extent<5, Args...>::value),
-    R6 = bool(is_integral_extent<6, Args...>::value)
-  };
-
-  enum {
-    rank = unsigned(R0) + unsigned(R1) + unsigned(R2) + unsigned(R3) +
-           unsigned(R4) + unsigned(R5) + unsigned(R6)
-  };
-
-  using array_layout = Kokkos::LayoutStride;
-
-  using value_type = typename SrcTraits::value_type;
-
-  using data_type = value_type*******;
-
- public:
-  using traits_type = Kokkos::ViewTraits<data_type, array_layout,
-                                         typename SrcTraits::device_type,
-                                         typename SrcTraits::memory_traits>;
-
-  using type =
-      Kokkos::View<data_type, array_layout, typename SrcTraits::device_type,
-                   typename SrcTraits::memory_traits>;
-
-  template <class MemoryTraits>
-  struct apply {
-    static_assert(Kokkos::is_memory_traits<MemoryTraits>::value);
-
-    using traits_type =
-        Kokkos::ViewTraits<data_type, array_layout,
-                           typename SrcTraits::device_type, MemoryTraits>;
-
-    using type = Kokkos::View<data_type, array_layout,
-                              typename SrcTraits::device_type, MemoryTraits>;
-  };
-
-  using dimension = typename SrcTraits::dimension;
-
-  template <class Arg0 = int, class Arg1 = int, class Arg2 = int,
-            class Arg3 = int, class Arg4 = int, class Arg5 = int,
-            class Arg6 = int>
-  struct ExtentGenerator {
-    KOKKOS_INLINE_FUNCTION
-    static SubviewExtents<7, rank> generator(
-        const dimension& dim, Arg0 arg0 = Arg0(), Arg1 arg1 = Arg1(),
-        Arg2 arg2 = Arg2(), Arg3 arg3 = Arg3(), Arg4 arg4 = Arg4(),
-        Arg5 arg5 = Arg5(), Arg6 arg6 = Arg6()) {
-      return SubviewExtents<7, rank>(dim, arg0, arg1, arg2, arg3, arg4, arg5,
-                                     arg6);
-    }
-  };
-
-  using ret_type = Kokkos::DynRankView<value_type, array_layout,
-                                       typename SrcTraits::device_type,
-                                       typename SrcTraits::memory_traits>;
-
-  template <typename T, class... P>
-  KOKKOS_INLINE_FUNCTION static ret_type subview(
-      const unsigned src_rank, Kokkos::DynRankView<T, P...> const& src,
-      Args... args) {
-    using DstType = ViewMapping<traits_type, typename traits_type::specialize>;
-
-    using DstDimType = std::conditional_t<
-        (rank == 0), ViewDimension<>,
-        std::conditional_t<
-            (rank == 1), ViewDimension<0>,
-            std::conditional_t<
-                (rank == 2), ViewDimension<0, 0>,
-                std::conditional_t<
-                    (rank == 3), ViewDimension<0, 0, 0>,
-                    std::conditional_t<
-                        (rank == 4), ViewDimension<0, 0, 0, 0>,
-                        std::conditional_t<
-                            (rank == 5), ViewDimension<0, 0, 0, 0, 0>,
-                            std::conditional_t<
-                                (rank == 6), ViewDimension<0, 0, 0, 0, 0, 0>,
-                                ViewDimension<0, 0, 0, 0, 0, 0, 0>>>>>>>>;
-
-    using dst_offset_type = ViewOffset<DstDimType, Kokkos::LayoutStride>;
-    using dst_handle_type = typename DstType::handle_type;
-
-    ret_type dst;
-
-    const SubviewExtents<7, rank> extents = ExtentGenerator<Args...>::generator(
-        src.m_map.m_impl_offset.m_dim, args...);
-
-    dst_offset_type tempdst(src.m_map.m_impl_offset, extents);
-
-    dst.m_track = src.m_track;
-
-    dst.m_map.m_impl_offset.m_dim.N0 = tempdst.m_dim.N0;
-    dst.m_map.m_impl_offset.m_dim.N1 = tempdst.m_dim.N1;
-    dst.m_map.m_impl_offset.m_dim.N2 = tempdst.m_dim.N2;
-    dst.m_map.m_impl_offset.m_dim.N3 = tempdst.m_dim.N3;
-    dst.m_map.m_impl_offset.m_dim.N4 = tempdst.m_dim.N4;
-    dst.m_map.m_impl_offset.m_dim.N5 = tempdst.m_dim.N5;
-    dst.m_map.m_impl_offset.m_dim.N6 = tempdst.m_dim.N6;
-
-    dst.m_map.m_impl_offset.m_stride.S0 = tempdst.m_stride.S0;
-    dst.m_map.m_impl_offset.m_stride.S1 = tempdst.m_stride.S1;
-    dst.m_map.m_impl_offset.m_stride.S2 = tempdst.m_stride.S2;
-    dst.m_map.m_impl_offset.m_stride.S3 = tempdst.m_stride.S3;
-    dst.m_map.m_impl_offset.m_stride.S4 = tempdst.m_stride.S4;
-    dst.m_map.m_impl_offset.m_stride.S5 = tempdst.m_stride.S5;
-    dst.m_map.m_impl_offset.m_stride.S6 = tempdst.m_stride.S6;
-
-    dst.m_map.m_impl_handle =
-        dst_handle_type(src.m_map.m_impl_handle +
-                        src.m_map.m_impl_offset(
-                            extents.domain_offset(0), extents.domain_offset(1),
-                            extents.domain_offset(2), extents.domain_offset(3),
-                            extents.domain_offset(4), extents.domain_offset(5),
-                            extents.domain_offset(6)));
-
-    dst.m_rank =
-        (src_rank > 0 ? unsigned(R0) : 0) + (src_rank > 1 ? unsigned(R1) : 0) +
-        (src_rank > 2 ? unsigned(R2) : 0) + (src_rank > 3 ? unsigned(R3) : 0) +
-        (src_rank > 4 ? unsigned(R4) : 0) + (src_rank > 5 ? unsigned(R5) : 0) +
-        (src_rank > 6 ? unsigned(R6) : 0);
-
-    return dst;
-  }
-};
-
-}  // namespace Impl
-
 template <class V, class... Args>
 using Subdynrankview =
     typename Kokkos::Impl::ViewMapping<Kokkos::Impl::DynRankSubviewTag, V,
                                        Args...>::ret_type;
 
-template <class D, class... P, class... Args>
-KOKKOS_INLINE_FUNCTION Subdynrankview<ViewTraits<D*******, P...>, Args...>
-subdynrankview(const Kokkos::DynRankView<D, P...>& src, Args... args) {
-  if (src.rank() > sizeof...(Args))  // allow sizeof...(Args) >= src.rank(),
-                                     // ignore the remaining args
-  {
-    Kokkos::abort(
-        "subdynrankview: num of args must be >= rank of the source "
-        "DynRankView");
-  }
-
-  using metafcn =
-      Kokkos::Impl::ViewMapping<Kokkos::Impl::DynRankSubviewTag,
-                                Kokkos::ViewTraits<D*******, P...>, Args...>;
-
-  return metafcn::subview(src.rank(), src, args...);
+template <class... DRVArgs, class SubArg0 = int, class SubArg1 = int,
+          class SubArg2 = int, class SubArg3 = int, class SubArg4 = int,
+          class SubArg5 = int, class SubArg6 = int>
+KOKKOS_INLINE_FUNCTION auto subdynrankview(
+    const DynRankView<DRVArgs...>& drv, SubArg0 arg0 = SubArg0{},
+    SubArg1 arg1 = SubArg1{}, SubArg2 arg2 = SubArg2{},
+    SubArg3 arg3 = SubArg3{}, SubArg4 arg4 = SubArg4{},
+    SubArg5 arg5 = SubArg5{}, SubArg6 arg6 = SubArg6{}) {
+  auto sub = subview(drv.DownCast(), arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+  using sub_t     = decltype(sub);
+  size_t new_rank = (drv.rank() > 0 && !std::is_integral_v<SubArg0> ? 1 : 0) +
+                    (drv.rank() > 1 && !std::is_integral_v<SubArg1> ? 1 : 0) +
+                    (drv.rank() > 2 && !std::is_integral_v<SubArg2> ? 1 : 0) +
+                    (drv.rank() > 3 && !std::is_integral_v<SubArg3> ? 1 : 0) +
+                    (drv.rank() > 4 && !std::is_integral_v<SubArg4> ? 1 : 0) +
+                    (drv.rank() > 5 && !std::is_integral_v<SubArg5> ? 1 : 0) +
+                    (drv.rank() > 6 && !std::is_integral_v<SubArg6> ? 1 : 0);
+  return DynRankView<typename sub_t::value_type, typename sub_t::layout_type,
+                     typename sub_t::device_type,
+                     typename sub_t::memory_traits>(sub, new_rank);
 }
-
-// Wrapper to allow subview function name
-template <class D, class... P, class... Args>
-KOKKOS_INLINE_FUNCTION Subdynrankview<ViewTraits<D*******, P...>, Args...>
-subview(const Kokkos::DynRankView<D, P...>& src, Args... args) {
-  return subdynrankview(src, args...);
+template <class... DRVArgs, class SubArg0 = int, class SubArg1 = int,
+          class SubArg2 = int, class SubArg3 = int, class SubArg4 = int,
+          class SubArg5 = int, class SubArg6 = int>
+KOKKOS_INLINE_FUNCTION auto subview(
+    const DynRankView<DRVArgs...>& drv, SubArg0 arg0 = SubArg0{},
+    SubArg1 arg1 = SubArg1{}, SubArg2 arg2 = SubArg2{},
+    SubArg3 arg3 = SubArg3{}, SubArg4 arg4 = SubArg4{},
+    SubArg5 arg5 = SubArg5{}, SubArg6 arg6 = SubArg6{}) {
+  return subdynrankview(drv, arg0, arg1, arg2, arg3, arg4, arg5, arg6);
 }
 
 }  // namespace Kokkos
@@ -1644,10 +988,9 @@ namespace Impl {
    underlying memory, to facilitate implementation of deep_copy() and
    other routines that are defined on View */
 template <unsigned N, typename T, typename... Args>
-KOKKOS_FUNCTION auto as_view_of_rank_n(
-    DynRankView<T, Args...> v,
-    std::enable_if_t<std::is_same_v<typename ViewTraits<T, Args...>::specialize,
-                                    void>>* = nullptr) {
+KOKKOS_FUNCTION
+    View<typename DataTypeFromExtents<T, dextents<int, N>>::type, Args...>
+    as_view_of_rank_n(DynRankView<T, Args...> v) {
   if (v.rank() != N) {
     KOKKOS_IF_ON_HOST(
         const std::string message =
@@ -1658,7 +1001,7 @@ KOKKOS_FUNCTION auto as_view_of_rank_n(
         Kokkos::abort("Converting DynRankView to a View of mis-matched rank!");)
   }
 
-  auto layout = v.impl_map().layout();
+  auto layout = v.DownCast().layout();
 
   if constexpr (std::is_same_v<decltype(layout), Kokkos::LayoutLeft> ||
                 std::is_same_v<decltype(layout), Kokkos::LayoutRight> ||
@@ -1695,33 +1038,6 @@ void apply_to_view_of_static_rank(Function&& f, DynRankView<Args...> a) {
 }
 
 }  // namespace Impl
-
-template <typename D, class... P>
-KOKKOS_INLINE_FUNCTION constexpr auto DynRankView<D, P...>::layout() const ->
-    typename traits::array_layout {
-  switch (rank()) {
-    case 0: return Impl::as_view_of_rank_n<0>(*this).layout();
-    case 1: return Impl::as_view_of_rank_n<1>(*this).layout();
-    case 2: return Impl::as_view_of_rank_n<2>(*this).layout();
-    case 3: return Impl::as_view_of_rank_n<3>(*this).layout();
-    case 4: return Impl::as_view_of_rank_n<4>(*this).layout();
-    case 5: return Impl::as_view_of_rank_n<5>(*this).layout();
-    case 6: return Impl::as_view_of_rank_n<6>(*this).layout();
-    case 7: return Impl::as_view_of_rank_n<7>(*this).layout();
-    default:
-      KOKKOS_IF_ON_HOST(
-          Kokkos::abort(
-              std::string(
-                  "Calling DynRankView::layout on DRV of unexpected rank " +
-                  std::to_string(rank()))
-                  .c_str());)
-      KOKKOS_IF_ON_DEVICE(
-          Kokkos::abort(
-              "Calling DynRankView::layout on DRV of unexpected rank");)
-  }
-  // control flow should never reach here
-  return m_map.layout();
-}
 
 /** \brief  Deep copy a value from Host memory into a view.  */
 template <class ExecSpace, class DT, class... DP>

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -431,18 +431,19 @@ class DynRankView : private View<DataType*******, Properties...> {
   using reference_type = typename view_type::reference_type;
   using pointer_type   = typename view_type::pointer_type;
 
-  using scalar_array_type       = typename view_type::scalar_array_type;
-  using const_scalar_array_type = typename view_type::const_scalar_array_type;
-  using non_const_scalar_array_type =
-      typename view_type::non_const_scalar_array_type;
-  using specialize = typename view_type::specialize;
+  using scalar_array_type           = value_type;
+  using const_scalar_array_type     = const_value_type;
+  using non_const_scalar_array_type = non_const_value_type;
+  using specialize                  = typename view_type::specialize;
 
   // typedefs in View for mdspan compatibility
   // cause issues with MSVC+CUDA
   // using layout_type  = typename view_type::layout_type;
-  using index_type   = typename view_type::index_type;
-  using element_type = typename view_type::element_type;
-  using rank_type    = typename view_type::rank_type;
+  using index_type       = typename view_type::index_type;
+  using element_type     = typename view_type::element_type;
+  using rank_type        = typename view_type::rank_type;
+  using reference        = reference_type;
+  using data_handle_type = pointer_type;
 
   KOKKOS_INLINE_FUNCTION
   view_type& DownCast() const { return (view_type&)(*this); }
@@ -475,6 +476,7 @@ class DynRankView : private View<DataType*******, Properties...> {
                                  typename drvtraits::array_layout,
                                  typename drvtraits::host_mirror_space>;
 
+  using host_mirror_type = HostMirror;
   //----------------------------------------
   // Domain rank and extents
 

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -59,6 +59,7 @@ SET(COMPILE_ONLY_SOURCES
   TestCreateMirror.cpp
   TestDualViewParameterPack.cpp
   TestIsViewTrait.cpp
+  TestDynRankViewTypedefs.cpp
 )
 KOKKOS_ADD_EXECUTABLE(
   ContainersTestCompileOnly

--- a/containers/unit_tests/TestDynRankViewTypedefs.cpp
+++ b/containers/unit_tests/TestDynRankViewTypedefs.cpp
@@ -57,7 +57,7 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::const_data_type, typename data_analysis<DataType>::const_data_type>);
   static_assert(std::is_same_v<typename ViewType::non_const_data_type, typename data_analysis<DataType>::non_const_data_type>);
   
-  // these should be deprecated and for proper testing (I.e. where this is different from data_type)
+  // FIXME: these should be deprecated and for proper testing (I.e. where this is different from data_type)
   // we would need ensemble types which use the hidden View dimension facility of View (i.e. which make
   // "specialize" not void)
   static_assert(std::is_same_v<typename ViewType::scalar_array_type, DataType>);
@@ -65,15 +65,15 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::non_const_scalar_array_type, typename data_analysis<DataType>::non_const_data_type>);
   static_assert(std::is_same_v<typename ViewType::specialize, void>);
 
-  // value_type definition conflicts with mdspan value_type
+  // FIXME: value_type definition conflicts with mdspan value_type
   static_assert(std::is_same_v<typename ViewType::value_type, ValueType>);
   static_assert(std::is_same_v<typename ViewType::const_value_type, const ValueType>);
   static_assert(std::is_same_v<typename ViewType::non_const_value_type, std::remove_const_t<ValueType>>);
 
-  // should maybe be deprecated
+  // FIXME: should maybe be deprecated
   static_assert(std::is_same_v<typename ViewType::array_layout, Layout>);
 
-  // should be deprecated and is some complicated impl type
+  // FIXME: should be deprecated and is some complicated impl type
   // static_assert(!std::is_void_v<typename ViewType::dimension>);
 
   static_assert(std::is_same_v<typename ViewType::execution_space, typename Space::execution_space>);
@@ -83,14 +83,16 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::host_mirror_space, HostMirrorSpace>);
   static_assert(std::is_same_v<typename ViewType::size_type, typename ViewType::memory_space::size_type>);
  
-  // should be deprecated in favor of reference
+  // FIXME: should be deprecated in favor of reference
   static_assert(std::is_same_v<typename ViewType::reference_type, ReferenceType>);
-  // should be deprecated in favor of data_handle_type
+  // FIXME: should be deprecated in favor of data_handle_type
   static_assert(std::is_same_v<typename ViewType::pointer_type, ValueType*>);
  
   // =========================================
   // in Legacy View: some helper View variants
   // =========================================
+
+  // FIXME: in contrast to View, hooks_policy is not propagated
   static_assert(std::is_same_v<typename ViewType::traits, ViewTraitsType>);
   static_assert(std::is_same_v<typename ViewType::array_type,
                                Kokkos::DynRankView<typename ViewType::data_type, typename ViewType::array_layout,
@@ -109,37 +111,37 @@ constexpr bool test_view_typedefs_impl() {
                                                    HostMirrorSpace
                                                    /*, typename ViewTraitsType::hooks_policy*/>>);
 
-/*
+/* FIXME: these don't exist in DynRankView, should they?
   using uniform_layout_type = std::conditional_t<ViewType::rank()==0 || (ViewType::rank()==0 &&
                                                  std::is_same_v<Layout, Kokkos::LayoutRight>),
                                                  Kokkos::LayoutLeft, Layout>;
 
   // Uhm uniformtype removes all memorytraits?
   static_assert(std::is_same_v<typename ViewType::uniform_type,
-                               Kokkos::View<typename ViewType::data_type, uniform_layout_type,
+                               Kokkos::DynRankView<typename ViewType::data_type, uniform_layout_type,
                                             typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_const_type,
-                               Kokkos::View<typename ViewType::const_data_type, uniform_layout_type,
+                               Kokkos::DynRankView<typename ViewType::const_data_type, uniform_layout_type,
                                             typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_runtime_type,
-                               Kokkos::View<typename data_analysis<DataType>::runtime_data_type, uniform_layout_type,
+                               Kokkos::DynRankView<typename data_analysis<DataType>::runtime_data_type, uniform_layout_type,
                                             typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_runtime_const_type,
-                               Kokkos::View<typename data_analysis<DataType>::runtime_const_data_type, uniform_layout_type,
+                               Kokkos::DynRankView<typename data_analysis<DataType>::runtime_const_data_type, uniform_layout_type,
                                             typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
 
   using anonymous_device_type = Kokkos::Device<typename ViewType::execution_space, Kokkos::AnonymousSpace>;
   static_assert(std::is_same_v<typename ViewType::uniform_nomemspace_type,
-                               Kokkos::View<typename ViewType::data_type, uniform_layout_type,
+                               Kokkos::DynRankView<typename ViewType::data_type, uniform_layout_type,
                                             anonymous_device_type, Kokkos::MemoryTraits<0>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_const_nomemspace_type,
-                               Kokkos::View<typename ViewType::const_data_type, uniform_layout_type,
+                               Kokkos::DynRankView<typename ViewType::const_data_type, uniform_layout_type,
                                             anonymous_device_type, Kokkos::MemoryTraits<0>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_runtime_nomemspace_type,
-                               Kokkos::View<typename data_analysis<DataType>::runtime_data_type, uniform_layout_type,
+                               Kokkos::DynRankView<typename data_analysis<DataType>::runtime_data_type, uniform_layout_type,
                                             anonymous_device_type, Kokkos::MemoryTraits<0>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_runtime_const_nomemspace_type,
-                               Kokkos::View<typename data_analysis<DataType>::runtime_const_data_type, uniform_layout_type,
+                               Kokkos::DynRankView<typename data_analysis<DataType>::runtime_const_data_type, uniform_layout_type,
                                             anonymous_device_type, Kokkos::MemoryTraits<0>>>);
 */
 
@@ -147,21 +149,21 @@ constexpr bool test_view_typedefs_impl() {
   // mdspan compatibility
   // ==================================
 
-  // This typedef caused some weird issue with MSVC+NVCC
+  // FIXME: This typedef caused some weird issue with MSVC+NVCC
   // static_assert(std::is_same_v<typename ViewType::layout_type, Layout>);
-  // Not supported yet
+  // FIXME: Not supported yet
   // static_assert(std::is_same_v<typename ViewType::extents_type, >);
   // static_assert(std::is_same_v<typename ViewType::mapping_type, >);
   // static_assert(std::is_same_v<typename ViewType::accessor_type, >);
 
   static_assert(std::is_same_v<typename ViewType::element_type, ValueType>);
-  // should be remove_const_t<element_type>
+  // FIXME: should be remove_const_t<element_type>
   static_assert(std::is_same_v<typename ViewType::value_type, ValueType>);
-  // should be extents_type::index_type
+  // FIXME: should be extents_type::index_type
   static_assert(std::is_same_v<typename ViewType::index_type, typename Space::memory_space::size_type>);
   static_assert(std::is_same_v<typename ViewType::rank_type, size_t>);
 
-  // should come from accessor_type
+  // FIXME: should come from accessor_type
   static_assert(std::is_same_v<typename ViewType::data_handle_type, typename ViewType::pointer_type>);
   static_assert(std::is_same_v<typename ViewType::reference, typename ViewType::reference_type>);
   return true;
@@ -181,9 +183,9 @@ constexpr bool test_view_typedefs(ViewParams<T, ViewArgs...>) {
 constexpr bool is_host_exec = std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
 
 #if defined(KOKKOS_ENABLE_CUDA_UVM) || defined(KOKKOS_ENABLE_IMPL_CUDA_UNIFIED_MEMORY) || defined(KOKKOS_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
-constexpr bool has_unified = true;
+constexpr bool has_unified_mem_space = true;
 #else
-constexpr bool has_unified = false;
+constexpr bool has_unified_mem_space = false;
 #endif
 
 // The test take explicit template arguments for: LayoutType, Space, MemoryTraits, HostMirrorSpace, ValueType, ReferenceType
@@ -197,7 +199,7 @@ namespace TestInt {
   // HostMirrorSpace is a mess so: if the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is not on its HostSpace
-                               std::conditional_t<!has_unified, Kokkos::HostSpace,
+                               std::conditional_t<!has_unified_mem_space, Kokkos::HostSpace,
   // otherwise its the following Device type
                                Kokkos::Device<Kokkos::DefaultHostExecutionSpace, typename Kokkos::DefaultExecutionSpace::memory_space>>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int, int&>(
@@ -212,7 +214,7 @@ namespace TestIntDefaultExecutionSpace {
   // HostMirrorSpace is a mess so: if the default exec is a host exec, it is HostSpace (note difference from View<int> ...)
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::HostSpace,
   // otherwise if unified memory is not on its also HostSpace!
-                               std::conditional_t<!has_unified, Kokkos::HostSpace,
+                               std::conditional_t<!has_unified_mem_space, Kokkos::HostSpace,
   // otherwise its the following memory space ...
                                Kokkos::DefaultExecutionSpace::memory_space>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int, int&>(
@@ -247,7 +249,7 @@ namespace TestIntAtomic {
   // HostMirrorSpace is a mess so: if the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is not on its HostSpace
-                               std::conditional_t<!has_unified, Kokkos::HostSpace,
+                               std::conditional_t<!has_unified_mem_space, Kokkos::HostSpace,
   // otherwise its the following Device type
                                Kokkos::Device<Kokkos::DefaultHostExecutionSpace, typename Kokkos::DefaultExecutionSpace::memory_space>>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int,

--- a/containers/unit_tests/TestDynRankViewTypedefs.cpp
+++ b/containers/unit_tests/TestDynRankViewTypedefs.cpp
@@ -1,0 +1,223 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+namespace {
+
+// clang-format off
+template<class DataType>
+struct data_analysis {
+  using data_type = DataType;
+  using const_data_type = const DataType;
+  using runtime_data_type = DataType;
+  using runtime_const_data_type = const DataType;
+  using non_const_data_type = std::remove_const_t<DataType>;
+};
+
+template<class DataType>
+struct data_analysis<DataType*> {
+  using data_type = typename data_analysis<DataType>::data_type*;
+  using const_data_type = typename data_analysis<DataType>::const_data_type*;
+  using runtime_data_type = typename data_analysis<DataType>::runtime_data_type*;
+  using runtime_const_data_type = typename data_analysis<DataType>::runtime_const_data_type*;
+  using non_const_data_type = typename data_analysis<DataType>::non_const_data_type*;
+};
+
+template<class DataType, size_t N>
+struct data_analysis<DataType[N]> {
+  using data_type = typename data_analysis<DataType>::data_type[N];
+  using const_data_type = typename data_analysis<DataType>::const_data_type[N];
+  using runtime_data_type = typename data_analysis<DataType>::runtime_data_type*;
+  using runtime_const_data_type = typename data_analysis<DataType>::runtime_const_data_type*;
+  using non_const_data_type = typename data_analysis<DataType>::non_const_data_type[N];
+};
+
+template<class ViewType, class ViewTraitsType, class DataType, class Layout, class Space, class MemoryTraitsType,
+         class HostMirrorSpace, class ValueType, class ReferenceType>
+constexpr bool test_view_typedefs_impl() {
+  // ========================
+  // inherited from ViewTraits
+  // ========================
+  static_assert(std::is_same_v<typename ViewType::data_type, DataType>);
+  static_assert(std::is_same_v<typename ViewType::const_data_type, typename  data_analysis<DataType>::const_data_type>);
+  static_assert(std::is_same_v<typename ViewType::non_const_data_type, typename  data_analysis<DataType>::non_const_data_type>);
+  
+  // these should be deprecated and for proper testing (I.e. where this is different from data_type)
+  // we would need ensemble types which use the hidden View dimension facility of View (i.e. which make
+  // "specialize" not void
+  static_assert(std::is_same_v<typename ViewType::scalar_array_type, DataType>);
+  static_assert(std::is_same_v<typename ViewType::const_scalar_array_type, typename  data_analysis<DataType>::const_data_type>);
+  static_assert(std::is_same_v<typename ViewType::non_const_scalar_array_type, typename  data_analysis<DataType>::non_const_data_type>);
+  static_assert(std::is_same_v<typename ViewType::specialize, void>);
+
+  // value_type definition conflicts with mdspan value_type
+  static_assert(std::is_same_v<typename ViewType::value_type, ValueType>);
+  static_assert(std::is_same_v<typename ViewType::const_value_type, const ValueType>);
+  static_assert(std::is_same_v<typename ViewType::non_const_value_type, std::remove_const_t<ValueType>>);
+
+  // should maybe be deprecated
+  static_assert(std::is_same_v<typename ViewType::array_layout, Layout>);
+
+  // should be deprecated and is some complicated impl type
+  static_assert(!std::is_void_v<typename ViewType::dimension>);
+
+  static_assert(std::is_same_v<typename ViewType::execution_space, typename Space::execution_space>);
+  static_assert(std::is_same_v<typename ViewType::memory_space, typename Space::memory_space>);
+  static_assert(std::is_same_v<typename ViewType::device_type, Kokkos::Device<typename ViewType::execution_space, typename ViewType::memory_space>>);
+  static_assert(std::is_same_v<typename ViewType::memory_traits, MemoryTraitsType>);
+  static_assert(std::is_same_v<typename ViewType::host_mirror_space, HostMirrorSpace>);
+  static_assert(std::is_same_v<typename ViewType::size_type, typename ViewType::memory_space::size_type>);
+ 
+  // should be deprecated in favor of reference
+  static_assert(std::is_same_v<typename ViewType::reference_type, ReferenceType>);
+  // should be deprecated in favor of data_handle_type
+  static_assert(std::is_same_v<typename ViewType::pointer_type, ValueType*>);
+ 
+  // =========================================
+  // in Legacy View: some helper View variants
+  // =========================================
+  static_assert(std::is_same_v<typename ViewType::traits, ViewTraitsType>);
+  static_assert(std::is_same_v<typename ViewType::array_type,
+                               Kokkos::View<typename ViewType::scalar_array_type, typename ViewType::array_layout,
+                                            typename ViewType::device_type, typename ViewTraitsType::hooks_policy,
+                                            typename ViewType::memory_traits>>);
+  static_assert(std::is_same_v<typename ViewType::const_type,
+                               Kokkos::View<typename ViewType::const_data_type, typename ViewType::array_layout,
+                                            typename ViewType::device_type, typename ViewTraitsType::hooks_policy,
+                                            typename ViewType::memory_traits>>);
+  static_assert(std::is_same_v<typename ViewType::non_const_type,
+                               Kokkos::View<typename ViewType::non_const_data_type, typename ViewType::array_layout,
+                                            typename ViewType::device_type, typename ViewTraitsType::hooks_policy,
+                                            typename ViewType::memory_traits>>);
+  static_assert(std::is_same_v<typename ViewType::host_mirror_type,
+                               Kokkos::View<typename ViewType::non_const_data_type, typename ViewType::array_layout,
+                                            Kokkos::Device<Kokkos::DefaultHostExecutionSpace,
+                                                           typename ViewType::host_mirror_space::memory_space>,
+                                            typename ViewTraitsType::hooks_policy>>);
+
+  using uniform_layout_type = std::conditional_t<ViewType::rank()==0 || (ViewType::rank()==0 &&
+                                                 std::is_same_v<Layout, Kokkos::LayoutRight>),
+                                                 Kokkos::LayoutLeft, Layout>;
+
+  // Uhm uniformtype removes all memorytraits?
+  static_assert(std::is_same_v<typename ViewType::uniform_type,
+                               Kokkos::View<typename ViewType::data_type, uniform_layout_type,
+                                            typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
+  static_assert(std::is_same_v<typename ViewType::uniform_const_type,
+                               Kokkos::View<typename ViewType::const_data_type, uniform_layout_type,
+                                            typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
+  static_assert(std::is_same_v<typename ViewType::uniform_runtime_type,
+                               Kokkos::View<typename data_analysis<DataType>::runtime_data_type, uniform_layout_type,
+                                            typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
+  static_assert(std::is_same_v<typename ViewType::uniform_runtime_const_type,
+                               Kokkos::View<typename data_analysis<DataType>::runtime_const_data_type, uniform_layout_type,
+                                            typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
+
+  using anonymous_device_type = Kokkos::Device<typename ViewType::execution_space, Kokkos::AnonymousSpace>;
+  static_assert(std::is_same_v<typename ViewType::uniform_nomemspace_type,
+                               Kokkos::View<typename ViewType::data_type, uniform_layout_type,
+                                            anonymous_device_type, Kokkos::MemoryTraits<0>>>);
+  static_assert(std::is_same_v<typename ViewType::uniform_const_nomemspace_type,
+                               Kokkos::View<typename ViewType::const_data_type, uniform_layout_type,
+                                            anonymous_device_type, Kokkos::MemoryTraits<0>>>);
+  static_assert(std::is_same_v<typename ViewType::uniform_runtime_nomemspace_type,
+                               Kokkos::View<typename data_analysis<DataType>::runtime_data_type, uniform_layout_type,
+                                            anonymous_device_type, Kokkos::MemoryTraits<0>>>);
+  static_assert(std::is_same_v<typename ViewType::uniform_runtime_const_nomemspace_type,
+                               Kokkos::View<typename data_analysis<DataType>::runtime_const_data_type, uniform_layout_type,
+                                            anonymous_device_type, Kokkos::MemoryTraits<0>>>);
+
+
+  // ==================================
+  // mdspan compatibility
+  // ==================================
+
+  static_assert(std::is_same_v<typename ViewType::layout_type, Layout>);
+  // Not supported yet
+  // static_assert(std::is_same_v<typename ViewType::extents_type, >);
+  // static_assert(std::is_same_v<typename ViewType::mapping_type, >);
+  // static_assert(std::is_same_v<typename ViewType::accessor_type, >);
+
+  static_assert(std::is_same_v<typename ViewType::element_type, ValueType>);
+  // should be remove_const_t<element_type>
+  static_assert(std::is_same_v<typename ViewType::value_type, ValueType>);
+  // should be extents_type::index_type
+  static_assert(std::is_same_v<typename ViewType::index_type, typename Space::memory_space::size_type>);
+  static_assert(std::is_same_v<typename ViewType::size_type, std::make_unsigned_t<typename ViewType::index_type>>);
+  static_assert(std::is_same_v<typename ViewType::rank_type, size_t>);
+
+  // should come from accessor_type
+  static_assert(std::is_same_v<typename ViewType::data_handle_type, typename ViewType::pointer_type>);
+  static_assert(std::is_same_v<typename ViewType::reference, typename ViewType::reference_type>);
+  return true;
+};
+
+template<class T, class ... ViewArgs>
+struct ViewParams {};
+
+template<class L, class S, class M, class HostMirrorSpace, class ValueType, class ReferenceType, class T, class ... ViewArgs>
+constexpr bool test_view_typedefs(ViewParams<T, ViewArgs...>) {
+  return test_view_typedefs_impl<Kokkos::View<T, ViewArgs...>, Kokkos::ViewTraits<T, ViewArgs...>,
+                            T, L, S, M, HostMirrorSpace, ValueType, ReferenceType>();
+}
+
+
+constexpr bool is_host_exec = Kokkos::Impl::MemorySpaceAccess<
+        Kokkos::DefaultExecutionSpace::memory_space,
+        Kokkos::HostSpace>::accessible;
+
+// These test take explicit template arguments for: LayoutType, Space, MemoryTraits, HostMirrorSpace, ValueType, ReferenceType
+// The ViewParams is just a type pack for the View template arguments
+static_assert(test_view_typedefs<
+                  Kokkos::DefaultExecutionSpace::array_layout,
+                  Kokkos::DefaultExecutionSpace, Kokkos::MemoryTraits<0>,
+                  std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace, Kokkos::HostSpace>,
+                  int, int&>
+                  (ViewParams<int>{}));
+// WTF: HostMirrorSpace is different from the first one ....
+static_assert(test_view_typedefs<
+                  Kokkos::DefaultExecutionSpace::array_layout,
+                  Kokkos::DefaultExecutionSpace, Kokkos::MemoryTraits<0>,
+                  std::conditional_t<is_host_exec, Kokkos::HostSpace, Kokkos::HostSpace>,
+                  int, int&>
+                  (ViewParams<int, Kokkos::DefaultExecutionSpace>{}));
+static_assert(test_view_typedefs<
+                  Kokkos::LayoutRight,
+                  Kokkos::HostSpace, Kokkos::MemoryTraits<0>,
+                  Kokkos::HostSpace,
+                  float, float&>
+                  (ViewParams<float**, Kokkos::HostSpace>{}));
+static_assert(test_view_typedefs<
+                  Kokkos::LayoutLeft,
+                  Kokkos::DefaultExecutionSpace, Kokkos::MemoryTraits<0>,
+                  std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace, Kokkos::HostSpace>,
+                  float, float&>
+                  (ViewParams<float*[3], Kokkos::LayoutLeft>{}));
+static_assert(test_view_typedefs<
+                  Kokkos::LayoutRight,
+                  Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, Kokkos::MemoryTraits<0>,
+                  Kokkos::HostSpace,
+                  float, float&>
+                  (ViewParams<float[2][3], Kokkos::LayoutRight, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>>{}));
+static_assert(test_view_typedefs<
+                  Kokkos::DefaultExecutionSpace::array_layout,
+                  Kokkos::DefaultExecutionSpace, Kokkos::MemoryTraits<Kokkos::Atomic>,
+                  std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace, Kokkos::HostSpace>,
+                  int, Kokkos::Impl::AtomicDataElement<Kokkos::ViewTraits<int, Kokkos::MemoryTraits<Kokkos::Atomic>>>>
+                  (ViewParams<int, Kokkos::MemoryTraits<Kokkos::Atomic>>{}));
+// clang-format on
+}  // namespace

--- a/core/unit_test/TestViewTypedefs.cpp
+++ b/core/unit_test/TestViewTypedefs.cpp
@@ -56,7 +56,7 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::const_data_type, typename data_analysis<DataType>::const_data_type>);
   static_assert(std::is_same_v<typename ViewType::non_const_data_type, typename data_analysis<DataType>::non_const_data_type>);
   
-  // these should be deprecated and for proper testing (I.e. where this is different from data_type)
+  // FIXME: these should be deprecated and for proper testing (I.e. where this is different from data_type)
   // we would need ensemble types which use the hidden View dimension facility of View (i.e. which make
   // "specialize" not void)
   static_assert(std::is_same_v<typename ViewType::scalar_array_type, DataType>);
@@ -64,15 +64,15 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::non_const_scalar_array_type, typename data_analysis<DataType>::non_const_data_type>);
   static_assert(std::is_same_v<typename ViewType::specialize, void>);
 
-  // value_type definition conflicts with mdspan value_type
+  // FIXME: value_type definition conflicts with mdspan value_type
   static_assert(std::is_same_v<typename ViewType::value_type, ValueType>);
   static_assert(std::is_same_v<typename ViewType::const_value_type, const ValueType>);
   static_assert(std::is_same_v<typename ViewType::non_const_value_type, std::remove_const_t<ValueType>>);
 
-  // should maybe be deprecated
+  // FIXME: should maybe be deprecated
   static_assert(std::is_same_v<typename ViewType::array_layout, Layout>);
 
-  // should be deprecated and is some complicated impl type
+  // FIXME: should be deprecated and is some complicated impl type
   static_assert(!std::is_void_v<typename ViewType::dimension>);
 
   static_assert(std::is_same_v<typename ViewType::execution_space, typename Space::execution_space>);
@@ -82,9 +82,9 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::host_mirror_space, HostMirrorSpace>);
   static_assert(std::is_same_v<typename ViewType::size_type, typename ViewType::memory_space::size_type>);
  
-  // should be deprecated in favor of reference
+  // FIXME: should be deprecated in favor of reference
   static_assert(std::is_same_v<typename ViewType::reference_type, ReferenceType>);
-  // should be deprecated in favor of data_handle_type
+  // FIXME: should be deprecated in favor of data_handle_type
   static_assert(std::is_same_v<typename ViewType::pointer_type, ValueType*>);
  
   // =========================================
@@ -113,7 +113,7 @@ constexpr bool test_view_typedefs_impl() {
                                                  std::is_same_v<Layout, Kokkos::LayoutRight>),
                                                  Kokkos::LayoutLeft, Layout>;
 
-  // Uhm uniformtype removes all memorytraits?
+  // FIXME: uniformtype removes all memorytraits?
   static_assert(std::is_same_v<typename ViewType::uniform_type,
                                Kokkos::View<typename ViewType::data_type, uniform_layout_type,
                                             typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
@@ -146,23 +146,23 @@ constexpr bool test_view_typedefs_impl() {
   // mdspan compatibility
   // ==================================
 
-  // This typedef caused some weird issue with MSVC+NVCC
+  // FIXME: This typedef caused some weird issue with MSVC+NVCC
   // static_assert(std::is_same_v<typename ViewType::layout_type, Layout>);
-  // Not supported yet
+  // FIXME: Not supported yet
   // static_assert(std::is_same_v<typename ViewType::extents_type, >);
   // static_assert(std::is_same_v<typename ViewType::mapping_type, >);
   // static_assert(std::is_same_v<typename ViewType::accessor_type, >);
 
   static_assert(std::is_same_v<typename ViewType::element_type, ValueType>);
-  // should be remove_const_t<element_type>
+  // FIXME: should be remove_const_t<element_type>
   static_assert(std::is_same_v<typename ViewType::value_type, ValueType>);
-  // should be extents_type::index_type
+  // FIXME: should be extents_type::index_type
   static_assert(std::is_same_v<typename ViewType::index_type, typename Space::memory_space::size_type>);
-  // this isn't given in View since for example SYCL has "int" as its size_type
+  // FIXME: this isn't given in View since for example SYCL has "int" as its size_type
   // static_assert(std::is_same_v<typename ViewType::size_type, std::make_unsigned_t<typename ViewType::index_type>>);
   static_assert(std::is_same_v<typename ViewType::rank_type, size_t>);
 
-  // should come from accessor_type
+  // FIXME: should come from accessor_type
   static_assert(std::is_same_v<typename ViewType::data_handle_type, typename ViewType::pointer_type>);
   static_assert(std::is_same_v<typename ViewType::reference, typename ViewType::reference_type>);
   return true;
@@ -182,9 +182,9 @@ constexpr bool test_view_typedefs(ViewParams<T, ViewArgs...>) {
 constexpr bool is_host_exec = std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
 
 #if defined(KOKKOS_ENABLE_CUDA_UVM) || defined(KOKKOS_ENABLE_IMPL_CUDA_UNIFIED_MEMORY) || defined(KOKKOS_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
-constexpr bool has_unified = true;
+constexpr bool has_unified_mem_space = true;
 #else
-constexpr bool has_unified = false;
+constexpr bool has_unified_mem_space = false;
 #endif
 
 // The test take explicit template arguments for: LayoutType, Space, MemoryTraits, HostMirrorSpace, ValueType, ReferenceType
@@ -198,7 +198,7 @@ namespace TestInt {
   // HostMirrorSpace is a mess so: if the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is not on its HostSpace
-                               std::conditional_t<!has_unified, Kokkos::HostSpace,
+                               std::conditional_t<!has_unified_mem_space, Kokkos::HostSpace,
   // otherwise its the following Device type
                                Kokkos::Device<Kokkos::DefaultHostExecutionSpace, typename Kokkos::DefaultExecutionSpace::memory_space>>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int, int&>(
@@ -213,7 +213,7 @@ namespace TestIntDefaultExecutionSpace {
   // HostMirrorSpace is a mess so: if the default exec is a host exec, it is HostSpace (note difference from View<int> ...)
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::HostSpace,
   // otherwise if unified memory is not on its also HostSpace!
-                               std::conditional_t<!has_unified, Kokkos::HostSpace,
+                               std::conditional_t<!has_unified_mem_space, Kokkos::HostSpace,
   // otherwise its the following memory space ...
                                Kokkos::DefaultExecutionSpace::memory_space>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int, int&>(
@@ -238,7 +238,7 @@ namespace TestFloatP3LayoutLeft {
   // HostMirrorSpace is a mess so: if the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is not on its HostSpace
-                               std::conditional_t<!has_unified, Kokkos::HostSpace,
+                               std::conditional_t<!has_unified_mem_space, Kokkos::HostSpace,
   // otherwise its the following Device type
                                Kokkos::Device<Kokkos::DefaultHostExecutionSpace, typename Kokkos::DefaultExecutionSpace::memory_space>>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, float, float&>(
@@ -263,7 +263,7 @@ namespace TestIntAtomic {
   // HostMirrorSpace is a mess so: if the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is not on its HostSpace
-                               std::conditional_t<!has_unified, Kokkos::HostSpace,
+                               std::conditional_t<!has_unified_mem_space, Kokkos::HostSpace,
   // otherwise its the following Device type
                                Kokkos::Device<Kokkos::DefaultHostExecutionSpace, typename Kokkos::DefaultExecutionSpace::memory_space>>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int,


### PR DESCRIPTION
This makes DynRankView not use implementation details of View, it also adds a test of typedefs to bring it in line with View. Note: the test as written passes with the old DynRankView implementation except for the couple of added mdspan compatibility typedefs. This PR sits on top of #7334 