### PR TITLE
Move BasicView to Impl and disable for classic Intel compiler

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -22,7 +22,7 @@ static_assert(false,
 #ifndef KOKKOS_VIEW_HPP
 #define KOKKOS_VIEW_HPP
 
-#ifdef KOKKOS_ENABLE_IMPL_MDSPAN
+#if defined(KOKKOS_ENABLE_IMPL_MDSPAN) && !defined(KOKKOS_COMPILER_INTEL)
 #include <View/Kokkos_BasicView.hpp>
 #endif
 

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -34,10 +34,10 @@ static_assert(false,
 #include <optional>
 #include <type_traits>
 
+// FIXME: we need to make this work for not using our mdspan impl
 #define KOKKOS_IMPL_NO_UNIQUE_ADDRESS _MDSPAN_NO_UNIQUE_ADDRESS
-namespace Kokkos {
+namespace Kokkos::Impl {
 
-namespace Impl {
 constexpr inline struct SubViewCtorTag {
   explicit SubViewCtorTag() = default;
 } subview_ctor_tag{};
@@ -83,8 +83,6 @@ struct is_layout_left_padded : public std::false_type {};
 template <size_t Pad>
 struct is_layout_left_padded<Kokkos::Experimental::layout_left_padded<Pad>>
     : public std::true_type {};
-
-}  // namespace Impl
 
 template <class ElementType, class Extents, class LayoutPolicy,
           class AccessorPolicy>
@@ -649,6 +647,6 @@ class BasicView {
   template <class, class, class, class>
   friend class BasicView;
 };
-}  // namespace Kokkos
+}  // namespace Kokkos::Impl
 
 #endif

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -658,25 +658,12 @@ struct SharedAllocationDisableTrackingGuard {
   // clang-format on
 };
 
-// Intel classic compiler screwed up the reference counting here
-// in the BasicView test. Apparently the code simplification in
-// BasicView over View, let it think it can optimize stuff away
-// and it ends up not setting the "do-not-deref" flag
-// because it skips some copy ctors.
-// I tried a lot of stuff to no avail (don't move, make an explicit
-// volatile copy first etc.), only reducing opt-level fixed it.
-#ifdef KOKKOS_COMPILER_INTEL
-#pragma optimize("", off)
-#endif
 template <class FunctorType, class... Args>
 inline FunctorType construct_with_shared_allocation_tracking_disabled(
     Args&&... args) {
   [[maybe_unused]] auto guard = SharedAllocationDisableTrackingGuard{};
   return {std::forward<Args>(args)...};
 }
-#ifdef KOKKOS_COMPILER_INTEL
-#pragma optimize("", on)
-#endif
 } /* namespace Impl */
 } /* namespace Kokkos */
 #endif

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -96,7 +96,7 @@ set(COMPILE_ONLY_SOURCES
     view/TestExtentsDatatypeConversion.cpp
 )
 
-if(NOT Kokkos_ENABLE_IMPL_MDSPAN)
+if(NOT Kokkos_ENABLE_IMPL_MDSPAN OR KOKKOS_CXX_COMPILER_ID STREQUAL "Intel")
   list(REMOVE_ITEM COMPILE_ONLY_SOURCES view/TestBasicViewMDSpanConversion.cpp)
 endif()
 
@@ -358,6 +358,9 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         configure_file(${dir}/dummy.cpp ${file})
         list(APPEND ${Tag}_VIEWSUPPORT ${file})
       endforeach()
+      if(KOKKOS_CXX_COMPILER_ID STREQUAL "Intel")
+        list(REMOVE_ITEM ${Tag}_VIEWSUPPORT ${dir}/Test${Tag}_View_BasicView.cpp)
+      endif()
       kokkos_add_executable_and_test(CoreUnitTest_${Tag}_ViewSupport SOURCES UnitTestMainInit.cpp ${${Tag}_VIEWSUPPORT})
     endif()
   endif()

