### PR TITLE
Abort instead of throwing on precondition violation in `OffsetView`

### DIFF
--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -393,7 +393,7 @@ class OffsetView : public View<DataType, Properties...> {
       message +=
           "ends.size() "
           "(" +
-          std::to_string(begins.size()) +
+          std::to_string(ends.size()) +
           ")"
           " != Rank "
           "(" +

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -122,7 +122,7 @@ KOKKOS_INLINE_FUNCTION void offsetview_verify_operator_bounds(
                                             label.c_str());
          offsetview_error_operator_bounds<0>(buffer + n, LEN - n, map, begins,
                                              args...);
-         Kokkos::Impl::throw_runtime_exception(std::string(buffer));))
+         Kokkos::abort(buffer);))
 
     KOKKOS_IF_ON_DEVICE(
         (Kokkos::abort("OffsetView bounds error"); (void)tracker;))
@@ -439,7 +439,7 @@ class OffsetView : public View<DataType, Properties...> {
       message =
           "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView\n" +
           message;
-      Kokkos::Impl::throw_runtime_exception(message);
+      Kokkos::abort(message.c_str());
     }
 
     return subtraction_failure::none;

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -353,7 +353,8 @@ void test_offsetview_unmanaged_construction_death() {
         offset_view_type(&s, {0}, {-1}),
         "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
         ".*"
-        "must be non-negative");
+        "\\(ends\\[0\\] \\(-1\\) - begins\\[0\\] \\(0\\)\\) must be "
+        "non-negative");
   }
 
   {
@@ -365,16 +366,20 @@ void test_offsetview_unmanaged_construction_death() {
         offset_view_type(&s, {-1}, {0x7fffffffffffffffl}),
         "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
         ".*"
+        "\\(ends\\[0\\] \\(9223372036854775807\\) - begins\\[0\\] \\(-1\\)\\) "
         "overflows");
     ASSERT_DEATH(
         offset_view_type(&s, {-0x7fffffffffffffffl - 1}, {0x7fffffffffffffffl}),
         "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
         ".*"
+        "\\(ends\\[0\\] \\(9223372036854775807\\) - begins\\[0\\] "
+        "\\(-9223372036854775808\\)\\) "
         "overflows");
     ASSERT_DEATH(
         offset_view_type(&s, {-0x7fffffffffffffffl - 1}, {0}),
         "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
         ".*"
+        "\\(ends\\[0\\] \\(0\\) - begins\\[0\\] \\(-9223372036854775808\\)\\) "
         "overflows");
   }
 
