### PR TITLE
Fix Intel19 issue with const variable requiring an initializer

### DIFF
--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -40,7 +40,7 @@ namespace Kokkos {
 namespace Impl {
 constexpr inline struct SubViewCtorTag {
   explicit SubViewCtorTag() = default;
-} subview_ctor_tag;
+} subview_ctor_tag{};
 
 template <class T>
 struct KokkosSliceToMDSpanSliceImpl {


### PR DESCRIPTION
Fix #7404 (not tested)