### PR TITLE
Deprecate array_type and scalar_array_type and more enums in ViewTraits

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -459,9 +459,14 @@ class DynRankView : private View<DataType*******, Properties...> {
   using reference_type = typename view_type::reference_type;
   using pointer_type   = typename view_type::pointer_type;
 
-  using scalar_array_type           = value_type;
-  using const_scalar_array_type     = const_value_type;
-  using non_const_scalar_array_type = non_const_value_type;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  using scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use data_type instead.") = data_type;
+  using const_scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use const_data_type instead.") = const_data_type;
+  using non_const_scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use non_const_data_type instead.") = non_const_data_type;
+#endif
 #ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   using specialize KOKKOS_DEPRECATED = void;
@@ -500,9 +505,14 @@ class DynRankView : private View<DataType*******, Properties...> {
   // rank 7 data_type of the traits
 
   /** \brief  Compatible view of array of scalar types */
-  using array_type = DynRankView<
-      typename drvtraits::scalar_array_type, typename drvtraits::array_layout,
+  using type = DynRankView<
+      typename drvtraits::data_type, typename drvtraits::array_layout,
       typename drvtraits::device_type, typename drvtraits::memory_traits>;
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  /** \brief  Compatible view of array of scalar types */
+  using array_type KOKKOS_DEPRECATED_WITH_COMMENT("Use type instead.") = type;
+#endif
 
   /** \brief  Compatible view of const data type */
   using const_type = DynRankView<
@@ -747,7 +757,7 @@ class DynRankView : private View<DataType*******, Properties...> {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_FUNCTION reference_type operator[](index_type i0) const {
     if constexpr (std::is_same_v<typename drvtraits::value_type,
-                                 typename drvtraits::scalar_array_type>) {
+                                 typename drvtraits::data_type>) {
       return view_type::data()[i0];
     } else {
       const size_t dim_scalar = view_type::impl_map().dimension_scalar();
@@ -1952,7 +1962,7 @@ namespace Experimental {
 template <class T, class... P>
 struct python_view_type<DynRankView<T, P...>> {
   using type = Kokkos::Impl::python_view_type_impl_t<
-      typename DynRankView<T, P...>::array_type>;
+      typename DynRankView<T, P...>::type>;
 };
 }  // namespace Experimental
 

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -459,7 +459,7 @@ class DynRankView : private View<DataType*******, Properties...> {
   using reference_type = typename view_type::reference_type;
   using pointer_type   = typename view_type::pointer_type;
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   using scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
       "Use data_type instead.") = data_type;
   using const_scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
@@ -509,7 +509,7 @@ class DynRankView : private View<DataType*******, Properties...> {
       typename drvtraits::data_type, typename drvtraits::array_layout,
       typename drvtraits::device_type, typename drvtraits::memory_traits>;
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   /** \brief  Compatible view of array of scalar types */
   using array_type KOKKOS_DEPRECATED_WITH_COMMENT("Use type instead.") = type;
 #endif

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -262,10 +262,15 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
 
  public:
   //----------------------------------------------------------------------
-
-  /** \brief  Compatible view of array of scalar types */
-  using array_type =
+  /** \brief  Compatible view of data type */
+  using uniform_type =
       DynamicView<typename traits::data_type, typename traits::device_type>;
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  /** \brief  Compatible view of array of scalar types */
+  using array_type KOKKOS_DEPRECATED_WITH_COMMENT("Use uniform_type instead.") =
+      uniform_type;
+#endif
 
   /** \brief  Compatible view of const data type */
   using const_type = DynamicView<typename traits::const_data_type,
@@ -282,9 +287,8 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
   using uniform_device =
       Kokkos::Device<typename traits::device_type::execution_space,
                      Kokkos::AnonymousSpace>;
-  using uniform_type               = array_type;
   using uniform_const_type         = const_type;
-  using uniform_runtime_type       = array_type;
+  using uniform_runtime_type       = uniform_type;
   using uniform_runtime_const_type = const_type;
   using uniform_nomemspace_type =
       DynamicView<typename traits::data_type, uniform_device>;

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -266,7 +266,7 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
   using uniform_type =
       DynamicView<typename traits::data_type, typename traits::device_type>;
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   /** \brief  Compatible view of array of scalar types */
   using array_type KOKKOS_DEPRECATED_WITH_COMMENT("Use uniform_type instead.") =
       uniform_type;

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -211,18 +211,15 @@ class OffsetView : public View<DataType, Properties...> {
 
  public:
   //----------------------------------------
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  /** \brief  Compatible view of array of scalar types */
-  using array_type KOKKOS_DEPRECATED_WITH_COMMENT("Use type instead.") =
-      OffsetView<typename traits::scalar_array_type,
-                 typename traits::array_layout, typename traits::device_type,
-                 typename traits::memory_traits>;
-#endif
   /** \brief  Compatible view of data type */
   using type =
       OffsetView<typename traits::data_type, typename traits::array_layout,
                  typename traits::device_type, typename traits::memory_traits>;
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  /** \brief  Compatible view of array of scalar types */
+  using array_type KOKKOS_DEPRECATED_WITH_COMMENT("Use type instead.") = type;
+#endif
 
   /** \brief  Compatible view of const data type */
   using const_type =

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -211,11 +211,18 @@ class OffsetView : public View<DataType, Properties...> {
 
  public:
   //----------------------------------------
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   /** \brief  Compatible view of array of scalar types */
-  using array_type =
+  using array_type KOKKOS_DEPRECATED_WITH_COMMENT("Use type instead.") =
       OffsetView<typename traits::scalar_array_type,
                  typename traits::array_layout, typename traits::device_type,
                  typename traits::memory_traits>;
+#endif
+  /** \brief  Compatible view of data type */
+  using type =
+      OffsetView<typename traits::data_type, typename traits::array_layout,
+                 typename traits::device_type, typename traits::memory_traits>;
 
   /** \brief  Compatible view of const data type */
   using const_type =
@@ -284,7 +291,7 @@ class OffsetView : public View<DataType, Properties...> {
   // interoperability with View
  private:
   using view_type =
-      View<typename traits::scalar_array_type, typename traits::array_layout,
+      View<typename traits::data_type, typename traits::array_layout,
            typename traits::device_type, typename traits::memory_traits>;
 
  public:

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -212,7 +212,7 @@ class OffsetView : public View<DataType, Properties...> {
  public:
   //----------------------------------------
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   /** \brief  Compatible view of array of scalar types */
   using array_type KOKKOS_DEPRECATED_WITH_COMMENT("Use type instead.") =
       OffsetView<typename traits::scalar_array_type,

--- a/containers/unit_tests/TestDynRankViewTypedefs.cpp
+++ b/containers/unit_tests/TestDynRankViewTypedefs.cpp
@@ -55,7 +55,7 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::const_data_type, typename data_analysis<DataType>::const_data_type>);
   static_assert(std::is_same_v<typename ViewType::non_const_data_type, typename data_analysis<DataType>::non_const_data_type>);
   
-  #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   // FIXME: these should be deprecated and for proper testing (I.e. where this is different from data_type)
   // we would need ensemble types which use the hidden View dimension facility of View (i.e. which make
   // "specialize" not void)
@@ -65,7 +65,7 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::non_const_scalar_array_type, typename data_analysis<DataType>::non_const_data_type>);
   KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
   #endif
-  #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   static_assert(std::is_same_v<typename ViewType::specialize, void>);
   #endif
 
@@ -98,7 +98,7 @@ constexpr bool test_view_typedefs_impl() {
 
   // FIXME: in contrast to View, hooks_policy is not propagated
   static_assert(std::is_same_v<typename ViewType::traits, ViewTraitsType>);
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
   static_assert(std::is_same_v<typename ViewType::array_type,
                                Kokkos::DynRankView<typename ViewType::scalar_array_type, typename ViewType::array_layout,

--- a/containers/unit_tests/TestDynRankViewTypedefs.cpp
+++ b/containers/unit_tests/TestDynRankViewTypedefs.cpp
@@ -54,16 +54,20 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::data_type, DataType>);
   static_assert(std::is_same_v<typename ViewType::const_data_type, typename data_analysis<DataType>::const_data_type>);
   static_assert(std::is_same_v<typename ViewType::non_const_data_type, typename data_analysis<DataType>::non_const_data_type>);
-
+  
+  #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   // FIXME: these should be deprecated and for proper testing (I.e. where this is different from data_type)
   // we would need ensemble types which use the hidden View dimension facility of View (i.e. which make
   // "specialize" not void)
+  KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
   static_assert(std::is_same_v<typename ViewType::scalar_array_type, DataType>);
   static_assert(std::is_same_v<typename ViewType::const_scalar_array_type, typename data_analysis<DataType>::const_data_type>);
   static_assert(std::is_same_v<typename ViewType::non_const_scalar_array_type, typename data_analysis<DataType>::non_const_data_type>);
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+  #endif
+  #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static_assert(std::is_same_v<typename ViewType::specialize, void>);
-#endif
+  #endif
 
   // FIXME: value_type definition conflicts with mdspan value_type
   static_assert(std::is_same_v<typename ViewType::value_type, ValueType>);
@@ -94,7 +98,15 @@ constexpr bool test_view_typedefs_impl() {
 
   // FIXME: in contrast to View, hooks_policy is not propagated
   static_assert(std::is_same_v<typename ViewType::traits, ViewTraitsType>);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
   static_assert(std::is_same_v<typename ViewType::array_type,
+                               Kokkos::DynRankView<typename ViewType::scalar_array_type, typename ViewType::array_layout,
+                                            typename ViewType::device_type, //typename ViewTraitsType::hooks_policy,
+                                            typename ViewType::memory_traits>>);
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+#endif
+  static_assert(std::is_same_v<typename ViewType::type,
                                Kokkos::DynRankView<typename ViewType::data_type, typename ViewType::array_layout,
                                             typename ViewType::device_type, //typename ViewTraitsType::hooks_policy,
                                             typename ViewType::memory_traits>>);

--- a/containers/unit_tests/TestDynRankViewTypedefs.cpp
+++ b/containers/unit_tests/TestDynRankViewTypedefs.cpp
@@ -65,7 +65,7 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::non_const_scalar_array_type, typename data_analysis<DataType>::non_const_data_type>);
   KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
   #endif
-  #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static_assert(std::is_same_v<typename ViewType::specialize, void>);
   #endif
 

--- a/core/src/KokkosExp_InterOp.hpp
+++ b/core/src/KokkosExp_InterOp.hpp
@@ -71,8 +71,7 @@ template <typename ViewT>
 struct python_view_type {
   static_assert(Kokkos::is_view<std::decay_t<ViewT>>::value);
 
-  using type =
-      Kokkos::Impl::python_view_type_impl_t<typename ViewT::array_type>;
+  using type = Kokkos::Impl::python_view_type_impl_t<typename ViewT::type>;
 };
 
 template <typename ViewT>

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -193,21 +193,30 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   using raw_allocation_value_type = std::remove_pointer_t<pointer_type>;
 
  public:
-  using scalar_array_type       = typename traits::scalar_array_type;
-  using const_scalar_array_type = typename traits::const_scalar_array_type;
-  using non_const_scalar_array_type =
-      typename traits::non_const_scalar_array_type;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  using scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use data_type instead.") = data_type;
+  using const_scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use const_data_type instead.") = const_data_type;
+  using non_const_scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use non_const_data_type instead.") = non_const_data_type;
+#endif
 
   // typedefs from BasicView
   using typename base_t::mdspan_type;
   using reference_type = typename base_t::reference;
 
   //----------------------------------------
+  // Compatible view of a data type
+  using type = View<typename traits::data_type, typename traits::array_layout,
+                    typename traits::device_type, typename traits::hooks_policy,
+                    typename traits::memory_traits>;
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  //----------------------------------------
   // Compatible view of array of scalar types
-  using array_type =
-      View<typename traits::scalar_array_type, typename traits::array_layout,
-           typename traits::device_type, typename traits::hooks_policy,
-           typename traits::memory_traits>;
+  using array_type KOKKOS_DEPRECATED_WITH_COMMENT("Use type instead.") = type;
+#endif
 
   // Compatible view of const data type
   using const_type =

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -193,7 +193,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   using raw_allocation_value_type = std::remove_pointer_t<pointer_type>;
 
  public:
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   using scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
       "Use data_type instead.") = data_type;
   using const_scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
@@ -212,7 +212,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
                     typename traits::device_type, typename traits::hooks_policy,
                     typename traits::memory_traits>;
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   //----------------------------------------
   // Compatible view of array of scalar types
   using array_type KOKKOS_DEPRECATED_WITH_COMMENT("Use type instead.") = type;

--- a/core/src/View/Kokkos_ViewCommonType.hpp
+++ b/core/src/View/Kokkos_ViewCommonType.hpp
@@ -26,7 +26,7 @@ struct CommonViewAllocProp<void, ValueType> {
   using value_type = ValueType;
   using data_type  = ValueType;
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   using scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
       "Use data_type instead.") = data_type;
 #endif

--- a/core/src/View/Kokkos_ViewCommonType.hpp
+++ b/core/src/View/Kokkos_ViewCommonType.hpp
@@ -23,8 +23,13 @@ struct CommonViewAllocProp;
 
 template <class ValueType>
 struct CommonViewAllocProp<void, ValueType> {
-  using value_type        = ValueType;
-  using scalar_array_type = ValueType;
+  using value_type = ValueType;
+  using data_type  = ValueType;
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  using scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use data_type instead.") = data_type;
+#endif
 
   template <class... Views>
   KOKKOS_INLINE_FUNCTION CommonViewAllocProp(const Views&...) {}

--- a/core/src/View/Kokkos_ViewDataAnalysis.hpp
+++ b/core/src/View/Kokkos_ViewDataAnalysis.hpp
@@ -374,7 +374,7 @@ struct ViewDataAnalysis {
   using non_const_data_type =
       typename ViewDataType<non_const_value_type, dimension>::type;
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   using type KOKKOS_DEPRECATED_WITH_COMMENT("Use data_type instead.") =
       data_type;
   using const_type KOKKOS_DEPRECATED_WITH_COMMENT(
@@ -383,7 +383,7 @@ struct ViewDataAnalysis {
       "Use non_const_data_type instead.") = non_const_data_type;
 #endif
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   // Generate "flattened" multidimensional array specification type.
   using scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
       "Use data_type instead.") = data_type;

--- a/core/src/View/Kokkos_ViewDataAnalysis.hpp
+++ b/core/src/View/Kokkos_ViewDataAnalysis.hpp
@@ -381,9 +381,7 @@ struct ViewDataAnalysis {
       "Use const_data_type instead.") = const_data_type;
   using non_const_type KOKKOS_DEPRECATED_WITH_COMMENT(
       "Use non_const_data_type instead.") = non_const_data_type;
-#endif
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   // Generate "flattened" multidimensional array specification type.
   using scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
       "Use data_type instead.") = data_type;

--- a/core/src/View/Kokkos_ViewDataAnalysis.hpp
+++ b/core/src/View/Kokkos_ViewDataAnalysis.hpp
@@ -368,15 +368,30 @@ struct ViewDataAnalysis {
   using non_const_value_type = typename array_analysis::non_const_value_type;
 
   // Generate analogous multidimensional array specification type.
-  using type       = typename ViewDataType<value_type, dimension>::type;
-  using const_type = typename ViewDataType<const_value_type, dimension>::type;
-  using non_const_type =
+  using data_type = typename ViewDataType<value_type, dimension>::type;
+  using const_data_type =
+      typename ViewDataType<const_value_type, dimension>::type;
+  using non_const_data_type =
       typename ViewDataType<non_const_value_type, dimension>::type;
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  using type KOKKOS_DEPRECATED_WITH_COMMENT("Use data_type instead.") =
+      data_type;
+  using const_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use const_data_type instead.") = const_data_type;
+  using non_const_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use non_const_data_type instead.") = non_const_data_type;
+#endif
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   // Generate "flattened" multidimensional array specification type.
-  using scalar_array_type           = type;
-  using const_scalar_array_type     = const_type;
-  using non_const_scalar_array_type = non_const_type;
+  using scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use data_type instead.") = data_type;
+  using const_scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use const_data_type instead.") = const_data_type;
+  using non_const_scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use non_const_data_type instead.") = non_const_data_type;
+#endif
 };
 
 template <class Dimension, class Layout, class Enable = void>

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -238,7 +238,7 @@ class View : public ViewTraits<DataType, Properties...> {
                     typename traits::device_type, typename traits::hooks_policy,
                     typename traits::memory_traits>;
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   /** \brief  Compatible view of array of data types */
   using array_type KOKKOS_DEPRECATED_WITH_COMMENT("Use type instead.") = type;
 #endif

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -233,11 +233,15 @@ class View : public ViewTraits<DataType, Properties...> {
 
  public:
   //----------------------------------------
-  /** \brief  Compatible view of array of scalar types */
-  using array_type =
-      View<typename traits::scalar_array_type, typename traits::array_layout,
-           typename traits::device_type, typename traits::hooks_policy,
-           typename traits::memory_traits>;
+  /** \brief  Compatible view of data type */
+  using type = View<typename traits::data_type, typename traits::array_layout,
+                    typename traits::device_type, typename traits::hooks_policy,
+                    typename traits::memory_traits>;
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  /** \brief  Compatible view of array of data types */
+  using array_type KOKKOS_DEPRECATED_WITH_COMMENT("Use type instead.") = type;
+#endif
 
   /** \brief  Compatible view of const data type */
   using const_type =

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -492,19 +492,20 @@ struct ViewTraits {
   //------------------------------------
   // Data type traits:
 
-  using data_type           = typename data_analysis::type;
-  using const_data_type     = typename data_analysis::const_type;
-  using non_const_data_type = typename data_analysis::non_const_type;
+  using data_type           = typename data_analysis::data_type;
+  using const_data_type     = typename data_analysis::const_data_type;
+  using non_const_data_type = typename data_analysis::non_const_data_type;
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   //------------------------------------
   // Compatible array of trivial type traits:
-
-  using scalar_array_type = typename data_analysis::scalar_array_type;
-  using const_scalar_array_type =
-      typename data_analysis::const_scalar_array_type;
-  using non_const_scalar_array_type =
-      typename data_analysis::non_const_scalar_array_type;
-
+  using scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use data_type instead.") = data_type;
+  using const_scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use const_data_type instead.") = const_data_type;
+  using non_const_scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use non_const_data_type instead.") = non_const_data_type;
+#endif
   //------------------------------------
   // Value type traits:
 

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -496,7 +496,7 @@ struct ViewTraits {
   using const_data_type     = typename data_analysis::const_data_type;
   using non_const_data_type = typename data_analysis::non_const_data_type;
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   //------------------------------------
   // Compatible array of trivial type traits:
   using scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(

--- a/core/unit_test/TestViewCtorPropEmbeddedDim.hpp
+++ b/core/unit_test/TestViewCtorPropEmbeddedDim.hpp
@@ -67,10 +67,10 @@ struct TestViewCtorProp_EmbeddedDim {
         Kokkos::deep_copy(hcv1, cv1);
 
         ASSERT_EQ((std::is_same_v<CommonViewValueType, double>), true);
-        ASSERT_EQ((std::is_same_v<
-                      typename decltype(view_alloc_arg)::scalar_array_type,
-                      CommonViewValueType>),
+        ASSERT_EQ((std::is_same_v<typename decltype(view_alloc_arg)::data_type,
+                                  CommonViewValueType>),
                   true);
+
 #if 0
       // debug output
       for ( int i = 0; i < N0*N1; ++i ) {
@@ -83,7 +83,7 @@ struct TestViewCtorProp_EmbeddedDim {
         printf("Proper common value_type\n");
       }
       else {
-        printf("WRONG common value_type\n");
+        printf("Wrong common value_type\n");
       }
       // end debug output
 #endif

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -590,52 +590,54 @@ void test_view_mapping() {
     static_assert(std::is_void_v<typename a_const_int_r1::specialize>);
     static_assert(std::is_same_v<typename a_const_int_r1::dimension,
                                  Kokkos::Impl::ViewDimension<0> >);
-
-    static_assert(std::is_same_v<typename a_const_int_r1::type, const int*>);
+    static_assert(
+        std::is_same_v<typename a_const_int_r1::data_type, const int*>);
+    static_assert(
+        std::is_same_v<typename a_const_int_r1::const_data_type, const int*>);
+    static_assert(
+        std::is_same_v<typename a_const_int_r1::non_const_data_type, int*>);
     static_assert(
         std::is_same_v<typename a_const_int_r1::value_type, const int>);
-
-    static_assert(
-        std::is_same_v<typename a_const_int_r1::scalar_array_type, const int*>);
-    static_assert(
-        std::is_same_v<typename a_const_int_r1::const_type, const int*>);
     static_assert(
         std::is_same_v<typename a_const_int_r1::const_value_type, const int>);
     static_assert(
+        std::is_same_v<typename a_const_int_r1::non_const_value_type, int>);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
+    static_assert(
+        std::is_same_v<typename a_const_int_r1::scalar_array_type, const int*>);
+    static_assert(
         std::is_same_v<typename a_const_int_r1::const_scalar_array_type,
                        const int*>);
-    static_assert(
-        std::is_same_v<typename a_const_int_r1::non_const_type, int*>);
-    static_assert(
-        std::is_same_v<typename a_const_int_r1::non_const_value_type, int>);
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+#endif
 
     using a_const_int_r3 = ViewDataAnalysis<const int** [4], void>;
 
     static_assert(std::is_void_v<typename a_const_int_r3::specialize>);
-
     static_assert(std::is_same_v<typename a_const_int_r3::dimension,
                                  Kokkos::Impl::ViewDimension<0, 0, 4> >);
-
     static_assert(
-        std::is_same_v<typename a_const_int_r3::type, const int** [4]>);
+        std::is_same_v<typename a_const_int_r3::data_type, const int** [4]>);
+    static_assert(std::is_same_v<typename a_const_int_r3::const_data_type,
+                                 const int** [4]>);
+    static_assert(std::is_same_v<typename a_const_int_r3::non_const_data_type,
+                                 int** [4]>);
     static_assert(
         std::is_same_v<typename a_const_int_r3::value_type, const int>);
-    static_assert(std::is_same_v<typename a_const_int_r3::scalar_array_type,
-                                 const int** [4]>);
-    static_assert(
-        std::is_same_v<typename a_const_int_r3::const_type, const int** [4]>);
     static_assert(
         std::is_same_v<typename a_const_int_r3::const_value_type, const int>);
     static_assert(
+        std::is_same_v<typename a_const_int_r3::non_const_value_type, int>);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
+    static_assert(std::is_same_v<typename a_const_int_r3::scalar_array_type,
+                                 const int** [4]>);
+    static_assert(
         std::is_same_v<typename a_const_int_r3::const_scalar_array_type,
                        const int** [4]>);
-    static_assert(
-        std::is_same_v<typename a_const_int_r3::non_const_type, int** [4]>);
-    static_assert(
-        std::is_same_v<typename a_const_int_r3::non_const_value_type, int>);
-    static_assert(
-        std::is_same_v<typename a_const_int_r3::non_const_scalar_array_type,
-                       int** [4]>);
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+#endif
   }
 
   //----------------------------------------
@@ -650,11 +652,15 @@ void test_view_mapping() {
     static_assert(std::is_same_v<typename T::const_data_type, const int*>);
     static_assert(std::is_same_v<typename T::non_const_data_type, int*>);
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
     static_assert(std::is_same_v<typename T::scalar_array_type, int*>);
     static_assert(
         std::is_same_v<typename T::const_scalar_array_type, const int*>);
     static_assert(
         std::is_same_v<typename T::non_const_scalar_array_type, int*>);
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+#endif
 
     static_assert(std::is_same_v<typename T::value_type, int>);
     static_assert(std::is_same_v<typename T::const_value_type, const int>);
@@ -670,12 +676,15 @@ void test_view_mapping() {
     static_assert(std::is_same_v<typename C::const_data_type, const int*>);
     static_assert(std::is_same_v<typename C::non_const_data_type, int*>);
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
     static_assert(std::is_same_v<typename C::scalar_array_type, const int*>);
     static_assert(
         std::is_same_v<typename C::const_scalar_array_type, const int*>);
     static_assert(
         std::is_same_v<typename C::non_const_scalar_array_type, int*>);
-
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+#endif
     static_assert(std::is_same_v<typename C::value_type, const int>);
     static_assert(std::is_same_v<typename C::const_value_type, const int>);
     static_assert(std::is_same_v<typename C::non_const_value_type, int>);
@@ -734,11 +743,15 @@ void test_view_mapping() {
     static_assert(std::is_same_v<typename T::const_data_type, const int*>);
     static_assert(std::is_same_v<typename T::non_const_data_type, int*>);
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
     static_assert(std::is_same_v<typename T::scalar_array_type, int*>);
     static_assert(
         std::is_same_v<typename T::const_scalar_array_type, const int*>);
     static_assert(
         std::is_same_v<typename T::non_const_scalar_array_type, int*>);
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+#endif
 
     static_assert(std::is_same_v<typename T::value_type, int>);
     static_assert(std::is_same_v<typename T::const_value_type, const int>);

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -602,7 +602,7 @@ void test_view_mapping() {
         std::is_same_v<typename a_const_int_r1::const_value_type, const int>);
     static_assert(
         std::is_same_v<typename a_const_int_r1::non_const_value_type, int>);
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
     KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
     static_assert(
         std::is_same_v<typename a_const_int_r1::scalar_array_type, const int*>);
@@ -629,7 +629,7 @@ void test_view_mapping() {
         std::is_same_v<typename a_const_int_r3::const_value_type, const int>);
     static_assert(
         std::is_same_v<typename a_const_int_r3::non_const_value_type, int>);
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
     KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
     static_assert(std::is_same_v<typename a_const_int_r3::scalar_array_type,
                                  const int** [4]>);
@@ -652,7 +652,7 @@ void test_view_mapping() {
     static_assert(std::is_same_v<typename T::const_data_type, const int*>);
     static_assert(std::is_same_v<typename T::non_const_data_type, int*>);
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
     KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
     static_assert(std::is_same_v<typename T::scalar_array_type, int*>);
     static_assert(
@@ -676,7 +676,7 @@ void test_view_mapping() {
     static_assert(std::is_same_v<typename C::const_data_type, const int*>);
     static_assert(std::is_same_v<typename C::non_const_data_type, int*>);
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
     KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
     static_assert(std::is_same_v<typename C::scalar_array_type, const int*>);
     static_assert(
@@ -743,7 +743,7 @@ void test_view_mapping() {
     static_assert(std::is_same_v<typename T::const_data_type, const int*>);
     static_assert(std::is_same_v<typename T::non_const_data_type, int*>);
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
     KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
     static_assert(std::is_same_v<typename T::scalar_array_type, int*>);
     static_assert(

--- a/core/unit_test/TestViewTypedefs.cpp
+++ b/core/unit_test/TestViewTypedefs.cpp
@@ -54,7 +54,7 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::const_data_type, typename data_analysis<DataType>::const_data_type>);
   static_assert(std::is_same_v<typename ViewType::non_const_data_type, typename data_analysis<DataType>::non_const_data_type>);
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   // FIXME: these should be deprecated and for proper testing (I.e. where this is different from data_type)
   // we would need ensemble types which use the hidden View dimension facility of View (i.e. which make
   // "specialize" not void)
@@ -97,7 +97,7 @@ constexpr bool test_view_typedefs_impl() {
   // in Legacy View: some helper View variants
   // =========================================
   static_assert(std::is_same_v<typename ViewType::traits, ViewTraitsType>);
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
   static_assert(std::is_same_v<typename ViewType::array_type,
                                Kokkos::View<typename ViewType::scalar_array_type, typename ViewType::array_layout,

--- a/core/unit_test/TestViewTypedefs.cpp
+++ b/core/unit_test/TestViewTypedefs.cpp
@@ -53,13 +53,17 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::data_type, DataType>);
   static_assert(std::is_same_v<typename ViewType::const_data_type, typename data_analysis<DataType>::const_data_type>);
   static_assert(std::is_same_v<typename ViewType::non_const_data_type, typename data_analysis<DataType>::non_const_data_type>);
-  
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   // FIXME: these should be deprecated and for proper testing (I.e. where this is different from data_type)
   // we would need ensemble types which use the hidden View dimension facility of View (i.e. which make
   // "specialize" not void)
+  KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
   static_assert(std::is_same_v<typename ViewType::scalar_array_type, DataType>);
   static_assert(std::is_same_v<typename ViewType::const_scalar_array_type, typename data_analysis<DataType>::const_data_type>);
   static_assert(std::is_same_v<typename ViewType::non_const_scalar_array_type, typename data_analysis<DataType>::non_const_data_type>);
+  KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+#endif
 #ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
   static_assert(std::is_same_v<typename ViewType::specialize, void>);
 #endif
@@ -93,8 +97,16 @@ constexpr bool test_view_typedefs_impl() {
   // in Legacy View: some helper View variants
   // =========================================
   static_assert(std::is_same_v<typename ViewType::traits, ViewTraitsType>);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
   static_assert(std::is_same_v<typename ViewType::array_type,
                                Kokkos::View<typename ViewType::scalar_array_type, typename ViewType::array_layout,
+                                            typename ViewType::device_type, typename ViewTraitsType::hooks_policy,
+                                            typename ViewType::memory_traits>>);
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+#endif
+  static_assert(std::is_same_v<typename ViewType::type,
+                               Kokkos::View<typename ViewType::data_type, typename ViewType::array_layout,
                                             typename ViewType::device_type, typename ViewTraitsType::hooks_policy,
                                             typename ViewType::memory_traits>>);
   static_assert(std::is_same_v<typename ViewType::const_type,

--- a/example/tutorial/Advanced_Views/04_dualviews/dual_view.cpp
+++ b/example/tutorial/Advanced_Views/04_dualviews/dual_view.cpp
@@ -48,10 +48,9 @@ struct localsum {
   // double**.
   Kokkos::View<idx_type::const_data_type, idx_type::array_layout, memory_space>
       idx;
-  // "scalar_array_type" is an alias in ViewTraits (and DualView) which is the
+  // "data_type" is an alias in ViewTraits (and DualView) which is the
   // array version of the value(s) stored in the View.
-  Kokkos::View<view_type::scalar_array_type, view_type::array_layout,
-               memory_space>
+  Kokkos::View<view_type::data_type, view_type::array_layout, memory_space>
       dest;
   Kokkos::View<view_type::const_data_type, view_type::array_layout,
                memory_space, Kokkos::MemoryRandomAccess>


### PR DESCRIPTION
Partially addressing https://github.com/kokkos/kokkos/issues/7350.
Changes:
- `scalar_array_type` -> marked deprecated in favor of `data_type`
- `const_scalar_array_type` -> marked deprecated in favor of `const_data_type`
- `non_const_scalar_array_type` -> marked deprecated in favor of `non_const_data_type`
- `array_type` -> marked deprecated in favor of `type`
-  `type`, `const_type` and `non_const_type` ViewDataAnalysis deprecated in favor of `data_type`, `const_data_type` and `non_const_data_type`.
- `array_type` is deprecated in favor of `uniform_type` in DynamicView
Note: Requires updates to the documentation


