### PR TITLE
OpenACC backend update to better support host

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -1472,6 +1472,10 @@ ifeq ($(KOKKOS_INTERNAL_USE_OPENACC), 1)
     ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 1)
       KOKKOS_CXXFLAGS += -acc=gpu,multicore
     endif
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_CLANG), 1)
+      KOKKOS_CXXFLAGS += --offload-arch=native
+      KOKKOS_LIBS += --offload-arch=native
+    endif
   endif
 endif
 

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -902,6 +902,7 @@ IF (KOKKOS_ENABLE_OPENACC)
     # to the host CPU if no available GPU is found.
     COMPILER_SPECIFIC_FLAGS(
       NVHPC -acc=gpu,multicore
+      Clang --offload-arch=native
     )
     MESSAGE(STATUS "No OpenACC target device is specificed; the OpenACC backend will be executed in an automatic fallback mode.")
   ENDIF()

--- a/core/src/OpenACC/Kokkos_OpenACCSpace.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.cpp
@@ -25,34 +25,14 @@
 #include <openacc.h>
 
 void *Kokkos::Experimental::OpenACCSpace::allocate(
-    const Kokkos::Experimental::OpenACC &exec_space,
-    const size_t arg_alloc_size) const {
-  return allocate(exec_space, "[unlabeled]", arg_alloc_size);
-}
-
-void *Kokkos::Experimental::OpenACCSpace::allocate(
     const size_t arg_alloc_size) const {
   return allocate("[unlabeled]", arg_alloc_size);
-}
-
-void *Kokkos::Experimental::OpenACCSpace::allocate(
-    const Kokkos::Experimental::OpenACC &exec_space, const char *arg_label,
-    const size_t arg_alloc_size, const size_t arg_logical_size) const {
-  return impl_allocate(exec_space, arg_label, arg_alloc_size, arg_logical_size);
 }
 
 void *Kokkos::Experimental::OpenACCSpace::allocate(
     const char *arg_label, const size_t arg_alloc_size,
     const size_t arg_logical_size) const {
   return impl_allocate(arg_label, arg_alloc_size, arg_logical_size);
-}
-
-void *Kokkos::Experimental::OpenACCSpace::impl_allocate(
-    const Kokkos::Experimental::OpenACC &exec_space, const char *arg_label,
-    const size_t arg_alloc_size, const size_t arg_logical_size,
-    const Kokkos::Tools::SpaceHandle arg_handle) const {
-  (void)exec_space;
-  return impl_allocate(arg_label, arg_alloc_size, arg_logical_size, arg_handle);
 }
 
 void *Kokkos::Experimental::OpenACCSpace::impl_allocate(

--- a/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
@@ -44,11 +44,18 @@ class OpenACCSpace {
   OpenACCSpace() = default;
 
   /**\brief  Allocate untracked memory in the space */
-  void* allocate(const Kokkos::Experimental::OpenACC& exec_space,
-                 const size_t arg_alloc_size) const;
-  void* allocate(const Kokkos::Experimental::OpenACC& exec_space,
-                 const char* arg_label, const size_t arg_alloc_size,
-                 const size_t arg_logical_size = 0) const;
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace& exec_space,
+                 const size_t arg_alloc_size) const {
+    return allocate(exec_space, "[unlabeled]", arg_alloc_size);
+  }
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace& exec_space, const char* arg_label,
+                 const size_t arg_alloc_size,
+                 const size_t arg_logical_size = 0) const {
+    return impl_allocate(exec_space, arg_label, arg_alloc_size,
+                         arg_logical_size);
+  }
   void* allocate(const size_t arg_alloc_size) const;
   void* allocate(const char* arg_label, const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;
@@ -62,11 +69,16 @@ class OpenACCSpace {
   static constexpr char const* name() { return "OpenACCSpace"; }
 
  private:
-  void* impl_allocate(const Kokkos::Experimental::OpenACC& exec_space,
-                      const char* arg_label, const size_t arg_alloc_size,
+  template <typename ExecutionSpace>
+  void* impl_allocate(const ExecutionSpace& exec_space, const char* arg_label,
+                      const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,
-                      const Kokkos::Tools::SpaceHandle =
-                          Kokkos::Tools::make_space_handle(name())) const;
+                      const Kokkos::Tools::SpaceHandle arg_handle =
+                          Kokkos::Tools::make_space_handle(name())) const {
+    (void)exec_space;
+    return impl_allocate(arg_label, arg_alloc_size, arg_logical_size,
+                         arg_handle);
+  }
   void* impl_allocate(const char* arg_label, const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,
                       const Kokkos::Tools::SpaceHandle =

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_MDRange.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_MDRange.hpp
@@ -34,12 +34,27 @@ void OpenACCParallelForMDRangePolicy(OpenACCCollapse, OpenACCIterateLeft,
   int end1   = end[1];
   int begin0 = begin[0];
   int end0   = end[0];
+
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
+// clang-format off
+#pragma acc parallel loop gang vector copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        functor(i0, i1);
+      }
+    }
+  } else {
 // clang-format off
 #pragma acc parallel loop gang vector collapse(2) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i1 = begin1; i1 < end1; ++i1) {
-    for (auto i0 = begin0; i0 < end0; ++i0) {
-      functor(i0, i1);
+    // clang-format on
+    for (auto i1 = begin1; i1 < end1; ++i1) {
+      for (auto i0 = begin0; i0 < end0; ++i0) {
+        functor(i0, i1);
+      }
     }
   }
 }
@@ -54,12 +69,27 @@ void OpenACCParallelForMDRangePolicy(OpenACCCollapse, OpenACCIterateRight,
   int end0   = end[0];
   int begin1 = begin[1];
   int end1   = end[1];
+
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
+// clang-format off
+#pragma acc parallel loop gang vector copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i1 = begin0; i1 < end1; ++i1) {
+      for (auto i0 = begin0; i0 < end0; ++i0) {
+        functor(i0, i1);
+      }
+    }
+  } else {
 // clang-format off
 #pragma acc parallel loop gang vector collapse(2) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i0 = begin0; i0 < end0; ++i0) {
-    for (auto i1 = begin1; i1 < end1; ++i1) {
-      functor(i0, i1);
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        functor(i0, i1);
+      }
     }
   }
 }
