### PR TITLE
Allow using SequentialHostInit with Kokkos::DualView

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -1072,10 +1072,8 @@ class DualView : public ViewTraits<DataType, Properties...> {
       if (sizeMismatch) {
         sync<typename t_host::memory_space>();
         ::Kokkos::resize(arg_prop, h_view, n0, n1, n2, n3, n4, n5, n6, n7);
-        resync_device(Kokkos::view_alloc(Kokkos::WithoutInitializing));
-
-        /* Mark Host copy as modified */
-        ++modified_flags(0);
+        d_view =
+            create_mirror_view_and_copy(typename t_dev::memory_space(), h_view);
       }
       return;
     } else if constexpr (alloc_prop_input::has_execution_space) {

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -279,11 +279,11 @@ class DualView : public ViewTraits<DataType, Properties...> {
     if constexpr (Impl::ViewCtorProp<P...>::sequential_host_init) {
       h_view = t_host(arg_prop, n0, n1, n2, n3, n4, n5, n6, n7);
       static_assert(Impl::ViewCtorProp<P...>::initialize,
-                    "DualView: Kokkos::SequentialHostInit isn't compatible "
-                    "with Kokkos::WithoutInitializing!");
+                    "DualView: SequentialHostInit isn't compatible with "
+                    "WithoutInitializing!");
       static_assert(!Impl::ViewCtorProp<P...>::has_execution_space,
-                    "DualView: Kokkos::SequentialHostInit isn't compatible "
-                    "with providing an execution space instance!");
+                    "DualView: SequentialHostInit isn't compatible with "
+                    "providing an execution space instance!");
 
       d_view = Kokkos::create_mirror_view_and_copy(
           typename traits::memory_space{}, h_view);
@@ -1063,11 +1063,11 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
     if constexpr (alloc_prop_input::sequential_host_init) {
       static_assert(alloc_prop_input::initialize,
-                    "DualView: Kokkos::SequentialHostInit isn't compatible "
-                    "with Kokkos::WithoutInitializing!");
+                    "DualView: SequentialHostInit isn't compatible with "
+                    "WithoutInitializing!");
       static_assert(!alloc_prop_input::has_execution_space,
-                    "DualView: Kokkos::SequentialHostInit isn't compatible "
-                    "with providing an execution space instance!");
+                    "DualView: SequentialHostInit isn't compatible with "
+                    "providing an execution space instance!");
 
       if (sizeMismatch) {
         sync<typename t_host::memory_space>();

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -634,7 +634,7 @@ class S {
 };
 
 template <typename V>
-void test_sequential_host_init() {
+auto test_sequential_host_init() {
   Kokkos::DualView<V*, TEST_EXECSPACE> dv_v(
       Kokkos::view_alloc("myView", Kokkos::SequentialHostInit), 3u);
 
@@ -646,13 +646,16 @@ void test_sequential_host_init() {
   dv_v.modify_host();
   dv_v.sync_device();
 
-  dv_v.resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), 2u);
-  ASSERT_EQ(dv_v.d_view.size(), 2u);
-  ASSERT_EQ(dv_v.h_view.size(), 2u);
+  return dv_v;
 }
 
 TEST(TEST_CATEGORY, dualview_sequential_host_init) {
-  test_sequential_host_init<Kokkos::View<double*, TEST_EXECSPACE>>();
+  auto dv_v =
+      test_sequential_host_init<Kokkos::View<double*, TEST_EXECSPACE>>();
+  dv_v.resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), 2u);
+  ASSERT_EQ(dv_v.d_view.size(), 2u);
+  ASSERT_EQ(dv_v.h_view.size(), 2u);
+
   test_sequential_host_init<S<Kokkos::View<double*, TEST_EXECSPACE>>>();
 }
 }  // anonymous namespace

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -658,13 +658,13 @@ TEST(TEST_CATEGORY, dualview_sequential_host_init) {
   initialize_view_of_views<S<Kokkos::View<double*, TEST_EXECSPACE>>>();
 
   Kokkos::DualView<double*> dv(
-      Kokkos::view_alloc("myView", Kokkos::SequentialHostInit), 1);
-  dv.resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), 2);
-  ASSERT_EQ(dv.d_view.size(), 2);
-  ASSERT_EQ(dv.h_view.size(), 2);
-  dv.realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), 3);
-  ASSERT_EQ(dv.d_view.size(), 3);
-  ASSERT_EQ(dv.h_view.size(), 3);
+      Kokkos::view_alloc("myView", Kokkos::SequentialHostInit), 1u);
+  dv.resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), 2u);
+  ASSERT_EQ(dv.d_view.size(), 2u);
+  ASSERT_EQ(dv.h_view.size(), 2u);
+  dv.realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), 3u);
+  ASSERT_EQ(dv.d_view.size(), 3u);
+  ASSERT_EQ(dv.h_view.size(), 3u);
 }
 }  // anonymous namespace
 }  // namespace Test

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -634,7 +634,7 @@ class S {
 };
 
 template <typename V>
