### PR TITLE
graph(global-kernel-launch): fix global launch for node kernel

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -51,7 +51,8 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
   Kokkos::ObservingRawPtr<cudaGraphNode_t> m_graph_node_ptr = nullptr;
   // Basically, we have to make this mutable for the same reasons that the
   // global kernel buffers in the Cuda instance are mutable...
-  mutable Kokkos::OwningRawPtr<base_t> m_driver_storage = nullptr;
+  mutable std::shared_ptr<base_t> m_driver_storage = nullptr;
+  std::string label;
 
  public:
   using Policy       = PolicyType;
@@ -61,25 +62,20 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
   //      attached to the policy?
   // TODO @graph kernel name info propagation
   template <class PolicyDeduced, class... ArgsDeduced>
-  GraphNodeKernelImpl(std::string, Kokkos::Cuda const&, Functor arg_functor,
+  GraphNodeKernelImpl(std::string label_, Cuda const&, Functor arg_functor,
                       PolicyDeduced&& arg_policy, ArgsDeduced&&... args)
       // This is super ugly, but it works for now and is the most minimal change
       // to the codebase for now...
       : base_t(std::move(arg_functor), (PolicyDeduced&&)arg_policy,
-               (ArgsDeduced&&)args...) {}
+               (ArgsDeduced&&)args...),
+        label(std::move(label_)) {}
 
   // FIXME @graph Forward through the instance once that works in the backends
   template <class PolicyDeduced>
   GraphNodeKernelImpl(Kokkos::Cuda const& ex, Functor arg_functor,
                       PolicyDeduced&& arg_policy)
