### PR TITLE
View-Refactor: BasicView

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -22,6 +22,10 @@ static_assert(false,
 #ifndef KOKKOS_VIEW_HPP
 #define KOKKOS_VIEW_HPP
 
+#ifdef KOKKOS_ENABLE_IMPL_MDSPAN
+#include <View/Kokkos_BasicView.hpp>
+#endif
+
 #include <View/Kokkos_ViewLegacy.hpp>
 
 #endif /* KOKKOS_VIEW_HPP */

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -348,8 +348,8 @@ class BasicView {
         arg_mapping.required_span_size(),
         Impl::get_property<Impl::LabelTag>(prop_copy),
         Impl::get_property<Impl::MemorySpaceTag>(prop_copy),
-        has_exec ? std::optional{Impl::get_property<Impl::ExecutionSpaceTag>(
-                       prop_copy)}
+        has_exec ? std::optional<execution_space>{Impl::get_property<
+                       Impl::ExecutionSpaceTag>(prop_copy)}
                  : std::optional<execution_space>{std::nullopt},
         std::integral_constant<bool, alloc_prop::initialize>(),
         std::integral_constant<bool, alloc_prop::sequential_host_init>()));

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -1,0 +1,623 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+static_assert(false,
+              "Including non-public Kokkos header files is not allowed.");
+#endif
+
+#ifndef KOKKOS_BASIC_VIEW_HPP
+#define KOKKOS_BASIC_VIEW_HPP
+#include <type_traits>
+#include <Kokkos_Macros.hpp>
+#include <impl/Kokkos_Utilities.hpp>
+#include <impl/Kokkos_SharedAlloc.hpp>
+#include <View/Kokkos_ViewAlloc.hpp>
+#include <View/Kokkos_ViewCtor.hpp>
+#include <View/Kokkos_ViewTraits.hpp>
+#include <View/MDSpan/Kokkos_MDSpan_Header.hpp>
+#include <View/MDSpan/Kokkos_MDSpan_Accessor.hpp>
+#include <View/MDSpan/Kokkos_MDSpan_Layout.hpp>
+#include <optional>
+
+#define KOKKOS_IMPL_NO_UNIQUE_ADDRESS _MDSPAN_NO_UNIQUE_ADDRESS
+namespace Kokkos {
+
+namespace Impl {
+constexpr inline struct subview_ctor_tag_t {
+} subview_ctor_tag;
+
+template <class T>
+struct KokkosSliceToMDSpanSliceImpl {
+  using type = T;
+  KOKKOS_FUNCTION
+  static constexpr decltype(auto) transform(const T &s) { return s; }
+};
+
+template <>
+struct KokkosSliceToMDSpanSliceImpl<Kokkos::ALL_t> {
+  using type = full_extent_t;
+  KOKKOS_FUNCTION
+  static constexpr decltype(auto) transform(Kokkos::ALL_t) {
+    return full_extent;
+  }
+};
+
+template <class T>
+using kokkos_slice_to_mdspan_slice =
+    typename KokkosSliceToMDSpanSliceImpl<T>::type;
+
+template <class T>
+KOKKOS_INLINE_FUNCTION constexpr decltype(auto)
+transform_kokkos_slice_to_mdspan_slice(const T &s) {
+  return KokkosSliceToMDSpanSliceImpl<T>::transform(s);
+}
+
+// We do have implementation detail versions of these in our mdspan impl
+// However they are not part of the public standard interface
+template <class T>
+struct is_layout_right_padded : public std::false_type {};
+
+template <size_t Pad>
+struct is_layout_right_padded<Kokkos::Experimental::layout_right_padded<Pad>>
+    : public std::true_type {};
+
+template <class T>
+struct is_layout_left_padded : public std::false_type {};
+
+template <size_t Pad>
+struct is_layout_left_padded<Kokkos::Experimental::layout_left_padded<Pad>>
+    : public std::true_type {};
+
+}  // namespace Impl
+
+template <class ElementType, class Extents, class LayoutPolicy,
+          class AccessorPolicy>
+class BasicView {
+ public:
+  using mdspan_type =
+      mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>;
+  using extents_type     = typename mdspan_type::extents_type;
+  using layout_type      = typename mdspan_type::layout_type;
+  using accessor_type    = typename mdspan_type::accessor_type;
+  using mapping_type     = typename mdspan_type::mapping_type;
+  using element_type     = typename mdspan_type::element_type;
+  using value_type       = typename mdspan_type::value_type;
+  using index_type       = typename mdspan_type::index_type;
+  using size_type        = typename mdspan_type::size_type;
+  using rank_type        = typename mdspan_type::rank_type;
+  using data_handle_type = typename mdspan_type::data_handle_type;
+  using reference        = typename mdspan_type::reference;
+  using memory_space     = typename accessor_type::memory_space;
+  using execution_space  = typename memory_space::execution_space;
+
+  // For now View and BasicView will have a restriction that the data handle
+  // needs to be convertible to element_type* and vice versa
+  static_assert(std::is_constructible_v<element_type *, data_handle_type>);
+  static_assert(std::is_constructible_v<data_handle_type, element_type *>);
+
+  KOKKOS_FUNCTION static constexpr rank_type rank() noexcept {
+    return extents_type::rank();
+  }
+  KOKKOS_FUNCTION static constexpr rank_type rank_dynamic() noexcept {
+    return extents_type::rank_dynamic();
+  }
+  KOKKOS_FUNCTION static constexpr size_t static_extent(rank_type r) noexcept {
+    return extents_type::static_extent(r);
+  }
+  KOKKOS_FUNCTION constexpr index_type extent(rank_type r) const noexcept {
+    return map.extents().extent(r);
+  };
+
+ protected:
+  // These are pre-condition checks which are unconditionally (i.e. in release
+  // mode) enabled in Kokkos::View 4.4
+  template <class OtherMapping>
+  KOKKOS_FUNCTION static constexpr void check_basic_view_constructibility(
+      const OtherMapping &rhs) {
+    using src_t          = typename OtherMapping::layout_type;
+    using dst_t          = layout_type;
+    constexpr size_t rnk = mdspan_type::rank();
+    if constexpr (!std::is_same_v<src_t, dst_t>) {
+      if constexpr (Impl::is_layout_left_padded<dst_t>::value) {
+        if constexpr (std::is_same_v<src_t, layout_stride>) {
+          index_type stride = 1;
+          for (size_t r = 0; r < rnk; r++) {
+            if (rhs.stride(r) != stride)
+              Kokkos::abort("View assignment must have compatible layouts");
+            if constexpr (rnk > 1)
+              stride *= (r == 0 ? rhs.stride(1) : rhs.extents().extent(r));
+          }
+        }
+      }
+      if constexpr (Impl::is_layout_right_padded<dst_t>::value) {
+        if constexpr (std::is_same_v<src_t, layout_stride>) {
+          index_type stride = 1;
+          if constexpr (rnk > 0) {
+            for (size_t r = rnk; r > 0; r--) {
+              if (rhs.stride(r - 1) != stride)
+                Kokkos::abort("View assignment must have compatible layouts");
+              if constexpr (rnk > 1)
+                stride *= (r == rnk ? rhs.stride(r - 2)
+                                    : rhs.extents().extent(r - 1));
+            }
+          }
+        }
+      }
+      if constexpr (std::is_same_v<dst_t, layout_left>) {
+        if constexpr (std::is_same_v<src_t, layout_stride>) {
+          index_type stride = 1;
+          for (size_t r = 0; r < rnk; r++) {
+            if (rhs.stride(r) != stride)
+              Kokkos::abort("View assignment must have compatible layouts");
+            stride *= rhs.extents().extent(r);
+          }
+        } else if constexpr (Impl::is_layout_left_padded<src_t>::value &&
+                             rnk > 1) {
+          if (rhs.stride(1) != rhs.extents().extent(0))
+            Kokkos::abort("View assignment must have compatible layouts");
+        }
+      }
+      if constexpr (std::is_same_v<dst_t, layout_right>) {
+        if constexpr (std::is_same_v<src_t, layout_stride>) {
+          index_type stride = 1;
+          if constexpr (rnk > 0) {
+            for (size_t r = rnk; r > 0; r--) {
+              if (rhs.stride(r - 1) != stride)
+                Kokkos::abort("View assignment must have compatible layouts");
+              stride *= rhs.extents().extent(r - 1);
+            }
+          }
+        } else if constexpr (Impl::is_layout_right_padded<src_t>::value &&
+                             rnk > 1) {
+          if (rhs.stride(rnk - 2) != rhs.extents().extent(rnk - 1))
+            Kokkos::abort("View assignment must have compatible layouts");
+        }
+      }
+    }
+  }
+
+ public:
+  KOKKOS_DEFAULTED_FUNCTION constexpr BasicView() = default;
+
+  KOKKOS_FUNCTION constexpr BasicView(const mdspan_type &other)
+      : ptr(other.data_handle()), map(other.mapping()), acc(other.accessor()){};
+  KOKKOS_FUNCTION constexpr BasicView(mdspan_type &&other)
+      : ptr(std::move(other.data_handle())),
+        map(std::move(other.mapping())),
+        acc(std::move(other.accessor())){};
+
+  template <class... OtherIndexTypes>
+  //    requires(std::is_constructible_v<mdspan_type, data_handle_type,
+  //                                     OtherIndexTypes...>)
+  KOKKOS_FUNCTION explicit constexpr BasicView(
+      std::enable_if_t<std::is_constructible_v<mdspan_type, data_handle_type,
+                                               OtherIndexTypes...>,
+                       data_handle_type>
+          p,
+      OtherIndexTypes... exts)
+      : ptr(std::move(p)),
+        map(extents_type(static_cast<index_type>(std::move(exts))...)),
+        acc{} {}
+
+  template <class OtherIndexType, size_t Size>
+  // When doing C++20 we should switch to this, the conditional explicit we
+  // can't do in 17
+  //    requires(std::is_constructible_v<mdspan_type, data_handle_type,
+  //                                     std::array<OtherIndexType, Size>>)
+  //  explicit(Size != rank_dynamic())
+  KOKKOS_FUNCTION constexpr BasicView(
+      std::enable_if_t<
+          std::is_constructible_v<mdspan_type, data_handle_type,
+                                  std::array<OtherIndexType, Size>>,
+          data_handle_type>
+          p,
+      const Array<OtherIndexType, Size> &exts)
+      : ptr(std::move(p)), map(extents_type(exts)), acc{} {}
+
+  KOKKOS_FUNCTION constexpr BasicView(data_handle_type p,
+                                      const extents_type &exts)
+// Compilation will simply fail in C++17 and overload set should not be an issue
+#ifndef KOKKOS_ENABLE_CXX17
+    requires(std::is_default_constructible_v<accessor_type> &&
+             std::is_constructible_v<mapping_type, const extents_type &>)
+#endif
+      : ptr(std::move(p)), map(exts), acc{} {
+  }
+
+  KOKKOS_FUNCTION constexpr BasicView(data_handle_type p, const mapping_type &m)
+// Compilation will simply fail in C++17 and overload set should not be an issue
+#ifndef KOKKOS_ENABLE_CXX17
+    requires(std::is_default_constructible_v<accessor_type>)
+#endif
+      : ptr(std::move(p)), map(m), acc{} {
+  }
+
+  KOKKOS_FUNCTION constexpr BasicView(data_handle_type p, const mapping_type &m,
+                                      const accessor_type &a)
+      : ptr(std::move(p)), map(m), acc(a) {}
+
+  template <class OtherT, class OtherE, class OtherL, class OtherA>
+//    requires(std::is_constructible_v<mdspan_type,
+//                                     typename BasicView<OtherT, OtherE,
+//                                     OtherL,
+//                                                        OtherA>::mdspan_type>)
+#ifndef KOKKOS_ENABLE_CXX17
+  explicit(
+      !std::is_convertible_v<const typename OtherL::template mapping<OtherE> &,
+                             mapping_type> ||
+      !std::is_convertible_v<const OtherA &, accessor_type>)
+#endif
+      KOKKOS_INLINE_FUNCTION
+      BasicView(const BasicView<OtherT, OtherE, OtherL, OtherA> &other,
+                std::enable_if_t<
+                    std::is_constructible_v<
+                        mdspan_type, typename BasicView<OtherT, OtherE, OtherL,
+                                                        OtherA>::mdspan_type>,
+                    void *> = nullptr)
+      : ptr(other.ptr), map(other.map), acc(other.acc) {
+    // Kokkos View precondition checks happen in release builds
+    check_basic_view_constructibility(other.mapping());
+
+    static_assert(
+        std::is_constructible_v<data_handle_type,
+                                const typename OtherA::data_handle_type &>,
+        "Kokkos::View: incompatible data_handle_type for View construction");
+    static_assert(std::is_constructible_v<extents_type, OtherE>,
+                  "Kokkos::View: incompatible extents for View construction");
+  }
+
+  template <class OtherT, class OtherE, class OtherL, class OtherA>
+//    requires(std::is_constructible_v<mdspan_type,
+//                                     mdspan<OtherT, OtherE, OtherL, OtherA>>)
+#ifndef KOKKOS_ENABLE_CXX17
+  explicit(
+      !std::is_convertible_v<const typename OtherL::template mapping<OtherE> &,
+                             mapping_type> ||
+      !std::is_convertible_v<const OtherA &, accessor_type>)
+#endif
+      KOKKOS_INLINE_FUNCTION
+      BasicView(const mdspan<OtherT, OtherE, OtherL, OtherA> &other,
+                std::enable_if_t<
+                    std::is_constructible_v<
+                        mdspan_type, mdspan<OtherT, OtherE, OtherL, OtherA>>,
+                    void *> = nullptr)
+      : ptr(other.data_handle()), map(other.mapping()), acc(other.accessor()) {
+    // Kokkos View precondition checks happen in release builds
+    check_basic_view_constructibility(other.mapping());
+
+    static_assert(
+        std::is_constructible_v<data_handle_type,
+                                const typename OtherA::data_handle_type &>,
+        "Kokkos::View: incompatible data_handle_type for View construction");
+    static_assert(std::is_constructible_v<extents_type, OtherE>,
+                  "Kokkos::View: incompatible extents for View construction");
+  }
+
+  // Allocating constructors specific to BasicView
+  ///
+  /// Construct from a given mapping
+  ///
+  explicit constexpr BasicView(const std::string &label,
+                               const mapping_type &mapping)
+      : BasicView(view_alloc(label), mapping) {}
+
+  ///
+  /// Construct from a given extents
+  ///
+  explicit constexpr BasicView(const std::string &label,
+                               const extents_type &ext)
+      : BasicView(view_alloc(label), mapping_type{ext}) {}
+
+ private:
+  template <class... P>
+  data_handle_type create_data_handle(
+      const Impl::ViewCtorProp<P...> &arg_prop,
+      const typename mdspan_type::mapping_type &arg_mapping) {
+    constexpr bool has_exec = Impl::ViewCtorProp<P...>::has_execution_space;
+    // Copy the input allocation properties with possibly defaulted properties
+    // We need to split it in two to avoid MSVC compiler errors
+    auto prop_copy_tmp =
+        Impl::with_properties_if_unset(arg_prop, std::string{});
+    auto prop_copy = Impl::with_properties_if_unset(
+        prop_copy_tmp, memory_space{}, execution_space{});
+    using alloc_prop = decltype(prop_copy);
+
+    if (alloc_prop::initialize &&
+        !alloc_prop::execution_space::impl_is_initialized()) {
+      // If initializing view data then
+      // the execution space must be initialized.
+      Kokkos::Impl::throw_runtime_exception(
+          "Constructing View and initializing data with uninitialized "
+          "execution space");
+    }
+    return data_handle_type(Impl::make_shared_allocation_record<ElementType>(
+        arg_mapping.required_span_size(),
+        Impl::get_property<Impl::LabelTag>(prop_copy),
+        Impl::get_property<Impl::MemorySpaceTag>(prop_copy),
+        has_exec ? std::optional{Impl::get_property<Impl::ExecutionSpaceTag>(
+                       prop_copy)}
+                 : std::optional<execution_space>{std::nullopt},
+        std::integral_constant<bool, alloc_prop::initialize>(),
+        std::integral_constant<bool, alloc_prop::sequential_host_init>()));
+  }
+
+ public:
+  template <class... P>
+  // requires(!Impl::ViewCtorProp<P...>::has_pointer)
+  explicit inline BasicView(
+      const Impl::ViewCtorProp<P...> &arg_prop,
+      std::enable_if_t<!Impl::ViewCtorProp<P...>::has_pointer,
+                       typename mdspan_type::mapping_type> const &arg_mapping)
+      : BasicView(create_data_handle(arg_prop, arg_mapping), arg_mapping) {}
+
+  template <class... P>
+  // requires(Impl::ViewCtorProp<P...>::has_pointer)
+  KOKKOS_FUNCTION explicit inline BasicView(
+      const Impl::ViewCtorProp<P...> &arg_prop,
+      std::enable_if_t<Impl::ViewCtorProp<P...>::has_pointer,
+                       typename mdspan_type::mapping_type> const &arg_mapping)
+      : BasicView(
+            data_handle_type(Impl::get_property<Impl::PointerTag>(arg_prop)),
+            arg_mapping) {}
+
+ protected:
+  template <class OtherElementType, class OtherExtents, class OtherLayoutPolicy,
+            class OtherAccessorPolicy, class... SliceSpecifiers>
+  KOKKOS_INLINE_FUNCTION BasicView(
+      Impl::subview_ctor_tag_t,
+      const BasicView<OtherElementType, OtherExtents, OtherLayoutPolicy,
+                      OtherAccessorPolicy> &src_view,
+      SliceSpecifiers... slices)
+      : BasicView(submdspan(
+            src_view.to_mdspan(),
+            Impl::transform_kokkos_slice_to_mdspan_slice(slices)...)) {}
+
+ public:
+  //----------------------------------------
+  // Conversion to MDSpan
+  template <class OtherElementType, class OtherExtents, class OtherLayoutPolicy,
+            class OtherAccessor,
+            typename = std::enable_if_t<
+                std::is_assignable_v<mdspan<OtherElementType, OtherExtents,
+                                            OtherLayoutPolicy, OtherAccessor>,
+                                     mdspan_type>>>
+  KOKKOS_INLINE_FUNCTION constexpr
+  operator mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy,
+                  OtherAccessor>() const {
+    return mdspan_type(ptr, map, acc);
+  }
+
+  // Here we use an overload instead of a default parameter as a workaround
+  // to a potential compiler bug with clang 17. It may be present in other
+  // compilers
+  template <class OtherAccessorType = AccessorPolicy,
+            typename                = std::enable_if_t<std::is_constructible_v<
+                typename mdspan_type::data_handle_type,
+                typename OtherAccessorType::data_handle_type>>>
+  KOKKOS_INLINE_FUNCTION constexpr auto to_mdspan() const {
+    using ret_mdspan_type =
+        mdspan<typename mdspan_type::element_type,
+               typename mdspan_type::extents_type,
+               typename mdspan_type::layout_type, OtherAccessorType>;
+    return ret_mdspan_type(
+        static_cast<typename OtherAccessorType::data_handle_type>(
+            data_handle()),
+        mapping(), static_cast<OtherAccessorType>(accessor()));
+  }
+
+  template <
+      class OtherAccessorType = AccessorPolicy,
+      typename                = std::enable_if_t<std::is_assignable_v<
+          data_handle_type, typename OtherAccessorType::data_handle_type>>>
+  KOKKOS_INLINE_FUNCTION constexpr auto to_mdspan(
+      const OtherAccessorType &other_accessor) const {
+    using ret_mdspan_type =
+        mdspan<element_type, extents_type, layout_type, OtherAccessorType>;
+    return ret_mdspan_type(
+        static_cast<typename OtherAccessorType::data_handle_type>(
+            data_handle()),
+        mapping(), other_accessor);
+  }
+
+  KOKKOS_FUNCTION void assign_data(element_type *ptr_) { ptr = ptr_; }
+
+  // ========================= mdspan =================================
+
+  // [mdspan.mdspan.members], members
+
+// Introducing the C++20 and C++23 variants of the operators already
+#ifndef KOKKOS_ENABLE_CXX17
+#ifndef KOKKOS_ENABLE_CXX20
+  // C++23 only operator[]
+  template <class... OtherIndexTypes>
+    requires((std::is_convertible_v<OtherIndexTypes, index_type> && ...) &&
+             (std::is_nothrow_constructible_v<index_type, OtherIndexTypes> &&
+              ...) &&
+             (sizeof...(OtherIndexTypes) == rank()))
+  KOKKOS_FUNCTION constexpr reference operator[](
+      OtherIndexTypes... indices) const {
+    return acc.access(ptr, map(static_cast<index_type>(std::move(indices))...));
+  }
+
+  template <class OtherIndexType>
+    requires(
+        std::is_convertible_v<const OtherIndexType &, index_type> &&
+        std::is_nothrow_constructible_v<index_type, const OtherIndexType &>)
+  KOKKOS_FUNCTION constexpr reference operator[](
+      const Array<OtherIndexType, rank()> &indices) const {
+    return acc.access(ptr, [&]<size_t... Idxs>(std::index_sequence<Idxs...>) {
+      return map(indices[Idxs]...);
+    }(std::make_index_sequence<rank()>()));
+  }
+
+  template <class OtherIndexType>
+    requires(
+        std::is_convertible_v<const OtherIndexType &, index_type> &&
+        std::is_nothrow_constructible_v<index_type, const OtherIndexType &>)
+  KOKKOS_FUNCTION constexpr reference operator[](
+      std::span<OtherIndexType, rank()> indices) const {
+    return acc.access(ptr, [&]<size_t... Idxs>(std::index_sequence<Idxs...>) {
+      return map(indices[Idxs]...);
+    }(std::make_index_sequence<rank()>()));
+  }
+#endif
+
+  // C++20 operator()
+  template <class... OtherIndexTypes>
+    requires((std::is_convertible_v<OtherIndexTypes, index_type> && ...) &&
+             (std::is_nothrow_constructible_v<index_type, OtherIndexTypes> &&
+              ...) &&
+             (sizeof...(OtherIndexTypes) == rank()))
+  KOKKOS_FUNCTION constexpr reference operator()(
+      OtherIndexTypes... indices) const {
+    return acc.access(ptr, map(static_cast<index_type>(std::move(indices))...));
+  }
+
+  template <class OtherIndexType>
+    requires(
+        std::is_convertible_v<const OtherIndexType &, index_type> &&
+        std::is_nothrow_constructible_v<index_type, const OtherIndexType &>)
+  KOKKOS_FUNCTION constexpr reference operator()(
+      const Array<OtherIndexType, rank()> &indices) const {
+    return acc.access(ptr, [&]<size_t... Idxs>(std::index_sequence<Idxs...>) {
+      return map(indices[Idxs]...);
+    }(std::make_index_sequence<rank()>()));
+  }
+
+  template <class OtherIndexType>
+    requires(
+        std::is_convertible_v<const OtherIndexType &, index_type> &&
+        std::is_nothrow_constructible_v<index_type, const OtherIndexType &>)
+  KOKKOS_FUNCTION constexpr reference operator()(
+      std::span<OtherIndexType, rank()> indices) const {
+    return acc.access(ptr, [&]<size_t... Idxs>(std::index_sequence<Idxs...>) {
+      return map(indices[Idxs]...);
+    }(std::make_index_sequence<rank()>()));
+  }
+#else
+  // C++17 variant of operator()
+  template <class... OtherIndexTypes>
+  KOKKOS_FUNCTION constexpr std::enable_if_t<
+      (std::is_convertible_v<OtherIndexTypes, index_type> && ...) &&
+          (std::is_nothrow_constructible_v<index_type, OtherIndexTypes> &&
+           ...) &&
+          (sizeof...(OtherIndexTypes) == rank()),
+      reference>
+  operator()(OtherIndexTypes... indices) const {
+    return acc.access(ptr, map(static_cast<index_type>(std::move(indices))...));
+  }
+#endif
+
+ private:
+  // FIXME_CXX20: could use inline templated lambda in C++20 mode inside size()
+  template <size_t... Idxs>
+  KOKKOS_FUNCTION constexpr size_type size_impl(
+      std::index_sequence<Idxs...>) const noexcept {
+    // Note we restrict data_handle to be convertible to element_type* for now.
+    // This is also different from mdspan: mdspan can NOT be legally in a state
+    // where ptr is nullptr and the product of extents is non-zero
+    // The default constructor of mdspan is constrained to dynamic_rank > 0
+    // For View we do not have that constraint today
+    if (data_handle() == nullptr) return 0u;
+    return ((static_cast<size_type>(map.extents().extent(Idxs))) * ... *
+            size_type(1));
+  }
+
+ public:
+  KOKKOS_FUNCTION constexpr size_type size() const noexcept {
+    return size_impl(std::make_index_sequence<rank()>());
+  }
+
+ private:
+  // FIXME_CXX20: could use inline templated lambda in C++20 mode inside empty()
+  template <size_t... Idxs>
+  KOKKOS_FUNCTION constexpr bool empty_impl(
+      std::index_sequence<Idxs...>) const noexcept {
+    // Note we restrict data_handle to be convertible to element_type* for now.
+    // This is also different from mdspan: mdspan can NOT be legally in a state
+    // where ptr is nullptr and the product of extents is non-zero
+    // The default constructor of mdspan is constrained to dynamic_rank > 0
+    // For View we do not have that constraint today
+    if (data_handle() == nullptr) return true;
+    return (rank() > 0) &&
+           ((map.extents().extent(Idxs) == index_type(0)) || ... || false);
+  }
+
+ public:
+  [[nodiscard]] KOKKOS_FUNCTION constexpr bool empty() const noexcept {
+    return empty_impl(std::make_index_sequence<rank()>());
+  }
+
+  KOKKOS_FUNCTION friend constexpr void swap(BasicView &x,
+                                             BasicView &y) noexcept {
+    kokkos_swap(x.ptr, y.ptr);
+    kokkos_swap(x.map, y.map);
+    kokkos_swap(x.acc, y.acc);
+  }
+
+  KOKKOS_FUNCTION constexpr const extents_type &extents() const noexcept {
+    return map.extents();
+  };
+  KOKKOS_FUNCTION constexpr const data_handle_type &data_handle()
+      const noexcept {
+    return ptr;
+  };
+  KOKKOS_FUNCTION constexpr const mapping_type &mapping() const noexcept {
+    return map;
+  };
+  KOKKOS_FUNCTION constexpr const accessor_type &accessor() const noexcept {
+    return acc;
+  };
+
+  KOKKOS_FUNCTION static constexpr bool is_always_unique() noexcept {
+    return mapping_type::is_always_unique();
+  };
+  KOKKOS_FUNCTION static constexpr bool is_always_exhaustive() noexcept {
+    return mapping_type::is_always_exhaustive();
+  };
+  KOKKOS_FUNCTION static constexpr bool is_always_strided() noexcept {
+    return mapping_type::is_always_strided();
+  };
+
+  KOKKOS_FUNCTION constexpr bool is_unique() const { return map.is_unique(); };
+  KOKKOS_FUNCTION constexpr bool is_exhaustive() const {
+    return map.is_exhaustive();
+  };
+  KOKKOS_FUNCTION constexpr bool is_strided() const {
+    return map.is_strided();
+  };
+  KOKKOS_FUNCTION constexpr index_type stride(rank_type r) const {
+    return map.stride(r);
+  };
+
+ protected:
+#ifndef __NVCC__
+  KOKKOS_IMPL_NO_UNIQUE_ADDRESS data_handle_type ptr{};
+  KOKKOS_IMPL_NO_UNIQUE_ADDRESS mapping_type map{};
+  KOKKOS_IMPL_NO_UNIQUE_ADDRESS accessor_type acc{};
+#else
+  data_handle_type ptr{};
+  mapping_type map{};
+  accessor_type acc{};
+#endif
+
+  template <class, class, class, class>
+  friend class BasicView;
+};
+}  // namespace Kokkos
+
+#endif

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -27,6 +27,10 @@ static_assert(false,
 #include <Kokkos_MemoryTraits.hpp>
 #include <Kokkos_ExecPolicy.hpp>
 #include <View/Hooks/Kokkos_ViewHooks.hpp>
+#ifdef KOKKOS_ENABLE_IMPL_MDSPAN
+#include <View/MDSpan/Kokkos_MDSpan_Layout.hpp>
+#include <View/MDSpan/Kokkos_MDSpan_Accessor.hpp>
+#endif
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -388,6 +388,23 @@ class ReferenceCountedAccessor {
   NestedAccessor m_nested_acc;
 };
 
+template <class ElementType, class MemorySpace>
+using checked_reference_counted_accessor =
+    SpaceAwareAccessor<MemorySpace,
+                       ReferenceCountedAccessor<ElementType, MemorySpace,
+                                                default_accessor<ElementType>>>;
+
+template <class ElementType, class MemorySpace,
+          class MemoryScope = desul::MemoryScopeDevice>
+using checked_atomic_accessor_relaxed =
+    SpaceAwareAccessor<MemorySpace, AtomicAccessorRelaxed<ElementType>>;
+
+template <class ElementType, class MemorySpace,
+          class MemoryScope = desul::MemoryScopeDevice>
+using checked_reference_counted_atomic_accessor_relaxed = SpaceAwareAccessor<
+    MemorySpace, ReferenceCountedAccessor<ElementType, MemorySpace,
+                                          AtomicAccessorRelaxed<ElementType>>>;
+
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -389,19 +389,19 @@ class ReferenceCountedAccessor {
 };
 
 template <class ElementType, class MemorySpace>
-using checked_reference_counted_accessor =
+using CheckedReferenceCountedAccessor =
     SpaceAwareAccessor<MemorySpace,
                        ReferenceCountedAccessor<ElementType, MemorySpace,
                                                 default_accessor<ElementType>>>;
 
 template <class ElementType, class MemorySpace,
           class MemoryScope = desul::MemoryScopeDevice>
-using checked_atomic_accessor_relaxed =
+using CheckedRelaxedAtomicAccessor =
     SpaceAwareAccessor<MemorySpace, AtomicAccessorRelaxed<ElementType>>;
 
 template <class ElementType, class MemorySpace,
           class MemoryScope = desul::MemoryScopeDevice>
-using checked_reference_counted_atomic_accessor_relaxed = SpaceAwareAccessor<
+using CheckedReferenceCountedRelaxedAtomicAccessor = SpaceAwareAccessor<
     MemorySpace, ReferenceCountedAccessor<ElementType, MemorySpace,
                                           AtomicAccessorRelaxed<ElementType>>>;
 

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -658,12 +658,25 @@ struct SharedAllocationDisableTrackingGuard {
   // clang-format on
 };
 
+// Intel classic compiler screwed up the reference counting here
+// in the BasicView test. Apparently the code simplification in
+// BasicView over View, let it think it can optimize stuff away
+// and it ends up not setting the "do-not-deref" flag
+// because it skips some copy ctors.
+// I tried a lot of stuff to no avail (don't move, make an explicit
+// volatile copy first etc.), only reducing opt-level fixed it.
+#ifdef KOKKOS_COMPILER_INTEL
+#pragma optimize("", off)
+#endif
 template <class FunctorType, class... Args>
 inline FunctorType construct_with_shared_allocation_tracking_disabled(
     Args&&... args) {
   [[maybe_unused]] auto guard = SharedAllocationDisableTrackingGuard{};
   return {std::forward<Args>(args)...};
 }
+#ifdef KOKKOS_COMPILER_INTEL
+#pragma optimize("", on)
+#endif
 } /* namespace Impl */
 } /* namespace Kokkos */
 #endif

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -98,6 +98,10 @@ set(COMPILE_ONLY_SOURCES
     view/TestExtentsDatatypeConversion.cpp
 )
 