--- a/core/unit_test/view/TestBasicView.hpp
+++ b/core/unit_test/view/TestBasicView.hpp
@@ -51,7 +51,7 @@ void test_default_constructor() {
   using accessor_type = Kokkos::Impl::CheckedReferenceCountedAccessor<
       T, typename ExecutionSpace::memory_space>;
   using view_type =
-      Kokkos::BasicView<T, extents_type, layout_type, accessor_type>;
+      Kokkos::Impl::BasicView<T, extents_type, layout_type, accessor_type>;
   view_type view;
 
   EXPECT_FALSE(view.data_handle().has_record());
@@ -75,7 +75,7 @@ void test_extents_constructor(const ExtentsType &extents) {
   using accessor_type = Kokkos::Impl::CheckedReferenceCountedAccessor<
       T, typename ExecutionSpace::memory_space>;
   using view_type =
-      Kokkos::BasicView<T, extents_type, layout_type, accessor_type>;
+      Kokkos::Impl::BasicView<T, extents_type, layout_type, accessor_type>;
 
   view_type view("test_view", extents);
 
@@ -110,7 +110,7 @@ void test_mapping_constructor(const ExtentsType &extents, std::size_t padding) {
   using accessor_type = Kokkos::Impl::CheckedReferenceCountedAccessor<
       T, typename ExecutionSpace::memory_space>;
   using view_type =
-      Kokkos::BasicView<T, extents_type, layout_type, accessor_type>;
+      Kokkos::Impl::BasicView<T, extents_type, layout_type, accessor_type>;
   static_assert(std::is_same_v<typename view_type::mapping_type, mapping_type>);
 
   auto mapping = mapping_type(extents, padding);
@@ -166,7 +166,7 @@ void test_access_with_extents(const ExtentsType &extents) {
   using accessor_type = Kokkos::Impl::CheckedReferenceCountedAccessor<
       T, typename ExecutionSpace::memory_space>;
   using view_type =
-      Kokkos::BasicView<T, extents_type, layout_type, accessor_type>;
+      Kokkos::Impl::BasicView<T, extents_type, layout_type, accessor_type>;
 
   auto view = view_type("test_view", extents);
 
@@ -206,7 +206,7 @@ TEST(TEST_CATEGORY, basic_view_access) {
     using accessor_type = Kokkos::Impl::CheckedReferenceCountedAccessor<
         T, typename ExecutionSpace::memory_space>;
     using basic_view_type =
-        Kokkos::BasicView<T, extents_type, layout_type, accessor_type>;
+        Kokkos::Impl::BasicView<T, extents_type, layout_type, accessor_type>;
     using view_type = SrcViewType;
     static_assert(std::is_constructible_v<basic_view_type, SrcViewType>);
   }
@@ -234,11 +234,11 @@ void test_atomic_accessor() {
       Kokkos::Impl::CheckedReferenceCountedRelaxedAtomicAccessor<
           T, typename ExecutionSpace::memory_space>;
   using view_type =
-      Kokkos::BasicView<T, extents_type, layout_type, accessor_type>;
+      Kokkos::Impl::BasicView<T, extents_type, layout_type, accessor_type>;
   using um_accessor_type = Kokkos::Impl::CheckedRelaxedAtomicAccessor<
       T, typename ExecutionSpace::memory_space>;
   using um_view_type =
-      Kokkos::BasicView<T, extents_type, layout_type, um_accessor_type>;
+      Kokkos::Impl::BasicView<T, extents_type, layout_type, um_accessor_type>;
 
   extents_type extents{};
   auto view = view_type("test_view", extents);

--- a/core/unit_test/view/TestBasicViewMDSpanConversion.cpp
+++ b/core/unit_test/view/TestBasicViewMDSpanConversion.cpp
@@ -21,18 +21,19 @@
 static_assert(
     std::is_convertible_v<
         Kokkos::View<long long ****, Kokkos::LayoutRight, Kokkos::Serial>,
-        Kokkos::BasicView<long long, Kokkos::dextents<size_t, 4>,
+        Kokkos::Impl::BasicView<long long, Kokkos::dextents<size_t, 4>,
                           Kokkos::Experimental::layout_right_padded<>,
                           Kokkos::Impl::CheckedReferenceCountedAccessor<
                               long long, Kokkos::HostSpace>>>);
 #endif
 
-static_assert(std::is_convertible_v<
-              Kokkos::BasicView<long long, Kokkos::dextents<size_t, 4>,
+static_assert(
+    std::is_convertible_v<
+        Kokkos::Impl::BasicView<long long, Kokkos::dextents<size_t, 4>,
                                 Kokkos::Experimental::layout_right_padded<>,
                                 Kokkos::Impl::CheckedReferenceCountedAccessor<
                                     long long, Kokkos::HostSpace>>,
-              Kokkos::BasicView<const long long, Kokkos::dextents<size_t, 4>,
+        Kokkos::Impl::BasicView<const long long, Kokkos::dextents<size_t, 4>,
                                 Kokkos::Experimental::layout_right_padded<>,
                                 Kokkos::Impl::CheckedReferenceCountedAccessor<
                                     const long long, Kokkos::HostSpace>>>);
@@ -40,7 +41,7 @@ static_assert(std::is_convertible_v<
 static_assert(
     std::is_convertible_v<
         Kokkos::View<long long ****, Kokkos::LayoutRight, Kokkos::Serial>,
-        Kokkos::BasicView<const long long, Kokkos::dextents<size_t, 4>,
+        Kokkos::Impl::BasicView<const long long, Kokkos::dextents<size_t, 4>,
                           Kokkos::Experimental::layout_right_padded<>,
                           Kokkos::Impl::CheckedReferenceCountedAccessor<
                               const long long, Kokkos::HostSpace>>>);


### PR DESCRIPTION
We had issues with the classic Intel compiler where BasicView exposes bugs which are hard to impossible to work around. 
Hence we disable BasicView here, and back out the attempted workaround in SharedAllocationTracker. That workaround had resulted in Intel compiler ICE when enabling AVX2 in other code.

I am also moving BasicView into Impl, so disabling it is not actually a user facing difference when using the Intel compiler. But BasicView was anyway meant to be in the Impl namespace, it was a mistake that it wasn't. 