@@ -77,35 +107,65 @@ void OpenACCParallelForMDRangePolicy(OpenACCTile, OpenACCIterateLeft,
   int end1   = end[1];
   int begin0 = begin[0];
   int end0   = end[0];
-// clang-format off
-#pragma acc parallel loop gang vector tile(tile0,tile1) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i1 = begin1; i1 < end1; ++i1) {
-    for (auto i0 = begin0; i0 < end0; ++i0) {
-      functor(i0, i1);
-    }
-  }
-}
 
-template <class Functor>
-void OpenACCParallelForMDRangePolicy(OpenACCTile, OpenACCIterateRight,
-                                     Functor const& functor,
-                                     OpenACCMDRangeBegin<2> const& begin,
-                                     OpenACCMDRangeEnd<2> const& end,
-                                     OpenACCMDRangeTile<2> const& tile,
-                                     int async_arg) {
-  int tile1  = tile[1];
-  int tile0  = tile[0];
-  int begin0 = begin[0];
-  int end0   = end[0];
-  int begin1 = begin[1];
-  int end1   = end[1];
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
 // clang-format off
 #pragma acc parallel loop gang vector tile(tile1,tile0) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i0 = begin0; i0 < end0; ++i0) {
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        functor(i0, i1);
+      }
+    }
+  } else {
+// clang-format off
+#pragma acc parallel loop gang vector tile(tile0,tile1) copyin(functor) async(async_arg)
+    // clang-format on
     for (auto i1 = begin1; i1 < end1; ++i1) {
-      functor(i0, i1);
+      for (auto i0 = begin0; i0 < end0; ++i0) {
+        functor(i0, i1);
+      }
+    }
+  }
+}
+
+template <class Functor>
+void OpenACCParallelForMDRangePolicy(OpenACCTile, OpenACCIterateRight,
+                                     Functor const& functor,
+                                     OpenACCMDRangeBegin<2> const& begin,
+                                     OpenACCMDRangeEnd<2> const& end,
+                                     OpenACCMDRangeTile<2> const& tile,
+                                     int async_arg) {
+  int tile1  = tile[1];
+  int tile0  = tile[0];
+  int begin0 = begin[0];
+  int end0   = end[0];
+  int begin1 = begin[1];
+  int end1   = end[1];
+
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
+// clang-format off
+#pragma acc parallel loop gang vector tile(tile0,tile1) copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i1 = begin1; i1 < end1; ++i1) {
+      for (auto i0 = begin0; i0 < end0; ++i0) {
+        functor(i0, i1);
+      }
+    }
+  } else {
+// clang-format off
+#pragma acc parallel loop gang vector tile(tile1,tile0) copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        functor(i0, i1);
+      }
     }
   }
 }
@@ -122,13 +182,30 @@ void OpenACCParallelForMDRangePolicy(OpenACCCollapse, OpenACCIterateLeft,
   int end1   = end[1];
   int begin0 = begin[0];
   int end0   = end[0];
+
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
+// clang-format off
+#pragma acc parallel loop gang vector copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          functor(i0, i1, i2);
+        }
+      }
+    }
+  } else {
 // clang-format off
 #pragma acc parallel loop gang vector collapse(3) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i2 = begin2; i2 < end2; ++i2) {
-    for (auto i1 = begin1; i1 < end1; ++i1) {
-      for (auto i0 = begin0; i0 < end0; ++i0) {
-        functor(i0, i1, i2);
+    // clang-format on
+    for (auto i2 = begin2; i2 < end2; ++i2) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i0 = begin0; i0 < end0; ++i0) {
+          functor(i0, i1, i2);
+        }
       }
     }
   }
@@ -146,13 +223,30 @@ void OpenACCParallelForMDRangePolicy(OpenACCCollapse, OpenACCIterateRight,
   int end1   = end[1];
   int begin2 = begin[2];
   int end2   = end[2];
+
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
+// clang-format off
+#pragma acc parallel loop gang vector copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i2 = begin2; i2 < end2; ++i2) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i0 = begin0; i0 < end0; ++i0) {
+          functor(i0, i1, i2);
+        }
+      }
+    }
+  } else {
 // clang-format off
 #pragma acc parallel loop gang vector collapse(3) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i0 = begin0; i0 < end0; ++i0) {
-    for (auto i1 = begin1; i1 < end1; ++i1) {
-      for (auto i2 = begin2; i2 < end2; ++i2) {
-        functor(i0, i1, i2);
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          functor(i0, i1, i2);
+        }
       }
     }
   }
@@ -174,41 +268,75 @@ void OpenACCParallelForMDRangePolicy(OpenACCTile, OpenACCIterateLeft,
   int end1   = end[1];
   int begin0 = begin[0];
   int end0   = end[0];
-// clang-format off
-#pragma acc parallel loop gang vector tile(tile0,tile1,tile2) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i2 = begin2; i2 < end2; ++i2) {
-    for (auto i1 = begin1; i1 < end1; ++i1) {
-      for (auto i0 = begin0; i0 < end0; ++i0) {
-        functor(i0, i1, i2);
-      }
-    }
-  }
-}
 
-template <class Functor>
-void OpenACCParallelForMDRangePolicy(OpenACCTile, OpenACCIterateRight,
-                                     Functor const& functor,
-                                     OpenACCMDRangeBegin<3> const& begin,
-                                     OpenACCMDRangeEnd<3> const& end,
-                                     OpenACCMDRangeTile<3> const& tile,
-                                     int async_arg) {
-  int tile2  = tile[2];
-  int tile1  = tile[1];
-  int tile0  = tile[0];
-  int begin0 = begin[0];
-  int end0   = end[0];
-  int begin1 = begin[1];
-  int end1   = end[1];
-  int begin2 = begin[2];
-  int end2   = end[2];
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
 // clang-format off
 #pragma acc parallel loop gang vector tile(tile2,tile1,tile0) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i0 = begin0; i0 < end0; ++i0) {
-    for (auto i1 = begin1; i1 < end1; ++i1) {
-      for (auto i2 = begin2; i2 < end2; ++i2) {
-        functor(i0, i1, i2);
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          functor(i0, i1, i2);
+        }
+      }
+    }
+  } else {
+// clang-format off
+#pragma acc parallel loop gang vector tile(tile0,tile1,tile2) copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i2 = begin2; i2 < end2; ++i2) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i0 = begin0; i0 < end0; ++i0) {
+          functor(i0, i1, i2);
+        }
+      }
+    }
+  }
+}
+
+template <class Functor>
+void OpenACCParallelForMDRangePolicy(OpenACCTile, OpenACCIterateRight,
+                                     Functor const& functor,
+                                     OpenACCMDRangeBegin<3> const& begin,
+                                     OpenACCMDRangeEnd<3> const& end,
+                                     OpenACCMDRangeTile<3> const& tile,
+                                     int async_arg) {
+  int tile2  = tile[2];
+  int tile1  = tile[1];
+  int tile0  = tile[0];
+  int begin0 = begin[0];
+  int end0   = end[0];
+  int begin1 = begin[1];
+  int end1   = end[1];
+  int begin2 = begin[2];
+  int end2   = end[2];
+
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
+// clang-format off
+#pragma acc parallel loop gang vector tile(tile0,tile1,tile2) copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i2 = begin2; i2 < end2; ++i2) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i0 = begin0; i0 < end0; ++i0) {
+          functor(i0, i1, i2);
+        }
+      }
+    }
+  } else {
+// clang-format off
+#pragma acc parallel loop gang vector tile(tile2,tile1,tile0) copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          functor(i0, i1, i2);
+        }
       }
     }
   }
