### PR TITLE
Reintroduce Phalanx special DynRankView operator[]

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -580,9 +580,37 @@ class DynRankView : private View<DataType*******, Properties...> {
              index_type i6 = 0) const {
     return view_type::operator()(i0, i1, i2, i3, i4, i5, i6);
   }
+
+// This is an accomodation for Phalanx, that is usint the operator[] to access
+// all elements in a linear fashion even when the rank is not 1
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_FUNCTION reference_type operator[](index_type i0) const {
+    if constexpr (std::is_same_v<typename drvtraits::value_type,
+                                 typename drvtraits::scalar_array_type>) {
+      return view_type::data()[i0];
+    } else {
+      const size_t dim_scalar = view_type::impl_map().dimension_scalar();
+      const size_t bytes      = view_type::span() / dim_scalar;
+
+      using tmp_view_type =
+          Kokkos::View<DataType*, typename traits::array_layout,
+                       typename traits::device_type,
+                       Kokkos::MemoryTraits<traits::memory_traits::impl_value |
+                                            unsigned(Kokkos::Unmanaged)>>;
+      tmp_view_type rankone_view(view_type::data(), bytes, dim_scalar);
+      return rankone_view(i0);
+    }
+  }
+#else
+  KOKKOS_FUNCTION reference_type operator[](index_type i0) const {
+#ifdef KOKKOS_ENABLE_DEBUG
+    if (rank() != 1u)
+      Kokkos::abort("DynRankView operator[] can only be used for rank-1");
+#endif
     return view_type::operator()(i0, 0, 0, 0, 0, 0, 0);
   }
+#endif
+
   KOKKOS_FUNCTION reference_type access(index_type i0 = 0, index_type i1 = 0,
                                         index_type i2 = 0, index_type i3 = 0,
                                         index_type i4 = 0, index_type i5 = 0,


### PR DESCRIPTION
@ndellingwood @rppawlo 

I am reintroducing some special sauce for Phalanx which got lost in the rewrite despite the very explicit comments in the old code: https://github.com/kokkos/kokkos/blob/15dc143e5f39949eece972a798e175c4b463d4b8/containers/src/Kokkos_DynRankView.hpp#L585-L621

However, the comment also indicates that that was meant as more of a temporary accommodation not a thing we support in perpetua so this PR introduces this behavior back in ONLY with deprecated code enabled, and in debug mode will check that the operator[] is only called if the dynamic rank is 1.

@rppawlo if this is absolutely unacceptable we can talk about this. But I have fairly strong reservations about carrying this behavior forward. 

Hopefully fixes all of: https://github.com/kokkos/kokkos/issues/7375