### PR TITLE
Use a kernel to zero memory on mi300a

### DIFF
--- a/Makefile.targets
+++ b/Makefile.targets
@@ -73,6 +73,8 @@ Kokkos_HIP_Space.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/HIP/Kokkos_HIP
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/HIP/Kokkos_HIP_Space.cpp
 Kokkos_HIP_Instance.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/HIP/Kokkos_HIP_Instance.cpp
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/HIP/Kokkos_HIP_Instance.cpp
+Kokkos_HIP_ZeroMemset.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/HIP/Kokkos_HIP_ZeroMemset.cpp
+	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/HIP/Kokkos_HIP_ZeroMemset.cpp
 Lock_Array_HIP.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/tpls/desul/src/Lock_Array_HIP.cpp
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/tpls/desul/src/Lock_Array_HIP.cpp
 endif

--- a/core/src/HIP/Kokkos_HIP_ZeroMemset.cpp
+++ b/core/src/HIP/Kokkos_HIP_ZeroMemset.cpp
@@ -27,7 +27,7 @@ namespace Impl {
 // alternative to hipMemsetAsync, which sets the first `cnt` bytes of `dst` to 0
 void zero_with_hip_kernel(const HIP& exec_space, void* dst, size_t cnt) {
   Kokkos::parallel_for(
-      "zero_with_hip_kernel",
+      "Kokkos::ZeroMemset via parallel_for",
       Kokkos::RangePolicy<Kokkos::HIP>(exec_space, 0, cnt),
       KOKKOS_LAMBDA(size_t i) { static_cast<char*>(dst)[i] = 0; });
 }

--- a/core/src/HIP/Kokkos_HIP_ZeroMemset.cpp
+++ b/core/src/HIP/Kokkos_HIP_ZeroMemset.cpp
@@ -1,0 +1,36 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+#define KOKKOS_IMPL_PUBLIC_INCLUDE
+#endif
+
+#include <HIP/Kokkos_HIP_ZeroMemset.hpp>
+#include <HIP/Kokkos_HIP_ParallelFor_Range.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+// alternative to hipMemsetAsync, which sets the first `cnt` bytes of `dst` to 0
+void zero_with_hip_kernel(const HIP& exec_space, void* dst, size_t cnt) {
+  Kokkos::parallel_for(
+      "zero_with_hip_kernel",
+      Kokkos::RangePolicy<Kokkos::HIP>(exec_space, 0, cnt),
+      KOKKOS_LAMBDA(size_t i) { static_cast<char*>(dst)[i] = 0; });
+}
+
+}  // namespace Impl
+}  // namespace Kokkos

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -733,8 +733,8 @@ if(Kokkos_ENABLE_CUDA)
 endif()
 
 if(Kokkos_ENABLE_HIP)
-  if (Kokkos_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
-    SET(HIP_UNIFIED_MEMORY_SOURCES hip/TestHIP_UnifiedMemory_ZeroMemset.cpp)
+  if(Kokkos_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
+    set(HIP_UNIFIED_MEMORY_SOURCES hip/TestHIP_UnifiedMemory_ZeroMemset.cpp)
   endif()
   kokkos_add_executable_and_test(
     CoreUnitTest_HIP

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -733,6 +733,9 @@ if(Kokkos_ENABLE_CUDA)
 endif()
 
 if(Kokkos_ENABLE_HIP)
+  if (Kokkos_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
+    SET(HIP_UNIFIED_MEMORY_SOURCES hip/TestHIP_UnifiedMemory_ZeroMemset.cpp)
+  endif()
   kokkos_add_executable_and_test(
     CoreUnitTest_HIP
     SOURCES
@@ -744,6 +747,7 @@ if(Kokkos_ENABLE_HIP)
     hip/TestHIP_TeamScratchStreams.cpp
     hip/TestHIP_AsyncLauncher.cpp
     hip/TestHIP_BlocksizeDeduction.cpp
+    ${HIP_UNIFIED_MEMORY_SOURCES}
   )
   kokkos_add_executable_and_test(CoreUnitTest_HIPInterOpInit SOURCES UnitTestMain.cpp hip/TestHIP_InterOp_Init.cpp)
   kokkos_add_executable_and_test(

--- a/core/unit_test/hip/TestHIP_UnifiedMemory_ZeroMemset.cpp
+++ b/core/unit_test/hip/TestHIP_UnifiedMemory_ZeroMemset.cpp
@@ -28,14 +28,10 @@ TEST(hip, unified_memory_zero_memset) {
 #endif
 
   constexpr size_t N = 1024 * 1024;  // size doesn't matter
-  int* ptr           = new int[N];
-  Kokkos::View<int*, Kokkos::HIPSpace> a(ptr, N);
+  std::vector<int> v(N, 1);          // initialize to non-zero
+  Kokkos::View<int*, Kokkos::HIPSpace> a(v.data(), N);
 
-  // initialize a to something non-zero
-  Kokkos::parallel_for(
-      N, KOKKOS_LAMBDA(int i) { a[i] = 1; });
-
-  // try the deep copy (this is where the error actually occured)
+  // zero with deep_copy (this is where the error occurs)
   Kokkos::deep_copy(a, 0);
 
   // see if it was zeroed

--- a/core/unit_test/hip/TestHIP_UnifiedMemory_ZeroMemset.cpp
+++ b/core/unit_test/hip/TestHIP_UnifiedMemory_ZeroMemset.cpp
@@ -1,0 +1,47 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <TestHIP_Category.hpp>
+#include <Kokkos_Core.hpp>
+
+namespace Test {
+
+// On MI300a with ROCM <= 6.2.0, hipMemsetAsync was failing with an error when
+// called on host-allocated buffers. The fix was in PR 7380 to use a
+// parallel_for to zero memory
+TEST(hip, unified_memory_zero_memset) {
+#if !defined(KOKKOS_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
+#error this test should only be run with HIP unified memory enabled
+#endif
+
+  constexpr size_t N = 1024 * 1024;  // size doesn't matter
+  int* ptr           = new int[N];
+  Kokkos::View<int*, Kokkos::HIPSpace> a(ptr, N);
+
+  // initialize a to something non-zero
+  Kokkos::parallel_for(
+      N, KOKKOS_LAMBDA(int i) { a[i] = 1; });
+
+  // try the deep copy (this is where the error actually occured)
+  Kokkos::deep_copy(a, 0);
+
+  // see if it was zeroed
+  int err;
+  Kokkos::parallel_reduce(
+      N, KOKKOS_LAMBDA(int i, int& lerr) { lerr += (a[i] != 0); }, err);
+  EXPECT_EQ(err, 0);
+}
+}  // namespace Test


### PR DESCRIPTION
Use a `parallel_for` to implement an alternative to `hipMemsetAsync` for MI300a, since `hipMemsetAsync` doesn't work for host-allocated pointers in ROCm <= 6.2.0 (and possibly later versions).

Potential fix for https://github.com/kokkos/kokkos/issues/7377

