### PR TITLE
Improve reloctable function example

### DIFF
--- a/example/relocatable_function/CMakeLists.txt
+++ b/example/relocatable_function/CMakeLists.txt
@@ -6,4 +6,4 @@ KOKKOS_ADD_EXECUTABLE(
   SOURCES main.cpp functor.cpp
 )
 
-add_test(NAME Kokkos_RelocatableFunction COMMAND Kokkos_example_relocatable_function)
+add_test(NAME Kokkos_Example_RelocatableFunction COMMAND Kokkos_example_relocatable_function)

--- a/example/relocatable_function/main.cpp
+++ b/example/relocatable_function/main.cpp
@@ -20,8 +20,8 @@
 
 KOKKOS_RELOCATABLE_FUNCTION void count_even(const long i, long& lcount);
 
-int main() {
-  Kokkos::ScopeGuard scope_guard;
+int main(int argc, char* argv[]) {
+  Kokkos::ScopeGuard scope_guard(argc, argv);
 
   for (int n = 10; n <= 100'000'000; n *= 10) {
     Kokkos::Timer timer;

--- a/example/relocatable_function/main.cpp
+++ b/example/relocatable_function/main.cpp
@@ -27,23 +27,24 @@ int main() {
     Kokkos::Timer timer;
 
     long count = 0;
-    // Compute the number of even integers from 0 to n-1, in parallel.
+    // Compute the number of even integers from 0 to n-1 using a relocatable
+    // functor
     Kokkos::parallel_reduce(
         n, KOKKOS_LAMBDA(const long i, long& lcount) { count_even(i, lcount); },
         count);
 
-    double count_time_rdc = timer.seconds();
+    double count_time_relocatable = timer.seconds();
 
     timer.reset();
 
-    // Compute the number of even integers from 0 to n-1, in parallel.
+    // Compute the number of even integers from 0 to n-1 using an inline lambda
     Kokkos::parallel_reduce(
         n,
         KOKKOS_LAMBDA(const long i, long& lcount) { lcount += (i % 2) == 0; },
         count);
 
-    double count_time_no_rdc = timer.seconds();
-    std::cout << std::scientific << n * 1. << ' ' << count_time_rdc
-              << "s (RDC) vs. " << count_time_no_rdc << "s (inline)\n";
+    double count_time_inline = timer.seconds();
+    std::cout << std::scientific << n * 1. << ' ' << count_time_relocatable
+              << "s (relocatable) vs. " << count_time_inline << "s (inline)\n";
   }
 }


### PR DESCRIPTION
Addresses the request in https://github.com/kokkos/kokkos/pull/5993#pullrequestreview-2303499048:
- rename to test to include "Example" in its name
- prefer "relocatable" over "RDC" and improve comments
- allow passing arguments via `argc` and `argv`.