### PR TITLE
View-Refactor: Add ReferenceCountedAccessor/DataHandle

### DIFF
--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -242,6 +242,70 @@ struct ViewValueFunctorSequentialHostInit {
   }
 };
 
+template <class ElementType, class MemorySpace, class ExecutionSpace,
+          bool AllowPadding, bool Initialize, bool SequentialInit>
+Kokkos::Impl::SharedAllocationRecord<void, void>* make_shared_allocation_record(
+    const size_t& required_span_size, std::string_view label,
+    const MemorySpace& memory_space, const ExecutionSpace* exec_space,
+    [[maybe_unused]] std::integral_constant<bool, AllowPadding> allow_padding,
+    [[maybe_unused]] std::integral_constant<bool, Initialize> initialize,
+    [[maybe_unused]] std::integral_constant<bool, SequentialInit>
+        sequential_init) {
+  static_assert(SpaceAccessibility<ExecutionSpace, MemorySpace>::accessible);
+
+  // Use this for constructing and destroying the view
+  using device_type  = Kokkos::Device<ExecutionSpace, MemorySpace>;
+  using functor_type = std::conditional_t<
+      SequentialInit,
+      ViewValueFunctorSequentialHostInit<device_type, ElementType>,
+      ViewValueFunctor<device_type, ElementType>>;
+  using record_type =
+      Kokkos::Impl::SharedAllocationRecord<MemorySpace, functor_type>;
+
+  // If padding is allowed then pass in sizeof value type
+  // for padding computation.
+  using padding =
+      std::integral_constant<std::size_t,
+                             AllowPadding ? sizeof(ElementType) : 0>;
+
+  static constexpr std::size_t align_mask   = 0x7;
+  static constexpr std::size_t element_size = sizeof(ElementType);
+
+  // Calculate the total size of the memory, in bytes, and make sure it is
+  // byte-aligned
+  const std::size_t alloc_size =
+      (required_span_size * element_size + align_mask) & ~align_mask;
+
+  auto* record =
+      exec_space
+          ? record_type::allocate(*exec_space, memory_space, std::string{label},
+                                  alloc_size)
+          : record_type::allocate(memory_space, std::string{label}, alloc_size);
+
+  auto ptr = static_cast<ElementType*>(record->data());
+
+  auto functor =
+      exec_space ? functor_type(*exec_space, ptr, required_span_size,
+                                std::string{label})
+                 : functor_type(ptr, required_span_size, std::string{label});
+
+  //  Only initialize if the allocation is non-zero.
+  //  May be zero if one of the dimensions is zero.
+  if constexpr (Initialize) {
+    if (alloc_size) {
+      // Assume destruction is only required when construction is requested.
+      // The ViewValueFunctor has both value construction and destruction
+      // operators.
+      record->m_destroy = std::move(functor);
+
+      // Construct values
+      record->m_destroy.construct_shared_allocation();
+    }
+  }
+
+  return record;
+}
+
 }  // namespace Kokkos::Impl
 
 #endif  // KOKKOS_VIEW_ALLOC_HPP

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -247,10 +247,9 @@ template <class ElementType, class MemorySpace, class ExecutionSpace,
 Kokkos::Impl::SharedAllocationRecord<void, void>* make_shared_allocation_record(
     const size_t& required_span_size, std::string_view label,
     const MemorySpace& memory_space, const ExecutionSpace* exec_space,
-    [[maybe_unused]] std::integral_constant<bool, AllowPadding> allow_padding,
-    [[maybe_unused]] std::integral_constant<bool, Initialize> initialize,
-    [[maybe_unused]] std::integral_constant<bool, SequentialInit>
-        sequential_init) {
+    std::integral_constant<bool, AllowPadding>,
+    std::integral_constant<bool, Initialize>,
+    std::integral_constant<bool, SequentialInit>) {
   static_assert(SpaceAccessibility<ExecutionSpace, MemorySpace>::accessible);
 
   // Use this for constructing and destroying the view

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -243,11 +243,10 @@ struct ViewValueFunctorSequentialHostInit {
 };
 
 template <class ElementType, class MemorySpace, class ExecutionSpace,
-          bool AllowPadding, bool Initialize, bool SequentialInit>
+          bool Initialize, bool SequentialInit>
 Kokkos::Impl::SharedAllocationRecord<void, void>* make_shared_allocation_record(
     const size_t& required_span_size, std::string_view label,
     const MemorySpace& memory_space, const ExecutionSpace* exec_space,
-    std::integral_constant<bool, AllowPadding>,
     std::integral_constant<bool, Initialize>,
     std::integral_constant<bool, SequentialInit>) {
   static_assert(SpaceAccessibility<ExecutionSpace, MemorySpace>::accessible);

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -262,12 +262,6 @@ Kokkos::Impl::SharedAllocationRecord<void, void>* make_shared_allocation_record(
   using record_type =
       Kokkos::Impl::SharedAllocationRecord<MemorySpace, functor_type>;
 
-  // If padding is allowed then pass in sizeof value type
-  // for padding computation.
-  using padding =
-      std::integral_constant<std::size_t,
-                             AllowPadding ? sizeof(ElementType) : 0>;
-
   static constexpr std::size_t align_mask   = 0x7;
   static constexpr std::size_t element_size = sizeof(ElementType);
 

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -259,16 +259,6 @@ class ReferenceCountedDataHandle {
       const ReferenceCountedDataHandle<OtherElementType, memory_space>& other)
       : m_tracker(other.m_tracker), m_handle(other.m_handle) {}
 
-  KOKKOS_DEFAULTED_FUNCTION
-  ReferenceCountedDataHandle(const ReferenceCountedDataHandle&) = default;
-  KOKKOS_DEFAULTED_FUNCTION
-  ReferenceCountedDataHandle(ReferenceCountedDataHandle&&) noexcept = default;
-  KOKKOS_DEFAULTED_FUNCTION
-  ReferenceCountedDataHandle& operator=(const ReferenceCountedDataHandle&) =
-      default;
-  KOKKOS_DEFAULTED_FUNCTION
-  ReferenceCountedDataHandle& operator=(ReferenceCountedDataHandle&&) = default;
-
   KOKKOS_FUNCTION
   pointer get() const noexcept { return m_handle; }
   KOKKOS_FUNCTION
@@ -337,16 +327,6 @@ class ReferenceCountedDataHandle<ElementType, AnonymousSpace> {
   KOKKOS_FUNCTION ReferenceCountedDataHandle(
       const ReferenceCountedDataHandle& other, OtherElementType* ptr)
       : m_tracker(other.m_tracker), m_handle(ptr) {}
-
-  KOKKOS_DEFAULTED_FUNCTION
-  ReferenceCountedDataHandle(const ReferenceCountedDataHandle&) = default;
-  KOKKOS_DEFAULTED_FUNCTION
-  ReferenceCountedDataHandle(ReferenceCountedDataHandle&&) noexcept = default;
-  KOKKOS_DEFAULTED_FUNCTION
-  ReferenceCountedDataHandle& operator=(const ReferenceCountedDataHandle&) =
-      default;
-  KOKKOS_DEFAULTED_FUNCTION
-  ReferenceCountedDataHandle& operator=(ReferenceCountedDataHandle&&) = default;
 
   template <class OtherElementType, class OtherSpace,
             class = std::enable_if_t<std::is_convertible_v<

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -309,10 +309,10 @@ template <class ElementType, class MemorySpace, class NestedAccessor>
 class ReferenceCountedAccessor;
 
 template <class Accessor>
-struct IsReferenceCountedAccessorImpl : std::false_type {};
+struct IsReferenceCountedAccessor : std::false_type {};
 
 template <class ElementType, class MemorySpace, class NestedAccessor>
-struct IsReferenceCountedAccessorImpl<
+struct IsReferenceCountedAccessor<
     ReferenceCountedAccessor<ElementType, MemorySpace, NestedAccessor>>
     : std::true_type {};
 
@@ -358,7 +358,7 @@ class ReferenceCountedAccessor {
 
   template <class DstAccessor,
             typename = std::enable_if_t<
-                !IsReferenceCountedAccessorImpl<DstAccessor>::value &&
+                !IsReferenceCountedAccessor<DstAccessor>::value &&
                 std::is_convertible_v<NestedAccessor, DstAccessor>>>
   KOKKOS_FUNCTION operator DstAccessor() const {
     return m_nested_acc;
@@ -385,23 +385,6 @@ class ReferenceCountedAccessor {
 #endif
   NestedAccessor m_nested_acc;
 };
-
-template <class ElementType, class MemorySpace>
-using checked_reference_counted_accessor =
-    SpaceAwareAccessor<MemorySpace,
-                       ReferenceCountedAccessor<ElementType, MemorySpace,
-                                                default_accessor<ElementType>>>;
-
-template <class ElementType, class MemorySpace,
-          class MemoryScope = desul::MemoryScopeDevice>
-using checked_atomic_accessor_relaxed =
-    SpaceAwareAccessor<MemorySpace, AtomicAccessorRelaxed<ElementType>>;
-
-template <class ElementType, class MemorySpace,
-          class MemoryScope = desul::MemoryScopeDevice>
-using checked_reference_counted_atomic_accessor_relaxed = SpaceAwareAccessor<
-    MemorySpace, ReferenceCountedAccessor<ElementType, MemorySpace,
-                                          AtomicAccessorRelaxed<ElementType>>>;
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -259,6 +259,16 @@ class ReferenceCountedDataHandle {
       const ReferenceCountedDataHandle<OtherElementType, memory_space>& other)
       : m_tracker(other.m_tracker), m_handle(other.m_handle) {}
 
+  template <class OtherElementType, class OtherSpace,
+            class = std::enable_if_t<
+	       std::is_convertible_v<OtherElementType (*)[], value_type (*)[]> &&
+	      !std::is_same_v<OtherSpace, AnonymousSpace> &&
+	       std::is_same_v<memory_space, AnonymousSpace>
+	       >>
+  KOKKOS_FUNCTION ReferenceCountedDataHandle(
+      const ReferenceCountedDataHandle<OtherElementType, OtherSpace>& other)
+      : m_tracker(other.m_tracker), m_handle(other.m_handle) {}
+
   KOKKOS_FUNCTION
   pointer get() const noexcept { return m_handle; }
   KOKKOS_FUNCTION
@@ -295,6 +305,7 @@ class ReferenceCountedDataHandle {
   pointer m_handle = nullptr;
 };
 
+/*
 template <class ElementType>
 class ReferenceCountedDataHandle<ElementType, AnonymousSpace> {
  public:
@@ -367,6 +378,7 @@ class ReferenceCountedDataHandle<ElementType, AnonymousSpace> {
   SharedAllocationTracker m_tracker;
   pointer m_handle = nullptr;
 };
+*/
 
 template <class ElementType, class MemorySpace, class NestedAccessor>
 class ReferenceCountedAccessor;

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -259,12 +259,12 @@ class ReferenceCountedDataHandle {
       const ReferenceCountedDataHandle<OtherElementType, memory_space>& other)
       : m_tracker(other.m_tracker), m_handle(other.m_handle) {}
 
-  template <class OtherElementType, class OtherSpace,
-            class = std::enable_if_t<
-	       std::is_convertible_v<OtherElementType (*)[], value_type (*)[]> &&
-	      !std::is_same_v<OtherSpace, AnonymousSpace> &&
-	       std::is_same_v<memory_space, AnonymousSpace>
-	       >>
+  template <
+      class OtherElementType, class OtherSpace,
+      class = std::enable_if_t<
+          std::is_convertible_v<OtherElementType (*)[], value_type (*)[]> &&
+          (std::is_same_v<OtherSpace, AnonymousSpace> ||
+           std::is_same_v<memory_space, AnonymousSpace>)>>
   KOKKOS_FUNCTION ReferenceCountedDataHandle(
       const ReferenceCountedDataHandle<OtherElementType, OtherSpace>& other)
       : m_tracker(other.m_tracker), m_handle(other.m_handle) {}
@@ -305,81 +305,6 @@ class ReferenceCountedDataHandle {
   pointer m_handle = nullptr;
 };
 
-/*
-template <class ElementType>
-class ReferenceCountedDataHandle<ElementType, AnonymousSpace> {
- public:
-  using value_type   = ElementType;
-  using pointer      = value_type*;
-  using reference    = value_type&;
-  using memory_space = AnonymousSpace;
-
-  KOKKOS_DEFAULTED_FUNCTION
-  ReferenceCountedDataHandle() = default;
-  explicit ReferenceCountedDataHandle(SharedAllocationRecord<void, void>* rec) {
-    m_tracker.assign_allocated_record_to_uninitialized(rec);
-    m_handle = static_cast<pointer>(get_record()->data());
-  }
-
-  KOKKOS_FUNCTION
-  ReferenceCountedDataHandle(const SharedAllocationTracker& tracker,
-                             pointer data_handle)
-      : m_tracker(tracker), m_handle(data_handle) {}
-
-  template <class OtherElementType,
-            class = std::enable_if_t<std::is_convertible_v<
-                OtherElementType (*)[], value_type (*)[]>>>
-  KOKKOS_FUNCTION ReferenceCountedDataHandle(OtherElementType* ptr)
-      : m_tracker(), m_handle(ptr) {}
-
-  template <class OtherElementType,
-            class = std::enable_if_t<std::is_convertible_v<
-                OtherElementType (*)[], value_type (*)[]>>>
-  KOKKOS_FUNCTION ReferenceCountedDataHandle(
-      const ReferenceCountedDataHandle& other, OtherElementType* ptr)
-      : m_tracker(other.m_tracker), m_handle(ptr) {}
-
-  template <class OtherElementType, class OtherSpace,
-            class = std::enable_if_t<std::is_convertible_v<
-                OtherElementType (*)[], value_type (*)[]>>>
-  KOKKOS_FUNCTION ReferenceCountedDataHandle(
-      const ReferenceCountedDataHandle<OtherElementType, OtherSpace>& other)
-      : m_tracker(other.m_tracker), m_handle(other.m_handle) {}
-
-  KOKKOS_FUNCTION
-  pointer get() const noexcept { return m_handle; }
-  KOKKOS_FUNCTION
-  explicit operator pointer() const noexcept { return m_handle; }
-
-  bool has_record() const { return m_tracker.has_record(); }
-  auto* get_record() const { return m_tracker.get_record<memory_space>(); }
-  int use_count() const noexcept { return m_tracker.use_count(); }
-
-  std::string get_label() const { return m_tracker.get_label<memory_space>(); }
-  KOKKOS_FUNCTION
-  const SharedAllocationTracker& tracker() const noexcept { return m_tracker; }
-
-  KOKKOS_FUNCTION
-  friend bool operator==(const ReferenceCountedDataHandle& lhs,
-                         const value_type* rhs) {
-    return lhs.m_handle == rhs;
-  }
-
-  KOKKOS_FUNCTION
-  friend bool operator==(const value_type* lhs,
-                         const ReferenceCountedDataHandle& rhs) {
-    return lhs == rhs.m_handle;
-  }
-
- private:
-  template <class OtherElementType, class OtherSpace>
-  friend class ReferenceCountedDataHandle;
-
-  SharedAllocationTracker m_tracker;
-  pointer m_handle = nullptr;
-};
-*/
-
 template <class ElementType, class MemorySpace, class NestedAccessor>
 class ReferenceCountedAccessor;
 
@@ -400,6 +325,7 @@ class ReferenceCountedAccessor {
   using offset_policy =
       ReferenceCountedAccessor<ElementType, MemorySpace,
                                typename NestedAccessor::offset_policy>;
+  using memory_space = MemorySpace;
 
   KOKKOS_DEFAULTED_FUNCTION
   constexpr ReferenceCountedAccessor() noexcept = default;
@@ -413,68 +339,13 @@ class ReferenceCountedAccessor {
       const ReferenceCountedAccessor<OtherElementType, MemorySpace,
                                      OtherNestedAccessor>&) {}
 
-  template <class OtherElementType,
-            class = std::enable_if_t<std::is_convertible_v<
-                OtherElementType (*)[], element_type (*)[]>>>
-  KOKKOS_FUNCTION constexpr ReferenceCountedAccessor(
-      const default_accessor<OtherElementType>&) {}
-
-  template <class DstAccessor,
-            typename = std::enable_if_t<
-                !IsReferenceCountedAccessorImpl<DstAccessor>::value &&
-                std::is_convertible_v<NestedAccessor, DstAccessor>>>
-  KOKKOS_FUNCTION operator DstAccessor() const {
-    return m_nested_acc;
-  }
-
-  KOKKOS_FUNCTION
-  constexpr reference access(data_handle_type p, size_t i) const {
-    return m_nested_acc.access(p.get(), i);
-  }
-
-  KOKKOS_FUNCTION
-  constexpr data_handle_type offset(data_handle_type p, size_t i) const {
-    return data_handle_type(p, m_nested_acc.offset(p.get(), i));
-  }
-
-  KOKKOS_FUNCTION
-  constexpr auto nested_accessor() const { return m_nested_acc; }
-
- private:
-#ifdef _MDSPAN_NO_UNIQUE_ADDRESS
-  _MDSPAN_NO_UNIQUE_ADDRESS
-#else
-  [[no_unique_address]]
-#endif
-  NestedAccessor m_nested_acc;
-};
-
-template <class ElementType, class NestedAccessor>
-class ReferenceCountedAccessor<ElementType, AnonymousSpace, NestedAccessor> {
- public:
-  using element_type = ElementType;
-  using data_handle_type =
-      ReferenceCountedDataHandle<ElementType, AnonymousSpace>;
-  using reference = typename NestedAccessor::reference;
-  using offset_policy =
-      ReferenceCountedAccessor<ElementType, AnonymousSpace,
-                               typename NestedAccessor::offset_policy>;
-
-  KOKKOS_DEFAULTED_FUNCTION
-  constexpr ReferenceCountedAccessor() noexcept = default;
-
-  template <class OtherSpace, class OtherNestedAccessor,
-            class = std::enable_if_t<
-                std::is_constructible_v<NestedAccessor, OtherNestedAccessor>>>
-  KOKKOS_FUNCTION constexpr ReferenceCountedAccessor(
-      const ReferenceCountedAccessor<ElementType, OtherSpace,
-                                     OtherNestedAccessor>&) {}
-
   template <
       class OtherElementType, class OtherSpace, class OtherNestedAccessor,
       class = std::enable_if_t<
           std::is_convertible_v<OtherElementType (*)[], element_type (*)[]> &&
-          std::is_constructible_v<NestedAccessor, OtherNestedAccessor>>>
+          (std::is_same_v<OtherSpace, AnonymousSpace> ||
+           std::is_same_v<memory_space, AnonymousSpace>)&&std::
+              is_constructible_v<NestedAccessor, OtherNestedAccessor>>>
   KOKKOS_FUNCTION constexpr ReferenceCountedAccessor(
       const ReferenceCountedAccessor<OtherElementType, OtherSpace,
                                      OtherNestedAccessor>&) {}

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -226,6 +226,8 @@ class ReferenceCountedDataHandle {
 
   KOKKOS_DEFAULTED_FUNCTION
   ReferenceCountedDataHandle() = default;
+
+  // this only ever works on host
   explicit ReferenceCountedDataHandle(SharedAllocationRecord<void, void>* rec) {
     m_tracker.assign_allocated_record_to_uninitialized(rec);
     m_handle = static_cast<pointer>(get_record()->data());

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -87,6 +87,7 @@ set(COMPILE_ONLY_SOURCES
     TestVersionMacros.cpp
     TestViewRank.cpp
     TestViewTypeTraits.cpp
+    TestViewTypedefs.cpp
     TestTypeInfo.cpp
     TestTypeList.cpp
     TestMDRangePolicyCTAD.cpp
@@ -117,10 +118,6 @@ else()
   endif()
 endif()
 
-#TestInterOp has a dependency on containers
-if(KOKKOS_HAS_TRILINOS)
-  list(REMOVE_ITEM COMPILE_ONLY_SOURCES TestInterOp.cpp)
-endif()
 if(Kokkos_ENABLE_OPENMPTARGET)
   list(REMOVE_ITEM COMPILE_ONLY_SOURCES TestNestedReducerCTAD.cpp)
 endif()
@@ -341,6 +338,10 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       list(APPEND ${Tag}_SOURCES2D ${file})
     endforeach()
 
+    set(${Tag}_SOURCES1 ${${Tag}_SOURCES1A} ${${Tag}_SOURCES1B})
+    set(${Tag}_SOURCES2 ${${Tag}_SOURCES2A} ${${Tag}_SOURCES2B} ${${Tag}_SOURCES2C} ${${Tag}_SOURCES2D})
+    set(${Tag}_SOURCES ${${Tag}_SOURCES1} ${${Tag}_SOURCES2})
+
     # ViewSupport should eventually contain the new implementation
     # detail tests for the mdspan based View
     set(${Tag}_VIEWSUPPORT)
@@ -355,10 +356,6 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       endforeach()
       kokkos_add_executable_and_test(CoreUnitTest_${Tag}_ViewSupport SOURCES UnitTestMainInit.cpp ${${Tag}_VIEWSUPPORT})
     endif()
-
-    set(${Tag}_SOURCES1 ${${Tag}_SOURCES1A} ${${Tag}_SOURCES1B})
-    set(${Tag}_SOURCES2 ${${Tag}_SOURCES2A} ${${Tag}_SOURCES2B} ${${Tag}_SOURCES2C} ${${Tag}_SOURCES2D})
-    set(${Tag}_SOURCES ${${Tag}_SOURCES1} ${${Tag}_SOURCES2})
   endif()
 endforeach()
 
@@ -1008,23 +1005,21 @@ if(KOKKOS_ENABLE_LIBDL)
     "kokkosp_init_library::kokkosp_parse_args:4:Kokkos_ProfilingAllCalls:-c:test:delimit::.*::kokkosp_allocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]source] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_allocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]destination] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_begin_deep_copy:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::.*kokkosp_end_deep_copy::kokkosp_begin_parallel_for:parallel_for:${SIZE_REGEX}:0::kokkosp_end_parallel_for:0::kokkosp_begin_parallel_reduce:parallel_reduce:${SIZE_REGEX}:1${SKIP_SCRATCH_INITIALIZATION_REGEX}::kokkosp_end_parallel_reduce:1::kokkosp_begin_parallel_scan:parallel_scan:${SIZE_REGEX}:2::kokkosp_end_parallel_scan:2::kokkosp_push_profile_region:push_region::kokkosp_pop_profile_region::kokkosp_create_profile_section:created_section:3::kokkosp_start_profile_section:3::kokkosp_stop_profile_section:3::kokkosp_destroy_profile_section:3::kokkosp_profile_event:profiling_event::kokkosp_declare_metadata:dogs:good::kokkosp_deallocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_deallocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_finalize_library::"
   )
 endif() #KOKKOS_ENABLE_LIBDL
-if(NOT KOKKOS_HAS_TRILINOS)
-  kokkos_add_test_executable(
-    StackTraceTestExec
-    SOURCES
-    TestStackTrace.cpp
-    TestStackTrace_f0.cpp
-    TestStackTrace_f1.cpp
-    TestStackTrace_f2.cpp
-    TestStackTrace_f3.cpp
-    TestStackTrace_f4.cpp
-  )
-  # We need -rdynamic on GNU platforms for the stacktrace functionality
-  # to work correctly with shared libraries
-  kokkos_set_exe_property(StackTraceTestExec ENABLE_EXPORTS ON)
+kokkos_add_test_executable(
+  StackTraceTestExec
+  SOURCES
+  TestStackTrace.cpp
+  TestStackTrace_f0.cpp
+  TestStackTrace_f1.cpp
+  TestStackTrace_f2.cpp
+  TestStackTrace_f3.cpp
+  TestStackTrace_f4.cpp
+)
+# We need -rdynamic on GNU platforms for the stacktrace functionality
+# to work correctly with shared libraries
+kokkos_set_exe_property(StackTraceTestExec ENABLE_EXPORTS ON)
 
-  kokkos_add_test(NAME CoreUnitTest_StackTraceTest EXE StackTraceTestExec FAIL_REGULAR_EXPRESSION "FAILED")
-endif()
+kokkos_add_test(NAME CoreUnitTest_StackTraceTest EXE StackTraceTestExec FAIL_REGULAR_EXPRESSION "FAILED")
 
 if(KOKKOS_ENABLE_HWLOC)
   kokkos_add_executable_and_test(CoreUnitTest_HWLOC SOURCES UnitTestMain.cpp TestHWLOC.cpp)
@@ -1087,29 +1082,40 @@ kokkos_add_executable_and_test(
   CoreUnitTest_CMakePassCmdLineArgs SOURCES UnitTest_CMakePassCmdLineArgs.cpp ARGS "one 2 THREE"
 )
 
-# This test is not properly set up to run within Trilinos
-if(NOT KOKKOS_HAS_TRILINOS)
-  set_source_files_properties(UnitTest_DeviceAndThreads.cpp PROPERTIES LANGUAGE ${KOKKOS_COMPILE_LANGUAGE})
-  add_executable(Kokkos_CoreUnitTest_DeviceAndThreads UnitTest_DeviceAndThreads.cpp)
-  target_link_libraries(Kokkos_CoreUnitTest_DeviceAndThreads Kokkos::kokkoscore)
-  find_package(Python3 COMPONENTS Interpreter)
-  if(Python3_Interpreter_FOUND AND Python3_VERSION VERSION_GREATER_EQUAL 3.7)
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)
-      set(USE_SOURCE_PERMISSIONS_WHEN_SUPPORTED USE_SOURCE_PERMISSIONS)
-    endif()
-    file(
-      GENERATE
-      OUTPUT $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py
-      INPUT TestDeviceAndThreads.py
-      ${USE_SOURCE_PERMISSIONS_WHEN_SUPPORTED}
-    )
-    add_test(NAME Kokkos_CoreUnitTest_DeviceAndThreads
-             COMMAND ${Python3_EXECUTABLE}
-                     $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py -v
-    )
+kokkos_add_executable(CoreUnitTest_CMakeTriBITSCompatibility SOURCES UnitTest_CMakeTriBITSCompatibility.cpp)
+
+kokkos_add_test(NAME CoreUnitTest_CMakeTriBITSCompatibilityWillFail EXE CoreUnitTest_CMakeTriBITSCompatibility)
+set_property(TEST Kokkos_CoreUnitTest_CMakeTriBITSCompatibilityWillFail PROPERTY WILL_FAIL TRUE)
+
+set(Kokkos_CoreUnitTest_CMakeTriBITSCompatibilityDisable_DISABLE ON)
+kokkos_add_test(NAME CoreUnitTest_CMakeTriBITSCompatibilityDisable EXE CoreUnitTest_CMakeTriBITSCompatibility)
+
+set(Kokkos_CoreUnitTest_CMakeTriBITSCompatibilityExtraArgs_EXTRA_ARGS "--kokkos-test-tribits-compatibility=1")
+kokkos_add_test(NAME CoreUnitTest_CMakeTriBITSCompatibilityExtraArgs EXE CoreUnitTest_CMakeTriBITSCompatibility)
+
+set(Kokkos_CoreUnitTest_CMakeTriBITSCompatibilityEnvironment_ENVIRONMENT "KOKKOS_TEST_TRIBITS_COMPATIBILITY=1")
+kokkos_add_test(NAME CoreUnitTest_CMakeTriBITSCompatibilityEnvironment EXE CoreUnitTest_CMakeTriBITSCompatibility)
+
+set_source_files_properties(UnitTest_DeviceAndThreads.cpp PROPERTIES LANGUAGE ${KOKKOS_COMPILE_LANGUAGE})
+add_executable(Kokkos_CoreUnitTest_DeviceAndThreads UnitTest_DeviceAndThreads.cpp)
+target_link_libraries(Kokkos_CoreUnitTest_DeviceAndThreads Kokkos::kokkoscore)
+find_package(Python3 COMPONENTS Interpreter)
+if(Python3_Interpreter_FOUND AND Python3_VERSION VERSION_GREATER_EQUAL 3.7)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)
+    set(USE_SOURCE_PERMISSIONS_WHEN_SUPPORTED USE_SOURCE_PERMISSIONS)
   endif()
+  file(
+    GENERATE
+    OUTPUT $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py
+    INPUT TestDeviceAndThreads.py
+    ${USE_SOURCE_PERMISSIONS_WHEN_SUPPORTED}
+  )
+  add_test(NAME Kokkos_CoreUnitTest_DeviceAndThreads
+           COMMAND ${Python3_EXECUTABLE}
+                   $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py -v
+  )
 endif()
 
-if(KOKKOS_ENABLE_HEADER_SELF_CONTAINMENT_TESTS AND NOT KOKKOS_HAS_TRILINOS AND NOT WIN32)
+if(KOKKOS_ENABLE_HEADER_SELF_CONTAINMENT_TESTS AND NOT WIN32)
   add_subdirectory(headers_self_contained)
 endif()

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -383,20 +383,22 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
     endforeach()
 
     set(${Tag}_VIEWSUPPORT)
-    foreach(Name
-      ReferenceCountedAccessor
-      ReferenceCountedDataHandle
-      )
-      set(file ${dir}/Test${Tag}_View_${Name}.cpp)
-      # Write to a temporary intermediate file and call configure_file to avoid
-      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-      file(WRITE ${dir}/dummy.cpp
-          "#include <Test${Tag}_Category.hpp>\n"
-          "#include <view/Test${Name}.hpp>\n"
-      )
-      configure_file(${dir}/dummy.cpp ${file})
-      list(APPEND ${Tag}_VIEWSUPPORT ${file})
-    endforeach()
+    IF (Kokkos_ENABLE_IMPL_MDSPAN)
+      foreach(Name
+        ReferenceCountedAccessor
+        ReferenceCountedDataHandle
+        )
+        set(file ${dir}/Test${Tag}_View_${Name}.cpp)
+        # Write to a temporary intermediate file and call configure_file to avoid
+        # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+        file(WRITE ${dir}/dummy.cpp
+            "#include <Test${Tag}_Category.hpp>\n"
+            "#include <view/Test${Name}.hpp>\n"
+        )
+        configure_file(${dir}/dummy.cpp ${file})
+        list(APPEND ${Tag}_VIEWSUPPORT ${file})
+      endforeach()
+    endif()
 
     SET(${Tag}_SOURCES1 ${${Tag}_SOURCES1A} ${${Tag}_SOURCES1B})
     SET(${Tag}_SOURCES2 ${${Tag}_SOURCES2A} ${${Tag}_SOURCES2B} ${${Tag}_SOURCES2C} ${${Tag}_SOURCES2D})

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -2,136 +2,129 @@
 # Add test-only library for gtest to be reused by all the subpackages
 #
 
-IF(NOT GTest_FOUND)  # fallback to internal gtest
-  SET(GTEST_SOURCE_DIR ${Kokkos_SOURCE_DIR}/tpls/gtest)
+if(NOT GTest_FOUND) # fallback to internal gtest
+  set(GTEST_SOURCE_DIR ${Kokkos_SOURCE_DIR}/tpls/gtest)
 
   #need here for tribits
-  KOKKOS_INCLUDE_DIRECTORIES(${GTEST_SOURCE_DIR})
-  KOKKOS_ADD_TEST_LIBRARY(
-    kokkos_gtest
-    HEADERS ${GTEST_SOURCE_DIR}/gtest/gtest.h
-    SOURCES ${GTEST_SOURCE_DIR}/gtest/gtest-all.cc
+  kokkos_include_directories(${GTEST_SOURCE_DIR})
+  kokkos_add_test_library(
+    kokkos_gtest HEADERS ${GTEST_SOURCE_DIR}/gtest/gtest.h SOURCES ${GTEST_SOURCE_DIR}/gtest/gtest-all.cc
   )
 
-  TARGET_INCLUDE_DIRECTORIES(kokkos_gtest PUBLIC ${GTEST_SOURCE_DIR})
-  IF((NOT (Kokkos_ENABLE_CUDA AND WIN32)) AND (NOT ("${KOKKOS_CXX_COMPILER_ID}" STREQUAL "Fujitsu")))
-    TARGET_COMPILE_FEATURES(kokkos_gtest PUBLIC cxx_std_14)
-  ENDIF()
+  target_include_directories(kokkos_gtest PUBLIC ${GTEST_SOURCE_DIR})
+  if((NOT (Kokkos_ENABLE_CUDA AND WIN32)) AND (NOT ("${KOKKOS_CXX_COMPILER_ID}" STREQUAL "Fujitsu")))
+    target_compile_features(kokkos_gtest PUBLIC cxx_std_14)
+  endif()
 
   # Suppress clang-tidy diagnostics on code that we do not have control over
-  IF(CMAKE_CXX_CLANG_TIDY)
-    SET_TARGET_PROPERTIES(kokkos_gtest PROPERTIES CXX_CLANG_TIDY "")
-  ENDIF()
+  if(CMAKE_CXX_CLANG_TIDY)
+    set_target_properties(kokkos_gtest PROPERTIES CXX_CLANG_TIDY "")
+  endif()
 
-  FIND_PACKAGE(Threads QUIET)
-  IF(TARGET Threads::Threads)
-    SET_TARGET_PROPERTIES(kokkos_gtest PROPERTIES
-                          INTERFACE_LINK_LIBRARIES Threads::Threads)
-  ENDIF()
-ENDIF()
+  find_package(Threads QUIET)
+  if(TARGET Threads::Threads)
+    set_target_properties(kokkos_gtest PROPERTIES INTERFACE_LINK_LIBRARIES Threads::Threads)
+  endif()
+endif()
 
 #
 # Define Incremental Testing Feature Levels
 # Define Device name mappings (i.e. what comes after Kokkos:: for the ExecSpace)
 #
 
-SET(KOKKOS_CUDA_FEATURE_LEVEL 999)
-SET(KOKKOS_CUDA_NAME Cuda)
-SET(KOKKOS_HIP_FEATURE_LEVEL 999)
-SET(KOKKOS_HIP_NAME HIP)
-SET(KOKKOS_HPX_FEATURE_LEVEL 999)
-SET(KOKKOS_HPX_NAME Experimental::HPX)
-SET(KOKKOS_OPENMP_FEATURE_LEVEL 999)
-SET(KOKKOS_OPENMP_NAME OpenMP)
+set(KOKKOS_CUDA_FEATURE_LEVEL 999)
+set(KOKKOS_CUDA_NAME Cuda)
+set(KOKKOS_HIP_FEATURE_LEVEL 999)
+set(KOKKOS_HIP_NAME HIP)
+set(KOKKOS_HPX_FEATURE_LEVEL 999)
+set(KOKKOS_HPX_NAME Experimental::HPX)
+set(KOKKOS_OPENMP_FEATURE_LEVEL 999)
+set(KOKKOS_OPENMP_NAME OpenMP)
 
 # FIXME_OPENMPTARGET - The NVIDIA HPC compiler nvc++ only compiles the first 8 incremental tests for the OpenMPTarget backend.
 # FIXME_OPENMPTARGET - Clang version 17 fails to compile incremental tests past 12 with verion 17. There is PR for this in upstream already. So it should be fixed by version 18.
-IF(KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
-  SET(KOKKOS_OPENMPTARGET_FEATURE_LEVEL 10)
-ELSEIF(KOKKOS_CXX_COMPILER_ID STREQUAL "Clang" AND KOKKOS_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 17.0.0)
-  SET(KOKKOS_OPENMPTARGET_FEATURE_LEVEL 12)
-ELSE()
-  SET(KOKKOS_OPENMPTARGET_FEATURE_LEVEL 14)
-ENDIF()
+if(KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
+  set(KOKKOS_OPENMPTARGET_FEATURE_LEVEL 10)
+elseif(KOKKOS_CXX_COMPILER_ID STREQUAL "Clang" AND KOKKOS_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 17.0.0)
+  set(KOKKOS_OPENMPTARGET_FEATURE_LEVEL 12)
+else()
+  set(KOKKOS_OPENMPTARGET_FEATURE_LEVEL 14)
+endif()
 
-SET(KOKKOS_OPENMPTARGET_NAME Experimental::OpenMPTarget)
-SET(KOKKOS_SERIAL_FEATURE_LEVEL 999)
-SET(KOKKOS_SERIAL_NAME Serial)
-SET(KOKKOS_SYCL_FEATURE_LEVEL 999)
-SET(KOKKOS_SYCL_NAME SYCL)
-SET(KOKKOS_THREADS_FEATURE_LEVEL 999)
-SET(KOKKOS_THREADS_NAME Threads)
+set(KOKKOS_OPENMPTARGET_NAME Experimental::OpenMPTarget)
+set(KOKKOS_SERIAL_FEATURE_LEVEL 999)
+set(KOKKOS_SERIAL_NAME Serial)
+set(KOKKOS_SYCL_FEATURE_LEVEL 999)
+set(KOKKOS_SYCL_NAME SYCL)
+set(KOKKOS_THREADS_FEATURE_LEVEL 999)
+set(KOKKOS_THREADS_NAME Threads)
 # FIXME_OPENACC - The Clang compiler only compiles the first 9 incremental tests for the OpenACC backend.
-IF(KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
-  SET(KOKKOS_OPENACC_FEATURE_LEVEL 9)
-ELSE()
-  SET(KOKKOS_OPENACC_FEATURE_LEVEL 17)
-ENDIF()
+if(KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
+  set(KOKKOS_OPENACC_FEATURE_LEVEL 9)
+else()
+  set(KOKKOS_OPENACC_FEATURE_LEVEL 17)
+endif()
 
-SET(KOKKOS_OPENACC_NAME Experimental::OpenACC)
-
+set(KOKKOS_OPENACC_NAME Experimental::OpenACC)
 
 #
 # Define the tests
 #
 
 #I will leave these alone for now because I don't need transitive dependencies on tests
-KOKKOS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
-KOKKOS_INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_DIR})
-KOKKOS_INCLUDE_DIRECTORIES(${KOKKOS_SOURCE_DIR}/core/unit_test/category_files)
+kokkos_include_directories(${CMAKE_CURRENT_BINARY_DIR})
+kokkos_include_directories(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_DIR})
+kokkos_include_directories(${KOKKOS_SOURCE_DIR}/core/unit_test/category_files)
 
-SET(COMPILE_ONLY_SOURCES
-  TestArray.cpp
-  TestCreateMirror.cpp
-  TestDetectionIdiom.cpp
-  TestBitManipulation.cpp
-  TestInterOp.cpp
-  TestRangePolicyCTAD.cpp
-  TestStringManipulation.cpp
-  TestVersionMacros.cpp
-  TestViewRank.cpp
-  TestViewTypeTraits.cpp
-  TestTypeInfo.cpp
-  TestTypeList.cpp
-  TestMDRangePolicyCTAD.cpp
-  TestTeamPolicyCTAD.cpp
-  TestTeamMDRangePolicyCTAD.cpp
-  TestNestedReducerCTAD.cpp
-  view/TestExtentsDatatypeConversion.cpp
+set(COMPILE_ONLY_SOURCES
+    TestArray.cpp
+    TestCreateMirror.cpp
+    TestDetectionIdiom.cpp
+    TestBitManipulation.cpp
+    TestInterOp.cpp
+    TestRangePolicyCTAD.cpp
+    TestStringManipulation.cpp
+    TestVersionMacros.cpp
+    TestViewRank.cpp
+    TestViewTypeTraits.cpp
+    TestTypeInfo.cpp
+    TestTypeList.cpp
+    TestMDRangePolicyCTAD.cpp
+    TestTeamPolicyCTAD.cpp
+    TestTeamMDRangePolicyCTAD.cpp
+    TestNestedReducerCTAD.cpp
+    view/TestExtentsDatatypeConversion.cpp
 )
 
 #testing if windows.h and Kokkos_Core.hpp can be included
 if(WIN32)
-  LIST(APPEND COMPILE_ONLY_SOURCES TestWindowsInclude.cpp)
+  list(APPEND COMPILE_ONLY_SOURCES TestWindowsInclude.cpp)
 endif()
 
-if(Kokkos_INSTALL_TESTING)  # FIXME Kokkos_ and KOKKOS_ variables are out of sync
+if(Kokkos_INSTALL_TESTING) # FIXME Kokkos_ and KOKKOS_ variables are out of sync
   if((Kokkos_CXX_COMPILER_ID STREQUAL "Intel" AND Kokkos_CXX_COMPILER_VERSION VERSION_LESS 2021.2.0)
      OR (Kokkos_CXX_COMPILER_ID STREQUAL "NVIDIA" AND Kokkos_CXX_COMPILER_VERSION VERSION_LESS 11.3.0)
-     OR (Kokkos_CXX_COMPILER_ID STREQUAL "NVIDIA" AND Kokkos_CXX_HOST_COMPILER_ID STREQUAL "MSVC"))
-    LIST(REMOVE_ITEM COMPILE_ONLY_SOURCES TestTypeInfo.cpp)
+     OR (Kokkos_CXX_COMPILER_ID STREQUAL "NVIDIA" AND Kokkos_CXX_HOST_COMPILER_ID STREQUAL "MSVC")
+  )
+    list(REMOVE_ITEM COMPILE_ONLY_SOURCES TestTypeInfo.cpp)
   endif()
 else()
   if((KOKKOS_CXX_COMPILER_ID STREQUAL "Intel" AND KOKKOS_CXX_COMPILER_VERSION VERSION_LESS 2021.2.0)
      OR (KOKKOS_CXX_COMPILER_ID STREQUAL "NVIDIA" AND KOKKOS_CXX_COMPILER_VERSION VERSION_LESS 11.3.0)
-     OR (KOKKOS_CXX_COMPILER_ID STREQUAL "NVIDIA" AND KOKKOS_CXX_HOST_COMPILER_ID STREQUAL "MSVC"))
-    LIST(REMOVE_ITEM COMPILE_ONLY_SOURCES TestTypeInfo.cpp)
+     OR (KOKKOS_CXX_COMPILER_ID STREQUAL "NVIDIA" AND KOKKOS_CXX_HOST_COMPILER_ID STREQUAL "MSVC")
+  )
+    list(REMOVE_ITEM COMPILE_ONLY_SOURCES TestTypeInfo.cpp)
   endif()
 endif()
 
 #TestInterOp has a dependency on containers
-IF(KOKKOS_HAS_TRILINOS)
-  LIST(REMOVE_ITEM COMPILE_ONLY_SOURCES TestInterOp.cpp)
-ENDIF()
+if(KOKKOS_HAS_TRILINOS)
+  list(REMOVE_ITEM COMPILE_ONLY_SOURCES TestInterOp.cpp)
+endif()
 if(Kokkos_ENABLE_OPENMPTARGET)
   list(REMOVE_ITEM COMPILE_ONLY_SOURCES TestNestedReducerCTAD.cpp)
 endif()
-KOKKOS_ADD_EXECUTABLE(
-  CoreTestCompileOnly
-  SOURCES
-  TestCompileMain.cpp
-  ${COMPILE_ONLY_SOURCES}
-)
+kokkos_add_executable(CoreTestCompileOnly SOURCES TestCompileMain.cpp ${COMPILE_ONLY_SOURCES})
 
 foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
   string(TOUPPER ${Tag} DEVICE)
@@ -144,53 +137,51 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
     # command line in an intermediate compilation step even if CMake generated a response
     # file. That then exceeded the shell command line max length.
     set(${Tag}_SOURCES1A)
-    foreach(Name
-        Abort
-        ArrayOps
-        AtomicOperations_complexdouble
-        AtomicOperations_complexfloat
-        AtomicOperations_double
-        AtomicOperations_float
-        AtomicOperations_int
-        AtomicOperations_longint
-        AtomicOperations_longlongint
-        AtomicOperations_shared
-        AtomicOperations_unsignedint
-        AtomicOperations_unsignedlongint
-        Atomics
-        AtomicViews
-        BitManipulationBuiltins
-        BlockSizeDeduction
-        CheckedIntegerOps
-        CommonPolicyConstructors
-        CommonPolicyInterface
-        Complex
-        Concepts
-        Crs
-        DeepCopyAlignment
-        ExecSpacePartitioning
-        ExecSpaceThreadSafety
-        ExecutionSpace
-        FunctorAnalysis
-        Graph
-        HostSharedPtr
-        HostSharedPtrAccessOnDevice
-        Init
-        JoinBackwardCompatibility
-        LocalDeepCopy
-        MathematicalConstants
-        MathematicalFunctions1
-        MathematicalFunctions2
-        MathematicalFunctions3
-        MathematicalSpecialFunctions
-        )
+    foreach(
+      Name
+      Abort
+      ArrayOps
+      AtomicOperations_complexdouble
+      AtomicOperations_complexfloat
+      AtomicOperations_double
+      AtomicOperations_float
+      AtomicOperations_int
+      AtomicOperations_longint
+      AtomicOperations_longlongint
+      AtomicOperations_shared
+      AtomicOperations_unsignedint
+      AtomicOperations_unsignedlongint
+      Atomics
+      AtomicViews
+      BitManipulationBuiltins
+      BlockSizeDeduction
+      CheckedIntegerOps
+      CommonPolicyConstructors
+      CommonPolicyInterface
+      Complex
+      Concepts
+      Crs
+      DeepCopyAlignment
+      ExecSpacePartitioning
+      ExecSpaceThreadSafety
+      ExecutionSpace
+      FunctorAnalysis
+      Graph
+      HostSharedPtr
+      HostSharedPtrAccessOnDevice
+      Init
+      JoinBackwardCompatibility
+      LocalDeepCopy
+      MathematicalConstants
+      MathematicalFunctions1
+      MathematicalFunctions2
+      MathematicalFunctions3
+      MathematicalSpecialFunctions
+    )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-      file(WRITE ${dir}/dummy.cpp
-          "#include <Test${Tag}_Category.hpp>\n"
-          "#include <Test${Name}.hpp>\n"
-      )
+      file(WRITE ${dir}/dummy.cpp "#include <Test${Tag}_Category.hpp>\n" "#include <Test${Name}.hpp>\n")
       configure_file(${dir}/dummy.cpp ${file})
       list(APPEND ${Tag}_SOURCES1A ${file})
     endforeach()
@@ -231,92 +222,79 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         SpaceAwareAccessorAccessViolation
         SpaceAwareAccessor
         Swap
-        )
-    IF (NOT Kokkos_ENABLE_IMPL_MDSPAN)
-      LIST(REMOVE_ITEM ${Tag}_TESTNAMES1B
-         MDSpanAtomicAccessor
-         MDSpanConversion
-         SpaceAwareAccessorAccessViolation
-         SpaceAwareAccessor
+    )
+    if(NOT Kokkos_ENABLE_IMPL_MDSPAN)
+      list(REMOVE_ITEM ${Tag}_TESTNAMES1B MDSpanAtomicAccessor MDSpanConversion SpaceAwareAccessorAccessViolation
+           SpaceAwareAccessor
       )
-    ENDIF()
+    endif()
     # This test case causes MSVC to fail with "number of sections exceeded object file format limit"
-    IF (MSVC)
-      LIST(REMOVE_ITEM ${Tag}_TESTNAMES1B
-        Reducers_d
-      )
-    ENDIF()
+    if(MSVC)
+      list(REMOVE_ITEM ${Tag}_TESTNAMES1B Reducers_d)
+    endif()
     foreach(Name IN LISTS ${Tag}_TESTNAMES1B)
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-      file(WRITE ${dir}/dummy.cpp
-          "#include <Test${Tag}_Category.hpp>\n"
-          "#include <Test${Name}.hpp>\n"
-      )
+      file(WRITE ${dir}/dummy.cpp "#include <Test${Tag}_Category.hpp>\n" "#include <Test${Name}.hpp>\n")
       configure_file(${dir}/dummy.cpp ${file})
       list(APPEND ${Tag}_SOURCES1B ${file})
     endforeach()
 
-    SET(${Tag}_SOURCES2A)
-    SET(${Tag}_TESTNAMES2A
-      TeamBasic
-      TeamCombinedReducers
-      TeamMDRange
-      TeamPolicyConstructors
-      TeamReductionScan
-      TeamScan
-      TeamScratch
-      TeamTeamSize
-      TeamVectorRange
-      UniqueToken
-      View_64bit
-      ViewAPI_a
-      ViewAPI_b
-      ViewAPI_c
-      ViewAPI_d
-      ViewAPI_e
-      ViewBadAlloc
-      ViewCopy_a
-      ViewCopy_b
-      ViewCopy_c
-      ViewCtorDimMatch
-      ViewEmptyRuntimeUnmanaged
-      ViewHooks
-      ViewLayoutStrideAssignment
-      ViewMapping_a
-      ViewMapping_b
-      ViewMapping_subview
-      ViewMemoryAccessViolation
-      ViewOfClass
-      ViewOfViews
-      ViewOutOfBoundsAccess
-      ViewResize
-      WorkGraph
-      WithoutInitializing
-      )
+    set(${Tag}_SOURCES2A)
+    set(${Tag}_TESTNAMES2A
+        TeamBasic
+        TeamCombinedReducers
+        TeamMDRange
+        TeamPolicyConstructors
+        TeamReductionScan
+        TeamScan
+        TeamScratch
+        TeamTeamSize
+        TeamVectorRange
+        UniqueToken
+        View_64bit
+        ViewAPI_a
+        ViewAPI_b
+        ViewAPI_c
+        ViewAPI_d
+        ViewAPI_e
+        ViewBadAlloc
+        ViewCopy_a
+        ViewCopy_b
+        ViewCopy_c
+        ViewCtorDimMatch
+        ViewEmptyRuntimeUnmanaged
+        ViewHooks
+        ViewLayoutStrideAssignment
+        ViewMapping_a
+        ViewMapping_b
+        ViewMapping_subview
+        ViewMemoryAccessViolation
+        ViewOfClass
+        ViewOfViews
+        ViewOutOfBoundsAccess
+        ViewResize
+        WorkGraph
+        WithoutInitializing
+    )
     # Workaround to internal compiler error with intel classic compilers
     # when using -no-ip flag in ViewCopy_c
     # See issue: https://github.com/kokkos/kokkos/issues/7084
-    IF(KOKKOS_CXX_COMPILER_ID STREQUAL Intel)
-      LIST(REMOVE_ITEM ${Tag}_TESTNAMES2A
-        ViewCopy_c
-      )
+    if(KOKKOS_CXX_COMPILER_ID STREQUAL Intel)
+      list(REMOVE_ITEM ${Tag}_TESTNAMES2A ViewCopy_c)
     endif()
     foreach(Name IN LISTS ${Tag}_TESTNAMES2A)
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-      file(WRITE ${dir}/dummy.cpp
-          "#include <Test${Tag}_Category.hpp>\n"
-          "#include <Test${Name}.hpp>\n"
-      )
+      file(WRITE ${dir}/dummy.cpp "#include <Test${Tag}_Category.hpp>\n" "#include <Test${Name}.hpp>\n")
       configure_file(${dir}/dummy.cpp ${file})
       list(APPEND ${Tag}_SOURCES2A ${file})
     endforeach()
 
     set(TagHostAccessible ${Tag})
-    if (Tag STREQUAL "Cuda")
+    if(Tag STREQUAL "Cuda")
       set(TagHostAccessible CudaUVM)
     elseif(Tag STREQUAL "HIP")
       set(TagHostAccessible HIPManaged)
@@ -325,7 +303,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
     endif()
 
     set(${Tag}_SOURCES2B)
-    foreach(Name
+    foreach(
+      Name
       SubView_a
       SubView_b
       SubView_c01
@@ -333,51 +312,31 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       SubView_c03
       SubView_c04
       SubView_c05
-      )
+    )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-      file(WRITE ${dir}/dummy.cpp
-          "#include <Test${TagHostAccessible}_Category.hpp>\n"
-          "#include <Test${Name}.hpp>\n"
-      )
+      file(WRITE ${dir}/dummy.cpp "#include <Test${TagHostAccessible}_Category.hpp>\n" "#include <Test${Name}.hpp>\n")
       configure_file(${dir}/dummy.cpp ${file})
       list(APPEND ${Tag}_SOURCES2B ${file})
     endforeach()
 
     set(${Tag}_SOURCES2C)
-    foreach(Name
-      SubView_c06
-      SubView_c07
-      SubView_c08
-      SubView_c09
-      )
+    foreach(Name SubView_c06 SubView_c07 SubView_c08 SubView_c09)
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-      file(WRITE ${dir}/dummy.cpp
-          "#include <Test${TagHostAccessible}_Category.hpp>\n"
-          "#include <Test${Name}.hpp>\n"
-      )
+      file(WRITE ${dir}/dummy.cpp "#include <Test${TagHostAccessible}_Category.hpp>\n" "#include <Test${Name}.hpp>\n")
       configure_file(${dir}/dummy.cpp ${file})
       list(APPEND ${Tag}_SOURCES2C ${file})
     endforeach()
 
     set(${Tag}_SOURCES2D)
-    foreach(Name
-      SubView_c10
-      SubView_c11
-      SubView_c12
-      SubView_c13
-      SubView_c14
-      )
+    foreach(Name SubView_c10 SubView_c11 SubView_c12 SubView_c13 SubView_c14)
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-      file(WRITE ${dir}/dummy.cpp
-          "#include <Test${TagHostAccessible}_Category.hpp>\n"
-          "#include <Test${Name}.hpp>\n"
-      )
+      file(WRITE ${dir}/dummy.cpp "#include <Test${TagHostAccessible}_Category.hpp>\n" "#include <Test${Name}.hpp>\n")
       configure_file(${dir}/dummy.cpp ${file})
       list(APPEND ${Tag}_SOURCES2D ${file})
     endforeach()
@@ -385,32 +344,21 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
     # ViewSupport should eventually contain the new implementation
     # detail tests for the mdspan based View
     set(${Tag}_VIEWSUPPORT)
-    IF (Kokkos_ENABLE_IMPL_MDSPAN)
-      foreach(Name
-        ReferenceCountedAccessor
-        ReferenceCountedDataHandle
-        )
+    if(Kokkos_ENABLE_IMPL_MDSPAN)
+      foreach(Name ReferenceCountedAccessor ReferenceCountedDataHandle)
         set(file ${dir}/Test${Tag}_View_${Name}.cpp)
         # Write to a temporary intermediate file and call configure_file to avoid
         # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-        file(WRITE ${dir}/dummy.cpp
-            "#include <Test${Tag}_Category.hpp>\n"
-            "#include <view/Test${Name}.hpp>\n"
-        )
+        file(WRITE ${dir}/dummy.cpp "#include <Test${Tag}_Category.hpp>\n" "#include <view/Test${Name}.hpp>\n")
         configure_file(${dir}/dummy.cpp ${file})
         list(APPEND ${Tag}_VIEWSUPPORT ${file})
       endforeach()
-      KOKKOS_ADD_EXECUTABLE_AND_TEST(
-        CoreUnitTest_${Tag}_ViewSupport
-        SOURCES
-        UnitTestMainInit.cpp
-        ${${Tag}_VIEWSUPPORT}
-      )
+      kokkos_add_executable_and_test(CoreUnitTest_${Tag}_ViewSupport SOURCES UnitTestMainInit.cpp ${${Tag}_VIEWSUPPORT})
     endif()
 
-    SET(${Tag}_SOURCES1 ${${Tag}_SOURCES1A} ${${Tag}_SOURCES1B})
-    SET(${Tag}_SOURCES2 ${${Tag}_SOURCES2A} ${${Tag}_SOURCES2B} ${${Tag}_SOURCES2C} ${${Tag}_SOURCES2D})
-    SET(${Tag}_SOURCES ${${Tag}_SOURCES1} ${${Tag}_SOURCES2})
+    set(${Tag}_SOURCES1 ${${Tag}_SOURCES1A} ${${Tag}_SOURCES1B})
+    set(${Tag}_SOURCES2 ${${Tag}_SOURCES2A} ${${Tag}_SOURCES2B} ${${Tag}_SOURCES2C} ${${Tag}_SOURCES2D})
+    set(${Tag}_SOURCES ${${Tag}_SOURCES1} ${${Tag}_SOURCES2})
   endif()
 endforeach()
 
@@ -424,7 +372,8 @@ foreach(PairDeviceSpace HIP-HostPinned;HIP-Managed;Cuda-HostPinned;Cuda-UVM;SYCL
   if(Kokkos_ENABLE_${UPPER_DEVICE})
     set(dir ${CMAKE_CURRENT_BINARY_DIR}/${dir})
     file(MAKE_DIRECTORY ${dir})
-    foreach(Name
+    foreach(
+      Name
       SharedAlloc
       ViewAPI_a
       ViewAPI_b
@@ -437,14 +386,11 @@ foreach(PairDeviceSpace HIP-HostPinned;HIP-Managed;Cuda-HostPinned;Cuda-UVM;SYCL
       ViewMapping_a
       ViewMapping_b
       ViewMapping_subview
-      )
+    )
       set(file ${dir}/Test${DEVICE}${SPACE}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-      file(WRITE ${dir}/dummy.cpp
-          "#include <Test${DEVICE}${SPACE}_Category.hpp>\n"
-          "#include <Test${Name}.hpp>\n"
-      )
+      file(WRITE ${dir}/dummy.cpp "#include <Test${DEVICE}${SPACE}_Category.hpp>\n" "#include <Test${Name}.hpp>\n")
       configure_file(${dir}/dummy.cpp ${file})
       list(APPEND ${DEVICE}_SOURCES3 ${file})
     endforeach()
@@ -454,54 +400,60 @@ endforeach()
 
 # Disable non-compiling tests based on clang version.
 if(Kokkos_ENABLE_OPENMPTARGET)
-  list(REMOVE_ITEM OpenMPTarget_SOURCES
+  list(
+    REMOVE_ITEM
+    OpenMPTarget_SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Other.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamCombinedReducers.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamReductionScan.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_WorkGraph.cpp
-    IF (KOKKOS_CXX_COMPILER_ID STREQUAL "Clang" AND KOKKOS_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0.0)
-        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_AtomicOperations_shared.cpp
-        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_MinMaxClamp.cpp
-        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_LocalDeepCopy.cpp
-        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_d.cpp
-        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamVectorRange.cpp
-        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_ViewAPI_e.cpp
-        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamScan.cpp
-        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamBasic.cpp
-        IF (KOKKOS_CXX_COMPILER_VERSION VERSION_LESS 17.0.3)
-            ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_SubView_c01.cpp
-            ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_SubView_c02.cpp
-            ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_SubView_c03.cpp
-            ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_d.cpp
-        endif()
-    endif()
+    IF
+    (KOKKOS_CXX_COMPILER_ID STREQUAL "Clang" AND KOKKOS_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0.0)
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_AtomicOperations_shared.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_MinMaxClamp.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_LocalDeepCopy.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_d.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamVectorRange.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_ViewAPI_e.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamScan.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamBasic.cpp
+    IF
+    (KOKKOS_CXX_COMPILER_VERSION VERSION_LESS 17.0.3)
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_SubView_c01.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_SubView_c02.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_SubView_c03.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_d.cpp
+    endif
+    ()
+    endif
+    ()
     # FIXME_OPENMPTARGET_CRAY: The following tests fail at compile time when the OpenMPTarget backend is enabled with the Cray compiler.
     # Atomic compare/exchange is used in these tests which can be one of the reasons for the compilation failures.
-    IF(KOKKOS_CXX_COMPILER_ID STREQUAL Cray)
-        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_AtomicOperations_complexdouble.cpp
-        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_UniqueToken.cpp
-        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_SharedAlloc.cpp
-    ENDIF()
-    )
+    IF
+    (KOKKOS_CXX_COMPILER_ID STREQUAL Cray)
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_AtomicOperations_complexdouble.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_UniqueToken.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_SharedAlloc.cpp
+    ENDIF
+    ()
+  )
 endif()
 
 # FIXME_OPENMPTARGET - MinMaxClamp fails even with the host backend when OpenMPTarget backend is enabled.
 # FIXME_OPENMPTARGET - Unsure of the reason as of now.
-IF (KOKKOS_CXX_COMPILER_ID STREQUAL "Clang" AND KOKKOS_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0.0)
-    IF(Kokkos_ENABLE_OPENMPTARGET AND Kokkos_ENABLE_OPENMP)
-      list(REMOVE_ITEM OpenMP_SOURCES
-          ${CMAKE_CURRENT_BINARY_DIR}/openmp/TestOpenMP_MinMaxClamp.cpp
-            )
-    ENDIF()
-    IF(Kokkos_ENABLE_OPENMPTARGET AND Kokkos_ENABLE_SERIAL)
-        list(REMOVE_ITEM Serial_SOURCES1
-            ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_MinMaxClamp.cpp
-            )
-    ENDIF()
-ENDIF()
+if(KOKKOS_CXX_COMPILER_ID STREQUAL "Clang" AND KOKKOS_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0.0)
+  if(Kokkos_ENABLE_OPENMPTARGET AND Kokkos_ENABLE_OPENMP)
+    list(REMOVE_ITEM OpenMP_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/openmp/TestOpenMP_MinMaxClamp.cpp)
+  endif()
+  if(Kokkos_ENABLE_OPENMPTARGET AND Kokkos_ENABLE_SERIAL)
+    list(REMOVE_ITEM Serial_SOURCES1 ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_MinMaxClamp.cpp)
+  endif()
+endif()
 
 if(Kokkos_ENABLE_OPENACC)
-  list(REMOVE_ITEM OpenACC_SOURCES
+  list(
+    REMOVE_ITEM
+    OpenACC_SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_complexdouble.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_complexfloat.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_Crs.cpp
@@ -522,25 +474,23 @@ endif()
 
 # FIXME_OPENMPTARGET - Comment non-passing tests with amdclang++
 # FIXME_OPENMPTARGET - Need to check on GFX1030 and GFX1100 architectures
-IF(KOKKOS_ARCH_VEGA)
-  SET(KOKKOS_AMDGPU_ARCH TRUE)
-ENDIF()
-IF(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang AND KOKKOS_AMDGPU_ARCH)
-  LIST(REMOVE_ITEM OpenMPTarget_SOURCES
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_e.cpp
-  )
-ENDIF()
+if(KOKKOS_ARCH_VEGA)
+  set(KOKKOS_AMDGPU_ARCH TRUE)
+endif()
+if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang AND KOKKOS_AMDGPU_ARCH)
+  list(REMOVE_ITEM OpenMPTarget_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_e.cpp)
+endif()
 # FIXME_OPENMPTARGET This test causes internal compiler errors as of 09/01/22
 # when compiling for Intel's Xe-HP GPUs.
-IF(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
-  LIST(REMOVE_ITEM OpenMPTarget_SOURCES
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamVectorRange.cpp
-  )
-ENDIF()
+if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
+  list(REMOVE_ITEM OpenMPTarget_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamVectorRange.cpp)
+endif()
 
 # FIXME_OPENMPTARGET - Comment non-passing tests with the NVIDIA HPC compiler nvc++
-IF(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
-  list(REMOVE_ITEM OpenMPTarget_SOURCES
+if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
+  list(
+    REMOVE_ITEM
+    OpenMPTarget_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/default/TestDefaultDeviceType_a1.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/default/TestDefaultDeviceType_b1.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_AtomicOperations.cpp
@@ -602,12 +552,14 @@ IF(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_ViewAPI_f.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_ViewMapping_b.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_ViewResize.cpp
-    )
+  )
 endif()
 
 # FIXME_OPENACC - Comment non-passing tests with the NVIDIA HPC compiler nvc++
-IF(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
-  list(REMOVE_ITEM OpenACC_SOURCES
+if(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
+  list(
+    REMOVE_ITEM
+    OpenACC_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/default/TestDefaultDeviceType_a1.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/default/TestDefaultDeviceType_b1.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_shared.cpp
@@ -632,12 +584,14 @@ IF(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_TeamTeamSize.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_UniqueToken.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewResize.cpp
-    )
+  )
 endif()
 
 # FIXME_OPENACC - Comment non-passing tests with the Clang compiler
-IF(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
-  list(REMOVE_ITEM OpenACC_SOURCES
+if(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
+  list(
+    REMOVE_ITEM
+    OpenACC_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/default/TestDefaultDeviceType_a1.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/default/TestDefaultDeviceType_b1.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_double.cpp
@@ -690,329 +644,205 @@ IF(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewAPI_d.cpp
     #Below test is disabled because it uses atomic operations not supported by Clacc.
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ExecSpaceThreadSafety.cpp
-    )
+  )
   # When tested on a systme with AMD MI60 GPU and ROCm V5.4.0, these cause
   # clang-linker-wrapper to hang for a long time while building the unit tests.
   # In some cases, including them caused the build not to complete after an hour,
   # but excluding them permitted the build to finish in 1.5 mins or less.
-  IF(KOKKOS_AMDGPU_ARCH)
-    list(REMOVE_ITEM OpenACC_SOURCES
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_BitManipulationBuiltins.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_MathematicalFunctions3.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ParallelScanRangePolicy.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c04.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c05.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c06.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c07.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c08.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c09.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c10.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c11.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c12.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewAPI_b.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewAPI_c.cpp
+  if(KOKKOS_AMDGPU_ARCH)
+    list(
+      REMOVE_ITEM
+      OpenACC_SOURCES
+      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_BitManipulationBuiltins.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_MathematicalFunctions3.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ParallelScanRangePolicy.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c04.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c05.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c06.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c07.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c08.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c09.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c10.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c11.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c12.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewAPI_b.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewAPI_c.cpp
     )
   endif()
   # Fails serial.atomics_tpetra_max_abs when we test with Clacc.
-  list(REMOVE_ITEM Serial_SOURCES1
-    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_Atomics.cpp)
+  list(REMOVE_ITEM Serial_SOURCES1 ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_Atomics.cpp)
 endif()
 
 if(Kokkos_ENABLE_SERIAL)
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_Serial1
-    SOURCES
-    UnitTestMainInit.cpp
-    ${Serial_SOURCES1}
-    serial/TestSerial_Task.cpp
+  kokkos_add_executable_and_test(
+    CoreUnitTest_Serial1 SOURCES UnitTestMainInit.cpp ${Serial_SOURCES1} serial/TestSerial_Task.cpp
   )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_Serial2
-    SOURCES
-    UnitTestMainInit.cpp
-    ${Serial_SOURCES2}
-  )
+  kokkos_add_executable_and_test(CoreUnitTest_Serial2 SOURCES UnitTestMainInit.cpp ${Serial_SOURCES2})
 endif()
 
 if(Kokkos_ENABLE_THREADS)
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_Threads
-    SOURCES ${Threads_SOURCES}
-    UnitTestMainInit.cpp
-  )
+  kokkos_add_executable_and_test(CoreUnitTest_Threads SOURCES ${Threads_SOURCES} UnitTestMainInit.cpp)
 endif()
 
-if (Kokkos_ENABLE_OPENMP)
-  set(OpenMP_EXTRA_SOURCES
-    openmp/TestOpenMP_Task.cpp
+if(Kokkos_ENABLE_OPENMP)
+  set(OpenMP_EXTRA_SOURCES openmp/TestOpenMP_Task.cpp)
+  kokkos_add_executable_and_test(
+    CoreUnitTest_OpenMP SOURCES UnitTestMainInit.cpp ${OpenMP_SOURCES} ${OpenMP_EXTRA_SOURCES}
   )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_OpenMP
-    SOURCES
-    UnitTestMainInit.cpp
-    ${OpenMP_SOURCES}
-    ${OpenMP_EXTRA_SOURCES}
-  )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_OpenMPInterOp
-    SOURCES
-      UnitTestMain.cpp
-      openmp/TestOpenMP_InterOp.cpp
-  )
+  kokkos_add_executable_and_test(CoreUnitTest_OpenMPInterOp SOURCES UnitTestMain.cpp openmp/TestOpenMP_InterOp.cpp)
 endif()
 
 if(Kokkos_ENABLE_HPX)
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_HPX
-    SOURCES
-      UnitTestMainInit.cpp
-      ${HPX_SOURCES}
-      hpx/TestHPX_Task.cpp
-  )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_HPXInterOp
-    SOURCES
-      UnitTestMain.cpp
-      hpx/TestHPX_InterOp.cpp
-  )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+  kokkos_add_executable_and_test(CoreUnitTest_HPX SOURCES UnitTestMainInit.cpp ${HPX_SOURCES} hpx/TestHPX_Task.cpp)
+  kokkos_add_executable_and_test(CoreUnitTest_HPXInterOp SOURCES UnitTestMain.cpp hpx/TestHPX_InterOp.cpp)
+  kokkos_add_executable_and_test(
     CoreUnitTest_HPX_IndependentInstances
     SOURCES
-      UnitTestMainInit.cpp
-      hpx/TestHPX_IndependentInstances.cpp
-      hpx/TestHPX_IndependentInstancesDelayedExecution.cpp
-      hpx/TestHPX_IndependentInstancesInstanceIds.cpp
-      hpx/TestHPX_IndependentInstancesRefCounting.cpp
-      hpx/TestHPX_IndependentInstancesSynchronization.cpp
+    UnitTestMainInit.cpp
+    hpx/TestHPX_IndependentInstances.cpp
+    hpx/TestHPX_IndependentInstancesDelayedExecution.cpp
+    hpx/TestHPX_IndependentInstancesInstanceIds.cpp
+    hpx/TestHPX_IndependentInstancesRefCounting.cpp
+    hpx/TestHPX_IndependentInstancesSynchronization.cpp
   )
-if(Kokkos_ENABLE_DEPRECATED_CODE_4)
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_HPX_InParallel
-    SOURCES
-      UnitTestMainInit.cpp
-      hpx/TestHPX_InParallel.cpp
-  )
+  if(Kokkos_ENABLE_DEPRECATED_CODE_4)
+    kokkos_add_executable_and_test(CoreUnitTest_HPX_InParallel SOURCES UnitTestMainInit.cpp hpx/TestHPX_InParallel.cpp)
   endif()
 endif()
 
 if(Kokkos_ENABLE_OPENMPTARGET)
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_OpenMPTarget
-    SOURCES
-    UnitTestMainInit.cpp
-    ${OpenMPTarget_SOURCES}
-  )
+  kokkos_add_executable_and_test(CoreUnitTest_OpenMPTarget SOURCES UnitTestMainInit.cpp ${OpenMPTarget_SOURCES})
 endif()
 
 if(Kokkos_ENABLE_OPENACC)
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_OpenACC
-    SOURCES
-    UnitTestMainInit.cpp
-    ${OpenACC_SOURCES}
-  )
+  kokkos_add_executable_and_test(CoreUnitTest_OpenACC SOURCES UnitTestMainInit.cpp ${OpenACC_SOURCES})
 endif()
 
 if(Kokkos_ENABLE_CUDA)
-    KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_Cuda1
-    SOURCES
-      UnitTestMainInit.cpp
-      ${Cuda_SOURCES1}
-      cuda/TestCuda_ReducerViewSizeLimit.cpp
-    )
+  kokkos_add_executable_and_test(
+    CoreUnitTest_Cuda1 SOURCES UnitTestMainInit.cpp ${Cuda_SOURCES1} cuda/TestCuda_ReducerViewSizeLimit.cpp
+  )
 
-    KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_Cuda2
-    SOURCES
-      UnitTestMainInit.cpp
-      ${Cuda_SOURCES2}
-    )
+  kokkos_add_executable_and_test(CoreUnitTest_Cuda2 SOURCES UnitTestMainInit.cpp ${Cuda_SOURCES2})
 
-    KOKKOS_ADD_EXECUTABLE_AND_TEST(
+  kokkos_add_executable_and_test(
     CoreUnitTest_Cuda3
     SOURCES
-      UnitTestMainInit.cpp
-      cuda/TestCuda_Task.cpp
-      cuda/TestCuda_TeamScratchStreams.cpp
-      ${Cuda_SOURCES3}
-      cuda/TestCuda_Spaces.cpp
-      ${Cuda_SOURCES_SHAREDSPACE}
-    )
-
-    KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_CudaTimingBased
-    SOURCES
-      UnitTestMainInit.cpp
-      cuda/TestCuda_DebugSerialExecution.cpp
-      cuda/TestCuda_DebugPinUVMSpace.cpp
+    UnitTestMainInit.cpp
+    cuda/TestCuda_Task.cpp
+    cuda/TestCuda_TeamScratchStreams.cpp
+    ${Cuda_SOURCES3}
+    cuda/TestCuda_Spaces.cpp
+    ${Cuda_SOURCES_SHAREDSPACE}
   )
 
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_CudaInterOpInit
-    SOURCES
-      UnitTestMain.cpp
-      cuda/TestCuda_InterOp_Init.cpp
+  kokkos_add_executable_and_test(
+    CoreUnitTest_CudaTimingBased SOURCES UnitTestMainInit.cpp cuda/TestCuda_DebugSerialExecution.cpp
+    cuda/TestCuda_DebugPinUVMSpace.cpp
   )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_CudaInterOpStreams
-    SOURCES
-      UnitTestMain.cpp
-      cuda/TestCuda_InterOp_Streams.cpp
+
+  kokkos_add_executable_and_test(CoreUnitTest_CudaInterOpInit SOURCES UnitTestMain.cpp cuda/TestCuda_InterOp_Init.cpp)
+  kokkos_add_executable_and_test(
+    CoreUnitTest_CudaInterOpStreams SOURCES UnitTestMain.cpp cuda/TestCuda_InterOp_Streams.cpp
   )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_CudaInterOpStreamsMultiGPU
-    SOURCES
-      UnitTestMainInit.cpp
-      cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+  kokkos_add_executable_and_test(
+    CoreUnitTest_CudaInterOpStreamsMultiGPU SOURCES UnitTestMainInit.cpp cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
   )
 endif()
 
 if(Kokkos_ENABLE_HIP)
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+  kokkos_add_executable_and_test(
     CoreUnitTest_HIP
     SOURCES
-      UnitTestMainInit.cpp
-      ${HIP_SOURCES}
-      hip/TestHIP_ScanUnit.cpp
-      hip/TestHIP_Spaces.cpp
-      hip/TestHIP_Memory_Requirements.cpp
-      hip/TestHIP_TeamScratchStreams.cpp
-      hip/TestHIP_AsyncLauncher.cpp
-      hip/TestHIP_BlocksizeDeduction.cpp
+    UnitTestMainInit.cpp
+    ${HIP_SOURCES}
+    hip/TestHIP_ScanUnit.cpp
+    hip/TestHIP_Spaces.cpp
+    hip/TestHIP_Memory_Requirements.cpp
+    hip/TestHIP_TeamScratchStreams.cpp
+    hip/TestHIP_AsyncLauncher.cpp
+    hip/TestHIP_BlocksizeDeduction.cpp
   )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_HIPInterOpInit
-    SOURCES
-      UnitTestMain.cpp
-      hip/TestHIP_InterOp_Init.cpp
-  )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_HIPInterOpStreams
-    SOURCES
-      UnitTestMain.cpp
-      hip/TestHIP_InterOp_Streams.cpp
+  kokkos_add_executable_and_test(CoreUnitTest_HIPInterOpInit SOURCES UnitTestMain.cpp hip/TestHIP_InterOp_Init.cpp)
+  kokkos_add_executable_and_test(
+    CoreUnitTest_HIPInterOpStreams SOURCES UnitTestMain.cpp hip/TestHIP_InterOp_Streams.cpp
   )
 endif()
 
 if(Kokkos_ENABLE_SYCL)
-  list(REMOVE_ITEM SYCL_SOURCES2A
-       ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_WorkGraph.cpp
-  )
+  list(REMOVE_ITEM SYCL_SOURCES2A ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_WorkGraph.cpp)
 
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_SYCL1A
-    SOURCES
-      UnitTestMainInit.cpp
-      ${SYCL_SOURCES1A}
-  )
+  kokkos_add_executable_and_test(CoreUnitTest_SYCL1A SOURCES UnitTestMainInit.cpp ${SYCL_SOURCES1A})
 
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_SYCL1B
-    SOURCES
-      UnitTestMainInit.cpp
-      ${SYCL_SOURCES1B}
-  )
+  kokkos_add_executable_and_test(CoreUnitTest_SYCL1B SOURCES UnitTestMainInit.cpp ${SYCL_SOURCES1B})
 
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_SYCL2A
-    SOURCES
-      UnitTestMainInit.cpp
-      ${SYCL_SOURCES2A}
-  )
+  kokkos_add_executable_and_test(CoreUnitTest_SYCL2A SOURCES UnitTestMainInit.cpp ${SYCL_SOURCES2A})
 
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_SYCL2B
-    SOURCES
-      UnitTestMainInit.cpp
-      ${SYCL_SOURCES2B}
-  )
+  kokkos_add_executable_and_test(CoreUnitTest_SYCL2B SOURCES UnitTestMainInit.cpp ${SYCL_SOURCES2B})
 
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_SYCL2C
-    SOURCES
-      UnitTestMainInit.cpp
-      ${SYCL_SOURCES2C}
-  )
+  kokkos_add_executable_and_test(CoreUnitTest_SYCL2C SOURCES UnitTestMainInit.cpp ${SYCL_SOURCES2C})
 
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_SYCL2D
-    SOURCES
-      UnitTestMainInit.cpp
-      ${SYCL_SOURCES2D}
-  )
+  kokkos_add_executable_and_test(CoreUnitTest_SYCL2D SOURCES UnitTestMainInit.cpp ${SYCL_SOURCES2D})
 
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+  kokkos_add_executable_and_test(
     CoreUnitTest_SYCL3
     SOURCES
-      UnitTestMainInit.cpp
-      # FIXME_SYCL
-      sycl/TestSYCL_Task.cpp
-      sycl/TestSYCL_TeamScratchStreams.cpp
-      ${SYCL_SOURCES3}
-      sycl/TestSYCL_Spaces.cpp
+    UnitTestMainInit.cpp
+    # FIXME_SYCL
+    sycl/TestSYCL_Task.cpp
+    sycl/TestSYCL_TeamScratchStreams.cpp
+    ${SYCL_SOURCES3}
+    sycl/TestSYCL_Spaces.cpp
   )
 
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_SYCLInterOpInit
-    SOURCES
-      UnitTestMain.cpp
-      sycl/TestSYCL_InterOp_Init.cpp
+  kokkos_add_executable_and_test(CoreUnitTest_SYCLInterOpInit SOURCES UnitTestMain.cpp sycl/TestSYCL_InterOp_Init.cpp)
+  kokkos_add_executable_and_test(
+    CoreUnitTest_SYCLInterOpInit_Context SOURCES UnitTestMainInit.cpp sycl/TestSYCL_InterOp_Init_Context.cpp
   )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_SYCLInterOpInit_Context
-    SOURCES
-      UnitTestMainInit.cpp
-      sycl/TestSYCL_InterOp_Init_Context.cpp
+  kokkos_add_executable_and_test(
+    CoreUnitTest_SYCLInterOpStreams SOURCES UnitTestMain.cpp sycl/TestSYCL_InterOp_Streams.cpp
   )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_SYCLInterOpStreams
-    SOURCES
-     UnitTestMain.cpp
-     sycl/TestSYCL_InterOp_Streams.cpp
-  )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-      CoreUnitTest_SYCLInterOpStreamsMultiGPU
-    SOURCES
-      UnitTestMainInit.cpp
-      sycl/TestSYCL_InterOp_StreamsMultiGPU.cpp
+  kokkos_add_executable_and_test(
+    CoreUnitTest_SYCLInterOpStreamsMultiGPU SOURCES UnitTestMainInit.cpp sycl/TestSYCL_InterOp_StreamsMultiGPU.cpp
   )
 endif()
 
-SET(DEFAULT_DEVICE_SOURCES
-  UnitTestMainInit.cpp
-  TestCStyleMemoryManagement.cpp
-  TestInitializationSettings.cpp
-  TestParseCmdLineArgsAndEnvVars.cpp
-  TestSharedSpace.cpp
-  TestSharedHostPinnedSpace.cpp
-  TestCompilerMacros.cpp
-  default/TestDefaultDeviceType.cpp
-  default/TestDefaultDeviceType_a1.cpp
-  default/TestDefaultDeviceType_b1.cpp
-  default/TestDefaultDeviceType_c1.cpp
-  default/TestDefaultDeviceType_a2.cpp
-  default/TestDefaultDeviceType_b2.cpp
-  default/TestDefaultDeviceType_c2.cpp
-  default/TestDefaultDeviceType_a3.cpp
-  default/TestDefaultDeviceType_b3.cpp
-  default/TestDefaultDeviceType_c3.cpp
-  default/TestDefaultDeviceTypeResize.cpp
-  default/TestDefaultDeviceTypeViewAPI.cpp
+set(DEFAULT_DEVICE_SOURCES
+    UnitTestMainInit.cpp
+    TestCStyleMemoryManagement.cpp
+    TestInitializationSettings.cpp
+    TestParseCmdLineArgsAndEnvVars.cpp
+    TestSharedSpace.cpp
+    TestSharedHostPinnedSpace.cpp
+    TestCompilerMacros.cpp
+    default/TestDefaultDeviceType.cpp
+    default/TestDefaultDeviceType_a1.cpp
+    default/TestDefaultDeviceType_b1.cpp
+    default/TestDefaultDeviceType_c1.cpp
+    default/TestDefaultDeviceType_a2.cpp
+    default/TestDefaultDeviceType_b2.cpp
+    default/TestDefaultDeviceType_c2.cpp
+    default/TestDefaultDeviceType_a3.cpp
+    default/TestDefaultDeviceType_b3.cpp
+    default/TestDefaultDeviceType_c3.cpp
+    default/TestDefaultDeviceTypeResize.cpp
+    default/TestDefaultDeviceTypeViewAPI.cpp
 )
 # FIXME_OPENMPTARGET and FIXME_OPENACC do not provide a MemorySpace that can be accessed from all ExecSpaces
 # FIXME_SYCL clock_tic does not give the correct timings for cloc_tic
-if (KOKKOS_ENABLE_OPENACC OR KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_SYCL)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedSpace.cpp)
+if(KOKKOS_ENABLE_OPENACC OR KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_SYCL)
+  list(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedSpace.cpp)
 endif()
 # FIXME_OPENMPTARGET and FIXME_OPENACC do not provide a HostPinnedMemorySpace that can be accessed from all ExecSpaces
-if (KOKKOS_ENABLE_OPENACC OR KOKKOS_ENABLE_OPENMPTARGET)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedHostPinnedSpace.cpp)
+if(KOKKOS_ENABLE_OPENACC OR KOKKOS_ENABLE_OPENMPTARGET)
+  list(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedHostPinnedSpace.cpp)
 endif()
 
 # FIXME_OPENMPTARGET, FIXME_OPENACC - Comment non-passing tests with the NVIDIA HPC compiler nvc++