-      : GraphNodeKernelImpl("", ex, std::move(arg_functor),
+      : GraphNodeKernelImpl("[unlabeled]", ex, std::move(arg_functor),
                             (PolicyDeduced&&)arg_policy) {}
-
-  ~GraphNodeKernelImpl() {
-    if (m_driver_storage) {
-      Kokkos::CudaSpace().deallocate(m_driver_storage, sizeof(base_t));
-    }
-  }
 
   void set_cuda_graph_ptr(cudaGraph_t* arg_graph_ptr) {
     m_graph_ptr = arg_graph_ptr;
@@ -90,13 +86,21 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
   cudaGraphNode_t* get_cuda_graph_node_ptr() const { return m_graph_node_ptr; }
   cudaGraph_t const* get_cuda_graph_ptr() const { return m_graph_ptr; }
 
-  Kokkos::ObservingRawPtr<base_t> allocate_driver_memory_buffer() const {
+  Kokkos::ObservingRawPtr<base_t> allocate_driver_memory_buffer(
+      const CudaSpace& mem) const {
     KOKKOS_EXPECTS(m_driver_storage == nullptr)
-    m_driver_storage = static_cast<base_t*>(Kokkos::CudaSpace().allocate(
-        "GraphNodeKernel global memory functor storage", sizeof(base_t)));
+    std::string alloc_label =
+        label + " - GraphNodeKernel global memory functor storage";
+    m_driver_storage = std::shared_ptr<base_t>(
+        static_cast<base_t*>(mem.allocate(alloc_label.c_str(), sizeof(base_t))),
+        [alloc_label, mem](base_t* ptr) {
+          mem.deallocate(alloc_label.c_str(), ptr, sizeof(base_t));
+        });
     KOKKOS_ENSURES(m_driver_storage != nullptr)
-    return m_driver_storage;
+    return m_driver_storage.get();
   }
+
+  auto get_driver_storage() const { return m_driver_storage; }
 };
 
 struct CudaGraphNodeAggregateKernel {
@@ -128,7 +132,8 @@ struct get_graph_node_kernel_type<KernelType, Kokkos::ParallelReduceTag>
 // <editor-fold desc="get_cuda_graph_*() helper functions"> {{{1
 
 template <class KernelType>
-auto* allocate_driver_storage_for_kernel(KernelType const& kernel) {
+auto* allocate_driver_storage_for_kernel(const CudaSpace& mem,
+                                         KernelType const& kernel) {
   using graph_node_kernel_t =
       typename get_graph_node_kernel_type<KernelType>::type;
   auto const& kernel_as_graph_kernel =
@@ -136,7 +141,7 @@ auto* allocate_driver_storage_for_kernel(KernelType const& kernel) {
   // TODO @graphs we need to somehow indicate the need for a fence in the
   //              destructor of the GraphImpl object (so that we don't have to
   //              just always do it)
-  return kernel_as_graph_kernel.allocate_driver_memory_buffer();
+  return kernel_as_graph_kernel.allocate_driver_memory_buffer(mem);
 }
 
 template <class KernelType>

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -491,7 +491,10 @@ struct CudaParallelLaunchKernelInvoker<
             cuda_instance->m_deviceProp, block_size, shmem, desired_occupancy);
       }
 
-      auto* driver_ptr = Impl::allocate_driver_storage_for_kernel(driver);
+      auto* driver_ptr = Impl::allocate_driver_storage_for_kernel(
+          CudaSpace::impl_create(cuda_instance->m_cudaDev,
+                                 cuda_instance->m_stream),
+          driver);
 
       // Unlike in the non-graph case, we can get away with doing an async copy
       // here because the `DriverType` instance is held in the GraphNodeImpl

--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -44,22 +44,17 @@ class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
 
   // TODO use the name and executionspace
   template <typename PolicyDeduced, typename... ArgsDeduced>
-  GraphNodeKernelImpl(std::string, Kokkos::HIP const&, Functor arg_functor,
+  GraphNodeKernelImpl(std::string label_, HIP const&, Functor arg_functor,
                       PolicyDeduced&& arg_policy, ArgsDeduced&&... args)
       : base_t(std::move(arg_functor), (PolicyDeduced&&)arg_policy,
-               (ArgsDeduced&&)args...) {}
+               (ArgsDeduced&&)args...),
+        label(std::move(label_)) {}
 
   template <typename PolicyDeduced>
   GraphNodeKernelImpl(Kokkos::HIP const& exec_space, Functor arg_functor,
                       PolicyDeduced&& arg_policy)
-      : GraphNodeKernelImpl("", exec_space, std::move(arg_functor),
+      : GraphNodeKernelImpl("[unlabeled]", exec_space, std::move(arg_functor),
                             (PolicyDeduced&&)arg_policy) {}
-
-  ~GraphNodeKernelImpl() {
-    if (m_driver_storage) {
-      Kokkos::HIPSpace().deallocate(m_driver_storage, sizeof(base_t));
-    }
-  }
 
   void set_hip_graph_ptr(hipGraph_t* arg_graph_ptr) {
     m_graph_ptr = arg_graph_ptr;
@@ -73,18 +68,29 @@ class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
 
   hipGraph_t const* get_hip_graph_ptr() const { return m_graph_ptr; }
 
-  Kokkos::ObservingRawPtr<base_t> allocate_driver_memory_buffer() const {
+  Kokkos::ObservingRawPtr<base_t> allocate_driver_memory_buffer(
+      const HIP& exec) const {
     KOKKOS_EXPECTS(m_driver_storage == nullptr);
-    m_driver_storage = static_cast<base_t*>(Kokkos::HIPSpace().allocate(
-        "GraphNodeKernel global memory functor storage", sizeof(base_t)));
+    std::string alloc_label =
+        label + " - GraphNodeKernel global memory functor storage";
+    m_driver_storage = std::shared_ptr<base_t>(
+        static_cast<base_t*>(
+            HIPSpace().allocate(exec, alloc_label.c_str(), sizeof(base_t))),
+        // FIXME_HIP Custom deletor should use same 'exec' as for allocation.
+        [alloc_label](base_t* ptr) {
+          HIPSpace().deallocate(alloc_label.c_str(), ptr, sizeof(base_t));
+        });
     KOKKOS_ENSURES(m_driver_storage != nullptr);
-    return m_driver_storage;
+    return m_driver_storage.get();
   }
+
+  auto get_driver_storage() const { return m_driver_storage; }
 
  private:
   Kokkos::ObservingRawPtr<const hipGraph_t> m_graph_ptr    = nullptr;
   Kokkos::ObservingRawPtr<hipGraphNode_t> m_graph_node_ptr = nullptr;
-  Kokkos::OwningRawPtr<base_t> m_driver_storage            = nullptr;
+  mutable std::shared_ptr<base_t> m_driver_storage         = nullptr;
+  std::string label;
 };
 
 struct HIPGraphNodeAggregateKernel {
@@ -114,13 +120,14 @@ struct get_graph_node_kernel_type<KernelType, Kokkos::ParallelReduceTag>
           Kokkos::ParallelReduceTag>> {};
 
 template <typename KernelType>
-auto* allocate_driver_storage_for_kernel(KernelType const& kernel) {
+auto* allocate_driver_storage_for_kernel(const HIP& exec,
+                                         KernelType const& kernel) {
   using graph_node_kernel_t =
       typename get_graph_node_kernel_type<KernelType>::type;
   auto const& kernel_as_graph_kernel =
       static_cast<graph_node_kernel_t const&>(kernel);
 
-  return kernel_as_graph_kernel.allocate_driver_memory_buffer();
+  return kernel_as_graph_kernel.allocate_driver_memory_buffer(exec);
 }
 
 template <typename KernelType>

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -19,6 +19,8 @@
 
 #include <gtest/gtest.h>
 
+#include <tools/include/ToolTestingUtilities.hpp>
+
 namespace Test {
 
 template <class ExecSpace, class ValueType>
@@ -401,6 +403,111 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), empty_graph) {
   graph.instantiate();
   graph.submit(ex);
   ex.fence();
+}
+
+template <typename ViewType>
+struct ForceGlobalLaunchFunctor {
+ public:
+  static constexpr size_t count =
+#if defined(KOKKOS_ENABLE_CUDA)
+      Kokkos::Impl::CudaTraits::ConstantMemoryUsage +
+#elif defined(KOKKOS_ENABLE_HIP)
+      Kokkos::Impl::HIPTraits::ConstantMemoryUsage +
+#endif
+      1;
+
+  ViewType data;
+
+  ForceGlobalLaunchFunctor(ViewType data_) : data(std::move(data_)) {}
+
+  template <typename T>
+  KOKKOS_FUNCTION void operator()(const T) const {
+    ++data();
+  }
+
+ private:
+  std::byte unused[count] = {};
+};
+
+// Ensure that "global memory launch" path works.
+TEST_F(TEST_CATEGORY_FIXTURE(graph), force_global_launch) {
+#if defined(KOKKOS_ENABLE_CUDA)
+  if constexpr (!std::is_same_v<TEST_EXECSPACE, Kokkos::Cuda>) {
+#elif defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
+  if constexpr (!std::is_same_v<TEST_EXECSPACE, Kokkos::HIP>) {
+#endif
+    GTEST_SKIP() << "This execution space does not support global launch.";
+
+#if defined(KOKKOS_ENABLE_CUDA) || \
+    (defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH))
+  }
+  using value_t   = int;
+  using view_t    = Kokkos::View<value_t, TEST_EXECSPACE,
+                              Kokkos::MemoryTraits<Kokkos::Atomic>>;
+  using functor_t = ForceGlobalLaunchFunctor<view_t>;
+
+  const std::string kernel_name = "Let's make it a huge kernel";
+  const std::string alloc_label =
+      kernel_name + " - GraphNodeKernel global memory functor storage";
+
+  view_t data(Kokkos::view_alloc("witness", ex));
+
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableAllocs());
+
+  std::optional<Kokkos::Experimental::Graph<TEST_EXECSPACE>> graph;
+
+  const void* ptr   = nullptr;
+  uint64_t ptr_size = 0;
+
+  ASSERT_TRUE(validate_existence(
+      [&]() {
+        graph = Kokkos::Experimental::create_graph(ex, [&](const auto& root) {
+          auto node = root.then_parallel_for(
+              kernel_name,
+              Kokkos::Experimental::require(
+                  Kokkos::RangePolicy<TEST_EXECSPACE>(0, functor_t::count),
+                  Kokkos::Experimental::WorkItemProperty::HintHeavyWeight),
+              functor_t(data));
+        });
+      },
+      [&](AllocateDataEvent alloc) {
+        if (alloc.name != alloc_label)
+          return MatchDiagnostic{
+              false, {"Allocation name mismatch (got " + alloc.name + ')'}};
+        if (alloc.size < functor_t::count)
+          return MatchDiagnostic{
+              false,
+              {"Allocation size mismatch (expected at least " +
+               std::to_string(functor_t::count) + " but got " +
+               std::to_string(alloc.size) + ')'}};
+        ptr      = alloc.ptr;
+        ptr_size = alloc.size;
+        return MatchDiagnostic{true};
+      }));
+
+  graph->instantiate();
+
+  // Fencing the default execution space instance, as the node policy
+  // was created without giving an instance (it used the default one).
+  TEST_EXECSPACE{}.fence(
+      "Ensure that kernel dispatch to global memory is finished "
+      "before submission.");
+
+  graph->submit(ex);
+  ASSERT_TRUE(contains(ex, data, functor_t::count));
+
+  ASSERT_TRUE(validate_event_set(
+      [&]() { graph.~optional(); },
+      [&](DeallocateDataEvent dealloc) {
+        if (dealloc.name == alloc_label && dealloc.ptr == ptr &&
+            dealloc.size == ptr_size)
+          return MatchDiagnostic{true};
+        return MatchDiagnostic{
+            false, {"Either the name or pointer or size did not match"}};
+      }));
+
+#endif
 }
 
 template <typename ViewType, size_t TargetIndex, size_t NumIndices = 0>

--- a/core/unit_test/tools/include/ToolTestingUtilities.hpp
+++ b/core/unit_test/tools/include/ToolTestingUtilities.hpp
@@ -972,7 +972,8 @@ static uint64_t last_kernel_id;
 static uint32_t last_section_id;
 
 /** Subscribes to all of the requested callbacks */
-static void set_tool_events_impl(const ToolValidatorConfiguration& config) {
+static inline void set_tool_events_impl(
+    const ToolValidatorConfiguration& config) {
   Kokkos::Tools::Experimental::pause_tools();  // remove all events
   if (config.profiling.kernels) {
     Kokkos::Tools::Experimental::set_begin_parallel_for_callback(


### PR DESCRIPTION
### Summary

This PR fixes `HIP` kernel node global launch.

This fix ensures that the lifetime of nodes is bounded to the graph lifetime, and not determined by how the user manages the created nodes.

### Description

First, I added a test in `TestGraph.cpp` enforces the global launch. Note that I added support for `ImplForceGlobalLaunch` for `Cuda`. This is a drive-by change that I think is valuable but I am fine reverting it if you want to.

Then, a `mutable` was missing for the code to compile.

Then, the test would **not** pass on my `HIP` configuration, and **would pass** on my `Cuda` configuration (I can provide more information if needed).

After investigation (see code below), it is clear that it should also fail for `Cuda`, but probably we're lucky enough that `Cuda` hasn't wiped out the memory of the driver pointer yet (though it has been freed by `Kokkos`).

The issue is that nodes created in the closure given to `create_graph` have a use count of 1. That is, as soon as we exit the closure, they go to zero use count and therefore freeing the underlying driver (that has been copied to the global memory):
https://github.com/kokkos/kokkos/blob/6cc8ceaa2a95856d4b6a36f813e115196a8b7414/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp#L58-L60

Here is an extract of the new test *without* the fix, in which we clearly see that the driver pointer gets deallocated before the fence that follows the `create_graph`:
```bash
KokkosP: Execution of fence 12 is completed.
KokkosP: Allocate<Cuda> name: GraphNodeKernel global memory functor storage pointer: 0x747e4c8bf400 size: 88
KokkosP: Deallocate<Cuda> name: [unlabeled] pointer: 0x747e4c8bf400 size: 88
KokkosP: Executing fence on device 33554433 with unique execution identifier 13
KokkosP:     Ensure that kernel dispatch to global memory is finished before submission.
KokkosP: Execution of fence 13 is completed.
```

### Code sample

This code compiles for `HIP` and `Cuda` (see first lines for command line to use).

It passes on both if we don't manually wipe out the driver pointer memory with a `memset`. This clearly indicates that though the test would work, it is in some sort of undefined behavior / brittle state. Thanks @Rombur for the joint investigation !

<details>

<summary>sample code to play with - too long so be shown</summary>

```c++
/**
 * Simple wrapper script for Cuda and HIP graph.
 *
 * Compiling for Cuda:
 *      /opt/Trilinos/gcc-Cuda/bin/nvcc_wrapper -DENABLE_CUDA -std=c++17 test_CudaOrHipGraph.cpp
 *
 * Compiling for HIP:
 *      hipcc -DENABLE_HIP -std=c++17 test_CudaOrHIPGraph.cpp
 *
 * Profiling for Cuda:
 *      nsys profile --trace=cuda,nvtx --cuda-graph-trace=node:host-and-device a.out
 */
#include <algorithm>
#include <iostream>
#include <ranges>
#include <vector>

#define KOKKOS_FUNCTION __host__ __device__

#if defined(ENABLE_CUDA)
    #define PREFIXED(what) cuda ##what
    #define CHECK_CALL(call) \
        { \
            auto error_code = call; \
            if(error_code != cudaSuccess) { \
                printf("Failure of statement %s: %s\n", #call, cudaGetErrorString(error_code)); \
                std::abort(); \
            } \
        }
    #include <cuda.h>
#elif defined(ENABLE_HIP)
    #define PREFIXED(what) hip ##what
    #define CHECK_CALL(call) if(hipSuccess != call) { printf("Failure of statement %s\n", #call); std::abort(); }
    #include <hip/hip_runtime.h>
#else
    #error "You must enable HIP or Cuda."
#endif

template <typename Functor>
__global__ void driver(const Functor functor) {
    int index = threadIdx.y;
    // printf("- work item %d (%s)\n", index, __PRETTY_FUNCTION__);
    if constexpr (std::is_pointer_v<Functor>) {
        functor->operator()(index);
        printf("%p\n", functor);
    } else {
        functor.operator()(index);
    }
}

template <typename Functor>
auto get_driver() { return driver<Functor>; }

//! Wrapper for a stream.
struct Stream
{
    PREFIXED(Stream_t) stream;

    Stream() {
        CHECK_CALL(PREFIXED(StreamCreateWithFlags)(&stream, PREFIXED(StreamNonBlocking)));
    }

    void fence() const {
        CHECK_CALL(PREFIXED(StreamSynchronize)(stream));
    }
};

//! Wrapper for a view over data.
template <typename T>
struct View
{
    size_t size = 0;
    T* buffer = nullptr;
    bool owning = false;

    View(const Stream& stream, const size_t size_) : size(size_), owning(true)
    {
        printf("> Allocating data of size %zu, memset it to 0.\n", size);
        CHECK_CALL(PREFIXED(MallocAsync)(&buffer,    size * sizeof(T), stream.stream));
        CHECK_CALL(PREFIXED(MemsetAsync)( buffer, 0, size * sizeof(T), stream.stream));
    }

    //! This is the simplest approach. The original view is the only one that owns and frees.
    View(const View& other) : size(other.size), buffer(other.buffer), owning(false) {}

    //! Get a host copy of the buffer.
    auto get_host_copy(const Stream& stream) const
    {
        std::vector<T> host_copy(size);
        CHECK_CALL(PREFIXED(MemcpyAsync)(host_copy.data(), buffer, size * sizeof(T), PREFIXED(MemcpyDeviceToHost), stream.stream));
        return host_copy;
    }

    KOKKOS_FUNCTION
    auto& operator()(const unsigned int index) const { return buffer[index]; }

    ~View()
    {
        if(owning)
        {
            printf("> Deallocating data of size %zu at %p.\n", size, buffer);
            CHECK_CALL(PREFIXED(Free)(buffer));
        }
    }
};

//! Wrapper for a graph.
struct Graph
{
    PREFIXED(Graph_t) graph;

    Graph()
    {
        printf("> Creating a graph.\n");
        CHECK_CALL(PREFIXED(GraphCreate)(&graph, 0));
    }

    ~Graph()
    {
        printf("> Destroying graph at %p.\n", graph);
        CHECK_CALL(PREFIXED(GraphDestroy)(graph));
    }
};

//! Wrapper for an executable graph.
struct GraphExecutable
{
    PREFIXED(GraphExec_t) graph_exec;

    GraphExecutable(const Graph& graph)
    {
        printf("> Instantiating an executable graph.\n");
        CHECK_CALL(PREFIXED(GraphInstantiate)(&graph_exec, graph.graph, nullptr, nullptr, 0));
    }

    ~GraphExecutable()
    {
        printf("> Destroying executable graph at %p.\n", graph_exec);
        CHECK_CALL(PREFIXED(GraphExecDestroy)(graph_exec));
    }

    void submit(const Stream& stream)
    {
        printf("> Submitting executable graph %p on stream %p.\n", graph_exec, stream.stream);
        CHECK_CALL(PREFIXED(GraphLaunch)(graph_exec, stream.stream));
    }
};

//! Wrapper for a graph node.
struct GraphNode
{
    PREFIXED(GraphNode_t) node = nullptr;

    auto transform_to_impl(const std::vector<GraphNode>& ancestors = {})
    {
        std::vector<PREFIXED(GraphNode_t)> ancestors_impl(ancestors.size());

        std::transform(
            ancestors.cbegin(), ancestors.cend(), ancestors_impl.begin(),
            [](const auto& anc) -> PREFIXED(GraphNode_t) { return anc.node; }
        );

        return ancestors_impl;
    }
};

//! Wrapper for a kernel node.
template <typename Functor>
struct GraphNodeKernel : public GraphNode
{
    PREFIXED(KernelNodeParams) params;
    std::vector<void*> inputs;

    GraphNodeKernel(const Functor& functor, const size_t shape)
    {
        printf("> Creating a kernel graph node with functor and size %zu (%s).\n", shape, __PRETTY_FUNCTION__);

        params = {};

        inputs.resize(1);
        inputs[0] = (void*)&functor;

        params.gridDim        = dim3(1,     1, 1);
        params.blockDim       = dim3(1, shape, 1);
        params.sharedMemBytes = 0;
        params.func           = (void * )get_driver<Functor>();
        params.kernelParams   = inputs.data();
        params.extra          = nullptr;
    }

    void add(const Graph& graph, const std::vector<GraphNode>& ancestors = {})
    {
        printf("> Adding graph node %p to graph %p with %zu ancestors.\n", node, graph.graph, ancestors.size());
        const auto ancestors_impl = transform_to_impl(ancestors);
        CHECK_CALL(PREFIXED(GraphAddKernelNode)(
            &node, graph.graph,
            (ancestors_impl.size() > 0 ? ancestors_impl.data() : nullptr), ancestors_impl.size(),
            &params
        ));
    }
};

template <typename view_t>
struct MyFunctor
{
    view_t data;

    KOKKOS_FUNCTION
    void operator()(const unsigned int index) const {
        ++data(index);
    }
};

void test()
{
    using view_t    = View<double>;
    using functor_t = MyFunctor<view_t>;

    constexpr size_t size = 32;

    Stream stream;

    view_t data_lcl_mem(stream, size), data_gbl_mem(stream, size);
    printf("> Data (lcl_mem) buffer address is %p.\n", data_lcl_mem.buffer);
    printf("> Data (gbl_mem) buffer address is %p.\n", data_gbl_mem.buffer);

    stream.fence();

    Graph graph;

    /// We explicitly create the node in a scope, just to see what happens.
    /// We mimic the local memory launch.
    /// Both Cuda and HIP are fine.
    {
        printf("> Adding node in a 'local memory launch' fashion...\n");

        functor_t functor {.data = data_lcl_mem};

        GraphNodeKernel node(functor, size);
        node.add(graph);
    }

    /// We explicitly create the node in a scope, just to see what happens.
    /// We mimic the global memory launch.
    /// We deallocate the driver pointer before running the graph to see what happens.
    {
        printf("> Adding node in a 'global memory launch' fashion...\n");

        functor_t functor {.data = data_gbl_mem};

        functor_t* driver_ptr = nullptr;

        CHECK_CALL(PREFIXED(MallocAsync)(&driver_ptr,           sizeof(functor_t),                               stream.stream));
        CHECK_CALL(PREFIXED(MemcpyAsync)( driver_ptr, &functor, sizeof(functor_t), PREFIXED(MemcpyHostToDevice), stream.stream));

        printf("> The driver pointer has been allocated at %p.\n", driver_ptr);

        GraphNodeKernel node(driver_ptr, size);
        node.add(graph);

        stream.fence();
        CHECK_CALL(PREFIXED(Free)(driver_ptr));

        /// To make sure that we wreck our example, let's manually wipe out memory where our driver pointer was.
        /// To make the test pass, just comment out this line...
        // CHECK_CALL(PREFIXED(Memset(driver_ptr, 0, sizeof(functor_t))));
    }

    GraphExecutable graph_exec(graph);

    graph_exec.submit(stream);

    //! Check data buffers contain ones.
    auto data_lcl_mem_h = data_lcl_mem.get_host_copy(stream);
    auto data_gbl_mem_h = data_gbl_mem.get_host_copy(stream);

    stream.fence();

    #define ASSERT_EQ(a, b) if(a != b) {std::cout << a << " != " << b << std::endl; throw std::runtime_error("The test failed.");}

    std::cout.precision(15);
    std::cout << std::scientific;

    printf("> Check data buffer for 'local memory' case...\n");
    for(const auto& i : data_lcl_mem_h) ASSERT_EQ(i, 1.);
    printf("> Check data buffer for 'global memory' case...\n");
    for(const auto& i : data_gbl_mem_h) ASSERT_EQ(i, 1.);
}

int main()
{
    test();
}
```

</details>