### PR TITLE
SYCL: Explicitly use the desired type in a ternary expression

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -283,8 +283,8 @@ class SYCLTeamMember {
 
     const auto update =
         Kokkos::Impl::SYCLReduction::shift_group_right(sg, value, vector_range);
-    Type intermediate = (group_id > 0 ? base_data[group_id - 1] : 0) +
-                        (id_in_sg >= vector_range ? update : 0);
+    Type intermediate = (group_id > 0 ? base_data[group_id - 1] : Type{0}) +
+                        (id_in_sg >= vector_range ? update : Type{0});
 
     if (global_accum) {
       if (id_in_sg == sub_group_range - 1 &&


### PR DESCRIPTION
This caused problems with https://github.com/E3SM-Project/EKAT/blob/5e9d57c2a4df044a5fe4014968f02246d4dcf110/src/ekat/ekat_pack.hpp#L167.