### PR TITLE
Cleanup pointless CUDA_LAMBDA guards

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -89,7 +89,6 @@ pipeline {
                                 -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_CUDA=ON \
-                                -DKokkos_ENABLE_CUDA_LAMBDA=ON \
                                 -DKokkos_ENABLE_OPENMP=ON \
                               .. && \
                               make -j8 && ctest --verbose'''
@@ -321,7 +320,6 @@ pipeline {
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_BENCHMARKS=ON \
                                 -DKokkos_ENABLE_CUDA=ON \
-                                -DKokkos_ENABLE_CUDA_LAMBDA=ON \
                                 -DKokkos_ENABLE_TUNING=ON \
                                 -DKokkos_ARCH_VOLTA70=ON \
                               .. && \
@@ -394,7 +392,6 @@ pipeline {
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_OPENMP=OFF \
                                 -DKokkos_ENABLE_CUDA=ON \
-                                -DKokkos_ENABLE_CUDA_LAMBDA=OFF \
                                 -DKokkos_ENABLE_CUDA_UVM=ON \
                                 -DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON \
                                 -DKokkos_ENABLE_DEPRECATED_CODE_4=ON \
@@ -461,7 +458,6 @@ pipeline {
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_BENCHMARKS=ON \
                                 -DKokkos_ENABLE_CUDA=ON \
-                                -DKokkos_ENABLE_CUDA_LAMBDA=ON \
                                 -DKokkos_ENABLE_LIBDL=OFF \
                                 -DKokkos_ENABLE_OPENMP=ON \
                                 -DKokkos_ENABLE_IMPL_MDSPAN=OFF \

--- a/containers/unit_tests/TestErrorReporter.hpp
+++ b/containers/unit_tests/TestErrorReporter.hpp
@@ -149,7 +149,6 @@ struct ErrorReporterDriver : public ErrorReporterDriverBase<DeviceType> {
   }
 };
 
-#if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 template <typename DeviceType>
 struct ErrorReporterDriverUseLambda
     : public ErrorReporterDriverBase<DeviceType> {
@@ -178,7 +177,6 @@ struct ErrorReporterDriverUseLambda
     driver_base::check_expectations(reporter_capacity, test_size);
   }
 };
-#endif
 
 #ifdef KOKKOS_ENABLE_OPENMP
 struct ErrorReporterDriverNativeOpenMP
@@ -205,8 +203,7 @@ struct ErrorReporterDriverNativeOpenMP
 
 // FIXME_MSVC MSVC just gets confused when using the base class in the
 // KOKKOS_CLASS_LAMBDA
-#if !defined(KOKKOS_COMPILER_MSVC) && \
-    (!defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA))
+#ifndef KOKKOS_COMPILER_MSVC
 TEST(TEST_CATEGORY, ErrorReporterViaLambda) {
   TestErrorReporter<ErrorReporterDriverUseLambda<TEST_EXECSPACE>>();
 }

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -74,7 +74,6 @@ void test_offsetview_construction() {
   ASSERT_EQ(ov.extent(0), 5u);
   ASSERT_EQ(ov.extent(1), 5u);
 
-#if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
   {
     Kokkos::Experimental::OffsetView<Scalar*, Device> offsetV1("OneDOffsetView",
                                                                range0);
@@ -156,7 +155,6 @@ void test_offsetview_construction() {
   }
 
   ASSERT_EQ(OVResult, answer) << "Bad data found in OffsetView";
-#endif
 
   {
     offset_view_type ovCopy(ov);
@@ -191,7 +189,6 @@ void test_offsetview_construction() {
     range3_type rangePolicy3DZero(point3_type{{0, 0, 0}},
                                   point3_type{{extent0, extent1, extent2}});
 
-#if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
     int view3DSum = 0;
     Kokkos::parallel_reduce(
         rangePolicy3DZero,
@@ -214,7 +211,6 @@ void test_offsetview_construction() {
 
     ASSERT_EQ(view3DSum, offsetView3DSum)
         << "construction of OffsetView from View and begins array broken.";
-#endif
   }
   view_type viewFromOV = ov.view();
 
@@ -239,7 +235,6 @@ void test_offsetview_construction() {
     view_type aView("aView", ov.extent(0), ov.extent(1));
     Kokkos::deep_copy(aView, ov);
 
-#if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
     int sum = 0;
     Kokkos::parallel_reduce(
         rangePolicy2D,
@@ -249,7 +244,6 @@ void test_offsetview_construction() {
         sum);
 
     ASSERT_EQ(sum, 0) << "deep_copy(view, offsetView) broken.";
-#endif
   }
 
   {  // test view to  offsetview deep copy
@@ -258,7 +252,6 @@ void test_offsetview_construction() {
     Kokkos::deep_copy(aView, 99);
     Kokkos::deep_copy(ov, aView);
 
-#if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
     int sum = 0;
     Kokkos::parallel_reduce(
         rangePolicy2D,
@@ -268,7 +261,6 @@ void test_offsetview_construction() {
         sum);
 
     ASSERT_EQ(sum, 0) << "deep_copy(offsetView, view) broken.";
-#endif
   }
 }
 
@@ -521,7 +513,6 @@ void test_offsetview_subview() {
       ASSERT_EQ(offsetSubview.begin(1), 0);
       ASSERT_EQ(offsetSubview.end(1), 9);
 
-#if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
       using range_type = Kokkos::MDRangePolicy<Device, Kokkos::Rank<2>,
                                                Kokkos::IndexType<int> >;
       using point_type = typename range_type::point_type;
@@ -547,7 +538,6 @@ void test_offsetview_subview() {
           sum);
 
       ASSERT_EQ(sum, 6 * (e0 - b0) * (e1 - b1));
-#endif
     }
 
     // slice 2
@@ -644,7 +634,6 @@ void test_offsetview_subview() {
   }
 }
 
-#if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
 template <class InputIt, class T, class BinaryOperation>
 KOKKOS_INLINE_FUNCTION T std_accumulate(InputIt first, InputIt last, T init,
                                         BinaryOperation op) {
@@ -748,7 +737,6 @@ void test_offsetview_offsets_rank3() {
 
   ASSERT_EQ(0, errors);
 }
-#endif
 
 TEST(TEST_CATEGORY, offsetview_construction) {
   test_offsetview_construction<int, TEST_EXECSPACE>();
@@ -767,7 +755,6 @@ TEST(TEST_CATEGORY, offsetview_subview) {
   test_offsetview_subview<int, TEST_EXECSPACE>();
 }
 
-#if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
 TEST(TEST_CATEGORY, offsetview_offsets_rank1) {
   test_offsetview_offsets_rank1<TEST_EXECSPACE>();
 }
@@ -779,7 +766,6 @@ TEST(TEST_CATEGORY, offsetview_offsets_rank2) {
 TEST(TEST_CATEGORY, offsetview_offsets_rank3) {
   test_offsetview_offsets_rank3<TEST_EXECSPACE>();
 }
-#endif
 
 }  // namespace Test
 

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -534,8 +534,6 @@ TEST(TEST_CATEGORY, UnorderedMap_shallow_copyable_on_device) {
   ASSERT_EQ(1u, test_map_copy.m_map.size());
 }
 
-#if !defined(KOKKOS_ENABLE_CUDA) || \
-    (defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ENABLE_CUDA_LAMBDA))
 void test_unordered_map_device_capture() {
   TestMapCopy::map_type map;
 
@@ -549,7 +547,6 @@ void test_unordered_map_device_capture() {
 TEST(TEST_CATEGORY, UnorderedMap_lambda_capturable) {
   test_unordered_map_device_capture();
 }
-#endif
 
 /**
  * @test This test ensures that an @ref UnorderedMap can be built

--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -128,9 +128,7 @@ endif()
 
 kokkos_add_benchmark(PerformanceTest_Benchmark SOURCES ${BENCHMARK_SOURCES})
 
-if(NOT KOKKOS_ENABLE_CUDA OR KOKKOS_ENABLE_CUDA_LAMBDA)
-  kokkos_add_benchmark(Benchmark_Atomic_MinMax SOURCES test_atomic_minmax_simple.cpp)
-endif()
+kokkos_add_benchmark(Benchmark_Atomic_MinMax SOURCES test_atomic_minmax_simple.cpp)
 
 # FIXME_NVHPC
 if(NOT KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)

--- a/core/perf_test/PerfTest_ViewCopy_Raw.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_Raw.cpp
@@ -18,7 +18,6 @@
 
 namespace Test {
 
-#if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
 BENCHMARK(ViewDeepCopy_Raw<Kokkos::LayoutLeft, Kokkos::LayoutLeft>)
     ->ArgName("N")
     ->Arg(10)
@@ -38,6 +37,5 @@ BENCHMARK(ViewDeepCopy_Raw<Kokkos::LayoutRight, Kokkos::LayoutLeft>)
     ->ArgName("N")
     ->Arg(10)
     ->UseManualTime();
-#endif
 
 }  // namespace Test

--- a/core/perf_test/PerfTest_ViewFill_Raw.cpp
+++ b/core/perf_test/PerfTest_ViewFill_Raw.cpp
@@ -18,7 +18,6 @@
 
 namespace Test {
 
-#if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
 BENCHMARK(ViewFill_Raw<Kokkos::LayoutLeft>)
     ->ArgName("N")
     ->Arg(N)
@@ -28,6 +27,5 @@ BENCHMARK(ViewFill_Raw<Kokkos::LayoutRight>)
     ->ArgName("N")
     ->Arg(N)
     ->UseManualTime();
-#endif
 
 }  // namespace Test

--- a/core/perf_test/PerfTest_ViewResize_Raw.cpp
+++ b/core/perf_test/PerfTest_ViewResize_Raw.cpp
@@ -18,7 +18,6 @@
 
 namespace Test {
 
-#if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
 BENCHMARK(ViewResize_NoInit_Raw<Kokkos::LayoutLeft>)
     ->ArgName("N")
     ->Arg(N)
@@ -30,6 +29,5 @@ BENCHMARK(ViewResize_NoInit_Raw<Kokkos::LayoutRight>)
     ->Arg(N)
     ->UseManualTime()
     ->Iterations(R);
-#endif
 
 }  // namespace Test

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -687,16 +687,6 @@ void Cuda::print_configuration(std::ostream &os, bool /*verbose*/) const {
   os << "  KOKKOS_ENABLE_CUDA: yes\n";
 
   os << "Cuda Options:\n";
-  os << "  KOKKOS_ENABLE_CUDA_LAMBDA: ";
-#ifdef KOKKOS_ENABLE_CUDA_LAMBDA
-  os << "yes\n";
-#else
-  os << "no\n";
-#endif
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  os << "  KOKKOS_ENABLE_CUDA_LDG_INTRINSIC: ";
-  os << "yes\n";
-#endif
   os << "  KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE: ";
 #ifdef KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE
   os << "yes\n";

--- a/core/unit_test/TestMDRangeReduce.hpp
+++ b/core/unit_test/TestMDRangeReduce.hpp
@@ -49,8 +49,6 @@ TEST(TEST_CATEGORY, mdrange_parallel_reduce_primitive_types) {
 #if defined(KOKKOS_ENABLE_OPENMPTARGET)
   GTEST_SKIP() << "FIXME OPENMPTARGET Tests of MDRange reduce over values "
                   "smaller than int would fail";
-#elif defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_CUDA_LAMBDA)
-  GTEST_SKIP() << "Skipped ENABLE_CUDA_LAMBDA";
 #else
   for (int bound : {0, 1, 7, 32, 65, 7000}) {
     for (int k = 0; k < bound; ++k) {

--- a/core/unit_test/TestTeamCombinedReducers.hpp
+++ b/core/unit_test/TestTeamCombinedReducers.hpp
@@ -19,10 +19,6 @@
 
 namespace {
 
-// Extended lambdas in parallel_for and parallel_reduce will not compile if
-// KOKKOS_ENABLE_CUDA_LAMBDA is off
-#if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
-
 struct TeamTeamCombinedReducer {
  public:
   void test_team_thread_range_only_scalars(const int n) {
@@ -509,7 +505,5 @@ TEST(TEST_CATEGORY, team_vector_range_combined_reducers) {
   tester.test_team_vector_range_combined_reducers(0);
   tester.test_team_vector_range_combined_reducers(9);
 }
-
-#endif
 
 }  // namespace

--- a/core/unit_test/TestTeamMDRange.hpp
+++ b/core/unit_test/TestTeamMDRange.hpp
@@ -148,10 +148,6 @@ struct TestTeamMDParallelFor {
   }
 };
 
-// If KOKKOS_ENABLE_CUDA_LAMBDA is off, extended lambdas used in parallel_for
-// and parallel_reduce in these tests will not compile correctly
-#if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
-
 template <typename ExecSpace>
 struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
   using TeamType = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
@@ -2248,8 +2244,6 @@ TEST(TEST_CATEGORY, TeamVectorMDRangeParallelReduce) {
   TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
       test_parallel_reduce_for_8D_TeamVectorMDRange<Right>(smallDims);
 }
-
-#endif
 
 }  // namespace TeamMDRange
 }  // namespace Test

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -782,7 +782,6 @@ namespace Test {
 // Computes y^T*A*x
 // ( modified from kokkos-tutorials/GTC2016/Exercises/ThreeLevelPar )
 
-#if (!defined(KOKKOS_ENABLE_CUDA)) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 template <typename ScalarType, class DeviceType>
 class TestTripleNestedReduce {
  public:
@@ -881,21 +880,6 @@ class TestTripleNestedReduce {
     ASSERT_EQ(solution, result);
   }
 };
-
-#else  // #if ( ! defined( KOKKOS_ENABLE_CUDA ) ) || defined(
-       // KOKKOS_ENABLE_CUDA_LAMBDA )
-
-template <typename ScalarType, class DeviceType>
-class TestTripleNestedReduce {
- public:
-  using execution_space = DeviceType;
-  using size_type       = typename execution_space::size_type;
-
-  TestTripleNestedReduce(const size_type &, const size_type, const size_type &,
-                         const size_type) {}
-};
-
-#endif
 
 namespace VectorScanReducer {
 enum class ScanType : bool { Inclusive, Exclusive };

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -1009,6 +1009,8 @@ void test_view_mapping() {
     ASSERT_EQ(a.use_count(), 1);
     ASSERT_EQ(b.use_count(), 0);
 
+// FIXME_NVCC For some reason, the use count is higher (but still constant) when
+// using nvcc. Replacing the lambda with a functor doesn't show this behavior.
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC)
     using host_exec_space =
         typename Kokkos::Impl::HostMirror<Space>::Space::execution_space;

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -1009,6 +1009,7 @@ void test_view_mapping() {
     ASSERT_EQ(a.use_count(), 1);
     ASSERT_EQ(b.use_count(), 0);
 
+#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC)
     using host_exec_space =
         typename Kokkos::Impl::HostMirror<Space>::Space::execution_space;
 
@@ -1029,6 +1030,7 @@ void test_view_mapping() {
         },
         errors);
     ASSERT_EQ(errors, 0);
+#endif
   }
 }
 

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -1009,9 +1009,6 @@ void test_view_mapping() {
     ASSERT_EQ(a.use_count(), 1);
     ASSERT_EQ(b.use_count(), 0);
 
-#if !defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_ENABLE_CUDA_LAMBDA)
-    // Cannot launch host lambda when CUDA lambda is enabled.
-
     using host_exec_space =
         typename Kokkos::Impl::HostMirror<Space>::Space::execution_space;
 
@@ -1032,7 +1029,6 @@ void test_view_mapping() {
         },
         errors);
     ASSERT_EQ(errors, 0);
-#endif  // #if !defined( KOKKOS_ENABLE_CUDA_LAMBDA )
   }
 }
 

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -1011,7 +1011,7 @@ void test_view_mapping() {
 
 // FIXME_NVCC For some reason, the use count is higher (but still constant) when
 // using nvcc. Replacing the lambda with a functor doesn't show this behavior.
-#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC)
+#if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC))
     using host_exec_space =
         typename Kokkos::Impl::HostMirror<Space>::Space::execution_space;
 


### PR DESCRIPTION
Also dropping CUDA_LAMBDA and CUDA_LDG_INTRINSIC from the information printed in`Cuda::print_configuration()`