### PR TITLE
Check that internal uses of team_size_recommended return positive values

### DIFF
--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Team.hpp
@@ -120,9 +120,14 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>, HIP> {
         m_vector_size(arg_policy.impl_vector_length()) {
     auto internal_space_instance =
         m_policy.space().impl_internal_space_instance();
-    m_team_size = m_team_size >= 0 ? m_team_size
-                                   : arg_policy.team_size_recommended(
-                                         arg_functor, ParallelForTag());
+    if (m_team_size < 0) {
+      m_team_size =
+          arg_policy.team_size_recommended(arg_functor, ParallelForTag());
+      if (m_team_size <= 0)
+        Kokkos::Impl::throw_runtime_exception(
+            "Kokkos::Impl::ParallelFor<HIP, TeamPolicy> could not find a "
+            "valid execution configuration.");
+    }
 
     m_shmem_begin = (sizeof(double) * (m_team_size + 2));
     m_shmem_size =

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
@@ -325,11 +325,15 @@ class ParallelReduce<CombinedFunctorReducerType,
         m_vector_size(arg_policy.impl_vector_length()) {
     auto internal_space_instance =
         m_policy.space().impl_internal_space_instance();
-    m_team_size = m_team_size >= 0 ? m_team_size
-                                   : arg_policy.team_size_recommended(
-                                         arg_functor_reducer.get_functor(),
-                                         arg_functor_reducer.get_reducer(),
-                                         ParallelReduceTag());
+    if (m_team_size < 0) {
+      m_team_size = arg_policy.team_size_recommended(
+          arg_functor_reducer.get_functor(), arg_functor_reducer.get_reducer(),
+          ParallelReduceTag());
+      if (m_team_size <= 0)
+        Kokkos::Impl::throw_runtime_exception(
+            "Kokkos::Impl::ParallelReduce<HIP, TeamPolicy> could not find a "
+            "valid execution configuration.");
+    }
 
     m_team_begin =
         UseShflReduction

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
@@ -164,10 +164,14 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
         m_league_size(arg_policy.league_size()),
         m_team_size(arg_policy.team_size()),
         m_vector_size(arg_policy.impl_vector_length()) {
-    // FIXME_SYCL optimize
-    if (m_team_size < 0)
+    if (m_team_size < 0) {
       m_team_size =
           m_policy.team_size_recommended(arg_functor, ParallelForTag{});
+      if (m_team_size <= 0)
+        Kokkos::Impl::throw_runtime_exception(
+            "Kokkos::Impl::ParallelFor<SYCL, TeamPolicy> could not find a "
+            "valid execution configuration.");
+    }
 
     m_shmem_begin = (sizeof(double) * (m_team_size + 2));
     m_shmem_size =

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -439,11 +439,16 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         m_league_size(arg_policy.league_size()),
         m_team_size(arg_policy.team_size()),
         m_vector_size(arg_policy.impl_vector_length()) {
-    // FIXME_SYCL optimize
-    if (m_team_size < 0)
+    if (m_team_size < 0) {
       m_team_size = m_policy.team_size_recommended(
           m_functor_reducer.get_functor(), m_functor_reducer.get_reducer(),
           ParallelReduceTag{});
+      if (m_team_size <= 0)
+        Kokkos::Impl::throw_runtime_exception(
+            "Kokkos::Impl::ParallelReduce<SYCL, TeamPolicy> could not find a "
+            "valid execution configuration.");
+    }
+
     // Must be a power of two greater than two, get the one not bigger than the
     // requested one.
     if ((m_team_size & m_team_size - 1) || m_team_size < 2) {

--- a/core/src/Threads/Kokkos_Threads_ParallelFor_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelFor_Team.hpp
@@ -88,8 +88,12 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
       policy.impl_set_vector_length(1);
     }
     if (policy.team_size() < 0) {
-      policy.impl_set_team_size(
-          policy.team_size_recommended(m_functor, ParallelForTag{}));
+      int team_size = policy.team_size_recommended(m_functor, ParallelForTag{});
+      if (team_size <= 0)
+        Kokkos::Impl::throw_runtime_exception(
+            "Kokkos::Impl::ParallelFor<Threads, TeamPolicy> could not find a "
+            "valid execution configuration.");
+      policy.impl_set_team_size(team_size);
     }
     return policy;
   }

--- a/core/src/Threads/Kokkos_Threads_ParallelReduce_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelReduce_Team.hpp
@@ -106,9 +106,14 @@ class ParallelReduce<CombinedFunctorReducerType,
       policy.impl_set_vector_length(1);
     }
     if (policy.team_size() < 0) {
-      policy.impl_set_team_size(policy.team_size_recommended(
+      int team_size = policy.team_size_recommended(
           m_functor_reducer.get_functor(), m_functor_reducer.get_reducer(),
-          ParallelReduceTag{}));
+          ParallelReduceTag{});
+      if (team_size <= 0)
+        Kokkos::Impl::throw_runtime_exception(
+            "Kokkos::Impl::ParallelReduce<Threads, TeamPolicy> could not find "
+            "a valid execution configuration.");
+      policy.impl_set_team_size(team_size);
     }
     return policy;
   }

--- a/core/unit_test/incremental/Test12a_ThreadScratch.hpp
+++ b/core/unit_test/incremental/Test12a_ThreadScratch.hpp
@@ -75,7 +75,8 @@ struct ThreadScratch {
             .set_scratch_size(scratch_level, Kokkos::PerThread(scratchSize));
 
     int max_team_size = policy.team_size_max(*this, Kokkos::ParallelForTag());
-    v                 = data_t("Matrix", pN, max_team_size);
+    ASSERT_GT(max_team_size, 0);
+    v = data_t("Matrix", pN, max_team_size);
 
     Kokkos::parallel_for(
         "Test12a_ThreadScratch",


### PR DESCRIPTION
Supersedes #7407. Related to #7399.
```
template <class ExecSpace>
struct ThreadScratch {
  KOKKOS_FUNCTION
  void operator()(const typename Kokkos::TeamPolicy<ExecSpace>::member_type &team) const {
  }
};

TEST(TEST_CATEGORY, IncrTest_12a_ThreadScratch) {
  using ExecSpace = Kokkos::DefaultExecutionSpace;
  using policy_t = Kokkos::TeamPolicy<ExecSpace>;
  using team_t   = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
  using data_t   = Kokkos::View<size_t **, ExecSpace>;

  using scratch_t = Kokkos::View<size_t *, ExecSpace,
                                 Kokkos::MemoryTraits<Kokkos::Unmanaged> >;

  int scratchSize = scratch_t::shmem_size(321);
    policy_t policy =
        policy_t(1, Kokkos::AUTO, 1)
            .set_scratch_size(0, Kokkos::PerThread(scratchSize));

  int max_team_size = policy.team_size_max(ThreadScratch<ExecSpace>{}, Kokkos::ParallelForTag());

  Kokkos::parallel_for(
        "Test12a_ThreadScratch",
        policy_t(1, max_team_size).set_scratch_size(0, Kokkos::PerThread(scratchSize)),
        *this);
}
```
would currently silently not run. We discussed that it's the users' job to make sure that `max_team_size` is positive (which is what the drive-by change does). On the other hand, we should make sure that internal uses of `team_size_max/recommended` are checked. Since `team_size_max` isn't used internally, that only leaves `team_sizee_recommended`. 