### PR TITLE
graph(diagnostic): enable compile-time diagnostic of illegal reduction target

### DIFF
--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -358,6 +358,23 @@ class GraphNodeRef {
                       Kokkos::is_reducer<return_type_remove_cvref>::value,
                   "Output argument to parallel reduce in a graph must be a "
                   "View or a Reducer");
+
+    if constexpr (Kokkos::is_reducer_v<return_type_remove_cvref>) {
+      static_assert(
+          Kokkos::SpaceAccessibility<
+              ExecutionSpace, typename return_type_remove_cvref::
+                                  result_view_type::memory_space>::accessible,
+          "The reduction target must be accessible by the graph execution "
+          "space.");
+    } else {
+      static_assert(
+          Kokkos::SpaceAccessibility<
+              ExecutionSpace,
+              typename return_type_remove_cvref::memory_space>::accessible,
+          "The reduction target must be accessible by the graph execution "
+          "space.");
+    }
+
     using return_type =
         // Yes, you do really have to do this...
         std::conditional_t<Kokkos::is_reducer<return_type_remove_cvref>::value,

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -329,32 +329,41 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), when_all_cycle) {
   //----------------------------------------
 }
 
-// This test is disabled because we don't currently support copying to host,
+// This test requires that the graph execution space can access
+// the host memoy space because we don't currently support copying to host,
 // even asynchronously. We _may_ want to do that eventually?
-TEST_F(TEST_CATEGORY_FIXTURE(graph), DISABLED_repeat_chain) {
-  auto graph = Kokkos::Experimental::create_graph(
-      ex, [&, count_host = count_host](auto root) {
-        //----------------------------------------
-        root.then_parallel_for(1, set_functor{count, 0})
-            .then_parallel_for(1, count_functor{count, bugs, 0, 0})
-            .then_parallel_for(1, count_functor{count, bugs, 1, 1})
-            .then_parallel_reduce(1, set_result_functor{count}, count_host)
-            .then_parallel_reduce(
-                1, set_result_functor{bugs},
-                Kokkos::Sum<int, Kokkos::HostSpace>{bugs_host});
-        //----------------------------------------
-      });
+TEST_F(TEST_CATEGORY_FIXTURE(graph), repeat_chain) {
+  constexpr bool result_not_accessible_by_exec = !Kokkos::SpaceAccessibility<
+      TEST_EXECSPACE, decltype(bugs_host)::memory_space>::accessible;
 
-  //----------------------------------------
-  constexpr int repeats = 10;
+  if constexpr (result_not_accessible_by_exec) {
+    GTEST_SKIP() << "The graph requires the reduction targets like 'bugs_host' "
+                    "to be accessible by the execution space.";
+  } else {
+    auto graph = Kokkos::Experimental::create_graph(
+        ex, [&, count_host = count_host](auto root) {
+          //----------------------------------------
+          root.then_parallel_for(1, set_functor{count, 0})
+              .then_parallel_for(1, count_functor{count, bugs, 0, 0})
+              .then_parallel_for(1, count_functor{count, bugs, 1, 1})
+              .then_parallel_reduce(1, set_result_functor{count}, count_host)
+              .then_parallel_reduce(
+                  1, set_result_functor{bugs},
+                  Kokkos::Sum<int, Kokkos::HostSpace>{bugs_host});
+          //----------------------------------------
+        });
 
-  for (int i = 0; i < repeats; ++i) {
-    graph.submit();
-    ex.fence();
-    EXPECT_EQ(2, count_host());
-    EXPECT_EQ(0, bugs_host());
+    //----------------------------------------
+    constexpr int repeats = 10;
+
+    for (int i = 0; i < repeats; ++i) {
+      graph.submit();
+      ex.fence();
+      EXPECT_EQ(2, count_host());
+      EXPECT_EQ(0, bugs_host());
+    }
+    //----------------------------------------
   }
-  //----------------------------------------
 }
 
 TEST_F(TEST_CATEGORY_FIXTURE(graph), zero_work_reduce) {


### PR DESCRIPTION
This PR ensures that a user trying to add a parallel-reduce node whose reduction target is not device accessible will be welcomed with a nice compile-time message.

This is a fundamental difference with regular parallel-reduce for which we make sure that the reduction target will be set to the expected value after the kernel finished using deep copies.

> ⚠️ This PR re-enables a test! The test name was `DISABLED_repeat_chain`, so it was compiled but **always** skipped. This PR re-enables the test, that due to the new `static_assert` cannot be compiled and has to be skipped for illegal configurations, *i.e.* when the graph execution space cannot access one of the reduction target memory space (*e.g.* `bugs_host`).