@@ -228,14 +356,33 @@ void OpenACCParallelForMDRangePolicy(OpenACCCollapse, OpenACCIterateLeft,
   int end1   = end[1];
   int begin0 = begin[0];
   int end0   = end[0];
+
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
+// clang-format off
+#pragma acc parallel loop gang vector copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          for (auto i3 = begin3; i3 < end3; ++i3) {
+            functor(i0, i1, i2, i3);
+          }
+        }
+      }
+    }
+  } else {
 // clang-format off
 #pragma acc parallel loop gang vector collapse(4) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i3 = begin3; i3 < end3; ++i3) {
-    for (auto i2 = begin2; i2 < end2; ++i2) {
-      for (auto i1 = begin1; i1 < end1; ++i1) {
-        for (auto i0 = begin0; i0 < end0; ++i0) {
-          functor(i0, i1, i2, i3);
+    // clang-format on
+    for (auto i3 = begin3; i3 < end3; ++i3) {
+      for (auto i2 = begin2; i2 < end2; ++i2) {
+        for (auto i1 = begin1; i1 < end1; ++i1) {
+          for (auto i0 = begin0; i0 < end0; ++i0) {
+            functor(i0, i1, i2, i3);
+          }
         }
       }
     }
@@ -256,14 +403,33 @@ void OpenACCParallelForMDRangePolicy(OpenACCCollapse, OpenACCIterateRight,
   int end2   = end[2];
   int begin3 = begin[3];
   int end3   = end[3];
+
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
+// clang-format off
+#pragma acc parallel loop gang vector copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i3 = begin3; i3 < end3; ++i3) {
+      for (auto i2 = begin2; i2 < end2; ++i2) {
+        for (auto i1 = begin1; i1 < end1; ++i1) {
+          for (auto i0 = begin0; i0 < end0; ++i0) {
+            functor(i0, i1, i2, i3);
+          }
+        }
+      }
+    }
+  } else {
 // clang-format off
 #pragma acc parallel loop gang vector collapse(4) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i0 = begin0; i0 < end0; ++i0) {
-    for (auto i1 = begin1; i1 < end1; ++i1) {
-      for (auto i2 = begin2; i2 < end2; ++i2) {
-        for (auto i3 = begin3; i3 < end3; ++i3) {
-          functor(i0, i1, i2, i3);
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          for (auto i3 = begin3; i3 < end3; ++i3) {
+            functor(i0, i1, i2, i3);
+          }
         }
       }
     }
@@ -289,47 +455,85 @@ void OpenACCParallelForMDRangePolicy(OpenACCTile, OpenACCIterateLeft,
   int end1   = end[1];
   int begin0 = begin[0];
   int end0   = end[0];
-// clang-format off
-#pragma acc parallel loop gang vector tile(tile0,tile1,tile2,tile3) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i3 = begin3; i3 < end3; ++i3) {
-    for (auto i2 = begin2; i2 < end2; ++i2) {
-      for (auto i1 = begin1; i1 < end1; ++i1) {
-        for (auto i0 = begin0; i0 < end0; ++i0) {
-          functor(i0, i1, i2, i3);
-        }
-      }
-    }
-  }
-}
 
-template <class Functor>
-void OpenACCParallelForMDRangePolicy(OpenACCTile, OpenACCIterateRight,
-                                     Functor const& functor,
-                                     OpenACCMDRangeBegin<4> const& begin,
-                                     OpenACCMDRangeEnd<4> const& end,
-                                     OpenACCMDRangeTile<4> const& tile,
-                                     int async_arg) {
-  int tile3  = tile[3];
-  int tile2  = tile[2];
-  int tile1  = tile[1];
-  int tile0  = tile[0];
-  int begin0 = begin[0];
-  int end0   = end[0];
-  int begin1 = begin[1];
-  int end1   = end[1];
-  int begin2 = begin[2];
-  int end2   = end[2];
-  int begin3 = begin[3];
-  int end3   = end[3];
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
 // clang-format off
 #pragma acc parallel loop gang vector tile(tile3,tile2,tile1,tile0) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i0 = begin0; i0 < end0; ++i0) {
-    for (auto i1 = begin1; i1 < end1; ++i1) {
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          for (auto i3 = begin3; i3 < end3; ++i3) {
+            functor(i0, i1, i2, i3);
+          }
+        }
+      }
+    }
+  } else {
+// clang-format off
+#pragma acc parallel loop gang vector tile(tile0,tile1,tile2,tile3) copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i3 = begin3; i3 < end3; ++i3) {
       for (auto i2 = begin2; i2 < end2; ++i2) {
-        for (auto i3 = begin3; i3 < end3; ++i3) {
-          functor(i0, i1, i2, i3);
+        for (auto i1 = begin1; i1 < end1; ++i1) {
+          for (auto i0 = begin0; i0 < end0; ++i0) {
+            functor(i0, i1, i2, i3);
+          }
+        }
+      }
+    }
+  }
+}
+
+template <class Functor>
+void OpenACCParallelForMDRangePolicy(OpenACCTile, OpenACCIterateRight,
+                                     Functor const& functor,
+                                     OpenACCMDRangeBegin<4> const& begin,
+                                     OpenACCMDRangeEnd<4> const& end,
+                                     OpenACCMDRangeTile<4> const& tile,
+                                     int async_arg) {
+  int tile3  = tile[3];
+  int tile2  = tile[2];
+  int tile1  = tile[1];
+  int tile0  = tile[0];
+  int begin0 = begin[0];
+  int end0   = end[0];
+  int begin1 = begin[1];
+  int end1   = end[1];
+  int begin2 = begin[2];
+  int end2   = end[2];
+  int begin3 = begin[3];
+  int end3   = end[3];
+
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
+// clang-format off
+#pragma acc parallel loop gang vector tile(tile0,tile1,tile2,tile3) copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i3 = begin3; i3 < end3; ++i3) {
+      for (auto i2 = begin2; i2 < end2; ++i2) {
+        for (auto i1 = begin1; i1 < end1; ++i1) {
+          for (auto i0 = begin0; i0 < end0; ++i0) {
+            functor(i0, i1, i2, i3);
+          }
+        }
+      }
+    }
+  } else {
+// clang-format off
+#pragma acc parallel loop gang vector tile(tile3,tile2,tile1,tile0) copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          for (auto i3 = begin3; i3 < end3; ++i3) {
+            functor(i0, i1, i2, i3);
+          }
         }
       }
     }
