### PR TITLE
Restrict OpenMP tests for OMP_NUM_THREADS detected at initialization

### DIFF
--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -79,7 +79,7 @@ void check_distinctive([[maybe_unused]] ExecSpace exec1,
 #ifdef KOKKOS_ENABLE_OPENMP
 template <class Lambda1, class Lambda2>
 void run_threaded_test(const Lambda1 l1, const Lambda2 l2) {
-  if (omp_get_max_threads() == 1)
+  if (omp_get_max_threads() < 2)
     GTEST_SKIP() << "insufficient number of supported concurrent threads";
 
 #pragma omp parallel num_threads(2)

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -79,6 +79,11 @@ void check_distinctive([[maybe_unused]] ExecSpace exec1,
 #ifdef KOKKOS_ENABLE_OPENMP
 template <class Lambda1, class Lambda2>
 void run_threaded_test(const Lambda1 l1, const Lambda2 l2) {
+#ifdef KOKKOS_ENABLE_OPENMP
+  if (Kokkos::OpenMP().concurrency() == 1)
+    GTEST_SKIP() << "test needs at least two OpenMP threads";
+#endif
+
 #pragma omp parallel num_threads(2)
   {
     if (omp_get_thread_num() == 0) l1();
@@ -126,6 +131,10 @@ void test_partitioning(std::vector<TEST_EXECSPACE>& instances) {
 }
 
 TEST(TEST_CATEGORY, partitioning_by_args) {
+#ifdef KOKKOS_ENABLE_OPENMP
+  if (Kokkos::OpenMP().concurrency() == 1)
+    GTEST_SKIP() << "test needs at least two OpenMP threads";
+#endif
   auto instances =
       Kokkos::Experimental::partition_space(TEST_EXECSPACE(), 1, 1);
   ASSERT_EQ(int(instances.size()), 2);
@@ -133,6 +142,10 @@ TEST(TEST_CATEGORY, partitioning_by_args) {
 }
 
 TEST(TEST_CATEGORY, partitioning_by_vector) {
+#ifdef KOKKOS_ENABLE_OPENMP
+  if (Kokkos::OpenMP().concurrency() == 1)
+    GTEST_SKIP() << "test needs at least two OpenMP threads";
+#endif
   // Make sure we can use a temporary as argument for weights
   auto instances = Kokkos::Experimental::partition_space(
       TEST_EXECSPACE(), std::vector<int> /*weights*/ {1, 1});

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -79,10 +79,8 @@ void check_distinctive([[maybe_unused]] ExecSpace exec1,
 #ifdef KOKKOS_ENABLE_OPENMP
 template <class Lambda1, class Lambda2>
 void run_threaded_test(const Lambda1 l1, const Lambda2 l2) {
-#ifdef KOKKOS_ENABLE_OPENMP
-  if (Kokkos::OpenMP().concurrency() == 1)
-    GTEST_SKIP() << "test needs at least two OpenMP threads";
-#endif
+  if (omp_get_max_threads() == 1)
+    GTEST_SKIP() << "insufficient number of supported concurrent threads";
 
 #pragma omp parallel num_threads(2)
   {
@@ -131,10 +129,6 @@ void test_partitioning(std::vector<TEST_EXECSPACE>& instances) {
 }
 
 TEST(TEST_CATEGORY, partitioning_by_args) {
-#ifdef KOKKOS_ENABLE_OPENMP
-  if (Kokkos::OpenMP().concurrency() == 1)
-    GTEST_SKIP() << "test needs at least two OpenMP threads";
-#endif
   auto instances =
       Kokkos::Experimental::partition_space(TEST_EXECSPACE(), 1, 1);
   ASSERT_EQ(int(instances.size()), 2);
@@ -142,10 +136,6 @@ TEST(TEST_CATEGORY, partitioning_by_args) {
 }
 
 TEST(TEST_CATEGORY, partitioning_by_vector) {
-#ifdef KOKKOS_ENABLE_OPENMP
-  if (Kokkos::OpenMP().concurrency() == 1)
-    GTEST_SKIP() << "test needs at least two OpenMP threads";
-#endif
   // Make sure we can use a temporary as argument for weights
   auto instances = Kokkos::Experimental::partition_space(
       TEST_EXECSPACE(), std::vector<int> /*weights*/ {1, 1});

--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -171,6 +171,11 @@ void run_exec_space_thread_safety_team_policy() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy) {
+#ifdef KOKKOS_ENABLE_OPENMP  // FIXME_OPENMP
+  if (Kokkos::OpenMP().concurrency() == 1)
+    GTEST_SKIP() << "test needs at least two OpenMP threads";
+#endif
+
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
   GTEST_SKIP()
       << "skipping OpenACC test since unsupported host-side atomics cause "
@@ -303,6 +308,11 @@ void run_exec_space_thread_safety_team_policy_reduce() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy_reduce) {
+#ifdef KOKKOS_ENABLE_OPENMP  // FIXME_OPENMP
+  if (Kokkos::OpenMP().concurrency() == 1)
+    GTEST_SKIP() << "test needs at least two OpenMP threads";
+#endif
+
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
   GTEST_SKIP()
       << "skipping OpenACC test since unsupported host-side atomics cause "

--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -28,7 +28,7 @@ namespace {
 #ifdef KOKKOS_ENABLE_OPENMP
 template <class Lambda1, class Lambda2>
 void run_threaded_test(const Lambda1 l1, const Lambda2 l2) {
-  if (omp_get_max_threads() == 1)
+  if (omp_get_max_threads() < 2)
     GTEST_SKIP() << "insufficient number of supported concurrent threads";
 
 #pragma omp parallel num_threads(2)

--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -28,6 +28,9 @@ namespace {
 #ifdef KOKKOS_ENABLE_OPENMP
 template <class Lambda1, class Lambda2>
 void run_threaded_test(const Lambda1 l1, const Lambda2 l2) {
+  if (omp_get_max_threads() == 1)
+    GTEST_SKIP() << "insufficient number of supported concurrent threads";
+
 #pragma omp parallel num_threads(2)
   {
     if (omp_get_thread_num() == 0) l1();
@@ -171,11 +174,6 @@ void run_exec_space_thread_safety_team_policy() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy) {
-#ifdef KOKKOS_ENABLE_OPENMP  // FIXME_OPENMP
-  if (Kokkos::OpenMP().concurrency() == 1)
-    GTEST_SKIP() << "test needs at least two OpenMP threads";
-#endif
-
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
   GTEST_SKIP()
       << "skipping OpenACC test since unsupported host-side atomics cause "
@@ -308,11 +306,6 @@ void run_exec_space_thread_safety_team_policy_reduce() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy_reduce) {
-#ifdef KOKKOS_ENABLE_OPENMP  // FIXME_OPENMP
-  if (Kokkos::OpenMP().concurrency() == 1)
-    GTEST_SKIP() << "test needs at least two OpenMP threads";
-#endif
-
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
   GTEST_SKIP()
       << "skipping OpenACC test since unsupported host-side atomics cause "

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -200,6 +200,11 @@ TEST_F(TEST_CATEGORY_FIXTURE_DEATH(graph), can_instantiate_only_once) {
 // one passed to the Kokkos::Graph constructor.
 TEST_F(TEST_CATEGORY_FIXTURE(graph),
        submit_onto_another_execution_space_instance) {
+#ifdef KOKKOS_ENABLE_OPENMP
+  if (Kokkos::OpenMP().concurrency() == 1)
+    GTEST_SKIP() << "test needs at least two OpenMP threads";
+#endif
+
   const auto execution_space_instances =
       Kokkos::Experimental::partition_space(ex, 1, 1);
 
@@ -441,6 +446,11 @@ FetchValuesAndContribute(ViewType, const size_t (&)[NumIndices],
 //  \ /         fence(exec_1)               enforce dependencies.
 //   D          D(exec_0)
 TEST_F(TEST_CATEGORY_FIXTURE(graph), diamond) {
+#ifdef KOKKOS_ENABLE_OPENMP
+  if (Kokkos::OpenMP().concurrency() < 4)
+    GTEST_SKIP() << "test needs at least 4 OpenMP threads";
+#endif
+
   const auto execution_space_instances =
       Kokkos::Experimental::partition_space(ex, 1, 1, 1, 1);
 
@@ -513,6 +523,11 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), diamond) {
 //                  fence(exec_1)
 //    F             F(exec_0)
 TEST_F(TEST_CATEGORY_FIXTURE(graph), end_of_submit_control_flow) {
+#ifdef KOKKOS_ENABLE_OPENMP
+  if (Kokkos::OpenMP().concurrency() < 4)
+    GTEST_SKIP() << "test needs at least 4 OpenMP threads";
+#endif
+
   const auto execution_space_instances =
       Kokkos::Experimental::partition_space(ex, 1, 1, 1, 1);
 

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -201,7 +201,7 @@ TEST_F(TEST_CATEGORY_FIXTURE_DEATH(graph), can_instantiate_only_once) {
 TEST_F(TEST_CATEGORY_FIXTURE(graph),
        submit_onto_another_execution_space_instance) {
 #ifdef KOKKOS_ENABLE_OPENMP  // FIXME_OPENMP partition_space
-  if (ex.concurrency() == 1)
+  if (ex.concurrency() < 2)
     GTEST_SKIP() << "insufficient number of supported concurrent threads";
 #endif
 

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -200,9 +200,9 @@ TEST_F(TEST_CATEGORY_FIXTURE_DEATH(graph), can_instantiate_only_once) {
 // one passed to the Kokkos::Graph constructor.
 TEST_F(TEST_CATEGORY_FIXTURE(graph),
        submit_onto_another_execution_space_instance) {
-#ifdef KOKKOS_ENABLE_OPENMP
-  if (Kokkos::OpenMP().concurrency() == 1)
-    GTEST_SKIP() << "test needs at least two OpenMP threads";
+#ifdef KOKKOS_ENABLE_OPENMP  // FIXME_OPENMP partition_space
+  if (ex.concurrency() == 1)
+    GTEST_SKIP() << "insufficient number of supported concurrent threads";
 #endif
 
   const auto execution_space_instances =
@@ -446,8 +446,8 @@ FetchValuesAndContribute(ViewType, const size_t (&)[NumIndices],
 //  \ /         fence(exec_1)               enforce dependencies.
 //   D          D(exec_0)
 TEST_F(TEST_CATEGORY_FIXTURE(graph), diamond) {
-#ifdef KOKKOS_ENABLE_OPENMP
-  if (Kokkos::OpenMP().concurrency() < 4)
+#ifdef KOKKOS_ENABLE_OPENMP  // FIXME_OPENMP partition_space
+  if (ex.concurrency() < 4)
     GTEST_SKIP() << "test needs at least 4 OpenMP threads";
 #endif
 
@@ -523,9 +523,9 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), diamond) {
 //                  fence(exec_1)
 //    F             F(exec_0)
 TEST_F(TEST_CATEGORY_FIXTURE(graph), end_of_submit_control_flow) {
-#ifdef KOKKOS_ENABLE_OPENMP
-  if (Kokkos::OpenMP().concurrency() < 4)
-    GTEST_SKIP() << "test needs at least 4 OpenMP threads";
+#ifdef KOKKOS_ENABLE_OPENMP  // FIXME_OPENMP partition_space
+  if (ex.concurrency() < 4)
+    GTEST_SKIP() << "insufficient number of supported concurrent threads";
 #endif
 
   const auto execution_space_instances =


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/7302#issuecomment-2349285849.

It's not quite clear why `exec_space_thread_safety_team_policy` and `exec_space_thread_safety_team_policy` also need `Kokkos` to be configure with at least two threads.

The backtrace looks like
```
 bt
* thread #2, stop reason = EXC_BAD_ACCESS (code=1, address=0x28)
  * frame #0: 0x00000001000d4b04 Kokkos_CoreUnitTest_OpenMP`Kokkos::Impl::HostThreadTeamData::team_shared(this=0x0000000000000000) const at Kokkos_HostThreadTeam.hpp:284:9
    frame #1: 0x00000001000d4a6c Kokkos_CoreUnitTest_OpenMP`Kokkos::Impl::HostThreadTeamMember<Kokkos::OpenMP>::HostThreadTeamMember(this=0x0000000170602790, arg_data=0x0000000000000000, arg_league_rank=0, arg_league_size=1) at Kokkos_HostThreadTeam.hpp:427:28
    frame #2: 0x00000001000d4420 Kokkos_CoreUnitTest_OpenMP`Kokkos::Impl::HostThreadTeamMember<Kokkos::OpenMP>::HostThreadTeamMember(this=0x0000000170602790, arg_data=0x0000000000000000, arg_league_rank=0, arg_league_size=1) at Kokkos_HostThreadTeam.hpp:431:40
    frame #3: 0x00000001003635ac Kokkos_CoreUnitTest_OpenMP`std::__1::enable_if<std::is_void<void>::value, void>::type Kokkos::Impl::ParallelFor<(anonymous namespace)::run_exec_space_thread_safety_team_policy()::$_0::operator()() const::'lambda'(Kokkos::Impl::HostThreadTeamMember<Kokkos::OpenMP> const&), Kokkos::TeamPolicy<Kokkos::OpenMP>, Kokkos::OpenMP>::exec_team<void>(functor=0x00000001706028c8, data=0x0000000000000000, league_rank_begin=0, league_rank_end=1, league_size=1) at Kokkos_OpenMP_Parallel_For.hpp:300:15
    frame #4: 0x0000000100362fc8 Kokkos_CoreUnitTest_OpenMP`Kokkos::Impl::ParallelFor<(anonymous namespace)::run_exec_space_thread_safety_team_policy()::$_0::operator()() const::'lambda'(Kokkos::Impl::HostThreadTeamMember<Kokkos::OpenMP> const&), Kokkos::TeamPolicy<Kokkos::OpenMP>, Kokkos::OpenMP>::execute(this=0x00000001706028c0) const at Kokkos_OpenMP_Parallel_For.hpp:348:7
    frame #5: 0x0000000100362cc4 Kokkos_CoreUnitTest_OpenMP`void Kokkos::parallel_for<Kokkos::TeamPolicy<Kokkos::OpenMP>, (anonymous namespace)::run_exec_space_thread_safety_team_policy()::$_0::operator()() const::'lambda'(Kokkos::Impl::HostThreadTeamMember<Kokkos::OpenMP> const&), void>(str="", policy=0x0000000170602a88, functor=0x0000000170602a48) at Kokkos_Parallel.hpp:146:11
    frame #6: 0x0000000100362bec Kokkos_CoreUnitTest_OpenMP`void Kokkos::parallel_for<Kokkos::TeamPolicy<Kokkos::OpenMP>, (anonymous namespace)::run_exec_space_thread_safety_team_policy()::$_0::operator()() const::'lambda'(Kokkos::Impl::HostThreadTeamMember<Kokkos::OpenMP> const&)>(policy=0x0000000170602a88, functor=0x0000000170602a48, (null)=0x0000000000000000) at Kokkos_Parallel.hpp:155:3
    frame #7: 0x0000000100362ac8 Kokkos_CoreUnitTest_OpenMP`(anonymous namespace)::run_exec_space_thread_safety_team_policy()::$_0::operator()(this=0x000000016fdfed38) const at TestExecSpaceThreadSafety.hpp:152:7
    frame #8: 0x0000000100362a24 Kokkos_CoreUnitTest_OpenMP`::_ZN12_GLOBAL__N_117run_threaded_testIZNS_40run_exec_space_thread_safety_team_policyEvE3$_0S1_EEvT_T0_.omp_outlined_debug__(.global_tid.=0x0000000170602b9c, .bound_tid.=0x0000000170602b98, l1=0x000000016fdfed68, l2=0x000000016fdfed38) &, const (unnamed class) &) at TestExecSpaceThreadSafety.hpp:34:36
    frame #9: 0x0000000100362ba4 Kokkos_CoreUnitTest_OpenMP`::_ZN12_GLOBAL__N_117run_threaded_testIZNS_40run_exec_space_thread_safety_team_policyEvE3$_0S1_EEvT_T0_.omp_outlined(.global_tid.=0x0000000170602b9c, .bound_tid.=0x0000000170602b98, l1=0x000000016fdfed68, l2=0x000000016fdfed38) at TestExecSpaceThreadSafety.hpp:31:1
    frame #10: 0x00000001091421bc libomp.dylib`__kmp_invoke_microtask + 156
    frame #11: 0x00000001090e2878 libomp.dylib`__kmp_invoke_task_func + 332
    frame #12: 0x00000001090e1554 libomp.dylib`__kmp_launch_thread + 420
    frame #13: 0x0000000109125d94 libomp.dylib`__kmp_launch_worker(void*) + 280
    frame #14: 0x0000000198e0df94 libsystem_pthread.dylib`_pthread_start + 136
```