### PR TITLE
MDSpan library changes for constexpr device code

### DIFF
--- a/tpls/mdspan/include/experimental/__p0009_bits/mdspan.hpp
+++ b/tpls/mdspan/include/experimental/__p0009_bits/mdspan.hpp
@@ -21,6 +21,7 @@
 #include "extents.hpp"
 #include "trait_backports.hpp"
 #include "compressed_pair.hpp"
+#include "utility.hpp"
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 template <
@@ -351,6 +352,7 @@ public:
 
   MDSPAN_INLINE_FUNCTION constexpr const extents_type& extents() const noexcept { return __mapping_ref().extents(); };
   MDSPAN_INLINE_FUNCTION constexpr const data_handle_type& data_handle() const noexcept { return __ptr_ref(); };
+  MDSPAN_INLINE_FUNCTION constexpr data_handle_type& data_handle(mdspan_non_standard_tag) noexcept { return __ptr_ref(); };
   MDSPAN_INLINE_FUNCTION constexpr const mapping_type& mapping() const noexcept { return __mapping_ref(); };
   MDSPAN_INLINE_FUNCTION constexpr const accessor_type& accessor() const noexcept { return __accessor_ref(); };
 

--- a/tpls/mdspan/include/experimental/__p0009_bits/utility.hpp
+++ b/tpls/mdspan/include/experimental/__p0009_bits/utility.hpp
@@ -77,12 +77,12 @@ struct integral_constant {
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED
   constexpr integral_constant() = default;
-
+ 
   // These interop functions work, because other than the value_type operator
-  // everything of std::integral_constant works on device (defaulted functions)
+  // everything of std::integral_constant works on device (defaulted functions)  
   MDSPAN_FUNCTION
   constexpr integral_constant(std::integral_constant<T,v>) {};
-
+  
   MDSPAN_FUNCTION constexpr operator std::integral_constant<T,v>() const noexcept {
     return std::integral_constant<T,v>{};
   }


### PR DESCRIPTION
This code, mostly authored by Christian, fixes warnings for using `constexpr` code on device. 
Commit SHA: https://github.com/kokkos/mdspan/commit/260f525ed71669e5dcf2438622d2c433b3e5c281