-if ((KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_OPENACC) AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES
+if((KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_OPENACC) AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
+  list(
+    REMOVE_ITEM
+    DEFAULT_DEVICE_SOURCES
     default/TestDefaultDeviceType_a1.cpp
     default/TestDefaultDeviceType_b1.cpp
     default/TestDefaultDeviceType_c1.cpp
@@ -1028,8 +858,10 @@ if ((KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_OPENACC) AND KOKKOS_CXX_COMPILE
 endif()
 
 # FIXME_OPENACC - Comment non-passing tests with the Clang compiler
-if (KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
-  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES
+if(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
+  list(
+    REMOVE_ITEM
+    DEFAULT_DEVICE_SOURCES
     default/TestDefaultDeviceType_a1.cpp
     default/TestDefaultDeviceType_b1.cpp
     default/TestDefaultDeviceType_c1.cpp
@@ -1044,280 +876,220 @@ if (KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
   )
 endif()
 
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  CoreUnitTest_Default
-  SOURCES ${DEFAULT_DEVICE_SOURCES}
-)
+kokkos_add_executable_and_test(CoreUnitTest_Default SOURCES ${DEFAULT_DEVICE_SOURCES})
 
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  CoreUnitTest_LegionInitialization
-  SOURCES
-    UnitTestMain.cpp
-    TestLegionInitialization.cpp
-)
+kokkos_add_executable_and_test(CoreUnitTest_LegionInitialization SOURCES UnitTestMain.cpp TestLegionInitialization.cpp)
 
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  CoreUnitTest_PushFinalizeHook
-  SOURCES
-    UnitTest_PushFinalizeHook.cpp
-)
+kokkos_add_executable_and_test(CoreUnitTest_PushFinalizeHook SOURCES UnitTest_PushFinalizeHook.cpp)
 
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  CoreUnitTest_ScopeGuard
-  SOURCES
-    UnitTestMain.cpp
-    UnitTest_ScopeGuard.cpp
-)
+kokkos_add_executable_and_test(CoreUnitTest_ScopeGuard SOURCES UnitTestMain.cpp UnitTest_ScopeGuard.cpp)
 
 # This test is intended for development and debugging by putting code
 # into TestDefaultDeviceDevelop.cpp. By default its empty.
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  CoreUnitTest_Develop
-  SOURCES
-    UnitTestMainInit.cpp
-    default/TestDefaultDeviceDevelop.cpp
-)
+kokkos_add_executable_and_test(CoreUnitTest_Develop SOURCES UnitTestMainInit.cpp default/TestDefaultDeviceDevelop.cpp)
 
 # With MSVC, the terminate handler is called and prints the message but the
 # program does not seem to exit and we get a timeout with ctest.
-if (NOT WIN32)
+if(NOT WIN32)
   # This test is special, because it passes exactly when it prints the
   # message "PASSED: I am the custom std::terminate handler.", AND calls
   # std::terminate.  This means that we can't use
   # KOKKOS_ADD_EXECUTABLE_AND_TEST.  See GitHub issue #2147.
-  KOKKOS_ADD_TEST_EXECUTABLE(
-    CoreUnitTest_PushFinalizeHookTerminate
-    SOURCES UnitTest_PushFinalizeHook_terminate.cpp
-  )
-  add_test(
-    NAME Kokkos_CoreUnitTest_PushFinalizeHookTerminateRegex
-    COMMAND ${CMAKE_COMMAND} -E env $<TARGET_FILE:Kokkos_CoreUnitTest_PushFinalizeHookTerminate>
+  kokkos_add_test_executable(CoreUnitTest_PushFinalizeHookTerminate SOURCES UnitTest_PushFinalizeHook_terminate.cpp)
+  add_test(NAME Kokkos_CoreUnitTest_PushFinalizeHookTerminateRegex
+           COMMAND ${CMAKE_COMMAND} -E env $<TARGET_FILE:Kokkos_CoreUnitTest_PushFinalizeHookTerminate>
   )
   set_property(
-    TEST Kokkos_CoreUnitTest_PushFinalizeHookTerminateRegex
-    PROPERTY PASS_REGULAR_EXPRESSION "PASSED: I am the custom std::terminate handler."
+    TEST Kokkos_CoreUnitTest_PushFinalizeHookTerminateRegex PROPERTY PASS_REGULAR_EXPRESSION
+                                                                     "PASSED: I am the custom std::terminate handler."
   )
-  add_test(
-    NAME Kokkos_CoreUnitTest_PushFinalizeHookTerminateFails
-    COMMAND ${CMAKE_COMMAND} -E env $<TARGET_FILE:Kokkos_CoreUnitTest_PushFinalizeHookTerminate>
+  add_test(NAME Kokkos_CoreUnitTest_PushFinalizeHookTerminateFails
+           COMMAND ${CMAKE_COMMAND} -E env $<TARGET_FILE:Kokkos_CoreUnitTest_PushFinalizeHookTerminate>
   )
-  set_property(
-    TEST Kokkos_CoreUnitTest_PushFinalizeHookTerminateFails
-    PROPERTY WILL_FAIL TRUE
-  )
+  set_property(TEST Kokkos_CoreUnitTest_PushFinalizeHookTerminateFails PROPERTY WILL_FAIL TRUE)
 endif()
 
-  if(KOKKOS_ENABLE_TUNING)
-    KOKKOS_ADD_EXECUTABLE_AND_TEST(
-      CoreUnitTest_TuningBuiltins
-      SOURCES
-      tools/TestBuiltinTuners.cpp
-    )
-    KOKKOS_ADD_EXECUTABLE_AND_TEST(
-      CoreUnitTest_TuningBasics
-      SOURCES
-        tools/TestTuning.cpp
-    )
-    KOKKOS_ADD_EXECUTABLE_AND_TEST(
-      CoreUnitTest_CategoricalTuner
-      SOURCES
-      tools/TestCategoricalTuner.cpp
-    )
+if(KOKKOS_ENABLE_TUNING)
+  kokkos_add_executable_and_test(CoreUnitTest_TuningBuiltins SOURCES tools/TestBuiltinTuners.cpp)
+  kokkos_add_executable_and_test(CoreUnitTest_TuningBasics SOURCES tools/TestTuning.cpp)
+  kokkos_add_executable_and_test(CoreUnitTest_CategoricalTuner SOURCES tools/TestCategoricalTuner.cpp)
+endif()
+
+set(KOKKOSP_SOURCES UnitTestMainInit.cpp tools/TestEventCorrectness.cpp tools/TestKernelNames.cpp
+                    tools/TestProfilingSection.cpp tools/TestScopedRegion.cpp tools/TestWithoutInitializing.cpp
+)
+
+# FIXME_OPENMPTARGET This test causes internal compiler errors as of 09/01/22
+# when compiling for Intel's Xe-HP GPUs.
+if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
+  list(REMOVE_ITEM KOKKOSP_SOURCES tools/TestEventCorrectness.cpp)
+endif()
+
+kokkos_add_executable_and_test(CoreUnitTest_KokkosP SOURCES ${KOKKOSP_SOURCES})
+if(KOKKOS_ENABLE_LIBDL)
+  kokkos_add_executable_and_test(CoreUnitTest_ToolIndependence SOURCES tools/TestIndependence.cpp)
+  target_compile_definitions(Kokkos_CoreUnitTest_ToolIndependence PUBLIC KOKKOS_TOOLS_INDEPENDENT_BUILD)
+  kokkos_add_test_library(kokkosprinter-tool SHARED SOURCES tools/printing-tool.cpp)
+
+  if((NOT (Kokkos_ENABLE_CUDA AND WIN32)) AND (NOT ("${KOKKOS_CXX_COMPILER_ID}" STREQUAL "Fujitsu")))
+    target_compile_features(kokkosprinter-tool PUBLIC cxx_std_14)
   endif()
 
-  SET(KOKKOSP_SOURCES
-    UnitTestMainInit.cpp
-    tools/TestEventCorrectness.cpp
-    tools/TestKernelNames.cpp
-    tools/TestProfilingSection.cpp
-    tools/TestScopedRegion.cpp
-    tools/TestWithoutInitializing.cpp
-    )
+  kokkos_add_test_executable(ProfilingAllCalls tools/TestAllCalls.cpp)
 
-  # FIXME_OPENMPTARGET This test causes internal compiler errors as of 09/01/22
-  # when compiling for Intel's Xe-HP GPUs.
-  if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
-    list(REMOVE_ITEM KOKKOSP_SOURCES tools/TestEventCorrectness.cpp)
-  endif()
+  kokkos_add_test_executable(ToolsInitialization UnitTestMain.cpp tools/TestToolsInitialization.cpp)
 
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_KokkosP
-    SOURCES
-    ${KOKKOSP_SOURCES}
+  set(ADDRESS_REGEX "0x[0-9a-f]*")
+  set(MEMSPACE_REGEX "[HC][ou][sd][ta][a-zA-Z]*")
+  set(SIZE_REGEX "[0-9]*")
+  set(SKIP_SCRATCH_INITIALIZATION_REGEX ".*")
+
+  # check help works via environment variable
+  kokkos_add_test(
+    SKIP_TRIBITS
+    NAME
+    ProfilingTestLibraryLoadHelp
+    EXE
+    ProfilingAllCalls
+    TOOL
+    kokkosprinter-tool
+    ARGS
+    --kokkos-tools-help
+    PASS_REGULAR_EXPRESSION
+    "kokkosp_init_library::kokkosp_print_help:Kokkos_ProfilingAllCalls::kokkosp_finalize_library::"
   )
-  if(KOKKOS_ENABLE_LIBDL)
-    KOKKOS_ADD_EXECUTABLE_AND_TEST(
-      CoreUnitTest_ToolIndependence
-      SOURCES
-      tools/TestIndependence.cpp
-    )
-    TARGET_COMPILE_DEFINITIONS(
-      Kokkos_CoreUnitTest_ToolIndependence PUBLIC
-      KOKKOS_TOOLS_INDEPENDENT_BUILD
-    )
-    KOKKOS_ADD_TEST_LIBRARY(
-      kokkosprinter-tool SHARED
-      SOURCES tools/printing-tool.cpp
-    )
 
-    if((NOT (Kokkos_ENABLE_CUDA AND WIN32)) AND (NOT ("${KOKKOS_CXX_COMPILER_ID}" STREQUAL "Fujitsu")))
-      TARGET_COMPILE_FEATURES(kokkosprinter-tool PUBLIC cxx_std_14)
-    endif()
+  # check help works via direct library specification
+  kokkos_add_test(
+    SKIP_TRIBITS
+    NAME
+    ProfilingTestLibraryCmdLineHelp
+    EXE
+    ProfilingAllCalls
+    ARGS
+    --kokkos-tools-help
+    --kokkos-tools-libs=$<TARGET_FILE:kokkosprinter-tool>
+    PASS_REGULAR_EXPRESSION
+    "kokkosp_init_library::kokkosp_print_help:Kokkos_ProfilingAllCalls::kokkosp_finalize_library::"
+  )
 
-    KOKKOS_ADD_TEST_EXECUTABLE(
-      ProfilingAllCalls
-      tools/TestAllCalls.cpp
-    )
+  kokkos_add_test(
+    SKIP_TRIBITS
+    NAME
+    ProfilingTestLibraryLoad
+    EXE
+    ProfilingAllCalls
+    TOOL
+    kokkosprinter-tool
+    ARGS
+    --kokkos-tools-args="-c test delimit"
+    PASS_REGULAR_EXPRESSION
+    "kokkosp_init_library::kokkosp_parse_args:4:Kokkos_ProfilingAllCalls:-c:test:delimit::.*::kokkosp_allocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]source] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_allocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]destination] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_begin_deep_copy:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::.*kokkosp_end_deep_copy::kokkosp_begin_parallel_for:parallel_for:${SIZE_REGEX}:0::kokkosp_end_parallel_for:0::kokkosp_begin_parallel_reduce:parallel_reduce:${SIZE_REGEX}:1${SKIP_SCRATCH_INITIALIZATION_REGEX}::kokkosp_end_parallel_reduce:1::kokkosp_begin_parallel_scan:parallel_scan:${SIZE_REGEX}:2::kokkosp_end_parallel_scan:2::kokkosp_push_profile_region:push_region::kokkosp_pop_profile_region::kokkosp_create_profile_section:created_section:3::kokkosp_start_profile_section:3::kokkosp_stop_profile_section:3::kokkosp_destroy_profile_section:3::kokkosp_profile_event:profiling_event::kokkosp_declare_metadata:dogs:good::kokkosp_deallocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_deallocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_finalize_library::"
+  )
 
-    KOKKOS_ADD_TEST_EXECUTABLE(
-      ToolsInitialization
-      UnitTestMain.cpp
-      tools/TestToolsInitialization.cpp
-    )
-
-    set(ADDRESS_REGEX "0x[0-9a-f]*")
-    set(MEMSPACE_REGEX "[HC][ou][sd][ta][a-zA-Z]*")
-    set(SIZE_REGEX "[0-9]*")
-    set(SKIP_SCRATCH_INITIALIZATION_REGEX ".*")
-
-    # check help works via environment variable
-    KOKKOS_ADD_TEST(
-      SKIP_TRIBITS
-      NAME ProfilingTestLibraryLoadHelp
-      EXE  ProfilingAllCalls
-      TOOL kokkosprinter-tool
-      ARGS --kokkos-tools-help
-      PASS_REGULAR_EXPRESSION
-        "kokkosp_init_library::kokkosp_print_help:Kokkos_ProfilingAllCalls::kokkosp_finalize_library::")
-
-    # check help works via direct library specification
-    KOKKOS_ADD_TEST(
-      SKIP_TRIBITS
-      NAME ProfilingTestLibraryCmdLineHelp
-      EXE  ProfilingAllCalls
-      ARGS --kokkos-tools-help
-           --kokkos-tools-libs=$<TARGET_FILE:kokkosprinter-tool>
-      PASS_REGULAR_EXPRESSION
-        "kokkosp_init_library::kokkosp_print_help:Kokkos_ProfilingAllCalls::kokkosp_finalize_library::")
-
-    KOKKOS_ADD_TEST(
-      SKIP_TRIBITS
-      NAME ProfilingTestLibraryLoad
-      EXE  ProfilingAllCalls
-      TOOL kokkosprinter-tool
-      ARGS --kokkos-tools-args="-c test delimit"
-      PASS_REGULAR_EXPRESSION "kokkosp_init_library::kokkosp_parse_args:4:Kokkos_ProfilingAllCalls:-c:test:delimit::.*::kokkosp_allocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]source] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_allocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]destination] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_begin_deep_copy:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::.*kokkosp_end_deep_copy::kokkosp_begin_parallel_for:parallel_for:${SIZE_REGEX}:0::kokkosp_end_parallel_for:0::kokkosp_begin_parallel_reduce:parallel_reduce:${SIZE_REGEX}:1${SKIP_SCRATCH_INITIALIZATION_REGEX}::kokkosp_end_parallel_reduce:1::kokkosp_begin_parallel_scan:parallel_scan:${SIZE_REGEX}:2::kokkosp_end_parallel_scan:2::kokkosp_push_profile_region:push_region::kokkosp_pop_profile_region::kokkosp_create_profile_section:created_section:3::kokkosp_start_profile_section:3::kokkosp_stop_profile_section:3::kokkosp_destroy_profile_section:3::kokkosp_profile_event:profiling_event::kokkosp_declare_metadata:dogs:good::kokkosp_deallocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_deallocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_finalize_library::"
-    )
-
-    # Above will test that leading/trailing quotes are stripped bc ctest cmd args is:
-    #       "--kokkos-tools-args="-c test delimit""
-    # The bracket argument syntax: [=[ and ]=] used below ensures it is treated as
-    # a single argument:
-    #       "--kokkos-tools-args=-c test delimit"
-    #
-    # https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#bracket-argument
-    #
-    KOKKOS_ADD_TEST(
-      SKIP_TRIBITS
-      NAME ProfilingTestLibraryCmdLine
-      EXE  ProfilingAllCalls
-      ARGS [=[--kokkos-tools-args=-c test delimit]=]
-            --kokkos-tools-libs=$<TARGET_FILE:kokkosprinter-tool>
-      PASS_REGULAR_EXPRESSION "kokkosp_init_library::kokkosp_parse_args:4:Kokkos_ProfilingAllCalls:-c:test:delimit::.*::kokkosp_allocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]source] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_allocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]destination] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_begin_deep_copy:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::.*kokkosp_end_deep_copy::kokkosp_begin_parallel_for:parallel_for:${SIZE_REGEX}:0::kokkosp_end_parallel_for:0::kokkosp_begin_parallel_reduce:parallel_reduce:${SIZE_REGEX}:1${SKIP_SCRATCH_INITIALIZATION_REGEX}::kokkosp_end_parallel_reduce:1::kokkosp_begin_parallel_scan:parallel_scan:${SIZE_REGEX}:2::kokkosp_end_parallel_scan:2::kokkosp_push_profile_region:push_region::kokkosp_pop_profile_region::kokkosp_create_profile_section:created_section:3::kokkosp_start_profile_section:3::kokkosp_stop_profile_section:3::kokkosp_destroy_profile_section:3::kokkosp_profile_event:profiling_event::kokkosp_declare_metadata:dogs:good::kokkosp_deallocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_deallocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_finalize_library::"
-    )
-  endif() #KOKKOS_ENABLE_LIBDL
+  # Above will test that leading/trailing quotes are stripped bc ctest cmd args is:
+  #       "--kokkos-tools-args="-c test delimit""
+  # The bracket argument syntax: [=[ and ]=] used below ensures it is treated as
+  # a single argument:
+  #       "--kokkos-tools-args=-c test delimit"
+  #
+  # https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#bracket-argument
+  #
+  kokkos_add_test(
+    SKIP_TRIBITS
+    NAME
+    ProfilingTestLibraryCmdLine
+    EXE
+    ProfilingAllCalls
+    ARGS
+    [=[--kokkos-tools-args=-c test delimit]=]
+    --kokkos-tools-libs=$<TARGET_FILE:kokkosprinter-tool>
+    PASS_REGULAR_EXPRESSION
+    "kokkosp_init_library::kokkosp_parse_args:4:Kokkos_ProfilingAllCalls:-c:test:delimit::.*::kokkosp_allocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]source] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_allocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]destination] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_begin_deep_copy:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::.*kokkosp_end_deep_copy::kokkosp_begin_parallel_for:parallel_for:${SIZE_REGEX}:0::kokkosp_end_parallel_for:0::kokkosp_begin_parallel_reduce:parallel_reduce:${SIZE_REGEX}:1${SKIP_SCRATCH_INITIALIZATION_REGEX}::kokkosp_end_parallel_reduce:1::kokkosp_begin_parallel_scan:parallel_scan:${SIZE_REGEX}:2::kokkosp_end_parallel_scan:2::kokkosp_push_profile_region:push_region::kokkosp_pop_profile_region::kokkosp_create_profile_section:created_section:3::kokkosp_start_profile_section:3::kokkosp_stop_profile_section:3::kokkosp_destroy_profile_section:3::kokkosp_profile_event:profiling_event::kokkosp_declare_metadata:dogs:good::kokkosp_deallocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_deallocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_finalize_library::"
+  )
+endif() #KOKKOS_ENABLE_LIBDL
 if(NOT KOKKOS_HAS_TRILINOS)
-KOKKOS_ADD_TEST_EXECUTABLE(
-  StackTraceTestExec
-  SOURCES
+  kokkos_add_test_executable(
+    StackTraceTestExec
+    SOURCES
     TestStackTrace.cpp
     TestStackTrace_f0.cpp
     TestStackTrace_f1.cpp
     TestStackTrace_f2.cpp
     TestStackTrace_f3.cpp
     TestStackTrace_f4.cpp
-)
-# We need -rdynamic on GNU platforms for the stacktrace functionality
-# to work correctly with shared libraries
-KOKKOS_SET_EXE_PROPERTY(StackTraceTestExec ENABLE_EXPORTS ON)
+  )
+  # We need -rdynamic on GNU platforms for the stacktrace functionality
+  # to work correctly with shared libraries
+  kokkos_set_exe_property(StackTraceTestExec ENABLE_EXPORTS ON)
 
-KOKKOS_ADD_TEST( NAME CoreUnitTest_StackTraceTest
-                 EXE  StackTraceTestExec
-                 FAIL_REGULAR_EXPRESSION "FAILED"
-               )
+  kokkos_add_test(NAME CoreUnitTest_StackTraceTest EXE StackTraceTestExec FAIL_REGULAR_EXPRESSION "FAILED")
 endif()
 
-if (KOKKOS_ENABLE_HWLOC)
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  CoreUnitTest_HWLOC
-  SOURCES UnitTestMain.cpp  TestHWLOC.cpp
-)
+if(KOKKOS_ENABLE_HWLOC)
+  kokkos_add_executable_and_test(CoreUnitTest_HWLOC SOURCES UnitTestMain.cpp TestHWLOC.cpp)
 endif()
 
-FUNCTION (KOKKOS_ADD_INCREMENTAL_TEST DEVICE)
-  KOKKOS_OPTION( ${DEVICE}_EXCLUDE_TESTS "" STRING "Incremental test exclude list" )
+function(KOKKOS_ADD_INCREMENTAL_TEST DEVICE)
+  kokkos_option(${DEVICE}_EXCLUDE_TESTS "" STRING "Incremental test exclude list")
   # Add unit test main
-  SET(${DEVICE}_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestMainInit.cpp)
+  set(${DEVICE}_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestMainInit.cpp)
 
   # Iterate over incremental tests in directory
 
-  APPEND_GLOB(INCREMENTAL_FILE_LIST ${CMAKE_CURRENT_SOURCE_DIR}/incremental/*.hpp)
+  append_glob(INCREMENTAL_FILE_LIST ${CMAKE_CURRENT_SOURCE_DIR}/incremental/*.hpp)
 
-  SET(DEVICE_NAME ${KOKKOS_${DEVICE}_NAME})
-  FOREACH (CURRENT_FILE_PATH ${INCREMENTAL_FILE_LIST})
-    GET_FILENAME_COMPONENT( CURRENT_FILE_NAME ${CURRENT_FILE_PATH} NAME )
-    STRING (REPLACE ".hpp" "" CURRENT_TEST_NAME ${CURRENT_FILE_NAME})
-    IF (NOT CURRENT_TEST_NAME IN_LIST Kokkos_${DEVICE}_EXCLUDE_TESTS)
-       SET (CURRENT_TEST_OUTPUT_FILENAME ${CURRENT_TEST_NAME}_${DEVICE})
-       FILE( STRINGS ${CURRENT_FILE_PATH} CURRENT_REQUIRED_FEATURE_LINE REGEX "Kokkos_Feature_Level_Required" )
-       # From each test get level implementation required
-       STRING( REGEX REPLACE ".*Kokkos_Feature_Level_Required:" "" CURRENT_REQUIRED_FEATURE_LEVEL ${CURRENT_REQUIRED_FEATURE_LINE} )
-       # Cross-reference list of dependencies with selected feature list > matching feature test files are added to test applications
-       IF (KOKKOS_${DEVICE}_FEATURE_LEVEL GREATER_EQUAL CURRENT_REQUIRED_FEATURE_LEVEL)
-          CONFIGURE_FILE (IncrementalTest.cpp.in ${CMAKE_BINARY_DIR}/core/unit_test/generated/${CURRENT_TEST_OUTPUT_FILENAME}.cpp )
-          SET(${DEVICE}_SOURCES ${${DEVICE}_SOURCES}; ${CMAKE_BINARY_DIR}/core/unit_test/generated/${CURRENT_TEST_OUTPUT_FILENAME}.cpp)
-       ENDIF()
-     ENDIF()
-  ENDFOREACH()
+  set(DEVICE_NAME ${KOKKOS_${DEVICE}_NAME})
+  foreach(CURRENT_FILE_PATH ${INCREMENTAL_FILE_LIST})
+    get_filename_component(CURRENT_FILE_NAME ${CURRENT_FILE_PATH} NAME)
+    string(REPLACE ".hpp" "" CURRENT_TEST_NAME ${CURRENT_FILE_NAME})
+    if(NOT CURRENT_TEST_NAME IN_LIST Kokkos_${DEVICE}_EXCLUDE_TESTS)
+      set(CURRENT_TEST_OUTPUT_FILENAME ${CURRENT_TEST_NAME}_${DEVICE})
+      file(STRINGS ${CURRENT_FILE_PATH} CURRENT_REQUIRED_FEATURE_LINE REGEX "Kokkos_Feature_Level_Required")
+      # From each test get level implementation required
+      string(REGEX REPLACE ".*Kokkos_Feature_Level_Required:" "" CURRENT_REQUIRED_FEATURE_LEVEL
+                           ${CURRENT_REQUIRED_FEATURE_LINE}
+      )
+      # Cross-reference list of dependencies with selected feature list > matching feature test files are added to test applications
+      if(KOKKOS_${DEVICE}_FEATURE_LEVEL GREATER_EQUAL CURRENT_REQUIRED_FEATURE_LEVEL)
+        configure_file(
+          IncrementalTest.cpp.in ${CMAKE_BINARY_DIR}/core/unit_test/generated/${CURRENT_TEST_OUTPUT_FILENAME}.cpp
+        )
+        set(${DEVICE}_SOURCES ${${DEVICE}_SOURCES};
+                              ${CMAKE_BINARY_DIR}/core/unit_test/generated/${CURRENT_TEST_OUTPUT_FILENAME}.cpp
+        )
+      endif()
+    endif()
+  endforeach()
 
-  STRING(TOUPPER ${DEVICE} UC_DEVICE)
+  string(TOUPPER ${DEVICE} UC_DEVICE)
 
-  KOKKOS_OPTION (
-    ENABLE_${UC_DEVICE} ON BOOL "ENABLE ${UC_DEVICE}"
-  )
+  kokkos_option(ENABLE_${UC_DEVICE} ON BOOL "ENABLE ${UC_DEVICE}")
 
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    IncrementalTest_${DEVICE}
-    SOURCES ${${DEVICE}_SOURCES}
-  )
+  kokkos_add_executable_and_test(IncrementalTest_${DEVICE} SOURCES ${${DEVICE}_SOURCES})
 
-  SET(EXE_NAME ${PACKAGE_NAME}_IncrementalTest_${DEVICE})
+  set(EXE_NAME ${PACKAGE_NAME}_IncrementalTest_${DEVICE})
   # Check that the target was actually created because in a TribITS build
   # where only tests marked as PERFORMANCE enabled it would not be.
-  IF(TARGET ${EXE_NAME})
-    TARGET_INCLUDE_DIRECTORIES(${EXE_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/incremental )
-  ENDIF()
+  if(TARGET ${EXE_NAME})
+    target_include_directories(${EXE_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/incremental)
+  endif()
 
-ENDFUNCTION()
+endfunction()
 
-FOREACH (DEVICE ${KOKKOS_ENABLED_DEVICES})
-  KOKKOS_ADD_INCREMENTAL_TEST(${DEVICE})
-ENDFOREACH()
+foreach(DEVICE ${KOKKOS_ENABLED_DEVICES})
+  kokkos_add_incremental_test(${DEVICE})
+endforeach()
 
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  CoreUnitTest_CTestDevice
-  SOURCES UnitTestMain.cpp  TestCTestDevice.cpp
-)
+kokkos_add_executable_and_test(CoreUnitTest_CTestDevice SOURCES UnitTestMain.cpp TestCTestDevice.cpp)
 
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  CoreUnitTest_CMakePassCmdLineArgs
-  SOURCES UnitTest_CMakePassCmdLineArgs.cpp
-  ARGS "one 2 THREE"
+kokkos_add_executable_and_test(
+  CoreUnitTest_CMakePassCmdLineArgs SOURCES UnitTest_CMakePassCmdLineArgs.cpp ARGS "one 2 THREE"
 )
 
 # This test is not properly set up to run within Trilinos
-if (NOT KOKKOS_HAS_TRILINOS)
-  SET_SOURCE_FILES_PROPERTIES(UnitTest_DeviceAndThreads.cpp PROPERTIES LANGUAGE ${KOKKOS_COMPILE_LANGUAGE})
+if(NOT KOKKOS_HAS_TRILINOS)
+  set_source_files_properties(UnitTest_DeviceAndThreads.cpp PROPERTIES LANGUAGE ${KOKKOS_COMPILE_LANGUAGE})
   add_executable(Kokkos_CoreUnitTest_DeviceAndThreads UnitTest_DeviceAndThreads.cpp)
   target_link_libraries(Kokkos_CoreUnitTest_DeviceAndThreads Kokkos::kokkoscore)
   find_package(Python3 COMPONENTS Interpreter)
@@ -1325,18 +1097,19 @@ if (NOT KOKKOS_HAS_TRILINOS)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)
       set(USE_SOURCE_PERMISSIONS_WHEN_SUPPORTED USE_SOURCE_PERMISSIONS)
     endif()
-    file(GENERATE
+    file(
+      GENERATE
       OUTPUT $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py
       INPUT TestDeviceAndThreads.py
       ${USE_SOURCE_PERMISSIONS_WHEN_SUPPORTED}
     )
-    add_test(
-      NAME Kokkos_CoreUnitTest_DeviceAndThreads
-      COMMAND ${Python3_EXECUTABLE} $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py -v
+    add_test(NAME Kokkos_CoreUnitTest_DeviceAndThreads
+             COMMAND ${Python3_EXECUTABLE}
+                     $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py -v
     )
   endif()
 endif()
 
-if (KOKKOS_ENABLE_HEADER_SELF_CONTAINMENT_TESTS AND NOT KOKKOS_HAS_TRILINOS AND NOT WIN32)
+if(KOKKOS_ENABLE_HEADER_SELF_CONTAINMENT_TESTS AND NOT KOKKOS_HAS_TRILINOS AND NOT WIN32)
   add_subdirectory(headers_self_contained)
 endif()

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -2,126 +2,136 @@
 # Add test-only library for gtest to be reused by all the subpackages
 #
 
-if(NOT GTest_FOUND) # fallback to internal gtest
-  set(GTEST_SOURCE_DIR ${Kokkos_SOURCE_DIR}/tpls/gtest)
+IF(NOT GTest_FOUND)  # fallback to internal gtest
+  SET(GTEST_SOURCE_DIR ${Kokkos_SOURCE_DIR}/tpls/gtest)
 
   #need here for tribits
-  kokkos_include_directories(${GTEST_SOURCE_DIR})
-  kokkos_add_test_library(
-    kokkos_gtest HEADERS ${GTEST_SOURCE_DIR}/gtest/gtest.h SOURCES ${GTEST_SOURCE_DIR}/gtest/gtest-all.cc
+  KOKKOS_INCLUDE_DIRECTORIES(${GTEST_SOURCE_DIR})
+  KOKKOS_ADD_TEST_LIBRARY(
+    kokkos_gtest
+    HEADERS ${GTEST_SOURCE_DIR}/gtest/gtest.h
+    SOURCES ${GTEST_SOURCE_DIR}/gtest/gtest-all.cc
   )
 
-  target_include_directories(kokkos_gtest PUBLIC ${GTEST_SOURCE_DIR})
-  if((NOT (Kokkos_ENABLE_CUDA AND WIN32)) AND (NOT ("${KOKKOS_CXX_COMPILER_ID}" STREQUAL "Fujitsu")))
-    target_compile_features(kokkos_gtest PUBLIC cxx_std_14)
-  endif()
+  TARGET_INCLUDE_DIRECTORIES(kokkos_gtest PUBLIC ${GTEST_SOURCE_DIR})
+  IF((NOT (Kokkos_ENABLE_CUDA AND WIN32)) AND (NOT ("${KOKKOS_CXX_COMPILER_ID}" STREQUAL "Fujitsu")))
+    TARGET_COMPILE_FEATURES(kokkos_gtest PUBLIC cxx_std_14)
+  ENDIF()
 
   # Suppress clang-tidy diagnostics on code that we do not have control over
-  if(CMAKE_CXX_CLANG_TIDY)
-    set_target_properties(kokkos_gtest PROPERTIES CXX_CLANG_TIDY "")
-  endif()
+  IF(CMAKE_CXX_CLANG_TIDY)
+    SET_TARGET_PROPERTIES(kokkos_gtest PROPERTIES CXX_CLANG_TIDY "")
+  ENDIF()
 
-  find_package(Threads QUIET)
-  if(TARGET Threads::Threads)
-    set_target_properties(kokkos_gtest PROPERTIES INTERFACE_LINK_LIBRARIES Threads::Threads)
-  endif()
-endif()
+  FIND_PACKAGE(Threads QUIET)
+  IF(TARGET Threads::Threads)
+    SET_TARGET_PROPERTIES(kokkos_gtest PROPERTIES
+                          INTERFACE_LINK_LIBRARIES Threads::Threads)
+  ENDIF()
+ENDIF()
 
 #
 # Define Incremental Testing Feature Levels
 # Define Device name mappings (i.e. what comes after Kokkos:: for the ExecSpace)
 #
 
-set(KOKKOS_CUDA_FEATURE_LEVEL 999)
-set(KOKKOS_CUDA_NAME Cuda)
-set(KOKKOS_HIP_FEATURE_LEVEL 999)
-set(KOKKOS_HIP_NAME HIP)
-set(KOKKOS_HPX_FEATURE_LEVEL 999)
-set(KOKKOS_HPX_NAME Experimental::HPX)
-set(KOKKOS_OPENMP_FEATURE_LEVEL 999)
-set(KOKKOS_OPENMP_NAME OpenMP)
+SET(KOKKOS_CUDA_FEATURE_LEVEL 999)
+SET(KOKKOS_CUDA_NAME Cuda)
+SET(KOKKOS_HIP_FEATURE_LEVEL 999)
+SET(KOKKOS_HIP_NAME HIP)
+SET(KOKKOS_HPX_FEATURE_LEVEL 999)
+SET(KOKKOS_HPX_NAME Experimental::HPX)
+SET(KOKKOS_OPENMP_FEATURE_LEVEL 999)
+SET(KOKKOS_OPENMP_NAME OpenMP)
 
 # FIXME_OPENMPTARGET - The NVIDIA HPC compiler nvc++ only compiles the first 8 incremental tests for the OpenMPTarget backend.
 # FIXME_OPENMPTARGET - Clang version 17 fails to compile incremental tests past 12 with verion 17. There is PR for this in upstream already. So it should be fixed by version 18.
-if(KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
-  set(KOKKOS_OPENMPTARGET_FEATURE_LEVEL 10)
-elseif(KOKKOS_CXX_COMPILER_ID STREQUAL "Clang" AND KOKKOS_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 17.0.0)
-  set(KOKKOS_OPENMPTARGET_FEATURE_LEVEL 12)
-else()
-  set(KOKKOS_OPENMPTARGET_FEATURE_LEVEL 14)
-endif()
+IF(KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
+  SET(KOKKOS_OPENMPTARGET_FEATURE_LEVEL 10)
+ELSEIF(KOKKOS_CXX_COMPILER_ID STREQUAL "Clang" AND KOKKOS_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 17.0.0)
+  SET(KOKKOS_OPENMPTARGET_FEATURE_LEVEL 12)
+ELSE()
+  SET(KOKKOS_OPENMPTARGET_FEATURE_LEVEL 14)
+ENDIF()
 
-set(KOKKOS_OPENMPTARGET_NAME Experimental::OpenMPTarget)
-set(KOKKOS_SERIAL_FEATURE_LEVEL 999)
-set(KOKKOS_SERIAL_NAME Serial)
-set(KOKKOS_SYCL_FEATURE_LEVEL 999)
-set(KOKKOS_SYCL_NAME SYCL)
-set(KOKKOS_THREADS_FEATURE_LEVEL 999)
-set(KOKKOS_THREADS_NAME Threads)
+SET(KOKKOS_OPENMPTARGET_NAME Experimental::OpenMPTarget)
+SET(KOKKOS_SERIAL_FEATURE_LEVEL 999)
+SET(KOKKOS_SERIAL_NAME Serial)
+SET(KOKKOS_SYCL_FEATURE_LEVEL 999)
+SET(KOKKOS_SYCL_NAME SYCL)
+SET(KOKKOS_THREADS_FEATURE_LEVEL 999)
+SET(KOKKOS_THREADS_NAME Threads)
 # FIXME_OPENACC - The Clang compiler only compiles the first 9 incremental tests for the OpenACC backend.
-if(KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
-  set(KOKKOS_OPENACC_FEATURE_LEVEL 9)
-else()
-  set(KOKKOS_OPENACC_FEATURE_LEVEL 17)
-endif()
+IF(KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
+  SET(KOKKOS_OPENACC_FEATURE_LEVEL 9)
+ELSE()
+  SET(KOKKOS_OPENACC_FEATURE_LEVEL 17)
+ENDIF()
 
-set(KOKKOS_OPENACC_NAME Experimental::OpenACC)
+SET(KOKKOS_OPENACC_NAME Experimental::OpenACC)
+
 
 #
 # Define the tests
 #
 
 #I will leave these alone for now because I don't need transitive dependencies on tests
-kokkos_include_directories(${CMAKE_CURRENT_BINARY_DIR})
-kokkos_include_directories(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_DIR})
-kokkos_include_directories(${KOKKOS_SOURCE_DIR}/core/unit_test/category_files)
+KOKKOS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
+KOKKOS_INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_DIR})
+KOKKOS_INCLUDE_DIRECTORIES(${KOKKOS_SOURCE_DIR}/core/unit_test/category_files)
 
-set(COMPILE_ONLY_SOURCES
-    TestArray.cpp
-    TestCreateMirror.cpp
-    TestDetectionIdiom.cpp
-    TestBitManipulation.cpp
-    TestInterOp.cpp
-    TestRangePolicyCTAD.cpp
-    TestStringManipulation.cpp
-    TestVersionMacros.cpp
-    TestViewRank.cpp
-    TestViewTypeTraits.cpp
-    TestViewTypedefs.cpp
-    TestTypeInfo.cpp
-    TestTypeList.cpp
-    TestMDRangePolicyCTAD.cpp
-    TestTeamPolicyCTAD.cpp
-    TestTeamMDRangePolicyCTAD.cpp
-    TestNestedReducerCTAD.cpp
-    view/TestExtentsDatatypeConversion.cpp
+SET(COMPILE_ONLY_SOURCES
+  TestArray.cpp
+  TestCreateMirror.cpp
+  TestDetectionIdiom.cpp
+  TestBitManipulation.cpp
+  TestInterOp.cpp
+  TestRangePolicyCTAD.cpp
+  TestStringManipulation.cpp
+  TestVersionMacros.cpp
+  TestViewRank.cpp
+  TestViewTypeTraits.cpp
+  TestTypeInfo.cpp
+  TestTypeList.cpp
+  TestMDRangePolicyCTAD.cpp
+  TestTeamPolicyCTAD.cpp
+  TestTeamMDRangePolicyCTAD.cpp
+  TestNestedReducerCTAD.cpp
+  view/TestExtentsDatatypeConversion.cpp
 )
 
 #testing if windows.h and Kokkos_Core.hpp can be included
 if(WIN32)
-  list(APPEND COMPILE_ONLY_SOURCES TestWindowsInclude.cpp)
+  LIST(APPEND COMPILE_ONLY_SOURCES TestWindowsInclude.cpp)
 endif()
 
-if(Kokkos_INSTALL_TESTING) # FIXME Kokkos_ and KOKKOS_ variables are out of sync
+if(Kokkos_INSTALL_TESTING)  # FIXME Kokkos_ and KOKKOS_ variables are out of sync
   if((Kokkos_CXX_COMPILER_ID STREQUAL "Intel" AND Kokkos_CXX_COMPILER_VERSION VERSION_LESS 2021.2.0)
      OR (Kokkos_CXX_COMPILER_ID STREQUAL "NVIDIA" AND Kokkos_CXX_COMPILER_VERSION VERSION_LESS 11.3.0)
-     OR (Kokkos_CXX_COMPILER_ID STREQUAL "NVIDIA" AND Kokkos_CXX_HOST_COMPILER_ID STREQUAL "MSVC")
-  )
-    list(REMOVE_ITEM COMPILE_ONLY_SOURCES TestTypeInfo.cpp)
+     OR (Kokkos_CXX_COMPILER_ID STREQUAL "NVIDIA" AND Kokkos_CXX_HOST_COMPILER_ID STREQUAL "MSVC"))
+    LIST(REMOVE_ITEM COMPILE_ONLY_SOURCES TestTypeInfo.cpp)
   endif()
 else()
   if((KOKKOS_CXX_COMPILER_ID STREQUAL "Intel" AND KOKKOS_CXX_COMPILER_VERSION VERSION_LESS 2021.2.0)
      OR (KOKKOS_CXX_COMPILER_ID STREQUAL "NVIDIA" AND KOKKOS_CXX_COMPILER_VERSION VERSION_LESS 11.3.0)
-     OR (KOKKOS_CXX_COMPILER_ID STREQUAL "NVIDIA" AND KOKKOS_CXX_HOST_COMPILER_ID STREQUAL "MSVC")
-  )
-    list(REMOVE_ITEM COMPILE_ONLY_SOURCES TestTypeInfo.cpp)
+     OR (KOKKOS_CXX_COMPILER_ID STREQUAL "NVIDIA" AND KOKKOS_CXX_HOST_COMPILER_ID STREQUAL "MSVC"))
+    LIST(REMOVE_ITEM COMPILE_ONLY_SOURCES TestTypeInfo.cpp)
   endif()
 endif()
 
+#TestInterOp has a dependency on containers
+IF(KOKKOS_HAS_TRILINOS)
+  LIST(REMOVE_ITEM COMPILE_ONLY_SOURCES TestInterOp.cpp)
+ENDIF()
 if(Kokkos_ENABLE_OPENMPTARGET)
   list(REMOVE_ITEM COMPILE_ONLY_SOURCES TestNestedReducerCTAD.cpp)
 endif()
-kokkos_add_executable(CoreTestCompileOnly SOURCES TestCompileMain.cpp ${COMPILE_ONLY_SOURCES})
+KOKKOS_ADD_EXECUTABLE(
+  CoreTestCompileOnly
+  SOURCES
+  TestCompileMain.cpp
+  ${COMPILE_ONLY_SOURCES}
+)
 
 foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
   string(TOUPPER ${Tag} DEVICE)
@@ -134,51 +144,53 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
     # command line in an intermediate compilation step even if CMake generated a response
     # file. That then exceeded the shell command line max length.
     set(${Tag}_SOURCES1A)
-    foreach(
-      Name
-      Abort
-      ArrayOps
-      AtomicOperations_complexdouble
-      AtomicOperations_complexfloat
-      AtomicOperations_double
-      AtomicOperations_float
-      AtomicOperations_int
-      AtomicOperations_longint
-      AtomicOperations_longlongint
-      AtomicOperations_shared
-      AtomicOperations_unsignedint
-      AtomicOperations_unsignedlongint
-      Atomics
-      AtomicViews
-      BitManipulationBuiltins
-      BlockSizeDeduction
-      CheckedIntegerOps
-      CommonPolicyConstructors
-      CommonPolicyInterface
-      Complex
-      Concepts
-      Crs
-      DeepCopyAlignment
-      ExecSpacePartitioning
-      ExecSpaceThreadSafety
-      ExecutionSpace
-      FunctorAnalysis
-      Graph
-      HostSharedPtr
-      HostSharedPtrAccessOnDevice
-      Init
-      JoinBackwardCompatibility
-      LocalDeepCopy
-      MathematicalConstants
-      MathematicalFunctions1
-      MathematicalFunctions2
-      MathematicalFunctions3
-      MathematicalSpecialFunctions
-    )
+    foreach(Name
+        Abort
+        ArrayOps
+        AtomicOperations_complexdouble
+        AtomicOperations_complexfloat
+        AtomicOperations_double
+        AtomicOperations_float
+        AtomicOperations_int
+        AtomicOperations_longint
+        AtomicOperations_longlongint
+        AtomicOperations_shared
+        AtomicOperations_unsignedint
+        AtomicOperations_unsignedlongint
+        Atomics
+        AtomicViews
+        BitManipulationBuiltins
+        BlockSizeDeduction
+        CheckedIntegerOps
+        CommonPolicyConstructors
+        CommonPolicyInterface
+        Complex
+        Concepts
+        Crs
+        DeepCopyAlignment
+        ExecSpacePartitioning
+        ExecSpaceThreadSafety
+        ExecutionSpace
+        FunctorAnalysis
+        Graph
+        HostSharedPtr
+        HostSharedPtrAccessOnDevice
+        Init
+        JoinBackwardCompatibility
+        LocalDeepCopy
+        MathematicalConstants
+        MathematicalFunctions1
+        MathematicalFunctions2
+        MathematicalFunctions3
+        MathematicalSpecialFunctions
+        )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-      file(WRITE ${dir}/dummy.cpp "#include <Test${Tag}_Category.hpp>\n" "#include <Test${Name}.hpp>\n")
+      file(WRITE ${dir}/dummy.cpp
+          "#include <Test${Tag}_Category.hpp>\n"
+          "#include <Test${Name}.hpp>\n"
+      )
       configure_file(${dir}/dummy.cpp ${file})
       list(APPEND ${Tag}_SOURCES1A ${file})
     endforeach()
@@ -219,79 +231,92 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         SpaceAwareAccessorAccessViolation
         SpaceAwareAccessor
         Swap
-    )
-    if(NOT Kokkos_ENABLE_IMPL_MDSPAN)
-      list(REMOVE_ITEM ${Tag}_TESTNAMES1B MDSpanAtomicAccessor MDSpanConversion SpaceAwareAccessorAccessViolation
-           SpaceAwareAccessor
+        )
+    IF (NOT Kokkos_ENABLE_IMPL_MDSPAN)
+      LIST(REMOVE_ITEM ${Tag}_TESTNAMES1B
+         MDSpanAtomicAccessor
+         MDSpanConversion
+         SpaceAwareAccessorAccessViolation
+         SpaceAwareAccessor
       )
-    endif()
+    ENDIF()
     # This test case causes MSVC to fail with "number of sections exceeded object file format limit"
-    if(MSVC)
-      list(REMOVE_ITEM ${Tag}_TESTNAMES1B Reducers_d)
-    endif()
+    IF (MSVC)
+      LIST(REMOVE_ITEM ${Tag}_TESTNAMES1B
+        Reducers_d
+      )
+    ENDIF()
     foreach(Name IN LISTS ${Tag}_TESTNAMES1B)
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-      file(WRITE ${dir}/dummy.cpp "#include <Test${Tag}_Category.hpp>\n" "#include <Test${Name}.hpp>\n")
+      file(WRITE ${dir}/dummy.cpp
+          "#include <Test${Tag}_Category.hpp>\n"
+          "#include <Test${Name}.hpp>\n"
+      )
       configure_file(${dir}/dummy.cpp ${file})
       list(APPEND ${Tag}_SOURCES1B ${file})
     endforeach()
 
-    set(${Tag}_SOURCES2A)
-    set(${Tag}_TESTNAMES2A
-        TeamBasic
-        TeamCombinedReducers
-        TeamMDRange
-        TeamPolicyConstructors
-        TeamReductionScan
-        TeamScan
-        TeamScratch
-        TeamTeamSize
-        TeamVectorRange
-        UniqueToken
-        View_64bit
-        ViewAPI_a
-        ViewAPI_b
-        ViewAPI_c
-        ViewAPI_d
-        ViewAPI_e
-        ViewBadAlloc
-        ViewCopy_a
-        ViewCopy_b
-        ViewCopy_c
-        ViewCtorDimMatch
-        ViewEmptyRuntimeUnmanaged
-        ViewHooks
-        ViewLayoutStrideAssignment
-        ViewMapping_a
-        ViewMapping_b
-        ViewMapping_subview
-        ViewMemoryAccessViolation
-        ViewOfClass
-        ViewOfViews
-        ViewOutOfBoundsAccess
-        ViewResize
-        WorkGraph
-        WithoutInitializing
-    )
+    SET(${Tag}_SOURCES2A)
+    SET(${Tag}_TESTNAMES2A
+      TeamBasic
+      TeamCombinedReducers
+      TeamMDRange
+      TeamPolicyConstructors
+      TeamReductionScan
+      TeamScan
+      TeamScratch
+      TeamTeamSize
+      TeamVectorRange
+      UniqueToken
+      View_64bit
+      ViewAPI_a
+      ViewAPI_b
+      ViewAPI_c
+      ViewAPI_d
+      ViewAPI_e
+      ViewBadAlloc
+      ViewCopy_a
+      ViewCopy_b
+      ViewCopy_c
+      ViewCtorDimMatch
+      ViewEmptyRuntimeUnmanaged
+      ViewHooks
+      ViewLayoutStrideAssignment
+      ViewMapping_a
+      ViewMapping_b
+      ViewMapping_subview
+      ViewMemoryAccessViolation
+      ViewOfClass
+      ViewOfViews
+      ViewOutOfBoundsAccess
+      ViewResize
+      WorkGraph
+      WithoutInitializing
+      )
     # Workaround to internal compiler error with intel classic compilers
     # when using -no-ip flag in ViewCopy_c
     # See issue: https://github.com/kokkos/kokkos/issues/7084
-    if(KOKKOS_CXX_COMPILER_ID STREQUAL Intel)
-      list(REMOVE_ITEM ${Tag}_TESTNAMES2A ViewCopy_c)
+    IF(KOKKOS_CXX_COMPILER_ID STREQUAL Intel)
+      LIST(REMOVE_ITEM ${Tag}_TESTNAMES2A
+        ViewCopy_c
+      )
     endif()
     foreach(Name IN LISTS ${Tag}_TESTNAMES2A)
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-      file(WRITE ${dir}/dummy.cpp "#include <Test${Tag}_Category.hpp>\n" "#include <Test${Name}.hpp>\n")
+      file(WRITE ${dir}/dummy.cpp
+          "#include <Test${Tag}_Category.hpp>\n"
+          "#include <Test${Name}.hpp>\n"
+      )
       configure_file(${dir}/dummy.cpp ${file})
       list(APPEND ${Tag}_SOURCES2A ${file})
     endforeach()
 
     set(TagHostAccessible ${Tag})
-    if(Tag STREQUAL "Cuda")
+    if (Tag STREQUAL "Cuda")
       set(TagHostAccessible CudaUVM)
     elseif(Tag STREQUAL "HIP")
       set(TagHostAccessible HIPManaged)
@@ -300,8 +325,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
     endif()
 
     set(${Tag}_SOURCES2B)
-    foreach(
-      Name
+    foreach(Name
       SubView_a
       SubView_b
       SubView_c01
@@ -309,38 +333,74 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       SubView_c03
       SubView_c04
       SubView_c05
-    )
+      )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-      file(WRITE ${dir}/dummy.cpp "#include <Test${TagHostAccessible}_Category.hpp>\n" "#include <Test${Name}.hpp>\n")
+      file(WRITE ${dir}/dummy.cpp
+          "#include <Test${TagHostAccessible}_Category.hpp>\n"
+          "#include <Test${Name}.hpp>\n"
+      )
       configure_file(${dir}/dummy.cpp ${file})
       list(APPEND ${Tag}_SOURCES2B ${file})
     endforeach()
 
     set(${Tag}_SOURCES2C)
-    foreach(Name SubView_c06 SubView_c07 SubView_c08 SubView_c09)
+    foreach(Name
+      SubView_c06
+      SubView_c07
+      SubView_c08
+      SubView_c09
+      )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-      file(WRITE ${dir}/dummy.cpp "#include <Test${TagHostAccessible}_Category.hpp>\n" "#include <Test${Name}.hpp>\n")
+      file(WRITE ${dir}/dummy.cpp
+          "#include <Test${TagHostAccessible}_Category.hpp>\n"
+          "#include <Test${Name}.hpp>\n"
+      )
       configure_file(${dir}/dummy.cpp ${file})
       list(APPEND ${Tag}_SOURCES2C ${file})
     endforeach()
 
     set(${Tag}_SOURCES2D)
-    foreach(Name SubView_c10 SubView_c11 SubView_c12 SubView_c13 SubView_c14)
+    foreach(Name
+      SubView_c10
+      SubView_c11
+      SubView_c12
+      SubView_c13
+      SubView_c14
+      )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-      file(WRITE ${dir}/dummy.cpp "#include <Test${TagHostAccessible}_Category.hpp>\n" "#include <Test${Name}.hpp>\n")
+      file(WRITE ${dir}/dummy.cpp
+          "#include <Test${TagHostAccessible}_Category.hpp>\n"
+          "#include <Test${Name}.hpp>\n"
+      )
       configure_file(${dir}/dummy.cpp ${file})
       list(APPEND ${Tag}_SOURCES2D ${file})
     endforeach()
 
-    set(${Tag}_SOURCES1 ${${Tag}_SOURCES1A} ${${Tag}_SOURCES1B})
-    set(${Tag}_SOURCES2 ${${Tag}_SOURCES2A} ${${Tag}_SOURCES2B} ${${Tag}_SOURCES2C} ${${Tag}_SOURCES2D})
-    set(${Tag}_SOURCES ${${Tag}_SOURCES1} ${${Tag}_SOURCES2})
+    set(${Tag}_VIEWSUPPORT)
+    foreach(Name
+      ReferenceCountedAccessor
+      ReferenceCountedDataHandle
+      )
+      set(file ${dir}/Test${Tag}_View_${Name}.cpp)
+      # Write to a temporary intermediate file and call configure_file to avoid
+      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+      file(WRITE ${dir}/dummy.cpp
+          "#include <Test${TagHostAccessible}_Category.hpp>\n"
+          "#include <view/Test${Name}.hpp>\n"
+      )
+      configure_file(${dir}/dummy.cpp ${file})
+      list(APPEND ${Tag}_VIEWSUPPORT ${file})
+    endforeach()
+
+    SET(${Tag}_SOURCES1 ${${Tag}_SOURCES1A} ${${Tag}_SOURCES1B})
+    SET(${Tag}_SOURCES2 ${${Tag}_SOURCES2A} ${${Tag}_SOURCES2B} ${${Tag}_SOURCES2C} ${${Tag}_SOURCES2D})
+    SET(${Tag}_SOURCES ${${Tag}_SOURCES1} ${${Tag}_SOURCES2})
   endif()
 endforeach()
 
@@ -354,8 +414,7 @@ foreach(PairDeviceSpace HIP-HostPinned;HIP-Managed;Cuda-HostPinned;Cuda-UVM;SYCL
   if(Kokkos_ENABLE_${UPPER_DEVICE})
     set(dir ${CMAKE_CURRENT_BINARY_DIR}/${dir})
     file(MAKE_DIRECTORY ${dir})
-    foreach(
-      Name
+    foreach(Name
       SharedAlloc
       ViewAPI_a
       ViewAPI_b
@@ -368,11 +427,14 @@ foreach(PairDeviceSpace HIP-HostPinned;HIP-Managed;Cuda-HostPinned;Cuda-UVM;SYCL
       ViewMapping_a
       ViewMapping_b
       ViewMapping_subview
-    )
+      )
       set(file ${dir}/Test${DEVICE}${SPACE}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-      file(WRITE ${dir}/dummy.cpp "#include <Test${DEVICE}${SPACE}_Category.hpp>\n" "#include <Test${Name}.hpp>\n")
+      file(WRITE ${dir}/dummy.cpp
+          "#include <Test${DEVICE}${SPACE}_Category.hpp>\n"
+          "#include <Test${Name}.hpp>\n"
+      )
       configure_file(${dir}/dummy.cpp ${file})
       list(APPEND ${DEVICE}_SOURCES3 ${file})
     endforeach()
@@ -382,60 +444,54 @@ endforeach()
 
 # Disable non-compiling tests based on clang version.
 if(Kokkos_ENABLE_OPENMPTARGET)
-  list(
-    REMOVE_ITEM
-    OpenMPTarget_SOURCES
+  list(REMOVE_ITEM OpenMPTarget_SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Other.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamCombinedReducers.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamReductionScan.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_WorkGraph.cpp
-    IF
-    (KOKKOS_CXX_COMPILER_ID STREQUAL "Clang" AND KOKKOS_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0.0)
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_AtomicOperations_shared.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_MinMaxClamp.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_LocalDeepCopy.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_d.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamVectorRange.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_ViewAPI_e.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamScan.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamBasic.cpp
-    IF
-    (KOKKOS_CXX_COMPILER_VERSION VERSION_LESS 17.0.3)
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_SubView_c01.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_SubView_c02.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_SubView_c03.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_d.cpp
-    endif
-    ()
-    endif
-    ()
+    IF (KOKKOS_CXX_COMPILER_ID STREQUAL "Clang" AND KOKKOS_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0.0)
+        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_AtomicOperations_shared.cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_MinMaxClamp.cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_LocalDeepCopy.cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_d.cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamVectorRange.cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_ViewAPI_e.cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamScan.cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamBasic.cpp
+        IF (KOKKOS_CXX_COMPILER_VERSION VERSION_LESS 17.0.3)
+            ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_SubView_c01.cpp
+            ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_SubView_c02.cpp
+            ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_SubView_c03.cpp
+            ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_d.cpp
+        endif()
+    endif()
     # FIXME_OPENMPTARGET_CRAY: The following tests fail at compile time when the OpenMPTarget backend is enabled with the Cray compiler.
     # Atomic compare/exchange is used in these tests which can be one of the reasons for the compilation failures.
-    IF
-    (KOKKOS_CXX_COMPILER_ID STREQUAL Cray)
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_AtomicOperations_complexdouble.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_UniqueToken.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_SharedAlloc.cpp
-    ENDIF
-    ()
-  )
+    IF(KOKKOS_CXX_COMPILER_ID STREQUAL Cray)
+        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_AtomicOperations_complexdouble.cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_UniqueToken.cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_SharedAlloc.cpp
+    ENDIF()
+    )
 endif()
 
 # FIXME_OPENMPTARGET - MinMaxClamp fails even with the host backend when OpenMPTarget backend is enabled.
 # FIXME_OPENMPTARGET - Unsure of the reason as of now.
-if(KOKKOS_CXX_COMPILER_ID STREQUAL "Clang" AND KOKKOS_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0.0)
-  if(Kokkos_ENABLE_OPENMPTARGET AND Kokkos_ENABLE_OPENMP)
-    list(REMOVE_ITEM OpenMP_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/openmp/TestOpenMP_MinMaxClamp.cpp)
-  endif()
-  if(Kokkos_ENABLE_OPENMPTARGET AND Kokkos_ENABLE_SERIAL)
-    list(REMOVE_ITEM Serial_SOURCES1 ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_MinMaxClamp.cpp)
-  endif()
-endif()
+IF (KOKKOS_CXX_COMPILER_ID STREQUAL "Clang" AND KOKKOS_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0.0)
+    IF(Kokkos_ENABLE_OPENMPTARGET AND Kokkos_ENABLE_OPENMP)
+      list(REMOVE_ITEM OpenMP_SOURCES
+          ${CMAKE_CURRENT_BINARY_DIR}/openmp/TestOpenMP_MinMaxClamp.cpp
+            )
+    ENDIF()
+    IF(Kokkos_ENABLE_OPENMPTARGET AND Kokkos_ENABLE_SERIAL)
+        list(REMOVE_ITEM Serial_SOURCES1
+            ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_MinMaxClamp.cpp
+            )
+    ENDIF()
+ENDIF()
 
 if(Kokkos_ENABLE_OPENACC)
-  list(
-    REMOVE_ITEM
-    OpenACC_SOURCES
+  list(REMOVE_ITEM OpenACC_SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_complexdouble.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_complexfloat.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_Crs.cpp
@@ -456,23 +512,25 @@ endif()
 
 # FIXME_OPENMPTARGET - Comment non-passing tests with amdclang++
 # FIXME_OPENMPTARGET - Need to check on GFX1030 and GFX1100 architectures
-if(KOKKOS_ARCH_VEGA)
-  set(KOKKOS_AMDGPU_ARCH TRUE)
-endif()
-if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang AND KOKKOS_AMDGPU_ARCH)
-  list(REMOVE_ITEM OpenMPTarget_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_e.cpp)
-endif()
+IF(KOKKOS_ARCH_VEGA)
+  SET(KOKKOS_AMDGPU_ARCH TRUE)
+ENDIF()
+IF(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang AND KOKKOS_AMDGPU_ARCH)
+  LIST(REMOVE_ITEM OpenMPTarget_SOURCES
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_e.cpp
+  )
+ENDIF()
 # FIXME_OPENMPTARGET This test causes internal compiler errors as of 09/01/22
 # when compiling for Intel's Xe-HP GPUs.
-if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
-  list(REMOVE_ITEM OpenMPTarget_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamVectorRange.cpp)
-endif()
+IF(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
+  LIST(REMOVE_ITEM OpenMPTarget_SOURCES
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamVectorRange.cpp
+  )
+ENDIF()
 
 # FIXME_OPENMPTARGET - Comment non-passing tests with the NVIDIA HPC compiler nvc++
-if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
-  list(
-    REMOVE_ITEM
-    OpenMPTarget_SOURCES
+IF(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
+  list(REMOVE_ITEM OpenMPTarget_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/default/TestDefaultDeviceType_a1.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/default/TestDefaultDeviceType_b1.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_AtomicOperations.cpp
@@ -534,14 +592,12 @@ if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_ViewAPI_f.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_ViewMapping_b.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_ViewResize.cpp
-  )
+    )
 endif()
 
 # FIXME_OPENACC - Comment non-passing tests with the NVIDIA HPC compiler nvc++
-if(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
-  list(
-    REMOVE_ITEM
-    OpenACC_SOURCES
+IF(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
+  list(REMOVE_ITEM OpenACC_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/default/TestDefaultDeviceType_a1.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/default/TestDefaultDeviceType_b1.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_shared.cpp
@@ -566,14 +622,12 @@ if(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_TeamTeamSize.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_UniqueToken.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewResize.cpp
-  )
+    )
 endif()
 
 # FIXME_OPENACC - Comment non-passing tests with the Clang compiler
-if(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
-  list(
-    REMOVE_ITEM
-    OpenACC_SOURCES
+IF(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
+  list(REMOVE_ITEM OpenACC_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/default/TestDefaultDeviceType_a1.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/default/TestDefaultDeviceType_b1.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_double.cpp
@@ -626,205 +680,377 @@ if(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewAPI_d.cpp
     #Below test is disabled because it uses atomic operations not supported by Clacc.
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ExecSpaceThreadSafety.cpp
-  )
+    )
   # When tested on a systme with AMD MI60 GPU and ROCm V5.4.0, these cause
   # clang-linker-wrapper to hang for a long time while building the unit tests.
   # In some cases, including them caused the build not to complete after an hour,
   # but excluding them permitted the build to finish in 1.5 mins or less.
-  if(KOKKOS_AMDGPU_ARCH)
-    list(
-      REMOVE_ITEM
-      OpenACC_SOURCES
-      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_BitManipulationBuiltins.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_MathematicalFunctions3.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ParallelScanRangePolicy.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c04.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c05.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c06.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c07.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c08.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c09.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c10.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c11.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c12.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewAPI_b.cpp
-      ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewAPI_c.cpp
+  IF(KOKKOS_AMDGPU_ARCH)
+    list(REMOVE_ITEM OpenACC_SOURCES
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_BitManipulationBuiltins.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_MathematicalFunctions3.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ParallelScanRangePolicy.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c04.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c05.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c06.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c07.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c08.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c09.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c10.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c11.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_SubView_c12.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewAPI_b.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewAPI_c.cpp
     )
   endif()
   # Fails serial.atomics_tpetra_max_abs when we test with Clacc.
-  list(REMOVE_ITEM Serial_SOURCES1 ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_Atomics.cpp)
+  list(REMOVE_ITEM Serial_SOURCES1
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_Atomics.cpp)
 endif()
 
 if(Kokkos_ENABLE_SERIAL)
-  kokkos_add_executable_and_test(
-    CoreUnitTest_Serial1 SOURCES UnitTestMainInit.cpp ${Serial_SOURCES1} serial/TestSerial_Task.cpp
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_Serial1
+    SOURCES
+    UnitTestMainInit.cpp
+    ${Serial_SOURCES1}
+    serial/TestSerial_Task.cpp
   )
-  kokkos_add_executable_and_test(CoreUnitTest_Serial2 SOURCES UnitTestMainInit.cpp ${Serial_SOURCES2})
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_Serial2
+    SOURCES
+    UnitTestMainInit.cpp
+    ${Serial_SOURCES2}
+  )
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_Serial_ViewSupport
+    SOURCES
+    UnitTestMainInit.cpp
+    ${Serial_VIEWSUPPORT}
+  )
 endif()
 
 if(Kokkos_ENABLE_THREADS)
-  kokkos_add_executable_and_test(CoreUnitTest_Threads SOURCES ${Threads_SOURCES} UnitTestMainInit.cpp)
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_Threads
+    SOURCES ${Threads_SOURCES}
+    UnitTestMainInit.cpp
+  )
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_Threads_ViewSupport
+    SOURCES
+    UnitTestMainInit.cpp
+    ${Threads_VIEWSUPPORT}
+  )
 endif()
 
-if(Kokkos_ENABLE_OPENMP)
-  set(OpenMP_EXTRA_SOURCES openmp/TestOpenMP_Task.cpp)
-  kokkos_add_executable_and_test(
-    CoreUnitTest_OpenMP SOURCES UnitTestMainInit.cpp ${OpenMP_SOURCES} ${OpenMP_EXTRA_SOURCES}
+if (Kokkos_ENABLE_OPENMP)
+  set(OpenMP_EXTRA_SOURCES
+    openmp/TestOpenMP_Task.cpp
   )
-  kokkos_add_executable_and_test(CoreUnitTest_OpenMPInterOp SOURCES UnitTestMain.cpp openmp/TestOpenMP_InterOp.cpp)
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_OpenMP
+    SOURCES
+    UnitTestMainInit.cpp
+    ${OpenMP_SOURCES}
+    ${OpenMP_EXTRA_SOURCES}
+  )
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_OpenMPInterOp
+    SOURCES
+      UnitTestMain.cpp
+      openmp/TestOpenMP_InterOp.cpp
+  )
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_OpenMP_ViewSupport
+    SOURCES
+    UnitTestMainInit.cpp
+    ${OpenMP_VIEWSUPPORT}
+  )
 endif()
 
 if(Kokkos_ENABLE_HPX)
-  kokkos_add_executable_and_test(CoreUnitTest_HPX SOURCES UnitTestMainInit.cpp ${HPX_SOURCES} hpx/TestHPX_Task.cpp)
-  kokkos_add_executable_and_test(CoreUnitTest_HPXInterOp SOURCES UnitTestMain.cpp hpx/TestHPX_InterOp.cpp)
-  kokkos_add_executable_and_test(
-    CoreUnitTest_HPX_IndependentInstances
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_HPX
+    SOURCES
+      UnitTestMainInit.cpp
+      ${HPX_SOURCES}
+      hpx/TestHPX_Task.cpp
+  )
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_HPX_ViewSupport
     SOURCES
     UnitTestMainInit.cpp
-    hpx/TestHPX_IndependentInstances.cpp
-    hpx/TestHPX_IndependentInstancesDelayedExecution.cpp
-    hpx/TestHPX_IndependentInstancesInstanceIds.cpp
-    hpx/TestHPX_IndependentInstancesRefCounting.cpp
-    hpx/TestHPX_IndependentInstancesSynchronization.cpp
+    ${HPX_VIEWSUPPORT}
   )
-  if(Kokkos_ENABLE_DEPRECATED_CODE_4)
-    kokkos_add_executable_and_test(CoreUnitTest_HPX_InParallel SOURCES UnitTestMainInit.cpp hpx/TestHPX_InParallel.cpp)
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_HPXInterOp
+    SOURCES
+      UnitTestMain.cpp
+      hpx/TestHPX_InterOp.cpp
+  )
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_HPX_IndependentInstances
+    SOURCES
+      UnitTestMainInit.cpp
+      hpx/TestHPX_IndependentInstances.cpp
+      hpx/TestHPX_IndependentInstancesDelayedExecution.cpp
+      hpx/TestHPX_IndependentInstancesInstanceIds.cpp
+      hpx/TestHPX_IndependentInstancesRefCounting.cpp
+      hpx/TestHPX_IndependentInstancesSynchronization.cpp
+  )
+if(Kokkos_ENABLE_DEPRECATED_CODE_4)
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_HPX_InParallel
+    SOURCES
+      UnitTestMainInit.cpp
+      hpx/TestHPX_InParallel.cpp
+  )
   endif()
 endif()
 
 if(Kokkos_ENABLE_OPENMPTARGET)
-  kokkos_add_executable_and_test(CoreUnitTest_OpenMPTarget SOURCES UnitTestMainInit.cpp ${OpenMPTarget_SOURCES})
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_OpenMPTarget
+    SOURCES
+    UnitTestMainInit.cpp
+    ${OpenMPTarget_SOURCES}
+  )
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_OpenMPTarget_ViewSupport
+    SOURCES
+    UnitTestMainInit.cpp
+    ${OpenMPTarget_VIEWSUPPORT}
+  )
 endif()
 
 if(Kokkos_ENABLE_OPENACC)
-  kokkos_add_executable_and_test(CoreUnitTest_OpenACC SOURCES UnitTestMainInit.cpp ${OpenACC_SOURCES})
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_OpenACC
+    SOURCES
+    UnitTestMainInit.cpp
+    ${OpenACC_SOURCES}
+  )
 endif()
 
 if(Kokkos_ENABLE_CUDA)
-  kokkos_add_executable_and_test(
-    CoreUnitTest_Cuda1 SOURCES UnitTestMainInit.cpp ${Cuda_SOURCES1} cuda/TestCuda_ReducerViewSizeLimit.cpp
-  )
+    KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_Cuda1
+    SOURCES
+      UnitTestMainInit.cpp
+      ${Cuda_SOURCES1}
+      cuda/TestCuda_ReducerViewSizeLimit.cpp
+    )
 
-  kokkos_add_executable_and_test(CoreUnitTest_Cuda2 SOURCES UnitTestMainInit.cpp ${Cuda_SOURCES2})
+    KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_Cuda2
+    SOURCES
+      UnitTestMainInit.cpp
+      ${Cuda_SOURCES2}
+    )
 
-  kokkos_add_executable_and_test(
+    KOKKOS_ADD_EXECUTABLE_AND_TEST(
     CoreUnitTest_Cuda3
     SOURCES
-    UnitTestMainInit.cpp
-    cuda/TestCuda_Task.cpp
-    cuda/TestCuda_TeamScratchStreams.cpp
-    ${Cuda_SOURCES3}
-    cuda/TestCuda_Spaces.cpp
-    ${Cuda_SOURCES_SHAREDSPACE}
+      UnitTestMainInit.cpp
+      cuda/TestCuda_Task.cpp
+      cuda/TestCuda_TeamScratchStreams.cpp
+      ${Cuda_SOURCES3}
+      cuda/TestCuda_Spaces.cpp
+      ${Cuda_SOURCES_SHAREDSPACE}
+    )
+    KOKKOS_ADD_EXECUTABLE_AND_TEST(
+      CoreUnitTest_Cuda_ViewSupport
+      SOURCES
+      UnitTestMainInit.cpp
+      ${Cuda_VIEWSUPPORT}
+    )
+
+    KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_CudaTimingBased
+    SOURCES
+      UnitTestMainInit.cpp
+      cuda/TestCuda_DebugSerialExecution.cpp
+      cuda/TestCuda_DebugPinUVMSpace.cpp
   )
 
-  kokkos_add_executable_and_test(
-    CoreUnitTest_CudaTimingBased SOURCES UnitTestMainInit.cpp cuda/TestCuda_DebugSerialExecution.cpp
-    cuda/TestCuda_DebugPinUVMSpace.cpp
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_CudaInterOpInit
+    SOURCES
+      UnitTestMain.cpp
+      cuda/TestCuda_InterOp_Init.cpp
   )
-
-  kokkos_add_executable_and_test(CoreUnitTest_CudaInterOpInit SOURCES UnitTestMain.cpp cuda/TestCuda_InterOp_Init.cpp)
-  kokkos_add_executable_and_test(
-    CoreUnitTest_CudaInterOpStreams SOURCES UnitTestMain.cpp cuda/TestCuda_InterOp_Streams.cpp
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_CudaInterOpStreams
+    SOURCES
+      UnitTestMain.cpp
+      cuda/TestCuda_InterOp_Streams.cpp
   )
-  kokkos_add_executable_and_test(
-    CoreUnitTest_CudaInterOpStreamsMultiGPU SOURCES UnitTestMainInit.cpp cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_CudaInterOpStreamsMultiGPU
+    SOURCES
+      UnitTestMainInit.cpp
+      cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
   )
 endif()
 
 if(Kokkos_ENABLE_HIP)
-  kokkos_add_executable_and_test(
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
     CoreUnitTest_HIP
     SOURCES
-    UnitTestMainInit.cpp
-    ${HIP_SOURCES}
-    hip/TestHIP_ScanUnit.cpp
-    hip/TestHIP_Spaces.cpp
-    hip/TestHIP_Memory_Requirements.cpp
-    hip/TestHIP_TeamScratchStreams.cpp
-    hip/TestHIP_AsyncLauncher.cpp
-    hip/TestHIP_BlocksizeDeduction.cpp
+      UnitTestMainInit.cpp
+      ${HIP_SOURCES}
+      hip/TestHIP_ScanUnit.cpp
+      hip/TestHIP_Spaces.cpp
+      hip/TestHIP_Memory_Requirements.cpp
+      hip/TestHIP_TeamScratchStreams.cpp
+      hip/TestHIP_AsyncLauncher.cpp
+      hip/TestHIP_BlocksizeDeduction.cpp
   )
-  kokkos_add_executable_and_test(CoreUnitTest_HIPInterOpInit SOURCES UnitTestMain.cpp hip/TestHIP_InterOp_Init.cpp)
-  kokkos_add_executable_and_test(
-    CoreUnitTest_HIPInterOpStreams SOURCES UnitTestMain.cpp hip/TestHIP_InterOp_Streams.cpp
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_HIP_ViewSupport
+    SOURCES
+    UnitTestMainInit.cpp
+    ${HIP_VIEWSUPPORT}
+  )
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_HIPInterOpInit
+    SOURCES
+      UnitTestMain.cpp
+      hip/TestHIP_InterOp_Init.cpp
+  )
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_HIPInterOpStreams
+    SOURCES
+      UnitTestMain.cpp
+      hip/TestHIP_InterOp_Streams.cpp
   )
 endif()
 
 if(Kokkos_ENABLE_SYCL)
-  list(REMOVE_ITEM SYCL_SOURCES2A ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_WorkGraph.cpp)
+  list(REMOVE_ITEM SYCL_SOURCES2A
+       ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_WorkGraph.cpp
+  )
 
-  kokkos_add_executable_and_test(CoreUnitTest_SYCL1A SOURCES UnitTestMainInit.cpp ${SYCL_SOURCES1A})
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_SYCL1A
+    SOURCES
+      UnitTestMainInit.cpp
+      ${SYCL_SOURCES1A}
+  )
 
-  kokkos_add_executable_and_test(CoreUnitTest_SYCL1B SOURCES UnitTestMainInit.cpp ${SYCL_SOURCES1B})
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_SYCL1B
+    SOURCES
+      UnitTestMainInit.cpp
+      ${SYCL_SOURCES1B}
+  )
 
-  kokkos_add_executable_and_test(CoreUnitTest_SYCL2A SOURCES UnitTestMainInit.cpp ${SYCL_SOURCES2A})
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_SYCL2A
+    SOURCES
+      UnitTestMainInit.cpp
+      ${SYCL_SOURCES2A}
+  )
 
-  kokkos_add_executable_and_test(CoreUnitTest_SYCL2B SOURCES UnitTestMainInit.cpp ${SYCL_SOURCES2B})
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_SYCL2B
+    SOURCES
+      UnitTestMainInit.cpp
+      ${SYCL_SOURCES2B}
+  )
 
-  kokkos_add_executable_and_test(CoreUnitTest_SYCL2C SOURCES UnitTestMainInit.cpp ${SYCL_SOURCES2C})
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_SYCL2C
+    SOURCES
+      UnitTestMainInit.cpp
+      ${SYCL_SOURCES2C}
+  )
 
-  kokkos_add_executable_and_test(CoreUnitTest_SYCL2D SOURCES UnitTestMainInit.cpp ${SYCL_SOURCES2D})
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_SYCL2D
+    SOURCES
+      UnitTestMainInit.cpp
+      ${SYCL_SOURCES2D}
+  )
 
-  kokkos_add_executable_and_test(
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
     CoreUnitTest_SYCL3
     SOURCES
+      UnitTestMainInit.cpp
+      # FIXME_SYCL
+      sycl/TestSYCL_Task.cpp
+      sycl/TestSYCL_TeamScratchStreams.cpp
+      ${SYCL_SOURCES3}
+      sycl/TestSYCL_Spaces.cpp
+  )
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_SYCL_ViewSupport
+    SOURCES
     UnitTestMainInit.cpp
-    # FIXME_SYCL
-    sycl/TestSYCL_Task.cpp
-    sycl/TestSYCL_TeamScratchStreams.cpp
-    ${SYCL_SOURCES3}
-    sycl/TestSYCL_Spaces.cpp
+    ${SYCL_VIEWSUPPORT}
   )
 
-  kokkos_add_executable_and_test(CoreUnitTest_SYCLInterOpInit SOURCES UnitTestMain.cpp sycl/TestSYCL_InterOp_Init.cpp)
-  kokkos_add_executable_and_test(
-    CoreUnitTest_SYCLInterOpInit_Context SOURCES UnitTestMainInit.cpp sycl/TestSYCL_InterOp_Init_Context.cpp
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_SYCLInterOpInit
+    SOURCES
+      UnitTestMain.cpp
+      sycl/TestSYCL_InterOp_Init.cpp
   )
-  kokkos_add_executable_and_test(
-    CoreUnitTest_SYCLInterOpStreams SOURCES UnitTestMain.cpp sycl/TestSYCL_InterOp_Streams.cpp
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_SYCLInterOpInit_Context
+    SOURCES
+      UnitTestMainInit.cpp
+      sycl/TestSYCL_InterOp_Init_Context.cpp
   )
-  kokkos_add_executable_and_test(
-    CoreUnitTest_SYCLInterOpStreamsMultiGPU SOURCES UnitTestMainInit.cpp sycl/TestSYCL_InterOp_StreamsMultiGPU.cpp
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_SYCLInterOpStreams
+    SOURCES
+     UnitTestMain.cpp
+     sycl/TestSYCL_InterOp_Streams.cpp
+  )
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+      CoreUnitTest_SYCLInterOpStreamsMultiGPU
+    SOURCES
+      UnitTestMainInit.cpp
+      sycl/TestSYCL_InterOp_StreamsMultiGPU.cpp
   )
 endif()
 
-set(DEFAULT_DEVICE_SOURCES
-    UnitTestMainInit.cpp
-    TestCStyleMemoryManagement.cpp
-    TestInitializationSettings.cpp
-    TestParseCmdLineArgsAndEnvVars.cpp
-    TestSharedSpace.cpp
-    TestSharedHostPinnedSpace.cpp
-    TestCompilerMacros.cpp
-    default/TestDefaultDeviceType.cpp
-    default/TestDefaultDeviceType_a1.cpp
-    default/TestDefaultDeviceType_b1.cpp
-    default/TestDefaultDeviceType_c1.cpp
-    default/TestDefaultDeviceType_a2.cpp
-    default/TestDefaultDeviceType_b2.cpp
-    default/TestDefaultDeviceType_c2.cpp
-    default/TestDefaultDeviceType_a3.cpp
-    default/TestDefaultDeviceType_b3.cpp
-    default/TestDefaultDeviceType_c3.cpp
-    default/TestDefaultDeviceTypeResize.cpp
-    default/TestDefaultDeviceTypeViewAPI.cpp
+SET(DEFAULT_DEVICE_SOURCES
+  UnitTestMainInit.cpp
+  TestCStyleMemoryManagement.cpp
+  TestInitializationSettings.cpp
+  TestParseCmdLineArgsAndEnvVars.cpp
+  TestSharedSpace.cpp
+  TestSharedHostPinnedSpace.cpp
+  TestCompilerMacros.cpp
+  default/TestDefaultDeviceType.cpp
+  default/TestDefaultDeviceType_a1.cpp
+  default/TestDefaultDeviceType_b1.cpp
+  default/TestDefaultDeviceType_c1.cpp
+  default/TestDefaultDeviceType_a2.cpp
+  default/TestDefaultDeviceType_b2.cpp
+  default/TestDefaultDeviceType_c2.cpp
+  default/TestDefaultDeviceType_a3.cpp
+  default/TestDefaultDeviceType_b3.cpp
+  default/TestDefaultDeviceType_c3.cpp
+  default/TestDefaultDeviceTypeResize.cpp
+  default/TestDefaultDeviceTypeViewAPI.cpp
 )
 # FIXME_OPENMPTARGET and FIXME_OPENACC do not provide a MemorySpace that can be accessed from all ExecSpaces
 # FIXME_SYCL clock_tic does not give the correct timings for cloc_tic
-if(KOKKOS_ENABLE_OPENACC OR KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_SYCL)
-  list(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedSpace.cpp)
+if (KOKKOS_ENABLE_OPENACC OR KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_SYCL)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedSpace.cpp)
 endif()
 # FIXME_OPENMPTARGET and FIXME_OPENACC do not provide a HostPinnedMemorySpace that can be accessed from all ExecSpaces
-if(KOKKOS_ENABLE_OPENACC OR KOKKOS_ENABLE_OPENMPTARGET)
-  list(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedHostPinnedSpace.cpp)
+if (KOKKOS_ENABLE_OPENACC OR KOKKOS_ENABLE_OPENMPTARGET)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedHostPinnedSpace.cpp)
 endif()
 
 # FIXME_OPENMPTARGET, FIXME_OPENACC - Comment non-passing tests with the NVIDIA HPC compiler nvc++
-if((KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_OPENACC) AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
-  list(
-    REMOVE_ITEM
-    DEFAULT_DEVICE_SOURCES
+if ((KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_OPENACC) AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES
     default/TestDefaultDeviceType_a1.cpp
     default/TestDefaultDeviceType_b1.cpp
     default/TestDefaultDeviceType_c1.cpp
@@ -840,10 +1066,8 @@ if((KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_OPENACC) AND KOKKOS_CXX_COMPILER
 endif()
 
 # FIXME_OPENACC - Comment non-passing tests with the Clang compiler
-if(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
-  list(
-    REMOVE_ITEM
-    DEFAULT_DEVICE_SOURCES
+if (KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES
     default/TestDefaultDeviceType_a1.cpp
     default/TestDefaultDeviceType_b1.cpp
     default/TestDefaultDeviceType_c1.cpp
@@ -858,249 +1082,299 @@ if(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
   )
 endif()
 
-kokkos_add_executable_and_test(CoreUnitTest_Default SOURCES ${DEFAULT_DEVICE_SOURCES})
+KOKKOS_ADD_EXECUTABLE_AND_TEST(
+  CoreUnitTest_Default
+  SOURCES ${DEFAULT_DEVICE_SOURCES}
+)
 
-kokkos_add_executable_and_test(CoreUnitTest_LegionInitialization SOURCES UnitTestMain.cpp TestLegionInitialization.cpp)
+KOKKOS_ADD_EXECUTABLE_AND_TEST(
+  CoreUnitTest_LegionInitialization
+  SOURCES
+    UnitTestMain.cpp
+    TestLegionInitialization.cpp
+)
 
-kokkos_add_executable_and_test(CoreUnitTest_PushFinalizeHook SOURCES UnitTest_PushFinalizeHook.cpp)
+KOKKOS_ADD_EXECUTABLE_AND_TEST(
+  CoreUnitTest_PushFinalizeHook
+  SOURCES
+    UnitTest_PushFinalizeHook.cpp
+)
 
-kokkos_add_executable_and_test(CoreUnitTest_ScopeGuard SOURCES UnitTestMain.cpp UnitTest_ScopeGuard.cpp)
+KOKKOS_ADD_EXECUTABLE_AND_TEST(
+  CoreUnitTest_ScopeGuard
+  SOURCES
+    UnitTestMain.cpp
+    UnitTest_ScopeGuard.cpp
+)
 
 # This test is intended for development and debugging by putting code
 # into TestDefaultDeviceDevelop.cpp. By default its empty.
-kokkos_add_executable_and_test(CoreUnitTest_Develop SOURCES UnitTestMainInit.cpp default/TestDefaultDeviceDevelop.cpp)
+KOKKOS_ADD_EXECUTABLE_AND_TEST(
+  CoreUnitTest_Develop
+  SOURCES
+    UnitTestMainInit.cpp
+    default/TestDefaultDeviceDevelop.cpp
+)
 
 # With MSVC, the terminate handler is called and prints the message but the
 # program does not seem to exit and we get a timeout with ctest.
-if(NOT WIN32)
+if (NOT WIN32)
   # This test is special, because it passes exactly when it prints the
   # message "PASSED: I am the custom std::terminate handler.", AND calls
   # std::terminate.  This means that we can't use
   # KOKKOS_ADD_EXECUTABLE_AND_TEST.  See GitHub issue #2147.
-  kokkos_add_test_executable(CoreUnitTest_PushFinalizeHookTerminate SOURCES UnitTest_PushFinalizeHook_terminate.cpp)
-  add_test(NAME Kokkos_CoreUnitTest_PushFinalizeHookTerminateRegex
-           COMMAND ${CMAKE_COMMAND} -E env $<TARGET_FILE:Kokkos_CoreUnitTest_PushFinalizeHookTerminate>
+  KOKKOS_ADD_TEST_EXECUTABLE(
+    CoreUnitTest_PushFinalizeHookTerminate
+    SOURCES UnitTest_PushFinalizeHook_terminate.cpp
+  )
+  add_test(
+    NAME Kokkos_CoreUnitTest_PushFinalizeHookTerminateRegex
+    COMMAND ${CMAKE_COMMAND} -E env $<TARGET_FILE:Kokkos_CoreUnitTest_PushFinalizeHookTerminate>
   )
   set_property(
-    TEST Kokkos_CoreUnitTest_PushFinalizeHookTerminateRegex PROPERTY PASS_REGULAR_EXPRESSION
-                                                                     "PASSED: I am the custom std::terminate handler."
+    TEST Kokkos_CoreUnitTest_PushFinalizeHookTerminateRegex
+    PROPERTY PASS_REGULAR_EXPRESSION "PASSED: I am the custom std::terminate handler."
   )
-  add_test(NAME Kokkos_CoreUnitTest_PushFinalizeHookTerminateFails
-           COMMAND ${CMAKE_COMMAND} -E env $<TARGET_FILE:Kokkos_CoreUnitTest_PushFinalizeHookTerminate>
+  add_test(
+    NAME Kokkos_CoreUnitTest_PushFinalizeHookTerminateFails
+    COMMAND ${CMAKE_COMMAND} -E env $<TARGET_FILE:Kokkos_CoreUnitTest_PushFinalizeHookTerminate>
   )
-  set_property(TEST Kokkos_CoreUnitTest_PushFinalizeHookTerminateFails PROPERTY WILL_FAIL TRUE)
+  set_property(
+    TEST Kokkos_CoreUnitTest_PushFinalizeHookTerminateFails
+    PROPERTY WILL_FAIL TRUE
+  )
 endif()
 
-if(KOKKOS_ENABLE_TUNING)
-  kokkos_add_executable_and_test(CoreUnitTest_TuningBuiltins SOURCES tools/TestBuiltinTuners.cpp)
-  kokkos_add_executable_and_test(CoreUnitTest_TuningBasics SOURCES tools/TestTuning.cpp)
-  kokkos_add_executable_and_test(CoreUnitTest_CategoricalTuner SOURCES tools/TestCategoricalTuner.cpp)
-endif()
-
-set(KOKKOSP_SOURCES UnitTestMainInit.cpp tools/TestEventCorrectness.cpp tools/TestKernelNames.cpp
-                    tools/TestProfilingSection.cpp tools/TestScopedRegion.cpp tools/TestWithoutInitializing.cpp
-)
-
-# FIXME_OPENMPTARGET This test causes internal compiler errors as of 09/01/22
-# when compiling for Intel's Xe-HP GPUs.
-if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
-  list(REMOVE_ITEM KOKKOSP_SOURCES tools/TestEventCorrectness.cpp)
-endif()
-
-kokkos_add_executable_and_test(CoreUnitTest_KokkosP SOURCES ${KOKKOSP_SOURCES})
-if(KOKKOS_ENABLE_LIBDL)
-  kokkos_add_executable_and_test(CoreUnitTest_ToolIndependence SOURCES tools/TestIndependence.cpp)
-  target_compile_definitions(Kokkos_CoreUnitTest_ToolIndependence PUBLIC KOKKOS_TOOLS_INDEPENDENT_BUILD)
-  kokkos_add_test_library(kokkosprinter-tool SHARED SOURCES tools/printing-tool.cpp)
-
-  if((NOT (Kokkos_ENABLE_CUDA AND WIN32)) AND (NOT ("${KOKKOS_CXX_COMPILER_ID}" STREQUAL "Fujitsu")))
-    target_compile_features(kokkosprinter-tool PUBLIC cxx_std_14)
+  if(KOKKOS_ENABLE_TUNING)
+    KOKKOS_ADD_EXECUTABLE_AND_TEST(
+      CoreUnitTest_TuningBuiltins
+      SOURCES
+      tools/TestBuiltinTuners.cpp
+    )
+    KOKKOS_ADD_EXECUTABLE_AND_TEST(
+      CoreUnitTest_TuningBasics
+      SOURCES
+        tools/TestTuning.cpp
+    )
+    KOKKOS_ADD_EXECUTABLE_AND_TEST(
+      CoreUnitTest_CategoricalTuner
+      SOURCES
+      tools/TestCategoricalTuner.cpp
+    )
   endif()
 
-  kokkos_add_test_executable(ProfilingAllCalls tools/TestAllCalls.cpp)
+  SET(KOKKOSP_SOURCES
+    UnitTestMainInit.cpp
+    tools/TestEventCorrectness.cpp
+    tools/TestKernelNames.cpp
+    tools/TestProfilingSection.cpp
+    tools/TestScopedRegion.cpp
+    tools/TestWithoutInitializing.cpp
+    )
 
-  kokkos_add_test_executable(ToolsInitialization UnitTestMain.cpp tools/TestToolsInitialization.cpp)
+  # FIXME_OPENMPTARGET This test causes internal compiler errors as of 09/01/22
+  # when compiling for Intel's Xe-HP GPUs.
+  if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
+    list(REMOVE_ITEM KOKKOSP_SOURCES tools/TestEventCorrectness.cpp)
+  endif()
 
-  set(ADDRESS_REGEX "0x[0-9a-f]*")
-  set(MEMSPACE_REGEX "[HC][ou][sd][ta][a-zA-Z]*")
-  set(SIZE_REGEX "[0-9]*")
-  set(SKIP_SCRATCH_INITIALIZATION_REGEX ".*")
-
-  # check help works via environment variable
-  kokkos_add_test(
-    SKIP_TRIBITS
-    NAME
-    ProfilingTestLibraryLoadHelp
-    EXE
-    ProfilingAllCalls
-    TOOL
-    kokkosprinter-tool
-    ARGS
-    --kokkos-tools-help
-    PASS_REGULAR_EXPRESSION
-    "kokkosp_init_library::kokkosp_print_help:Kokkos_ProfilingAllCalls::kokkosp_finalize_library::"
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    CoreUnitTest_KokkosP
+    SOURCES
+    ${KOKKOSP_SOURCES}
   )
+  if(KOKKOS_ENABLE_LIBDL)
+    KOKKOS_ADD_EXECUTABLE_AND_TEST(
+      CoreUnitTest_ToolIndependence
+      SOURCES
+      tools/TestIndependence.cpp
+    )
+    TARGET_COMPILE_DEFINITIONS(
+      Kokkos_CoreUnitTest_ToolIndependence PUBLIC
+      KOKKOS_TOOLS_INDEPENDENT_BUILD
+    )
+    KOKKOS_ADD_TEST_LIBRARY(
+      kokkosprinter-tool SHARED
+      SOURCES tools/printing-tool.cpp
+    )
 
-  # check help works via direct library specification
-  kokkos_add_test(
-    SKIP_TRIBITS
-    NAME
-    ProfilingTestLibraryCmdLineHelp
-    EXE
-    ProfilingAllCalls
-    ARGS
-    --kokkos-tools-help
-    --kokkos-tools-libs=$<TARGET_FILE:kokkosprinter-tool>
-    PASS_REGULAR_EXPRESSION
-    "kokkosp_init_library::kokkosp_print_help:Kokkos_ProfilingAllCalls::kokkosp_finalize_library::"
-  )
+    if((NOT (Kokkos_ENABLE_CUDA AND WIN32)) AND (NOT ("${KOKKOS_CXX_COMPILER_ID}" STREQUAL "Fujitsu")))
+      TARGET_COMPILE_FEATURES(kokkosprinter-tool PUBLIC cxx_std_14)
+    endif()
 
-  kokkos_add_test(
-    SKIP_TRIBITS
-    NAME
-    ProfilingTestLibraryLoad
-    EXE
-    ProfilingAllCalls
-    TOOL
-    kokkosprinter-tool
-    ARGS
-    --kokkos-tools-args="-c test delimit"
-    PASS_REGULAR_EXPRESSION
-    "kokkosp_init_library::kokkosp_parse_args:4:Kokkos_ProfilingAllCalls:-c:test:delimit::.*::kokkosp_allocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]source] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_allocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]destination] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_begin_deep_copy:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::.*kokkosp_end_deep_copy::kokkosp_begin_parallel_for:parallel_for:${SIZE_REGEX}:0::kokkosp_end_parallel_for:0::kokkosp_begin_parallel_reduce:parallel_reduce:${SIZE_REGEX}:1${SKIP_SCRATCH_INITIALIZATION_REGEX}::kokkosp_end_parallel_reduce:1::kokkosp_begin_parallel_scan:parallel_scan:${SIZE_REGEX}:2::kokkosp_end_parallel_scan:2::kokkosp_push_profile_region:push_region::kokkosp_pop_profile_region::kokkosp_create_profile_section:created_section:3::kokkosp_start_profile_section:3::kokkosp_stop_profile_section:3::kokkosp_destroy_profile_section:3::kokkosp_profile_event:profiling_event::kokkosp_declare_metadata:dogs:good::kokkosp_deallocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_deallocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_finalize_library::"
-  )
+    KOKKOS_ADD_TEST_EXECUTABLE(
+      ProfilingAllCalls
+      tools/TestAllCalls.cpp
+    )
 
-  # Above will test that leading/trailing quotes are stripped bc ctest cmd args is:
-  #       "--kokkos-tools-args="-c test delimit""
-  # The bracket argument syntax: [=[ and ]=] used below ensures it is treated as
-  # a single argument:
-  #       "--kokkos-tools-args=-c test delimit"
-  #
-  # https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#bracket-argument
-  #
-  kokkos_add_test(
-    SKIP_TRIBITS
-    NAME
-    ProfilingTestLibraryCmdLine
-    EXE
-    ProfilingAllCalls
-    ARGS
-    [=[--kokkos-tools-args=-c test delimit]=]
-    --kokkos-tools-libs=$<TARGET_FILE:kokkosprinter-tool>
-    PASS_REGULAR_EXPRESSION
-    "kokkosp_init_library::kokkosp_parse_args:4:Kokkos_ProfilingAllCalls:-c:test:delimit::.*::kokkosp_allocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]source] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_allocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]destination] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_begin_deep_copy:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::.*kokkosp_end_deep_copy::kokkosp_begin_parallel_for:parallel_for:${SIZE_REGEX}:0::kokkosp_end_parallel_for:0::kokkosp_begin_parallel_reduce:parallel_reduce:${SIZE_REGEX}:1${SKIP_SCRATCH_INITIALIZATION_REGEX}::kokkosp_end_parallel_reduce:1::kokkosp_begin_parallel_scan:parallel_scan:${SIZE_REGEX}:2::kokkosp_end_parallel_scan:2::kokkosp_push_profile_region:push_region::kokkosp_pop_profile_region::kokkosp_create_profile_section:created_section:3::kokkosp_start_profile_section:3::kokkosp_stop_profile_section:3::kokkosp_destroy_profile_section:3::kokkosp_profile_event:profiling_event::kokkosp_declare_metadata:dogs:good::kokkosp_deallocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_deallocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_finalize_library::"
-  )
-endif() #KOKKOS_ENABLE_LIBDL
-kokkos_add_test_executable(
+    KOKKOS_ADD_TEST_EXECUTABLE(
+      ToolsInitialization
+      UnitTestMain.cpp
+      tools/TestToolsInitialization.cpp
+    )
+
+    set(ADDRESS_REGEX "0x[0-9a-f]*")
+    set(MEMSPACE_REGEX "[HC][ou][sd][ta][a-zA-Z]*")
+    set(SIZE_REGEX "[0-9]*")
+    set(SKIP_SCRATCH_INITIALIZATION_REGEX ".*")
+
+    # check help works via environment variable
+    KOKKOS_ADD_TEST(
+      SKIP_TRIBITS
+      NAME ProfilingTestLibraryLoadHelp
+      EXE  ProfilingAllCalls
+      TOOL kokkosprinter-tool
+      ARGS --kokkos-tools-help
+      PASS_REGULAR_EXPRESSION
+        "kokkosp_init_library::kokkosp_print_help:Kokkos_ProfilingAllCalls::kokkosp_finalize_library::")
+
+    # check help works via direct library specification
+    KOKKOS_ADD_TEST(
+      SKIP_TRIBITS
+      NAME ProfilingTestLibraryCmdLineHelp
+      EXE  ProfilingAllCalls
+      ARGS --kokkos-tools-help
+           --kokkos-tools-libs=$<TARGET_FILE:kokkosprinter-tool>
+      PASS_REGULAR_EXPRESSION
+        "kokkosp_init_library::kokkosp_print_help:Kokkos_ProfilingAllCalls::kokkosp_finalize_library::")
+
+    KOKKOS_ADD_TEST(
+      SKIP_TRIBITS
+      NAME ProfilingTestLibraryLoad
+      EXE  ProfilingAllCalls
+      TOOL kokkosprinter-tool
+      ARGS --kokkos-tools-args="-c test delimit"
+      PASS_REGULAR_EXPRESSION "kokkosp_init_library::kokkosp_parse_args:4:Kokkos_ProfilingAllCalls:-c:test:delimit::.*::kokkosp_allocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]source] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_allocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]destination] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_begin_deep_copy:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::.*kokkosp_end_deep_copy::kokkosp_begin_parallel_for:parallel_for:${SIZE_REGEX}:0::kokkosp_end_parallel_for:0::kokkosp_begin_parallel_reduce:parallel_reduce:${SIZE_REGEX}:1${SKIP_SCRATCH_INITIALIZATION_REGEX}::kokkosp_end_parallel_reduce:1::kokkosp_begin_parallel_scan:parallel_scan:${SIZE_REGEX}:2::kokkosp_end_parallel_scan:2::kokkosp_push_profile_region:push_region::kokkosp_pop_profile_region::kokkosp_create_profile_section:created_section:3::kokkosp_start_profile_section:3::kokkosp_stop_profile_section:3::kokkosp_destroy_profile_section:3::kokkosp_profile_event:profiling_event::kokkosp_declare_metadata:dogs:good::kokkosp_deallocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_deallocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_finalize_library::"
+    )
+
+    # Above will test that leading/trailing quotes are stripped bc ctest cmd args is:
+    #       "--kokkos-tools-args="-c test delimit""
+    # The bracket argument syntax: [=[ and ]=] used below ensures it is treated as
+    # a single argument:
+    #       "--kokkos-tools-args=-c test delimit"
+    #
+    # https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#bracket-argument
+    #
+    KOKKOS_ADD_TEST(
+      SKIP_TRIBITS
+      NAME ProfilingTestLibraryCmdLine
+      EXE  ProfilingAllCalls
+      ARGS [=[--kokkos-tools-args=-c test delimit]=]
+            --kokkos-tools-libs=$<TARGET_FILE:kokkosprinter-tool>
+      PASS_REGULAR_EXPRESSION "kokkosp_init_library::kokkosp_parse_args:4:Kokkos_ProfilingAllCalls:-c:test:delimit::.*::kokkosp_allocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]source] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_allocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]destination] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_begin_deep_copy:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::.*kokkosp_end_deep_copy::kokkosp_begin_parallel_for:parallel_for:${SIZE_REGEX}:0::kokkosp_end_parallel_for:0::kokkosp_begin_parallel_reduce:parallel_reduce:${SIZE_REGEX}:1${SKIP_SCRATCH_INITIALIZATION_REGEX}::kokkosp_end_parallel_reduce:1::kokkosp_begin_parallel_scan:parallel_scan:${SIZE_REGEX}:2::kokkosp_end_parallel_scan:2::kokkosp_push_profile_region:push_region::kokkosp_pop_profile_region::kokkosp_create_profile_section:created_section:3::kokkosp_start_profile_section:3::kokkosp_stop_profile_section:3::kokkosp_destroy_profile_section:3::kokkosp_profile_event:profiling_event::kokkosp_declare_metadata:dogs:good::kokkosp_deallocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_deallocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_finalize_library::"
+    )
+  endif() #KOKKOS_ENABLE_LIBDL
+if(NOT KOKKOS_HAS_TRILINOS)
+KOKKOS_ADD_TEST_EXECUTABLE(
   StackTraceTestExec
   SOURCES
-  TestStackTrace.cpp
-  TestStackTrace_f0.cpp
-  TestStackTrace_f1.cpp
-  TestStackTrace_f2.cpp
-  TestStackTrace_f3.cpp
-  TestStackTrace_f4.cpp
+    TestStackTrace.cpp
+    TestStackTrace_f0.cpp
+    TestStackTrace_f1.cpp
+    TestStackTrace_f2.cpp
+    TestStackTrace_f3.cpp
+    TestStackTrace_f4.cpp
 )
 # We need -rdynamic on GNU platforms for the stacktrace functionality
 # to work correctly with shared libraries
-kokkos_set_exe_property(StackTraceTestExec ENABLE_EXPORTS ON)
+KOKKOS_SET_EXE_PROPERTY(StackTraceTestExec ENABLE_EXPORTS ON)
 
-kokkos_add_test(NAME CoreUnitTest_StackTraceTest EXE StackTraceTestExec FAIL_REGULAR_EXPRESSION "FAILED")
-
-if(KOKKOS_ENABLE_HWLOC)
-  kokkos_add_executable_and_test(CoreUnitTest_HWLOC SOURCES UnitTestMain.cpp TestHWLOC.cpp)
+KOKKOS_ADD_TEST( NAME CoreUnitTest_StackTraceTest
+                 EXE  StackTraceTestExec
+                 FAIL_REGULAR_EXPRESSION "FAILED"
+               )
 endif()
 
-function(KOKKOS_ADD_INCREMENTAL_TEST DEVICE)
-  kokkos_option(${DEVICE}_EXCLUDE_TESTS "" STRING "Incremental test exclude list")
+if (KOKKOS_ENABLE_HWLOC)
+KOKKOS_ADD_EXECUTABLE_AND_TEST(
+  CoreUnitTest_HWLOC
+  SOURCES UnitTestMain.cpp  TestHWLOC.cpp
+)
+endif()
+
+FUNCTION (KOKKOS_ADD_INCREMENTAL_TEST DEVICE)
+  KOKKOS_OPTION( ${DEVICE}_EXCLUDE_TESTS "" STRING "Incremental test exclude list" )
   # Add unit test main
-  set(${DEVICE}_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestMainInit.cpp)
+  SET(${DEVICE}_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestMainInit.cpp)
 
   # Iterate over incremental tests in directory
 
-  append_glob(INCREMENTAL_FILE_LIST ${CMAKE_CURRENT_SOURCE_DIR}/incremental/*.hpp)
+  APPEND_GLOB(INCREMENTAL_FILE_LIST ${CMAKE_CURRENT_SOURCE_DIR}/incremental/*.hpp)
 
-  set(DEVICE_NAME ${KOKKOS_${DEVICE}_NAME})
-  foreach(CURRENT_FILE_PATH ${INCREMENTAL_FILE_LIST})
-    get_filename_component(CURRENT_FILE_NAME ${CURRENT_FILE_PATH} NAME)
-    string(REPLACE ".hpp" "" CURRENT_TEST_NAME ${CURRENT_FILE_NAME})
-    if(NOT CURRENT_TEST_NAME IN_LIST Kokkos_${DEVICE}_EXCLUDE_TESTS)
-      set(CURRENT_TEST_OUTPUT_FILENAME ${CURRENT_TEST_NAME}_${DEVICE})
-      file(STRINGS ${CURRENT_FILE_PATH} CURRENT_REQUIRED_FEATURE_LINE REGEX "Kokkos_Feature_Level_Required")
-      # From each test get level implementation required
-      string(REGEX REPLACE ".*Kokkos_Feature_Level_Required:" "" CURRENT_REQUIRED_FEATURE_LEVEL
-                           ${CURRENT_REQUIRED_FEATURE_LINE}
-      )
-      # Cross-reference list of dependencies with selected feature list > matching feature test files are added to test applications
-      if(KOKKOS_${DEVICE}_FEATURE_LEVEL GREATER_EQUAL CURRENT_REQUIRED_FEATURE_LEVEL)
-        configure_file(
-          IncrementalTest.cpp.in ${CMAKE_BINARY_DIR}/core/unit_test/generated/${CURRENT_TEST_OUTPUT_FILENAME}.cpp
-        )
-        set(${DEVICE}_SOURCES ${${DEVICE}_SOURCES};
-                              ${CMAKE_BINARY_DIR}/core/unit_test/generated/${CURRENT_TEST_OUTPUT_FILENAME}.cpp
-        )
-      endif()
-    endif()
-  endforeach()
+  SET(DEVICE_NAME ${KOKKOS_${DEVICE}_NAME})
+  FOREACH (CURRENT_FILE_PATH ${INCREMENTAL_FILE_LIST})
+    GET_FILENAME_COMPONENT( CURRENT_FILE_NAME ${CURRENT_FILE_PATH} NAME )
+    STRING (REPLACE ".hpp" "" CURRENT_TEST_NAME ${CURRENT_FILE_NAME})
+    IF (NOT CURRENT_TEST_NAME IN_LIST Kokkos_${DEVICE}_EXCLUDE_TESTS)
+       SET (CURRENT_TEST_OUTPUT_FILENAME ${CURRENT_TEST_NAME}_${DEVICE})
+       FILE( STRINGS ${CURRENT_FILE_PATH} CURRENT_REQUIRED_FEATURE_LINE REGEX "Kokkos_Feature_Level_Required" )
+       # From each test get level implementation required
+       STRING( REGEX REPLACE ".*Kokkos_Feature_Level_Required:" "" CURRENT_REQUIRED_FEATURE_LEVEL ${CURRENT_REQUIRED_FEATURE_LINE} )
+       # Cross-reference list of dependencies with selected feature list > matching feature test files are added to test applications
+       IF (KOKKOS_${DEVICE}_FEATURE_LEVEL GREATER_EQUAL CURRENT_REQUIRED_FEATURE_LEVEL)
+          CONFIGURE_FILE (IncrementalTest.cpp.in ${CMAKE_BINARY_DIR}/core/unit_test/generated/${CURRENT_TEST_OUTPUT_FILENAME}.cpp )
+          SET(${DEVICE}_SOURCES ${${DEVICE}_SOURCES}; ${CMAKE_BINARY_DIR}/core/unit_test/generated/${CURRENT_TEST_OUTPUT_FILENAME}.cpp)
+       ENDIF()
+     ENDIF()
+  ENDFOREACH()
 
-  string(TOUPPER ${DEVICE} UC_DEVICE)
+  STRING(TOUPPER ${DEVICE} UC_DEVICE)
 
-  kokkos_option(ENABLE_${UC_DEVICE} ON BOOL "ENABLE ${UC_DEVICE}")
+  KOKKOS_OPTION (
+    ENABLE_${UC_DEVICE} ON BOOL "ENABLE ${UC_DEVICE}"
+  )
 
-  kokkos_add_executable_and_test(IncrementalTest_${DEVICE} SOURCES ${${DEVICE}_SOURCES})
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    IncrementalTest_${DEVICE}
+    SOURCES ${${DEVICE}_SOURCES}
+  )
 
-  set(EXE_NAME ${PACKAGE_NAME}_IncrementalTest_${DEVICE})
+  SET(EXE_NAME ${PACKAGE_NAME}_IncrementalTest_${DEVICE})
   # Check that the target was actually created because in a TribITS build
   # where only tests marked as PERFORMANCE enabled it would not be.
-  if(TARGET ${EXE_NAME})
-    target_include_directories(${EXE_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/incremental)
-  endif()
+  IF(TARGET ${EXE_NAME})
+    TARGET_INCLUDE_DIRECTORIES(${EXE_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/incremental )
+  ENDIF()
 
-endfunction()
+ENDFUNCTION()
 
-foreach(DEVICE ${KOKKOS_ENABLED_DEVICES})
-  kokkos_add_incremental_test(${DEVICE})
-endforeach()
+FOREACH (DEVICE ${KOKKOS_ENABLED_DEVICES})
+  KOKKOS_ADD_INCREMENTAL_TEST(${DEVICE})
+ENDFOREACH()
 
-kokkos_add_executable_and_test(CoreUnitTest_CTestDevice SOURCES UnitTestMain.cpp TestCTestDevice.cpp)
-
-kokkos_add_executable_and_test(
-  CoreUnitTest_CMakePassCmdLineArgs SOURCES UnitTest_CMakePassCmdLineArgs.cpp ARGS "one 2 THREE"
+KOKKOS_ADD_EXECUTABLE_AND_TEST(
+  CoreUnitTest_CTestDevice
+  SOURCES UnitTestMain.cpp  TestCTestDevice.cpp
 )
 
-kokkos_add_executable(CoreUnitTest_CMakeTriBITSCompatibility SOURCES UnitTest_CMakeTriBITSCompatibility.cpp)
+KOKKOS_ADD_EXECUTABLE_AND_TEST(
+  CoreUnitTest_CMakePassCmdLineArgs
+  SOURCES UnitTest_CMakePassCmdLineArgs.cpp
+  ARGS "one 2 THREE"
+)
 
-kokkos_add_test(NAME CoreUnitTest_CMakeTriBITSCompatibilityWillFail EXE CoreUnitTest_CMakeTriBITSCompatibility)
-set_property(TEST Kokkos_CoreUnitTest_CMakeTriBITSCompatibilityWillFail PROPERTY WILL_FAIL TRUE)
-
-set(Kokkos_CoreUnitTest_CMakeTriBITSCompatibilityDisable_DISABLE ON)
-kokkos_add_test(NAME CoreUnitTest_CMakeTriBITSCompatibilityDisable EXE CoreUnitTest_CMakeTriBITSCompatibility)
-
-set(Kokkos_CoreUnitTest_CMakeTriBITSCompatibilityExtraArgs_EXTRA_ARGS "--kokkos-test-tribits-compatibility=1")
-kokkos_add_test(NAME CoreUnitTest_CMakeTriBITSCompatibilityExtraArgs EXE CoreUnitTest_CMakeTriBITSCompatibility)
-
-set(Kokkos_CoreUnitTest_CMakeTriBITSCompatibilityEnvironment_ENVIRONMENT "KOKKOS_TEST_TRIBITS_COMPATIBILITY=1")
-kokkos_add_test(NAME CoreUnitTest_CMakeTriBITSCompatibilityEnvironment EXE CoreUnitTest_CMakeTriBITSCompatibility)
-
-set_source_files_properties(UnitTest_DeviceAndThreads.cpp PROPERTIES LANGUAGE ${KOKKOS_COMPILE_LANGUAGE})
-add_executable(Kokkos_CoreUnitTest_DeviceAndThreads UnitTest_DeviceAndThreads.cpp)
-target_link_libraries(Kokkos_CoreUnitTest_DeviceAndThreads Kokkos::kokkoscore)
-find_package(Python3 COMPONENTS Interpreter)
-if(Python3_Interpreter_FOUND AND Python3_VERSION VERSION_GREATER_EQUAL 3.7)
-  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)
-    set(USE_SOURCE_PERMISSIONS_WHEN_SUPPORTED USE_SOURCE_PERMISSIONS)
+# This test is not properly set up to run within Trilinos
+if (NOT KOKKOS_HAS_TRILINOS)
+  SET_SOURCE_FILES_PROPERTIES(UnitTest_DeviceAndThreads.cpp PROPERTIES LANGUAGE ${KOKKOS_COMPILE_LANGUAGE})
+  add_executable(Kokkos_CoreUnitTest_DeviceAndThreads UnitTest_DeviceAndThreads.cpp)
+  target_link_libraries(Kokkos_CoreUnitTest_DeviceAndThreads Kokkos::kokkoscore)
+  find_package(Python3 COMPONENTS Interpreter)
+  if(Python3_Interpreter_FOUND AND Python3_VERSION VERSION_GREATER_EQUAL 3.7)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)
+      set(USE_SOURCE_PERMISSIONS_WHEN_SUPPORTED USE_SOURCE_PERMISSIONS)
+    endif()
+    file(GENERATE
+      OUTPUT $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py
+      INPUT TestDeviceAndThreads.py
+      ${USE_SOURCE_PERMISSIONS_WHEN_SUPPORTED}
+    )
+    add_test(
+      NAME Kokkos_CoreUnitTest_DeviceAndThreads
+      COMMAND ${Python3_EXECUTABLE} $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py -v
+    )
   endif()
-  file(
-    GENERATE
-    OUTPUT $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py
-    INPUT TestDeviceAndThreads.py
-    ${USE_SOURCE_PERMISSIONS_WHEN_SUPPORTED}
-  )
-  add_test(NAME Kokkos_CoreUnitTest_DeviceAndThreads
-           COMMAND ${Python3_EXECUTABLE}
-                   $<TARGET_FILE_DIR:Kokkos_CoreUnitTest_DeviceAndThreads>/TestDeviceAndThreads.py -v
-  )
 endif()
 
-if(KOKKOS_ENABLE_HEADER_SELF_CONTAINMENT_TESTS AND NOT WIN32)
+if (KOKKOS_ENABLE_HEADER_SELF_CONTAINMENT_TESTS AND NOT KOKKOS_HAS_TRILINOS AND NOT WIN32)
   add_subdirectory(headers_self_contained)
 endif()

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -391,7 +391,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
       file(WRITE ${dir}/dummy.cpp
-          "#include <Test${TagHostAccessible}_Category.hpp>\n"
+          "#include <Test${Tag}_Category.hpp>\n"
           "#include <view/Test${Name}.hpp>\n"
       )
       configure_file(${dir}/dummy.cpp ${file})

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -382,6 +382,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       list(APPEND ${Tag}_SOURCES2D ${file})
     endforeach()
 
+    # ViewSupport should eventually contain the new implementation
+    # detail tests for the mdspan based View
     set(${Tag}_VIEWSUPPORT)
     IF (Kokkos_ENABLE_IMPL_MDSPAN)
       foreach(Name
@@ -398,6 +400,12 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         configure_file(${dir}/dummy.cpp ${file})
         list(APPEND ${Tag}_VIEWSUPPORT ${file})
       endforeach()
+      KOKKOS_ADD_EXECUTABLE_AND_TEST(
+        CoreUnitTest_${Tag}_ViewSupport
+        SOURCES
+        UnitTestMainInit.cpp
+        ${${Tag}_VIEWSUPPORT}
+      )
     endif()
 
     SET(${Tag}_SOURCES1 ${${Tag}_SOURCES1A} ${${Tag}_SOURCES1B})
@@ -724,12 +732,6 @@ if(Kokkos_ENABLE_SERIAL)
     UnitTestMainInit.cpp
     ${Serial_SOURCES2}
   )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_Serial_ViewSupport
-    SOURCES
-    UnitTestMainInit.cpp
-    ${Serial_VIEWSUPPORT}
-  )
 endif()
 
 if(Kokkos_ENABLE_THREADS)
@@ -737,12 +739,6 @@ if(Kokkos_ENABLE_THREADS)
     CoreUnitTest_Threads
     SOURCES ${Threads_SOURCES}
     UnitTestMainInit.cpp
-  )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_Threads_ViewSupport
-    SOURCES
-    UnitTestMainInit.cpp
-    ${Threads_VIEWSUPPORT}
   )
 endif()
 
@@ -763,12 +759,6 @@ if (Kokkos_ENABLE_OPENMP)
       UnitTestMain.cpp
       openmp/TestOpenMP_InterOp.cpp
   )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_OpenMP_ViewSupport
-    SOURCES
-    UnitTestMainInit.cpp
-    ${OpenMP_VIEWSUPPORT}
-  )
 endif()
 
 if(Kokkos_ENABLE_HPX)
@@ -778,12 +768,6 @@ if(Kokkos_ENABLE_HPX)
       UnitTestMainInit.cpp
       ${HPX_SOURCES}
       hpx/TestHPX_Task.cpp
-  )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_HPX_ViewSupport
-    SOURCES
-    UnitTestMainInit.cpp
-    ${HPX_VIEWSUPPORT}
   )
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     CoreUnitTest_HPXInterOp
@@ -817,12 +801,6 @@ if(Kokkos_ENABLE_OPENMPTARGET)
     SOURCES
     UnitTestMainInit.cpp
     ${OpenMPTarget_SOURCES}
-  )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_OpenMPTarget_ViewSupport
-    SOURCES
-    UnitTestMainInit.cpp
-    ${OpenMPTarget_VIEWSUPPORT}
   )
 endif()
 
@@ -860,12 +838,6 @@ if(Kokkos_ENABLE_CUDA)
       ${Cuda_SOURCES3}
       cuda/TestCuda_Spaces.cpp
       ${Cuda_SOURCES_SHAREDSPACE}
-    )
-    KOKKOS_ADD_EXECUTABLE_AND_TEST(
-      CoreUnitTest_Cuda_ViewSupport
-      SOURCES
-      UnitTestMainInit.cpp
-      ${Cuda_VIEWSUPPORT}
     )
 
     KOKKOS_ADD_EXECUTABLE_AND_TEST(
@@ -908,12 +880,6 @@ if(Kokkos_ENABLE_HIP)
       hip/TestHIP_TeamScratchStreams.cpp
       hip/TestHIP_AsyncLauncher.cpp
       hip/TestHIP_BlocksizeDeduction.cpp
-  )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_HIP_ViewSupport
-    SOURCES
-    UnitTestMainInit.cpp
-    ${HIP_VIEWSUPPORT}
   )
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     CoreUnitTest_HIPInterOpInit
@@ -985,12 +951,6 @@ if(Kokkos_ENABLE_SYCL)
       sycl/TestSYCL_TeamScratchStreams.cpp
       ${SYCL_SOURCES3}
       sycl/TestSYCL_Spaces.cpp
-  )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    CoreUnitTest_SYCL_ViewSupport
-    SOURCES
-    UnitTestMainInit.cpp
-    ${SYCL_VIEWSUPPORT}
   )
 
   KOKKOS_ADD_EXECUTABLE_AND_TEST(

--- a/core/unit_test/view/TestReferenceCountedAccessor.hpp
+++ b/core/unit_test/view/TestReferenceCountedAccessor.hpp
@@ -20,32 +20,32 @@
 
 namespace {
 using element_t      = float;
-using mem_t          = typename TEST_EXECSPACE::memory_space;
+using memory_space_t = TEST_EXECSPACE::memory_space;
 using defacc_t       = Kokkos::default_accessor<element_t>;
 using const_defacc_t = Kokkos::default_accessor<const element_t>;
 using acc_t =
-    Kokkos::Impl::ReferenceCountedAccessor<element_t, mem_t, defacc_t>;
+    Kokkos::Impl::ReferenceCountedAccessor<element_t, memory_space_t, defacc_t>;
 using const_acc_t =
-    Kokkos::Impl::ReferenceCountedAccessor<const element_t, mem_t,
+    Kokkos::Impl::ReferenceCountedAccessor<const element_t, memory_space_t,
                                            const_defacc_t>;
 using data_handle_t       = typename acc_t::data_handle_type;
 using const_data_handle_t = typename const_acc_t::data_handle_type;
 }  // namespace
 
-void test_refcountedacc_typedefs() {
+TEST(TEST_CATEGORY, RefCountedAcc_Typedefs) {
   static_assert(std::is_same_v<typename acc_t::element_type, element_t>);
-  static_assert(std::is_same_v<
-                typename acc_t::data_handle_type,
-                Kokkos::Impl::ReferenceCountedDataHandle<element_t, mem_t>>);
+  static_assert(
+      std::is_same_v<
+          typename acc_t::data_handle_type,
+          Kokkos::Impl::ReferenceCountedDataHandle<element_t, memory_space_t>>);
   static_assert(
       std::is_same_v<typename acc_t::reference, typename defacc_t::reference>);
   static_assert(
-      std::is_same_v<typename acc_t::offset_policy,
-                     Kokkos::Impl::ReferenceCountedAccessor<
-                         element_t, mem_t, typename defacc_t::offset_policy>>);
+      std::is_same_v<
+          typename acc_t::offset_policy,
+          Kokkos::Impl::ReferenceCountedAccessor<
+              element_t, memory_space_t, typename defacc_t::offset_policy>>);
 }
-
-TEST(TEST_CATEGORY, RefCountedAcc_Typedefs) { test_refcountedacc_typedefs(); }
 
 template <class T>
 KOKKOS_FUNCTION void unused_variable_sink(T) {}
@@ -142,9 +142,9 @@ void test_refcountedacc_conversion() {
         static_assert(
             !std::is_constructible_v<acc_anonym_t, const_acc_anonym_t>);
         static_assert(
-            !std::is_constructible_v<
-                Kokkos::Impl::ReferenceCountedAccessor<double, mem_t, defacc_t>,
-                acc_t>);
+            !std::is_constructible_v<Kokkos::Impl::ReferenceCountedAccessor<
+                                         double, memory_space_t, defacc_t>,
+                                     acc_t>);
 
         unused_variable_sink(c_acc);
         unused_variable_sink(c_acc_anonym);

--- a/core/unit_test/view/TestReferenceCountedAccessor.hpp
+++ b/core/unit_test/view/TestReferenceCountedAccessor.hpp
@@ -114,9 +114,9 @@ TEST(TEST_CATEGORY, RefCountedAcc_ConversionToDefaultAcc) {
 }
 
 void test_refcountedacc_access() {
-  element_t* ptr =
-      (element_t*)Kokkos::kokkos_malloc<TEST_EXECSPACE::memory_space>(
-          100 * sizeof(element_t));
+  element_t* ptr = static_cast<element_t*>(
+      Kokkos::kokkos_malloc<TEST_EXECSPACE::memory_space>(100 *
+                                                          sizeof(element_t)));
   // Gonna use unmanaged data handles here (i.e. not actually referfence
   // counted)
   data_handle_t dh(ptr);

--- a/core/unit_test/view/TestReferenceCountedAccessor.hpp
+++ b/core/unit_test/view/TestReferenceCountedAccessor.hpp
@@ -119,7 +119,7 @@ void test_refcountedacc_access() {
   Kokkos::deep_copy(h_errors, errors);
   ASSERT_FALSE(h_errors & 1);
   ASSERT_FALSE(h_errors & 2);
-  Kokkos::kokkos_free(ptr);
+  Kokkos::kokkos_free<TEST_EXECSPACE>(ptr);
 }
 
 TEST(TEST_CATEGORY, RefCountedAcc_Access) { test_refcountedacc_access(); }

--- a/core/unit_test/view/TestReferenceCountedAccessor.hpp
+++ b/core/unit_test/view/TestReferenceCountedAccessor.hpp
@@ -66,6 +66,7 @@ TEST(TEST_CATEGORY, RefCountedAcc_Ctors) {
       {
         acc_t acc;
         const_acc_t c_acc(acc);
+        (void) c_acc;
         static_assert(!std::is_constructible_v<acc_t, const_acc_t>);
 }
 // from default_accessor
@@ -75,6 +76,9 @@ TEST(TEST_CATEGORY, RefCountedAcc_Ctors) {
   acc_t acc(defacc);
   const_acc_t c_acc1(defacc);
   const_acc_t c_acc2(c_defacc);
+  (void)acc;
+  (void)c_acc1;
+  (void)c_acc2;
   static_assert(!std::is_constructible_v<acc_t, const_defacc_t>);
 }
 });
@@ -89,6 +93,9 @@ TEST(TEST_CATEGORY, RefCountedAcc_ConversionToDefaultAcc) {
         defacc_t defacc(acc);
         const_defacc_t c_defacc1(acc);
         const_defacc_t c_defacc2(c_acc);
+        (void)defacc;
+        (void)c_defacc1;
+        (void)c_defacc2;
         static_assert(!std::is_constructible_v<defacc_t, const_acc_t>);
       });
 }

--- a/core/unit_test/view/TestReferenceCountedAccessor.hpp
+++ b/core/unit_test/view/TestReferenceCountedAccessor.hpp
@@ -43,7 +43,7 @@ using data_handle_t       = typename acc_t::data_handle_type;
 using const_data_handle_t = typename const_acc_t::data_handle_type;
 }  // namespace
 
-TEST(TEST_CATEGORY, RefCountedAcc_Typedefs) {
+void test_refcountedacc_typedefs() {
   Kokkos::parallel_for(
       Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), KOKKOS_LAMBDA(int) {
         static_assert(std::is_same_v<typename acc_t::element_type, element_t>);
@@ -60,7 +60,11 @@ TEST(TEST_CATEGORY, RefCountedAcc_Typedefs) {
       });
 }
 
-TEST(TEST_CATEGORY, RefCountedAcc_Ctors) {
+TEST(TEST_CATEGORY, RefCountedAcc_Typedefs) {
+  test_refcountedacc_typedefs();
+}
+
+void test_refcountedacc_ctors() {
   Kokkos::parallel_for(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), KOKKOS_LAMBDA(int) {
       // default ctor and non-const to const
       {
@@ -84,7 +88,11 @@ TEST(TEST_CATEGORY, RefCountedAcc_Ctors) {
 });
 }
 
-TEST(TEST_CATEGORY, RefCountedAcc_ConversionToDefaultAcc) {
+TEST(TEST_CATEGORY, RefCountedAcc_Ctors) {
+  test_refcountedacc_ctors();
+}
+
+void test_refcountedacc_conversion_to_default_acc() {
   Kokkos::parallel_for(
       Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), KOKKOS_LAMBDA(int) {
         // default ctor and non-const to const
@@ -100,7 +108,11 @@ TEST(TEST_CATEGORY, RefCountedAcc_ConversionToDefaultAcc) {
       });
 }
 
-TEST(TEST_CATEGORY, RefCountedAcc_Access) {
+TEST(TEST_CATEGORY, RefCountedAcc_ConversionToDefaultAcc) {
+  test_refcountedacc_conversion_to_default_acc();
+}
+
+void test_refcountedacc_access() {
   element_t* ptr =
       (element_t*)Kokkos::kokkos_malloc<TEST_EXECSPACE::memory_space>(
           100 * sizeof(element_t));
@@ -122,4 +134,8 @@ TEST(TEST_CATEGORY, RefCountedAcc_Access) {
   ASSERT_FALSE(h_errors & 1);
   ASSERT_FALSE(h_errors & 2);
   Kokkos::kokkos_free(ptr);
+}
+
+TEST(TEST_CATEGORY, RefCountedAcc_Access) {
+  test_refcountedacc_access();
 }

--- a/core/unit_test/view/TestReferenceCountedAccessor.hpp
+++ b/core/unit_test/view/TestReferenceCountedAccessor.hpp
@@ -18,17 +18,6 @@
 
 #include <gtest/gtest.h>
 
-/*
-template <class ElementType, class MemorySpace, class NestedAccessor>
-class ReferenceCountedAccessor {
- public:
-  using element_type     = ElementType;
-  using data_handle_type = ReferenceCountedDataHandle<ElementType, MemorySpace>;
-  using reference        = typename NestedAccessor::reference;
-  using offset_policy    = ReferenceCountedAccessor;
-}
-*/
-
 namespace {
 using element_t      = float;
 using mem_t          = typename TEST_EXECSPACE::memory_space;
@@ -44,20 +33,16 @@ using const_data_handle_t = typename const_acc_t::data_handle_type;
 }  // namespace
 
 void test_refcountedacc_typedefs() {
-  Kokkos::parallel_for(
-      Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), KOKKOS_LAMBDA(int) {
-        static_assert(std::is_same_v<typename acc_t::element_type, element_t>);
-        static_assert(
-            std::is_same_v<
+  static_assert(std::is_same_v<typename acc_t::element_type, element_t>);
+  static_assert(std::is_same_v<
                 typename acc_t::data_handle_type,
                 Kokkos::Impl::ReferenceCountedDataHandle<element_t, mem_t>>);
-        static_assert(std::is_same_v<typename acc_t::reference,
-                                     typename defacc_t::reference>);
-        static_assert(std::is_same_v<
-                      typename acc_t::offset_policy,
-                      Kokkos::Impl::ReferenceCountedAccessor<
-                          element_t, mem_t, typename defacc_t::offset_policy>>);
-      });
+  static_assert(
+      std::is_same_v<typename acc_t::reference, typename defacc_t::reference>);
+  static_assert(
+      std::is_same_v<typename acc_t::offset_policy,
+                     Kokkos::Impl::ReferenceCountedAccessor<
+                         element_t, mem_t, typename defacc_t::offset_policy>>);
 }
 
 TEST(TEST_CATEGORY, RefCountedAcc_Typedefs) { test_refcountedacc_typedefs(); }

--- a/core/unit_test/view/TestReferenceCountedAccessor.hpp
+++ b/core/unit_test/view/TestReferenceCountedAccessor.hpp
@@ -1,0 +1,118 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+#include <gtest/gtest.h>
+
+/*
+template <class ElementType, class MemorySpace, class NestedAccessor>
+class ReferenceCountedAccessor {
+ public:
+  using element_type     = ElementType;
+  using data_handle_type = ReferenceCountedDataHandle<ElementType, MemorySpace>;
+  using reference        = typename NestedAccessor::reference;
+  using offset_policy    = ReferenceCountedAccessor;
+}
+*/
+
+namespace {
+using element_t      = float;
+using mem_t          = typename TEST_EXECSPACE::memory_space;
+using defacc_t       = Kokkos::default_accessor<element_t>;
+using const_defacc_t = Kokkos::default_accessor<const element_t>;
+using acc_t =
+    Kokkos::Impl::ReferenceCountedAccessor<element_t, mem_t, defacc_t>;
+using const_acc_t =
+    Kokkos::Impl::ReferenceCountedAccessor<const element_t, mem_t,
+                                           const_defacc_t>;
+using data_handle_t       = typename acc_t::data_handle_type;
+using const_data_handle_t = typename const_acc_t::data_handle_type;
+}  // namespace
+
+TEST(TEST_CATEGORY, RefCountedAcc_Typedefs) {
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), KOKKOS_LAMBDA(int) {
+        static_assert(std::is_same_v<typename acc_t::element_type, element_t>);
+        static_assert(
+            std::is_same_v<
+                typename acc_t::data_handle_type,
+                Kokkos::Impl::ReferenceCountedDataHandle<element_t, mem_t>>);
+        static_assert(std::is_same_v<typename acc_t::reference,
+                                     typename defacc_t::reference>);
+        static_assert(std::is_same_v<
+                      typename acc_t::offset_policy,
+                      Kokkos::Impl::ReferenceCountedAccessor<
+                          element_t, mem_t, typename defacc_t::offset_policy>>);
+      });
+}
+
+TEST(TEST_CATEGORY, RefCountedAcc_Ctors) {
+  Kokkos::parallel_for(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), KOKKOS_LAMBDA(int) {
+      // default ctor and non-const to const
+      {
+        acc_t acc;
+        const_acc_t c_acc(acc);
+        static_assert(!std::is_constructible_v<acc_t, const_acc_t>);
+}
+// from default_accessor
+{
+  defacc_t defacc;
+  const_defacc_t c_defacc;
+  acc_t acc(defacc);
+  const_acc_t c_acc1(defacc);
+  const_acc_t c_acc2(c_defacc);
+  static_assert(!std::is_constructible_v<acc_t, const_defacc_t>);
+}
+});
+}
+
+TEST(TEST_CATEGORY, RefCountedAcc_ConversionToDefaultAcc) {
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), KOKKOS_LAMBDA(int) {
+        // default ctor and non-const to const
+        acc_t acc;
+        const_acc_t c_acc;
+        defacc_t defacc(acc);
+        const_defacc_t c_defacc1(acc);
+        const_defacc_t c_defacc2(c_acc);
+        static_assert(!std::is_constructible_v<defacc_t, const_acc_t>);
+      });
+}
+
+TEST(TEST_CATEGORY, RefCountedAcc_Access) {
+  element_t* ptr =
+      (element_t*)Kokkos::kokkos_malloc<TEST_EXECSPACE::memory_space>(
+          100 * sizeof(element_t));
+  // Gonna use unmanaged data handles here (i.e. not actually referfence
+  // counted)
+  data_handle_t dh(ptr);
+  const_data_handle_t cdh(ptr);
+
+  Kokkos::View<int, TEST_EXECSPACE> errors("Errors");
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), KOKKOS_LAMBDA(int) {
+        acc_t acc;
+        const_acc_t c_acc;
+        if (&acc.access(dh, 5) != ptr + 5) errors() += 1;
+        if (&c_acc.access(cdh, 5) != ptr + 5) errors() += 2;
+      });
+  int h_errors = 0;
+  Kokkos::deep_copy(h_errors, errors);
+  ASSERT_FALSE(h_errors & 1);
+  ASSERT_FALSE(h_errors & 2);
+  Kokkos::kokkos_free(ptr);
+}

