### PR TITLE
OpenACC update for host part 1

### DIFF
--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -1195,7 +1195,10 @@ if(KOKKOS_ENABLE_OPENACC)
   else()
     # Automatic fallback mode; try to offload any available GPU, and fall back
     # to the host CPU if no available GPU is found.
-    compiler_specific_flags(NVHPC -acc=gpu,multicore)
+    compiler_specific_flags(
+      NVHPC -acc=gpu,multicore
+      Clang --offload-arch=native
+    )
     message(
       STATUS
         "No OpenACC target device is specified; the OpenACC backend will be executed in an automatic fallback mode."

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -1195,10 +1195,7 @@ if(KOKKOS_ENABLE_OPENACC)
   else()
     # Automatic fallback mode; try to offload any available GPU, and fall back
     # to the host CPU if no available GPU is found.
-    compiler_specific_flags(
-      NVHPC -acc=gpu,multicore
-      Clang --offload-arch=native
-    )
+    compiler_specific_flags(NVHPC -acc=gpu,multicore Clang --offload-arch=native)
     message(
       STATUS
         "No OpenACC target device is specified; the OpenACC backend will be executed in an automatic fallback mode."

--- a/core/src/OpenACC/Kokkos_OpenACCSpace.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.cpp
@@ -12,34 +12,14 @@
 #include <openacc.h>
 
 void *Kokkos::Experimental::OpenACCSpace::allocate(
-    const Kokkos::Experimental::OpenACC &exec_space,
-    const size_t arg_alloc_size) const {
-  return allocate(exec_space, "[unlabeled]", arg_alloc_size);
-}
-
-void *Kokkos::Experimental::OpenACCSpace::allocate(
     const size_t arg_alloc_size) const {
   return allocate("[unlabeled]", arg_alloc_size);
-}
-
-void *Kokkos::Experimental::OpenACCSpace::allocate(
-    const Kokkos::Experimental::OpenACC &exec_space, const char *arg_label,
-    const size_t arg_alloc_size, const size_t arg_logical_size) const {
-  return impl_allocate(exec_space, arg_label, arg_alloc_size, arg_logical_size);
 }
 
 void *Kokkos::Experimental::OpenACCSpace::allocate(
     const char *arg_label, const size_t arg_alloc_size,
     const size_t arg_logical_size) const {
   return impl_allocate(arg_label, arg_alloc_size, arg_logical_size);
-}
-
-void *Kokkos::Experimental::OpenACCSpace::impl_allocate(
-    const Kokkos::Experimental::OpenACC &exec_space, const char *arg_label,
-    const size_t arg_alloc_size, const size_t arg_logical_size,
-    const Kokkos::Tools::SpaceHandle arg_handle) const {
-  (void)exec_space;
-  return impl_allocate(arg_label, arg_alloc_size, arg_logical_size, arg_handle);
 }
 
 void *Kokkos::Experimental::OpenACCSpace::impl_allocate(

--- a/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
@@ -32,11 +32,18 @@ class OpenACCSpace {
   OpenACCSpace() = default;
 
   /**\brief  Allocate untracked memory in the space */
-  void* allocate(const Kokkos::Experimental::OpenACC& exec_space,
-                 const size_t arg_alloc_size) const;
-  void* allocate(const Kokkos::Experimental::OpenACC& exec_space,
-                 const char* arg_label, const size_t arg_alloc_size,
-                 const size_t arg_logical_size = 0) const;
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace& exec_space,
+                 const size_t arg_alloc_size) const {
+    return allocate(exec_space, "[unlabeled]", arg_alloc_size);
+  }
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace& exec_space, const char* arg_label,
+                 const size_t arg_alloc_size,
+                 const size_t arg_logical_size = 0) const {
+    return impl_allocate(exec_space, arg_label, arg_alloc_size,
+                         arg_logical_size);
+  }
   void* allocate(const size_t arg_alloc_size) const;
   void* allocate(const char* arg_label, const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;
@@ -50,11 +57,16 @@ class OpenACCSpace {
   static constexpr char const* name() { return "OpenACCSpace"; }
 
  private:
-  void* impl_allocate(const Kokkos::Experimental::OpenACC& exec_space,
-                      const char* arg_label, const size_t arg_alloc_size,
+  template <typename ExecutionSpace>
+  void* impl_allocate(const ExecutionSpace& exec_space, const char* arg_label,
+                      const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,
-                      const Kokkos::Tools::SpaceHandle =
-                          Kokkos::Tools::make_space_handle(name())) const;
+                      const Kokkos::Tools::SpaceHandle arg_handle =
+                          Kokkos::Tools::make_space_handle(name())) const {
+    (void)exec_space;
+    return impl_allocate(arg_label, arg_alloc_size, arg_logical_size,
+                         arg_handle);
+  }
   void* impl_allocate(const char* arg_label, const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,
                       const Kokkos::Tools::SpaceHandle =

--- a/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
@@ -84,25 +84,21 @@ class OpenACCSpace {
 template <>
 struct Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
                                        Kokkos::Experimental::OpenACCSpace> {
+  enum : bool { assignable = false };
 #if defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)
-  enum : bool{assignable = false};
   enum : bool{accessible = true};
 #else
-  enum : bool { assignable = false };
   enum : bool { accessible = false };
 #endif
+  enum : bool { deepcopy = true };
 };
 
 template <>
 struct Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::OpenACCSpace,
                                        Kokkos::HostSpace> {
-#if defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)
-  enum : bool{assignable = false};
-  enum : bool{accessible = false};
-#else
   enum : bool { assignable = false };
   enum : bool { accessible = false };
-#endif
+  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -110,6 +106,7 @@ struct Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::OpenACCSpace,
                                        Kokkos::Experimental::OpenACCSpace> {
   enum : bool { assignable = true };
   enum : bool { accessible = true };
+  enum : bool { deepcopy = true };
 };
 /*--------------------------------------------------------------------------*/
 

--- a/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
@@ -58,12 +58,11 @@ class OpenACCSpace {
 
  private:
   template <typename ExecutionSpace>
-  void* impl_allocate(const ExecutionSpace& exec_space, const char* arg_label,
+  void* impl_allocate(const ExecutionSpace&, const char* arg_label,
                       const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,
                       const Kokkos::Tools::SpaceHandle arg_handle =
                           Kokkos::Tools::make_space_handle(name())) const {
-    (void)exec_space;
     return impl_allocate(arg_label, arg_alloc_size, arg_logical_size,
                          arg_handle);
   }

--- a/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
@@ -86,7 +86,7 @@ template <>
 struct Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
                                        Kokkos::Experimental::OpenACCSpace> {
 #if defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)
-  enum : bool{assignable = true};
+  enum : bool{assignable = false};
   enum : bool{accessible = true};
 #else
   enum : bool { assignable = false };
@@ -98,8 +98,8 @@ template <>
 struct Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::OpenACCSpace,
                                        Kokkos::HostSpace> {
 #if defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)
-  enum : bool{assignable = true};
-  enum : bool{accessible = true};
+  enum : bool{assignable = false};
+  enum : bool{accessible = false};
 #else
   enum : bool { assignable = false };
   enum : bool { accessible = false };

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp
@@ -40,7 +40,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     for (int i = 0; i < league_size * team_size * vector_length; i++) {
       int league_rank = i / (team_size * vector_length);
 #if defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)
-      int team_rank   = i % (team_size * vector_length);
+      int team_rank = i % (team_size * vector_length);
       typename Policy::member_type team(league_rank, league_size, team_rank,
                                         team_size, vector_length);
 #else

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp
@@ -38,13 +38,12 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
 #pragma acc parallel loop gang vector num_gangs(league_size) \
     vector_length(team_size* vector_length) copyin(a_functor) async(async_arg)
     for (int i = 0; i < league_size * team_size * vector_length; i++) {
-#if defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)
       int league_rank = i / (team_size * vector_length);
+#if defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)
       int team_rank   = i % (team_size * vector_length);
       typename Policy::member_type team(league_rank, league_size, team_rank,
                                         team_size, vector_length);
 #else
-      int league_rank = i / (team_size * vector_length);
       typename Policy::member_type team(league_rank, league_size, team_size,
                                         vector_length);
 #endif

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp
@@ -38,9 +38,16 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
 #pragma acc parallel loop gang vector num_gangs(league_size) \
     vector_length(team_size* vector_length) copyin(a_functor) async(async_arg)
     for (int i = 0; i < league_size * team_size * vector_length; i++) {
-      int league_id = i / (team_size * vector_length);
-      typename Policy::member_type team(league_id, league_size, team_size,
+#if defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)
+      int league_rank = i / (team_size * vector_length);
+      int team_rank   = i % (team_size * vector_length);
+      typename Policy::member_type team(league_rank, league_size, team_rank,
+                                        team_size, vector_length);
+#else
+      int league_rank = i / (team_size * vector_length);
+      typename Policy::member_type team(league_rank, league_size, team_size,
                                         vector_length);
+#endif
       a_functor(team);
     }
   }
@@ -141,8 +148,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
 #pragma acc parallel loop gang num_gangs(league_size) num_workers(team_size) \
     vector_length(vector_length) copyin(a_functor) async(async_arg)
     for (int i = 0; i < league_size; i++) {
-      int league_id = i;
-      typename Policy::member_type team(league_id, league_size, team_size,
+      int league_rank = i;
+      typename Policy::member_type team(league_rank, league_size, team_size,
                                         vector_length);
       a_functor(team);
     }

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
@@ -138,8 +138,18 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
 #define KOKKOS_IMPL_ACC_REDUCE_TEAM_PRAGMA \
   vector vector_length(team_size* vector_length)
 #define KOKKOS_IMPL_ACC_REDUCE_TEAM_ITRS league_size* team_size* vector_length
-#define KOKKOS_IMPL_ACC_REDUCE_TEAM_LEAGUE_ID_INIT \
-  i / (team_size * vector_length)
+#ifdef KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE
+#define KOKKOS_IMPL_ACC_REDUCE_TEAM_MEMBER_INIT                          \
+  int league_rank = i / (team_size * vector_length);                     \
+  int team_rank   = i % (team_size * vector_length);                     \
+  typename Policy::member_type team(league_rank, league_size, team_rank, \
+                                    team_size, vector_length);
+#else
+#define KOKKOS_IMPL_ACC_REDUCE_TEAM_MEMBER_INIT                          \
+  int league_rank = i / (team_size * vector_length);                     \
+  typename Policy::member_type team(league_rank, league_size, team_size, \
+                                    vector_length);
+#endif
 
 namespace Kokkos {
 
@@ -298,7 +308,10 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
 #define KOKKOS_IMPL_ACC_REDUCE_TEAM_PRAGMA \
   num_workers(team_size) vector_length(vector_length)
 #define KOKKOS_IMPL_ACC_REDUCE_TEAM_ITRS league_size
-#define KOKKOS_IMPL_ACC_REDUCE_TEAM_LEAGUE_ID_INIT i
+#define KOKKOS_IMPL_ACC_REDUCE_TEAM_MEMBER_INIT                          \
+  int league_rank = i;                                                   \
+  typename Policy::member_type team(league_rank, league_size, team_size, \
+                                    vector_length);
 
 // FIXME_OPENACC: below implementation conforms to the OpenACC standard, but
 // the NVHPC compiler (V22.11) fails due to the lack of support for lambda
@@ -447,31 +460,29 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
 
 #endif /* #ifdef KOKKOS_ENABLE_OPENACC_COLLAPSE_HIERARCHICAL_CONSTRUCTS */
 
-#define KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_DISPATCH_SCHEDULE(REDUCER,     \
-                                                              OPERATOR)    \
-  namespace Kokkos::Experimental::Impl {                                   \
-  template <class Policy, class ValueType, class Functor>                  \
-  void OpenACCParallelReduceTeam##REDUCER(Policy const policy,             \
-                                          ValueType& aval,                 \
-                                          Functor const& afunctor,         \
-                                          int async_arg) {                 \
-    auto const functor       = afunctor;                                   \
-    auto val                 = aval;                                       \
-    auto const league_size   = policy.league_size();                       \
-    auto const team_size     = policy.team_size();                         \
-    auto const vector_length = policy.impl_vector_length();                \
+#define KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_DISPATCH_SCHEDULE(REDUCER,  \
+                                                              OPERATOR) \
+  namespace Kokkos::Experimental::Impl {                                \
+  template <class Policy, class ValueType, class Functor>               \
+  void OpenACCParallelReduceTeam##REDUCER(Policy const policy,          \
+                                          ValueType& aval,              \
+                                          Functor const& afunctor,      \
+                                          int async_arg) {              \
+    auto const functor       = afunctor;                                \
+    auto val                 = aval;                                    \
+    auto const league_size   = policy.league_size();                    \
+    auto const team_size     = policy.team_size();                      \
+    auto const vector_length = policy.impl_vector_length();             \
     /* clang-format off */ \
-    KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang num_gangs(league_size) KOKKOS_IMPL_ACC_REDUCE_TEAM_PRAGMA reduction(OPERATOR : val) copyin(functor) async(async_arg))                                               \
-    /* clang-format on */                                                  \
-    for (int i = 0; i < KOKKOS_IMPL_ACC_REDUCE_TEAM_ITRS; i++) {           \
-      int league_id = KOKKOS_IMPL_ACC_REDUCE_TEAM_LEAGUE_ID_INIT;          \
-      typename Policy::member_type team(league_id, league_size, team_size, \
-                                        vector_length);                    \
-      functor(team, val);                                                  \
-    }                                                                      \
-    acc_wait(async_arg);                                                   \
-    aval = val;                                                            \
-  }                                                                        \
+    KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang num_gangs(league_size) KOKKOS_IMPL_ACC_REDUCE_TEAM_PRAGMA reduction(OPERATOR : val) copyin(functor) async(async_arg))                                            \
+    /* clang-format on */                                               \
+    for (int i = 0; i < KOKKOS_IMPL_ACC_REDUCE_TEAM_ITRS; i++) {        \
+      KOKKOS_IMPL_ACC_REDUCE_TEAM_MEMBER_INIT                           \
+      functor(team, val);                                               \
+    }                                                                   \
+    acc_wait(async_arg);                                                \
+    aval = val;                                                         \
+  }                                                                     \
   }  // namespace Kokkos::Experimental::Impl
 
 #define KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_TEAM_HELPER(REDUCER, OPERATOR) \
@@ -520,6 +531,6 @@ KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_TEAM_HELPER(BOr, |);
 #undef KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_DISPATCH_SCHEDULE
 #undef KOKKOS_IMPL_ACC_REDUCE_TEAM_PRAGMA
 #undef KOKKOS_IMPL_ACC_REDUCE_TEAM_ITRS
-#undef KOKKOS_IMPL_ACC_REDUCE_TEAM_LEAGUE_ID_INIT
+#undef KOKKOS_IMPL_ACC_REDUCE_TEAM_MEMBER_INIT
 
 #endif /* #ifndef KOKKOS_OPENACC_PARALLEL_REDUCE_TEAM_HPP */

--- a/core/src/OpenACC/Kokkos_OpenACC_SharedAllocationRecord.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_SharedAllocationRecord.cpp
@@ -9,5 +9,10 @@
 
 #include <impl/Kokkos_SharedAlloc_timpl.hpp>
 
+#if defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)
+KOKKOS_IMPL_SHARED_ALLOCATION_RECORD_EXPLICIT_INSTANTIATION(
+    Kokkos::Experimental::OpenACCSpace);
+#else
 KOKKOS_IMPL_HOST_INACCESSIBLE_SHARED_ALLOCATION_RECORD_EXPLICIT_INSTANTIATION(
     Kokkos::Experimental::OpenACCSpace);
+#endif

--- a/core/src/OpenACC/Kokkos_OpenACC_SharedAllocationRecord.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_SharedAllocationRecord.hpp
@@ -7,7 +7,12 @@
 #include <OpenACC/Kokkos_OpenACCSpace.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>
 
+#if defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)
+KOKKOS_IMPL_SHARED_ALLOCATION_SPECIALIZATION(
+    Kokkos::Experimental::OpenACCSpace);
+#else
 KOKKOS_IMPL_HOST_INACCESSIBLE_SHARED_ALLOCATION_SPECIALIZATION(
     Kokkos::Experimental::OpenACCSpace);
+#endif
 
 #endif

--- a/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
@@ -9,6 +9,9 @@
 #include <OpenACC/Kokkos_OpenACC.hpp>
 #include <Kokkos_BitManipulation.hpp>
 #include <Kokkos_ExecPolicy.hpp>
+#ifdef KOKKOS_COMPILER_CLANG
+#include <omp.h>
+#endif
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -30,10 +33,10 @@ class OpenACCTeamMember {
 
   scratch_memory_space m_team_shared;
   int m_team_scratch_size[2];
-  int m_team_rank;
-  int m_team_size;
   int m_league_rank;
   int m_league_size;
+  int m_team_rank;
+  int m_team_size;
   int m_vector_length;
 
  public:
@@ -55,7 +58,11 @@ class OpenACCTeamMember {
 
   KOKKOS_FUNCTION int league_rank() const { return m_league_rank; }
   KOKKOS_FUNCTION int league_size() const { return m_league_size; }
+#ifdef KOKKOS_COMPILER_CLANG
+  KOKKOS_FUNCTION int team_rank() const { return omp_get_thread_num(); }
+#else
   KOKKOS_FUNCTION int team_rank() const { return m_team_rank; }
+#endif
   KOKKOS_FUNCTION int vector_length() const { return m_vector_length; }
   KOKKOS_FUNCTION int team_size() const { return m_team_size; }
 
@@ -122,16 +129,29 @@ class OpenACCTeamMember {
                     const int team_size,
                     const int vector_length)  // const TeamPolicyInternal<
                                               // OpenACC, Properties ...> & team
-      : m_team_size(team_size),
-        m_league_rank(league_rank),
+      : m_league_rank(league_rank),
         m_league_size(league_size),
+        m_team_size(team_size),
         m_vector_length(vector_length) {
 #ifdef KOKKOS_COMPILER_NVHPC
     m_team_rank = __pgi_vectoridx();
 #else
+#ifdef KOKKOS_COMPILER_CLANG
+    m_team_rank = omp_get_thread_num();
+#else
     m_team_rank = 0;
 #endif
+#endif
   }
+
+  OpenACCTeamMember(const int league_rank, const int league_size,
+                    const int team_rank, const int team_size,
+                    const int vector_length)
+      : m_league_rank(league_rank),
+        m_league_size(league_size),
+        m_team_rank(team_rank),
+        m_team_size(team_size),
+        m_vector_length(vector_length) {}
 
   static int team_reduce_size() { return TEAM_REDUCE_SIZE; }
 };

--- a/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
@@ -135,12 +135,10 @@ class OpenACCTeamMember {
         m_vector_length(vector_length) {
 #ifdef KOKKOS_COMPILER_NVHPC
     m_team_rank = __pgi_vectoridx();
-#else
-#ifdef KOKKOS_COMPILER_CLANG
+#elif defined(KOKKOS_COMPILER_CLANG)
     m_team_rank = omp_get_thread_num();
 #else
     m_team_rank = 0;
-#endif
 #endif
   }
 

--- a/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
@@ -125,6 +125,8 @@ class OpenACCTeamMember {
   // FIXME_OPENACC - 512(16*32) bytes at the begining of the scratch space
   // for each league is saved for reduction. It should actually be based on the
   // ValueType of the reduction variable.
+#if !defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE) || \
+    !defined(KOKKOS_ENABLE_OPENACC_COLLAPSE_HIERARCHICAL_CONSTRUCTS)
   OpenACCTeamMember(const int league_rank, const int league_size,
                     const int team_size,
                     const int vector_length)  // const TeamPolicyInternal<
@@ -141,7 +143,7 @@ class OpenACCTeamMember {
     m_team_rank = 0;
 #endif
   }
-
+#else
   OpenACCTeamMember(const int league_rank, const int league_size,
                     const int team_rank, const int team_size,
                     const int vector_length)
@@ -150,6 +152,7 @@ class OpenACCTeamMember {
         m_team_rank(team_rank),
         m_team_size(team_size),
         m_vector_length(vector_length) {}
+#endif
 
   static int team_reduce_size() { return TEAM_REDUCE_SIZE; }
 };

--- a/core/unit_test/TestViewTypedefs.cpp
+++ b/core/unit_test/TestViewTypedefs.cpp
@@ -204,7 +204,7 @@ constexpr bool test_view_typedefs(ViewParams<T, ViewArgs...>) {
 
 constexpr bool is_host_exec = std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>;
 
-#if defined(KOKKOS_ENABLE_IMPL_CUDA_UNIFIED_MEMORY) || defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
+#if defined(KOKKOS_ENABLE_IMPL_CUDA_UNIFIED_MEMORY) || defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY) || defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)
 constexpr bool has_unified_mem_space = true;
 #else
 constexpr bool has_unified_mem_space = false;


### PR DESCRIPTION
This PR contains a subset of PR #7343 : 
- Update cmake/make for Clacc to use `--offload-arch=native` option in the automatic fallback mode.
- Use different shared allocation specializations for the CPU target and the GPU target.
- Change MemorySpaceAccess behavior of OpenACCSpace when targeting the host to mimic the CudaUVMSpace behavior.
- Apply different iteration-to-thread mapping strategies for TeamPolicy targeting CPU and GPU.