### PR TITLE
Add CEA weekly test config

### DIFF
--- a/.github/workflows/weekly-cea.yml
+++ b/.github/workflows/weekly-cea.yml
@@ -31,6 +31,8 @@ jobs:
           cmake -B build \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_CXX_FLAGS=-Werror \
+            -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
             -DKokkos_ENABLE_TESTS=ON \
             -DKokkos_ENABLE_EXAMPLES=ON \
             ${{ matrix.backend.flags }}

--- a/.github/workflows/weekly-cea.yml
+++ b/.github/workflows/weekly-cea.yml
@@ -14,9 +14,8 @@ jobs:
           - Debug
         backend:
           - name: cuda-a100
-            flags:
-              cmake: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
-              module: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
+            flags: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
+            modules: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
             queue: gpua100
             runner: [self-hosted, cuda]
 
@@ -28,21 +27,21 @@ jobs:
 
       - name: Configure
         run: |
-          module load ${{ matrix.backend.flags.module }}
+          module load ${{ matrix.backend.modules }}
           cmake -B build \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_CXX_STANDARD=17 \
             -DKokkos_ENABLE_TESTS=ON \
             -DKokkos_ENABLE_EXAMPLES=ON \
-            ${{ matrix.backend.flags.cmake }}
+            ${{ matrix.backend.flags }}
 
       - name: Build
         run: |
-          module load ${{ matrix.backend.flags.module }}
+          module load ${{ matrix.backend.modules }}
           cmake --build build --parallel 20
 
       - name: Test
         run: |
-          module load ${{ matrix.backend.flags.module }}
+          module load ${{ matrix.backend.modules }}
           srun --nodes=1 --time=01:00:00 -p ${{ matrix.backend.queue }} --gres=gpu:1 \
           ctest --test-dir build --output-on-failure

--- a/.github/workflows/weekly-cea.yml
+++ b/.github/workflows/weekly-cea.yml
@@ -22,8 +22,7 @@ jobs:
     runs-on: ${{ matrix.backend.runner }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Configure
         run: |

--- a/.github/workflows/weekly-cea.yml
+++ b/.github/workflows/weekly-cea.yml
@@ -1,0 +1,48 @@
+name: Weekly CEA CI
+
+on:
+  schedule:
+    - cron: "0 2 * * 6" # every Saturday at 2am UTC
+  workflow_dispatch:
+
+jobs:
+  build_and_test:
+    strategy:
+      matrix:
+        build_type:
+          - Release
+          - Debug
+        backend:
+          - name: cuda-a100
+            flags:
+              cmake: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
+              module: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
+            queue: gpua100
+            runner: [self-hosted, cuda]
+
+    runs-on: ${{ matrix.backend.runner }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure
+        run: |
+          module load ${{ matrix.backend.flags.module }}
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DKokkos_ENABLE_TESTS=ON \
+            -DKokkos_ENABLE_EXAMPLES=ON \
+            ${{ matrix.backend.flags.cmake }}
+
+      - name: Build
+        run: |
+          module load ${{ matrix.backend.flags.module }}
+          cmake --build build --parallel 20
+
+      - name: Test
+        run: |
+          module load ${{ matrix.backend.flags.module }}
+          srun --nodes=1 --time=01:00:00 -p ${{ matrix.backend.queue }} --gres=gpu:1 \
+          ctest --test-dir build --output-on-failure

--- a/.github/workflows/weekly-cea.yml
+++ b/.github/workflows/weekly-cea.yml
@@ -1,4 +1,4 @@
-name: Weekly CEA CI
+name: Weekly CEA builds
 
 on:
   schedule:

--- a/.github/workflows/weekly-cea.yml
+++ b/.github/workflows/weekly-cea.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   build_and_test:
+    env:
+      build_jobs: 20
+
     strategy:
       matrix:
         build_type:
@@ -39,7 +42,7 @@ jobs:
       - name: Build
         run: |
           module load ${{ matrix.backend.modules }}
-          cmake --build build --parallel 20
+          cmake --build build --parallel $build_jobs
 
       - name: Test
         run: |


### PR DESCRIPTION
This PR aims to extend testing by running Kokkos tests on a weekly basis on the Ruche local cluster, by CEA means. The configuration is minimal for now and consists in a debug and release builds for the Cuda backend, on A100 GPUs.

The workflow is scheduled to run every Saturday at 2 am UTC, or manually.

The self-hosted runner on Ruche checks if the job can be executed. Scheduled runs can only take place on weekend. Manual runs have to be triggered by a white-listed user (I prefer to discuss about the members of the list on nucleus). No other job types (on push, etc.) are allowed.

Registration of the self-hosted runner was done with @crtrott.

The same configuration was tested on a dummy project, so it should run on the first try here...