-auto test_sequential_host_init() {
+auto initialize_view_of_views() {
   Kokkos::DualView<V*, TEST_EXECSPACE> dv_v(
       Kokkos::view_alloc("myView", Kokkos::SequentialHostInit), 3u);
 
@@ -650,13 +650,21 @@ auto test_sequential_host_init() {
 }
 
 TEST(TEST_CATEGORY, dualview_sequential_host_init) {
-  auto dv_v =
-      test_sequential_host_init<Kokkos::View<double*, TEST_EXECSPACE>>();
+  auto dv_v = initialize_view_of_views<Kokkos::View<double*, TEST_EXECSPACE>>();
   dv_v.resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), 2u);
   ASSERT_EQ(dv_v.d_view.size(), 2u);
   ASSERT_EQ(dv_v.h_view.size(), 2u);
 
-  test_sequential_host_init<S<Kokkos::View<double*, TEST_EXECSPACE>>>();
+  initialize_view_of_views<S<Kokkos::View<double*, TEST_EXECSPACE>>>();
+
+  Kokkos::DualView<double*> dv(
+      Kokkos::view_alloc("myView", Kokkos::SequentialHostInit), 1);
+  dv.resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), 2);
+  ASSERT_EQ(dv.d_view.size(), 2);
+  ASSERT_EQ(dv.h_view.size(), 2);
+  dv.realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), 3);
+  ASSERT_EQ(dv.d_view.size(), 3);
+  ASSERT_EQ(dv.h_view.size(), 3);
 }
 }  // anonymous namespace
 }  // namespace Test

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -622,6 +622,22 @@ TEST(TEST_CATEGORY,
             const_dv.view<Kokkos::DefaultExecutionSpace>());
 }
 
+TEST(TEST_CATEGORY, dualview_of_view) {
+  Kokkos::DualView<Kokkos::View<double*, TEST_EXECSPACE>*, TEST_EXECSPACE> dv_v(
+      Kokkos::view_alloc("myView", Kokkos::SequentialHostInit), 3u);
+
+  Kokkos::View<double*, TEST_EXECSPACE> v("v", 2);
+  Kokkos::View<double*, TEST_EXECSPACE> w("w", 2);
+  dv_v.h_view(0) = v;
+  dv_v.h_view(1) = w;
+
+  dv_v.modify_host();
+  dv_v.sync_device();
+
+  dv_v.resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), 2u);
+  ASSERT_EQ(dv_v.d_view.size(), 2u);
+  ASSERT_EQ(dv_v.h_view.size(), 2u);
+}
 }  // anonymous namespace
 }  // namespace Test
 


### PR DESCRIPTION
Fixes #7373. @stanmoore1 Can you confirm that this works for you?

This fixes using `SequentialHostInit` with `DualView` for the constructor and `resize`. `realloc` doesn't work properly with `View` of `Views` anyway so I decided to leave it alone for this pull request.