### PR TITLE
Remove statics variables in HIPInternal

### DIFF
--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -52,12 +52,6 @@ void HIP::impl_initialize(InitializationSettings const& settings) {
   const auto& hipProp = Impl::HIPInternal::m_deviceProp;
   KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(hip_device_id));
 
-  //----------------------------------
-  // Maximum number of blocks
-  Impl::HIPInternal::m_maxBlock[0] = hipProp.maxGridSize[0];
-  Impl::HIPInternal::m_maxBlock[1] = hipProp.maxGridSize[1];
-  Impl::HIPInternal::m_maxBlock[2] = hipProp.maxGridSize[2];
-
   // theoretically, we can get 40 WF's / CU, but only can sustain 32 see
   // https://github.com/ROCm-Developer-Tools/HIP/blob/a0b5dfd625d99af7e288629747b40dd057183173/vdi/hip_platform.cpp#L742
   Impl::HIPInternal::m_maxWavesPerCU = 32;

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -60,7 +60,6 @@ void HIP::impl_initialize(InitializationSettings const& settings) {
 #else
   const int maxWavesPerCU = 32;
 #endif
-  Impl::HIPInternal::m_shmemPerSM = hipProp.maxSharedMemoryPerMultiProcessor;
   Impl::HIPInternal::m_maxShmemPerBlock = hipProp.sharedMemPerBlock;
   Impl::HIPInternal::m_maxThreadsPerSM =
       maxWavesPerCU * Impl::HIPTraits::WarpSize;

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -53,15 +53,6 @@ void HIP::impl_initialize(InitializationSettings const& settings) {
   KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(hip_device_id));
 
   //----------------------------------
-  // Maximum number of warps,
-  // at most one warp per thread in a warp for reduction.
-  Impl::HIPInternal::m_maxWarpCount =
-      hipProp.maxThreadsPerBlock / Impl::HIPTraits::WarpSize;
-  if (Impl::HIPTraits::WarpSize < Impl::HIPInternal::m_maxWarpCount) {
-    Impl::HIPInternal::m_maxWarpCount = Impl::HIPTraits::WarpSize;
-  }
-
-  //----------------------------------
   // Maximum number of blocks
   Impl::HIPInternal::m_maxBlock[0] = hipProp.maxGridSize[0];
   Impl::HIPInternal::m_maxBlock[1] = hipProp.maxGridSize[1];

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -50,15 +50,10 @@ void HIP::impl_initialize(InitializationSettings const& settings) {
   KOKKOS_IMPL_HIP_SAFE_CALL(
       hipGetDeviceProperties(&Impl::HIPInternal::m_deviceProp, hip_device_id));
   KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(hip_device_id));
-
   // theoretically, we can get 40 WF's / CU, but only can sustain 32 see
   // https://github.com/ROCm/clr/blob/4d0b815d06751735e6a50fa46e913fdf85f751f0/hipamd/src/hip_platform.cpp#L362-L366
-#if defined(KOKKOS_ARCH_AMD_GFX1030) || defined(KOKKOS_ARCH_AMD_GFX1100) || \
-    defined(KOKKOS_ARCH_AMD_GFX1103)
-  const int maxWavesPerCU = 64;
-#else
-  const int maxWavesPerCU = 32;
-#endif
+  const int maxWavesPerCU =
+      Impl::HIPInternal::m_deviceProp.major <= 9 ? 32 : 64;
   Impl::HIPInternal::m_maxThreadsPerSM =
       maxWavesPerCU * Impl::HIPTraits::WarpSize;
 

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -52,9 +52,6 @@ void HIP::impl_initialize(InitializationSettings const& settings) {
   const auto& hipProp = Impl::HIPInternal::m_deviceProp;
   KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(hip_device_id));
 
-  // number of multiprocessors
-  Impl::HIPInternal::m_multiProcCount = hipProp.multiProcessorCount;
-
   //----------------------------------
   // Maximum number of warps,
   // at most one warp per thread in a warp for reduction.

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -49,7 +49,6 @@ void HIP::impl_initialize(InitializationSettings const& settings) {
   Impl::HIPInternal::m_hipDev = hip_device_id;
   KOKKOS_IMPL_HIP_SAFE_CALL(
       hipGetDeviceProperties(&Impl::HIPInternal::m_deviceProp, hip_device_id));
-  const auto& hipProp = Impl::HIPInternal::m_deviceProp;
   KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(hip_device_id));
 
   // theoretically, we can get 40 WF's / CU, but only can sustain 32 see
@@ -60,7 +59,6 @@ void HIP::impl_initialize(InitializationSettings const& settings) {
 #else
   const int maxWavesPerCU = 32;
 #endif
-  Impl::HIPInternal::m_maxShmemPerBlock = hipProp.sharedMemPerBlock;
   Impl::HIPInternal::m_maxThreadsPerSM =
       maxWavesPerCU * Impl::HIPTraits::WarpSize;
 

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -50,7 +50,8 @@ void HIP::impl_initialize(InitializationSettings const& settings) {
   KOKKOS_IMPL_HIP_SAFE_CALL(
       hipGetDeviceProperties(&Impl::HIPInternal::m_deviceProp, hip_device_id));
   KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(hip_device_id));
-  // theoretically, we can get 40 WF's / CU, but only can sustain 32 see
+  // theoretically on GFX 9XX GPUs, we can get 40 WF's / CU, but only can
+  // sustain 32 see
   // https://github.com/ROCm/clr/blob/4d0b815d06751735e6a50fa46e913fdf85f751f0/hipamd/src/hip_platform.cpp#L362-L366
   const int maxWavesPerCU =
       Impl::HIPInternal::m_deviceProp.major <= 9 ? 32 : 64;

--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -113,8 +113,9 @@ unsigned hip_internal_get_block_size(const HIPInternal *hip_instance,
   const unsigned min_waves_per_eu =
       LaunchBounds::minBperSM ? LaunchBounds::minBperSM : 1;
   const unsigned min_threads_per_sm = min_waves_per_eu * HIPTraits::WarpSize;
-  const unsigned shmem_per_sm       = hip_instance->m_shmemPerSM;
-  unsigned block_size               = tperb_reg;
+  const unsigned shmem_per_sm =
+      hip_instance->m_deviceProp.maxSharedMemoryPerMultiProcessor;
+  unsigned block_size = tperb_reg;
   do {
     unsigned total_shmem = f(block_size);
     // find how many threads we can fit with this blocksize based on LDS usage

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -77,7 +77,8 @@ std::size_t scratch_count(const std::size_t size) {
 //----------------------------------------------------------------------------
 
 int HIPInternal::concurrency() {
-  static int const concurrency = m_maxThreadsPerSM * m_multiProcCount;
+  static int const concurrency =
+      m_maxThreadsPerSM * m_deviceProp.multiProcessorCount;
 
   return concurrency;
 }
@@ -254,7 +255,7 @@ Kokkos::HIP::size_type *HIPInternal::stage_functor_for_execution(
     m_scratchFunctorSize = size;
 
     m_scratchFunctor     = static_cast<size_type *>(device_mem_space.allocate(
-        "Kokkos::InternalScratchFunctor", m_scratchFunctorSize));
+            "Kokkos::InternalScratchFunctor", m_scratchFunctorSize));
     m_scratchFunctorHost = static_cast<size_type *>(host_mem_space.allocate(
         "Kokkos::InternalScratchFunctorHost", m_scratchFunctorSize));
   }
@@ -354,7 +355,6 @@ void HIPInternal::finalize() {
 }
 
 int HIPInternal::m_hipDev                                     = -1;
-unsigned HIPInternal::m_multiProcCount                        = 0;
 unsigned HIPInternal::m_maxWarpCount                          = 0;
 std::array<HIPInternal::size_type, 3> HIPInternal::m_maxBlock = {0, 0, 0};
 unsigned HIPInternal::m_maxWavesPerCU                         = 0;
@@ -372,7 +372,7 @@ std::mutex HIPInternal::constantMemMutex;
 //----------------------------------------------------------------------------
 
 Kokkos::HIP::size_type hip_internal_multiprocessor_count() {
-  return HIPInternal::singleton().m_multiProcCount;
+  return HIPInternal::singleton().m_deviceProp.multiProcessorCount;
 }
 
 Kokkos::HIP::size_type hip_internal_maximum_warp_count() {

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -263,7 +263,7 @@ Kokkos::HIP::size_type *HIPInternal::stage_functor_for_execution(
     m_scratchFunctorSize = size;
 
     m_scratchFunctor     = static_cast<size_type *>(device_mem_space.allocate(
-            "Kokkos::InternalScratchFunctor", m_scratchFunctorSize));
+        "Kokkos::InternalScratchFunctor", m_scratchFunctorSize));
     m_scratchFunctorHost = static_cast<size_type *>(host_mem_space.allocate(
         "Kokkos::InternalScratchFunctorHost", m_scratchFunctorSize));
   }
@@ -362,9 +362,8 @@ void HIPInternal::finalize() {
   m_num_scratch_locks = 0;
 }
 
-int HIPInternal::m_hipDev           = -1;
-int HIPInternal::m_maxShmemPerBlock = 0;
-int HIPInternal::m_maxThreadsPerSM  = 0;
+int HIPInternal::m_hipDev          = -1;
+int HIPInternal::m_maxThreadsPerSM = 0;
 
 hipDeviceProp_t HIPInternal::m_deviceProp;
 

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -375,10 +375,6 @@ Kokkos::HIP::size_type hip_internal_multiprocessor_count() {
   return HIPInternal::singleton().m_deviceProp.multiProcessorCount;
 }
 
-Kokkos::HIP::size_type hip_internal_maximum_warp_count() {
-  return HIPInternal::singleton().m_maxWarpCount;
-}
-
 std::array<Kokkos::HIP::size_type, 3> hip_internal_maximum_grid_count() {
   return HIPInternal::singleton().m_maxBlock;
 }

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -362,11 +362,10 @@ void HIPInternal::finalize() {
   m_num_scratch_locks = 0;
 }
 
-int HIPInternal::m_hipDev             = -1;
-unsigned HIPInternal::m_maxWavesPerCU = 0;
-int HIPInternal::m_shmemPerSM         = 0;
-int HIPInternal::m_maxShmemPerBlock   = 0;
-int HIPInternal::m_maxThreadsPerSM    = 0;
+int HIPInternal::m_hipDev           = -1;
+int HIPInternal::m_shmemPerSM       = 0;
+int HIPInternal::m_maxShmemPerBlock = 0;
+int HIPInternal::m_maxThreadsPerSM  = 0;
 
 hipDeviceProp_t HIPInternal::m_deviceProp;
 

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -362,12 +362,11 @@ void HIPInternal::finalize() {
   m_num_scratch_locks = 0;
 }
 
-int HIPInternal::m_hipDev                                     = -1;
-std::array<HIPInternal::size_type, 3> HIPInternal::m_maxBlock = {0, 0, 0};
-unsigned HIPInternal::m_maxWavesPerCU                         = 0;
-int HIPInternal::m_shmemPerSM                                 = 0;
-int HIPInternal::m_maxShmemPerBlock                           = 0;
-int HIPInternal::m_maxThreadsPerSM                            = 0;
+int HIPInternal::m_hipDev             = -1;
+unsigned HIPInternal::m_maxWavesPerCU = 0;
+int HIPInternal::m_shmemPerSM         = 0;
+int HIPInternal::m_maxShmemPerBlock   = 0;
+int HIPInternal::m_maxThreadsPerSM    = 0;
 
 hipDeviceProp_t HIPInternal::m_deviceProp;
 
@@ -380,10 +379,6 @@ std::mutex HIPInternal::constantMemMutex;
 
 Kokkos::HIP::size_type hip_internal_multiprocessor_count() {
   return HIPInternal::singleton().m_deviceProp.multiProcessorCount;
-}
-
-std::array<Kokkos::HIP::size_type, 3> hip_internal_maximum_grid_count() {
-  return HIPInternal::singleton().m_maxBlock;
 }
 
 Kokkos::HIP::size_type *hip_internal_scratch_space(const HIP &instance,

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -363,7 +363,6 @@ void HIPInternal::finalize() {
 }
 
 int HIPInternal::m_hipDev           = -1;
-int HIPInternal::m_shmemPerSM       = 0;
 int HIPInternal::m_maxShmemPerBlock = 0;
 int HIPInternal::m_maxThreadsPerSM  = 0;
 

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -72,7 +72,6 @@ class HIPInternal {
   using size_type = ::Kokkos::HIP::size_type;
 
   static int m_hipDev;
-  static unsigned m_multiProcCount;
   static unsigned m_maxWarpCount;
   static std::array<size_type, 3> m_maxBlock;
   static unsigned m_maxWavesPerCU;

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -52,7 +52,6 @@ struct HIPTraits {
 
 //----------------------------------------------------------------------------
 
-HIP::size_type hip_internal_maximum_warp_count();
 std::array<HIP::size_type, 3> hip_internal_maximum_grid_count();
 HIP::size_type hip_internal_multiprocessor_count();
 

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -70,7 +70,6 @@ class HIPInternal {
   using size_type = ::Kokkos::HIP::size_type;
 
   static int m_hipDev;
-  static int m_maxShmemPerBlock;
   static int m_maxThreadsPerSM;
 
   static hipDeviceProp_t m_deviceProp;

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -52,7 +52,6 @@ struct HIPTraits {
 
 //----------------------------------------------------------------------------
 
-std::array<HIP::size_type, 3> hip_internal_maximum_grid_count();
 HIP::size_type hip_internal_multiprocessor_count();
 
 HIP::size_type *hip_internal_scratch_space(const HIP &instance,
@@ -71,7 +70,6 @@ class HIPInternal {
   using size_type = ::Kokkos::HIP::size_type;
 
   static int m_hipDev;
-  static std::array<size_type, 3> m_maxBlock;
   static unsigned m_maxWavesPerCU;
   static int m_shmemPerSM;
   static int m_maxShmemPerBlock;

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -71,7 +71,6 @@ class HIPInternal {
   using size_type = ::Kokkos::HIP::size_type;
 
   static int m_hipDev;
-  static unsigned m_maxWarpCount;
   static std::array<size_type, 3> m_maxBlock;
   static unsigned m_maxWavesPerCU;
   static int m_shmemPerSM;

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -70,7 +70,6 @@ class HIPInternal {
   using size_type = ::Kokkos::HIP::size_type;
 
   static int m_hipDev;
-  static unsigned m_maxWavesPerCU;
   static int m_shmemPerSM;
   static int m_maxShmemPerBlock;
   static int m_maxThreadsPerSM;

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -70,7 +70,6 @@ class HIPInternal {
   using size_type = ::Kokkos::HIP::size_type;
 
   static int m_hipDev;
-  static int m_shmemPerSM;
   static int m_maxShmemPerBlock;
   static int m_maxThreadsPerSM;
 

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -551,11 +551,11 @@ struct HIPParallelLaunch<
       LaunchMechanism>;
 
   HIPParallelLaunch(const DriverType &driver, const dim3 &grid,
-                    const dim3 &block, const int shmem,
+                    const dim3 &block, const unsigned int shmem,
                     const HIPInternal *hip_instance,
                     const bool /*prefer_shmem*/) {
     if ((grid.x != 0) && ((block.x * block.y * block.z) != 0)) {
-      if (hip_instance->m_maxShmemPerBlock < shmem) {
+      if (hip_instance->m_deviceProp.sharedMemPerBlock < shmem) {
         Kokkos::Impl::throw_runtime_exception(
             "HIPParallelLaunch FAILED: shared memory request is too large");
       }

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -57,7 +57,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
   inline void execute() const {
     using ClosureType = ParallelFor<FunctorType, Policy, HIP>;
     if (m_policy.m_num_tiles == 0) return;
-    auto const maxblocks = hip_internal_maximum_grid_count();
+    auto const maxblocks = m_policy.space().hip_device_prop().maxGridSize;
     if (Policy::rank == 2) {
       dim3 const block(m_policy.m_tile[0], m_policy.m_tile[1], 1);
       dim3 const grid(

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Team.hpp
@@ -149,8 +149,9 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>, HIP> {
                   static_cast<std::int64_t>(m_league_size))));
     }
 
-    int const shmem_size_total = m_shmem_begin + m_shmem_size;
-    if (internal_space_instance->m_maxShmemPerBlock < shmem_size_total) {
+    unsigned int const shmem_size_total = m_shmem_begin + m_shmem_size;
+    if (internal_space_instance->m_deviceProp.sharedMemPerBlock <
+        shmem_size_total) {
       Kokkos::Impl::throw_runtime_exception(std::string(
           "Kokkos::Impl::ParallelFor< HIP > insufficient shared memory"));
     }

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
@@ -375,7 +375,8 @@ class ParallelReduce<CombinedFunctorReducerType,
     // Functor's reduce memory, team scan memory, and team shared memory depend
     // upon team size.
 
-    const int shmem_size_total = m_team_begin + m_shmem_begin + m_shmem_size;
+    const unsigned int shmem_size_total =
+        m_team_begin + m_shmem_begin + m_shmem_size;
 
     if (!Kokkos::Impl::is_integral_power_of_two(m_team_size) &&
         !UseShflReduction) {
@@ -383,7 +384,8 @@ class ParallelReduce<CombinedFunctorReducerType,
           std::string("Kokkos::Impl::ParallelReduce< HIP > bad team size"));
     }
 
-    if (internal_space_instance->m_maxShmemPerBlock < shmem_size_total) {
+    if (internal_space_instance->m_deviceProp.sharedMemPerBlock <
+        shmem_size_total) {
       Kokkos::Impl::throw_runtime_exception(
           std::string("Kokkos::Impl::ParallelReduce< HIP > requested too much "
                       "L0 scratch memory"));

--- a/core/src/HIP/Kokkos_HIP_TeamPolicyInternal.hpp
+++ b/core/src/HIP/Kokkos_HIP_TeamPolicyInternal.hpp
@@ -222,7 +222,8 @@ class TeamPolicyInternal<HIP, Properties...>
         m_tune_team_size(bool(team_size_request <= 0)),
         m_tune_vector_length(bool(vector_length_request <= 0)) {
     // Make sure league size is permissible
-    if (league_size_ >= static_cast<int>(hip_internal_maximum_grid_count()[0]))
+    const int max_grid_size_x = m_space.hip_device_prop().maxGridSize[0];
+    if (league_size_ >= max_grid_size_x)
       Impl::throw_runtime_exception(
           "Requested too large league_size for TeamPolicy on HIP execution "
           "space.");


### PR DESCRIPTION
This is similar to https://github.com/kokkos/kokkos/pull/6544: do not store individual device properties as static members of `HIPInternal`. Instead always refer to the `hipDeviceProp` that is stored. I mostly just moved code around except for `maxWavesPerCU` where I have updated the link to the current code in the ROCm repo and changed the value for GFX 1030, 1100, and 1103. I ran the CI on a GFX 1030 and everything passes.