+if(NOT Kokkos_ENABLE_IMPL_MDSPAN)
+  list(REMOVE_ITEM COMPILE_ONLY_SOURCES view/TestBasicViewMDSpanConversion.cpp)
+endif()
+
 #testing if windows.h and Kokkos_Core.hpp can be included
 if(WIN32)
   list(APPEND COMPILE_ONLY_SOURCES TestWindowsInclude.cpp)

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -94,6 +94,7 @@ set(COMPILE_ONLY_SOURCES
     TestTeamPolicyCTAD.cpp
     TestTeamMDRangePolicyCTAD.cpp
     TestNestedReducerCTAD.cpp
+    view/TestBasicViewMDSpanConversion.cpp
     view/TestExtentsDatatypeConversion.cpp
 )
 
@@ -346,7 +347,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
     # detail tests for the mdspan based View
     set(${Tag}_VIEWSUPPORT)
     if(Kokkos_ENABLE_IMPL_MDSPAN)
-      foreach(Name ReferenceCountedAccessor ReferenceCountedDataHandle)
+      foreach(Name BasicView ReferenceCountedAccessor ReferenceCountedDataHandle)
         set(file ${dir}/Test${Tag}_View_${Name}.cpp)
         # Write to a temporary intermediate file and call configure_file to avoid
         # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.