@@ -352,15 +556,36 @@ void OpenACCParallelForMDRangePolicy(OpenACCCollapse, OpenACCIterateLeft,
   int end1   = end[1];
   int begin0 = begin[0];
   int end0   = end[0];
+
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
+// clang-format off
+#pragma acc parallel loop gang vector copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          for (auto i3 = begin3; i3 < end3; ++i3) {
+            for (auto i4 = begin4; i4 < end4; ++i4) {
+              functor(i0, i1, i2, i3, i4);
+            }
+          }
+        }
+      }
+    }
+  } else {
 // clang-format off
 #pragma acc parallel loop gang vector collapse(5) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i4 = begin4; i4 < end4; ++i4) {
-    for (auto i3 = begin3; i3 < end3; ++i3) {
-      for (auto i2 = begin2; i2 < end2; ++i2) {
-        for (auto i1 = begin1; i1 < end1; ++i1) {
-          for (auto i0 = begin0; i0 < end0; ++i0) {
-            functor(i0, i1, i2, i3, i4);
+    // clang-format on
+    for (auto i4 = begin4; i4 < end4; ++i4) {
+      for (auto i3 = begin3; i3 < end3; ++i3) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          for (auto i1 = begin1; i1 < end1; ++i1) {
+            for (auto i0 = begin0; i0 < end0; ++i0) {
+              functor(i0, i1, i2, i3, i4);
+            }
           }
         }
       }
@@ -384,15 +609,36 @@ void OpenACCParallelForMDRangePolicy(OpenACCCollapse, OpenACCIterateRight,
   int end3   = end[3];
   int begin4 = begin[4];
   int end4   = end[4];
+
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
+// clang-format off
+#pragma acc parallel loop gang vector copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i4 = begin4; i4 < end4; ++i4) {
+      for (auto i3 = begin3; i3 < end3; ++i3) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          for (auto i1 = begin1; i1 < end1; ++i1) {
+            for (auto i0 = begin0; i0 < end0; ++i0) {
+              functor(i0, i1, i2, i3, i4);
+            }
+          }
+        }
+      }
+    }
+  } else {
 // clang-format off
 #pragma acc parallel loop gang vector collapse(5) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i0 = begin0; i0 < end0; ++i0) {
-    for (auto i1 = begin1; i1 < end1; ++i1) {
-      for (auto i2 = begin2; i2 < end2; ++i2) {
-        for (auto i3 = begin3; i3 < end3; ++i3) {
-          for (auto i4 = begin4; i4 < end4; ++i4) {
-            functor(i0, i1, i2, i3, i4);
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          for (auto i3 = begin3; i3 < end3; ++i3) {
+            for (auto i4 = begin4; i4 < end4; ++i4) {
+              functor(i0, i1, i2, i3, i4);
+            }
           }
         }
       }
@@ -422,53 +668,95 @@ void OpenACCParallelForMDRangePolicy(OpenACCTile, OpenACCIterateLeft,
   int end1   = end[1];
   int begin0 = begin[0];
   int end0   = end[0];
-// clang-format off
-#pragma acc parallel loop gang vector tile(tile0,tile1,tile2,tile3,tile4) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i4 = begin4; i4 < end4; ++i4) {
-    for (auto i3 = begin3; i3 < end3; ++i3) {
-      for (auto i2 = begin2; i2 < end2; ++i2) {
-        for (auto i1 = begin1; i1 < end1; ++i1) {
-          for (auto i0 = begin0; i0 < end0; ++i0) {
-            functor(i0, i1, i2, i3, i4);
-          }
-        }
-      }
-    }
-  }
-}
 
-template <class Functor>
-void OpenACCParallelForMDRangePolicy(OpenACCTile, OpenACCIterateRight,
-                                     Functor const& functor,
-                                     OpenACCMDRangeBegin<5> const& begin,
-                                     OpenACCMDRangeEnd<5> const& end,
-                                     OpenACCMDRangeTile<5> const& tile,
-                                     int async_arg) {
-  int tile4  = tile[4];
-  int tile3  = tile[3];
-  int tile2  = tile[2];
-  int tile1  = tile[1];
-  int tile0  = tile[0];
-  int begin0 = begin[0];
-  int end0   = end[0];
-  int begin1 = begin[1];
-  int end1   = end[1];
-  int begin2 = begin[2];
-  int end2   = end[2];
-  int begin3 = begin[3];
-  int end3   = end[3];
-  int begin4 = begin[4];
-  int end4   = end[4];
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
 // clang-format off
 #pragma acc parallel loop gang vector tile(tile4,tile3,tile2,tile1,tile0) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i0 = begin0; i0 < end0; ++i0) {
-    for (auto i1 = begin1; i1 < end1; ++i1) {
-      for (auto i2 = begin2; i2 < end2; ++i2) {
-        for (auto i3 = begin3; i3 < end3; ++i3) {
-          for (auto i4 = begin4; i4 < end4; ++i4) {
-            functor(i0, i1, i2, i3, i4);
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          for (auto i3 = begin3; i3 < end3; ++i3) {
+            for (auto i4 = begin4; i4 < end4; ++i4) {
+              functor(i0, i1, i2, i3, i4);
+            }
+          }
+        }
+      }
+    }
+  } else {
+// clang-format off
+#pragma acc parallel loop gang vector tile(tile0,tile1,tile2,tile3,tile4) copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i4 = begin4; i4 < end4; ++i4) {
+      for (auto i3 = begin3; i3 < end3; ++i3) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          for (auto i1 = begin1; i1 < end1; ++i1) {
+            for (auto i0 = begin0; i0 < end0; ++i0) {
+              functor(i0, i1, i2, i3, i4);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+template <class Functor>
+void OpenACCParallelForMDRangePolicy(OpenACCTile, OpenACCIterateRight,
+                                     Functor const& functor,
+                                     OpenACCMDRangeBegin<5> const& begin,
+                                     OpenACCMDRangeEnd<5> const& end,
+                                     OpenACCMDRangeTile<5> const& tile,
+                                     int async_arg) {
+  int tile4  = tile[4];
+  int tile3  = tile[3];
+  int tile2  = tile[2];
+  int tile1  = tile[1];
+  int tile0  = tile[0];
+  int begin0 = begin[0];
+  int end0   = end[0];
+  int begin1 = begin[1];
+  int end1   = end[1];
+  int begin2 = begin[2];
+  int end2   = end[2];
+  int begin3 = begin[3];
+  int end3   = end[3];
+  int begin4 = begin[4];
+  int end4   = end[4];
+
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
+// clang-format off
+#pragma acc parallel loop gang vector tile(tile0,tile1,tile2,tile3,tile4) copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i4 = begin4; i4 < end4; ++i4) {
+      for (auto i3 = begin3; i3 < end3; ++i3) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          for (auto i1 = begin1; i1 < end1; ++i1) {
+            for (auto i0 = begin0; i0 < end0; ++i0) {
+              functor(i0, i1, i2, i3, i4);
+            }
+          }
+        }
+      }
+    }
+  } else {
+// clang-format off
+#pragma acc parallel loop gang vector tile(tile4,tile3,tile2,tile1,tile0) copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          for (auto i3 = begin3; i3 < end3; ++i3) {
+            for (auto i4 = begin4; i4 < end4; ++i4) {
+              functor(i0, i1, i2, i3, i4);
+            }
           }
         }
       }
@@ -494,16 +782,39 @@ void OpenACCParallelForMDRangePolicy(OpenACCCollapse, OpenACCIterateLeft,
   int end1   = end[1];
   int begin0 = begin[0];
   int end0   = end[0];
+
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
+// clang-format off
+#pragma acc parallel loop gang vector copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          for (auto i3 = begin3; i3 < end3; ++i3) {
+            for (auto i4 = begin4; i4 < end4; ++i4) {
+              for (auto i5 = begin5; i5 < end5; ++i5) {
+                functor(i0, i1, i2, i3, i4, i5);
+              }
+            }
+          }
+        }
+      }
+    }
+  } else {
 // clang-format off
 #pragma acc parallel loop gang vector collapse(6) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i5 = begin5; i5 < end5; ++i5) {
-    for (auto i4 = begin4; i4 < end4; ++i4) {
-      for (auto i3 = begin3; i3 < end3; ++i3) {
-        for (auto i2 = begin2; i2 < end2; ++i2) {
-          for (auto i1 = begin1; i1 < end1; ++i1) {
-            for (auto i0 = begin0; i0 < end0; ++i0) {
-              functor(i0, i1, i2, i3, i4, i5);
+    // clang-format on
+    for (auto i5 = begin5; i5 < end5; ++i5) {
+      for (auto i4 = begin4; i4 < end4; ++i4) {
+        for (auto i3 = begin3; i3 < end3; ++i3) {
+          for (auto i2 = begin2; i2 < end2; ++i2) {
+            for (auto i1 = begin1; i1 < end1; ++i1) {
+              for (auto i0 = begin0; i0 < end0; ++i0) {
+                functor(i0, i1, i2, i3, i4, i5);
+              }
             }
           }
         }
@@ -530,16 +841,39 @@ void OpenACCParallelForMDRangePolicy(OpenACCCollapse, OpenACCIterateRight,
   int end4   = end[4];
   int begin5 = begin[5];
   int end5   = end[5];
+
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
+// clang-format off
+#pragma acc parallel loop gang vector copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i5 = begin5; i5 < end5; ++i5) {
+      for (auto i4 = begin4; i4 < end4; ++i4) {
+        for (auto i3 = begin3; i3 < end3; ++i3) {
+          for (auto i2 = begin2; i2 < end2; ++i2) {
+            for (auto i1 = begin1; i1 < end1; ++i1) {
+              for (auto i0 = begin0; i0 < end0; ++i0) {
+                functor(i0, i1, i2, i3, i4, i5);
+              }
+            }
+          }
+        }
+      }
+    }
+  } else {
 // clang-format off
 #pragma acc parallel loop gang vector collapse(6) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i0 = begin0; i0 < end0; ++i0) {
-    for (auto i1 = begin1; i1 < end1; ++i1) {
-      for (auto i2 = begin2; i2 < end2; ++i2) {
-        for (auto i3 = begin3; i3 < end3; ++i3) {
-          for (auto i4 = begin4; i4 < end4; ++i4) {
-            for (auto i5 = begin5; i5 < end5; ++i5) {
-              functor(i0, i1, i2, i3, i4, i5);
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          for (auto i3 = begin3; i3 < end3; ++i3) {
+            for (auto i4 = begin4; i4 < end4; ++i4) {
+              for (auto i5 = begin5; i5 < end5; ++i5) {
+                functor(i0, i1, i2, i3, i4, i5);
+              }
             }
           }
         }
@@ -573,16 +907,39 @@ void OpenACCParallelForMDRangePolicy(OpenACCTile, OpenACCIterateLeft,
   int end1   = end[1];
   int begin0 = begin[0];
   int end0   = end[0];
+
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
+// clang-format off
+#pragma acc parallel loop gang vector tile(tile5,tile4,tile3,tile2,tile1,tile0) copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          for (auto i3 = begin3; i3 < end3; ++i3) {
+            for (auto i4 = begin4; i4 < end4; ++i4) {
+              for (auto i5 = begin5; i5 < end5; ++i5) {
+                functor(i0, i1, i2, i3, i4, i5);
+              }
+            }
+          }
+        }
+      }
+    }
+  } else {
 // clang-format off
 #pragma acc parallel loop gang vector tile(tile0,tile1,tile2,tile3,tile4,tile5) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i5 = begin5; i5 < end5; ++i5) {
-    for (auto i4 = begin4; i4 < end4; ++i4) {
-      for (auto i3 = begin3; i3 < end3; ++i3) {
-        for (auto i2 = begin2; i2 < end2; ++i2) {
-          for (auto i1 = begin1; i1 < end1; ++i1) {
-            for (auto i0 = begin0; i0 < end0; ++i0) {
-              functor(i0, i1, i2, i3, i4, i5);
+    // clang-format on
+    for (auto i5 = begin5; i5 < end5; ++i5) {
+      for (auto i4 = begin4; i4 < end4; ++i4) {
+        for (auto i3 = begin3; i3 < end3; ++i3) {
+          for (auto i2 = begin2; i2 < end2; ++i2) {
+            for (auto i1 = begin1; i1 < end1; ++i1) {
+              for (auto i0 = begin0; i0 < end0; ++i0) {
+                functor(i0, i1, i2, i3, i4, i5);
+              }
             }
           }
         }
@@ -616,16 +973,39 @@ void OpenACCParallelForMDRangePolicy(OpenACCTile, OpenACCIterateRight,
   int end4   = end[4];
   int begin5 = begin[5];
   int end5   = end[5];
+
+  acc_device_t target_dev;
+  target_dev = acc_get_device_type();
+
+  if (target_dev == acc_device_host) {
+// clang-format off
+#pragma acc parallel loop gang vector tile(tile0,tile1,tile2,tile3,tile4,tile5) copyin(functor) async(async_arg)
+    // clang-format on
+    for (auto i5 = begin5; i5 < end5; ++i5) {
+      for (auto i4 = begin4; i4 < end4; ++i4) {
+        for (auto i3 = begin3; i3 < end3; ++i3) {
+          for (auto i2 = begin2; i2 < end2; ++i2) {
+            for (auto i1 = begin1; i1 < end1; ++i1) {
+              for (auto i0 = begin0; i0 < end0; ++i0) {
+                functor(i0, i1, i2, i3, i4, i5);
+              }
+            }
+          }
+        }
+      }
+    }
+  } else {
 // clang-format off
 #pragma acc parallel loop gang vector tile(tile5,tile4,tile3,tile2,tile1,tile0) copyin(functor) async(async_arg)
-  // clang-format on
-  for (auto i0 = begin0; i0 < end0; ++i0) {
-    for (auto i1 = begin1; i1 < end1; ++i1) {
-      for (auto i2 = begin2; i2 < end2; ++i2) {
-        for (auto i3 = begin3; i3 < end3; ++i3) {
-          for (auto i4 = begin4; i4 < end4; ++i4) {
-            for (auto i5 = begin5; i5 < end5; ++i5) {
-              functor(i0, i1, i2, i3, i4, i5);
+    // clang-format on
+    for (auto i0 = begin0; i0 < end0; ++i0) {
+      for (auto i1 = begin1; i1 < end1; ++i1) {
+        for (auto i2 = begin2; i2 < end2; ++i2) {
+          for (auto i3 = begin3; i3 < end3; ++i3) {
+            for (auto i4 = begin4; i4 < end4; ++i4) {
+              for (auto i5 = begin5; i5 < end5; ++i5) {
+                functor(i0, i1, i2, i3, i4, i5);
+              }
             }
           }
         }

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp
@@ -24,6 +24,14 @@
 #include <Kokkos_Parallel.hpp>
 #include <type_traits>
 
+// FIXME_OPENACC FIXME_NVHPC NVHPC 24.5 generates very inefficient code for
+// gang(static:*)
+#ifdef KOKKOS_COMPILER_NVHPC
+#define KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_RANGE_GANG gang(static : 32)
+#else
+#define KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_RANGE_GANG gang(static : *)
+#endif
+
 namespace Kokkos::Experimental::Impl {
 
 // primary template: catch-all non-implemented custom reducers
@@ -111,68 +119,68 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
   }
 };
 
-#define KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_DISPATCH_SCHEDULE(REDUCER,    \
-                                                              OPERATOR)   \
-  namespace Kokkos::Experimental::Impl {                                  \
-  template <class IndexType, class ValueType, class Functor>              \
-  void OpenACCParallelReduce##REDUCER(Schedule<Static>, int chunk_size,   \
-                                      IndexType begin, IndexType end,     \
-                                      ValueType& aval,                    \
-                                      Functor const& afunctor,            \
-                                      int async_arg) {                    \
-    /* FIXME_OPENACC FIXME_NVHPC workaround compiler bug (incorrect scope \
-       analysis)                                                          \
-       NVC++-S-1067-Cannot determine bounds for array - functor */        \
-    auto const functor(afunctor);                                         \
-    auto val = aval;                                                      \
-    if (chunk_size >= 1) {                                                \
+#define KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_DISPATCH_SCHEDULE(REDUCER,      \
+                                                              OPERATOR)     \
+  namespace Kokkos::Experimental::Impl {                                    \
+  template <class IndexType, class ValueType, class Functor>                \
+  void OpenACCParallelReduce##REDUCER(Schedule<Static>, int chunk_size,     \
+                                      IndexType begin, IndexType end,       \
+                                      ValueType& aval,                      \
+                                      Functor const& afunctor,              \
+                                      int async_arg) {                      \
+    /* FIXME_OPENACC FIXME_NVHPC workaround compiler bug (incorrect scope   \
+       analysis)                                                            \
+       NVC++-S-1067-Cannot determine bounds for array - functor */          \
+    auto const functor(afunctor);                                           \
+    auto val = aval;                                                        \
+    if (chunk_size >= OpenACC_Traits::WarpSize) {                           \
+      /* clang-format off */                                              \
+      KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang(static:chunk_size) vector reduction(OPERATOR:val) copyin(functor) async(async_arg)) \
+      /* clang-format on */                                                 \
+      for (auto i = begin; i < end; i++) {                                  \
+        functor(i, val);                                                    \
+      }                                                                     \
+    } else {                                                                \
       /* clang-format off */ \
-      KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang(static:chunk_size) vector reduction(OPERATOR:val) copyin(functor) async(async_arg))                                            \
-      /* clang-format on */                                               \
-      for (auto i = begin; i < end; i++) {                                \
-        functor(i, val);                                                  \
-      }                                                                   \
-    } else {                                                              \
+      KOKKOS_IMPL_ACC_PRAGMA(parallel loop KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_RANGE_GANG vector reduction(OPERATOR:val) copyin(functor) async(async_arg))                                              \
+      /* clang-format on */                                                 \
+      for (auto i = begin; i < end; i++) {                                  \
+        functor(i, val);                                                    \
+      }                                                                     \
+    }                                                                       \
+    acc_wait(async_arg);                                                    \
+    aval = val;                                                             \
+  }                                                                         \
+                                                                            \
+  template <class IndexType, class ValueType, class Functor>                \
+  void OpenACCParallelReduce##REDUCER(Schedule<Dynamic>, int chunk_size,    \
+                                      IndexType begin, IndexType end,       \
+                                      ValueType& aval,                      \
+                                      Functor const& afunctor,              \
+                                      int async_arg) {                      \
+    /* FIXME_OPENACC FIXME_NVHPC workaround compiler bug (incorrect scope   \
+       analysis)                                                            \
+       NVC++-S-1067-Cannot determine bounds for array - functor */          \
+    auto const functor(afunctor);                                           \
+    auto val = aval;                                                        \
+    if (chunk_size >= OpenACC_Traits::WarpSize) {                           \
       /* clang-format off */ \
-      KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang(static:*) vector reduction(OPERATOR:val) copyin(functor) async(async_arg))                                            \
-      /* clang-format on */                                               \
-      for (auto i = begin; i < end; i++) {                                \
-        functor(i, val);                                                  \
-      }                                                                   \
-    }                                                                     \
-    acc_wait(async_arg);                                                  \
-    aval = val;                                                           \
-  }                                                                       \
-                                                                          \
-  template <class IndexType, class ValueType, class Functor>              \
-  void OpenACCParallelReduce##REDUCER(Schedule<Dynamic>, int chunk_size,  \
-                                      IndexType begin, IndexType end,     \
-                                      ValueType& aval,                    \
-                                      Functor const& afunctor,            \
-                                      int async_arg) {                    \
-    /* FIXME_OPENACC FIXME_NVHPC workaround compiler bug (incorrect scope \
-       analysis)                                                          \
-       NVC++-S-1067-Cannot determine bounds for array - functor */        \
-    auto const functor(afunctor);                                         \
-    auto val = aval;                                                      \
-    if (chunk_size >= 1) {                                                \
+      KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang(static:chunk_size) vector reduction(OPERATOR:val) copyin(functor) async(async_arg))                                              \
+      /* clang-format on */                                                 \
+      for (auto i = begin; i < end; i++) {                                  \
+        functor(i, val);                                                    \
+      }                                                                     \
+    } else {                                                                \
       /* clang-format off */ \
-      KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang(static:chunk_size) vector reduction(OPERATOR:val) copyin(functor) async(async_arg))                                            \
-      /* clang-format on */                                               \
-      for (auto i = begin; i < end; i++) {                                \
-        functor(i, val);                                                  \
-      }                                                                   \
-    } else {                                                              \
-      /* clang-format off */ \
-      KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang vector reduction(OPERATOR:val) copyin(functor) async(async_arg))                                            \
-      /* clang-format on */                                               \
-      for (auto i = begin; i < end; i++) {                                \
-        functor(i, val);                                                  \
-      }                                                                   \
-    }                                                                     \
-    acc_wait(async_arg);                                                  \
-    aval = val;                                                           \
-  }                                                                       \
+      KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang vector reduction(OPERATOR:val) copyin(functor) async(async_arg))                                              \
+      /* clang-format on */                                                 \
+      for (auto i = begin; i < end; i++) {                                  \
+        functor(i, val);                                                    \
+      }                                                                     \
+    }                                                                       \
+    acc_wait(async_arg);                                                    \
+    aval = val;                                                             \
+  }                                                                         \
   }  // namespace Kokkos::Experimental::Impl
 
 #define KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_HELPER(REDUCER, OPERATOR)          \

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelScan_Range.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelScan_Range.hpp
@@ -73,7 +73,7 @@ class ParallelScanOpenACCBase {
   void OpenACCParallelScanRangePolicy(const IndexType begin,
                                       const IndexType end, IndexType chunk_size,
                                       const int async_arg) const {
-    if (chunk_size > 1) {
+    if (chunk_size >= Kokkos::Experimental::Impl::OpenACC_Traits::WarpSize) {
       if (!Impl::is_integral_power_of_two(chunk_size))
         Kokkos::abort(
             "RangePolicy blocking granularity must be power of two to be used "

--- a/core/src/OpenACC/Kokkos_OpenACC_SharedAllocationRecord.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_SharedAllocationRecord.cpp
@@ -22,5 +22,10 @@
 
 #include <impl/Kokkos_SharedAlloc_timpl.hpp>
 
+#if defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)
+KOKKOS_IMPL_SHARED_ALLOCATION_RECORD_EXPLICIT_INSTANTIATION(
+    Kokkos::Experimental::OpenACCSpace);
+#else
 KOKKOS_IMPL_HOST_INACCESSIBLE_SHARED_ALLOCATION_RECORD_EXPLICIT_INSTANTIATION(
     Kokkos::Experimental::OpenACCSpace);
+#endif

--- a/core/src/OpenACC/Kokkos_OpenACC_SharedAllocationRecord.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_SharedAllocationRecord.hpp
@@ -20,7 +20,12 @@
 #include <OpenACC/Kokkos_OpenACCSpace.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>
 
+#if defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)
+KOKKOS_IMPL_SHARED_ALLOCATION_SPECIALIZATION(
+    Kokkos::Experimental::OpenACCSpace);
+#else
 KOKKOS_IMPL_HOST_INACCESSIBLE_SHARED_ALLOCATION_SPECIALIZATION(
     Kokkos::Experimental::OpenACCSpace);
+#endif
 
 #endif

--- a/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
@@ -21,6 +21,9 @@
 #include <impl/Kokkos_Traits.hpp>
 #include <OpenACC/Kokkos_OpenACC.hpp>
 #include <Kokkos_ExecPolicy.hpp>
+#ifdef KOKKOS_COMPILER_CLANG
+#include <omp.h>
+#endif
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -42,10 +45,10 @@ class OpenACCTeamMember {
 
   scratch_memory_space m_team_shared;
   int m_team_scratch_size[2];
-  int m_team_rank;
-  int m_team_size;
   int m_league_rank;
   int m_league_size;
+  int m_team_rank;
+  int m_team_size;
   int m_vector_length;
 
  public:
@@ -67,7 +70,11 @@ class OpenACCTeamMember {
 
   KOKKOS_FUNCTION int league_rank() const { return m_league_rank; }
   KOKKOS_FUNCTION int league_size() const { return m_league_size; }
+#ifdef KOKKOS_COMPILER_CLANG
+  KOKKOS_FUNCTION int team_rank() const { return omp_get_thread_num(); }
+#else
   KOKKOS_FUNCTION int team_rank() const { return m_team_rank; }
+#endif
   KOKKOS_FUNCTION int vector_length() const { return m_vector_length; }
   KOKKOS_FUNCTION int team_size() const { return m_team_size; }
 
@@ -134,16 +141,29 @@ class OpenACCTeamMember {
                     const int team_size,
                     const int vector_length)  // const TeamPolicyInternal<
                                               // OpenACC, Properties ...> & team
-      : m_team_size(team_size),
-        m_league_rank(league_rank),
+      : m_league_rank(league_rank),
         m_league_size(league_size),
+        m_team_size(team_size),
         m_vector_length(vector_length) {
 #ifdef KOKKOS_COMPILER_NVHPC
     m_team_rank = __pgi_vectoridx();
 #else
+#ifdef KOKKOS_COMPILER_CLANG
+    m_team_rank = omp_get_thread_num();
+#else
     m_team_rank = 0;
 #endif
+#endif
   }
+
+  OpenACCTeamMember(const int league_rank, const int league_size,
+                    const int team_rank, const int team_size,
+                    const int vector_length)
+      : m_league_rank(league_rank),
+        m_league_size(league_size),
+        m_team_rank(team_rank),
+        m_team_size(team_size),
+        m_vector_length(vector_length) {}
 
   static int team_reduce_size() { return TEAM_REDUCE_SIZE; }
 };

--- a/core/src/OpenACC/Kokkos_OpenACC_Traits.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Traits.hpp
@@ -23,25 +23,25 @@ namespace Kokkos::Experimental::Impl {
 
 struct OpenACC_Traits {
 #if defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
-  static constexpr acc_device_t dev_type            = acc_device_nvidia;
-  static constexpr bool may_fallback_to_host        = false;
-  static constexpr int WarpSize = 32;
+  static constexpr acc_device_t dev_type     = acc_device_nvidia;
+  static constexpr bool may_fallback_to_host = false;
+  static constexpr int WarpSize              = 32;
 #elif defined(KOKKOS_ARCH_AMD_GPU)
-  static constexpr acc_device_t dev_type            = acc_device_radeon;
-  static constexpr bool may_fallback_to_host        = false;
+  static constexpr acc_device_t dev_type     = acc_device_radeon;
+  static constexpr bool may_fallback_to_host = false;
 #if defined(KOKKOS_ARCH_AMD_GFX1030) || defined(KOKKOS_ARCH_AMD_GFX1100)
-  static constexpr int WarpSize = 32;
+  static constexpr int WarpSize              = 32;
 #else
   static constexpr int WarpSize = 64;
 #endif
 #elif defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)
-  static constexpr acc_device_t dev_type            = acc_device_host;
-  static constexpr bool may_fallback_to_host        = true;
-  static constexpr int WarpSize = 32;
+  static constexpr acc_device_t dev_type     = acc_device_host;
+  static constexpr bool may_fallback_to_host = true;
+  static constexpr int WarpSize              = 32;
 #else
-  static constexpr acc_device_t dev_type            = acc_device_not_host;
-  static constexpr bool may_fallback_to_host        = true;
-  static constexpr int WarpSize = 32;
+  static constexpr acc_device_t dev_type     = acc_device_not_host;
+  static constexpr bool may_fallback_to_host = true;
+  static constexpr int WarpSize              = 32;
 #endif
 };
 

--- a/core/src/OpenACC/Kokkos_OpenACC_Traits.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Traits.hpp
@@ -23,17 +23,25 @@ namespace Kokkos::Experimental::Impl {
 
 struct OpenACC_Traits {
 #if defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
-  static constexpr acc_device_t dev_type     = acc_device_nvidia;
-  static constexpr bool may_fallback_to_host = false;
+  static constexpr acc_device_t dev_type            = acc_device_nvidia;
+  static constexpr bool may_fallback_to_host        = false;
+  static constexpr int WarpSize = 32;
 #elif defined(KOKKOS_ARCH_AMD_GPU)
-  static constexpr acc_device_t dev_type     = acc_device_radeon;
-  static constexpr bool may_fallback_to_host = false;
-#elif defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)
-  static constexpr acc_device_t dev_type     = acc_device_host;
-  static constexpr bool may_fallback_to_host = true;
+  static constexpr acc_device_t dev_type            = acc_device_radeon;
+  static constexpr bool may_fallback_to_host        = false;
+#if defined(KOKKOS_ARCH_AMD_GFX1030) || defined(KOKKOS_ARCH_AMD_GFX1100)
+  static constexpr int WarpSize = 32;
 #else
-  static constexpr acc_device_t dev_type     = acc_device_default;
-  static constexpr bool may_fallback_to_host = true;
+  static constexpr int WarpSize = 64;
+#endif
+#elif defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)
+  static constexpr acc_device_t dev_type            = acc_device_host;
+  static constexpr bool may_fallback_to_host        = true;
+  static constexpr int WarpSize = 32;
+#else
+  static constexpr acc_device_t dev_type            = acc_device_not_host;
+  static constexpr bool may_fallback_to_host        = true;
+  static constexpr int WarpSize = 32;
 #endif
 };
 


### PR DESCRIPTION
Update the OpenACC backend to better support the host as the offloading target.
        - MDRangePolicy applies different iteration-to-thread mapping strategies for the CPU target and the GPU target.
        - TeamPolicy applies different iteration-to-thread mapping strategies for the CPU target and the GPU target.
        - Different shared allocation specializations are used for the CPU target and the GPU target.
        - Apply the Kokkos chunk_size only if it is bigger than or equal to the target device warp size.