### PR TITLE
ViewRefactor: Fix issues with view refactor in Sacado

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -108,6 +108,9 @@ struct DynRankDimTraits {
   }
 
   // Create the layout for the rank-7 view.
+  // Because the underlying View is rank-7, preserve "unspecified" for
+  // dimension 8.
+
   // Non-strided Layout
   template <typename Layout>
   KOKKOS_INLINE_FUNCTION static std::enable_if_t<
@@ -123,7 +126,7 @@ struct DynRankDimTraits {
         layout.dimension[4] != unspecified ? layout.dimension[4] : 1,
         layout.dimension[5] != unspecified ? layout.dimension[5] : 1,
         layout.dimension[6] != unspecified ? layout.dimension[6] : 1,
-        layout.dimension[7] != unspecified ? layout.dimension[7] : 1);
+        layout.dimension[7] != unspecified ? layout.dimension[7] : unspecified);
     new_layout.stride = layout.stride;
     return new_layout;
   }
@@ -133,22 +136,23 @@ struct DynRankDimTraits {
   KOKKOS_INLINE_FUNCTION static std::enable_if_t<
       (std::is_same_v<Layout, Kokkos::LayoutStride>), Layout>
   createLayout(const Layout& layout) {
-    return Layout(layout.dimension[0] != unspecified ? layout.dimension[0] : 1,
-                  layout.stride[0],
-                  layout.dimension[1] != unspecified ? layout.dimension[1] : 1,
-                  layout.stride[1],
-                  layout.dimension[2] != unspecified ? layout.dimension[2] : 1,
-                  layout.stride[2],
-                  layout.dimension[3] != unspecified ? layout.dimension[3] : 1,
-                  layout.stride[3],
-                  layout.dimension[4] != unspecified ? layout.dimension[4] : 1,
-                  layout.stride[4],
-                  layout.dimension[5] != unspecified ? layout.dimension[5] : 1,
-                  layout.stride[5],
-                  layout.dimension[6] != unspecified ? layout.dimension[6] : 1,
-                  layout.stride[6],
-                  layout.dimension[7] != unspecified ? layout.dimension[7] : 1,
-                  layout.stride[7]);
+    return Layout(
+        layout.dimension[0] != unspecified ? layout.dimension[0] : 1,
+        layout.stride[0],
+        layout.dimension[1] != unspecified ? layout.dimension[1] : 1,
+        layout.stride[1],
+        layout.dimension[2] != unspecified ? layout.dimension[2] : 1,
+        layout.stride[2],
+        layout.dimension[3] != unspecified ? layout.dimension[3] : 1,
+        layout.stride[3],
+        layout.dimension[4] != unspecified ? layout.dimension[4] : 1,
+        layout.stride[4],
+        layout.dimension[5] != unspecified ? layout.dimension[5] : 1,
+        layout.stride[5],
+        layout.dimension[6] != unspecified ? layout.dimension[6] : 1,
+        layout.stride[6],
+        layout.dimension[7] != unspecified ? layout.dimension[7] : unspecified,
+        layout.stride[7]);
   }
 
   // Extra overload to match that for specialize types

--- a/core/src/View/Kokkos_ViewMapping.hpp
+++ b/core/src/View/Kokkos_ViewMapping.hpp
@@ -871,7 +871,8 @@ struct ViewOffset<
                    (r > 5 ? m_dim.N5 : KOKKOS_INVALID_INDEX),
                    (r > 6 ? m_dim.N6 : KOKKOS_INVALID_INDEX),
                    (r > 7 ? m_dim.N7 : KOKKOS_INVALID_INDEX));
-    l.stride = m_stride;
+    // Without span_is_contiguous Sacado hidden dimensions get messed up
+    l.stride = span_is_contiguous() ? KOKKOS_IMPL_CTOR_DEFAULT_ARG : m_stride;
     return l;
   }
 
@@ -1557,7 +1558,8 @@ struct ViewOffset<
                    (r > 5 ? m_dim.N5 : KOKKOS_INVALID_INDEX),
                    (r > 6 ? m_dim.N6 : KOKKOS_INVALID_INDEX),
                    (r > 7 ? m_dim.N7 : KOKKOS_INVALID_INDEX));
-    l.stride = m_stride;
+    // Without span_is_contiguous Sacado hidden dimensions get messed up
+    l.stride = span_is_contiguous() ? KOKKOS_IMPL_CTOR_DEFAULT_ARG : m_stride;
     return l;
   }
 


### PR DESCRIPTION
Somehow the nested dimensions wouldn't be correclty represented in strides, and DynRankView wasn't accounting for all the specialized helper things in Sacado.

There is a few nasty things here: DynRankView can either take the hidden dimension as an additional argument to its constructor, or pass it through the ViewAllocation properties, via a specialization of these properties in Sacado. Also the DynRankDimTraits are specialized etc. 

It's all fairly messy, but maybe we can get rid of all of it after the full View refactor by rewriting Sacado via using Accessors. 