### PR TITLE
Cuda: fix long double suppression

### DIFF
--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -6,7 +6,7 @@ NVIDIA-GH200:
     - cmake
       -B build
       -DCMAKE_CXX_COMPILER=`pwd`/bin/nvcc_wrapper
-      -DCMAKE_CXX_FLAGS="-Werror all-warnings -Werror"
+      -DCMAKE_CXX_FLAGS="-Werror=all-warnings -Werror"
       -DKokkos_ARCH_HOPPER90=ON
       -DKokkos_ENABLE_CUDA=ON
       -DKokkos_ENABLE_COMPILER_WARNINGS=ON

--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -3,7 +3,15 @@ NVIDIA-GH200:
   tags: [nvidia-gh200]
   image: masterleinad/kokkos-nvcc:12.6.1
   script:
-    - cmake -B build -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_HOPPER90=ON -DKokkos_ENABLE_IMPL_CUDA_UNIFIED_MEMORY=ON -DKokkos_ENABLE_TESTS=ON
+    - cmake
+      -B build
+      -DCMAKE_CXX_COMPILER=`pwd`/bin/nvcc_wrapper
+      -DCMAKE_CXX_FLAGS="-Werror all-warnings -Werror"
+      -DKokkos_ARCH_HOPPER90=ON
+      -DKokkos_ENABLE_CUDA=ON
+      -DKokkos_ENABLE_COMPILER_WARNINGS=ON
+      -DKokkos_ENABLE_IMPL_CUDA_UNIFIED_MEMORY=ON
+      -DKokkos_ENABLE_TESTS=ON
     - cmake --build build -j48
     - cd build
     - ctest -V

--- a/.jenkins
+++ b/.jenkins
@@ -454,7 +454,7 @@ pipeline {
                                 -DCMAKE_BUILD_TYPE=Debug \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=$WORKSPACE/bin/nvcc_wrapper \
-                                -DCMAKE_CXX_FLAGS="-Werror -Werror all-warnings -Xcudafe --diag_suppress=20208" \
+                                -DCMAKE_CXX_FLAGS="-Werror -Werror all-warnings" \
                                 -DCMAKE_CXX_STANDARD=17 \
                                 -DKokkos_ARCH_NATIVE=ON \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
@@ -495,7 +495,7 @@ pipeline {
                         sh '''rm -rf build && mkdir -p build && cd build && \
                               ../gnu_generate_makefile.bash \
                                 --with-options=compiler_warnings \
-                                --cxxflags="-Werror -Werror all-warnings -Xcudafe --diag_suppress=20208" \
+                                --cxxflags="-Werror -Werror all-warnings" \
                                 --cxxstandard=c++17 \
                                 --with-cuda \
                                 --with-cuda-options=enable_lambda \

--- a/.jenkins
+++ b/.jenkins
@@ -146,7 +146,7 @@ pipeline {
                                 -DCMAKE_BUILD_TYPE=Release \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=$WORKSPACE/bin/nvcc_wrapper \
-                                -DCMAKE_CXX_FLAGS="-Werror --Werror=all-warnings -Xcudafe --diag_suppress=3159 -Xcudafe --diag_suppress=940" \
+                                -DCMAKE_CXX_FLAGS="-Werror --Werror=all-warnings -Xcudafe --diag_suppress=940" \
                                 -DCMAKE_EXE_LINKER_FLAGS="-Xnvlink -suppress-stack-size-warning" \
                                 -DCMAKE_CXX_STANDARD=17 \
                                 -DKokkos_INSTALL_TESTING=ON \

--- a/.jenkins
+++ b/.jenkins
@@ -454,7 +454,7 @@ pipeline {
                                 -DCMAKE_BUILD_TYPE=Debug \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=$WORKSPACE/bin/nvcc_wrapper \
-                                -DCMAKE_CXX_FLAGS="-Werror -Werror all-warnings" \
+                                -DCMAKE_CXX_FLAGS="-Werror -Werror=all-warnings" \
                                 -DCMAKE_CXX_STANDARD=17 \
                                 -DKokkos_ARCH_NATIVE=ON \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
@@ -495,7 +495,7 @@ pipeline {
                         sh '''rm -rf build && mkdir -p build && cd build && \
                               ../gnu_generate_makefile.bash \
                                 --with-options=compiler_warnings \
-                                --cxxflags="-Werror -Werror all-warnings" \
+                                --cxxflags="-Werror -Werror=all-warnings" \
                                 --cxxstandard=c++17 \
                                 --with-cuda \
                                 --with-cuda-options=enable_lambda \

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -14,8 +14,7 @@
 //
 //@HEADER
 
-#include <Kokkos_Core.hpp>
-#include <sstream>
+#include <Kokkos_Macros.hpp>
 
 // Suppress "'long double' is treated as 'double' in device code"
 #ifdef KOKKOS_COMPILER_NVCC
@@ -29,6 +28,9 @@
 #endif
 #endif
 #endif
+
+#include <Kokkos_Core.hpp>
+#include <sstream>
 
 namespace {
 template <typename... Ts>

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -17,6 +17,8 @@
 #include <Kokkos_Macros.hpp>
 
 // Suppress "'long double' is treated as 'double' in device code"
+// The suppression needs to happen before Kokkos_Complex.hpp is included to be
+// effective
 #ifdef KOKKOS_COMPILER_NVCC
 #ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
 #pragma nv_diagnostic push

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -498,7 +498,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), force_global_launch) {
   ASSERT_TRUE(contains(ex, data, functor_t::count));
 
   ASSERT_TRUE(validate_event_set(
-      [&]() { graph.~optional(); },
+      [&]() { graph.reset(); },
       [&](DeallocateDataEvent dealloc) {
         if (dealloc.name == alloc_label && dealloc.ptr == ptr &&
             dealloc.size == ptr_size)

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -36,7 +36,6 @@
 #include <Kokkos_Core.hpp>
 #include <type_traits>
 #include <limits>
-#include "Kokkos_NumericTraits.hpp"
 
 struct extrema {
 #define DEFINE_EXTREMA(T, m, M)                 \

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -17,6 +17,8 @@
 #include <Kokkos_Macros.hpp>
 
 // Suppress "'long double' is treated as 'double' in device code"
+// The suppression needs to happen before Kokkos_NumericTraits.hpp is included
+// to be effective
 #ifdef KOKKOS_COMPILER_NVCC
 #ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
 #pragma nv_diagnostic push

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -14,12 +14,7 @@
 //
 //@HEADER
 
-#include <gtest/gtest.h>
-
-#include <Kokkos_Core.hpp>
-#include <type_traits>
-#include <limits>
-#include "Kokkos_NumericTraits.hpp"
+#include <Kokkos_Macros.hpp>
 
 // Suppress "'long double' is treated as 'double' in device code"
 #ifdef KOKKOS_COMPILER_NVCC
@@ -33,6 +28,13 @@
 #endif
 #endif
 #endif
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+#include <type_traits>
+#include <limits>
+#include "Kokkos_NumericTraits.hpp"
 
 struct extrema {
 #define DEFINE_EXTREMA(T, m, M)                 \


### PR DESCRIPTION
We need to have the suppress before `Kokkos_Core.hpp` to be effective for the `Kokkos_NumcericTraits.hpp` and `Kokkos_Complex.hpp`.

Also, enable warning and warnings as errors in the GitLab GH200 build.