### PR TITLE
Fix multiplication result converted to larger type reports in tests

### DIFF
--- a/algorithms/unit_tests/TestBinSortA.hpp
+++ b/algorithms/unit_tests/TestBinSortA.hpp
@@ -77,7 +77,7 @@ struct sum3D {
 };
 
 template <class ExecutionSpace, typename KeyType>
-void test_3D_sort_impl(unsigned int n) {
+void test_3D_sort_impl(size_t n) {
   using KeyViewType = Kokkos::View<KeyType* [3], ExecutionSpace>;
 
   KeyViewType keys("Keys", n * n * n);

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamCount.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamCount.cpp
@@ -111,7 +111,7 @@ void test_A(const bool searched_value_exist, std::size_t numTeams,
 
   using rand_pool =
       Kokkos::Random_XorShift64_Pool<Kokkos::DefaultHostExecutionSpace>;
-  rand_pool pool(lowerBound * upperBound);
+  rand_pool pool(static_cast<uint64_t>(lowerBound) * upperBound);
 
   if (searched_value_exist) {
     Kokkos::View<std::size_t*, Kokkos::DefaultHostExecutionSpace> randomIndices(

--- a/containers/unit_tests/TestBitset.hpp
+++ b/containers/unit_tests/TestBitset.hpp
@@ -39,7 +39,7 @@ struct TestBitset {
 
   TestBitset(bitset_type const& bitset) : m_bitset(bitset) {}
 
-  unsigned testit(unsigned collisions) {
+  unsigned testit(unsigned long long collisions) {
     execution_space().fence();
 
     unsigned count = 0;

--- a/containers/unit_tests/TestViewCtorPropEmbeddedDim.hpp
+++ b/containers/unit_tests/TestViewCtorPropEmbeddedDim.hpp
@@ -48,7 +48,7 @@ struct TestViewCtorProp_EmbeddedDim {
     void operator()(const int i) const { v(i) = i; }
   };
 
-  static void test_vcpt(const int N0, const int N1) {
+  static void test_vcpt(const size_t N0, const size_t N1) {
     // Create two views to test
     {
       using VIT = typename TestViewCtorProp_EmbeddedDim::ViewIntType;
@@ -81,7 +81,7 @@ struct TestViewCtorProp_EmbeddedDim {
         ASSERT_EQ((std::is_same_v<CommonViewValueType, double>), true);
 #if 0
       // debug output
-      for ( int i = 0; i < N0*N1; ++i ) {
+      for ( size_t i = 0; i < N0*N1; ++i ) {
         printf(" Output check: hcv1(%d) = %lf\n ", i, hcv1(i) );
       }
 

--- a/containers/unit_tests/TestViewCtorPropEmbeddedDim.hpp
+++ b/containers/unit_tests/TestViewCtorPropEmbeddedDim.hpp
@@ -82,7 +82,7 @@ struct TestViewCtorProp_EmbeddedDim {
 #if 0
       // debug output
       for ( size_t i = 0; i < N0*N1; ++i ) {
-        printf(" Output check: hcv1(%d) = %lf\n ", i, hcv1(i) );
+        printf(" Output check: hcv1(%zu) = %lf\n ", i, hcv1(i) );
       }
 
       printf( " Common value type view: %s \n", typeid( CVT() ).name() );

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -279,7 +279,7 @@ class ReduceTeamFunctor {
     const int thread_size = ind.team_size() * ind.league_size();
     const int chunk       = (nwork + thread_size - 1) / thread_size;
 
-    size_type iwork           = chunk * thread_rank;
+    size_type iwork           = static_cast<size_type>(chunk) * thread_rank;
     const size_type iwork_end = iwork + chunk < nwork ? iwork + chunk : nwork;
 
     for (; iwork < iwork_end; ++iwork) {
@@ -465,8 +465,9 @@ class ScanTeamFunctor {
   void operator()(const typename policy_type::member_type ind,
                   value_type &error) const {
     if (0 == ind.league_rank() && 0 == ind.team_rank()) {
-      const int64_t thread_count = ind.league_size() * ind.team_size();
-      total()                    = (thread_count * (thread_count + 1)) / 2;
+      const int64_t thread_count =
+          static_cast<int64_t>(ind.league_size()) * ind.team_size();
+      total() = (thread_count * (thread_count + 1)) / 2;
     }
 
     // Team max:

--- a/core/unit_test/TestViewCtorPropEmbeddedDim.hpp
+++ b/core/unit_test/TestViewCtorPropEmbeddedDim.hpp
@@ -44,7 +44,7 @@ struct TestViewCtorProp_EmbeddedDim {
     void operator()(const int i) const { v(i) = i; }
   };
 
-  static void test_vcpt(const int N0, const int N1) {
+  static void test_vcpt(const size_t N0, const size_t N1) {
     // Create views to test
     {
       using VIT = typename TestViewCtorProp_EmbeddedDim::ViewIntType;


### PR DESCRIPTION
Fix 
https://github.com/kokkos/kokkos/security/code-scanning/23
https://github.com/kokkos/kokkos/security/code-scanning/22
https://github.com/kokkos/kokkos/security/code-scanning/19
https://github.com/kokkos/kokkos/security/code-scanning/18
https://github.com/kokkos/kokkos/security/code-scanning/9
https://github.com/kokkos/kokkos/security/code-scanning/8
https://github.com/kokkos/kokkos/security/code-scanning/7
https://github.com/kokkos/kokkos/security/code-scanning/6
https://github.com/kokkos/kokkos/security/code-scanning/5
https://github.com/kokkos/kokkos/security/code-scanning/4
https://github.com/kokkos/kokkos/security/code-scanning/3

After this, only benchmarks and performance tests will be left