--- a/core/unit_test/view/TestBasicView.hpp
+++ b/core/unit_test/view/TestBasicView.hpp
@@ -1,0 +1,232 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+#include <type_traits>
+#include <experimental/__p0009_bits/dynamic_extent.hpp>
+#include <experimental/__p2642_bits/layout_padded_fwd.hpp>
+#define KOKKOS_IMPL_PUBLIC_INCLUDE
+#include <View/MDSpan/Kokkos_MDSpan_Accessor.hpp>
+#include <View/Kokkos_BasicView.hpp>
+#undef KOKKOS_IMPL_PUBLIC_INCLUDE
+
+namespace {
+template <class IndexType, std::size_t>
+IndexType fill_zero() {
+  return IndexType(0);
+}
+
+template <class ExecutionSpace, class Extents>
+auto make_spanning_mdrange_policy_from_extents_impl(const Extents &extents,
+                                                    std::index_sequence<0>) {
+  return Kokkos::RangePolicy<ExecutionSpace>{0, extents.extent(0)};
+}
+
+template <class ExecutionSpace, class Extents, std::size_t... Indices>
+auto make_spanning_mdrange_policy_from_extents_impl(
+    const Extents &extents, std::index_sequence<Indices...>) {
+  using index_type    = typename Extents::index_type;
+  constexpr auto rank = Extents::rank();
+  return Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<rank>>{
+      {fill_zero<index_type, Indices>()...}, {extents.extent(Indices)...}};
+}
+
+template <class ExecutionSpace, class Extents>
+auto make_spanning_mdrange_policy_from_extents(const Extents &extents) {
+  return make_spanning_mdrange_policy_from_extents_impl<ExecutionSpace>(
+      extents, std::make_index_sequence<Extents::rank()>{});
+}
+
+template <class T, class ExecutionSpace>
+struct TestBasicView {
+  template <class ExtentsType>
+  static void test_default_constructor() {
+    using extents_type  = ExtentsType;
+    using layout_type   = Kokkos::Experimental::layout_right_padded<>;
+    using accessor_type = Kokkos::Impl::checked_reference_counted_accessor<
+        T, typename ExecutionSpace::memory_space>;
+    using view_type =
+        Kokkos::BasicView<T, extents_type, layout_type, accessor_type>;
+    view_type view;
+
+    EXPECT_FALSE(view.data_handle().has_record());
+    EXPECT_EQ(view.data_handle().get(), nullptr);
+    EXPECT_EQ(view.extents(), extents_type{});
+    EXPECT_EQ(view.data_handle().use_count(), 0);
+    EXPECT_TRUE(view.is_exhaustive());
+    EXPECT_EQ(view.data_handle().get_label(), "");
+    EXPECT_TRUE(view.empty());
+    EXPECT_EQ(view.size(), 0u);
+  }
+
+  template <class ExtentsType>
+  static void test_extents_constructor(const ExtentsType &extents) {
+    using extents_type  = ExtentsType;
+    using layout_type   = Kokkos::Experimental::layout_right_padded<>;
+    using accessor_type = Kokkos::Impl::checked_reference_counted_accessor<
+        T, typename ExecutionSpace::memory_space>;
+    using view_type =
+        Kokkos::BasicView<T, extents_type, layout_type, accessor_type>;
+
+    view_type view("test_view", extents);
+
+    EXPECT_TRUE(view.data_handle().has_record());
+    EXPECT_NE(view.data_handle().get(), nullptr);
+    EXPECT_EQ(view.extents(), extents);
+    EXPECT_EQ(view.data_handle().use_count(), 1);
+    EXPECT_TRUE(view.is_exhaustive());
+    EXPECT_EQ(view.data_handle().get_label(), "test_view");
+    size_t expected_size = 1;
+    // Avoid pointless comparison of unsigned warning for rank==0
+    for (int r = 0; r < static_cast<int>(view_type::rank()); r++)
+      expected_size *= extents.extent(r);
+    EXPECT_EQ(view.size(), expected_size);
+    EXPECT_EQ(view.empty(), expected_size == 0u);
+  }
+
+  template <template <std::size_t> class LayoutType, class ExtentsType>
+  static void test_mapping_constructor(const ExtentsType &extents,
+                                       std::size_t _padding) {
+    using extents_type  = ExtentsType;
+    using layout_type   = LayoutType<Kokkos::dynamic_extent>;
+    using mapping_type  = typename layout_type::template mapping<ExtentsType>;
+    using accessor_type = Kokkos::Impl::checked_reference_counted_accessor<
+        T, typename ExecutionSpace::memory_space>;
+    using view_type =
+        Kokkos::BasicView<T, extents_type, layout_type, accessor_type>;
+    static_assert(
+        std::is_same_v<typename view_type::mapping_type, mapping_type>);
+
+    auto mapping = mapping_type(extents, _padding);
+
+    view_type view("test_view", mapping);
+
+    EXPECT_TRUE(view.data_handle().has_record());
+    EXPECT_NE(view.data_handle().get(), nullptr);
+    EXPECT_EQ(view.extents(), mapping.extents());
+    EXPECT_EQ(view.data_handle().use_count(), 1);
+    EXPECT_EQ(view.is_exhaustive(), mapping.is_exhaustive());
+    EXPECT_EQ(view.data_handle().get_label(), "test_view");
+    size_t expected_size = 1;
+    // Avoid pointless comparison of unsigned warning for rank==0
+    for (int r = 0; r < static_cast<int>(view_type::rank()); r++)
+      expected_size *= view.extent(r);
+    EXPECT_EQ(view.size(), expected_size);
+    EXPECT_EQ(view.empty(), expected_size == 0u);
+  }
+
+  template <class ViewType>
+  struct MDRangeTestFunctor {
+    ViewType view;
+    template <class... Idxs>
+    KOKKOS_FUNCTION void operator()(Idxs... idxs) const {
+      view(idxs...) = (idxs + ...);
+    }
+  };
+
+  template <class LayoutType, class ExtentsType>
+  static void test_access_with_extents(const ExtentsType &extents) {
+    using extents_type  = ExtentsType;
+    using layout_type   = Kokkos::Experimental::layout_right_padded<>;
+    using accessor_type = Kokkos::Impl::checked_reference_counted_accessor<
+        T, typename ExecutionSpace::memory_space>;
+    using view_type =
+        Kokkos::BasicView<T, extents_type, layout_type, accessor_type>;
+
+    auto view = view_type("test_view", extents);
+
+    EXPECT_TRUE(view.data_handle().has_record());
+    EXPECT_NE(view.data_handle().get(), nullptr);
+
+    auto mdrange_policy =
+        make_spanning_mdrange_policy_from_extents<ExecutionSpace>(extents);
+
+    Kokkos::parallel_for(mdrange_policy, MDRangeTestFunctor<view_type>{view});
+  }
+
+#if 0  // TODO: this test should be active after View is put on top of BasicView
+  template <template <std::size_t> class LayoutType, class SrcViewType,
+            class ExtentsType>
+  static void test_construct_from_view(const ExtentsType &extents,
+                                       std::size_t _padding) {
+    using extents_type  = ExtentsType;
+    using layout_type   = LayoutType<Kokkos::dynamic_extent>;
+    using mapping_type  = typename layout_type::template mapping<ExtentsType>;
+    using accessor_type = Kokkos::Impl::checked_reference_counted_accessor<
+        T, typename ExecutionSpace::memory_space>;
+    using basic_view_type =
+        Kokkos::BasicView<T, extents_type, layout_type, accessor_type>;
+    using view_type = SrcViewType;
+    static_assert(std::is_constructible_v<basic_view_type, SrcViewType>);
+  }
+#endif
+
+  template <class LayoutType>
+  static void test_access() {
+    test_access_with_extents<LayoutType>(Kokkos::extents<std::size_t, 5>());
+  }
+
+  static void run_test() {
+    test_default_constructor<Kokkos::extents<std::size_t, 1>>();
+
+    test_extents_constructor(
+        Kokkos::extents<std::size_t, 2, Kokkos::dynamic_extent, 4>(8));
+    test_extents_constructor(Kokkos::extents<std::size_t, 2, 4>());
+    test_extents_constructor(Kokkos::extents<std::size_t>());
+
+    test_mapping_constructor<Kokkos::Experimental::layout_left_padded>(
+        Kokkos::extents<std::size_t, 2, Kokkos::dynamic_extent>(2, 5), 8);
+    test_mapping_constructor<Kokkos::Experimental::layout_left_padded>(
+        Kokkos::extents<std::size_t>(), 4);
+    test_mapping_constructor<Kokkos::Experimental::layout_left_padded>(
+        Kokkos::extents<std::size_t, 2, 3>(), 9);
+
+    test_mapping_constructor<Kokkos::Experimental::layout_right_padded>(
+        Kokkos::extents<std::size_t, 2, Kokkos::dynamic_extent>(2, 5), 8);
+    test_mapping_constructor<Kokkos::Experimental::layout_right_padded>(
+        Kokkos::extents<std::size_t>(), 4);
+    test_mapping_constructor<Kokkos::Experimental::layout_right_padded>(
+        Kokkos::extents<std::size_t, 2, 3>(), 9);
+
+#if 0  // TODO: this test should be active after View is put on top of BasicView
+    test_construct_from_view<
+        Kokkos::Experimental::layout_left_padded,
+        Kokkos::View<double[3], Kokkos::LayoutLeft, ExecutionSpace>>(
+        Kokkos::extents<std::size_t, 3>(), 0);
+
+    test_construct_from_view<
+        Kokkos::Experimental::layout_left_padded,
+        Kokkos::View<double[3], Kokkos::LayoutLeft, ExecutionSpace>>(
+        Kokkos::extents<std::size_t, Kokkos::dynamic_extent>(3), 0);
+#endif
+
+    test_access<
+        Kokkos::Experimental::layout_left_padded<Kokkos::dynamic_extent>>();
+    test_access<
+        Kokkos::Experimental::layout_right_padded<Kokkos::dynamic_extent>>();
+  }
+};
+}  // namespace
+
+namespace Test {
+
+TEST(TEST_CATEGORY, basic_view) {
+  TestBasicView<double, TEST_EXECSPACE>::run_test();
+}
+
+}  // namespace Test

