### PR TITLE
Clean up OpenMPTarget

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_MDRange.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_MDRange.hpp
@@ -52,21 +52,19 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
     Policy policy = m_policy;
 
-    typename Policy::point_type unused;
     static_assert(1 < Policy::rank && Policy::rank < 7);
     static_assert(Policy::inner_direction == Iterate::Left ||
                   Policy::inner_direction == Iterate::Right);
 
     execute_tile<Policy::rank>(
-        unused, m_functor, policy,
+        m_functor, policy,
         std::integral_constant<Iterate, Policy::inner_direction>());
   }
 
   template <int Rank>
   inline std::enable_if_t<Rank == 2> execute_tile(
-      typename Policy::point_type offset, const FunctorAdapter& functor,
-      const Policy& policy, OpenMPTargetIterateRight) const {
-    (void)offset;
+      const FunctorAdapter& functor, const Policy& policy,
+      OpenMPTargetIterateRight) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
 
@@ -82,9 +80,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
   template <int Rank>
   inline std::enable_if_t<Rank == 3> execute_tile(
-      typename Policy::point_type offset, const FunctorAdapter& functor,
-      const Policy& policy, OpenMPTargetIterateRight) const {
-    (void)offset;
+      const FunctorAdapter& functor, const Policy& policy,
+      OpenMPTargetIterateRight) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];
@@ -105,9 +102,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
   template <int Rank>
   inline std::enable_if_t<Rank == 4> execute_tile(
-      typename Policy::point_type offset, const FunctorAdapter& functor,
-      const Policy& policy, OpenMPTargetIterateRight) const {
-    (void)offset;
+      const FunctorAdapter& functor, const Policy& policy,
+      OpenMPTargetIterateRight) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];
@@ -132,9 +128,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
   template <int Rank>
   inline std::enable_if_t<Rank == 5> execute_tile(
-      typename Policy::point_type offset, const FunctorAdapter& functor,
-      const Policy& policy, OpenMPTargetIterateRight) const {
-    (void)offset;
+      const FunctorAdapter& functor, const Policy& policy,
+      OpenMPTargetIterateRight) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];
@@ -163,9 +158,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
   template <int Rank>
   inline std::enable_if_t<Rank == 6> execute_tile(
-      typename Policy::point_type offset, const FunctorAdapter& functor,
-      const Policy& policy, OpenMPTargetIterateRight) const {
-    (void)offset;
+      const FunctorAdapter& functor, const Policy& policy,
+      OpenMPTargetIterateRight) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];
@@ -200,9 +194,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
   template <int Rank>
   inline std::enable_if_t<Rank == 2> execute_tile(
-      typename Policy::point_type offset, const FunctorAdapter& functor,
-      const Policy& policy, OpenMPTargetIterateLeft) const {
-    (void)offset;
+      const FunctorAdapter& functor, const Policy& policy,
+      OpenMPTargetIterateLeft) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
 
@@ -218,9 +211,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
   template <int Rank>
   inline std::enable_if_t<Rank == 3> execute_tile(
-      typename Policy::point_type offset, const FunctorAdapter& functor,
-      const Policy& policy, OpenMPTargetIterateLeft) const {
-    (void)offset;
+      const FunctorAdapter& functor, const Policy& policy,
+      OpenMPTargetIterateLeft) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];
@@ -241,9 +233,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
   template <int Rank>
   inline std::enable_if_t<Rank == 4> execute_tile(
-      typename Policy::point_type offset, const FunctorAdapter& functor,
-      const Policy& policy, OpenMPTargetIterateLeft) const {
-    (void)offset;
+      const FunctorAdapter& functor, const Policy& policy,
+      OpenMPTargetIterateLeft) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];
@@ -268,9 +259,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
   template <int Rank>
   inline std::enable_if_t<Rank == 5> execute_tile(
-      typename Policy::point_type offset, const FunctorAdapter& functor,
-      const Policy& policy, OpenMPTargetIterateLeft) const {
-    (void)offset;
+      const FunctorAdapter& functor, const Policy& policy,
+      OpenMPTargetIterateLeft) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];
@@ -299,9 +289,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
   template <int Rank>
   inline std::enable_if_t<Rank == 6> execute_tile(
-      typename Policy::point_type offset, const FunctorAdapter& functor,
-      const Policy& policy, OpenMPTargetIterateLeft) const {
-    (void)offset;
+      const FunctorAdapter& functor, const Policy& policy,
+      OpenMPTargetIterateLeft) const {
     const Index begin_0 = policy.m_lower[0];
     const Index begin_1 = policy.m_lower[1];
     const Index begin_2 = policy.m_lower[2];

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Reducer.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Reducer.hpp
@@ -35,9 +35,6 @@ struct OpenMPTargetReducerWrapper {
   static void join(value_type&, const value_type&) = delete;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type&, const volatile value_type&) = delete;
-
-  KOKKOS_INLINE_FUNCTION
   static void init(value_type&) = delete;
 };
 
