### PR TITLE
tests(graph): filesystem not supported by old compilers so skip these tests

### DIFF
--- a/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
@@ -97,6 +97,10 @@ TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), count_nodes) {
 TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), debug_dot_print) {
 #if CUDA_VERSION < 11600
   GTEST_SKIP() << "Export a graph to DOT requires Cuda 11.6.";
+#elif KOKKOS_COMPILER_GNU < 910
+  GTEST_SKIP() << "'filesystem' is not fully supported prior to GCC 9.1.0.";
+#elif KOKKOS_COMPILER_CLANG < 1100
+  GTEST_SKIP() << "'filesystem' is not fully supported prior to LLVM 11.";
 #else
   graph->instantiate();
 

--- a/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
@@ -71,6 +71,10 @@ TEST(TEST_CATEGORY, graph_promises_on_native_objects) {
 TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 #if !defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
   GTEST_SKIP() << "This test will not work without native graph support";
+#elif KOKKOS_COMPILER_GNU < 910
+  GTEST_SKIP() << "'filesystem' is not fully supported prior to GCC 9.1.0.";
+#elif KOKKOS_COMPILER_CLANG < 1100
+  GTEST_SKIP() << "'filesystem' is not fully supported prior to LLVM 11.";
 #else
   using view_t = Kokkos::View<int, Kokkos::HIP>;
 


### PR DESCRIPTION
Fixes #7416.

Basically, `gcc` older than `9.1.0` and `LLVM` older than `11` would require additional link flags (that sometimes do not even fix all the undefined references).

Therefore, this PR disables the problematic tests for old host compilers that fall into the above condition.

See https://github.com/kokkos/kokkos/issues/7416#issuecomment-2400691182 for more details.