### PR TITLE
hip(graph): introduce `IMPL` macro to detect if there is a valid native support of `hipGraph_t`

### DIFF
--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -25,11 +25,7 @@
 #include <HIP/Kokkos_HIP_Instance.hpp>
 #include <HIP/Kokkos_HIP_Space.hpp>
 
-#if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 2))
-#define KOKKOS_IMPL_HIP_GRAPH_ENABLED
-#endif
-
-#ifdef KOKKOS_IMPL_HIP_GRAPH_ENABLED
+#ifdef KOKKOS_IMPL_HIP_NATIVE_GRAPH
 #include <HIP/Kokkos_HIP_GraphNodeKernel.hpp>
 #include <impl/Kokkos_GraphImpl_fwd.hpp>
 #endif
@@ -384,7 +380,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
         driver);
   }
 
-#ifdef KOKKOS_IMPL_HIP_GRAPH_ENABLED
+#ifdef KOKKOS_IMPL_HIP_NATIVE_GRAPH
   static void create_parallel_launch_graph_node(
       DriverType const &driver, dim3 const &grid, dim3 const &block, int shmem,
       HIPInternal const * /*hip_instance*/) {
@@ -442,7 +438,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
         driver_ptr);
   }
 
-#ifdef KOKKOS_IMPL_HIP_GRAPH_ENABLED
+#ifdef KOKKOS_IMPL_HIP_NATIVE_GRAPH
   static void create_parallel_launch_graph_node(
       DriverType const &driver, dim3 const &grid, dim3 const &block, int shmem,
       HIPInternal const *hip_instance) {
@@ -585,7 +581,7 @@ void hip_parallel_launch(const DriverType &driver, const dim3 &grid,
                          const dim3 &block, const int shmem,
                          const HIPInternal *hip_instance,
                          const bool prefer_shmem) {
-#ifdef KOKKOS_IMPL_HIP_GRAPH_ENABLED
+#ifdef KOKKOS_IMPL_HIP_NATIVE_GRAPH
   if constexpr (DoGraph) {
     // Graph launch
     using base_t = HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
@@ -627,8 +623,6 @@ void hip_parallel_launch(const DriverType &driver, const dim3 &grid,
 }
 }  // namespace Impl
 }  // namespace Kokkos
-
-#undef KOKKOS_IMPL_HIP_GRAPH_ENABLED
 
 #endif
 

--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -180,7 +180,7 @@ create_graph(Closure&& arg_closure) {
 #include <Cuda/Kokkos_Cuda_Graph_Impl.hpp>
 #if defined(KOKKOS_ENABLE_HIP)
 // The implementation of hipGraph in ROCm 5.2 is bugged, so we cannot use it.
-#if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 2))
+#if defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
 #include <HIP/Kokkos_HIP_Graph_Impl.hpp>
 #endif
 #endif

--- a/core/src/setup/Kokkos_Setup_HIP.hpp
+++ b/core/src/setup/Kokkos_Setup_HIP.hpp
@@ -43,6 +43,11 @@
 #endif
 // clang-format on
 
+// The implementation of hipGraph in ROCm 5.2 is bugged, so we cannot use it.
+#if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 2))
+#define KOKKOS_IMPL_HIP_NATIVE_GRAPH
+#endif
+
 #endif  // #if defined( KOKKOS_ENABLE_HIP )
 
 #endif


### PR DESCRIPTION
This PR brings the `KOKKOS_IMPL_HIP_NATIVE_GRAPH` to `Kokkos_Setup_HIP.hpp` to enable many files to reuse this macro. It is used to check if the `hipGraph_t` implementation from `HIP` works (valid) or is bugged (invalid).

This is needed in both:
- #6904
- #7365