@@ -385,29 +390,53 @@ void test_offsetview_unmanaged_construction_death() {
     // of OffsetView
     ASSERT_DEATH(
         offset_view_type(&s, {0}, {1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView");
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)"
+        ".*"
+        "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)");
     ASSERT_DEATH(
         offset_view_type(&s, {0}, {1, 1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView");
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)");
     ASSERT_DEATH(
         offset_view_type(&s, {0}, {1, 1, 1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView");
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)"
+        ".*"
+        "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)");
     ASSERT_DEATH(
         offset_view_type(&s, {0, 0}, {1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView");
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)");
     (void)offset_view_type(&s, {0, 0}, {1, 1});
     ASSERT_DEATH(
         offset_view_type(&s, {0, 0}, {1, 1, 1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView");
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)");
     ASSERT_DEATH(
         offset_view_type(&s, {0, 0, 0}, {1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView");
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)"
+        ".*"
+        "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)");
     ASSERT_DEATH(
         offset_view_type(&s, {0, 0, 0}, {1, 1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView");
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)");
     ASSERT_DEATH(
         offset_view_type(&s, {0, 0, 0}, {1, 1, 1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView");
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)"
+        ".*"
+        "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)");
   }
 }
 

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -353,8 +353,7 @@ void test_offsetview_unmanaged_construction_death() {
         offset_view_type(&s, {0}, {-1}),
         "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
         ".*"
-        "\\(ends\\[0\\] \\(-1\\) - begins\\[0\\] \\(0\\)\\) must be "
-        "non-negative");
+        "must be non-negative");
   }
 
   {
@@ -366,20 +365,16 @@ void test_offsetview_unmanaged_construction_death() {
         offset_view_type(&s, {-1}, {0x7fffffffffffffffl}),
         "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
         ".*"
-        "\\(ends\\[0\\] \\(9223372036854775807\\) - begins\\[0\\] \\(-1\\)\\) "
         "overflows");
     ASSERT_DEATH(
         offset_view_type(&s, {-0x7fffffffffffffffl - 1}, {0x7fffffffffffffffl}),
         "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
         ".*"
-        "\\(ends\\[0\\] \\(9223372036854775807\\) - begins\\[0\\] "
-        "\\(-9223372036854775808\\)\\) "
         "overflows");
     ASSERT_DEATH(
         offset_view_type(&s, {-0x7fffffffffffffffl - 1}, {0}),
         "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
         ".*"
-        "\\(ends\\[0\\] \\(0\\) - begins\\[0\\] \\(-9223372036854775808\\)\\) "
         "overflows");
   }
 
@@ -390,53 +385,29 @@ void test_offsetview_unmanaged_construction_death() {
     // of OffsetView
     ASSERT_DEATH(
         offset_view_type(&s, {0}, {1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)"
-        ".*"
-        "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)");
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView");
     ASSERT_DEATH(
         offset_view_type(&s, {0}, {1, 1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)");
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView");
     ASSERT_DEATH(
         offset_view_type(&s, {0}, {1, 1, 1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)"
-        ".*"
-        "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)");
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView");
     ASSERT_DEATH(
         offset_view_type(&s, {0, 0}, {1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)");
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView");
     (void)offset_view_type(&s, {0, 0}, {1, 1});
     ASSERT_DEATH(
         offset_view_type(&s, {0, 0}, {1, 1, 1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)");
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView");
     ASSERT_DEATH(
         offset_view_type(&s, {0, 0, 0}, {1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)"
-        ".*"
-        "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)");
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView");
     ASSERT_DEATH(
         offset_view_type(&s, {0, 0, 0}, {1, 1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)");
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView");
     ASSERT_DEATH(
         offset_view_type(&s, {0, 0, 0}, {1, 1, 1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)"
-        ".*"
-        "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)");
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView");
   }
 }
 

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -336,45 +336,107 @@ void test_offsetview_unmanaged_construction() {
     ASSERT_EQ(bb, ib);
     ASSERT_EQ(bb, ii);
   }
+}
+
+template <typename Scalar, typename Device>
+void test_offsetview_unmanaged_construction_death() {
+  // Preallocated memory (Only need a valid address for this test)
+  Scalar s;
 
   {
     using offset_view_type = Kokkos::Experimental::OffsetView<Scalar*, Device>;
 
     // Range calculations must be positive
-    ASSERT_NO_THROW(offset_view_type(&s, {0}, {1}));
-    ASSERT_NO_THROW(offset_view_type(&s, {0}, {0}));
-    ASSERT_THROW(offset_view_type(&s, {0}, {-1}), std::runtime_error);
+    (void)offset_view_type(&s, {0}, {1});
+    (void)offset_view_type(&s, {0}, {0});
+    ASSERT_DEATH(
+        offset_view_type(&s, {0}, {-1}),
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "\\(ends\\[0\\] \\(-1\\) - begins\\[0\\] \\(0\\)\\) must be "
+        "non-negative");
   }
 
   {
     using offset_view_type = Kokkos::Experimental::OffsetView<Scalar*, Device>;
 
     // Range calculations must not overflow
-    ASSERT_NO_THROW(offset_view_type(&s, {0}, {0x7fffffffffffffffl}));
-    ASSERT_THROW(offset_view_type(&s, {-1}, {0x7fffffffffffffffl}),
-                 std::runtime_error);
-    ASSERT_THROW(
+    (void)offset_view_type(&s, {0}, {0x7fffffffffffffffl});
+    ASSERT_DEATH(
+        offset_view_type(&s, {-1}, {0x7fffffffffffffffl}),
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "\\(ends\\[0\\] \\(9223372036854775807\\) - begins\\[0\\] \\(-1\\)\\) "
+        "overflows");
+    ASSERT_DEATH(
         offset_view_type(&s, {-0x7fffffffffffffffl - 1}, {0x7fffffffffffffffl}),
-        std::runtime_error);
-    ASSERT_THROW(offset_view_type(&s, {-0x7fffffffffffffffl - 1}, {0}),
-                 std::runtime_error);
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "\\(ends\\[0\\] \\(9223372036854775807\\) - begins\\[0\\] "
+        "\\(-9223372036854775808\\)\\) "
+        "overflows");
+    ASSERT_DEATH(
+        offset_view_type(&s, {-0x7fffffffffffffffl - 1}, {0}),
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "\\(ends\\[0\\] \\(0\\) - begins\\[0\\] \\(-9223372036854775808\\)\\) "
+        "overflows");
   }
 
   {
     using offset_view_type = Kokkos::Experimental::OffsetView<Scalar**, Device>;
 
-    // Should throw when the rank of begins and/or ends doesn't match that of
-    // OffsetView
-    ASSERT_THROW(offset_view_type(&s, {0}, {1}), std::runtime_error);
-    ASSERT_THROW(offset_view_type(&s, {0}, {1, 1}), std::runtime_error);
-    ASSERT_THROW(offset_view_type(&s, {0}, {1, 1, 1}), std::runtime_error);
-    ASSERT_THROW(offset_view_type(&s, {0, 0}, {1}), std::runtime_error);
-    ASSERT_NO_THROW(offset_view_type(&s, {0, 0}, {1, 1}));
-    ASSERT_THROW(offset_view_type(&s, {0, 0}, {1, 1, 1}), std::runtime_error);
-    ASSERT_THROW(offset_view_type(&s, {0, 0, 0}, {1}), std::runtime_error);
-    ASSERT_THROW(offset_view_type(&s, {0, 0, 0}, {1, 1}), std::runtime_error);
-    ASSERT_THROW(offset_view_type(&s, {0, 0, 0}, {1, 1, 1}),
-                 std::runtime_error);
+    // Should throw when the rank of begins and/or ends doesn't match that
+    // of OffsetView
+    ASSERT_DEATH(
+        offset_view_type(&s, {0}, {1}),
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)"
+        ".*"
+        "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)");
+    ASSERT_DEATH(
+        offset_view_type(&s, {0}, {1, 1}),
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)");
+    ASSERT_DEATH(
+        offset_view_type(&s, {0}, {1, 1, 1}),
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)"
+        ".*"
+        "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)");
+    ASSERT_DEATH(
+        offset_view_type(&s, {0, 0}, {1}),
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)");
+    (void)offset_view_type(&s, {0, 0}, {1, 1});
+    ASSERT_DEATH(
+        offset_view_type(&s, {0, 0}, {1, 1, 1}),
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)");
+    ASSERT_DEATH(
+        offset_view_type(&s, {0, 0, 0}, {1}),
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)"
+        ".*"
+        "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)");
+    ASSERT_DEATH(
+        offset_view_type(&s, {0, 0, 0}, {1, 1}),
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)");
+    ASSERT_DEATH(
+        offset_view_type(&s, {0, 0, 0}, {1, 1, 1}),
+        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+        ".*"
+        "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)"
+        ".*"
+        "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)");
   }
 }
 
@@ -671,6 +733,11 @@ TEST(TEST_CATEGORY, offsetview_construction) {
 
 TEST(TEST_CATEGORY, offsetview_unmanaged_construction) {
   test_offsetview_unmanaged_construction<int, TEST_EXECSPACE>();
+}
+
+TEST(TEST_CATEGORY_DEATH, offsetview_unmanaged_construction) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  test_offsetview_unmanaged_construction_death<int, TEST_EXECSPACE>();
 }
 
 TEST(TEST_CATEGORY, offsetview_subview) {

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -343,6 +343,14 @@ void test_offsetview_unmanaged_construction_death() {
   // Preallocated memory (Only need a valid address for this test)
   Scalar s;
 
+  // Regular expression syntax on Windows is a pain. `.` does not match `\n`.
+  // Feel free to make it work if you have time to spare.
+#ifdef _WIN32
+#define SKIP_REGEX_ON_WINDOWS(REGEX) ""
+#else
+#define SKIP_REGEX_ON_WINDOWS(REGEX) REGEX
+#endif
+
   {
     using offset_view_type = Kokkos::Experimental::OffsetView<Scalar*, Device>;
 
@@ -351,10 +359,11 @@ void test_offsetview_unmanaged_construction_death() {
     (void)offset_view_type(&s, {0}, {0});
     ASSERT_DEATH(
         offset_view_type(&s, {0}, {-1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "\\(ends\\[0\\] \\(-1\\) - begins\\[0\\] \\(0\\)\\) must be "
-        "non-negative");
+        SKIP_REGEX_ON_WINDOWS(
+            "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+            ".*"
+            "\\(ends\\[0\\] \\(-1\\) - begins\\[0\\] \\(0\\)\\) must be "
+            "non-negative"));
   }
 
   {
@@ -364,23 +373,28 @@ void test_offsetview_unmanaged_construction_death() {
     (void)offset_view_type(&s, {0}, {0x7fffffffffffffffl});
     ASSERT_DEATH(
         offset_view_type(&s, {-1}, {0x7fffffffffffffffl}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "\\(ends\\[0\\] \\(9223372036854775807\\) - begins\\[0\\] \\(-1\\)\\) "
-        "overflows");
+        SKIP_REGEX_ON_WINDOWS(
+            "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+            ".*"
+            "\\(ends\\[0\\] \\(9223372036854775807\\) - begins\\[0\\] "
+            "\\(-1\\)\\) "
+            "overflows"));
     ASSERT_DEATH(
         offset_view_type(&s, {-0x7fffffffffffffffl - 1}, {0x7fffffffffffffffl}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "\\(ends\\[0\\] \\(9223372036854775807\\) - begins\\[0\\] "
-        "\\(-9223372036854775808\\)\\) "
-        "overflows");
+        SKIP_REGEX_ON_WINDOWS(
+            "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+            ".*"
+            "\\(ends\\[0\\] \\(9223372036854775807\\) - begins\\[0\\] "
+            "\\(-9223372036854775808\\)\\) "
+            "overflows"));
     ASSERT_DEATH(
         offset_view_type(&s, {-0x7fffffffffffffffl - 1}, {0}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "\\(ends\\[0\\] \\(0\\) - begins\\[0\\] \\(-9223372036854775808\\)\\) "
-        "overflows");
+        SKIP_REGEX_ON_WINDOWS(
+            "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+            ".*"
+            "\\(ends\\[0\\] \\(0\\) - begins\\[0\\] "
+            "\\(-9223372036854775808\\)\\) "
+            "overflows"));
   }
 
   {
@@ -390,54 +404,63 @@ void test_offsetview_unmanaged_construction_death() {
     // of OffsetView
     ASSERT_DEATH(
         offset_view_type(&s, {0}, {1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)"
-        ".*"
-        "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)");
+        SKIP_REGEX_ON_WINDOWS(
+            "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+            ".*"
+            "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)"
+            ".*"
+            "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
         offset_view_type(&s, {0}, {1, 1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)");
+        SKIP_REGEX_ON_WINDOWS(
+            "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+            ".*"
+            "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
         offset_view_type(&s, {0}, {1, 1, 1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)"
-        ".*"
-        "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)");
+        SKIP_REGEX_ON_WINDOWS(
+            "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+            ".*"
+            "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)"
+            ".*"
+            "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
         offset_view_type(&s, {0, 0}, {1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)");
+        SKIP_REGEX_ON_WINDOWS(
+            "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+            ".*"
+            "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)"));
     (void)offset_view_type(&s, {0, 0}, {1, 1});
     ASSERT_DEATH(
         offset_view_type(&s, {0, 0}, {1, 1, 1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)");
+        SKIP_REGEX_ON_WINDOWS(
+            "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+            ".*"
+            "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
         offset_view_type(&s, {0, 0, 0}, {1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)"
-        ".*"
-        "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)");
+        SKIP_REGEX_ON_WINDOWS(
+            "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+            ".*"
+            "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)"
+            ".*"
+            "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
         offset_view_type(&s, {0, 0, 0}, {1, 1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)");
+        SKIP_REGEX_ON_WINDOWS(
+            "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+            ".*"
+            "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
         offset_view_type(&s, {0, 0, 0}, {1, 1, 1}),
-        "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
-        ".*"
-        "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)"
-        ".*"
-        "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)");
+        SKIP_REGEX_ON_WINDOWS(
+            "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
+            ".*"
+            "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)"
+            ".*"
+            "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)"));
   }
+#undef SKIP_REGEX_ON_WINDOWS
 }
 
 template <typename Scalar, typename Device>


### PR DESCRIPTION
Working towards #7037 
Affects error reporting on invalid number of begin/end arguments on unmanaged OffsetView constructor and on out of bounds accesses.
The regexes are painful but they did catch a misprint in the error.  Let me know if you want to simplify or even ignore the messages.