--- a/core/unit_test/view/TestBasicView.hpp
+++ b/core/unit_test/view/TestBasicView.hpp
@@ -147,6 +147,9 @@ TEST(TEST_CATEGORY, basic_view_mapping_ctor_right) {
       Kokkos::extents<std::size_t, 2, 3>(), 9);
 }
 
+// There seems to be some hard to track down issue.
+// See: https://github.com/kokkos/kokkos/pull/7385#issuecomment-2392528089
+#ifndef KOKKOS_ENABLE_OPENACC
 template <class ViewType>
 struct MDRangeTestFunctor {
   ViewType view;
@@ -260,5 +263,6 @@ TEST(TEST_CATEGORY, basic_view_atomic_accessor) {
   test_atomic_accessor<Kokkos::complex<double>>();
 #endif
 }
+#endif
 
 }  // namespace

--- a/core/unit_test/view/TestBasicViewMDSpanConversion.cpp
+++ b/core/unit_test/view/TestBasicViewMDSpanConversion.cpp
@@ -1,0 +1,98 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+#include <type_traits>
+
+#ifdef KOKKOS_ENABLE_IMPL_MDSPAN
+
+#if 0  // TODO: after View is using BasicView this should be true
+static_assert(
+    std::is_convertible_v<
+        Kokkos::View<long long ****, Kokkos::LayoutRight, Kokkos::Serial>,
+        Kokkos::BasicView<long long, Kokkos::dextents<size_t, 4>,
+                          Kokkos::Experimental::layout_right_padded<>,
+                          Kokkos::Impl::checked_reference_counted_accessor<
+                              long long, Kokkos::HostSpace>>>);
+#endif
+
+static_assert(
+    std::is_convertible_v<
+        Kokkos::BasicView<long long, Kokkos::dextents<size_t, 4>,
+                          Kokkos::Experimental::layout_right_padded<>,
+                          Kokkos::Impl::checked_reference_counted_accessor<
+                              long long, Kokkos::HostSpace>>,
+        Kokkos::BasicView<const long long, Kokkos::dextents<size_t, 4>,
+                          Kokkos::Experimental::layout_right_padded<>,
+                          Kokkos::Impl::checked_reference_counted_accessor<
+                              const long long, Kokkos::HostSpace>>>);
+#if 0  // TODO: after View is using BasicView this should be true
+static_assert(
+    std::is_convertible_v<
+        Kokkos::View<long long ****, Kokkos::LayoutRight, Kokkos::Serial>,
+        Kokkos::BasicView<const long long, Kokkos::dextents<size_t, 4>,
+                          Kokkos::Experimental::layout_right_padded<>,
+                          Kokkos::Impl::checked_reference_counted_accessor<
+                              const long long, Kokkos::HostSpace>>>);
+
+using test_atomic_view = Kokkos::View<double *, Kokkos::Serial,
+                                      Kokkos::MemoryTraits<Kokkos::Atomic>>;
+static_assert(std::is_same_v<
+              decltype(std::declval<test_atomic_view>()(std::declval<int>())),
+              desul::AtomicRef<double, desul::MemoryOrderRelaxed,
+                               desul::MemoryScopeDevice>>);
+#endif
+
+static_assert(std::is_convertible_v<Kokkos::default_accessor<double>,
+                                    Kokkos::Impl::ReferenceCountedAccessor<
+                                        double, Kokkos::HostSpace,
+                                        Kokkos::default_accessor<double>>>);
+
+static_assert(std::is_constructible_v<Kokkos::default_accessor<const double>,
+                                      Kokkos::default_accessor<double>>);
+
+static_assert(std::is_convertible_v<Kokkos::default_accessor<double>,
+                                    Kokkos::default_accessor<const double>>);
+
+static_assert(
+    std::is_constructible_v<
+        Kokkos::Impl::ReferenceCountedAccessor<
+            const double, Kokkos::HostSpace,
+            Kokkos::default_accessor<const double>>,
+        Kokkos::Impl::ReferenceCountedAccessor<
+            double, Kokkos::HostSpace, Kokkos::default_accessor<double>>>);
+
+static_assert(std::is_convertible_v<
+              Kokkos::Impl::ReferenceCountedAccessor<
+                  double, Kokkos::HostSpace, Kokkos::default_accessor<double>>,
+              Kokkos::Impl::ReferenceCountedAccessor<
+                  const double, Kokkos::HostSpace,
+                  Kokkos::default_accessor<const double>>>);
+
+static_assert(std::is_constructible_v<Kokkos::default_accessor<const double>,
+                                      Kokkos::Impl::ReferenceCountedAccessor<
+                                          double, Kokkos::HostSpace,
+                                          Kokkos::default_accessor<double>>>);
+
+static_assert(
+    std::is_convertible_v<
+        Kokkos::Impl::SpaceAwareAccessor<
+            Kokkos::HostSpace,
+            Kokkos::Impl::ReferenceCountedAccessor<
+                double, Kokkos::HostSpace, Kokkos::default_accessor<double>>>,
+        Kokkos::Impl::SpaceAwareAccessor<
+            Kokkos::HostSpace, Kokkos::default_accessor<const double>>>);
+#endif