--- a/core/unit_test/view/TestReferenceCountedDataHandle.hpp
+++ b/core/unit_test/view/TestReferenceCountedDataHandle.hpp
@@ -45,7 +45,7 @@ using const_data_handle_anonym_t =
 
 }  // namespace
 
-TEST(TEST_CATEGORY, RefCountedDataHandle_Typedefs) {
+void test_ref_counted_data_handle_typedefs() {
   Kokkos::parallel_for(
       Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), KOKKOS_LAMBDA(int) {
         static_assert(
@@ -57,6 +57,10 @@ TEST(TEST_CATEGORY, RefCountedDataHandle_Typedefs) {
         static_assert(
             std::is_same_v<typename data_handle_t::memory_space, mem_t>);
       });
+}
+
+TEST(TEST_CATEGORY, RefCountedDataHandle_Typedefs) {
+  test_ref_counted_data_handle_typedefs();
 }
 
 template <class DataHandleType, class ConstDataHandleType>

--- a/core/unit_test/view/TestReferenceCountedDataHandle.hpp
+++ b/core/unit_test/view/TestReferenceCountedDataHandle.hpp
@@ -33,15 +33,11 @@ using const_data_handle_anonym_t =
 
 }  // namespace
 
-void test_ref_counted_data_handle_typedefs() {
-  static_assert(std::is_same_v<typename data_handle_t::value_type, element_t>);
-  static_assert(std::is_same_v<typename data_handle_t::pointer, element_t*>);
-  static_assert(std::is_same_v<typename data_handle_t::reference, element_t&>);
-  static_assert(std::is_same_v<typename data_handle_t::memory_space, mem_t>);
-}
-
 TEST(TEST_CATEGORY, RefCountedDataHandle_Typedefs) {
-  test_ref_counted_data_handle_typedefs();
+  static_assert(std::is_same_v<data_handle_t::value_type, element_t>);
+  static_assert(std::is_same_v<data_handle_t::pointer, element_t*>);
+  static_assert(std::is_same_v<data_handle_t::reference, element_t&>);
+  static_assert(std::is_same_v<data_handle_t::memory_space, mem_t>);
 }
 
 template <class DataHandleType, class ConstDataHandleType>
@@ -49,9 +45,9 @@ void test_ref_counted_data_handle() {
   auto shared_alloc =
       Kokkos::Impl::make_shared_allocation_record<element_t, mem_t,
                                                   TEST_EXECSPACE>(
-          100, "Test", mem_t(), nullptr,
-          std::integral_constant<bool, true>(),    // init
-          std::integral_constant<bool, false>());  // sequential_host_init
+          100, "Test", mem_t(), std::optional<TEST_EXECSPACE>(std::nullopt),
+          std::bool_constant<true>(),    // init
+          std::bool_constant<false>());  // sequential_host_init
 
   element_t* ptr         = static_cast<element_t*>(shared_alloc->data());
   const element_t* c_ptr = ptr;
@@ -145,9 +141,9 @@ void test_ref_counted_data_handle_conversion() {
   auto shared_alloc1 =
       Kokkos::Impl::make_shared_allocation_record<element_t, mem_t,
                                                   TEST_EXECSPACE>(
-          100, "Test1", mem_t(), nullptr,
-          std::integral_constant<bool, true>(),    // init
-          std::integral_constant<bool, false>());  // sequential_host_init
+          100, "Test1", mem_t(), std::optional<TEST_EXECSPACE>(std::nullopt),
+          std::bool_constant<true>(),    // init
+          std::bool_constant<false>());  // sequential_host_init
 
   element_t* ptr1         = static_cast<element_t*>(shared_alloc1->data());
   const element_t* c_ptr1 = ptr1;
@@ -162,9 +158,9 @@ void test_ref_counted_data_handle_conversion() {
   auto shared_alloc2 =
       Kokkos::Impl::make_shared_allocation_record<element_t, mem_t,
                                                   TEST_EXECSPACE>(
-          100, "Test2", mem_t(), nullptr,
-          std::integral_constant<bool, true>(),    // init
-          std::integral_constant<bool, false>());  // sequential_host_init
+          100, "Test2", mem_t(), std::optional<TEST_EXECSPACE>(std::nullopt),
+          std::bool_constant<true>(),    // init
+          std::bool_constant<false>());  // sequential_host_init
 
   element_t* ptr2         = static_cast<element_t*>(shared_alloc2->data());
   const element_t* c_ptr2 = ptr2;

--- a/core/unit_test/view/TestReferenceCountedDataHandle.hpp
+++ b/core/unit_test/view/TestReferenceCountedDataHandle.hpp
@@ -18,18 +18,6 @@
 
 #include <gtest/gtest.h>
 
-/*
-template <class ElementType, class MemorySpace>
-class ReferenceCountedDataHandle {
- public:
-  using value_type   = ElementType;
-  using pointer      = value_type*;
-  using reference    = value_type&;
-  using memory_space = MemorySpace;
-  ...
-}
-*/
-
 namespace {
 using element_t = float;
 using mem_t     = typename TEST_EXECSPACE::memory_space;
@@ -46,17 +34,10 @@ using const_data_handle_anonym_t =
 }  // namespace
 
 void test_ref_counted_data_handle_typedefs() {
-  Kokkos::parallel_for(
-      Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), KOKKOS_LAMBDA(int) {
-        static_assert(
-            std::is_same_v<typename data_handle_t::value_type, element_t>);
-        static_assert(
-            std::is_same_v<typename data_handle_t::pointer, element_t*>);
-        static_assert(
-            std::is_same_v<typename data_handle_t::reference, element_t&>);
-        static_assert(
-            std::is_same_v<typename data_handle_t::memory_space, mem_t>);
-      });
+  static_assert(std::is_same_v<typename data_handle_t::value_type, element_t>);
+  static_assert(std::is_same_v<typename data_handle_t::pointer, element_t*>);
+  static_assert(std::is_same_v<typename data_handle_t::reference, element_t&>);
+  static_assert(std::is_same_v<typename data_handle_t::memory_space, mem_t>);
 }
 
 TEST(TEST_CATEGORY, RefCountedDataHandle_Typedefs) {

--- a/core/unit_test/view/TestReferenceCountedDataHandle.hpp
+++ b/core/unit_test/view/TestReferenceCountedDataHandle.hpp
@@ -50,7 +50,6 @@ void test_ref_counted_data_handle() {
       Kokkos::Impl::make_shared_allocation_record<element_t, mem_t,
                                                   TEST_EXECSPACE>(
           100, "Test", mem_t(), nullptr,
-          std::integral_constant<bool, false>(),   // padding
           std::integral_constant<bool, true>(),    // init
           std::integral_constant<bool, false>());  // sequential_host_init
 
@@ -147,7 +146,6 @@ void test_ref_counted_data_handle_conversion() {
       Kokkos::Impl::make_shared_allocation_record<element_t, mem_t,
                                                   TEST_EXECSPACE>(
           100, "Test1", mem_t(), nullptr,
-          std::integral_constant<bool, false>(),   // padding
           std::integral_constant<bool, true>(),    // init
           std::integral_constant<bool, false>());  // sequential_host_init
 
@@ -165,7 +163,6 @@ void test_ref_counted_data_handle_conversion() {
       Kokkos::Impl::make_shared_allocation_record<element_t, mem_t,
                                                   TEST_EXECSPACE>(
           100, "Test2", mem_t(), nullptr,
-          std::integral_constant<bool, false>(),   // padding
           std::integral_constant<bool, true>(),    // init
           std::integral_constant<bool, false>());  // sequential_host_init
 

--- a/core/unit_test/view/TestReferenceCountedDataHandle.hpp
+++ b/core/unit_test/view/TestReferenceCountedDataHandle.hpp
@@ -1,0 +1,131 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+#include <gtest/gtest.h>
+
+/*
+template <class ElementType, class MemorySpace>
+class ReferenceCountedDataHandle {
+ public:
+  using value_type   = ElementType;
+  using pointer      = value_type*;
+  using reference    = value_type&;
+  using memory_space = MemorySpace;
+  ...
+}
+*/
+
+namespace {
+using element_t = float;
+using mem_t     = typename TEST_EXECSPACE::memory_space;
+using data_handle_t =
+    Kokkos::Impl::ReferenceCountedDataHandle<element_t, mem_t>;
+using const_data_handle_t =
+    Kokkos::Impl::ReferenceCountedDataHandle<const element_t, mem_t>;
+;
+}  // namespace
+
+TEST(TEST_CATEGORY, RefCountedDataHandle_Typedefs) {
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), KOKKOS_LAMBDA(int) {
+        static_assert(
+            std::is_same_v<typename data_handle_t::value_type, element_t>);
+        static_assert(
+            std::is_same_v<typename data_handle_t::pointer, element_t*>);
+        static_assert(
+            std::is_same_v<typename data_handle_t::reference, element_t&>);
+        static_assert(
+            std::is_same_v<typename data_handle_t::memory_space, mem_t>);
+      });
+}
+
+TEST(TEST_CATEGORY, RefCountedDataHandle) {
+  auto shared_alloc =
+      Kokkos::Impl::make_shared_allocation_record<element_t, mem_t,
+                                                  TEST_EXECSPACE>(
+          100, "Test", mem_t(), nullptr,
+          std::integral_constant<bool, false>(),   // padding
+          std::integral_constant<bool, true>(),    // init
+          std::integral_constant<bool, false>());  // sequential_host_init
+
+  element_t* ptr         = static_cast<element_t*>(shared_alloc->data());
+  const element_t* c_ptr = ptr;
+  data_handle_t dh(shared_alloc);
+  ASSERT_EQ(dh.use_count(), 1);
+  ASSERT_EQ(dh.get_label(), std::string("Test"));
+  ASSERT_EQ(dh.get(), ptr);
+  ASSERT_EQ(dh.has_record(), true);
+  {
+    element_t* ptr_tmp(dh);
+    ASSERT_EQ(ptr_tmp, ptr);
+    static_assert(!std::is_convertible_v<data_handle_t, element_t*>);
+  }
+  {
+    const_data_handle_t c_dh(dh);
+    ASSERT_EQ(dh.use_count(), 2);
+    ASSERT_EQ(c_dh.use_count(), 2);
+  }
+  ASSERT_EQ(dh.use_count(), 1);
+
+  data_handle_t um_dh(ptr);
+  ASSERT_EQ(um_dh.get(), ptr);
+  ASSERT_EQ(um_dh.has_record(), false);
+
+  data_handle_t dh_offset(dh, ptr + 5);
+  ASSERT_EQ(dh_offset.use_count(), 2);
+  ASSERT_EQ(dh_offset.get(), ptr + 5);
+  ASSERT_EQ(dh_offset.get_label(), std::string("Test"));
+  ASSERT_EQ(dh_offset.has_record(), true);
+  {
+    element_t* ptr_tmp(dh_offset);
+    ASSERT_EQ(ptr_tmp, ptr + 5);
+  }
+  Kokkos::View<int, TEST_EXECSPACE> errors("Errors");
+  Kokkos::parallel_for(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), KOKKOS_LAMBDA(int) {
+    // default ctor and non-const to const
+    {
+      data_handle_t dh2(dh);
+      if(dh2.get() != ptr) errors() += 1;
+      const_data_handle_t c_dh2(dh);
+      const_data_handle_t c_dh3(c_dh2);
+      static_assert(!std::is_constructible_v<data_handle_t, const_data_handle_t>);
+}
+// ctor from pointer
+{
+  data_handle_t dh2(ptr);
+  if (dh2.get() != ptr) errors() += 2;
+  const_data_handle_t c_dh1(ptr);
+  if (c_dh1.get() != ptr) errors() += 4;
+  const_data_handle_t c_dh2(c_ptr);
+  if (c_dh2.get() != ptr) errors() += 8;
+  static_assert(!std::is_constructible_v<data_handle_t, decltype(c_ptr)>);
+}
+// ctor for subviews
+{
+  data_handle_t dh2(dh, ptr + 5);
+  if (dh2.get() != ptr + 5) errors() += 16;
+}
+});
+int h_errors = 0;
+Kokkos::deep_copy(h_errors, errors);
+ASSERT_FALSE(h_errors & 1);
+ASSERT_FALSE(h_errors & 2);
+ASSERT_FALSE(h_errors & 4);
+ASSERT_FALSE(h_errors & 8);
+ASSERT_FALSE(h_errors & 16);
+}


### PR DESCRIPTION
This PR adds a `ReferenceCountedDataHandle` and `ReferenceCountedAccessor`. The data handle packages the pre-existing `SharedAllocationTracker` and a pointer. Note that pointer can be something else than the base pointer of the allocation to support subviews/submdspan. One tricky question is the convertibility of these things. But we can revisit that when View comes in and everyone can see which current tests would fail because conversions are allowed. In either case I am not planning to make these types public for now. I.e. they are meant as implementation details for View. The tests aren't as exhaustive as they could be yet, but cover the basics. A lot of this will be implicitly tested as well when the View replacement is in. 

One helper function added here (`make_shared_allocation_record`) returns a pointer to a record, this is what the view tracker actually consumes. Note that after that record is passed on, ownership is actually transferred, so you can't do it again. We may wanna consider rewriting this - but we have thought that about a lot of the implementation of SharedAlloc. For now this function fits into the existing scheme. 