### PR TITLE
SYCL: InterOp_Graph skip dot file when filesystem isn't fully supported

### DIFF
--- a/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
@@ -98,11 +98,13 @@ TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), debug_dot_print) {
 #if CUDA_VERSION < 11600
   GTEST_SKIP() << "Export a graph to DOT requires Cuda 11.6.";
 #elif defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 9
-  GTEST_SKIP() << "The GNU C++ Library (libstdc++) versions less than 9.1 "
-                  "require linking with `-lstdc++fs`";
+  GTEST_SKIP()
+      << "The GNU C++ Library (libstdc++) versions less than 9.1 "
+         "require linking with `-lstdc++fs` when using std::filesystem";
 #elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 110000
-  GTEST_SKIP() << "The LLVM C++ Standard Library (libc++) versions less than "
-                  "11 require linking with `-lc++fs`";
+  GTEST_SKIP()
+      << "The LLVM C++ Standard Library (libc++) versions less than "
+         "11 require linking with `-lc++fs` when using std::filesystem";
 #else
   graph->instantiate();
 

--- a/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
@@ -72,11 +72,13 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 #if !defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
   GTEST_SKIP() << "This test will not work without native graph support";
 #elif defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 9
-  GTEST_SKIP() << "The GNU C++ Library (libstdc++) versions less than 9.1 "
-                  "require linking with `-lstdc++fs`";
+  GTEST_SKIP()
+      << "The GNU C++ Library (libstdc++) versions less than 9.1 "
+         "require linking with `-lstdc++fs` when using std::filesystem";
 #elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 110000
-  GTEST_SKIP() << "The LLVM C++ Standard Library (libc++) versions less than "
-                  "11 require linking with `-lc++fs`";
+  GTEST_SKIP()
+      << "The LLVM C++ Standard Library (libc++) versions less than "
+         "11 require linking with `-lc++fs` when using std::filesystem";
 #else
   using view_t = Kokkos::View<int, Kokkos::HIP>;
 

--- a/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
@@ -80,6 +80,15 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 
   ASSERT_EQ(graph.native_graph().get_nodes().size(), 2u);
 
+#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 9
+  GTEST_SKIP()
+      << "The GNU C++ Library (libstdc++) versions less than 9.1 "
+         "require linking with `-lstdc++fs` when using std::filesystem";
+#elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 110000
+  GTEST_SKIP()
+      << "The LLVM C++ Standard Library (libc++) versions less than "
+         "11 require linking with `-lc++fs` when using std::filesystem";
+#else
   const auto dot = std::filesystem::temp_directory_path() / "sycl_graph.dot";
 
   graph.native_graph().print_graph(dot, true);
@@ -99,6 +108,7 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
   ASSERT_TRUE(std::regex_search(buffer.str(), std::regex(expected)))
       << "Could not find expected signature regex " << std::quoted(expected)
       << " in " << dot;
+#endif
 }
 
 }  // namespace


### PR DESCRIPTION
Addressing https://github.com/kokkos/kokkos/pull/7421#issuecomment-2403484898:
> It's probably more unlikely to trigger the same problem with SYCL but I think we should apply the same fix for consistency. In our CI, I see _GLIBCXX_RELEASE is 11 and on the testbeds 12 but it's conceivable to use an older libstdc++. For completeness, _LIBCPP_VERSION isn't defined.