--- a/core/unit_test/view/TestBasicViewMDSpanConversion.cpp
+++ b/core/unit_test/view/TestBasicViewMDSpanConversion.cpp
@@ -17,35 +17,32 @@
 #include <Kokkos_Core.hpp>
 #include <type_traits>
 
-#ifdef KOKKOS_ENABLE_IMPL_MDSPAN
-
 #if 0  // TODO: after View is using BasicView this should be true
 static_assert(
     std::is_convertible_v<
         Kokkos::View<long long ****, Kokkos::LayoutRight, Kokkos::Serial>,
         Kokkos::BasicView<long long, Kokkos::dextents<size_t, 4>,
                           Kokkos::Experimental::layout_right_padded<>,
-                          Kokkos::Impl::checked_reference_counted_accessor<
+                          Kokkos::Impl::CheckedReferenceCountedAccessor<
                               long long, Kokkos::HostSpace>>>);
 #endif
 
-static_assert(
-    std::is_convertible_v<
-        Kokkos::BasicView<long long, Kokkos::dextents<size_t, 4>,
-                          Kokkos::Experimental::layout_right_padded<>,
-                          Kokkos::Impl::checked_reference_counted_accessor<
-                              long long, Kokkos::HostSpace>>,
-        Kokkos::BasicView<const long long, Kokkos::dextents<size_t, 4>,
-                          Kokkos::Experimental::layout_right_padded<>,
-                          Kokkos::Impl::checked_reference_counted_accessor<
-                              const long long, Kokkos::HostSpace>>>);
+static_assert(std::is_convertible_v<
+              Kokkos::BasicView<long long, Kokkos::dextents<size_t, 4>,
+                                Kokkos::Experimental::layout_right_padded<>,
+                                Kokkos::Impl::CheckedReferenceCountedAccessor<
+                                    long long, Kokkos::HostSpace>>,
+              Kokkos::BasicView<const long long, Kokkos::dextents<size_t, 4>,
+                                Kokkos::Experimental::layout_right_padded<>,
+                                Kokkos::Impl::CheckedReferenceCountedAccessor<
+                                    const long long, Kokkos::HostSpace>>>);
 #if 0  // TODO: after View is using BasicView this should be true
 static_assert(
     std::is_convertible_v<
         Kokkos::View<long long ****, Kokkos::LayoutRight, Kokkos::Serial>,
         Kokkos::BasicView<const long long, Kokkos::dextents<size_t, 4>,
                           Kokkos::Experimental::layout_right_padded<>,
-                          Kokkos::Impl::checked_reference_counted_accessor<
+                          Kokkos::Impl::CheckedReferenceCountedAccessor<
                               const long long, Kokkos::HostSpace>>>);
 
 using test_atomic_view = Kokkos::View<double *, Kokkos::Serial,
@@ -95,4 +92,3 @@ static_assert(
                 double, Kokkos::HostSpace, Kokkos::default_accessor<double>>>,
         Kokkos::Impl::SpaceAwareAccessor<
             Kokkos::HostSpace, Kokkos::default_accessor<const double>>>);
-#endif


### PR DESCRIPTION
This introduces BasicView as a base class for the View refactor. The next PR in the series will make View publicly inherit from this class. The intend is that BasicView for now contains a much more restricted set of constructors and members to implement the fundamental versions of the required functionality. In particular BasicView should have few if any of the APIs and quirks of View which we anyway intend to deprecate. For example it does not have a constructor which takes more integers as arguments than the rank. It also doesn't have stuff like `View::Rank` or `View::rank` (as opposed to `View::rank()`).

Note this PR sits on top of #7345 . Only the last 3 commits are new. 

Link during initial PR submit - this may break when we push/rebase etc.: https://github.com/kokkos/kokkos/pull/7385/files/d901c5c032d33e5e8d7258759d53f75e8979829e..65ac829ca2fa67451867993e30958609f1f23f67