### PR TITLE
OpenMP: Deprecate support for Kokkos parallel inside OpenMP parallel without nested OpenMP enabled

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -122,8 +122,18 @@ inline bool execute_in_serial(OpenMP const& space = OpenMP()) {
 #else
   bool is_nested = static_cast<bool>(omp_get_nested());
 #endif
-  return (space.impl_internal_space_instance()->get_level() < omp_get_level() &&
-          !(is_nested && (omp_get_level() == 1)));
+  bool max_parallel_level_exceeded =
+      (space.impl_internal_space_instance()->get_level() < omp_get_level() &&
+       !(is_nested && (omp_get_level() == 1)));
+
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  if (max_parallel_level_exceeded)
+    Kokkos::abort(
+        "Kokkos::OpenMP: Nested parallelism requires the maximum active levels "
+        "to be larger than 1!");
+#endif
+
+  return max_parallel_level_exceeded;
 }
 
 }  // namespace Impl

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -130,7 +130,7 @@ inline bool execute_in_serial(OpenMP const& space = OpenMP()) {
   if (max_parallel_level_exceeded)
     Kokkos::abort(
         "Kokkos::OpenMP: Nested parallelism requires the maximum active levels "
-        "to be larger than 1!");
+        "to be larger than 1 and not more than two levels are supported!");
 #endif
 
   return max_parallel_level_exceeded;

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -111,6 +111,20 @@ void test_partitioning(std::vector<TEST_EXECSPACE>& instances) {
   check_space_member_for_policies(instances[0]);
   check_space_member_for_policies(instances[1]);
 
+#ifdef KOKKOS_ENABLE_OPENMP
+  if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::OpenMP>) {
+#if (!defined(KOKKOS_COMPILER_GNU) || KOKKOS_COMPILER_GNU >= 1110) && \
+    _OPENMP >= 201511
+    bool supports_nested = omp_get_max_active_levels() > 1;
+#else
+    bool supports_nested = static_cast<bool>(omp_get_nested());
+#endif
+    if (!supports_nested)
+      GTEST_SKIP()
+          << "The OpenMP configuration doesn't allow nested parallelism";
+  }
+#endif
+
   int sum1, sum2;
   int N = 3910;
   run_threaded_test(

--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -28,6 +28,18 @@ namespace {
 #ifdef KOKKOS_ENABLE_OPENMP
 template <class Lambda1, class Lambda2>
 void run_threaded_test(const Lambda1 l1, const Lambda2 l2) {
+  if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::OpenMP>) {
+#if (!defined(KOKKOS_COMPILER_GNU) || KOKKOS_COMPILER_GNU >= 1110) && \
+    _OPENMP >= 201511
+    bool supports_nested = omp_get_max_active_levels() > 1;
+#else
+    bool supports_nested = static_cast<bool>(omp_get_nested());
+#endif
+    if (!supports_nested)
+      GTEST_SKIP()
+          << "The OpenMP configuration doesn't allow nested parallelism";
+  }
+
   if (omp_get_max_threads() < 2)
     GTEST_SKIP() << "insufficient number of supported concurrent threads";
 


### PR DESCRIPTION
Addressing https://github.com/kokkos/kokkos/pull/7368#issuecomment-2389330353.
This avoids using the buggy code path fixed in #7368 when we compile without deprecated code enabled.