### PR TITLE
`ViewCtorProp`: default constructor and move semantics

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -261,6 +261,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         ViewCopy_b
         ViewCopy_c
         ViewCtorDimMatch
+        ViewCtorProp
         ViewEmptyRuntimeUnmanaged
         ViewHooks
         ViewLayoutStrideAssignment

--- a/core/unit_test/TestViewCtorProp.hpp
+++ b/core/unit_test/TestViewCtorProp.hpp
@@ -1,0 +1,95 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+
+namespace {
+
+using vcp_empty_t      = Kokkos::Impl::ViewCtorProp<>;
+using vcp_label_base_t = Kokkos::Impl::ViewCtorProp<void, std::string>;
+using vcp_label_t      = Kokkos::Impl::ViewCtorProp<std::string>;
+
+// Check traits of Kokkos::Impl::ViewCtorProp<>.
+TEST(TEST_CATEGORY, vcp_empty_traits) {
+  // Check that the empty view constructor properties class is default
+  // constructible. This is needed for calls of Kokkos::view_alloc().
+  static_assert(std::is_default_constructible_v<vcp_empty_t>);
+  static_assert(std::is_same_v<decltype(Kokkos::view_alloc()), vcp_empty_t>);
+}
+
+// Check Kokkos::Impl::is_view_label.
+TEST(TEST_CATEGORY, is_view_label) {
+  static_assert(Kokkos::Impl::is_view_label<std::string>::value);
+
+  static_assert(Kokkos::Impl::is_view_label<const char[3]>::value);
+  static_assert(Kokkos::Impl::is_view_label<char[3]>::value);
+
+  // A char* is not a label. Thus, a label is distinguished from a pointer type.
+  static_assert(!Kokkos::Impl::is_view_label<char*>::value);
+}
+
+// Check traits of base class Kokkos::Impl::ViewCtorProp<void, std::string>.
+TEST(TEST_CATEGORY, vcp_label_base_traits) {
+  static_assert(std::is_same_v<typename vcp_label_base_t::type, std::string>);
+
+  // Check that the base class is default constructible. The default constructor
+  // may be called by the copy constructor of derived classes, such as when
+  // copy constructing a view constructor properties object from another view
+  // constructor properties object that holds fewer properties.
+  static_assert(std::is_default_constructible_v<vcp_label_base_t>);
+}
+
+// Check traits of derived class Kokkos::Impl::ViewCtorProp<std::string>.
+TEST(TEST_CATEGORY, vcp_label_traits) {
+  static_assert(std::is_base_of_v<vcp_label_base_t, vcp_label_t>);
+
+  static_assert(vcp_label_t::has_label);
+
+  // Check that the derived class is not default constructible. It is a design
+  // choice to not allow the default constructor to be called.
+  static_assert(!std::is_default_constructible_v<vcp_label_t>);
+}
+
+// Check that Kokkos::view_alloc perfect forwards a label passed by
+// rvalue reference, and check that the constructor
+// of Kokkos::Impl::ViewCtorProp<std::string> moves this label.
+TEST(TEST_CATEGORY, view_alloc_can_perfect_forward_label) {
+  std::string label("our label");
+
+  auto prop = Kokkos::view_alloc(std::move(label));
+
+  ASSERT_TRUE(label.empty());
+  ASSERT_EQ(Kokkos::Impl::get_property<Kokkos::Impl::LabelTag>(prop),
+            "our label");
+}
+
+// Check the copy constructor of Kokkos::Impl::ViewCtorProp<std::string>.
+TEST(TEST_CATEGORY, vcp_label_copy_constructor) {
+  // Copy construction from a view constructor properties object with a label.
+  static_assert(std::is_copy_constructible_v<vcp_label_t>);
+
+  vcp_label_t prop = Kokkos::view_alloc("our label");
+  vcp_label_t prop_copy(prop);
+
+  ASSERT_EQ(Kokkos::Impl::get_property<Kokkos::Impl::LabelTag>(prop),
+            "our label");
+  ASSERT_EQ(Kokkos::Impl::get_property<Kokkos::Impl::LabelTag>(prop_copy),
+            "our label");
+}
+
+}  // namespace


### PR DESCRIPTION
The `ViewCtorProp` class is important in the implementation of the often used `view_alloc` function.

We have recently looked at this class in more detail and noted several issues:

- As it stands, the `ViewCtorProp` is not default constructible. For example, the following code doesn't compile:

```
using vcp_t = Kokkos::Impl::ViewCtorProp<std::string>;
vcp_t prop; // compilation errror
```

- Even though some of the base classes of `ViewCtorProp` have constructors that take arguments by rvalue reference, these constructors do not subsequently move the passed arguments. Hence, they may ultimately not move. For example, the following test fails:

```
using vcp_t = Kokkos::Impl::ViewCtorProp<std::string>;
std::string label("my label we like to move around because it is soooo long !");
const vcp_t prop(std::move(label));
ASSERT_TRUE(label.empty()); // runtime test failure
```

- Even though the functionalities of `ViewCtorProp` and `view_alloc` are tested implicitly by numerous tests that use them, it seems there are no unit tests of these functionalities just by themselves.

Just for context/use case, we noted these issues while we explored how to make the new `SequentialHostInit` property work with `DualView`. This led us to think about passing different view constructor properties to the host and device sides. And this is how default constructing view constructor properties, moving them, and so on came up.

Thus, this PR: 
- adds a default constructor to `ViewCtorProp`
- modifies a constructor and adds a move constructor to `ViewCtorProp`
- modifies a constructor of the `ViewCtorProp` base class dealing with labels to support move semantics
- adds unit tests for `ViewCtorProp`

As you will see, the modifications are limited to the main `ViewCtorProp` class and the base class dealing with labels. In this way, the PR remains small for a first review. Similar modifications could be made for the other base classes. I would be happy to do it in this PR or in a follow up.

Joint work with @romintomasetti 









