### PR TITLE
Print warning instead of erroring out when checking HIP architecture

### DIFF
--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -27,6 +27,8 @@
 
 #include <hip/hip_runtime_api.h>
 
+#include <iostream>
+
 namespace Kokkos {
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -52,12 +54,14 @@ void HIP::impl_initialize(InitializationSettings const& settings) {
   KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(hip_device_id));
 
   // Check that we are running on the expected architecture
-  if (std::string arch_name = Impl::HIPInternal::m_deviceProp.gcnArchName;
-      arch_name.find(KOKKOS_ARCH_AMD_GPU) != 0) {
-    std::string error_message =
-        "Kokkos::HIP::initialize ERROR: running kernels compiled for " +
-        std::string(KOKKOS_ARCH_AMD_GPU) + " on " + arch_name + " device.\n";
-    Kokkos::abort(error_message.c_str());
+  if (Kokkos::show_warnings()) {
+    if (std::string arch_name = Impl::HIPInternal::m_deviceProp.gcnArchName;
+        arch_name.find(KOKKOS_ARCH_AMD_GPU) != 0) {
+      std::cerr
+          << "Kokkos::HIP::initialize WARNING: running kernels compiled for " +
+                 std::string(KOKKOS_ARCH_AMD_GPU) + " on " + arch_name +
+                 " device.\n";
+    }
   }
 
   // theoretically on GFX 9XX GPUs, we can get 40 WF's / CU, but only can

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -53,14 +53,16 @@ void HIP::impl_initialize(InitializationSettings const& settings) {
       hipGetDeviceProperties(&Impl::HIPInternal::m_deviceProp, hip_device_id));
   KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(hip_device_id));
 
-  // Check that we are running on the expected architecture
+  // Check that we are running on the expected architecture. We print a warning
+  // instead of erroring out because AMD does not guarantee that gcnArchName
+  // will always contain the gfx flag.
   if (Kokkos::show_warnings()) {
-    if (std::string arch_name = Impl::HIPInternal::m_deviceProp.gcnArchName;
+    if (std::string_view arch_name =
+            Impl::HIPInternal::m_deviceProp.gcnArchName;
         arch_name.find(KOKKOS_ARCH_AMD_GPU) != 0) {
       std::cerr
-          << "Kokkos::HIP::initialize WARNING: running kernels compiled for " +
-                 std::string(KOKKOS_ARCH_AMD_GPU) + " on " + arch_name +
-                 " device.\n";
+          << "Kokkos::HIP::initialize WARNING: running kernels compiled for "
+          << KOKKOS_ARCH_AMD_GPU << " on " << arch_name << " device.\n";
     }
   }
 


### PR DESCRIPTION
This change was asked by AMD because: 
1. They do not guarantee that the current code will always work.
2. This makes it easier for them to port Kokkos to new architecture.

Related to https://github.com/kokkos/kokkos/pull/7379
