### PR TITLE
tests(graph): filesystem not supported by old compilers so skip these tests (followup of #7418)

### DIFF
--- a/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
@@ -97,10 +97,12 @@ TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), count_nodes) {
 TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), debug_dot_print) {
 #if CUDA_VERSION < 11600
   GTEST_SKIP() << "Export a graph to DOT requires Cuda 11.6.";
-#elif KOKKOS_COMPILER_GNU < 910
-  GTEST_SKIP() << "'filesystem' is not fully supported prior to GCC 9.1.0.";
-#elif KOKKOS_COMPILER_CLANG < 1100
-  GTEST_SKIP() << "'filesystem' is not fully supported prior to LLVM 11.";
+#elif defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 9
+  GTEST_SKIP() << "The GNU C++ Library (libstdc++) versions less than 9.1 "
+                  "require linking with `-lstdc++fs`";
+#elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 110000
+  GTEST_SKIP() << "The LLVM C++ Standard Library (libc++) versions less than "
+                  "11 require linking with `-lc++fs`";
 #else
   graph->instantiate();
 

--- a/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
@@ -71,10 +71,12 @@ TEST(TEST_CATEGORY, graph_promises_on_native_objects) {
 TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 #if !defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
   GTEST_SKIP() << "This test will not work without native graph support";
-#elif KOKKOS_COMPILER_GNU < 910
-  GTEST_SKIP() << "'filesystem' is not fully supported prior to GCC 9.1.0.";
-#elif KOKKOS_COMPILER_CLANG < 1100
-  GTEST_SKIP() << "'filesystem' is not fully supported prior to LLVM 11.";
+#elif defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 9
+  GTEST_SKIP() << "The GNU C++ Library (libstdc++) versions less than 9.1 "
+                  "require linking with `-lstdc++fs`";
+#elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 110000
+  GTEST_SKIP() << "The LLVM C++ Standard Library (libc++) versions less than "
+                  "11 require linking with `-lc++fs`";
 #else
   using view_t = Kokkos::View<int, Kokkos::HIP>;
 


### PR DESCRIPTION
This PR is a followup of #7418.

Instead of comparing the compiler version, we need to check the `libstdc++` version. Indeed, the most recent `hipcc` compiler could be used with an old `libstdc++` for instance.

I also applied the proposed skip messages that @dalg24 proposed in #7418.