@@ -50,11 +47,6 @@ struct OpenMPTargetReducerWrapper<Sum<Scalar, Space>> {
   // Required
   KOKKOS_INLINE_FUNCTION
   static void join(value_type& dest, const value_type& src) { dest += src; }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    dest += src;
-  }
 
   KOKKOS_INLINE_FUNCTION
   static void init(value_type& val) {
@@ -73,11 +65,6 @@ struct OpenMPTargetReducerWrapper<Prod<Scalar, Space>> {
   static void join(value_type& dest, const value_type& src) { dest *= src; }
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    dest *= src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   static void init(value_type& val) {
     val = reduction_identity<value_type>::prod();
   }
@@ -92,11 +79,6 @@ struct OpenMPTargetReducerWrapper<Min<Scalar, Space>> {
   // Required
   KOKKOS_INLINE_FUNCTION
   static void join(value_type& dest, const value_type& src) {
-    if (src < dest) dest = src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
     if (src < dest) dest = src;
   }
 
@@ -118,11 +100,6 @@ struct OpenMPTargetReducerWrapper<Max<Scalar, Space>> {
     if (src > dest) dest = src;
   }
 
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    if (src > dest) dest = src;
-  }
-
   // Required
   KOKKOS_INLINE_FUNCTION
   static void init(value_type& val) {
@@ -138,11 +115,6 @@ struct OpenMPTargetReducerWrapper<LAnd<Scalar, Space>> {
 
   KOKKOS_INLINE_FUNCTION
   static void join(value_type& dest, const value_type& src) {
-    dest = dest && src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
     dest = dest && src;
   }
 
@@ -167,11 +139,6 @@ struct OpenMPTargetReducerWrapper<LOr<Scalar, Space>> {
   }
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    dest = dest || src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   static void init(value_type& val) {
     val = reduction_identity<value_type>::lor();
   }
@@ -190,11 +157,6 @@ struct OpenMPTargetReducerWrapper<BAnd<Scalar, Space>> {
   }
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    dest = dest & src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   static void init(value_type& val) {
     val = reduction_identity<value_type>::band();
   }
@@ -209,11 +171,6 @@ struct OpenMPTargetReducerWrapper<BOr<Scalar, Space>> {
   // Required
   KOKKOS_INLINE_FUNCTION
   static void join(value_type& dest, const value_type& src) {
-    dest = dest | src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
     dest = dest | src;
   }
 
@@ -240,11 +197,6 @@ struct OpenMPTargetReducerWrapper<MinLoc<Scalar, Index, Space>> {
   }
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    if (src.val < dest.val) dest = src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   static void init(value_type& val) {
     val.val = reduction_identity<scalar_type>::min();
     val.loc = reduction_identity<index_type>::min();
@@ -263,11 +215,6 @@ struct OpenMPTargetReducerWrapper<MaxLoc<Scalar, Index, Space>> {
 
   KOKKOS_INLINE_FUNCTION
   static void join(value_type& dest, const value_type& src) {
-    if (src.val > dest.val) dest = src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
     if (src.val > dest.val) dest = src;
   }
 
@@ -299,16 +246,6 @@ struct OpenMPTargetReducerWrapper<MinMax<Scalar, Space>> {
   }
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    if (src.min_val < dest.min_val) {
-      dest.min_val = src.min_val;
-    }
-    if (src.max_val > dest.max_val) {
-      dest.max_val = src.max_val;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
   static void init(value_type& val) {
     val.max_val = reduction_identity<scalar_type>::max();
     val.min_val = reduction_identity<scalar_type>::min();
@@ -328,18 +265,6 @@ struct OpenMPTargetReducerWrapper<MinMaxLoc<Scalar, Index, Space>> {
   // Required
   KOKKOS_INLINE_FUNCTION
   static void join(value_type& dest, const value_type& src) {
-    if (src.min_val < dest.min_val) {
-      dest.min_val = src.min_val;
-      dest.min_loc = src.min_loc;
-    }
-    if (src.max_val > dest.max_val) {
-      dest.max_val = src.max_val;
-      dest.max_loc = src.max_loc;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
     if (src.min_val < dest.min_val) {
       dest.min_val = src.min_val;
       dest.min_loc = src.min_loc;
@@ -386,15 +311,6 @@ struct OpenMPTargetReducerWrapper<MaxFirstLoc<Scalar, Index, Space>> {
   }
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    if (dest.val < src.val) {
-      dest = src;
-    } else if (!(src.val < dest.val)) {
-      dest.loc = (src.loc < dest.loc) ? src.loc : dest.loc;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
   static void init(value_type& val) {
     val.val = reduction_identity<scalar_type>::max();
     val.loc = reduction_identity<index_type>::min();
@@ -421,15 +337,6 @@ struct OpenMPTargetReducerWrapper<MinFirstLoc<Scalar, Index, Space>> {
 #pragma omp declare target
   KOKKOS_INLINE_FUNCTION
   static void join(value_type& dest, const value_type& src) {
-    if (src.val < dest.val) {
-      dest = src;
-    } else if (!(dest.val < src.val)) {
-      dest.loc = (src.loc < dest.loc) ? src.loc : dest.loc;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
     if (src.val < dest.val) {
       dest = src;
     } else if (!(dest.val < src.val)) {
@@ -481,23 +388,6 @@ struct OpenMPTargetReducerWrapper<MinMaxFirstLastLoc<Scalar, Index, Space>> {
   }
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    if (src.min_val < dest.min_val) {
-      dest.min_val = src.min_val;
-      dest.min_loc = src.min_loc;
-    } else if (!(dest.min_val < src.min_val)) {
-      dest.min_loc = (src.min_loc < dest.min_loc) ? src.min_loc : dest.min_loc;
-    }
-
-    if (dest.max_val < src.max_val) {
-      dest.max_val = src.max_val;
-      dest.max_loc = src.max_loc;
-    } else if (!(src.max_val < dest.max_val)) {
-      dest.max_loc = (src.max_loc > dest.max_loc) ? src.max_loc : dest.max_loc;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
   static void init(value_type& val) {
     val.max_val = reduction_identity<scalar_type>::max();
     val.min_val = reduction_identity<scalar_type>::min();
@@ -532,13 +422,6 @@ struct OpenMPTargetReducerWrapper<FirstLoc<Index, Space>> {
   }
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    dest.min_loc_true = (src.min_loc_true < dest.min_loc_true)
-                            ? src.min_loc_true
-                            : dest.min_loc_true;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   static void init(value_type& val) {
     val.min_loc_true = reduction_identity<index_type>::min();
   }
@@ -564,13 +447,6 @@ struct OpenMPTargetReducerWrapper<LastLoc<Index, Space>> {
   // Required
   KOKKOS_INLINE_FUNCTION
   static void join(value_type& dest, const value_type& src) {
-    dest.max_loc_true = (src.max_loc_true > dest.max_loc_true)
-                            ? src.max_loc_true
-                            : dest.max_loc_true;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
     dest.max_loc_true = (src.max_loc_true > dest.max_loc_true)
                             ? src.max_loc_true
                             : dest.max_loc_true;
@@ -612,17 +488,6 @@ struct OpenMPTargetReducerWrapper<StdIsPartitioned<Index, Space>> {
   }
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    dest.max_loc_true = (dest.max_loc_true < src.max_loc_true)
-                            ? src.max_loc_true
-                            : dest.max_loc_true;
-
-    dest.min_loc_false = (dest.min_loc_false < src.min_loc_false)
-                             ? dest.min_loc_false
-                             : src.min_loc_false;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   static void init(value_type& val) {
     val.max_loc_true  = ::Kokkos::reduction_identity<index_type>::max();
     val.min_loc_false = ::Kokkos::reduction_identity<index_type>::min();
@@ -649,13 +514,6 @@ struct OpenMPTargetReducerWrapper<StdPartitionPoint<Index, Space>> {
   // Required
   KOKKOS_INLINE_FUNCTION
   static void join(value_type& dest, const value_type& src) {
-    dest.min_loc_false = (dest.min_loc_false < src.min_loc_false)
-                             ? dest.min_loc_false
-                             : src.min_loc_false;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
     dest.min_loc_false = (dest.min_loc_false < src.min_loc_false)
                              ? dest.min_loc_false
                              : src.min_loc_false;


### PR DESCRIPTION
- remove the reducer `volatile` overloads. The respective overloads for the builtin reducers were removed in https://github.com/kokkos/kokkos/commit/067c2593b58e1d9204d097432e221cfd524d7978. Related to https://github.com/kokkos/kokkos/pull/7330#discussion_r1763675491.
- `execute_tile` doesn't used its first argument in `ParallelFor` `MDRange`.