### PR TITLE
Serial: Kokkos_ENABLE_ATOMICS_BYPASS removes mutex around parallel regions

### DIFF
--- a/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
@@ -44,11 +44,16 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
  public:
   inline void execute() const {
+    // caused a possibly codegen-related slowdown, especially in GCC 9-11
+    // with KOKKOS_ARCH_NATIVE
+    // https://github.com/kokkos/kokkos/issues/7268
+#ifndef KOKKOS_ENABLE_ATOMICS_BYPASS
     // Make sure kernels are running sequentially even when using multiple
     // threads
     auto* internal_instance =
         m_iter.m_rp.space().impl_internal_space_instance();
     std::lock_guard<std::mutex> lock(internal_instance->m_instance_mutex);
+#endif
     this->exec();
   }
   template <typename Policy, typename Functor>
@@ -112,10 +117,15 @@ class ParallelReduce<CombinedFunctorReducerType,
     auto* internal_instance =
         m_iter.m_rp.space().impl_internal_space_instance();
 
+    // caused a possibly codegen-related slowdown, especially in GCC 9-11
+    // with KOKKOS_ARCH_NATIVE
+    // https://github.com/kokkos/kokkos/issues/7268
+#ifndef KOKKOS_ENABLE_ATOMICS_BYPASS
     // Make sure kernels are running sequentially even when using multiple
     // threads, lock resize_thread_team_data
     std::lock_guard<std::mutex> instance_lock(
         internal_instance->m_instance_mutex);
+#endif
     internal_instance->resize_thread_team_data(
         pool_reduce_size, team_reduce_size, team_shared_size,
         thread_local_size);

--- a/core/src/Serial/Kokkos_Serial_Parallel_Range.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Range.hpp
@@ -49,10 +49,15 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Serial> {
 
  public:
   inline void execute() const {
+    // caused a possibly codegen-related slowdown, especially in GCC 9-11
+    // with KOKKOS_ARCH_NATIVE
+    // https://github.com/kokkos/kokkos/issues/7268
+#ifndef KOKKOS_ENABLE_ATOMICS_BYPASS
     // Make sure kernels are running sequentially even when using multiple
     // threads
     auto* internal_instance = m_policy.space().impl_internal_space_instance();
     std::lock_guard<std::mutex> lock(internal_instance->m_instance_mutex);
+#endif
     this->template exec<typename Policy::work_tag>();
   }
 
@@ -108,10 +113,15 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
 
     auto* internal_instance = m_policy.space().impl_internal_space_instance();
 
+    // caused a possibly codegen-related slowdown, especially in GCC 9-11
+    // with KOKKOS_ARCH_NATIVE
+    // https://github.com/kokkos/kokkos/issues/7268
+#ifndef KOKKOS_ENABLE_ATOMICS_BYPASS
     // Make sure kernels are running sequentially even when using multiple
     // threads, lock resize_thread_team_data
     std::lock_guard<std::mutex> instance_lock(
         internal_instance->m_instance_mutex);
+#endif
     internal_instance->resize_thread_team_data(
         pool_reduce_size, team_reduce_size, team_shared_size,
         thread_local_size);
@@ -194,10 +204,16 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
     const size_t thread_local_size = 0;  // Never shrinks
 
     auto* internal_instance = m_policy.space().impl_internal_space_instance();
+
+    // caused a possibly codegen-related slowdown, especially in GCC 9-11
+    // with KOKKOS_ARCH_NATIVE
+    // https://github.com/kokkos/kokkos/issues/7268
+#ifndef KOKKOS_ENABLE_ATOMICS_BYPASS
     // Make sure kernels are running sequentially even when using multiple
     // threads, lock resize_thread_team_data
     std::lock_guard<std::mutex> instance_lock(
         internal_instance->m_instance_mutex);
+#endif
 
     internal_instance->resize_thread_team_data(
         pool_reduce_size, team_reduce_size, team_shared_size,
@@ -262,10 +278,16 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
     const size_t thread_local_size = 0;  // Never shrinks
 
     auto* internal_instance = m_policy.space().impl_internal_space_instance();
+
+    // caused a possibly codegen-related slowdown, especially in GCC 9-11
+    // with KOKKOS_ARCH_NATIVE
+    // https://github.com/kokkos/kokkos/issues/7268
+#ifndef KOKKOS_ENABLE_ATOMICS_BYPASS
     // Make sure kernels are running sequentially even when using multiple
     // threads, lock resize_thread_team_data
     std::lock_guard<std::mutex> instance_lock(
         internal_instance->m_instance_mutex);
+#endif
 
     internal_instance->resize_thread_team_data(
         pool_reduce_size, team_reduce_size, team_shared_size,

--- a/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
@@ -247,10 +247,16 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     const size_t thread_local_size = 0;  // Never shrinks
 
     auto* internal_instance = m_policy.space().impl_internal_space_instance();
+
+    // caused a possibly codegen-related slowdown, especially in GCC 9-11
+    // with KOKKOS_ARCH_NATIVE
+    // https://github.com/kokkos/kokkos/issues/7268
+#ifndef KOKKOS_ENABLE_ATOMICS_BYPASS
     // Make sure kernels are running sequentially even when using multiple
     // threads, lock resize_thread_team_data
     std::lock_guard<std::mutex> instance_lock(
         internal_instance->m_instance_mutex);
+#endif
 
     internal_instance->resize_thread_team_data(
         pool_reduce_size, team_reduce_size, team_shared_size,
@@ -321,10 +327,16 @@ class ParallelReduce<CombinedFunctorReducerType,
     const size_t thread_local_size = 0;  // Never shrinks
 
     auto* internal_instance = m_policy.space().impl_internal_space_instance();
+
+    // caused a possibly codegen-related slowdown, especially in GCC 9-11
+    // with KOKKOS_ARCH_NATIVE
+    // https://github.com/kokkos/kokkos/issues/7268
+#ifndef KOKKOS_ENABLE_ATOMICS_BYPASS
     // Make sure kernels are running sequentially even when using multiple
     // threads, lock resize_thread_team_data
     std::lock_guard<std::mutex> instance_lock(
         internal_instance->m_instance_mutex);
+#endif
 
     internal_instance->resize_thread_team_data(
         pool_reduce_size, team_reduce_size, team_shared_size,


### PR DESCRIPTION
This PR causes `Kokkos_ENABLE_ATOMICS_BYPASS` to remove mutexes introduced around parallel regions in the Serial backend. These mutexes were introduced to preserve Kokkos semantics when multiple threads are hitting the Serial backend. This is not needed in the usual case where a single thread is using the Serial backend.

Experiments in https://github.com/kokkos/kokkos/issues/7268 suggest that the mere presence of some memory operations in these locations can mess up codegen (?) and introduce a 20% slowdown.

These "alternatives" for a lock / unlock were tried and found not to fix the regression.

* incrementing / decrementing `volatile char *`
* atomic increment/decrement
* acquire / release atomic fence

Removing the mutex reliably resolves the problem.