### PR TITLE
Profiling Support: Moving convenience function to tools-available header

### DIFF
--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -201,15 +201,6 @@ void profile_fence_event(const std::string& name, DirectFenceIDHandle devIDTag,
   Kokkos::Tools::endFence(handle);
 }
 
-inline uint32_t int_for_synchronization_reason(
-    Kokkos::Tools::Experimental::SpecialSynchronizationCases reason) {
-  switch (reason) {
-    case GlobalDeviceSynchronization: return 0;
-    case DeepCopyResourceSynchronization: return 0x00ffffff;
-  }
-  return 0;
-}
-
 template <typename Space, typename FencingFunctor>
 void profile_fence_event(
     const std::string& name,

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -101,10 +101,7 @@ inline uint32_t device_id(ExecutionSpace const& space) noexcept {
           << num_instance_bits) +
          space.impl_instance_id();
 }
-}  // namespace Experimental
-}  // namespace Tools
 
-namespace Impl {
 inline uint32_t int_for_synchronization_reason(
     Kokkos::Tools::Experimental::SpecialSynchronizationCases reason) {
   switch (reason) {
@@ -113,7 +110,8 @@ inline uint32_t int_for_synchronization_reason(
   }
   return 0;
 }
-}  // namespace Impl
+}  // namespace Experimental
+}  // namespace Tools
 }  // end namespace Kokkos
 
 #if defined(KOKKOS_ENABLE_LIBDL)

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -103,6 +103,17 @@ inline uint32_t device_id(ExecutionSpace const& space) noexcept {
 }
 }  // namespace Experimental
 }  // namespace Tools
+
+namespace Impl {
+inline uint32_t int_for_synchronization_reason(
+    Kokkos::Tools::Experimental::SpecialSynchronizationCases reason) {
+  switch (reason) {
+    case GlobalDeviceSynchronization: return 0;
+    case DeepCopyResourceSynchronization: return 0x00ffffff;
+  }
+  return 0;
+}
+}  // namespace Impl
 }  // end namespace Kokkos
 
 #if defined(KOKKOS_ENABLE_LIBDL)


### PR DESCRIPTION
In order to make my changes to kokkos-tools to prettify debugging/kernel-logger output, I needed to move `int_for_synchronization_reason` into impl/Kokkos_Profiling_Interface.hpp from Kokkos_Profiling.hpp.

Feel free to move this to another part of the file.

Initial discussions with @crtrott last week.