### PR TITLE
By default, do not use cudaMallocAsync

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -465,7 +465,7 @@ pipeline {
                                 -DKokkos_ENABLE_LIBDL=OFF \
                                 -DKokkos_ENABLE_OPENMP=ON \
                                 -DKokkos_ENABLE_IMPL_MDSPAN=OFF \
-                                -DKokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=OFF \
+                                -DKokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=ON \
                               .. && \
                               make -j8 && ctest --verbose && \
                               cd ../example/build_cmake_in_tree && \

--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -30,7 +30,7 @@ KOKKOS_TRIBITS ?= "no"
 KOKKOS_STANDALONE_CMAKE ?= "no"
 
 # Default settings specific options.
-# Options: force_uvm,use_ldg,rdc,enable_lambda,enable_constexpr,disable_malloc_async
+# Options: force_uvm,use_ldg,rdc,enable_lambda,enable_constexpr,enable_malloc_async
 KOKKOS_CUDA_OPTIONS ?= ""
 
 # Options: rdc
@@ -85,7 +85,7 @@ KOKKOS_INTERNAL_CUDA_USE_UVM := $(call kokkos_has_string,$(KOKKOS_CUDA_OPTIONS),
 KOKKOS_INTERNAL_CUDA_USE_RELOC := $(call kokkos_has_string,$(KOKKOS_CUDA_OPTIONS),rdc)
 KOKKOS_INTERNAL_CUDA_USE_LAMBDA := $(call kokkos_has_string,$(KOKKOS_CUDA_OPTIONS),enable_lambda)
 KOKKOS_INTERNAL_CUDA_USE_CONSTEXPR := $(call kokkos_has_string,$(KOKKOS_CUDA_OPTIONS),enable_constexpr)
-KOKKOS_INTERNAL_CUDA_DISABLE_MALLOC_ASYNC := $(call kokkos_has_string,$(KOKKOS_CUDA_OPTIONS),disable_malloc_async)
+KOKKOS_INTERNAL_CUDA_ENABLE_MALLOC_ASYNC := $(call kokkos_has_string,$(KOKKOS_CUDA_OPTIONS),enable_malloc_async)
 KOKKOS_INTERNAL_HPX_ENABLE_ASYNC_DISPATCH := $(call kokkos_has_string,$(KOKKOS_HPX_OPTIONS),enable_async_dispatch)
 # deprecated
 KOKKOS_INTERNAL_ENABLE_DESUL_ATOMICS := $(call kokkos_has_string,$(KOKKOS_OPTIONS),enable_desul_atomics)
@@ -740,7 +740,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_CUDA), 1)
     endif
   endif
 
-  ifeq ($(KOKKOS_INTERNAL_CUDA_DISABLE_MALLOC_ASYNC), 0)
+  ifeq ($(KOKKOS_INTERNAL_CUDA_ENABLE_MALLOC_ASYNC), 1)
     tmp := $(call kokkos_append_header,"$H""define KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC")
   else
     tmp := $(call kokkos_append_header,"/* $H""undef KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC */")

--- a/cmake/kokkos_enable_options.cmake
+++ b/cmake/kokkos_enable_options.cmake
@@ -43,15 +43,9 @@ ELSE()
 ENDIF()
 KOKKOS_ENABLE_OPTION(CUDA_LAMBDA ${CUDA_LAMBDA_DEFAULT} "Whether to allow lambda expressions on the device with NVCC **DEPRECATED**")
 
-# May be used to disable our use of CudaMallocAsync.  It had caused issues in
-# the past when UCX was used as MPI communication layer.  We expect it is
-# resolved but we keep the option around a bit longer to be safe.
-IF(KOKKOS_ENABLE_CUDA)
-  SET(CUDA_MALLOC_ASYNC_DEFAULT ON)
-ELSE()
-  SET(CUDA_MALLOC_ASYNC_DEFAULT OFF)
-ENDIF()
-KOKKOS_ENABLE_OPTION(IMPL_CUDA_MALLOC_ASYNC ${CUDA_MALLOC_ASYNC_DEFAULT}  "Whether to enable CudaMallocAsync (requires CUDA Toolkit 11.2)")
+# As of 09/2024, cudaMallocAsync causes issues with ICP and older version of UCX
+# as MPI communication layer.
+KOKKOS_ENABLE_OPTION(IMPL_CUDA_MALLOC_ASYNC OFF  "Whether to enable CudaMallocAsync (requires CUDA Toolkit 11.2)")
 KOKKOS_ENABLE_OPTION(IMPL_NVHPC_AS_DEVICE_COMPILER OFF "Whether to allow nvc++ as Cuda device compiler")
 KOKKOS_ENABLE_OPTION(IMPL_CUDA_UNIFIED_MEMORY OFF "Whether to leverage unified memory architectures for CUDA")
 


### PR DESCRIPTION
Given all the problems that users reported on slack, stop using `cudaMallocAsync` by default. This is a partial revert of https://github.com/kokkos/kokkos/pull/6402