### PR TITLE
Use std::thread::hardware_concurrency as default for the Threads backend

### DIFF
--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -493,7 +493,7 @@ void ThreadsInternal::initialize(int thread_count_arg) {
                          ? Kokkos::hwloc::get_available_numa_count() *
                                Kokkos::hwloc::get_available_cores_per_numa() *
                                Kokkos::hwloc::get_available_threads_per_core()
-                         : 1;
+                         : std::thread::hardware_concurrency();
     }
 
     const bool allow_asynchronous_threadpool = false;


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/issues/7090. It's strane that the `Threads` backend only uses one thread by default whereas we autodetect the number of hardware concurrent threads for other host parallel backends.