### PR TITLE
Ensure RandomAccessIterator fulfills the std::random_access_iterator concept

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
@@ -164,6 +164,10 @@ class RandomAccessIterator<::Kokkos::View<DataType, Args...>> {
     return it;
   }
 
+  friend iterator_type operator+(difference_type n, iterator_type other) {
+    return other + n;
+  }
+
   KOKKOS_FUNCTION
   iterator_type operator-(difference_type n) const {
     auto it = *this;

--- a/algorithms/unit_tests/TestStdAlgorithmsCompileOnly.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCompileOnly.cpp
@@ -507,6 +507,20 @@ struct TestStruct {
   }
 };
 
+#ifndef KOKKOS_ENABLE_CXX17
+template <typename ViewType>
+constexpr bool
+test_kokkos_iterator_satify_std_random_access_iterator_concept() {
+  return std::random_access_iterator<
+      Kokkos::Experimental::Impl::RandomAccessIterator<ViewType>>;
+}
+
+static_assert(test_kokkos_iterator_satify_std_random_access_iterator_concept<
+              Kokkos::View<int *>>());
+static_assert(test_kokkos_iterator_satify_std_random_access_iterator_concept<
+              Kokkos::View<const int *>>());
+#endif
+
 }  // namespace compileonly
 }  // namespace stdalgos
 }  // namespace Test


### PR DESCRIPTION
Addressing https://github.com/kokkos/kokkos/pull/7304#discussion_r1747883125. 
~~This pull request also makes sure that we can construct a `RandomAccessIterator` from a `const`-qualified `View`.~~