### PR TITLE
Fix node memory value in CEA weekly tests

### DIFF
--- a/.github/workflows/weekly-cea.yml
+++ b/.github/workflows/weekly-cea.yml
@@ -19,7 +19,7 @@ jobs:
           - name: cuda-a100
             flags: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
             modules: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
-            queue: gpua100
+            slurm_args: --nodes=1 --time=01:00:00 --mem=80G -p gpua100 --gres=gpu:1
             runner: [self-hosted, cuda]
 
     runs-on: ${{ matrix.backend.runner }}
@@ -47,5 +47,5 @@ jobs:
       - name: Test
         run: |
           module load ${{ matrix.backend.modules }}
-          srun --nodes=1 --time=01:00:00 -p ${{ matrix.backend.queue }} --gres=gpu:1 \
+          srun ${{ matrix.backend.slurm_args }} \
           ctest --test-dir build --output-on-failure


### PR DESCRIPTION
This PR fixes an incomplete configuration for CEA weekly tests, where the amount of memory was left to default on Ruche, and was too low for `*.view_allocation_large_rank` tests to pass.