### PR TITLE
simd: refactor simd classes and hide simd_abi

### DIFF
--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -170,9 +170,9 @@ using native = ForSpace<Kokkos::DefaultExecutionSpace>;
 }  // namespace simd_abi
 
 template <class T>
-using native_simd = simd<T, simd_abi::native<T>>;
+using native_simd = basic_simd<T, simd_abi::native<T>>;
 template <class T>
-using native_simd_mask = simd_mask<T, simd_abi::native<T>>;
+using native_simd_mask = basic_simd_mask<T, simd_abi::native<T>>;
 
 namespace Impl {
 

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -224,8 +224,8 @@ using native_simd_mask KOKKOS_DEPRECATED =
     basic_simd_mask<T, simd_abi::native<T>>;
 
 template <class T, class Abi>
-using simd KOKKOS_DEPRECATED_WITH_COMMENT("Temporarily use Impl::simd<T> instead") =
-    basic_simd<T, Abi>;
+using simd KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Temporarily use Impl::simd<T> instead") = basic_simd<T, Abi>;
 
 template <class T, class Abi>
 using simd_mask KOKKOS_DEPRECATED_WITH_COMMENT(

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -218,11 +218,11 @@ using native = ForSpace<Kokkos::DefaultExecutionSpace>;
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class T>
 using native_simd KOKKOS_DEPRECATED_WITH_COMMENT(
-    "Temporarily use Impl::simd<T> instead") =
+    "native_simd is deprecated. Use simd<T> instead") =
     basic_simd<T, simd_abi::native<T>>;
 template <class T>
 using native_simd_mask KOKKOS_DEPRECATED_WITH_COMMENT(
-    "Temporarily use Impl::simd_mask<T> instead") =
+    "native_simd_mask is deprecated. Use simd_mask<T> instead") =
     basic_simd_mask<T, simd_abi::native<T>>;
 #endif
 

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -224,17 +224,7 @@ template <class T>
 using native_simd_mask KOKKOS_DEPRECATED_WITH_COMMENT(
     "Temporarily use Impl::simd_mask<T> instead") =
     basic_simd_mask<T, simd_abi::native<T>>;
-
-template <class T, class Abi>
-using simd KOKKOS_DEPRECATED_WITH_COMMENT(
-    "Temporarily use Impl::simd<T> instead") = basic_simd<T, Abi>;
-
-template <class T, class Abi>
-using simd_mask KOKKOS_DEPRECATED_WITH_COMMENT(
-    "Temporarily use Impl::simd_mask<T> instead") = basic_simd_mask<T, Abi>;
 #endif
-
-namespace Impl {
 
 template <class T, int N = 0>
 using simd =
@@ -246,6 +236,8 @@ template <class T, int N = 0>
 using simd_mask = basic_simd_mask<
     T, std::conditional_t<(N == 0), simd_abi::Impl::native_fixed_abi<>,
                           simd_abi::Impl::native_abi<N>>>;
+
+namespace Impl {
 
 template <class... Abis>
 class abi_set {};

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -207,20 +207,22 @@ using native_abi = typename ForSpace<Space>::template simd_abi<N>;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class Space>
-using ForSpace KOKKOS_DEPRECATED =
-    typename Impl::ForSpace<typename Space::execution_space>::type;
+using ForSpace = typename Impl::ForSpace<typename Space::execution_space>::type;
 
 template <class T>
-using native KOKKOS_DEPRECATED = ForSpace<Kokkos::DefaultExecutionSpace>;
+using native = ForSpace<Kokkos::DefaultExecutionSpace>;
 #endif
 
 }  // namespace simd_abi
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class T>
-using native_simd KOKKOS_DEPRECATED = basic_simd<T, simd_abi::native<T>>;
+using native_simd KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Temporarily use Impl::simd<T> instead") =
+    basic_simd<T, simd_abi::native<T>>;
 template <class T>
-using native_simd_mask KOKKOS_DEPRECATED =
+using native_simd_mask KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Temporarily use Impl::simd_mask<T> instead") =
     basic_simd_mask<T, simd_abi::native<T>>;
 
 template <class T, class Abi>

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -50,7 +50,7 @@ class avx2_fixed_size {};
 }  // namespace simd_abi
 
 template <>
-class simd_mask<double, simd_abi::avx2_fixed_size<4>> {
+class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
   __m256d m_value;
 
  public:
@@ -82,8 +82,9 @@ class simd_mask<double, simd_abi::avx2_fixed_size<4>> {
   };
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      value_type value)
       : m_value(_mm256_castsi256_pd(_mm256_set1_epi64x(-std::int64_t(value)))) {
   }
   template <class G,
@@ -91,19 +92,20 @@ class simd_mask<double, simd_abi::avx2_fixed_size<4>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm256_castsi256_pd(_mm256_setr_epi64x(
             -std::int64_t(gen(std::integral_constant<std::size_t, 0>())),
             -std::int64_t(gen(std::integral_constant<std::size_t, 1>())),
             -std::int64_t(gen(std::integral_constant<std::size_t, 2>())),
             -std::int64_t(gen(std::integral_constant<std::size_t, 3>()))))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& i32_mask);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
+      basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
+          i32_mask);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m256d const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256d()
@@ -118,30 +120,30 @@ class simd_mask<double, simd_abi::avx2_fixed_size<4>> {
     return static_cast<value_type>(
         reference(const_cast<__m256d&>(m_value), int(i)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator||(simd_mask const& other) const {
-    return simd_mask(_mm256_or_pd(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator||(basic_simd_mask const& other) const {
+    return basic_simd_mask(_mm256_or_pd(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator&&(simd_mask const& other) const {
-    return simd_mask(_mm256_and_pd(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator&&(basic_simd_mask const& other) const {
+    return basic_simd_mask(_mm256_and_pd(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
-    auto const true_value = static_cast<__m256d>(simd_mask(true));
-    return simd_mask(_mm256_andnot_pd(m_value, true_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+    auto const true_value = static_cast<__m256d>(basic_simd_mask(true));
+    return basic_simd_mask(_mm256_andnot_pd(m_value, true_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return _mm256_movemask_pd(m_value) == _mm256_movemask_pd(other.m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return !operator==(other);
   }
 };
 
 template <>
-class simd_mask<float, simd_abi::avx2_fixed_size<4>> {
+class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
   __m128 m_value;
 
  public:
@@ -173,15 +175,16 @@ class simd_mask<float, simd_abi::avx2_fixed_size<4>> {
   };
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      value_type value)
       : m_value(_mm_castsi128_ps(_mm_set1_epi32(-std::int32_t(value)))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm_castsi128_ps(_mm_setr_epi32(
             -std::int32_t(gen(std::integral_constant<std::size_t, 0>())),
@@ -191,7 +194,7 @@ class simd_mask<float, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m128 const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128()
@@ -206,30 +209,30 @@ class simd_mask<float, simd_abi::avx2_fixed_size<4>> {
     return static_cast<value_type>(
         reference(const_cast<__m128&>(m_value), int(i)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator||(simd_mask const& other) const {
-    return simd_mask(_mm_or_ps(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator||(basic_simd_mask const& other) const {
+    return basic_simd_mask(_mm_or_ps(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator&&(simd_mask const& other) const {
-    return simd_mask(_mm_and_ps(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator&&(basic_simd_mask const& other) const {
+    return basic_simd_mask(_mm_and_ps(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
-    auto const true_value = static_cast<__m128>(simd_mask(true));
-    return simd_mask(_mm_andnot_ps(m_value, true_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+    auto const true_value = static_cast<__m128>(basic_simd_mask(true));
+    return basic_simd_mask(_mm_andnot_ps(m_value, true_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return _mm_movemask_ps(m_value) == _mm_movemask_ps(other.m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return !operator==(other);
   }
 };
 
 template <>
-class simd_mask<float, simd_abi::avx2_fixed_size<8>> {
+class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
   __m256 m_value;
 
  public:
@@ -269,15 +272,16 @@ class simd_mask<float, simd_abi::avx2_fixed_size<8>> {
   };
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      value_type value)
       : m_value(_mm256_castsi256_ps(_mm256_set1_epi32(-std::int32_t(value)))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm256_castsi256_ps(_mm256_setr_epi32(
             -std::int32_t(gen(std::integral_constant<std::size_t, 0>())),
@@ -291,7 +295,7 @@ class simd_mask<float, simd_abi::avx2_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m256 const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256()
@@ -306,30 +310,30 @@ class simd_mask<float, simd_abi::avx2_fixed_size<8>> {
     return static_cast<value_type>(
         reference(const_cast<__m256&>(m_value), int(i)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator||(simd_mask const& other) const {
-    return simd_mask(_mm256_or_ps(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator||(basic_simd_mask const& other) const {
+    return basic_simd_mask(_mm256_or_ps(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator&&(simd_mask const& other) const {
-    return simd_mask(_mm256_and_ps(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator&&(basic_simd_mask const& other) const {
+    return basic_simd_mask(_mm256_and_ps(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
-    auto const true_value = static_cast<__m256>(simd_mask(true));
-    return simd_mask(_mm256_andnot_ps(m_value, true_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+    auto const true_value = static_cast<__m256>(basic_simd_mask(true));
+    return basic_simd_mask(_mm256_andnot_ps(m_value, true_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return _mm256_movemask_ps(m_value) == _mm256_movemask_ps(other.m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return !operator==(other);
   }
 };
 
 template <>
-class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
+class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   __m128i m_value;
 
  public:
@@ -361,13 +365,14 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   };
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      value_type value)
       : m_value(_mm_set1_epi32(-std::int32_t(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m128i const& value_in)
       : m_value(value_in) {}
   template <class G,
@@ -375,7 +380,7 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm_setr_epi32(
             -std::int32_t(gen(std::integral_constant<std::size_t, 0>())),
@@ -383,8 +388,8 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
             -std::int32_t(gen(std::integral_constant<std::size_t, 2>())),
             -std::int32_t(gen(std::integral_constant<std::size_t, 3>())))) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<U, abi_type> const& other) {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
+      basic_simd_mask<U, abi_type> const& other) {
     for (std::size_t i = 0; i < size(); ++i) (*this)[i] = other[i];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128i()
@@ -399,31 +404,31 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
     return static_cast<value_type>(
         reference(const_cast<__m128i&>(m_value), int(i)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator||(simd_mask const& other) const {
-    return simd_mask(_mm_or_si128(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator||(basic_simd_mask const& other) const {
+    return basic_simd_mask(_mm_or_si128(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator&&(simd_mask const& other) const {
-    return simd_mask(_mm_and_si128(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator&&(basic_simd_mask const& other) const {
+    return basic_simd_mask(_mm_and_si128(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
-    auto const true_value = static_cast<__m128i>(simd_mask(true));
-    return simd_mask(_mm_andnot_si128(m_value, true_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+    auto const true_value = static_cast<__m128i>(basic_simd_mask(true));
+    return basic_simd_mask(_mm_andnot_si128(m_value, true_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return _mm_movemask_ps(_mm_castsi128_ps(m_value)) ==
            _mm_movemask_ps(_mm_castsi128_ps(other.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return !operator==(other);
   }
 };
 
 template <>
-class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
+class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
   __m256i m_value;
 
  public:
@@ -458,13 +463,14 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
   };
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      value_type value)
       : m_value(_mm256_set1_epi32(-std::int32_t(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m256i const& value_in)
       : m_value(value_in) {}
   template <class G,
@@ -472,7 +478,7 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi32(
             -std::int32_t(gen(std::integral_constant<std::size_t, 0>())),
@@ -484,8 +490,8 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
             -std::int32_t(gen(std::integral_constant<std::size_t, 6>())),
             -std::int32_t(gen(std::integral_constant<std::size_t, 7>())))) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<U, abi_type> const& other) {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
+      basic_simd_mask<U, abi_type> const& other) {
     for (std::size_t i = 0; i < size(); ++i) (*this)[i] = other[i];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
@@ -500,31 +506,31 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
     return static_cast<value_type>(
         reference(const_cast<__m256i&>(m_value), int(i)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator||(simd_mask const& other) const {
-    return simd_mask(_mm256_or_si256(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator||(basic_simd_mask const& other) const {
+    return basic_simd_mask(_mm256_or_si256(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator&&(simd_mask const& other) const {
-    return simd_mask(_mm256_and_si256(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator&&(basic_simd_mask const& other) const {
+    return basic_simd_mask(_mm256_and_si256(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
-    auto const true_value = static_cast<__m256i>(simd_mask(true));
-    return simd_mask(_mm256_andnot_si256(m_value, true_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+    auto const true_value = static_cast<__m256i>(basic_simd_mask(true));
+    return basic_simd_mask(_mm256_andnot_si256(m_value, true_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return _mm256_movemask_ps(_mm256_castsi256_ps(m_value)) ==
            _mm256_movemask_ps(_mm256_castsi256_ps(other.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return !operator==(other);
   }
 };
 
 template <>
-class simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
+class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   __m256i m_value;
 
  public:
@@ -557,13 +563,14 @@ class simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   };
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      value_type value)
       : m_value(_mm256_set1_epi64x(-std::int64_t(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m256i const& value_in)
       : m_value(value_in) {}
   template <class G,
@@ -571,15 +578,15 @@ class simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi64x(
             -std::int64_t(gen(std::integral_constant<std::size_t, 0>())),
             -std::int64_t(gen(std::integral_constant<std::size_t, 1>())),
             -std::int64_t(gen(std::integral_constant<std::size_t, 2>())),
             -std::int64_t(gen(std::integral_constant<std::size_t, 3>())))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<std::int32_t, abi_type> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
+      basic_simd_mask<std::int32_t, abi_type> const& other)
       : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
       const {
@@ -593,31 +600,31 @@ class simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
     return static_cast<value_type>(
         reference(const_cast<__m256i&>(m_value), int(i)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator||(simd_mask const& other) const {
-    return simd_mask(_mm256_or_si256(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator||(basic_simd_mask const& other) const {
+    return basic_simd_mask(_mm256_or_si256(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator&&(simd_mask const& other) const {
-    return simd_mask(_mm256_and_si256(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator&&(basic_simd_mask const& other) const {
+    return basic_simd_mask(_mm256_and_si256(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
-    auto const true_value = static_cast<__m256i>(simd_mask(true));
-    return simd_mask(_mm256_andnot_si256(m_value, true_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+    auto const true_value = static_cast<__m256i>(basic_simd_mask(true));
+    return basic_simd_mask(_mm256_andnot_si256(m_value, true_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return _mm256_movemask_pd(_mm256_castsi256_pd(m_value)) ==
            _mm256_movemask_pd(_mm256_castsi256_pd(other.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return !operator==(other);
   }
 };
 
 template <>
-class simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
+class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   __m256i m_value;
 
  public:
@@ -650,16 +657,17 @@ class simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   };
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      value_type value)
       : m_value(_mm256_set1_epi64x(-std::int64_t(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<std::int32_t, abi_type> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
+      basic_simd_mask<std::int32_t, abi_type> const& other)
       : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m256i const& value_in)
       : m_value(value_in) {}
   template <class G,
@@ -667,7 +675,7 @@ class simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi64x(
             -std::int64_t(gen(std::integral_constant<std::size_t, 0>())),
@@ -686,57 +694,59 @@ class simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     return static_cast<value_type>(
         reference(const_cast<__m256i&>(m_value), int(i)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator||(simd_mask const& other) const {
-    return simd_mask(_mm256_or_si256(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator||(basic_simd_mask const& other) const {
+    return basic_simd_mask(_mm256_or_si256(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator&&(simd_mask const& other) const {
-    return simd_mask(_mm256_and_si256(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator&&(basic_simd_mask const& other) const {
+    return basic_simd_mask(_mm256_and_si256(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
-    auto const true_value = static_cast<__m256i>(simd_mask(true));
-    return simd_mask(_mm256_andnot_si256(m_value, true_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+    auto const true_value = static_cast<__m256i>(basic_simd_mask(true));
+    return basic_simd_mask(_mm256_andnot_si256(m_value, true_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return _mm256_movemask_pd(_mm256_castsi256_pd(m_value)) ==
            _mm256_movemask_pd(_mm256_castsi256_pd(other.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return !operator==(other);
   }
 };
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd_mask<double, simd_abi::avx2_fixed_size<4>>::simd_mask(
-    simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& i32_mask)
+basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
+    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& i32_mask)
     : m_value(_mm256_castsi256_pd(
           _mm256_cvtepi32_epi64(static_cast<__m128i>(i32_mask)))) {}
 
 template <>
-class simd<double, simd_abi::avx2_fixed_size<4>> {
+class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
   __m256d m_value;
 
  public:
   using value_type = double;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm256_set1_pd(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256d const& value_in)
       : m_value(value_in) {}
   template <class G,
@@ -744,7 +754,7 @@ class simd<double, simd_abi::avx2_fixed_size<4>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm256_setr_pd(gen(std::integral_constant<std::size_t, 0>()),
                                gen(std::integral_constant<std::size_t, 1>()),
@@ -778,63 +788,63 @@ class simd<double, simd_abi::avx2_fixed_size<4>> {
       const {
     return m_value;
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
-    return simd(
+    return basic_simd(
         _mm256_sub_pd(_mm256_set1_pd(0.0), static_cast<__m256d>(m_value)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm256_mul_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm256_div_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm256_add_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm256_sub_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_LT_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_GT_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_LE_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_GE_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_EQ_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_NEQ_OS));
   }
@@ -843,175 +853,190 @@ class simd<double, simd_abi::avx2_fixed_size<4>> {
 }  // namespace Experimental
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    copysign(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    copysign(Experimental::basic_simd<
                  double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-             Experimental::simd<
+             Experimental::basic_simd<
                  double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
   __m256d const sign_mask = _mm256_set1_pd(-0.0);
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_xor_pd(_mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)),
                     _mm256_and_pd(sign_mask, static_cast<__m256d>(b))));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    abs(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    abs(Experimental::basic_simd<
         double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   __m256d const sign_mask = _mm256_set1_pd(-0.0);
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    floor(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    floor(Experimental::basic_simd<
           double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_round_pd(static_cast<__m256d>(a),
                       (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    ceil(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    ceil(Experimental::basic_simd<
          double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_round_pd(static_cast<__m256d>(a),
                       (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    round(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    round(Experimental::basic_simd<
           double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_round_pd(static_cast<__m256d>(a),
                       (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    trunc(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    trunc(Experimental::basic_simd<
           double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_round_pd(static_cast<__m256d>(a),
                       (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    sqrt(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    sqrt(Experimental::basic_simd<
          double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_sqrt_pd(static_cast<__m256d>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    cbrt(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    cbrt(Experimental::basic_simd<
          double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cbrt_pd(static_cast<__m256d>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    exp(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    exp(Experimental::basic_simd<
         double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_exp_pd(static_cast<__m256d>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    log(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    log(Experimental::basic_simd<
         double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_log_pd(static_cast<__m256d>(a)));
 }
 
 #endif
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    fma(Experimental::simd<double,
-                           Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-        Experimental::simd<double,
-                           Experimental::simd_abi::avx2_fixed_size<4>> const& b,
-        Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    fma(Experimental::basic_simd<
+            double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+        Experimental::basic_simd<
+            double, Experimental::simd_abi::avx2_fixed_size<4>> const& b,
+        Experimental::basic_simd<
             double, Experimental::simd_abi::avx2_fixed_size<4>> const& c) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_fmadd_pd(static_cast<__m256d>(a), static_cast<__m256d>(b),
                       static_cast<__m256d>(c)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    max(Experimental::simd<double,
-                           Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-        Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    max(Experimental::basic_simd<
+            double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+        Experimental::basic_simd<
             double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_max_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    min(Experimental::simd<double,
-                           Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-        Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    min(Experimental::basic_simd<
+            double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+        Experimental::basic_simd<
             double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_min_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx2_fixed_size<4>>
-    condition(simd_mask<double, simd_abi::avx2_fixed_size<4>> const& a,
-              simd<double, simd_abi::avx2_fixed_size<4>> const& b,
-              simd<double, simd_abi::avx2_fixed_size<4>> const& c) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
+    basic_simd<double, simd_abi::avx2_fixed_size<4>>
+    condition(basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& a,
+              basic_simd<double, simd_abi::avx2_fixed_size<4>> const& b,
+              basic_simd<double, simd_abi::avx2_fixed_size<4>> const& c) {
+  return basic_simd<double, simd_abi::avx2_fixed_size<4>>(
       _mm256_blendv_pd(static_cast<__m256d>(c), static_cast<__m256d>(b),
                        static_cast<__m256d>(a)));
 }
 
 template <>
-class simd<float, simd_abi::avx2_fixed_size<4>> {
+class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
   __m128 m_value;
 
  public:
   using value_type = float;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm_set1_ps(value_type(value))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(G&& gen)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen)
       : m_value(_mm_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                             gen(std::integral_constant<std::size_t, 1>()),
                             gen(std::integral_constant<std::size_t, 2>()),
                             gen(std::integral_constant<std::size_t, 3>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m128 const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
@@ -1041,219 +1066,233 @@ class simd<float, simd_abi::avx2_fixed_size<4>> {
       const {
     return m_value;
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
-    return simd(_mm_sub_ps(_mm_set1_ps(0.0), m_value));
+    return basic_simd(_mm_sub_ps(_mm_set1_ps(0.0), m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm_mul_ps(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm_mul_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm_div_ps(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm_div_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm_add_ps(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm_add_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm_sub_ps(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm_sub_ps(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm_cmplt_ps(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm_cmpgt_ps(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm_cmple_ps(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm_cmpge_ps(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm_cmpeq_ps(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm_cmpneq_ps(lhs.m_value, rhs.m_value));
   }
 };
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    float, Experimental::simd_abi::avx2_fixed_size<4>>
-copysign(
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
-        a,
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
-        b) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    copysign(Experimental::basic_simd<
+                 float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+             Experimental::basic_simd<
+                 float, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
   __m128 const sign_mask = _mm_set1_ps(-0.0);
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_xor_ps(_mm_andnot_ps(sign_mask, static_cast<__m128>(a)),
                  _mm_and_ps(sign_mask, static_cast<__m128>(b))));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    abs(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    abs(Experimental::basic_simd<
         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   __m128 const sign_mask = _mm_set1_ps(-0.0);
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_andnot_ps(sign_mask, static_cast<__m128>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    floor(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    floor(Experimental::basic_simd<
           float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_round_ps(static_cast<__m128>(a),
                    (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    ceil(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    ceil(Experimental::basic_simd<
          float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_round_ps(static_cast<__m128>(a),
                    (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    round(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    round(Experimental::basic_simd<
           float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_round_ps(static_cast<__m128>(a),
                    (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    trunc(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    trunc(Experimental::basic_simd<
           float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_round_ps(static_cast<__m128>(a),
                    (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    sqrt(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    sqrt(Experimental::basic_simd<
          float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_sqrt_ps(static_cast<__m128>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    cbrt(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    cbrt(Experimental::basic_simd<
          float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_cbrt_ps(static_cast<__m128>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    exp(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    exp(Experimental::basic_simd<
         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_exp_ps(static_cast<__m128>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    log(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    log(Experimental::basic_simd<
         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_log_ps(static_cast<__m128>(a)));
 }
 
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    float, Experimental::simd_abi::avx2_fixed_size<4>>
-fma(Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
-        a,
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
-        b,
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
-        c) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    fma(Experimental::basic_simd<
+            float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+        Experimental::basic_simd<
+            float, Experimental::simd_abi::avx2_fixed_size<4>> const& b,
+        Experimental::basic_simd<
+            float, Experimental::simd_abi::avx2_fixed_size<4>> const& c) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_fmadd_ps(static_cast<__m128>(a), static_cast<__m128>(b),
                    static_cast<__m128>(c)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    float, Experimental::simd_abi::avx2_fixed_size<4>>
-max(Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
-        a,
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
-        b) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    max(Experimental::basic_simd<
+            float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+        Experimental::basic_simd<
+            float, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_max_ps(static_cast<__m128>(a), static_cast<__m128>(b)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    float, Experimental::simd_abi::avx2_fixed_size<4>>
-min(Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
-        a,
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>> const&
-        b) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<4>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+    min(Experimental::basic_simd<
+            float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+        Experimental::basic_simd<
+            float, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_min_ps(static_cast<__m128>(a), static_cast<__m128>(b)));
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::avx2_fixed_size<4>>
-    condition(simd_mask<float, simd_abi::avx2_fixed_size<4>> const& a,
-              simd<float, simd_abi::avx2_fixed_size<4>> const& b,
-              simd<float, simd_abi::avx2_fixed_size<4>> const& c) {
-  return simd<float, simd_abi::avx2_fixed_size<4>>(_mm_blendv_ps(
+    basic_simd<float, simd_abi::avx2_fixed_size<4>>
+    condition(basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& a,
+              basic_simd<float, simd_abi::avx2_fixed_size<4>> const& b,
+              basic_simd<float, simd_abi::avx2_fixed_size<4>> const& c) {
+  return basic_simd<float, simd_abi::avx2_fixed_size<4>>(_mm_blendv_ps(
       static_cast<__m128>(c), static_cast<__m128>(b), static_cast<__m128>(a)));
 }
 
 template <>
-class simd<float, simd_abi::avx2_fixed_size<8>> {
+class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
   __m256 m_value;
 
  public:
   using value_type = float;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm256_set1_ps(value_type(value))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(G&& gen)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen)
       : m_value(_mm256_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                                gen(std::integral_constant<std::size_t, 1>()),
                                gen(std::integral_constant<std::size_t, 2>()),
@@ -1263,7 +1302,7 @@ class simd<float, simd_abi::avx2_fixed_size<8>> {
                                gen(std::integral_constant<std::size_t, 6>()),
                                gen(std::integral_constant<std::size_t, 7>()))) {
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256 const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
@@ -1293,53 +1332,53 @@ class simd<float, simd_abi::avx2_fixed_size<8>> {
       const {
     return m_value;
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
-    return simd(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
+    return basic_simd(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_mul_ps(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_mul_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_div_ps(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_div_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_add_ps(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_add_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_sub_ps(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_sub_ps(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_LT_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_GT_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_LE_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_GE_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_EQ_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_NEQ_OS));
   }
@@ -1347,182 +1386,196 @@ class simd<float, simd_abi::avx2_fixed_size<8>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    float, Experimental::simd_abi::avx2_fixed_size<8>>
-copysign(
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
-        a,
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
-        b) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    copysign(Experimental::basic_simd<
+                 float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
+             Experimental::basic_simd<
+                 float, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
   __m256 const sign_mask = _mm256_set1_ps(-0.0);
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_xor_ps(_mm256_andnot_ps(sign_mask, static_cast<__m256>(a)),
                     _mm256_and_ps(sign_mask, static_cast<__m256>(b))));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    abs(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    abs(Experimental::basic_simd<
         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   __m256 const sign_mask = _mm256_set1_ps(-0.0);
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_andnot_ps(sign_mask, static_cast<__m256>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    floor(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    floor(Experimental::basic_simd<
           float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_round_ps(static_cast<__m256>(a),
                       (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    ceil(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    ceil(Experimental::basic_simd<
          float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_round_ps(static_cast<__m256>(a),
                       (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    round(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    round(Experimental::basic_simd<
           float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_round_ps(static_cast<__m256>(a),
                       (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    trunc(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    trunc(Experimental::basic_simd<
           float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_round_ps(static_cast<__m256>(a),
                       (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    sqrt(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    sqrt(Experimental::basic_simd<
          float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_sqrt_ps(static_cast<__m256>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    cbrt(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    cbrt(Experimental::basic_simd<
          float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_cbrt_ps(static_cast<__m256>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    exp(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    exp(Experimental::basic_simd<
         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_exp_ps(static_cast<__m256>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    log(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    log(Experimental::basic_simd<
         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_log_ps(static_cast<__m256>(a)));
 }
 
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    float, Experimental::simd_abi::avx2_fixed_size<8>>
-fma(Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
-        a,
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
-        b,
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
-        c) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    fma(Experimental::basic_simd<
+            float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
+        Experimental::basic_simd<
+            float, Experimental::simd_abi::avx2_fixed_size<8>> const& b,
+        Experimental::basic_simd<
+            float, Experimental::simd_abi::avx2_fixed_size<8>> const& c) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_fmadd_ps(static_cast<__m256>(a), static_cast<__m256>(b),
                       static_cast<__m256>(c)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    float, Experimental::simd_abi::avx2_fixed_size<8>>
-max(Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
-        a,
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
-        b) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    max(Experimental::basic_simd<
+            float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
+        Experimental::basic_simd<
+            float, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_max_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    float, Experimental::simd_abi::avx2_fixed_size<8>>
-min(Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
-        a,
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>> const&
-        b) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    min(Experimental::basic_simd<
+            float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
+        Experimental::basic_simd<
+            float, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_min_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::avx2_fixed_size<8>>
-    condition(simd_mask<float, simd_abi::avx2_fixed_size<8>> const& a,
-              simd<float, simd_abi::avx2_fixed_size<8>> const& b,
-              simd<float, simd_abi::avx2_fixed_size<8>> const& c) {
-  return simd<float, simd_abi::avx2_fixed_size<8>>(_mm256_blendv_ps(
+    basic_simd<float, simd_abi::avx2_fixed_size<8>>
+    condition(basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& a,
+              basic_simd<float, simd_abi::avx2_fixed_size<8>> const& b,
+              basic_simd<float, simd_abi::avx2_fixed_size<8>> const& c) {
+  return basic_simd<float, simd_abi::avx2_fixed_size<8>>(_mm256_blendv_ps(
       static_cast<__m256>(c), static_cast<__m256>(b), static_cast<__m256>(a)));
 }
 
 template <>
-class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
+class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   __m128i m_value;
 
  public:
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm_set1_epi32(value_type(value))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
                                gen(std::integral_constant<std::size_t, 1>()),
                                gen(std::integral_constant<std::size_t, 2>()),
                                gen(std::integral_constant<std::size_t, 3>()))) {
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m128i const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::uint64_t, abi_type> const& other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::uint64_t, abi_type> const& other);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -1562,155 +1615,163 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         _mm_cmpeq_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         _mm_cmpgt_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         _mm_cmplt_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return (lhs < rhs) || (lhs == rhs);
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return (lhs > rhs) || (lhs == rhs);
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm_sub_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm_add_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm_mullo_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm_srai_epi32(static_cast<__m128i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm_srai_epi32(static_cast<__m128i>(lhs), rhs));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm_srav_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm_slli_epi32(static_cast<__m128i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm_slli_epi32(static_cast<__m128i>(lhs), rhs));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm_sllv_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
 };
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>>
-    abs(Experimental::simd<
-        std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>>
+abs(Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   __m128i const rhs = static_cast<__m128i>(a);
-  return Experimental::simd<std::int32_t,
-                            Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<std::int32_t,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_abs_epi32(rhs));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    floor(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    floor(Experimental::basic_simd<
           std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    ceil(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    ceil(Experimental::basic_simd<
          std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    round(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    round(Experimental::basic_simd<
           std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    trunc(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    trunc(Experimental::basic_simd<
           std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
-    condition(simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a,
-              simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& b,
-              simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& c) {
-  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(_mm_castps_si128(
-      _mm_blendv_ps(_mm_castsi128_ps(static_cast<__m128i>(c)),
-                    _mm_castsi128_ps(static_cast<__m128i>(b)),
-                    _mm_castsi128_ps(static_cast<__m128i>(a)))));
+    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
+    condition(
+        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a,
+        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& b,
+        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& c) {
+  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+      _mm_castps_si128(
+          _mm_blendv_ps(_mm_castsi128_ps(static_cast<__m128i>(c)),
+                        _mm_castsi128_ps(static_cast<__m128i>(b)),
+                        _mm_castsi128_ps(static_cast<__m128i>(a)))));
 }
 
 template <>
-class simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
+class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
   __m256i m_value;
 
  public:
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm256_set1_epi32(value_type(value))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(
             _mm256_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
@@ -1721,7 +1782,7 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256i const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
@@ -1764,129 +1825,135 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
     return m_value;
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epi32(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpgt_epi32(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs >= rhs);
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return (lhs < rhs) || (lhs == rhs);
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return (lhs > rhs) || (lhs == rhs);
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
-                                   static_cast<__m256i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
+                                         static_cast<__m256i>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_srav_epi32(static_cast<__m256i>(lhs),
-                                  static_cast<__m256i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_srav_epi32(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
-                                  static_cast<__m256i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
   }
 };
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>>
-    abs(Experimental::simd<
-        std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>>
+abs(Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   __m256i const rhs = static_cast<__m256i>(a);
-  return Experimental::simd<std::int32_t,
-                            Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_simd<std::int32_t,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_abs_epi32(rhs));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    floor(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    floor(Experimental::basic_simd<
           std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    ceil(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    ceil(Experimental::basic_simd<
          std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    round(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    round(Experimental::basic_simd<
           std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    trunc(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+    trunc(Experimental::basic_simd<
           std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
-    condition(simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& a,
-              simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& b,
-              simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& c) {
-  return simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(_mm256_castps_si256(
-      _mm256_blendv_ps(_mm256_castsi256_ps(static_cast<__m256i>(c)),
-                       _mm256_castsi256_ps(static_cast<__m256i>(b)),
-                       _mm256_castsi256_ps(static_cast<__m256i>(a)))));
+    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
+    condition(
+        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& a,
+        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& b,
+        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& c) {
+  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(
+      _mm256_castps_si256(
+          _mm256_blendv_ps(_mm256_castsi256_ps(static_cast<__m256i>(c)),
+                           _mm256_castsi256_ps(static_cast<__m256i>(b)),
+                           _mm256_castsi256_ps(static_cast<__m256i>(a)))));
 }
 
 template <>
-class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
+class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   __m256i m_value;
 
   static_assert(sizeof(long long) == 8);
@@ -1894,39 +1961,41 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
  public:
   using value_type = std::int64_t;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm256_set1_epi64x(value_type(value))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi64x(
             gen(std::integral_constant<std::size_t, 0>()),
             gen(std::integral_constant<std::size_t, 1>()),
             gen(std::integral_constant<std::size_t, 2>()),
             gen(std::integral_constant<std::size_t, 3>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256i const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(
-      simd<std::uint64_t, abi_type> const& other);
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(
-      simd<std::int32_t, abi_type> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::uint64_t, abi_type> const& other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other)
       : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
@@ -1968,81 +2037,81 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
-    return simd(
+    return basic_simd(
         _mm256_sub_epi64(_mm256_set1_epi64x(0), static_cast<__m256i>(m_value)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
 
-  // fallback simd multiplication using generator constructor
+  // fallback basic_simd multiplication using generator constructor
   // multiplying vectors of 64-bit signed integers is not available in AVX2
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
   }
 
   // AVX2 only has eq and gt comparisons for int64
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epi64(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpgt_epi64(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return rhs > lhs;
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return (lhs < rhs) || (lhs == rhs);
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return (lhs > rhs) || (lhs == rhs);
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
 
-  // fallback simd shift right arithmetic using generator constructor
+  // fallback basic_simd shift right arithmetic using generator constructor
   // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) noexcept {
-    return simd([&](std::size_t i) { return lhs[i] >> rhs; });
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd([&](std::size_t i) { return lhs[i] >> rhs; });
   }
 
-  // fallback simd shift right arithmetic using generator constructor
+  // fallback basic_simd shift right arithmetic using generator constructor
   // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd([&](std::size_t i) { return lhs[i] >> rhs[i]; });
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd([&](std::size_t i) { return lhs[i] >> rhs[i]; });
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_sllv_epi64(static_cast<__m256i>(lhs),
-                                  static_cast<__m256i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_sllv_epi64(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
   }
 };
 
@@ -2050,80 +2119,88 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
 
 // Manually computing absolute values, because _mm256_abs_epi64
 // is not in AVX2; it's available in AVX512.
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>>
-    abs(Experimental::simd<
-        std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<std::int64_t,
-                            Experimental::simd_abi::avx2_fixed_size<4>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>>
+abs(Experimental::basic_simd<
+    std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::basic_simd<std::int64_t,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       [&](std::size_t i) { return (a[i] < 0) ? -a[i] : a[i]; });
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    floor(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    floor(Experimental::basic_simd<
           std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    ceil(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    ceil(Experimental::basic_simd<
          std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    round(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    round(Experimental::basic_simd<
           std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    trunc(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    trunc(Experimental::basic_simd<
           std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
-    condition(simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a,
-              simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& b,
-              simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& c) {
-  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(_mm256_castpd_si256(
-      _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
-                       _mm256_castsi256_pd(static_cast<__m256i>(b)),
-                       _mm256_castsi256_pd(static_cast<__m256i>(a)))));
+    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
+    condition(
+        basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a,
+        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& b,
+        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& c) {
+  return basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+      _mm256_castpd_si256(
+          _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
+                           _mm256_castsi256_pd(static_cast<__m256i>(b)),
+                           _mm256_castsi256_pd(static_cast<__m256i>(a)))));
 }
 
 template <>
-class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
+class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   __m256i m_value;
 
  public:
   using value_type = std::uint64_t;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm256_set1_epi64x(
             Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
   template <class G,
@@ -2131,20 +2208,21 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi64x(
             gen(std::integral_constant<std::size_t, 0>()),
             gen(std::integral_constant<std::size_t, 1>()),
             gen(std::integral_constant<std::size_t, 2>()),
             gen(std::integral_constant<std::size_t, 3>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m256i const& value_in)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
+      __m256i const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int32_t, abi_type> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other)
       : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int64_t, abi_type> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int64_t, abi_type> const& other)
       : m_value(static_cast<__m256i>(other)) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
@@ -2185,137 +2263,144 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
       const {
     return m_value;
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
 
-  // fallback simd multiplication using generator constructor
+  // fallback basic_simd multiplication using generator constructor
   // multiplying vectors of 64-bit unsigned integers is not available in AVX2
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) noexcept {
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
     return _mm256_srli_epi64(static_cast<__m256i>(lhs), rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return _mm256_srlv_epi64(static_cast<__m256i>(lhs),
                              static_cast<__m256i>(rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) noexcept {
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
     return _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return _mm256_sllv_epi64(static_cast<__m256i>(lhs),
                              static_cast<__m256i>(rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator&(
-      simd const& lhs, simd const& rhs) noexcept {
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator&(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return _mm256_and_si256(static_cast<__m256i>(lhs),
                             static_cast<__m256i>(rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator|(
-      simd const& lhs, simd const& rhs) noexcept {
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator|(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return _mm256_or_si256(static_cast<__m256i>(lhs),
                            static_cast<__m256i>(rhs));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epi64(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
 };
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::simd(
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other)
+basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
+    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other)
     : m_value(static_cast<__m256i>(other)) {}
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>>
-abs(Experimental::simd<std::uint64_t,
-                       Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+abs(Experimental::basic_simd<
+    std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return a;
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    floor(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    floor(Experimental::basic_simd<
           std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    ceil(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    ceil(Experimental::basic_simd<
          std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    round(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    round(Experimental::basic_simd<
           std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    trunc(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+    trunc(Experimental::basic_simd<
           std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
-    condition(simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a,
-              simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& b,
-              simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& c) {
-  return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(_mm256_castpd_si256(
-      _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
-                       _mm256_castsi256_pd(static_cast<__m256i>(b)),
-                       _mm256_castsi256_pd(static_cast<__m256i>(a)))));
+    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
+    condition(
+        basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a,
+        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& b,
+        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& c) {
+  return basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
+      _mm256_castpd_si256(
+          _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
+                           _mm256_castsi256_pd(static_cast<__m256i>(b)),
+                           _mm256_castsi256_pd(static_cast<__m256i>(a)))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::simd(
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other) {
+basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
+    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other) {
   for (std::size_t i = 0; i < 4; ++i) {
     (*this)[i] = std::int32_t(other[i]);
   }
 }
 
 template <>
-class const_where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
-                             simd<double, simd_abi::avx2_fixed_size<4>>> {
+class const_where_expression<
+    basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>,
+    basic_simd<double, simd_abi::avx2_fixed_size<4>>> {
  public:
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using value_type = simd<double, abi_type>;
-  using mask_type  = simd_mask<double, abi_type>;
+  using value_type = basic_simd<double, abi_type>;
+  using mask_type  = basic_simd_mask<double, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2336,9 +2421,9 @@ class const_where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
                         static_cast<__m256d>(m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      double* mem,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) const {
+  void scatter_to(double* mem,
+                  basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
+                      index) const {
     for (std::size_t lane = 0; lane < 4; ++lane) {
       if (m_mask[lane]) mem[index[lane]] = m_value[lane];
     }
@@ -2356,15 +2441,15 @@ class const_where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
 };
 
 template <>
-class where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
-                       simd<double, simd_abi::avx2_fixed_size<4>>>
+class where_expression<basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>,
+                       basic_simd<double, simd_abi::avx2_fixed_size<4>>>
     : public const_where_expression<
-          simd_mask<double, simd_abi::avx2_fixed_size<4>>,
-          simd<double, simd_abi::avx2_fixed_size<4>>> {
+          basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>,
+          basic_simd<double, simd_abi::avx2_fixed_size<4>>> {
  public:
   where_expression(
-      simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask_arg,
-      simd<double, simd_abi::avx2_fixed_size<4>>& value_arg)
+      basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask_arg,
+      basic_simd<double, simd_abi::avx2_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, element_aligned_tag) {
@@ -2379,32 +2464,34 @@ class where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       double const* mem,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
     m_value = value_type(_mm256_mask_i32gather_pd(
         static_cast<__m256d>(m_value), mem, static_cast<__m128i>(index),
         static_cast<__m256d>(m_mask), 8));
   }
-  template <class U,
-            std::enable_if_t<std::is_convertible_v<
-                                 U, simd<double, simd_abi::avx2_fixed_size<4>>>,
-                             bool> = false>
+  template <
+      class U,
+      std::enable_if_t<std::is_convertible_v<
+                           U, basic_simd<double, simd_abi::avx2_fixed_size<4>>>,
+                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<double, simd_abi::avx2_fixed_size<4>>>(
+        static_cast<basic_simd<double, simd_abi::avx2_fixed_size<4>>>(
             std::forward<U>(x));
-    m_value = simd<double, simd_abi::avx2_fixed_size<4>>(_mm256_blendv_pd(
+    m_value = basic_simd<double, simd_abi::avx2_fixed_size<4>>(_mm256_blendv_pd(
         static_cast<__m256d>(m_value), static_cast<__m256d>(x_as_value_type),
         static_cast<__m256d>(m_mask)));
   }
 };
 
 template <>
-class const_where_expression<simd_mask<float, simd_abi::avx2_fixed_size<4>>,
-                             simd<float, simd_abi::avx2_fixed_size<4>>> {
+class const_where_expression<
+    basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>,
+    basic_simd<float, simd_abi::avx2_fixed_size<4>>> {
  public:
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using value_type = simd<float, abi_type>;
-  using mask_type  = simd_mask<float, abi_type>;
+  using value_type = basic_simd<float, abi_type>;
+  using mask_type  = basic_simd_mask<float, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2425,9 +2512,9 @@ class const_where_expression<simd_mask<float, simd_abi::avx2_fixed_size<4>>,
                      static_cast<__m128>(m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      float* mem,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) const {
+  void scatter_to(float* mem,
+                  basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
+                      index) const {
     for (std::size_t lane = 0; lane < 4; ++lane) {
       if (m_mask[lane]) mem[index[lane]] = m_value[lane];
     }
@@ -2445,15 +2532,15 @@ class const_where_expression<simd_mask<float, simd_abi::avx2_fixed_size<4>>,
 };
 
 template <>
-class where_expression<simd_mask<float, simd_abi::avx2_fixed_size<4>>,
-                       simd<float, simd_abi::avx2_fixed_size<4>>>
+class where_expression<basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>,
+                       basic_simd<float, simd_abi::avx2_fixed_size<4>>>
     : public const_where_expression<
-          simd_mask<float, simd_abi::avx2_fixed_size<4>>,
-          simd<float, simd_abi::avx2_fixed_size<4>>> {
+          basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>,
+          basic_simd<float, simd_abi::avx2_fixed_size<4>>> {
  public:
   where_expression(
-      simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask_arg,
-      simd<float, simd_abi::avx2_fixed_size<4>>& value_arg)
+      basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask_arg,
+      basic_simd<float, simd_abi::avx2_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
@@ -2468,32 +2555,34 @@ class where_expression<simd_mask<float, simd_abi::avx2_fixed_size<4>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
     m_value = value_type(_mm_mask_i32gather_ps(static_cast<__m128>(m_value),
                                                mem, static_cast<__m128i>(index),
                                                static_cast<__m128>(m_mask), 4));
   }
-  template <class U,
-            std::enable_if_t<std::is_convertible_v<
-                                 U, simd<float, simd_abi::avx2_fixed_size<4>>>,
-                             bool> = false>
+  template <
+      class U,
+      std::enable_if_t<std::is_convertible_v<
+                           U, basic_simd<float, simd_abi::avx2_fixed_size<4>>>,
+                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<float, simd_abi::avx2_fixed_size<4>>>(
+        static_cast<basic_simd<float, simd_abi::avx2_fixed_size<4>>>(
             std::forward<U>(x));
-    m_value = simd<float, simd_abi::avx2_fixed_size<4>>(_mm_blendv_ps(
+    m_value = basic_simd<float, simd_abi::avx2_fixed_size<4>>(_mm_blendv_ps(
         static_cast<__m128>(m_value), static_cast<__m128>(x_as_value_type),
         static_cast<__m128>(m_mask)));
   }
 };
 
 template <>
-class const_where_expression<simd_mask<float, simd_abi::avx2_fixed_size<8>>,
-                             simd<float, simd_abi::avx2_fixed_size<8>>> {
+class const_where_expression<
+    basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>,
+    basic_simd<float, simd_abi::avx2_fixed_size<8>>> {
  public:
   using abi_type   = simd_abi::avx2_fixed_size<8>;
-  using value_type = simd<float, abi_type>;
-  using mask_type  = simd_mask<float, abi_type>;
+  using value_type = basic_simd<float, abi_type>;
+  using mask_type  = basic_simd_mask<float, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2514,9 +2603,9 @@ class const_where_expression<simd_mask<float, simd_abi::avx2_fixed_size<8>>,
                         static_cast<__m256>(m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      float* mem,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& index) const {
+  void scatter_to(float* mem,
+                  basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const&
+                      index) const {
     for (std::size_t lane = 0; lane < value_type::size(); ++lane) {
       if (m_mask[lane]) mem[index[lane]] = m_value[lane];
     }
@@ -2534,15 +2623,15 @@ class const_where_expression<simd_mask<float, simd_abi::avx2_fixed_size<8>>,
 };
 
 template <>
-class where_expression<simd_mask<float, simd_abi::avx2_fixed_size<8>>,
-                       simd<float, simd_abi::avx2_fixed_size<8>>>
+class where_expression<basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>,
+                       basic_simd<float, simd_abi::avx2_fixed_size<8>>>
     : public const_where_expression<
-          simd_mask<float, simd_abi::avx2_fixed_size<8>>,
-          simd<float, simd_abi::avx2_fixed_size<8>>> {
+          basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>,
+          basic_simd<float, simd_abi::avx2_fixed_size<8>>> {
  public:
   where_expression(
-      simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask_arg,
-      simd<float, simd_abi::avx2_fixed_size<8>>& value_arg)
+      basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask_arg,
+      basic_simd<float, simd_abi::avx2_fixed_size<8>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
@@ -2556,20 +2645,21 @@ class where_expression<simd_mask<float, simd_abi::avx2_fixed_size<8>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& index) {
+      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& index) {
     m_value = value_type(_mm256_mask_i32gather_ps(
         static_cast<__m256>(m_value), mem, static_cast<__m256i>(index),
         static_cast<__m256>(m_mask), 4));
   }
-  template <class U,
-            std::enable_if_t<std::is_convertible_v<
-                                 U, simd<float, simd_abi::avx2_fixed_size<8>>>,
-                             bool> = false>
+  template <
+      class U,
+      std::enable_if_t<std::is_convertible_v<
+                           U, basic_simd<float, simd_abi::avx2_fixed_size<8>>>,
+                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<float, simd_abi::avx2_fixed_size<8>>>(
+        static_cast<basic_simd<float, simd_abi::avx2_fixed_size<8>>>(
             std::forward<U>(x));
-    m_value = simd<float, simd_abi::avx2_fixed_size<8>>(_mm256_blendv_ps(
+    m_value = basic_simd<float, simd_abi::avx2_fixed_size<8>>(_mm256_blendv_ps(
         static_cast<__m256>(m_value), static_cast<__m256>(x_as_value_type),
         static_cast<__m256>(m_mask)));
   }
@@ -2577,12 +2667,12 @@ class where_expression<simd_mask<float, simd_abi::avx2_fixed_size<8>>,
 
 template <>
 class const_where_expression<
-    simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
+    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
  public:
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using value_type = simd<std::int32_t, abi_type>;
-  using mask_type  = simd_mask<std::int32_t, abi_type>;
+  using value_type = basic_simd<std::int32_t, abi_type>;
+  using mask_type  = basic_simd_mask<std::int32_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2604,9 +2694,9 @@ class const_where_expression<
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      std::int32_t* mem,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) const {
+  void scatter_to(std::int32_t* mem,
+                  basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
+                      index) const {
     for (std::size_t lane = 0; lane < 4; ++lane) {
       if (m_mask[lane]) mem[index[lane]] = m_value[lane];
     }
@@ -2624,15 +2714,17 @@ class const_where_expression<
 };
 
 template <>
-class where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
-                       simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+class where_expression<
+    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
     : public const_where_expression<
-          simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
-          simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
+          basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+          basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
  public:
   where_expression(
-      simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask_arg,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>>& value_arg)
+      basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
+          mask_arg,
+      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
@@ -2656,35 +2748,36 @@ class where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
     m_value = value_type(_mm_mask_i32gather_epi32(
         static_cast<__m128i>(m_value), mem, static_cast<__m128i>(index),
         static_cast<__m128i>(m_mask), 4));
   }
-  template <
-      class U,
-      std::enable_if_t<std::is_convertible_v<
-                           U, simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>,
-                       bool> = false>
+  template <class U,
+            std::enable_if_t<
+                std::is_convertible_v<
+                    U, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>,
+                bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>(
+        static_cast<basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>(
             std::forward<U>(x));
-    m_value = simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(_mm_castps_si128(
-        _mm_blendv_ps(_mm_castsi128_ps(static_cast<__m128i>(m_value)),
-                      _mm_castsi128_ps(static_cast<__m128i>(x_as_value_type)),
-                      _mm_castsi128_ps(static_cast<__m128i>(m_mask)))));
+    m_value = basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+        _mm_castps_si128(_mm_blendv_ps(
+            _mm_castsi128_ps(static_cast<__m128i>(m_value)),
+            _mm_castsi128_ps(static_cast<__m128i>(x_as_value_type)),
+            _mm_castsi128_ps(static_cast<__m128i>(m_mask)))));
   }
 };
 
 template <>
 class const_where_expression<
-    simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
-    simd<std::int32_t, simd_abi::avx2_fixed_size<8>>> {
+    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
+    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>> {
  public:
   using abi_type   = simd_abi::avx2_fixed_size<8>;
-  using value_type = simd<std::int32_t, abi_type>;
-  using mask_type  = simd_mask<std::int32_t, abi_type>;
+  using value_type = basic_simd<std::int32_t, abi_type>;
+  using mask_type  = basic_simd_mask<std::int32_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2705,9 +2798,9 @@ class const_where_expression<
                            static_cast<__m256i>(m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      std::int32_t* mem,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& index) const {
+  void scatter_to(std::int32_t* mem,
+                  basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const&
+                      index) const {
     for (std::size_t lane = 0; lane < value_type::size(); ++lane) {
       if (m_mask[lane]) mem[index[lane]] = m_value[lane];
     }
@@ -2725,15 +2818,17 @@ class const_where_expression<
 };
 
 template <>
-class where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
-                       simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+class where_expression<
+    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
+    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
     : public const_where_expression<
-          simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
-          simd<std::int32_t, simd_abi::avx2_fixed_size<8>>> {
+          basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
+          basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>> {
  public:
   where_expression(
-      simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask_arg,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<8>>& value_arg)
+      basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const&
+          mask_arg,
+      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
@@ -2758,21 +2853,21 @@ class where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& index) {
+      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& index) {
     m_value = value_type(_mm256_mask_i32gather_epi32(
         static_cast<__m256i>(m_value), mem, static_cast<__m256i>(index),
         static_cast<__m256i>(m_mask), 4));
   }
-  template <
-      class U,
-      std::enable_if_t<std::is_convertible_v<
-                           U, simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>,
-                       bool> = false>
+  template <class U,
+            std::enable_if_t<
+                std::is_convertible_v<
+                    U, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>,
+                bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>(
+        static_cast<basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>(
             std::forward<U>(x));
-    m_value = simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(
+    m_value = basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(
         _mm256_castps_si256(_mm256_blendv_ps(
             _mm256_castsi256_ps(static_cast<__m256i>(m_value)),
             _mm256_castsi256_ps(static_cast<__m256i>(x_as_value_type)),
@@ -2782,12 +2877,12 @@ class where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
 
 template <>
 class const_where_expression<
-    simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
-    simd<std::int64_t, simd_abi::avx2_fixed_size<4>>> {
+    basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
+    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>> {
  public:
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using value_type = simd<std::int64_t, abi_type>;
-  using mask_type  = simd_mask<std::int64_t, abi_type>;
+  using value_type = basic_simd<std::int64_t, abi_type>;
+  using mask_type  = basic_simd_mask<std::int64_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2811,9 +2906,9 @@ class const_where_expression<
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      std::int64_t* mem,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) const {
+  void scatter_to(std::int64_t* mem,
+                  basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
+                      index) const {
     for (std::size_t lane = 0; lane < 4; ++lane) {
       if (m_mask[lane]) mem[index[lane]] = m_value[lane];
     }
@@ -2831,15 +2926,17 @@ class const_where_expression<
 };
 
 template <>
-class where_expression<simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
-                       simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+class where_expression<
+    basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
+    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
     : public const_where_expression<
-          simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
-          simd<std::int64_t, simd_abi::avx2_fixed_size<4>>> {
+          basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
+          basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>> {
  public:
   where_expression(
-      simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask_arg,
-      simd<std::int64_t, simd_abi::avx2_fixed_size<4>>& value_arg)
+      basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const&
+          mask_arg,
+      basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(std::int64_t const* mem,
                                                        element_aligned_tag) {
@@ -2865,21 +2962,21 @@ class where_expression<simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int64_t const* mem,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
     m_value = value_type(_mm256_mask_i32gather_epi64(
         static_cast<__m256i>(m_value), reinterpret_cast<long long const*>(mem),
         static_cast<__m128i>(index), static_cast<__m256i>(m_mask), 8));
   }
-  template <
-      class u,
-      std::enable_if_t<std::is_convertible_v<
-                           u, simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>,
-                       bool> = false>
+  template <class u,
+            std::enable_if_t<
+                std::is_convertible_v<
+                    u, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>,
+                bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(u&& x) {
     auto const x_as_value_type =
-        static_cast<simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>(
+        static_cast<basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>(
             std::forward<u>(x));
-    m_value = simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+    m_value = basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
         _mm256_castpd_si256(_mm256_blendv_pd(
             _mm256_castsi256_pd(static_cast<__m256i>(m_value)),
             _mm256_castsi256_pd(static_cast<__m256i>(x_as_value_type)),
@@ -2889,12 +2986,12 @@ class where_expression<simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
 
 template <>
 class const_where_expression<
-    simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>> {
+    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
+    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>> {
  public:
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using value_type = simd<std::uint64_t, abi_type>;
-  using mask_type  = simd_mask<std::uint64_t, abi_type>;
+  using value_type = basic_simd<std::uint64_t, abi_type>;
+  using mask_type  = basic_simd_mask<std::uint64_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2918,9 +3015,9 @@ class const_where_expression<
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      std::uint64_t* mem,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) const {
+  void scatter_to(std::uint64_t* mem,
+                  basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
+                      index) const {
     for (std::size_t lane = 0; lane < 4; ++lane) {
       if (m_mask[lane]) mem[index[lane]] = m_value[lane];
     }
@@ -2938,15 +3035,17 @@ class const_where_expression<
 };
 
 template <>
-class where_expression<simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
-                       simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+class where_expression<
+    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
+    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
     : public const_where_expression<
-          simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
-          simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>> {
+          basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
+          basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>> {
  public:
   where_expression(
-      simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask_arg,
-      simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>& value_arg)
+      basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const&
+          mask_arg,
+      basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(std::uint64_t const* mem,
                                                        element_aligned_tag) {
@@ -2972,7 +3071,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint64_t const* mem,
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
     m_value = value_type(_mm256_mask_i32gather_epi64(
         static_cast<__m256i>(m_value), reinterpret_cast<long long const*>(mem),
         static_cast<__m128i>(index), static_cast<__m256i>(m_mask), 8));
@@ -2980,13 +3079,13 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
   template <class u,
             std::enable_if_t<
                 std::is_convertible_v<
-                    u, simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>,
+                    u, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>,
                 bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(u&& x) {
     auto const x_as_value_type =
-        static_cast<simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>(
+        static_cast<basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>(
             std::forward<u>(x));
-    m_value = simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
+    m_value = basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
         _mm256_castpd_si256(_mm256_blendv_pd(
             _mm256_castsi256_pd(static_cast<__m256i>(m_value)),
             _mm256_castsi256_pd(static_cast<__m256i>(x_as_value_type)),

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -41,7 +41,7 @@ class avx512_fixed_size {};
 }  // namespace simd_abi
 
 template <class T>
-class simd_mask<T, simd_abi::avx512_fixed_size<8>> {
+class basic_simd_mask<T, simd_abi::avx512_fixed_size<8>> {
   __mmask8 m_value;
 
  public:
@@ -69,20 +69,22 @@ class simd_mask<T, simd_abi::avx512_fixed_size<8>> {
       return (m_mask & bit_mask()) != 0;
     }
   };
-  using value_type                                  = bool;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+  using value_type                                        = bool;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      value_type value)
       : m_value(-std::int16_t(value)) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<U, simd_abi::avx512_fixed_size<8>> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
+      basic_simd_mask<U, simd_abi::avx512_fixed_size<8>> const& other)
       : m_value(static_cast<__mmask8>(other)) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(G&& gen) : m_value(false) {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(G&& gen)
+      : m_value(false) {
     reference(m_value, int(0)) =
         static_cast<bool>(gen(std::integral_constant<std::size_t, 0>()));
     reference(m_value, int(1)) =
@@ -103,7 +105,7 @@ class simd_mask<T, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __mmask8 const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __mmask8()
@@ -118,30 +120,31 @@ class simd_mask<T, simd_abi::avx512_fixed_size<8>> {
     auto const bit_mask = __mmask8(std::int16_t(1 << i));
     return (m_value & bit_mask) != 0;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator||(simd_mask const& other) const {
-    return simd_mask(_kor_mask8(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator||(basic_simd_mask const& other) const {
+    return basic_simd_mask(_kor_mask8(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator&&(simd_mask const& other) const {
-    return simd_mask(_kand_mask8(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator&&(basic_simd_mask const& other) const {
+    return basic_simd_mask(_kand_mask8(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
-    static const __mmask8 true_value(static_cast<__mmask8>(simd_mask(true)));
-    return simd_mask(_kxor_mask8(true_value, m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+    static const __mmask8 true_value(
+        static_cast<__mmask8>(basic_simd_mask(true)));
+    return basic_simd_mask(_kxor_mask8(true_value, m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return m_value == other.m_value;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return m_value != other.m_value;
   }
 };
 
 template <class T>
-class simd_mask<T, simd_abi::avx512_fixed_size<16>> {
+class basic_simd_mask<T, simd_abi::avx512_fixed_size<16>> {
   __mmask16 m_value;
 
  public:
@@ -169,20 +172,22 @@ class simd_mask<T, simd_abi::avx512_fixed_size<16>> {
       return (m_mask & bit_mask()) != 0;
     }
   };
-  using value_type                                  = bool;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+  using value_type                                        = bool;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      value_type value)
       : m_value(-std::int32_t(value)) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<U, simd_abi::avx512_fixed_size<16>> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
+      basic_simd_mask<U, simd_abi::avx512_fixed_size<16>> const& other)
       : m_value(static_cast<__mmask16>(other)) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(G&& gen) : m_value(false) {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(G&& gen)
+      : m_value(false) {
     reference(m_value, int(0)) =
         static_cast<bool>(gen(std::integral_constant<std::size_t, 0>()));
     reference(m_value, int(1)) =
@@ -219,7 +224,7 @@ class simd_mask<T, simd_abi::avx512_fixed_size<16>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 16;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __mmask16 const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __mmask16()
@@ -234,50 +239,53 @@ class simd_mask<T, simd_abi::avx512_fixed_size<16>> {
     auto const bit_mask = __mmask16(std::int32_t(1 << i));
     return (m_value & bit_mask) != 0;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator||(simd_mask const& other) const {
-    return simd_mask(_kor_mask16(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator||(basic_simd_mask const& other) const {
+    return basic_simd_mask(_kor_mask16(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
-  operator&&(simd_mask const& other) const {
-    return simd_mask(_kand_mask16(m_value, other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator&&(basic_simd_mask const& other) const {
+    return basic_simd_mask(_kand_mask16(m_value, other.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
-    static const __mmask16 true_value(static_cast<__mmask16>(simd_mask(true)));
-    return simd_mask(_kxor_mask16(true_value, m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+    static const __mmask16 true_value(
+        static_cast<__mmask16>(basic_simd_mask(true)));
+    return basic_simd_mask(_kxor_mask16(true_value, m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return m_value == other.m_value;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      simd_mask const& other) const {
+      basic_simd_mask const& other) const {
     return m_value != other.m_value;
   }
 };
 
 template <>
-class simd<double, simd_abi::avx512_fixed_size<8>> {
+class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
   __m512d m_value;
 
  public:
   using value_type = double;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm512_set1_pd(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m512d const& value_in)
       : m_value(value_in) {}
   template <class G,
@@ -287,7 +295,7 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm512_setr_pd(gen(std::integral_constant<std::size_t, 0>()),
                                gen(std::integral_constant<std::size_t, 1>()),
@@ -325,58 +333,58 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
       const {
     return m_value;
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
-    return simd(_mm512_sub_pd(_mm512_set1_pd(0.0), m_value));
+    return basic_simd(_mm512_sub_pd(_mm512_set1_pd(0.0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm512_mul_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm512_div_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm512_add_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm512_sub_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
                                         static_cast<__m512d>(rhs), _CMP_LT_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(rhs),
                                         static_cast<__m512d>(lhs), _CMP_GT_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
                                         static_cast<__m512d>(rhs), _CMP_LE_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(rhs),
                                         static_cast<__m512d>(lhs), _CMP_GE_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
                                         static_cast<__m512d>(rhs), _CMP_EQ_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(
         static_cast<__m512d>(lhs), static_cast<__m512d>(rhs), _CMP_NEQ_OS));
   }
@@ -384,19 +392,18 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-copysign(
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a,
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
+copysign(Experimental::basic_simd<
+             double, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
+         Experimental::basic_simd<
+             double, Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
   static const __m512i sign_mask =
       reinterpret_cast<__m512i>(static_cast<__m512d>(
-          Experimental::simd<
+          Experimental::basic_simd<
               double, Experimental::simd_abi::avx512_fixed_size<8>>(-0.0)));
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       reinterpret_cast<__m512d>(_mm512_xor_epi64(
           _mm512_andnot_epi64(
               sign_mask, reinterpret_cast<__m512i>(static_cast<__m512d>(a))),
@@ -404,173 +411,175 @@ copysign(
               sign_mask, reinterpret_cast<__m512i>(static_cast<__m512d>(b))))));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
-    abs(Experimental::simd<
-        double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+abs(Experimental::basic_simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m512d const rhs = static_cast<__m512d>(a);
 #if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 830)
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       (__m512d)_mm512_and_epi64((__m512i)rhs,
                                 _mm512_set1_epi64(0x7fffffffffffffffLL)));
 #else
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_abs_pd(rhs));
 #endif
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
-    floor(Experimental::simd<
-          double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+floor(Experimental::basic_simd<
+      double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m512d const val = static_cast<__m512d>(a);
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_roundscale_pd(val, _MM_FROUND_TO_NEG_INF));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
-    ceil(Experimental::simd<
-         double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+ceil(Experimental::basic_simd<
+     double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m512d const val = static_cast<__m512d>(a);
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_roundscale_pd(val, _MM_FROUND_TO_POS_INF));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
-    round(Experimental::simd<
-          double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+round(Experimental::basic_simd<
+      double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m512d const val = static_cast<__m512d>(a);
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_roundscale_pd(val, _MM_FROUND_TO_NEAREST_INT));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
-    trunc(Experimental::simd<
-          double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+trunc(Experimental::basic_simd<
+      double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m512d const val = static_cast<__m512d>(a);
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_roundscale_pd(val, _MM_FROUND_TO_ZERO));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
-    sqrt(Experimental::simd<
-         double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+sqrt(Experimental::basic_simd<
+     double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_sqrt_pd(static_cast<__m512d>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
-    cbrt(Experimental::simd<
-         double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+cbrt(Experimental::basic_simd<
+     double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cbrt_pd(static_cast<__m512d>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
-    exp(Experimental::simd<
-        double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+exp(Experimental::basic_simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_exp_pd(static_cast<__m512d>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
-    log(Experimental::simd<
-        double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+log(Experimental::basic_simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_log_pd(static_cast<__m512d>(a)));
 }
 
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-fma(Experimental::simd<double,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a,
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& b,
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& c) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+fma(Experimental::basic_simd<
+        double, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
+    Experimental::basic_simd<
+        double, Experimental::simd_abi::avx512_fixed_size<8>> const& b,
+    Experimental::basic_simd<
+        double, Experimental::simd_abi::avx512_fixed_size<8>> const& c) {
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_fmadd_pd(static_cast<__m512d>(a), static_cast<__m512d>(b),
                       static_cast<__m512d>(c)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-max(Experimental::simd<double,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a,
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+max(Experimental::basic_simd<
+        double, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
+    Experimental::basic_simd<
+        double, Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_max_pd(static_cast<__m512d>(a), static_cast<__m512d>(b)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-min(Experimental::simd<double,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a,
-    Experimental::simd<double,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+min(Experimental::basic_simd<
+        double, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
+    Experimental::basic_simd<
+        double, Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_min_pd(static_cast<__m512d>(a), static_cast<__m512d>(b)));
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    condition(simd_mask<double, simd_abi::avx512_fixed_size<8>> const& a,
-              simd<double, simd_abi::avx512_fixed_size<8>> const& b,
-              simd<double, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
+    basic_simd<double, simd_abi::avx512_fixed_size<8>>
+    condition(basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& a,
+              basic_simd<double, simd_abi::avx512_fixed_size<8>> const& b,
+              basic_simd<double, simd_abi::avx512_fixed_size<8>> const& c) {
+  return basic_simd<double, simd_abi::avx512_fixed_size<8>>(
       _mm512_mask_blend_pd(static_cast<__mmask8>(a), static_cast<__m512d>(c),
                            static_cast<__m512d>(b)));
 }
 
 template <>
-class simd<float, simd_abi::avx512_fixed_size<8>> {
+class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
   __m256 m_value;
 
  public:
   using value_type = float;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm256_set1_ps(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256 const& value_in)
       : m_value(value_in) {}
   template <class G,
@@ -578,7 +587,7 @@ class simd<float, simd_abi::avx512_fixed_size<8>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(G&& gen)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen)
       : m_value(_mm256_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                                gen(std::integral_constant<std::size_t, 1>()),
                                gen(std::integral_constant<std::size_t, 2>()),
@@ -615,49 +624,49 @@ class simd<float, simd_abi::avx512_fixed_size<8>> {
       const {
     return m_value;
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
-    return simd(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
+    return basic_simd(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_mul_ps(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_mul_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_div_ps(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_div_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_add_ps(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_add_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_sub_ps(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_sub_ps(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LT_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GT_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LE_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GE_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_EQ_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_NEQ_OS));
   }
 };
@@ -665,179 +674,180 @@ class simd<float, simd_abi::avx512_fixed_size<8>> {
 }  // namespace Experimental
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
-copysign(
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a,
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
+copysign(Experimental::basic_simd<
+             float, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
+         Experimental::basic_simd<
+             float, Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
   __m256 const sign_mask = _mm256_set1_ps(-0.0);
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_xor_ps(_mm256_andnot_ps(sign_mask, static_cast<__m256>(a)),
                     _mm256_and_ps(sign_mask, static_cast<__m256>(b))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> abs(
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
+abs(Experimental::basic_simd<
+    float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256 const sign_mask = _mm256_set1_ps(-0.0);
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_andnot_ps(sign_mask, static_cast<__m256>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
-    floor(Experimental::simd<
-          float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    float, Experimental::simd_abi::avx512_fixed_size<8>>
+floor(Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256 const val = static_cast<__m256>(a);
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_roundscale_ps(val, _MM_FROUND_TO_NEG_INF));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
-    ceil(Experimental::simd<
-         float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    float, Experimental::simd_abi::avx512_fixed_size<8>>
+ceil(Experimental::basic_simd<
+     float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256 const val = static_cast<__m256>(a);
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_roundscale_ps(val, _MM_FROUND_TO_POS_INF));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
-    round(Experimental::simd<
-          float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    float, Experimental::simd_abi::avx512_fixed_size<8>>
+round(Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256 const val = static_cast<__m256>(a);
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_roundscale_ps(val, _MM_FROUND_TO_NEAREST_INT));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
-    trunc(Experimental::simd<
-          float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    float, Experimental::simd_abi::avx512_fixed_size<8>>
+trunc(Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256 const val = static_cast<__m256>(a);
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_roundscale_ps(val, _MM_FROUND_TO_ZERO));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> sqrt(
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
+sqrt(Experimental::basic_simd<
+     float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_sqrt_ps(static_cast<__m256>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> cbrt(
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
+cbrt(Experimental::basic_simd<
+     float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_cbrt_ps(static_cast<__m256>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> exp(
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
+exp(Experimental::basic_simd<
+    float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_exp_ps(static_cast<__m256>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> log(
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
+log(Experimental::basic_simd<
+    float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_log_ps(static_cast<__m256>(a)));
 }
 
 #endif
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> fma(
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a,
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& b,
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& c) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
+fma(Experimental::basic_simd<
+        float, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx512_fixed_size<8>> const& b,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx512_fixed_size<8>> const& c) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_fmadd_ps(static_cast<__m256>(a), static_cast<__m256>(b),
                       static_cast<__m256>(c)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> max(
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a,
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
+max(Experimental::basic_simd<
+        float, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_max_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<8>> min(
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a,
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
+min(Experimental::basic_simd<
+        float, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_min_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
 }
 
 namespace Experimental {
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx512_fixed_size<8>> condition(
-    simd_mask<float, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<float, simd_abi::avx512_fixed_size<8>> const& b,
-    simd<float, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<float, simd_abi::avx512_fixed_size<8>>(
+basic_simd<float, simd_abi::avx512_fixed_size<8>> condition(
+    basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& a,
+    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& b,
+    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& c) {
+  return basic_simd<float, simd_abi::avx512_fixed_size<8>>(
       _mm256_mask_blend_ps(static_cast<__mmask8>(a), static_cast<__m256>(c),
                            static_cast<__m256>(b)));
 }
 
 template <>
-class simd<float, simd_abi::avx512_fixed_size<16>> {
+class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
   __m512 m_value;
 
  public:
   using value_type = float;
   using abi_type   = simd_abi::avx512_fixed_size<16>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 16;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm512_set1_ps(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m512 const& value_in)
       : m_value(value_in) {}
   template <class G,
@@ -845,7 +855,7 @@ class simd<float, simd_abi::avx512_fixed_size<16>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(G&& gen)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen)
       : m_value(
             _mm512_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                            gen(std::integral_constant<std::size_t, 1>()),
@@ -890,49 +900,49 @@ class simd<float, simd_abi::avx512_fixed_size<16>> {
       const {
     return m_value;
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
-    return simd(_mm512_sub_ps(_mm512_set1_ps(0.0), m_value));
+    return basic_simd(_mm512_sub_ps(_mm512_set1_ps(0.0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm512_mul_ps(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_mul_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm512_div_ps(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_div_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm512_add_ps(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_add_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm512_sub_ps(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_sub_ps(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LT_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GT_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LE_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GE_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_EQ_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_NEQ_OS));
   }
 };
@@ -940,182 +950,183 @@ class simd<float, simd_abi::avx512_fixed_size<16>> {
 }  // namespace Experimental
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
-copysign(Experimental::simd<
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
+copysign(Experimental::basic_simd<
              float, Experimental::simd_abi::avx512_fixed_size<16>> const& a,
-         Experimental::simd<
+         Experimental::basic_simd<
              float, Experimental::simd_abi::avx512_fixed_size<16>> const& b) {
   __m512 const sign_mask = _mm512_set1_ps(-0.0);
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_xor_ps(_mm512_andnot_ps(sign_mask, static_cast<__m512>(a)),
                     _mm512_and_ps(sign_mask, static_cast<__m512>(b))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>> abs(
-    Experimental::simd<
-        float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
+abs(Experimental::basic_simd<
+    float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
   __m512 const sign_mask = _mm512_set1_ps(-0.0);
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_andnot_ps(sign_mask, static_cast<__m512>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
-    floor(Experimental::simd<
-          float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    float, Experimental::simd_abi::avx512_fixed_size<16>>
+floor(Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
   __m512 const val = static_cast<__m512>(a);
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_roundscale_ps(val, _MM_FROUND_TO_NEG_INF));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
-    ceil(Experimental::simd<
-         float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    float, Experimental::simd_abi::avx512_fixed_size<16>>
+ceil(Experimental::basic_simd<
+     float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
   __m512 const val = static_cast<__m512>(a);
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_roundscale_ps(val, _MM_FROUND_TO_POS_INF));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
-    round(Experimental::simd<
-          float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    float, Experimental::simd_abi::avx512_fixed_size<16>>
+round(Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
   __m512 const val = static_cast<__m512>(a);
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_roundscale_ps(val, _MM_FROUND_TO_NEAREST_INT));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
-    trunc(Experimental::simd<
-          float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    float, Experimental::simd_abi::avx512_fixed_size<16>>
+trunc(Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
   __m512 const val = static_cast<__m512>(a);
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_roundscale_ps(val, _MM_FROUND_TO_ZERO));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>> sqrt(
-    Experimental::simd<
-        float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
+sqrt(Experimental::basic_simd<
+     float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_sqrt_ps(static_cast<__m512>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>> cbrt(
-    Experimental::simd<
-        float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
+cbrt(Experimental::basic_simd<
+     float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cbrt_ps(static_cast<__m512>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>> exp(
-    Experimental::simd<
-        float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
+exp(Experimental::basic_simd<
+    float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_exp_ps(static_cast<__m512>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>> log(
-    Experimental::simd<
-        float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
+log(Experimental::basic_simd<
+    float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_log_ps(static_cast<__m512>(a)));
 }
 
 #endif
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>> fma(
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<16>> const& a,
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<16>> const& b,
-    Experimental::simd<
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
+fma(Experimental::basic_simd<
+        float, Experimental::simd_abi::avx512_fixed_size<16>> const& a,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx512_fixed_size<16>> const& b,
+    Experimental::basic_simd<
         float, Experimental::simd_abi::avx512_fixed_size<16>> const& c) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
-      _mm512_fmadd_ps(static_cast<__m512>(a), static_cast<__m512>(b),
-                      static_cast<__m512>(c)));
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(_mm512_fmadd_ps(
+      static_cast<__m512>(a), static_cast<__m512>(b), static_cast<__m512>(c)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>> max(
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<16>> const& a,
-    Experimental::simd<
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
+max(Experimental::basic_simd<
+        float, Experimental::simd_abi::avx512_fixed_size<16>> const& a,
+    Experimental::basic_simd<
         float, Experimental::simd_abi::avx512_fixed_size<16>> const& b) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_max_ps(static_cast<__m512>(a), static_cast<__m512>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::simd<float, Experimental::simd_abi::avx512_fixed_size<16>> min(
-    Experimental::simd<float,
-                       Experimental::simd_abi::avx512_fixed_size<16>> const& a,
-    Experimental::simd<
+Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
+min(Experimental::basic_simd<
+        float, Experimental::simd_abi::avx512_fixed_size<16>> const& a,
+    Experimental::basic_simd<
         float, Experimental::simd_abi::avx512_fixed_size<16>> const& b) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_min_ps(static_cast<__m512>(a), static_cast<__m512>(b)));
 }
 
 namespace Experimental {
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<float, simd_abi::avx512_fixed_size<16>> condition(
-    simd_mask<float, simd_abi::avx512_fixed_size<16>> const& a,
-    simd<float, simd_abi::avx512_fixed_size<16>> const& b,
-    simd<float, simd_abi::avx512_fixed_size<16>> const& c) {
-  return simd<float, simd_abi::avx512_fixed_size<16>>(
+basic_simd<float, simd_abi::avx512_fixed_size<16>> condition(
+    basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& a,
+    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& b,
+    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& c) {
+  return basic_simd<float, simd_abi::avx512_fixed_size<16>>(
       _mm512_mask_blend_ps(static_cast<__mmask16>(a), static_cast<__m512>(c),
                            static_cast<__m512>(b)));
 }
 
 template <>
-class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
+class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
   __m256i m_value;
 
  public:
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm256_set1_epi32(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256i const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::uint64_t, abi_type> const& other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::uint64_t, abi_type> const& other);
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -1123,7 +1134,7 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(
             _mm256_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
@@ -1166,163 +1177,166 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
-    return simd(_mm256_sub_epi32(_mm256_set1_epi32(0), m_value));
+    return basic_simd(_mm256_sub_epi32(_mm256_set1_epi32(0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
-                                   static_cast<__m256i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
+                                         static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
         _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
         _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmplt_epi32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmplt_epi32_mask(static_cast<__m256i>(rhs),
                                              static_cast<__m256i>(lhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmple_epi32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmple_epi32_mask(static_cast<__m256i>(rhs),
                                              static_cast<__m256i>(lhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epi32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpneq_epi32_mask(static_cast<__m256i>(lhs),
                                               static_cast<__m256i>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_srav_epi32(static_cast<__m256i>(lhs),
-                                  static_cast<__m256i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_srav_epi32(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
-                                  static_cast<__m256i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
   }
 };
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>>
-abs(Experimental::simd<std::int32_t,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+abs(Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256i const rhs = static_cast<__m256i>(a);
-  return Experimental::simd<std::int32_t,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<std::int32_t,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_abs_epi32(rhs));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-floor(Experimental::simd<
+floor(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepi32_pd(static_cast<__m256i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
-    ceil(Experimental::simd<
-         std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+ceil(Experimental::basic_simd<
+     std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepi32_pd(static_cast<__m256i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-round(Experimental::simd<
+round(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepi32_pd(static_cast<__m256i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-trunc(Experimental::simd<
+trunc(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepi32_pd(static_cast<__m256i>(a)));
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
-    condition(simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a,
-              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& b,
-              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
+    condition(
+        basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a,
+        basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& b,
+        basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& c) {
+  return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
                               static_cast<__m256i>(b)));
 }
 
 template <>
-class simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
+class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
   __m512i m_value;
 
  public:
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx512_fixed_size<16>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 16;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm512_set1_epi32(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m512i const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::uint64_t, abi_type> const& other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::uint64_t, abi_type> const& other);
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -1330,7 +1344,7 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm512_setr_epi32(
             gen(std::integral_constant<std::size_t, 0>()),
@@ -1381,165 +1395,168 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
-    return simd(_mm512_sub_epi32(_mm512_set1_epi32(0), m_value));
+    return basic_simd(_mm512_sub_epi32(_mm512_set1_epi32(0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
-                                   static_cast<__m512i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
+                                         static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
         _mm512_add_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
         _mm512_sub_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epi32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epi32_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmple_epi32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmple_epi32_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpeq_epi32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpneq_epi32_mask(static_cast<__m512i>(lhs),
                                               static_cast<__m512i>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm512_srai_epi32(static_cast<__m512i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm512_srai_epi32(static_cast<__m512i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm512_srav_epi32(static_cast<__m512i>(lhs),
-                                  static_cast<__m512i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_srav_epi32(static_cast<__m512i>(lhs),
+                                        static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm512_slli_epi32(static_cast<__m512i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm512_slli_epi32(static_cast<__m512i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm512_sllv_epi32(static_cast<__m512i>(lhs),
-                                  static_cast<__m512i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_sllv_epi32(static_cast<__m512i>(lhs),
+                                        static_cast<__m512i>(rhs)));
   }
 };
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>>
-abs(Experimental::simd<
+abs(Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
   __m512i const rhs = static_cast<__m512i>(a);
-  return Experimental::simd<std::int32_t,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_abs_epi32(rhs));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-floor(Experimental::simd<
+floor(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cvtepi32_ps(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-ceil(Experimental::simd<
+ceil(Experimental::basic_simd<
      std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cvtepi32_ps(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-round(Experimental::simd<
+round(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cvtepi32_ps(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-trunc(Experimental::simd<
+trunc(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cvtepi32_ps(static_cast<__m512i>(a)));
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx512_fixed_size<16>>
-    condition(simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& a,
-              simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& b,
-              simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& c) {
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>
+    condition(
+        basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& a,
+        basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& b,
+        basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& c) {
+  return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
       _mm512_mask_blend_epi32(static_cast<__mmask16>(a),
                               static_cast<__m512i>(c),
                               static_cast<__m512i>(b)));
 }
 
 template <>
-class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
+class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
   __m256i m_value;
 
  public:
   using value_type = std::uint32_t;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm256_set1_epi32(
             Kokkos::bit_cast<std::int32_t>(value_type(value)))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256i const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other)
       : m_value(static_cast<__m256i>(other)) {}
   template <class G,
             std::enable_if_t<
@@ -1548,7 +1565,7 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(
             _mm256_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
@@ -1591,157 +1608,160 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
-                                   static_cast<__m256i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
+                                         static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(rhs),
                                              static_cast<__m256i>(lhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(rhs),
                                              static_cast<__m256i>(lhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epu32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpneq_epu32_mask(static_cast<__m256i>(lhs),
                                               static_cast<__m256i>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_srlv_epi32(static_cast<__m256i>(lhs),
-                                  static_cast<__m256i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_srlv_epi32(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
-                                  static_cast<__m256i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
   }
 };
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>>
-abs(Experimental::simd<std::uint32_t,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+abs(Experimental::basic_simd<
+    std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-floor(Experimental::simd<
+floor(Experimental::basic_simd<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepu32_pd(static_cast<__m256i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-ceil(Experimental::simd<
+ceil(Experimental::basic_simd<
      std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepu32_pd(static_cast<__m256i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-round(Experimental::simd<
+round(Experimental::basic_simd<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepu32_pd(static_cast<__m256i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-trunc(Experimental::simd<
+trunc(Experimental::basic_simd<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepu32_pd(static_cast<__m256i>(a)));
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
-    condition(simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a,
-              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& b,
-              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
+    condition(
+        basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a,
+        basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& b,
+        basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& c) {
+  return basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
                               static_cast<__m256i>(b)));
 }
 
 template <>
-class simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
+class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
   __m512i m_value;
 
  public:
   using value_type = std::uint32_t;
   using abi_type   = simd_abi::avx512_fixed_size<16>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 16;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm512_set1_epi32(
             Kokkos::bit_cast<std::int32_t>(value_type(value)))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m512i const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& other)
       : m_value(static_cast<__m512i>(other)) {}
   template <class G,
             std::enable_if_t<
@@ -1750,7 +1770,7 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm512_setr_epi32(
             gen(std::integral_constant<std::size_t, 0>()),
@@ -1800,158 +1820,160 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
       const {
     return m_value;
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
-                                   static_cast<__m512i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
+                                         static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm512_add_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm512_sub_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epu32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epu32_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmple_epu32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmple_epu32_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpeq_epu32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpneq_epu32_mask(static_cast<__m512i>(lhs),
                                               static_cast<__m512i>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm512_srli_epi32(static_cast<__m512i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm512_srli_epi32(static_cast<__m512i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm512_srlv_epi32(static_cast<__m512i>(lhs),
-                                  static_cast<__m512i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_srlv_epi32(static_cast<__m512i>(lhs),
+                                        static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) noexcept {
-    return simd(_mm512_slli_epi32(static_cast<__m512i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm512_slli_epi32(static_cast<__m512i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm512_sllv_epi32(static_cast<__m512i>(lhs),
-                                  static_cast<__m512i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_sllv_epi32(static_cast<__m512i>(lhs),
+                                        static_cast<__m512i>(rhs)));
   }
 };
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>>
-abs(Experimental::simd<
+abs(Experimental::basic_simd<
     std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-floor(Experimental::simd<
+floor(Experimental::basic_simd<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cvtepu32_ps(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-ceil(Experimental::simd<
+ceil(Experimental::basic_simd<
      std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cvtepu32_ps(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-round(Experimental::simd<
+round(Experimental::basic_simd<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cvtepu32_ps(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-trunc(Experimental::simd<
+trunc(Experimental::basic_simd<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::simd<float,
-                            Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_simd<
+      float, Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cvtepu32_ps(static_cast<__m512i>(a)));
 }
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>
-    condition(
-        simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& a,
-        simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& b,
-        simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& c) {
-  return simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
+    std::uint32_t, simd_abi::avx512_fixed_size<16>>
+condition(
+    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& a,
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& b,
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& c) {
+  return basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>(
       _mm512_mask_blend_epi32(static_cast<__mmask16>(a),
                               static_cast<__m512i>(c),
                               static_cast<__m512i>(b)));
 }
 
 template <>
-class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
+class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
   __m512i m_value;
 
  public:
   using value_type = std::int64_t;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm512_set1_epi64(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other)
       : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other);
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -1959,7 +1981,7 @@ class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(
             _mm512_setr_epi64(gen(std::integral_constant<std::size_t, 0>()),
@@ -1970,7 +1992,8 @@ class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m512i const& value_in)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
+      __m512i const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
@@ -2001,165 +2024,169 @@ class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
-    return simd(_mm512_sub_epi64(_mm512_set1_epi64(0), m_value));
+    return basic_simd(_mm512_sub_epi64(_mm512_set1_epi64(0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
-                                   static_cast<__m512i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
+                                         static_cast<__m512i>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epi64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epi64_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmple_epi64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmple_epi64_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpeq_epi64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpneq_epi64_mask(static_cast<__m512i>(lhs),
                                               static_cast<__m512i>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) {
-    return simd(_mm512_srai_epi64(static_cast<__m512i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) {
+    return basic_simd(_mm512_srai_epi64(static_cast<__m512i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) {
-    return simd(_mm512_srav_epi64(static_cast<__m512i>(lhs),
-                                  static_cast<__m512i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) {
+    return basic_simd(_mm512_srav_epi64(static_cast<__m512i>(lhs),
+                                        static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) {
-    return simd(_mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) {
+    return basic_simd(_mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) {
-    return simd(_mm512_sllv_epi64(static_cast<__m512i>(lhs),
-                                  static_cast<__m512i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) {
+    return basic_simd(_mm512_sllv_epi64(static_cast<__m512i>(lhs),
+                                        static_cast<__m512i>(rhs)));
   }
 };
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>>
-abs(Experimental::simd<std::int64_t,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+abs(Experimental::basic_simd<
+    std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m512i const rhs = static_cast<__m512i>(a);
-  return Experimental::simd<std::int64_t,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<std::int64_t,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_abs_epi64(rhs));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-floor(Experimental::simd<
+floor(Experimental::basic_simd<
       std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepi64_pd(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::avx512_fixed_size<8>>
-    ceil(Experimental::simd<
-         std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    double, Experimental::simd_abi::avx512_fixed_size<8>>
+ceil(Experimental::basic_simd<
+     std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepi64_pd(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-round(Experimental::simd<
+round(Experimental::basic_simd<
       std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepi64_pd(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-trunc(Experimental::simd<
+trunc(Experimental::basic_simd<
       std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepi64_pd(static_cast<__m512i>(a)));
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
-    condition(simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a,
-              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& b,
-              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
+    condition(
+        basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a,
+        basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& b,
+        basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& c) {
+  return basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_mask_blend_epi64(static_cast<__mmask8>(a), static_cast<__m512i>(c),
                               static_cast<__m512i>(b)));
 }
 
 template <>
-class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
+class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   __m512i m_value;
 
  public:
   using value_type = std::uint64_t;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm512_set1_epi64(
             Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m512i const& value_in)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
+      __m512i const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int32_t, abi_type> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other)
       : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
   template <class G,
             std::enable_if_t<
@@ -2168,7 +2195,7 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(
             _mm512_setr_epi64(gen(std::integral_constant<std::size_t, 0>()),
@@ -2179,8 +2206,8 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int64_t, abi_type> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int64_t, abi_type> const& other)
       : m_value(static_cast<__m512i>(other)) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
@@ -2211,77 +2238,77 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
-                                   static_cast<__m512i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
+                                         static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) noexcept {
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
     return _mm512_srli_epi64(static_cast<__m512i>(lhs), rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return _mm512_srlv_epi64(static_cast<__m512i>(lhs),
                              static_cast<__m512i>(rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) noexcept {
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
     return _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return _mm512_sllv_epi64(static_cast<__m512i>(lhs),
                              static_cast<__m512i>(rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator&(
-      simd const& lhs, simd const& rhs) noexcept {
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator&(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return _mm512_and_epi64(static_cast<__m512i>(lhs),
                             static_cast<__m512i>(rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator|(
-      simd const& lhs, simd const& rhs) noexcept {
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator|(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return _mm512_or_epi64(static_cast<__m512i>(lhs),
                            static_cast<__m512i>(rhs));
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epu64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epu64_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmple_epu64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmple_epu64_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpeq_epu64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpneq_epu64_mask(static_cast<__m512i>(lhs),
                                               static_cast<__m512i>(rhs)));
   }
@@ -2289,78 +2316,80 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>>
-abs(Experimental::simd<std::uint64_t,
-                       Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+abs(Experimental::basic_simd<
+    std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-floor(Experimental::simd<
+floor(Experimental::basic_simd<
       std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepu64_pd(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-ceil(Experimental::simd<
+ceil(Experimental::basic_simd<
      std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepu64_pd(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-round(Experimental::simd<
+round(Experimental::basic_simd<
       std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepu64_pd(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-trunc(Experimental::simd<
+trunc(Experimental::basic_simd<
       std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::simd<double,
-                            Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepu64_pd(static_cast<__m512i>(a)));
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
-    condition(simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a,
-              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& b,
-              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
+    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
+    condition(
+        basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a,
+        basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& b,
+        basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& c) {
+  return basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_mask_blend_epi64(static_cast<__mmask8>(a), static_cast<__m512i>(c),
                               static_cast<__m512i>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::simd(
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other)
+basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other)
     : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::simd(
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other)
+basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other)
     : m_value(static_cast<__m512i>(other)) {}
 
 template <>
-class const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-                             simd<double, simd_abi::avx512_fixed_size<8>>> {
+class const_where_expression<
+    basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+    basic_simd<double, simd_abi::avx512_fixed_size<8>>> {
  public:
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using value_type = simd<double, abi_type>;
-  using mask_type  = simd_mask<double, abi_type>;
+  using value_type = basic_simd<double, abi_type>;
+  using mask_type  = basic_simd_mask<double, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2383,7 +2412,8 @@ class const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       double* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index)
+      const {
     _mm512_mask_i32scatter_pd(mem, static_cast<__mmask8>(m_mask),
                               static_cast<__m256i>(index),
                               static_cast<__m512d>(m_value), 8);
@@ -2401,15 +2431,15 @@ class const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
 };
 
 template <>
-class where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-                       simd<double, simd_abi::avx512_fixed_size<8>>>
+class where_expression<basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+                       basic_simd<double, simd_abi::avx512_fixed_size<8>>>
     : public const_where_expression<
-          simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-          simd<double, simd_abi::avx512_fixed_size<8>>> {
+          basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+          basic_simd<double, simd_abi::avx512_fixed_size<8>>> {
  public:
   where_expression(
-      simd_mask<double, simd_abi::avx512_fixed_size<8>> const& mask_arg,
-      simd<double, simd_abi::avx512_fixed_size<8>>& value_arg)
+      basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& mask_arg,
+      basic_simd<double, simd_abi::avx512_fixed_size<8>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, element_aligned_tag) {
@@ -2424,32 +2454,35 @@ class where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       double const* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
     m_value = value_type(_mm512_mask_i32gather_pd(
         static_cast<__m512d>(m_value), static_cast<__mmask8>(m_mask),
         static_cast<__m256i>(index), mem, 8));
   }
-  template <class U, std::enable_if_t<
-                         std::is_convertible_v<
-                             U, simd<double, simd_abi::avx512_fixed_size<8>>>,
-                         bool> = false>
+  template <class U,
+            std::enable_if_t<
+                std::is_convertible_v<
+                    U, basic_simd<double, simd_abi::avx512_fixed_size<8>>>,
+                bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<double, simd_abi::avx512_fixed_size<8>>>(
+        static_cast<basic_simd<double, simd_abi::avx512_fixed_size<8>>>(
             std::forward<U>(x));
-    m_value = simd<double, simd_abi::avx512_fixed_size<8>>(_mm512_mask_blend_pd(
-        static_cast<__mmask8>(m_mask), static_cast<__m512d>(m_value),
-        static_cast<__m512d>(x_as_value_type)));
+    m_value =
+        basic_simd<double, simd_abi::avx512_fixed_size<8>>(_mm512_mask_blend_pd(
+            static_cast<__mmask8>(m_mask), static_cast<__m512d>(m_value),
+            static_cast<__m512d>(x_as_value_type)));
   }
 };
 
 template <>
-class const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-                             simd<float, simd_abi::avx512_fixed_size<8>>> {
+class const_where_expression<
+    basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+    basic_simd<float, simd_abi::avx512_fixed_size<8>>> {
  public:
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using value_type = simd<float, abi_type>;
-  using mask_type  = simd_mask<float, abi_type>;
+  using value_type = basic_simd<float, abi_type>;
+  using mask_type  = basic_simd_mask<float, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2472,7 +2505,8 @@ class const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       float* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index)
+      const {
     _mm256_mask_i32scatter_ps(mem, static_cast<__mmask8>(m_mask),
                               static_cast<__m256i>(index),
                               static_cast<__m256>(m_value), 4);
@@ -2490,15 +2524,15 @@ class const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
 };
 
 template <>
-class where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-                       simd<float, simd_abi::avx512_fixed_size<8>>>
+class where_expression<basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+                       basic_simd<float, simd_abi::avx512_fixed_size<8>>>
     : public const_where_expression<
-          simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-          simd<float, simd_abi::avx512_fixed_size<8>>> {
+          basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+          basic_simd<float, simd_abi::avx512_fixed_size<8>>> {
  public:
   where_expression(
-      simd_mask<float, simd_abi::avx512_fixed_size<8>> const& mask_arg,
-      simd<float, simd_abi::avx512_fixed_size<8>>& value_arg)
+      basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& mask_arg,
+      basic_simd<float, simd_abi::avx512_fixed_size<8>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
@@ -2512,35 +2546,37 @@ class where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
     __m256 on   = _mm256_castsi256_ps(_mm256_set1_epi32(-1));
     __m256 mask = _mm256_maskz_mov_ps(static_cast<__mmask8>(m_mask), on);
     m_value     = value_type(
         _mm256_mask_i32gather_ps(static_cast<__m256>(m_value), mem,
                                      static_cast<__m256i>(index), mask, 4));
   }
-  template <
-      class U,
-      std::enable_if_t<
-          std::is_convertible_v<U, simd<float, simd_abi::avx512_fixed_size<8>>>,
-          bool> = false>
+  template <class U,
+            std::enable_if_t<
+                std::is_convertible_v<
+                    U, basic_simd<float, simd_abi::avx512_fixed_size<8>>>,
+                bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<float, simd_abi::avx512_fixed_size<8>>>(
+        static_cast<basic_simd<float, simd_abi::avx512_fixed_size<8>>>(
             std::forward<U>(x));
-    m_value = simd<float, simd_abi::avx512_fixed_size<8>>(_mm256_mask_blend_ps(
-        static_cast<__mmask8>(m_mask), static_cast<__m256>(m_value),
-        static_cast<__m256>(x_as_value_type)));
+    m_value =
+        basic_simd<float, simd_abi::avx512_fixed_size<8>>(_mm256_mask_blend_ps(
+            static_cast<__mmask8>(m_mask), static_cast<__m256>(m_value),
+            static_cast<__m256>(x_as_value_type)));
   }
 };
 
 template <>
-class const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<16>>,
-                             simd<float, simd_abi::avx512_fixed_size<16>>> {
+class const_where_expression<
+    basic_simd_mask<float, simd_abi::avx512_fixed_size<16>>,
+    basic_simd<float, simd_abi::avx512_fixed_size<16>>> {
  public:
   using abi_type   = simd_abi::avx512_fixed_size<16>;
-  using value_type = simd<float, abi_type>;
-  using mask_type  = simd_mask<float, abi_type>;
+  using value_type = basic_simd<float, abi_type>;
+  using mask_type  = basic_simd_mask<float, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2563,7 +2599,8 @@ class const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<16>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       float* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) const {
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index)
+      const {
     _mm512_mask_i32scatter_ps(mem, static_cast<__mmask16>(m_mask),
                               static_cast<__m512i>(index),
                               static_cast<__m512>(m_value), 4);
@@ -2581,15 +2618,15 @@ class const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<16>>,
 };
 
 template <>
-class where_expression<simd_mask<float, simd_abi::avx512_fixed_size<16>>,
-                       simd<float, simd_abi::avx512_fixed_size<16>>>
+class where_expression<basic_simd_mask<float, simd_abi::avx512_fixed_size<16>>,
+                       basic_simd<float, simd_abi::avx512_fixed_size<16>>>
     : public const_where_expression<
-          simd_mask<float, simd_abi::avx512_fixed_size<16>>,
-          simd<float, simd_abi::avx512_fixed_size<16>>> {
+          basic_simd_mask<float, simd_abi::avx512_fixed_size<16>>,
+          basic_simd<float, simd_abi::avx512_fixed_size<16>>> {
  public:
   where_expression(
-      simd_mask<float, simd_abi::avx512_fixed_size<16>> const& mask_arg,
-      simd<float, simd_abi::avx512_fixed_size<16>>& value_arg)
+      basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& mask_arg,
+      basic_simd<float, simd_abi::avx512_fixed_size<16>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
@@ -2604,33 +2641,35 @@ class where_expression<simd_mask<float, simd_abi::avx512_fixed_size<16>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) {
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) {
     m_value = value_type(_mm512_mask_i32gather_ps(
         static_cast<__m512>(m_value), static_cast<__mmask16>(m_mask),
         static_cast<__m512i>(index), mem, 4));
   }
-  template <class U, std::enable_if_t<
-                         std::is_convertible_v<
-                             U, simd<float, simd_abi::avx512_fixed_size<16>>>,
-                         bool> = false>
+  template <class U,
+            std::enable_if_t<
+                std::is_convertible_v<
+                    U, basic_simd<float, simd_abi::avx512_fixed_size<16>>>,
+                bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<float, simd_abi::avx512_fixed_size<16>>>(
+        static_cast<basic_simd<float, simd_abi::avx512_fixed_size<16>>>(
             std::forward<U>(x));
-    m_value = simd<float, simd_abi::avx512_fixed_size<16>>(_mm512_mask_blend_ps(
-        static_cast<__mmask16>(m_mask), static_cast<__m512>(m_value),
-        static_cast<__m512>(x_as_value_type)));
+    m_value =
+        basic_simd<float, simd_abi::avx512_fixed_size<16>>(_mm512_mask_blend_ps(
+            static_cast<__mmask16>(m_mask), static_cast<__m512>(m_value),
+            static_cast<__m512>(x_as_value_type)));
   }
 };
 
 template <>
 class const_where_expression<
-    simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> {
+    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> {
  public:
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using value_type = simd<std::int32_t, abi_type>;
-  using mask_type  = simd_mask<std::int32_t, abi_type>;
+  using value_type = basic_simd<std::int32_t, abi_type>;
+  using mask_type  = basic_simd_mask<std::int32_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2654,7 +2693,8 @@ class const_where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::int32_t* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index)
+      const {
     _mm256_mask_i32scatter_epi32(mem, static_cast<__mmask8>(m_mask),
                                  static_cast<__m256i>(index),
                                  static_cast<__m256i>(m_value), 4);
@@ -2672,15 +2712,17 @@ class const_where_expression<
 };
 
 template <>
-class where_expression<simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-                       simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+class where_expression<
+    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
     : public const_where_expression<
-          simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-          simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> {
+          basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> {
  public:
   where_expression(
-      simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask_arg,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>>& value_arg)
+      basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+          mask_arg,
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
@@ -2695,22 +2737,23 @@ class where_expression<simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
     m_value = value_type(_mm256_mmask_i32gather_epi32(
         static_cast<__m256i>(m_value), static_cast<__mmask8>(m_mask),
         static_cast<__m256i>(index), mem, 4));
   }
 
-  template <class U,
-            std::enable_if_t<
-                std::is_convertible_v<
-                    U, simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>,
-                bool> = false>
+  template <
+      class U,
+      std::enable_if_t<
+          std::is_convertible_v<
+              U, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>,
+          bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>(
+        static_cast<basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>(
             std::forward<U>(x));
-    m_value = simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+    m_value = basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
         _mm256_mask_blend_epi32(static_cast<__mmask8>(m_mask),
                                 static_cast<__m256i>(m_value),
                                 static_cast<__m256i>(x_as_value_type)));
@@ -2719,12 +2762,12 @@ class where_expression<simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
 
 template <>
 class const_where_expression<
-    simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
-    simd<std::int32_t, simd_abi::avx512_fixed_size<16>>> {
+    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>> {
  public:
   using abi_type   = simd_abi::avx512_fixed_size<16>;
-  using value_type = simd<std::int32_t, abi_type>;
-  using mask_type  = simd_mask<std::int32_t, abi_type>;
+  using value_type = basic_simd<std::int32_t, abi_type>;
+  using mask_type  = basic_simd_mask<std::int32_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2747,194 +2790,8 @@ class const_where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::int32_t* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) const {
-    _mm512_mask_i32scatter_epi32(mem, static_cast<__mmask16>(m_mask),
-                                 static_cast<__m512i>(index),
-                                 static_cast<__m512i>(m_value), 4);
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
-    return m_value;
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
-    return m_mask;
-  }
-};
-
-template <>
-class where_expression<simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
-                       simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-    : public const_where_expression<
-          simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
-          simd<std::int32_t, simd_abi::avx512_fixed_size<16>>> {
- public:
-  where_expression(
-      simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask_arg,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<16>>& value_arg)
-      : const_where_expression(mask_arg, value_arg) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void copy_from(std::int32_t const* mem, element_aligned_tag) {
-    m_value = value_type(_mm512_mask_loadu_epi32(
-        _mm512_set1_epi32(0), static_cast<__mmask16>(m_mask), mem));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void copy_from(std::int32_t const* mem, vector_aligned_tag) {
-    m_value = value_type(_mm512_mask_load_epi32(
-        _mm512_set1_epi32(0), static_cast<__mmask16>(m_mask), mem));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void gather_from(
-      std::int32_t const* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) {
-    m_value = value_type(_mm512_mask_i32gather_epi32(
-        static_cast<__m512i>(m_value), static_cast<__mmask16>(m_mask),
-        static_cast<__m512i>(index), mem, 4));
-  }
-  template <class U,
-            std::enable_if_t<
-                std::is_convertible_v<
-                    U, simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>,
-                bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
-    auto const x_as_value_type =
-        static_cast<simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>(
-            std::forward<U>(x));
-    m_value = simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
-        _mm512_mask_blend_epi32(static_cast<__mmask16>(m_mask),
-                                static_cast<__m512i>(m_value),
-                                static_cast<__m512i>(x_as_value_type)));
-  }
-};
-
-template <>
-class const_where_expression<
-    simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> {
- public:
-  using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using value_type = simd<std::uint32_t, abi_type>;
-  using mask_type  = simd_mask<std::uint32_t, abi_type>;
-
- protected:
-  value_type& m_value;
-  mask_type const& m_mask;
-
- public:
-  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
-      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void copy_to(std::uint32_t* mem, element_aligned_tag) const {
-    _mm256_mask_storeu_epi32(mem, static_cast<__mmask8>(m_mask),
-                             static_cast<__m256i>(m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void copy_to(std::uint32_t* mem, vector_aligned_tag) const {
-    _mm256_mask_store_epi32(mem, static_cast<__mmask8>(m_mask),
-                            static_cast<__m256i>(m_value));
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      std::uint32_t* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
-    _mm256_mask_i32scatter_epi32(mem, static_cast<__mmask8>(m_mask),
-                                 static_cast<__m256i>(index),
-                                 static_cast<__m256i>(m_value), 4);
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
-    return m_value;
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
-    return m_mask;
-  }
-};
-
-template <>
-class where_expression<simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
-                       simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-    : public const_where_expression<
-          simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
-          simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> {
- public:
-  where_expression(
-      simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask_arg,
-      simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>& value_arg)
-      : const_where_expression(mask_arg, value_arg) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void copy_from(std::uint32_t const* mem, element_aligned_tag) {
-    m_value = value_type(_mm256_mask_loadu_epi32(
-        _mm256_set1_epi32(0), static_cast<__mmask8>(m_mask), mem));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void copy_from(std::uint32_t const* mem, vector_aligned_tag) {
-    m_value = value_type(_mm256_mask_load_epi32(
-        _mm256_set1_epi32(0), static_cast<__mmask8>(m_mask), mem));
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void gather_from(
-      std::uint32_t const* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
-    m_value = value_type(_mm256_mmask_i32gather_epi32(
-        static_cast<__m256i>(m_value), static_cast<__mmask8>(m_mask),
-        static_cast<__m256i>(index), mem, 4));
-  }
-
-  template <class U,
-            std::enable_if_t<
-                std::is_convertible_v<
-                    U, simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>,
-                bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
-    auto const x_as_value_type =
-        static_cast<simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>(
-            std::forward<U>(x));
-    m_value = simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-        _mm256_mask_blend_epi32(static_cast<__mmask8>(m_mask),
-                                static_cast<__m256i>(m_value),
-                                static_cast<__m256i>(x_as_value_type)));
-  }
-};
-
-template <>
-class const_where_expression<
-    simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>> {
- public:
-  using abi_type   = simd_abi::avx512_fixed_size<16>;
-  using value_type = simd<std::uint32_t, abi_type>;
-  using mask_type  = simd_mask<std::uint32_t, abi_type>;
-
- protected:
-  value_type& m_value;
-  mask_type const& m_mask;
-
- public:
-  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
-      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void copy_to(std::uint32_t* mem, element_aligned_tag) const {
-    _mm512_mask_storeu_epi32(mem, static_cast<__mmask16>(m_mask),
-                             static_cast<__m512i>(m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void copy_to(std::uint32_t* mem, vector_aligned_tag) const {
-    _mm512_mask_store_epi32(mem, static_cast<__mmask16>(m_mask),
-                            static_cast<__m512i>(m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      std::uint32_t* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) const {
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index)
+      const {
     _mm512_mask_i32scatter_epi32(mem, static_cast<__mmask16>(m_mask),
                                  static_cast<__m512i>(index),
                                  static_cast<__m512i>(m_value), 4);
@@ -2953,15 +2810,211 @@ class const_where_expression<
 
 template <>
 class where_expression<
-    simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
     : public const_where_expression<
-          simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
-          simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>> {
+          basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>> {
  public:
   where_expression(
-      simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask_arg,
-      simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>& value_arg)
+      basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
+          mask_arg,
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::int32_t const* mem, element_aligned_tag) {
+    m_value = value_type(_mm512_mask_loadu_epi32(
+        _mm512_set1_epi32(0), static_cast<__mmask16>(m_mask), mem));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::int32_t const* mem, vector_aligned_tag) {
+    m_value = value_type(_mm512_mask_load_epi32(
+        _mm512_set1_epi32(0), static_cast<__mmask16>(m_mask), mem));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      std::int32_t const* mem,
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) {
+    m_value = value_type(_mm512_mask_i32gather_epi32(
+        static_cast<__m512i>(m_value), static_cast<__mmask16>(m_mask),
+        static_cast<__m512i>(index), mem, 4));
+  }
+  template <
+      class U,
+      std::enable_if_t<
+          std::is_convertible_v<
+              U, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>,
+          bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>(
+            std::forward<U>(x));
+    m_value = basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
+        _mm512_mask_blend_epi32(static_cast<__mmask16>(m_mask),
+                                static_cast<__m512i>(m_value),
+                                static_cast<__m512i>(x_as_value_type)));
+  }
+};
+
+template <>
+class const_where_expression<
+    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> {
+ public:
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using value_type = basic_simd<std::uint32_t, abi_type>;
+  using mask_type  = basic_simd_mask<std::uint32_t, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::uint32_t* mem, element_aligned_tag) const {
+    _mm256_mask_storeu_epi32(mem, static_cast<__mmask8>(m_mask),
+                             static_cast<__m256i>(m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::uint32_t* mem, vector_aligned_tag) const {
+    _mm256_mask_store_epi32(mem, static_cast<__mmask8>(m_mask),
+                            static_cast<__m256i>(m_value));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      std::uint32_t* mem,
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index)
+      const {
+    _mm256_mask_i32scatter_epi32(mem, static_cast<__mmask8>(m_mask),
+                                 static_cast<__m256i>(index),
+                                 static_cast<__m256i>(m_value), 4);
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
+  impl_get_value() const {
+    return m_value;
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
+  impl_get_mask() const {
+    return m_mask;
+  }
+};
+
+template <>
+class where_expression<
+    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+    : public const_where_expression<
+          basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+          basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> {
+ public:
+  where_expression(
+      basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+          mask_arg,
+      basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::uint32_t const* mem, element_aligned_tag) {
+    m_value = value_type(_mm256_mask_loadu_epi32(
+        _mm256_set1_epi32(0), static_cast<__mmask8>(m_mask), mem));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::uint32_t const* mem, vector_aligned_tag) {
+    m_value = value_type(_mm256_mask_load_epi32(
+        _mm256_set1_epi32(0), static_cast<__mmask8>(m_mask), mem));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      std::uint32_t const* mem,
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+    m_value = value_type(_mm256_mmask_i32gather_epi32(
+        static_cast<__m256i>(m_value), static_cast<__mmask8>(m_mask),
+        static_cast<__m256i>(index), mem, 4));
+  }
+
+  template <
+      class U,
+      std::enable_if_t<
+          std::is_convertible_v<
+              U, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>,
+          bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>(
+            std::forward<U>(x));
+    m_value = basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+        _mm256_mask_blend_epi32(static_cast<__mmask8>(m_mask),
+                                static_cast<__m256i>(m_value),
+                                static_cast<__m256i>(x_as_value_type)));
+  }
+};
+
+template <>
+class const_where_expression<
+    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>> {
+ public:
+  using abi_type   = simd_abi::avx512_fixed_size<16>;
+  using value_type = basic_simd<std::uint32_t, abi_type>;
+  using mask_type  = basic_simd_mask<std::uint32_t, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::uint32_t* mem, element_aligned_tag) const {
+    _mm512_mask_storeu_epi32(mem, static_cast<__mmask16>(m_mask),
+                             static_cast<__m512i>(m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::uint32_t* mem, vector_aligned_tag) const {
+    _mm512_mask_store_epi32(mem, static_cast<__mmask16>(m_mask),
+                            static_cast<__m512i>(m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      std::uint32_t* mem,
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index)
+      const {
+    _mm512_mask_i32scatter_epi32(mem, static_cast<__mmask16>(m_mask),
+                                 static_cast<__m512i>(index),
+                                 static_cast<__m512i>(m_value), 4);
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
+  impl_get_value() const {
+    return m_value;
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
+  impl_get_mask() const {
+    return m_mask;
+  }
+};
+
+template <>
+class where_expression<
+    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+    : public const_where_expression<
+          basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
+          basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>> {
+ public:
+  where_expression(
+      basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
+          mask_arg,
+      basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::uint32_t const* mem, element_aligned_tag) {
@@ -2976,21 +3029,22 @@ class where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint32_t const* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) {
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) {
     m_value = value_type(_mm512_mask_i32gather_epi32(
         static_cast<__m512i>(m_value), static_cast<__mmask16>(m_mask),
         static_cast<__m512i>(index), mem, 4));
   }
-  template <class U,
-            std::enable_if_t<
-                std::is_convertible_v<
-                    U, simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>,
-                bool> = false>
+  template <
+      class U,
+      std::enable_if_t<
+          std::is_convertible_v<
+              U, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>,
+          bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>(
+        static_cast<basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>(
             std::forward<U>(x));
-    m_value = simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>(
+    m_value = basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>(
         _mm512_mask_blend_epi32(static_cast<__mmask16>(m_mask),
                                 static_cast<__m512i>(m_value),
                                 static_cast<__m512i>(x_as_value_type)));
@@ -2999,12 +3053,12 @@ class where_expression<
 
 template <>
 class const_where_expression<
-    simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> {
+    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> {
  public:
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using value_type = simd<std::int64_t, abi_type>;
-  using mask_type  = simd_mask<std::int64_t, abi_type>;
+  using value_type = basic_simd<std::int64_t, abi_type>;
+  using mask_type  = basic_simd_mask<std::int64_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3028,7 +3082,8 @@ class const_where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::int64_t* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index)
+      const {
     _mm512_mask_i32scatter_epi64(mem, static_cast<__mmask8>(m_mask),
                                  static_cast<__m256i>(index),
                                  static_cast<__m512i>(m_value), 8);
@@ -3046,15 +3101,17 @@ class const_where_expression<
 };
 
 template <>
-class where_expression<simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-                       simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+class where_expression<
+    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
     : public const_where_expression<
-          simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-          simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> {
+          basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+          basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> {
  public:
   where_expression(
-      simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask_arg,
-      simd<std::int64_t, simd_abi::avx512_fixed_size<8>>& value_arg)
+      basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+          mask_arg,
+      basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int64_t const* mem, element_aligned_tag) {
@@ -3070,22 +3127,23 @@ class where_expression<simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int64_t const* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
     m_value = value_type(_mm512_mask_i32gather_epi64(
         static_cast<__m512i>(m_value), static_cast<__mmask8>(m_mask),
         static_cast<__m256i>(index), mem, 8));
   }
 
-  template <class U,
-            std::enable_if_t<
-                std::is_convertible_v<
-                    U, simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>,
-                bool> = false>
+  template <
+      class U,
+      std::enable_if_t<
+          std::is_convertible_v<
+              U, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>,
+          bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>(
+        static_cast<basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>(
             std::forward<U>(x));
-    m_value = simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+    m_value = basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
         _mm512_mask_blend_epi64(static_cast<__mmask8>(m_mask),
                                 static_cast<__m512i>(m_value),
                                 static_cast<__m512i>(x_as_value_type)));
@@ -3094,12 +3152,12 @@ class where_expression<simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
 
 template <>
 class const_where_expression<
-    simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> {
+    basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> {
  public:
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using value_type = simd<std::uint64_t, abi_type>;
-  using mask_type  = simd_mask<std::uint64_t, abi_type>;
+  using value_type = basic_simd<std::uint64_t, abi_type>;
+  using mask_type  = basic_simd_mask<std::uint64_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3123,7 +3181,8 @@ class const_where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::uint64_t* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index)
+      const {
     _mm512_mask_i32scatter_epi64(mem, static_cast<__mmask8>(m_mask),
                                  static_cast<__m256i>(index),
                                  static_cast<__m512i>(m_value), 8);
@@ -3141,15 +3200,17 @@ class const_where_expression<
 };
 
 template <>
-class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
-                       simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+class where_expression<
+    basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
     : public const_where_expression<
-          simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
-          simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> {
+          basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+          basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> {
  public:
   where_expression(
-      simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask_arg,
-      simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>& value_arg)
+      basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+          mask_arg,
+      basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::uint64_t const* mem, element_aligned_tag) {
@@ -3164,22 +3225,23 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint64_t const* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
     m_value = value_type(_mm512_mask_i32gather_epi64(
         static_cast<__m512i>(m_value), static_cast<__mmask8>(m_mask),
         static_cast<__m256i>(index), mem, 8));
   }
 
-  template <class U,
-            std::enable_if_t<
-                std::is_convertible_v<
-                    U, simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>,
-                bool> = false>
+  template <
+      class U,
+      std::enable_if_t<
+          std::is_convertible_v<
+              U, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>,
+          bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>(
+        static_cast<basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>(
             std::forward<U>(x));
-    m_value = simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
+    m_value = basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
         _mm512_mask_blend_epi64(static_cast<__mmask8>(m_mask),
                                 static_cast<__m512i>(m_value),
                                 static_cast<__m512i>(x_as_value_type)));
@@ -3188,34 +3250,34 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t hmax(
     const_where_expression<
-        simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-        simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+        basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+        basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   return _mm512_mask_reduce_max_epi32(
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double hmin(
-    const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-                           simd<double, simd_abi::avx512_fixed_size<8>>> const&
-        x) {
+    const_where_expression<
+        basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+        basic_simd<double, simd_abi::avx512_fixed_size<8>>> const& x) {
   return _mm512_mask_reduce_min_pd(static_cast<__mmask8>(x.impl_get_mask()),
                                    static_cast<__m512d>(x.impl_get_value()));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce(
     const_where_expression<
-        simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-        simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x,
+        basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+        basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x,
     std::int64_t, std::plus<>) {
   return _mm512_mask_reduce_add_epi64(static_cast<__mmask8>(x.impl_get_mask()),
                                       static_cast<__m512i>(x.impl_get_value()));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
-    const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-                           simd<double, simd_abi::avx512_fixed_size<8>>> const&
-        x,
+    const_where_expression<
+        basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+        basic_simd<double, simd_abi::avx512_fixed_size<8>>> const& x,
     double, std::plus<>) {
   return _mm512_mask_reduce_add_pd(static_cast<__mmask8>(x.impl_get_mask()),
                                    static_cast<__m512d>(x.impl_get_value()));

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -31,14 +31,6 @@ class basic_simd;
 template <class T, class Abi>
 class basic_simd_mask;
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-template <class T, class Abi>
-using simd KOKKOS_DEPRECATED = basic_simd<T, Abi>;
-
-template <class T, class Abi>
-using simd_mask KOKKOS_DEPRECATED = basic_simd_mask<T, Abi>;
-#endif
-
 class simd_alignment_vector_aligned {};
 
 template <typename... Flags>

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -26,10 +26,18 @@ namespace Kokkos {
 namespace Experimental {
 
 template <class T, class Abi>
-class simd;
+class basic_simd;
 
 template <class T, class Abi>
-class simd_mask;
+class basic_simd_mask;
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+template <class T, class Abi>
+using simd KOKKOS_DEPRECATED = basic_simd<T, Abi>;
+
+template <class T, class Abi>
+using simd_mask KOKKOS_DEPRECATED = basic_simd_mask<T, Abi>;
+#endif
 
 class simd_alignment_vector_aligned {};
 
@@ -101,16 +109,17 @@ class where_expression<bool, T> : public const_where_expression<bool, T> {
 
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    where_expression<simd_mask<T, Abi>, simd<T, Abi>>
-    where(typename simd<T, Abi>::mask_type const& mask, simd<T, Abi>& value) {
+    where_expression<basic_simd_mask<T, Abi>, basic_simd<T, Abi>>
+    where(typename basic_simd<T, Abi>::mask_type const& mask,
+          basic_simd<T, Abi>& value) {
   return where_expression(mask, value);
 }
 
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    const_where_expression<simd_mask<T, Abi>, simd<T, Abi>>
-    where(typename simd<T, Abi>::mask_type const& mask,
-          simd<T, Abi> const& value) {
+    const_where_expression<basic_simd_mask<T, Abi>, basic_simd<T, Abi>>
+    where(typename basic_simd<T, Abi>::mask_type const& mask,
+          basic_simd<T, Abi> const& value) {
   return const_where_expression(mask, value);
 }
 
@@ -127,32 +136,32 @@ template <class T>
 }
 
 // The code below provides:
-// operator@(simd<T, Abi>, Arithmetic)
-// operator@(Arithmetic, simd<T, Abi>)
-// operator@=(simd<T, Abi>&, U&&)
+// operator@(basic_simd<T, Abi>, Arithmetic)
+// operator@(Arithmetic, basic_simd<T, Abi>)
+// operator@=(basic_simd<T, Abi>&, U&&)
 // operator@=(where_expression<M, T>&, U&&)
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator+(
-    Experimental::simd<T, Abi> const& lhs, U rhs) {
+    Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] + rhs);
-  return Experimental::simd<result_member, Abi>(lhs) +
-         Experimental::simd<result_member, Abi>(rhs);
+  return Experimental::basic_simd<result_member, Abi>(lhs) +
+         Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator+(
-    U lhs, Experimental::simd<T, Abi> const& rhs) {
+    U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs + rhs[0]);
-  return Experimental::simd<result_member, Abi>(lhs) +
-         Experimental::simd<result_member, Abi>(rhs);
+  return Experimental::basic_simd<result_member, Abi>(lhs) +
+         Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
 template <class T, class U, class Abi>
-KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>& operator+=(simd<T, Abi>& lhs,
-                                                     U&& rhs) {
+KOKKOS_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator+=(
+    basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs + std::forward<U>(rhs);
   return lhs;
 }
@@ -167,24 +176,24 @@ KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator+=(
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator-(
-    Experimental::simd<T, Abi> const& lhs, U rhs) {
+    Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] - rhs);
-  return Experimental::simd<result_member, Abi>(lhs) -
-         Experimental::simd<result_member, Abi>(rhs);
+  return Experimental::basic_simd<result_member, Abi>(lhs) -
+         Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator-(
-    U lhs, Experimental::simd<T, Abi> const& rhs) {
+    U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs - rhs[0]);
-  return Experimental::simd<result_member, Abi>(lhs) -
-         Experimental::simd<result_member, Abi>(rhs);
+  return Experimental::basic_simd<result_member, Abi>(lhs) -
+         Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
 template <class T, class U, class Abi>
-KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>& operator-=(simd<T, Abi>& lhs,
-                                                     U&& rhs) {
+KOKKOS_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator-=(
+    basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs - std::forward<U>(rhs);
   return lhs;
 }
@@ -199,24 +208,24 @@ KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator-=(
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator*(
-    Experimental::simd<T, Abi> const& lhs, U rhs) {
+    Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] * rhs);
-  return Experimental::simd<result_member, Abi>(lhs) *
-         Experimental::simd<result_member, Abi>(rhs);
+  return Experimental::basic_simd<result_member, Abi>(lhs) *
+         Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator*(
-    U lhs, Experimental::simd<T, Abi> const& rhs) {
+    U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs * rhs[0]);
-  return Experimental::simd<result_member, Abi>(lhs) *
-         Experimental::simd<result_member, Abi>(rhs);
+  return Experimental::basic_simd<result_member, Abi>(lhs) *
+         Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
 template <class T, class U, class Abi>
-KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>& operator*=(simd<T, Abi>& lhs,
-                                                     U&& rhs) {
+KOKKOS_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator*=(
+    basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs * std::forward<U>(rhs);
   return lhs;
 }
@@ -231,24 +240,24 @@ KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator*=(
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator/(
-    Experimental::simd<T, Abi> const& lhs, U rhs) {
+    Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] / rhs);
-  return Experimental::simd<result_member, Abi>(lhs) /
-         Experimental::simd<result_member, Abi>(rhs);
+  return Experimental::basic_simd<result_member, Abi>(lhs) /
+         Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator/(
-    U lhs, Experimental::simd<T, Abi> const& rhs) {
+    U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs / rhs[0]);
-  return Experimental::simd<result_member, Abi>(lhs) /
-         Experimental::simd<result_member, Abi>(rhs);
+  return Experimental::basic_simd<result_member, Abi>(lhs) /
+         Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
 template <class T, class U, class Abi>
-KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>& operator/=(simd<T, Abi>& lhs,
-                                                     U&& rhs) {
+KOKKOS_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator/=(
+    basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs / std::forward<U>(rhs);
   return lhs;
 }
@@ -261,7 +270,7 @@ KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator/=(
 }
 
 // implement mask reductions for type bool to allow generic code to accept
-// both simd<double, Abi> and just double
+// both basic_simd<double, Abi> and just double
 
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr bool all_of(bool a) {
   return a;
@@ -275,24 +284,24 @@ KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator/=(
   return !a;
 }
 
-// fallback implementations of reductions across simd_mask:
+// fallback implementations of reductions across basic_simd_mask:
 
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool all_of(
-    simd_mask<T, Abi> const& a) {
-  return a == simd_mask<T, Abi>(true);
+    basic_simd_mask<T, Abi> const& a) {
+  return a == basic_simd_mask<T, Abi>(true);
 }
 
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool any_of(
-    simd_mask<T, Abi> const& a) {
-  return a != simd_mask<T, Abi>(false);
+    basic_simd_mask<T, Abi> const& a) {
+  return a != basic_simd_mask<T, Abi>(false);
 }
 
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool none_of(
-    simd_mask<T, Abi> const& a) {
-  return a == simd_mask<T, Abi>(false);
+    basic_simd_mask<T, Abi> const& a) {
+  return a == basic_simd_mask<T, Abi>(false);
 }
 
 // A temporary device-callable implemenation of round half to nearest even

--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -29,14 +29,6 @@ class basic_simd;
 template <class T, class Abi>
 class basic_simd_mask;
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-template <class T, class Abi>
-using simd KOKKOS_DEPRECATED = basic_simd<T, Abi>;
-
-template <class T, class Abi>
-using simd_mask KOKKOS_DEPRECATED = basic_simd_mask<T, Abi>;
-#endif
-
 template <class M, class T>
 class const_where_expression;
 

--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -24,17 +24,26 @@ namespace Kokkos {
 namespace Experimental {
 
 template <class T, class Abi>
-class simd;
+class basic_simd;
 
 template <class T, class Abi>
-class simd_mask;
+class basic_simd_mask;
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+template <class T, class Abi>
+using simd KOKKOS_DEPRECATED = basic_simd<T, Abi>;
+
+template <class T, class Abi>
+using simd_mask KOKKOS_DEPRECATED = basic_simd_mask<T, Abi>;
+#endif
 
 template <class M, class T>
 class const_where_expression;
 
 template <typename T, typename Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-hmin(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
+hmin(const_where_expression<basic_simd_mask<T, Abi>, basic_simd<T, Abi>> const&
+         x) {
   auto const& v = x.impl_get_value();
   auto const& m = x.impl_get_mask();
   auto result   = Kokkos::reduction_identity<T>::min();
@@ -46,7 +55,8 @@ hmin(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
 
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-hmax(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
+hmax(const_where_expression<basic_simd_mask<T, Abi>, basic_simd<T, Abi>> const&
+         x) {
   auto const& v = x.impl_get_value();
   auto const& m = x.impl_get_mask();
   auto result   = Kokkos::reduction_identity<T>::max();
@@ -57,9 +67,10 @@ hmax(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-reduce(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x, T,
-       std::plus<>) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T reduce(
+    const_where_expression<basic_simd_mask<T, Abi>, basic_simd<T, Abi>> const&
+        x,
+    T, std::plus<>) {
   auto const& v = x.impl_get_value();
   auto const& m = x.impl_get_mask();
   auto result   = Kokkos::reduction_identity<T>::sum();
@@ -72,10 +83,11 @@ reduce(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x, T,
 }  // namespace Experimental
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> min(
-    Experimental::simd<T, Abi> const& a, Experimental::simd<T, Abi> const& b) {
-  Experimental::simd<T, Abi> result;
-  for (std::size_t i = 0; i < Experimental::simd<T, Abi>::size(); ++i) {
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> min(
+    Experimental::basic_simd<T, Abi> const& a,
+    Experimental::basic_simd<T, Abi> const& b) {
+  Experimental::basic_simd<T, Abi> result;
+  for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size(); ++i) {
     result[i] = Kokkos::min(a[i], b[i]);
   }
   return result;
@@ -85,19 +97,20 @@ template <class T, class Abi>
 namespace Experimental {
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<T, Abi>
-    min(Experimental::simd<T, Abi> const& a,
-        Experimental::simd<T, Abi> const& b) {
+    Experimental::basic_simd<T, Abi>
+    min(Experimental::basic_simd<T, Abi> const& a,
+        Experimental::basic_simd<T, Abi> const& b) {
   return Kokkos::min(a, b);
 }
 }  // namespace Experimental
 #endif
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> max(
-    Experimental::simd<T, Abi> const& a, Experimental::simd<T, Abi> const& b) {
-  Experimental::simd<T, Abi> result;
-  for (std::size_t i = 0; i < Experimental::simd<T, Abi>::size(); ++i) {
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> max(
+    Experimental::basic_simd<T, Abi> const& a,
+    Experimental::basic_simd<T, Abi> const& b) {
+  Experimental::basic_simd<T, Abi> result;
+  for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size(); ++i) {
     result[i] = Kokkos::max(a[i], b[i]);
   }
   return result;
@@ -107,9 +120,9 @@ template <class T, class Abi>
 namespace Experimental {
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<T, Abi>
-    max(Experimental::simd<T, Abi> const& a,
-        Experimental::simd<T, Abi> const& b) {
+    Experimental::basic_simd<T, Abi>
+    max(Experimental::basic_simd<T, Abi> const& a,
+        Experimental::basic_simd<T, Abi> const& b) {
   return Kokkos::max(a, b);
 }
 }  // namespace Experimental
@@ -122,10 +135,11 @@ template <class T, class Abi>
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 #define KOKKOS_IMPL_SIMD_UNARY_FUNCTION(FUNC)                                \
   template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> FUNC( \
-      Experimental::simd<T, Abi> const& a) {                                 \
-    Experimental::simd<T, Abi> result;                                       \
-    for (std::size_t i = 0; i < Experimental::simd<T, Abi>::size(); ++i) {   \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> \
+  FUNC(Experimental::basic_simd<T, Abi> const& a) {                          \
+    Experimental::basic_simd<T, Abi> result;                                 \
+    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
+         ++i) {                                                              \
       result[i] = Kokkos::FUNC(a[i]);                                        \
     }                                                                        \
     return result;                                                           \
@@ -133,18 +147,19 @@ template <class T, class Abi>
   namespace Experimental {                                                   \
   template <class T, class Abi>                                              \
   [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION      \
-      simd<T, Abi>                                                           \
-      FUNC(simd<T, Abi> const& a) {                                          \
+      basic_simd<T, Abi>                                                     \
+      FUNC(basic_simd<T, Abi> const& a) {                                    \
     return Kokkos::FUNC(a);                                                  \
   }                                                                          \
   }
 #else
 #define KOKKOS_IMPL_SIMD_UNARY_FUNCTION(FUNC)                                \
   template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> FUNC( \
-      Experimental::simd<T, Abi> const& a) {                                 \
-    Experimental::simd<T, Abi> result;                                       \
-    for (std::size_t i = 0; i < Experimental::simd<T, Abi>::size(); ++i) {   \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> \
+  FUNC(Experimental::basic_simd<T, Abi> const& a) {                          \
+    Experimental::basic_simd<T, Abi> result;                                 \
+    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
+         ++i) {                                                              \
       result[i] = Kokkos::FUNC(a[i]);                                        \
     }                                                                        \
     return result;                                                           \
@@ -179,11 +194,12 @@ KOKKOS_IMPL_SIMD_UNARY_FUNCTION(lgamma)
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 #define KOKKOS_IMPL_SIMD_BINARY_FUNCTION(FUNC)                               \
   template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> FUNC( \
-      Experimental::simd<T, Abi> const& a,                                   \
-      Experimental::simd<T, Abi> const& b) {                                 \
-    Experimental::simd<T, Abi> result;                                       \
-    for (std::size_t i = 0; i < Experimental::simd<T, Abi>::size(); ++i) {   \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> \
+  FUNC(Experimental::basic_simd<T, Abi> const& a,                            \
+       Experimental::basic_simd<T, Abi> const& b) {                          \
+    Experimental::basic_simd<T, Abi> result;                                 \
+    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
+         ++i) {                                                              \
       result[i] = Kokkos::FUNC(a[i], b[i]);                                  \
     }                                                                        \
     return result;                                                           \
@@ -191,19 +207,20 @@ KOKKOS_IMPL_SIMD_UNARY_FUNCTION(lgamma)
   namespace Experimental {                                                   \
   template <class T, class Abi>                                              \
   [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION      \
-      simd<T, Abi>                                                           \
-      FUNC(simd<T, Abi> const& a, simd<T, Abi> const& b) {                   \
+      basic_simd<T, Abi>                                                     \
+      FUNC(basic_simd<T, Abi> const& a, basic_simd<T, Abi> const& b) {       \
     Kokkos::FUNC(a, b);                                                      \
   }                                                                          \
   }
 #else
 #define KOKKOS_IMPL_SIMD_BINARY_FUNCTION(FUNC)                               \
   template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> FUNC( \
-      Experimental::simd<T, Abi> const& a,                                   \
-      Experimental::simd<T, Abi> const& b) {                                 \
-    Experimental::simd<T, Abi> result;                                       \
-    for (std::size_t i = 0; i < Experimental::simd<T, Abi>::size(); ++i) {   \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> \
+  FUNC(Experimental::basic_simd<T, Abi> const& a,                            \
+       Experimental::basic_simd<T, Abi> const& b) {                          \
+    Experimental::basic_simd<T, Abi> result;                                 \
+    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
+         ++i) {                                                              \
       result[i] = Kokkos::FUNC(a[i], b[i]);                                  \
     }                                                                        \
     return result;                                                           \
@@ -218,12 +235,13 @@ KOKKOS_IMPL_SIMD_BINARY_FUNCTION(copysign)
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 #define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                              \
   template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> FUNC( \
-      Experimental::simd<T, Abi> const& a,                                   \
-      Experimental::simd<T, Abi> const& b,                                   \
-      Experimental::simd<T, Abi> const& c) {                                 \
-    Experimental::simd<T, Abi> result;                                       \
-    for (std::size_t i = 0; i < Experimental::simd<T, Abi>::size(); ++i) {   \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> \
+  FUNC(Experimental::basic_simd<T, Abi> const& a,                            \
+       Experimental::basic_simd<T, Abi> const& b,                            \
+       Experimental::basic_simd<T, Abi> const& c) {                          \
+    Experimental::basic_simd<T, Abi> result;                                 \
+    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
+         ++i) {                                                              \
       result[i] = Kokkos::FUNC(a[i], b[i], c[i]);                            \
     }                                                                        \
     return result;                                                           \
@@ -231,21 +249,22 @@ KOKKOS_IMPL_SIMD_BINARY_FUNCTION(copysign)
   namespace Experimental {                                                   \
   template <class T, class Abi>                                              \
   [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION      \
-      simd<T, Abi>                                                           \
-      FUNC(simd<T, Abi> const& a, simd<T, Abi> const& b,                     \
-           simd<T, Abi> const& c) {                                          \
+      basic_simd<T, Abi>                                                     \
+      FUNC(basic_simd<T, Abi> const& a, basic_simd<T, Abi> const& b,         \
+           basic_simd<T, Abi> const& c) {                                    \
     return Kokkos::FUNC(a, b, c);                                            \
   }                                                                          \
   }
 #else
 #define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                              \
   template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::simd<T, Abi> FUNC( \
-      Experimental::simd<T, Abi> const& a,                                   \
-      Experimental::simd<T, Abi> const& b,                                   \
-      Experimental::simd<T, Abi> const& c) {                                 \
-    Experimental::simd<T, Abi> result;                                       \
-    for (std::size_t i = 0; i < Experimental::simd<T, Abi>::size(); ++i) {   \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> \
+  FUNC(Experimental::basic_simd<T, Abi> const& a,                            \
+       Experimental::basic_simd<T, Abi> const& b,                            \
+       Experimental::basic_simd<T, Abi> const& c) {                          \
+    Experimental::basic_simd<T, Abi> result;                                 \
+    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
+         ++i) {                                                              \
       result[i] = Kokkos::FUNC(a[i], b[i], c[i]);                            \
     }                                                                        \
     return result;                                                           \

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -377,22 +377,23 @@ class neon_mask<Derived, 32, 4> {
 }  // namespace Impl
 
 template <class T>
-class simd_mask<T, simd_abi::neon_fixed_size<2>>
-    : public Impl::neon_mask<simd_mask<T, simd_abi::neon_fixed_size<2>>,
+class basic_simd_mask<T, simd_abi::neon_fixed_size<2>>
+    : public Impl::neon_mask<basic_simd_mask<T, simd_abi::neon_fixed_size<2>>,
                              sizeof(T) * 8, 2> {
-  using base_type = Impl::neon_mask<simd_mask<T, simd_abi::neon_fixed_size<2>>,
-                                    sizeof(T) * 8, 2>;
+  using base_type =
+      Impl::neon_mask<basic_simd_mask<T, simd_abi::neon_fixed_size<2>>,
+                      sizeof(T) * 8, 2>;
 
  public:
   using implementation_type = typename base_type::implementation_type;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(bool value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(bool value)
       : base_type(value) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<U, simd_abi::neon_fixed_size<2>> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
+      basic_simd_mask<U, simd_abi::neon_fixed_size<2>> const& other)
       : base_type(other) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       implementation_type const& value)
       : base_type(value) {}
   template <class G,
@@ -400,28 +401,29 @@ class simd_mask<T, simd_abi::neon_fixed_size<2>>
                 std::is_invocable_r_v<typename base_type::value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : base_type(gen) {}
 };
 
 template <class T>
-class simd_mask<T, simd_abi::neon_fixed_size<4>>
-    : public Impl::neon_mask<simd_mask<T, simd_abi::neon_fixed_size<4>>,
+class basic_simd_mask<T, simd_abi::neon_fixed_size<4>>
+    : public Impl::neon_mask<basic_simd_mask<T, simd_abi::neon_fixed_size<4>>,
                              sizeof(T) * 8, 4> {
-  using base_type = Impl::neon_mask<simd_mask<T, simd_abi::neon_fixed_size<4>>,
-                                    sizeof(T) * 8, 4>;
+  using base_type =
+      Impl::neon_mask<basic_simd_mask<T, simd_abi::neon_fixed_size<4>>,
+                      sizeof(T) * 8, 4>;
 
  public:
   using implementation_type = typename base_type::implementation_type;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(bool value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(bool value)
       : base_type(value) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<U, simd_abi::neon_fixed_size<4>> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
+      basic_simd_mask<U, simd_abi::neon_fixed_size<4>> const& other)
       : base_type(other) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       implementation_type const& value)
       : base_type(value) {}
   template <class G,
@@ -429,19 +431,19 @@ class simd_mask<T, simd_abi::neon_fixed_size<4>>
                 std::is_invocable_r_v<typename base_type::value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : base_type(gen) {}
 };
 
 template <>
-class simd<double, simd_abi::neon_fixed_size<2>> {
+class basic_simd<double, simd_abi::neon_fixed_size<2>> {
   float64x2_t m_value;
 
  public:
   using value_type = double;
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   class reference {
     float64x2_t& m_value;
     int m_lane;
@@ -466,17 +468,19 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
       return 0;
     }
   };
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(vmovq_n_f64(value_type(value))) {}
   template <class G,
             std::enable_if_t<
@@ -485,14 +489,14 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     m_value = vsetq_lane_f64(gen(std::integral_constant<std::size_t, 0>()),
                              m_value, 0);
     m_value = vsetq_lane_f64(gen(std::integral_constant<std::size_t, 1>()),
                              m_value, 1);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       float64x2_t const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
@@ -500,7 +504,7 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reference(const_cast<simd*>(this)->m_value, int(i));
+    return reference(const_cast<basic_simd*>(this)->m_value, int(i));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -522,60 +526,60 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
   operator float64x2_t() const {
     return m_value;
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
-    return simd(vnegq_f64(m_value));
+    return basic_simd(vnegq_f64(m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vmulq_f64(static_cast<float64x2_t>(lhs),
-                          static_cast<float64x2_t>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(vmulq_f64(static_cast<float64x2_t>(lhs),
+                                static_cast<float64x2_t>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vdivq_f64(static_cast<float64x2_t>(lhs),
-                          static_cast<float64x2_t>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(vdivq_f64(static_cast<float64x2_t>(lhs),
+                                static_cast<float64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vaddq_f64(static_cast<float64x2_t>(lhs),
-                          static_cast<float64x2_t>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(vaddq_f64(static_cast<float64x2_t>(lhs),
+                                static_cast<float64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vsubq_f64(static_cast<float64x2_t>(lhs),
-                          static_cast<float64x2_t>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(vsubq_f64(static_cast<float64x2_t>(lhs),
+                                static_cast<float64x2_t>(rhs)));
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcltq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcgtq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcleq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcgeq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vceqq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(operator==(lhs, rhs));
   }
 };
@@ -583,53 +587,59 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
 }  // namespace Experimental
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    abs(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    abs(Experimental::basic_simd<
         double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vabsq_f64(static_cast<float64x2_t>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    floor(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    floor(Experimental::basic_simd<
           double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vrndmq_f64(static_cast<float64x2_t>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    ceil(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    ceil(Experimental::basic_simd<
          double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vrndpq_f64(static_cast<float64x2_t>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    round(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    round(Experimental::basic_simd<
           double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vrndxq_f64(static_cast<float64x2_t>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    trunc(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    trunc(Experimental::basic_simd<
           double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vrndq_f64(static_cast<float64x2_t>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    copysign(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    copysign(Experimental::basic_simd<
                  double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-             Experimental::simd<
+             Experimental::basic_simd<
                  double, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
   uint64x2_t const sign_mask = vreinterpretq_u64_f64(vmovq_n_f64(-0.0));
-  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vreinterpretq_f64_u64(vorrq_u64(
           vreinterpretq_u64_f64(static_cast<float64x2_t>(abs(a))),
           vandq_u64(sign_mask,
@@ -637,66 +647,70 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    sqrt(Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    sqrt(Experimental::basic_simd<
          double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vsqrtq_f64(static_cast<float64x2_t>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    fma(Experimental::simd<double,
-                           Experimental::simd_abi::neon_fixed_size<2>> const& a,
-        Experimental::simd<double,
-                           Experimental::simd_abi::neon_fixed_size<2>> const& b,
-        Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    fma(Experimental::basic_simd<
+            double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
+        Experimental::basic_simd<
+            double, Experimental::simd_abi::neon_fixed_size<2>> const& b,
+        Experimental::basic_simd<
             double, Experimental::simd_abi::neon_fixed_size<2>> const& c) {
-  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vfmaq_f64(static_cast<float64x2_t>(c), static_cast<float64x2_t>(b),
                 static_cast<float64x2_t>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    max(Experimental::simd<double,
-                           Experimental::simd_abi::neon_fixed_size<2>> const& a,
-        Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    max(Experimental::basic_simd<
+            double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
+        Experimental::basic_simd<
             double, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
-  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vmaxq_f64(static_cast<float64x2_t>(a), static_cast<float64x2_t>(b)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    min(Experimental::simd<double,
-                           Experimental::simd_abi::neon_fixed_size<2>> const& a,
-        Experimental::simd<
+    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+    min(Experimental::basic_simd<
+            double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
+        Experimental::basic_simd<
             double, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
-  return Experimental::simd<double, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<double,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vminq_f64(static_cast<float64x2_t>(a), static_cast<float64x2_t>(b)));
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::neon_fixed_size<2>>
-    condition(simd_mask<double, simd_abi::neon_fixed_size<2>> const& a,
-              simd<double, simd_abi::neon_fixed_size<2>> const& b,
-              simd<double, simd_abi::neon_fixed_size<2>> const& c) {
-  return simd<double, simd_abi::neon_fixed_size<2>>(
+    basic_simd<double, simd_abi::neon_fixed_size<2>>
+    condition(basic_simd_mask<double, simd_abi::neon_fixed_size<2>> const& a,
+              basic_simd<double, simd_abi::neon_fixed_size<2>> const& b,
+              basic_simd<double, simd_abi::neon_fixed_size<2>> const& c) {
+  return basic_simd<double, simd_abi::neon_fixed_size<2>>(
       vbslq_f64(static_cast<uint64x2_t>(a), static_cast<float64x2_t>(b),
                 static_cast<float64x2_t>(c)));
 }
 
 template <>
-class simd<float, simd_abi::neon_fixed_size<2>> {
+class basic_simd<float, simd_abi::neon_fixed_size<2>> {
   float32x2_t m_value;
 
  public:
   using value_type = float;
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   class reference {
     float32x2_t& m_value;
     int m_lane;
@@ -721,30 +735,32 @@ class simd<float, simd_abi::neon_fixed_size<2>> {
       return 0;
     }
   };
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(vmov_n_f32(value_type(value))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(G&& gen) {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) {
     m_value = vset_lane_f32(gen(std::integral_constant<std::size_t, 0>()),
                             m_value, 0);
     m_value = vset_lane_f32(gen(std::integral_constant<std::size_t, 1>()),
                             m_value, 1);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       float32x2_t const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
@@ -752,7 +768,7 @@ class simd<float, simd_abi::neon_fixed_size<2>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reference(const_cast<simd*>(this)->m_value, int(i));
+    return reference(const_cast<basic_simd*>(this)->m_value, int(i));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -774,49 +790,49 @@ class simd<float, simd_abi::neon_fixed_size<2>> {
   operator float32x2_t() const {
     return m_value;
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
-    return simd(vneg_f32(m_value));
+    return basic_simd(vneg_f32(m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vmul_f32(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(vmul_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vdiv_f32(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(vdiv_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vadd_f32(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(vadd_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vsub_f32(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(vsub_f32(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vclt_f32(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcgt_f32(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcle_f32(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcge_f32(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vceq_f32(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
 };
@@ -824,54 +840,59 @@ class simd<float, simd_abi::neon_fixed_size<2>> {
 }  // namespace Experimental
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-    abs(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+    abs(Experimental::basic_simd<
         float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vabs_f32(static_cast<float32x2_t>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-    floor(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+    floor(Experimental::basic_simd<
           float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vrndm_f32(static_cast<float32x2_t>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-    ceil(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+    ceil(Experimental::basic_simd<
          float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vrndp_f32(static_cast<float32x2_t>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-    round(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+    round(Experimental::basic_simd<
           float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vrndx_f32(static_cast<float32x2_t>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-    trunc(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+    trunc(Experimental::basic_simd<
           float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vrnd_f32(static_cast<float32x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    float, Experimental::simd_abi::neon_fixed_size<2>>
-copysign(
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
-        a,
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
-        b) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+    copysign(Experimental::basic_simd<
+                 float, Experimental::simd_abi::neon_fixed_size<2>> const& a,
+             Experimental::basic_simd<
+                 float, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
   uint32x2_t const sign_mask = vreinterpret_u32_f32(vmov_n_f32(-0.0));
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vreinterpret_f32_u32(vorr_u32(
           vreinterpret_u32_f32(static_cast<float32x2_t>(abs(a))),
           vand_u32(sign_mask,
@@ -879,66 +900,70 @@ copysign(
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-    sqrt(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+    sqrt(Experimental::basic_simd<
          float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vsqrt_f32(static_cast<float32x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    float, Experimental::simd_abi::neon_fixed_size<2>>
-fma(Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
-        a,
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
-        b,
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
-        c) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+    fma(Experimental::basic_simd<
+            float, Experimental::simd_abi::neon_fixed_size<2>> const& a,
+        Experimental::basic_simd<
+            float, Experimental::simd_abi::neon_fixed_size<2>> const& b,
+        Experimental::basic_simd<
+            float, Experimental::simd_abi::neon_fixed_size<2>> const& c) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vfma_f32(static_cast<float32x2_t>(c), static_cast<float32x2_t>(b),
                static_cast<float32x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    float, Experimental::simd_abi::neon_fixed_size<2>>
-max(Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
-        a,
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
-        b) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+    max(Experimental::basic_simd<
+            float, Experimental::simd_abi::neon_fixed_size<2>> const& a,
+        Experimental::basic_simd<
+            float, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vmax_f32(static_cast<float32x2_t>(a), static_cast<float32x2_t>(b)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    float, Experimental::simd_abi::neon_fixed_size<2>>
-min(Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
-        a,
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>> const&
-        b) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<2>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+    min(Experimental::basic_simd<
+            float, Experimental::simd_abi::neon_fixed_size<2>> const& a,
+        Experimental::basic_simd<
+            float, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vmin_f32(static_cast<float32x2_t>(a), static_cast<float32x2_t>(b)));
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::neon_fixed_size<2>>
-    condition(simd_mask<float, simd_abi::neon_fixed_size<2>> const& a,
-              simd<float, simd_abi::neon_fixed_size<2>> const& b,
-              simd<float, simd_abi::neon_fixed_size<2>> const& c) {
-  return simd<float, simd_abi::neon_fixed_size<2>>(
+    basic_simd<float, simd_abi::neon_fixed_size<2>>
+    condition(basic_simd_mask<float, simd_abi::neon_fixed_size<2>> const& a,
+              basic_simd<float, simd_abi::neon_fixed_size<2>> const& b,
+              basic_simd<float, simd_abi::neon_fixed_size<2>> const& c) {
+  return basic_simd<float, simd_abi::neon_fixed_size<2>>(
       vbsl_f32(static_cast<uint32x2_t>(a), static_cast<float32x2_t>(b),
                static_cast<float32x2_t>(c)));
 }
 
 template <>
-class simd<float, simd_abi::neon_fixed_size<4>> {
+class basic_simd<float, simd_abi::neon_fixed_size<4>> {
   float32x4_t m_value;
 
  public:
   using value_type = float;
   using abi_type   = simd_abi::neon_fixed_size<4>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   class reference {
     float32x4_t& m_value;
     int m_lane;
@@ -967,24 +992,26 @@ class simd<float, simd_abi::neon_fixed_size<4>> {
       return 0;
     }
   };
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(vmovq_n_f32(value_type(value))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(G&& gen) {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) {
     m_value = vsetq_lane_f32(gen(std::integral_constant<std::size_t, 0>()),
                              m_value, 0);
     m_value = vsetq_lane_f32(gen(std::integral_constant<std::size_t, 1>()),
@@ -994,7 +1021,7 @@ class simd<float, simd_abi::neon_fixed_size<4>> {
     m_value = vsetq_lane_f32(gen(std::integral_constant<std::size_t, 3>()),
                              m_value, 3);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       float32x4_t const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
@@ -1002,7 +1029,7 @@ class simd<float, simd_abi::neon_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reference(const_cast<simd*>(this)->m_value, int(i));
+    return reference(const_cast<basic_simd*>(this)->m_value, int(i));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1024,49 +1051,49 @@ class simd<float, simd_abi::neon_fixed_size<4>> {
   operator float32x4_t() const {
     return m_value;
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
-    return simd(vnegq_f32(m_value));
+    return basic_simd(vnegq_f32(m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vmulq_f32(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(vmulq_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vdivq_f32(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(vdivq_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vaddq_f32(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(vaddq_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vsubq_f32(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(vsubq_f32(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcltq_f32(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcgtq_f32(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcleq_f32(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcgeq_f32(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vceqq_f32(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
 };
@@ -1074,54 +1101,59 @@ class simd<float, simd_abi::neon_fixed_size<4>> {
 }  // namespace Experimental
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-    abs(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+    abs(Experimental::basic_simd<
         float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<4>>(
       vabsq_f32(static_cast<float32x4_t>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-    floor(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+    floor(Experimental::basic_simd<
           float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<4>>(
       vrndmq_f32(static_cast<float32x4_t>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-    ceil(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+    ceil(Experimental::basic_simd<
          float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<4>>(
       vrndpq_f32(static_cast<float32x4_t>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-    round(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+    round(Experimental::basic_simd<
           float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<4>>(
       vrndxq_f32(static_cast<float32x4_t>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-    trunc(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+    trunc(Experimental::basic_simd<
           float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<4>>(
       vrndq_f32(static_cast<float32x4_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    float, Experimental::simd_abi::neon_fixed_size<4>>
-copysign(
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
-        a,
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
-        b) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+    copysign(Experimental::basic_simd<
+                 float, Experimental::simd_abi::neon_fixed_size<4>> const& a,
+             Experimental::basic_simd<
+                 float, Experimental::simd_abi::neon_fixed_size<4>> const& b) {
   uint32x4_t const sign_mask = vreinterpretq_u32_f32(vmovq_n_f32(-0.0));
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<4>>(
       vreinterpretq_f32_u32(vorrq_u32(
           vreinterpretq_u32_f32(static_cast<float32x4_t>(abs(a))),
           vandq_u32(sign_mask,
@@ -1129,66 +1161,70 @@ copysign(
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-    sqrt(Experimental::simd<
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+    sqrt(Experimental::basic_simd<
          float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<4>>(
       vsqrtq_f32(static_cast<float32x4_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    float, Experimental::simd_abi::neon_fixed_size<4>>
-fma(Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
-        a,
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
-        b,
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
-        c) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+    fma(Experimental::basic_simd<
+            float, Experimental::simd_abi::neon_fixed_size<4>> const& a,
+        Experimental::basic_simd<
+            float, Experimental::simd_abi::neon_fixed_size<4>> const& b,
+        Experimental::basic_simd<
+            float, Experimental::simd_abi::neon_fixed_size<4>> const& c) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<4>>(
       vfmaq_f32(static_cast<float32x4_t>(c), static_cast<float32x4_t>(b),
                 static_cast<float32x4_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    float, Experimental::simd_abi::neon_fixed_size<4>>
-max(Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
-        a,
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
-        b) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+    max(Experimental::basic_simd<
+            float, Experimental::simd_abi::neon_fixed_size<4>> const& a,
+        Experimental::basic_simd<
+            float, Experimental::simd_abi::neon_fixed_size<4>> const& b) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<4>>(
       vmaxq_f32(static_cast<float32x4_t>(a), static_cast<float32x4_t>(b)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
-    float, Experimental::simd_abi::neon_fixed_size<4>>
-min(Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
-        a,
-    Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>> const&
-        b) {
-  return Experimental::simd<float, Experimental::simd_abi::neon_fixed_size<4>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+    min(Experimental::basic_simd<
+            float, Experimental::simd_abi::neon_fixed_size<4>> const& a,
+        Experimental::basic_simd<
+            float, Experimental::simd_abi::neon_fixed_size<4>> const& b) {
+  return Experimental::basic_simd<float,
+                                  Experimental::simd_abi::neon_fixed_size<4>>(
       vminq_f32(static_cast<float32x4_t>(a), static_cast<float32x4_t>(b)));
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::neon_fixed_size<4>>
-    condition(simd_mask<float, simd_abi::neon_fixed_size<4>> const& a,
-              simd<float, simd_abi::neon_fixed_size<4>> const& b,
-              simd<float, simd_abi::neon_fixed_size<4>> const& c) {
-  return simd<float, simd_abi::neon_fixed_size<4>>(
+    basic_simd<float, simd_abi::neon_fixed_size<4>>
+    condition(basic_simd_mask<float, simd_abi::neon_fixed_size<4>> const& a,
+              basic_simd<float, simd_abi::neon_fixed_size<4>> const& b,
+              basic_simd<float, simd_abi::neon_fixed_size<4>> const& c) {
+  return basic_simd<float, simd_abi::neon_fixed_size<4>>(
       vbslq_f32(static_cast<uint32x4_t>(a), static_cast<float32x4_t>(b),
                 static_cast<float32x4_t>(c)));
 }
 
 template <>
-class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
+class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
   int32x2_t m_value;
 
  public:
   using value_type = std::int32_t;
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   class reference {
     int32x2_t& m_value;
     int m_lane;
@@ -1213,41 +1249,43 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
       return 0;
     }
   };
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(vmov_n_s32(value_type(value))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     m_value = vset_lane_s32(gen(std::integral_constant<std::size_t, 0>()),
                             m_value, 0);
     m_value = vset_lane_s32(gen(std::integral_constant<std::size_t, 1>()),
                             m_value, 1);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       int32x2_t const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::uint64_t, abi_type> const& other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::uint64_t, abi_type> const& other);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reference(m_value, int(i));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reference(const_cast<simd*>(this)->m_value, int(i));
+    return reference(const_cast<basic_simd*>(this)->m_value, int(i));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1270,137 +1308,138 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
-    return simd(vneg_s32(m_value));
+    return basic_simd(vneg_s32(m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         vsub_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         vadd_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         vmul_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vceq_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcgt_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vclt_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcle_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcge_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) noexcept {
-    return simd(vshl_s32(static_cast<int32x2_t>(lhs),
-                         vneg_s32(vmov_n_s32(std::int32_t(rhs)))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(vshl_s32(static_cast<int32x2_t>(lhs),
+                               vneg_s32(vmov_n_s32(std::int32_t(rhs)))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vshl_s32(static_cast<int32x2_t>(lhs),
-                         vneg_s32(static_cast<int32x2_t>(rhs))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(vshl_s32(static_cast<int32x2_t>(lhs),
+                               vneg_s32(static_cast<int32x2_t>(rhs))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(
         vshl_s32(static_cast<int32x2_t>(lhs), vmov_n_s32(std::int32_t(rhs))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         vshl_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
 };
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
-    abs(Experimental::simd<
-        std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::simd<std::int32_t,
-                            Experimental::simd_abi::neon_fixed_size<2>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
+abs(Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::basic_simd<std::int32_t,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vabs_s32(static_cast<int32x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
-    floor(Experimental::simd<
-          std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
+floor(Experimental::basic_simd<
+      std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
-    ceil(Experimental::simd<
-         std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
+ceil(Experimental::basic_simd<
+     std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
-    round(Experimental::simd<
-          std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
+round(Experimental::basic_simd<
+      std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
-    trunc(Experimental::simd<
-          std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
+trunc(Experimental::basic_simd<
+      std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>>
-    condition(simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& a,
-              simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& b,
-              simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& c) {
-  return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
+    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>
+    condition(
+        basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& a,
+        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& b,
+        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& c) {
+  return basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
       vbsl_s32(static_cast<uint32x2_t>(a), static_cast<int32x2_t>(b),
                static_cast<int32x2_t>(c)));
 }
 
 template <>
-class simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
+class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
   int32x4_t m_value;
 
  public:
   using value_type = std::int32_t;
   using abi_type   = simd_abi::neon_fixed_size<4>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   class reference {
     int32x4_t& m_value;
     int m_lane;
@@ -1429,24 +1468,26 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
       return 0;
     }
   };
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(vmovq_n_s32(value_type(value))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     m_value = vsetq_lane_s32(gen(std::integral_constant<std::size_t, 0>()),
                              m_value, 0);
@@ -1457,17 +1498,17 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
     m_value = vsetq_lane_s32(gen(std::integral_constant<std::size_t, 3>()),
                              m_value, 3);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       int32x4_t const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::uint64_t, abi_type> const& other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::uint64_t, abi_type> const& other);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reference(m_value, int(i));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reference(const_cast<simd*>(this)->m_value, int(i));
+    return reference(const_cast<basic_simd*>(this)->m_value, int(i));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1490,137 +1531,138 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
-    return simd(vnegq_s32(m_value));
+    return basic_simd(vnegq_s32(m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         vsubq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         vaddq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         vmulq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vceqq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcgtq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcltq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcleq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcgeq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) noexcept {
-    return simd(vshlq_s32(static_cast<int32x4_t>(lhs),
-                          vnegq_s32(vmovq_n_s32(std::int32_t(rhs)))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(vshlq_s32(static_cast<int32x4_t>(lhs),
+                                vnegq_s32(vmovq_n_s32(std::int32_t(rhs)))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vshlq_s32(static_cast<int32x4_t>(lhs),
-                          vnegq_s32(static_cast<int32x4_t>(rhs))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(vshlq_s32(static_cast<int32x4_t>(lhs),
+                                vnegq_s32(static_cast<int32x4_t>(rhs))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(
         vshlq_s32(static_cast<int32x4_t>(lhs), vmovq_n_s32(std::int32_t(rhs))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         vshlq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
 };
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
-    abs(Experimental::simd<
-        std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
-  return Experimental::simd<std::int32_t,
-                            Experimental::simd_abi::neon_fixed_size<4>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
+abs(Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+  return Experimental::basic_simd<std::int32_t,
+                                  Experimental::simd_abi::neon_fixed_size<4>>(
       vabsq_s32(static_cast<int32x4_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
-    floor(Experimental::simd<
-          std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
+floor(Experimental::basic_simd<
+      std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
-    ceil(Experimental::simd<
-         std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
+ceil(Experimental::basic_simd<
+     std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
-    round(Experimental::simd<
-          std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
+round(Experimental::basic_simd<
+      std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
-    trunc(Experimental::simd<
-          std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
+trunc(Experimental::basic_simd<
+      std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return a;
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::neon_fixed_size<4>>
-    condition(simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& a,
-              simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& b,
-              simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& c) {
-  return simd<std::int32_t, simd_abi::neon_fixed_size<4>>(
+    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>
+    condition(
+        basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& a,
+        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& b,
+        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& c) {
+  return basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>(
       vbslq_s32(static_cast<uint32x4_t>(a), static_cast<int32x4_t>(b),
                 static_cast<int32x4_t>(c)));
 }
 
 template <>
-class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
+class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
   int64x2_t m_value;
 
  public:
   using value_type = std::int64_t;
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   class reference {
     int64x2_t& m_value;
     int m_lane;
@@ -1645,41 +1687,43 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
       return 0;
     }
   };
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(vmovq_n_s64(value_type(value))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     m_value = vsetq_lane_s64(gen(std::integral_constant<std::size_t, 0>()),
                              m_value, 0);
     m_value = vsetq_lane_s64(gen(std::integral_constant<std::size_t, 1>()),
                              m_value, 1);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       int64x2_t const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::uint64_t, abi_type> const&);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::uint64_t, abi_type> const&);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reference(m_value, int(i));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reference(const_cast<simd*>(this)->m_value, int(i));
+    return reference(const_cast<basic_simd*>(this)->m_value, int(i));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1702,136 +1746,137 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
-    return simd(vnegq_s64(m_value));
+    return basic_simd(vnegq_s64(m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         vsubq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         vaddq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vceqq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcgtq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcltq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcleq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcgeq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) noexcept {
-    return simd(vshlq_s64(static_cast<int64x2_t>(lhs),
-                          vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(vshlq_s64(static_cast<int64x2_t>(lhs),
+                                vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vshlq_s64(static_cast<int64x2_t>(lhs),
-                          vnegq_s64(static_cast<int64x2_t>(rhs))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(vshlq_s64(static_cast<int64x2_t>(lhs),
+                                vnegq_s64(static_cast<int64x2_t>(rhs))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(
         vshlq_s64(static_cast<int64x2_t>(lhs), vmovq_n_s64(std::int64_t(rhs))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         vshlq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
 };
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
-    abs(Experimental::simd<
-        std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::simd<std::int64_t,
-                            Experimental::simd_abi::neon_fixed_size<2>>(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
+abs(Experimental::basic_simd<
+    std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::basic_simd<std::int64_t,
+                                  Experimental::simd_abi::neon_fixed_size<2>>(
       vabsq_s64(static_cast<int64x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
-    floor(Experimental::simd<
-          std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
+floor(Experimental::basic_simd<
+      std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
-    ceil(Experimental::simd<
-         std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
+ceil(Experimental::basic_simd<
+     std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
-    round(Experimental::simd<
-          std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
+round(Experimental::basic_simd<
+      std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::simd<std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
-    trunc(Experimental::simd<
-          std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+    std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
+trunc(Experimental::basic_simd<
+      std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::neon_fixed_size<2>>
-    condition(simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& a,
-              simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& b,
-              simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& c) {
-  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
+    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>
+    condition(
+        basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& a,
+        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& b,
+        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& c) {
+  return basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
       vbslq_s64(static_cast<uint64x2_t>(a), static_cast<int64x2_t>(b),
                 static_cast<int64x2_t>(c)));
 }
 
 template <>
-class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
+class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   uint64x2_t m_value;
 
  public:
   using value_type = std::uint64_t;
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = basic_simd_mask<value_type, abi_type>;
   class reference {
     uint64x2_t& m_value;
     int m_lane;
@@ -1856,35 +1901,37 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
       return 0;
     }
   };
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()                       = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&)            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
+      default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(vmovq_n_u64(value_type(value))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 0>()),
                              m_value, 0);
     m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 1>()),
                              m_value, 1);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       uint64x2_t const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int32_t, abi_type> const& other)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other)
       : m_value(
             vreinterpretq_u64_s64(vmovl_s32(static_cast<int32x2_t>(other)))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
@@ -1892,7 +1939,7 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reference(const_cast<simd*>(this)->m_value, int(i));
+    return reference(const_cast<basic_simd*>(this)->m_value, int(i));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1915,129 +1962,132 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         vsubq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         vaddq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator&(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator&(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         vandq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator|(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator|(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
         vorrq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vceqq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, int rhs) noexcept {
-    return simd(vshlq_u64(static_cast<uint64x2_t>(lhs),
-                          vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(vshlq_u64(static_cast<uint64x2_t>(lhs),
+                                vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vshlq_u64(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(vshlq_u64(
         static_cast<uint64x2_t>(lhs),
         vnegq_s64(vreinterpretq_s64_u64(static_cast<uint64x2_t>(rhs)))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, int rhs) noexcept {
-    return simd(vshlq_u64(static_cast<uint64x2_t>(lhs),
-                          vmovq_n_s64(std::int64_t(rhs))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(vshlq_u64(static_cast<uint64x2_t>(lhs),
+                                vmovq_n_s64(std::int64_t(rhs))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(vshlq_u64(static_cast<uint64x2_t>(lhs),
-                          vreinterpretq_s64_u64(static_cast<uint64x2_t>(rhs))));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        vshlq_u64(static_cast<uint64x2_t>(lhs),
+                  vreinterpretq_s64_u64(static_cast<uint64x2_t>(rhs))));
   }
 };
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::neon_fixed_size<2>>::simd(
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other)
+basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>::basic_simd(
+    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other)
     : m_value(
           vmovn_s64(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other)))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other)
+basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>::basic_simd(
+    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other)
     : m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other))) {}
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>>
-    abs(simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a) {
+    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>
+    abs(basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>>
-floor(Experimental::simd<std::uint64_t,
-                         Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+floor(Experimental::basic_simd<
+      std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>>
-ceil(Experimental::simd<std::uint64_t,
-                        Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+ceil(Experimental::basic_simd<
+     std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>>
-round(Experimental::simd<std::uint64_t,
-                         Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+round(Experimental::basic_simd<
+      std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::simd<
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>>
-trunc(Experimental::simd<std::uint64_t,
-                         Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+trunc(Experimental::basic_simd<
+      std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
 namespace Experimental {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>>
-    condition(simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a,
-              simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& b,
-              simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& c) {
-  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
+    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>
+    condition(
+        basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a,
+        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& b,
+        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& c) {
+  return basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
       vbslq_u64(static_cast<uint64x2_t>(a), static_cast<uint64x2_t>(b),
                 static_cast<uint64x2_t>(c)));
 }
 
 template <>
-class const_where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
-                             simd<double, simd_abi::neon_fixed_size<2>>> {
+class const_where_expression<
+    basic_simd_mask<double, simd_abi::neon_fixed_size<2>>,
+    basic_simd<double, simd_abi::neon_fixed_size<2>>> {
  public:
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using value_type = simd<double, abi_type>;
-  using mask_type  = simd_mask<double, abi_type>;
+  using value_type = basic_simd<double, abi_type>;
+  using mask_type  = basic_simd_mask<double, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2058,9 +2108,9 @@ class const_where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
     if (m_mask[1]) mem[1] = m_value[1];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      double* mem,
-      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) const {
+  void scatter_to(double* mem,
+                  basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const&
+                      index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
   }
@@ -2077,15 +2127,15 @@ class const_where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
 };
 
 template <>
-class where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
-                       simd<double, simd_abi::neon_fixed_size<2>>>
+class where_expression<basic_simd_mask<double, simd_abi::neon_fixed_size<2>>,
+                       basic_simd<double, simd_abi::neon_fixed_size<2>>>
     : public const_where_expression<
-          simd_mask<double, simd_abi::neon_fixed_size<2>>,
-          simd<double, simd_abi::neon_fixed_size<2>>> {
+          basic_simd_mask<double, simd_abi::neon_fixed_size<2>>,
+          basic_simd<double, simd_abi::neon_fixed_size<2>>> {
  public:
   where_expression(
-      simd_mask<double, simd_abi::neon_fixed_size<2>> const& mask_arg,
-      simd<double, simd_abi::neon_fixed_size<2>>& value_arg)
+      basic_simd_mask<double, simd_abi::neon_fixed_size<2>> const& mask_arg,
+      basic_simd<double, simd_abi::neon_fixed_size<2>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, element_aligned_tag) {
@@ -2100,19 +2150,20 @@ class where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       double const* mem,
-      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
+      basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
     if (m_mask[0]) m_value[0] = mem[index[0]];
     if (m_mask[1]) m_value[1] = mem[index[1]];
   }
-  template <class U,
-            std::enable_if_t<std::is_convertible_v<
-                                 U, simd<double, simd_abi::neon_fixed_size<2>>>,
-                             bool> = false>
+  template <
+      class U,
+      std::enable_if_t<std::is_convertible_v<
+                           U, basic_simd<double, simd_abi::neon_fixed_size<2>>>,
+                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<double, simd_abi::neon_fixed_size<2>>>(
+        static_cast<basic_simd<double, simd_abi::neon_fixed_size<2>>>(
             std::forward<U>(x));
-    m_value = static_cast<simd<double, simd_abi::neon_fixed_size<2>>>(
+    m_value = static_cast<basic_simd<double, simd_abi::neon_fixed_size<2>>>(
         vbslq_f64(static_cast<uint64x2_t>(m_mask),
                   static_cast<float64x2_t>(x_as_value_type),
                   static_cast<float64x2_t>(m_value)));
@@ -2120,12 +2171,13 @@ class where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
 };
 
 template <>
-class const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
-                             simd<float, simd_abi::neon_fixed_size<2>>> {
+class const_where_expression<
+    basic_simd_mask<float, simd_abi::neon_fixed_size<2>>,
+    basic_simd<float, simd_abi::neon_fixed_size<2>>> {
  public:
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using value_type = simd<float, abi_type>;
-  using mask_type  = simd_mask<float, abi_type>;
+  using value_type = basic_simd<float, abi_type>;
+  using mask_type  = basic_simd_mask<float, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2146,9 +2198,9 @@ class const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
     if (m_mask[1]) mem[1] = m_value[1];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      float* mem,
-      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) const {
+  void scatter_to(float* mem,
+                  basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const&
+                      index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
   }
@@ -2165,15 +2217,15 @@ class const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
 };
 
 template <>
-class where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
-                       simd<float, simd_abi::neon_fixed_size<2>>>
+class where_expression<basic_simd_mask<float, simd_abi::neon_fixed_size<2>>,
+                       basic_simd<float, simd_abi::neon_fixed_size<2>>>
     : public const_where_expression<
-          simd_mask<float, simd_abi::neon_fixed_size<2>>,
-          simd<float, simd_abi::neon_fixed_size<2>>> {
+          basic_simd_mask<float, simd_abi::neon_fixed_size<2>>,
+          basic_simd<float, simd_abi::neon_fixed_size<2>>> {
  public:
   where_expression(
-      simd_mask<float, simd_abi::neon_fixed_size<2>> const& mask_arg,
-      simd<float, simd_abi::neon_fixed_size<2>>& value_arg)
+      basic_simd_mask<float, simd_abi::neon_fixed_size<2>> const& mask_arg,
+      basic_simd<float, simd_abi::neon_fixed_size<2>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
@@ -2187,19 +2239,20 @@ class where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
-      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
+      basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
     if (m_mask[0]) m_value[0] = mem[index[0]];
     if (m_mask[1]) m_value[1] = mem[index[1]];
   }
-  template <class U,
-            std::enable_if_t<std::is_convertible_v<
-                                 U, simd<float, simd_abi::neon_fixed_size<2>>>,
-                             bool> = false>
+  template <
+      class U,
+      std::enable_if_t<std::is_convertible_v<
+                           U, basic_simd<float, simd_abi::neon_fixed_size<2>>>,
+                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<float, simd_abi::neon_fixed_size<2>>>(
+        static_cast<basic_simd<float, simd_abi::neon_fixed_size<2>>>(
             std::forward<U>(x));
-    m_value = static_cast<simd<float, simd_abi::neon_fixed_size<2>>>(
+    m_value = static_cast<basic_simd<float, simd_abi::neon_fixed_size<2>>>(
         vbsl_f32(static_cast<uint32x2_t>(m_mask),
                  static_cast<float32x2_t>(x_as_value_type),
                  static_cast<float32x2_t>(m_value)));
@@ -2207,12 +2260,13 @@ class where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
 };
 
 template <>
-class const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<4>>,
-                             simd<float, simd_abi::neon_fixed_size<4>>> {
+class const_where_expression<
+    basic_simd_mask<float, simd_abi::neon_fixed_size<4>>,
+    basic_simd<float, simd_abi::neon_fixed_size<4>>> {
  public:
   using abi_type   = simd_abi::neon_fixed_size<4>;
-  using value_type = simd<float, abi_type>;
-  using mask_type  = simd_mask<float, abi_type>;
+  using value_type = basic_simd<float, abi_type>;
+  using mask_type  = basic_simd_mask<float, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2237,9 +2291,9 @@ class const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<4>>,
     if (m_mask[3]) mem[3] = m_value[3];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      float* mem,
-      simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) const {
+  void scatter_to(float* mem,
+                  basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const&
+                      index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
     if (m_mask[2]) mem[index[2]] = m_value[2];
@@ -2258,15 +2312,15 @@ class const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<4>>,
 };
 
 template <>
-class where_expression<simd_mask<float, simd_abi::neon_fixed_size<4>>,
-                       simd<float, simd_abi::neon_fixed_size<4>>>
+class where_expression<basic_simd_mask<float, simd_abi::neon_fixed_size<4>>,
+                       basic_simd<float, simd_abi::neon_fixed_size<4>>>
     : public const_where_expression<
-          simd_mask<float, simd_abi::neon_fixed_size<4>>,
-          simd<float, simd_abi::neon_fixed_size<4>>> {
+          basic_simd_mask<float, simd_abi::neon_fixed_size<4>>,
+          basic_simd<float, simd_abi::neon_fixed_size<4>>> {
  public:
   where_expression(
-      simd_mask<float, simd_abi::neon_fixed_size<4>> const& mask_arg,
-      simd<float, simd_abi::neon_fixed_size<4>>& value_arg)
+      basic_simd_mask<float, simd_abi::neon_fixed_size<4>> const& mask_arg,
+      basic_simd<float, simd_abi::neon_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
@@ -2285,21 +2339,22 @@ class where_expression<simd_mask<float, simd_abi::neon_fixed_size<4>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
-      simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) {
+      basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) {
     if (m_mask[0]) m_value[0] = mem[index[0]];
     if (m_mask[1]) m_value[1] = mem[index[1]];
     if (m_mask[2]) m_value[2] = mem[index[2]];
     if (m_mask[3]) m_value[3] = mem[index[3]];
   }
-  template <class U,
-            std::enable_if_t<std::is_convertible_v<
-                                 U, simd<float, simd_abi::neon_fixed_size<4>>>,
-                             bool> = false>
+  template <
+      class U,
+      std::enable_if_t<std::is_convertible_v<
+                           U, basic_simd<float, simd_abi::neon_fixed_size<4>>>,
+                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<float, simd_abi::neon_fixed_size<4>>>(
+        static_cast<basic_simd<float, simd_abi::neon_fixed_size<4>>>(
             std::forward<U>(x));
-    m_value = static_cast<simd<float, simd_abi::neon_fixed_size<4>>>(
+    m_value = static_cast<basic_simd<float, simd_abi::neon_fixed_size<4>>>(
         vbslq_f32(static_cast<uint32x4_t>(m_mask),
                   static_cast<float32x4_t>(x_as_value_type),
                   static_cast<float32x4_t>(m_value)));
@@ -2308,12 +2363,12 @@ class where_expression<simd_mask<float, simd_abi::neon_fixed_size<4>>,
 
 template <>
 class const_where_expression<
-    simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>>> {
+    basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
+    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>> {
  public:
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using value_type = simd<std::int32_t, abi_type>;
-  using mask_type  = simd_mask<std::int32_t, abi_type>;
+  using value_type = basic_simd<std::int32_t, abi_type>;
+  using mask_type  = basic_simd_mask<std::int32_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2335,9 +2390,9 @@ class const_where_expression<
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      std::int32_t* mem,
-      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) const {
+  void scatter_to(std::int32_t* mem,
+                  basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const&
+                      index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
   }
@@ -2354,15 +2409,17 @@ class const_where_expression<
 };
 
 template <>
-class where_expression<simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
-                       simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+class where_expression<
+    basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
+    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
     : public const_where_expression<
-          simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
-          simd<std::int32_t, simd_abi::neon_fixed_size<2>>> {
+          basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
+          basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>> {
  public:
   where_expression(
-      simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& mask_arg,
-      simd<std::int32_t, simd_abi::neon_fixed_size<2>>& value_arg)
+      basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const&
+          mask_arg,
+      basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
@@ -2378,21 +2435,21 @@ class where_expression<simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
-      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
+      basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
     if (m_mask[0]) m_value[0] = mem[index[0]];
     if (m_mask[1]) m_value[1] = mem[index[1]];
   }
 
-  template <
-      class U,
-      std::enable_if_t<
-          std::is_convertible_v<U, simd<int32_t, simd_abi::neon_fixed_size<2>>>,
-          bool> = false>
+  template <class U,
+            std::enable_if_t<
+                std::is_convertible_v<
+                    U, basic_simd<int32_t, simd_abi::neon_fixed_size<2>>>,
+                bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<int32_t, simd_abi::neon_fixed_size<2>>>(
+        static_cast<basic_simd<int32_t, simd_abi::neon_fixed_size<2>>>(
             std::forward<U>(x));
-    m_value = static_cast<simd<int32_t, simd_abi::neon_fixed_size<2>>>(
+    m_value = static_cast<basic_simd<int32_t, simd_abi::neon_fixed_size<2>>>(
         vbsl_s32(static_cast<uint32x2_t>(m_mask),
                  static_cast<int32x2_t>(x_as_value_type),
                  static_cast<int32x2_t>(m_value)));
@@ -2401,12 +2458,12 @@ class where_expression<simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
 
 template <>
 class const_where_expression<
-    simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
-    simd<std::int32_t, simd_abi::neon_fixed_size<4>>> {
+    basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
+    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>> {
  public:
   using abi_type   = simd_abi::neon_fixed_size<4>;
-  using value_type = simd<std::int32_t, abi_type>;
-  using mask_type  = simd_mask<std::int32_t, abi_type>;
+  using value_type = basic_simd<std::int32_t, abi_type>;
+  using mask_type  = basic_simd_mask<std::int32_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2431,9 +2488,9 @@ class const_where_expression<
     if (m_mask[3]) mem[3] = m_value[3];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      std::int32_t* mem,
-      simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) const {
+  void scatter_to(std::int32_t* mem,
+                  basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const&
+                      index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
     if (m_mask[2]) mem[index[2]] = m_value[2];
@@ -2452,15 +2509,17 @@ class const_where_expression<
 };
 
 template <>
-class where_expression<simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
-                       simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+class where_expression<
+    basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
+    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
     : public const_where_expression<
-          simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
-          simd<std::int32_t, simd_abi::neon_fixed_size<4>>> {
+          basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
+          basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>> {
  public:
   where_expression(
-      simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask_arg,
-      simd<std::int32_t, simd_abi::neon_fixed_size<4>>& value_arg)
+      basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const&
+          mask_arg,
+      basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
@@ -2479,22 +2538,22 @@ class where_expression<simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
-      simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) {
+      basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) {
     if (m_mask[0]) m_value[0] = mem[index[0]];
     if (m_mask[1]) m_value[1] = mem[index[1]];
     if (m_mask[2]) m_value[2] = mem[index[2]];
     if (m_mask[3]) m_value[3] = mem[index[3]];
   }
-  template <
-      class U,
-      std::enable_if_t<
-          std::is_convertible_v<U, simd<int32_t, simd_abi::neon_fixed_size<4>>>,
-          bool> = false>
+  template <class U,
+            std::enable_if_t<
+                std::is_convertible_v<
+                    U, basic_simd<int32_t, simd_abi::neon_fixed_size<4>>>,
+                bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<int32_t, simd_abi::neon_fixed_size<4>>>(
+        static_cast<basic_simd<int32_t, simd_abi::neon_fixed_size<4>>>(
             std::forward<U>(x));
-    m_value = static_cast<simd<int32_t, simd_abi::neon_fixed_size<4>>>(
+    m_value = static_cast<basic_simd<int32_t, simd_abi::neon_fixed_size<4>>>(
         vbslq_s32(static_cast<uint32x4_t>(m_mask),
                   static_cast<int32x4_t>(x_as_value_type),
                   static_cast<int32x4_t>(m_value)));
@@ -2503,12 +2562,12 @@ class where_expression<simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
 
 template <>
 class const_where_expression<
-    simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
-    simd<std::int64_t, simd_abi::neon_fixed_size<2>>> {
+    basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
+    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>> {
  public:
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using value_type = simd<std::int64_t, abi_type>;
-  using mask_type  = simd_mask<std::int64_t, abi_type>;
+  using value_type = basic_simd<std::int64_t, abi_type>;
+  using mask_type  = basic_simd_mask<std::int64_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2530,9 +2589,9 @@ class const_where_expression<
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      std::int64_t* mem,
-      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) const {
+  void scatter_to(std::int64_t* mem,
+                  basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const&
+                      index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
   }
@@ -2549,15 +2608,17 @@ class const_where_expression<
 };
 
 template <>
-class where_expression<simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
-                       simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+class where_expression<
+    basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
+    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
     : public const_where_expression<
-          simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
-          simd<std::int64_t, simd_abi::neon_fixed_size<2>>> {
+          basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
+          basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>> {
  public:
   where_expression(
-      simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask_arg,
-      simd<std::int64_t, simd_abi::neon_fixed_size<2>>& value_arg)
+      basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const&
+          mask_arg,
+      basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int64_t const* mem, element_aligned_tag) {
@@ -2573,35 +2634,36 @@ class where_expression<simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int64_t const* mem,
-      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
+      basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
     if (m_mask[0]) m_value[0] = mem[index[0]];
     if (m_mask[1]) m_value[1] = mem[index[1]];
   }
 
-  template <
-      class U,
-      std::enable_if_t<std::is_convertible_v<
-                           U, simd<std::int64_t, simd_abi::neon_fixed_size<2>>>,
-                       bool> = false>
+  template <class U,
+            std::enable_if_t<
+                std::is_convertible_v<
+                    U, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>,
+                bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<std::int64_t, simd_abi::neon_fixed_size<2>>>(
+        static_cast<basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>(
             std::forward<U>(x));
-    m_value = static_cast<simd<std::int64_t, simd_abi::neon_fixed_size<2>>>(
-        vbslq_s64(static_cast<uint64x2_t>(m_mask),
-                  static_cast<int64x2_t>(x_as_value_type),
-                  static_cast<int64x2_t>(m_value)));
+    m_value =
+        static_cast<basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>(
+            vbslq_s64(static_cast<uint64x2_t>(m_mask),
+                      static_cast<int64x2_t>(x_as_value_type),
+                      static_cast<int64x2_t>(m_value)));
   }
 };
 
 template <>
 class const_where_expression<
-    simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>>> {
+    basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
+    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>> {
  public:
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using value_type = simd<std::uint64_t, abi_type>;
-  using mask_type  = simd_mask<std::uint64_t, abi_type>;
+  using value_type = basic_simd<std::uint64_t, abi_type>;
+  using mask_type  = basic_simd_mask<std::uint64_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2623,9 +2685,9 @@ class const_where_expression<
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      std::uint64_t* mem,
-      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) const {
+  void scatter_to(std::uint64_t* mem,
+                  basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const&
+                      index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
   }
@@ -2642,15 +2704,17 @@ class const_where_expression<
 };
 
 template <>
-class where_expression<simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
-                       simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+class where_expression<
+    basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
+    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
     : public const_where_expression<
-          simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
-          simd<std::uint64_t, simd_abi::neon_fixed_size<2>>> {
+          basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
+          basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>> {
  public:
   where_expression(
-      simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask_arg,
-      simd<std::uint64_t, simd_abi::neon_fixed_size<2>>& value_arg)
+      basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const&
+          mask_arg,
+      basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::uint64_t const* mem, element_aligned_tag) {
@@ -2666,7 +2730,7 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint64_t const* mem,
-      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
+      basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
     if (m_mask[0]) m_value[0] = mem[index[0]];
     if (m_mask[1]) m_value[1] = mem[index[1]];
   }
@@ -2674,16 +2738,17 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
   template <class U,
             std::enable_if_t<
                 std::is_convertible_v<
-                    U, simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>,
+                    U, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>,
                 bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>(
+        static_cast<basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>(
             std::forward<U>(x));
-    m_value = static_cast<simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>(
-        vbslq_u64(static_cast<uint64x2_t>(m_mask),
-                  static_cast<uint64x2_t>(x_as_value_type),
-                  static_cast<uint64x2_t>(m_value)));
+    m_value =
+        static_cast<basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>(
+            vbslq_u64(static_cast<uint64x2_t>(m_mask),
+                      static_cast<uint64x2_t>(x_as_value_type),
+                      static_cast<uint64x2_t>(m_value)));
   }
 };
 

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -38,28 +38,29 @@ class scalar {};
 }  // namespace simd_abi
 
 template <class T>
-class simd_mask<T, simd_abi::scalar> {
+class basic_simd_mask<T, simd_abi::scalar> {
   bool m_value;
 
  public:
-  using value_type                      = bool;
-  using simd_type                       = simd<T, simd_abi::scalar>;
-  using abi_type                        = simd_abi::scalar;
-  using reference                       = value_type&;
-  KOKKOS_DEFAULTED_FUNCTION simd_mask() = default;
+  using value_type                            = bool;
+  using simd_type                             = basic_simd<T, simd_abi::scalar>;
+  using abi_type                              = simd_abi::scalar;
+  using reference                             = value_type&;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd_mask() = default;
   KOKKOS_FORCEINLINE_FUNCTION static constexpr std::size_t size() { return 1; }
-  KOKKOS_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(value_type value)
       : m_value(value) {}
   template <
       class G,
       std::enable_if_t<std::is_invocable_r_v<
                            value_type, G, std::integral_constant<bool, false>>,
                        bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit simd_mask(G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+      G&& gen) noexcept
       : m_value(gen(0)) {}
   template <class U>
-  KOKKOS_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<U, simd_abi::scalar> const& other)
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask(
+      basic_simd_mask<U, simd_abi::scalar> const& other)
       : m_value(static_cast<bool>(other)) {}
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator bool() const {
     return m_value;
@@ -70,46 +71,49 @@ class simd_mask<T, simd_abi::scalar> {
   KOKKOS_FORCEINLINE_FUNCTION value_type operator[](std::size_t) const {
     return m_value;
   }
-  KOKKOS_FORCEINLINE_FUNCTION simd_mask
-  operator||(simd_mask const& other) const {
-    return simd_mask(m_value || other.m_value);
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask
+  operator||(basic_simd_mask const& other) const {
+    return basic_simd_mask(m_value || other.m_value);
   }
-  KOKKOS_FORCEINLINE_FUNCTION simd_mask
-  operator&&(simd_mask const& other) const {
-    return simd_mask(m_value && other.m_value);
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask
+  operator&&(basic_simd_mask const& other) const {
+    return basic_simd_mask(m_value && other.m_value);
   }
-  KOKKOS_FORCEINLINE_FUNCTION simd_mask operator!() const {
-    return simd_mask(!m_value);
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+    return basic_simd_mask(!m_value);
   }
-  KOKKOS_FORCEINLINE_FUNCTION bool operator==(simd_mask const& other) const {
+  KOKKOS_FORCEINLINE_FUNCTION bool operator==(
+      basic_simd_mask const& other) const {
     return m_value == other.m_value;
   }
-  KOKKOS_FORCEINLINE_FUNCTION bool operator!=(simd_mask const& other) const {
+  KOKKOS_FORCEINLINE_FUNCTION bool operator!=(
+      basic_simd_mask const& other) const {
     return m_value != other.m_value;
   }
 };
 
 template <class T>
-class simd<T, simd_abi::scalar> {
+class basic_simd<T, simd_abi::scalar> {
   T m_value;
 
  public:
-  using value_type                            = T;
-  using abi_type                              = simd_abi::scalar;
-  using mask_type                             = simd_mask<T, abi_type>;
-  using reference                             = value_type&;
-  KOKKOS_DEFAULTED_FUNCTION simd()            = default;
-  KOKKOS_DEFAULTED_FUNCTION simd(simd const&) = default;
-  KOKKOS_DEFAULTED_FUNCTION simd(simd&&)      = default;
-  KOKKOS_DEFAULTED_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_DEFAULTED_FUNCTION simd& operator=(simd&&)      = default;
+  using value_type                       = T;
+  using abi_type                         = simd_abi::scalar;
+  using mask_type                        = basic_simd_mask<T, abi_type>;
+  using reference                        = value_type&;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd() = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd(basic_simd const&)            = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd(basic_simd&&)                 = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd& operator=(basic_simd const&) = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd& operator=(basic_simd&&)      = default;
   KOKKOS_FORCEINLINE_FUNCTION static constexpr std::size_t size() { return 1; }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION simd(U&& value) : m_value(value) {}
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd(U&& value) : m_value(value) {}
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION explicit simd(simd<U, abi_type> const& other)
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<U, abi_type> const& other)
       : m_value(static_cast<U>(other)) {}
   template <class G,
             std::enable_if_t<
@@ -118,7 +122,7 @@ class simd<T, simd_abi::scalar> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit simd(G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(G&& gen) noexcept
       : m_value(gen(0)) {}
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator T() const {
     return m_value;
@@ -143,72 +147,72 @@ class simd<T, simd_abi::scalar> {
   KOKKOS_FORCEINLINE_FUNCTION value_type operator[](std::size_t) const {
     return m_value;
   }
-  KOKKOS_FORCEINLINE_FUNCTION simd operator-() const noexcept {
-    return simd(-m_value);
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
+    return basic_simd(-m_value);
   }
 
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator*(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(lhs.m_value * rhs.m_value);
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(lhs.m_value * rhs.m_value);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator/(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(lhs.m_value / rhs.m_value);
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
+  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(lhs.m_value / rhs.m_value);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator+(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(lhs.m_value + rhs.m_value);
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(lhs.m_value + rhs.m_value);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator-(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(lhs.m_value - rhs.m_value);
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(lhs.m_value - rhs.m_value);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator>>(
-      simd const& lhs, int rhs) noexcept {
-    return simd(lhs.m_value >> rhs);
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(lhs.m_value >> rhs);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator>>(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(lhs.m_value >> rhs.m_value);
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(lhs.m_value >> rhs.m_value);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator<<(
-      simd const& lhs, int rhs) noexcept {
-    return simd(lhs.m_value << rhs);
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(lhs.m_value << rhs);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator<<(
-      simd const& lhs, simd const& rhs) noexcept {
-    return simd(lhs.m_value << rhs.m_value);
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(lhs.m_value << rhs.m_value);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator&(
-      simd const& lhs, simd const& rhs) noexcept {
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
+  operator&(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return lhs.m_value & rhs.m_value;
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator|(
-      simd const& lhs, simd const& rhs) noexcept {
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
+  operator|(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return lhs.m_value | rhs.m_value;
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(lhs.m_value < rhs.m_value);
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(lhs.m_value > rhs.m_value);
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
-  operator<=(simd const& lhs, simd const& rhs) noexcept {
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(lhs.m_value <= rhs.m_value);
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
-  operator>=(simd const& lhs, simd const& rhs) noexcept {
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(lhs.m_value >= rhs.m_value);
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(lhs.m_value == rhs.m_value);
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
-  operator!=(simd const& lhs, simd const& rhs) noexcept {
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(lhs.m_value != rhs.m_value);
   }
 };
@@ -217,8 +221,8 @@ class simd<T, simd_abi::scalar> {
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION
-    Experimental::simd<T, Experimental::simd_abi::scalar>
-    abs(Experimental::simd<T, Experimental::simd_abi::scalar> const& a) {
+    Experimental::basic_simd<T, Experimental::simd_abi::scalar>
+    abs(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   if constexpr (std::is_signed_v<T>) {
     return (a < 0 ? -a : a);
   }
@@ -227,80 +231,82 @@ template <class T>
 
 template <typename T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto floor(
-    Experimental::simd<T, Experimental::simd_abi::scalar> const& a) {
+    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
-  return Experimental::simd<data_type, Experimental::simd_abi::scalar>(
+  return Experimental::basic_simd<data_type, Experimental::simd_abi::scalar>(
       Kokkos::floor(static_cast<data_type>(a[0])));
 }
 
 template <typename T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto ceil(
-    Experimental::simd<T, Experimental::simd_abi::scalar> const& a) {
+    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
-  return Experimental::simd<data_type, Experimental::simd_abi::scalar>(
+  return Experimental::basic_simd<data_type, Experimental::simd_abi::scalar>(
       Kokkos::ceil(static_cast<data_type>(a[0])));
 }
 
 template <typename T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto round(
-    Experimental::simd<T, Experimental::simd_abi::scalar> const& a) {
+    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
-  return Experimental::simd<data_type, Experimental::simd_abi::scalar>(
+  return Experimental::basic_simd<data_type, Experimental::simd_abi::scalar>(
       Experimental::round_half_to_nearest_even(static_cast<data_type>(a[0])));
 }
 
 template <typename T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto trunc(
-    Experimental::simd<T, Experimental::simd_abi::scalar> const& a) {
+    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
-  return Experimental::simd<data_type, Experimental::simd_abi::scalar>(
+  return Experimental::basic_simd<data_type, Experimental::simd_abi::scalar>(
       Kokkos::trunc(static_cast<data_type>(a[0])));
 }
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION
-    Experimental::simd<T, Experimental::simd_abi::scalar>
-    sqrt(Experimental::simd<T, Experimental::simd_abi::scalar> const& a) {
-  return Experimental::simd<T, Experimental::simd_abi::scalar>(
+    Experimental::basic_simd<T, Experimental::simd_abi::scalar>
+    sqrt(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
+  return Experimental::basic_simd<T, Experimental::simd_abi::scalar>(
       std::sqrt(static_cast<T>(a)));
 }
 
 template <class T>
 KOKKOS_FORCEINLINE_FUNCTION
-    Experimental::simd<T, Experimental::simd_abi::scalar>
-    fma(Experimental::simd<T, Experimental::simd_abi::scalar> const& x,
-        Experimental::simd<T, Experimental::simd_abi::scalar> const& y,
-        Experimental::simd<T, Experimental::simd_abi::scalar> const& z) {
-  return Experimental::simd<T, Experimental::simd_abi::scalar>(
+    Experimental::basic_simd<T, Experimental::simd_abi::scalar>
+    fma(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
+        Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& y,
+        Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& z) {
+  return Experimental::basic_simd<T, Experimental::simd_abi::scalar>(
       (static_cast<T>(x) * static_cast<T>(y)) + static_cast<T>(z));
 }
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION
-    Experimental::simd<T, Experimental::simd_abi::scalar>
-    copysign(Experimental::simd<T, Experimental::simd_abi::scalar> const& a,
-             Experimental::simd<T, Experimental::simd_abi::scalar> const& b) {
+    Experimental::basic_simd<T, Experimental::simd_abi::scalar>
+    copysign(
+        Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a,
+        Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& b) {
   return std::copysign(static_cast<T>(a), static_cast<T>(b));
 }
 
 namespace Experimental {
 
 template <class T>
-KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> condition(
+KOKKOS_FORCEINLINE_FUNCTION basic_simd<T, simd_abi::scalar> condition(
     desul::Impl::dont_deduce_this_parameter_t<
-        simd_mask<T, simd_abi::scalar>> const& a,
-    simd<T, simd_abi::scalar> const& b, simd<T, simd_abi::scalar> const& c) {
-  return simd<T, simd_abi::scalar>(static_cast<bool>(a) ? static_cast<T>(b)
-                                                        : static_cast<T>(c));
+        basic_simd_mask<T, simd_abi::scalar>> const& a,
+    basic_simd<T, simd_abi::scalar> const& b,
+    basic_simd<T, simd_abi::scalar> const& c) {
+  return basic_simd<T, simd_abi::scalar>(
+      static_cast<bool>(a) ? static_cast<T>(b) : static_cast<T>(c));
 }
 
 template <class T>
-class const_where_expression<simd_mask<T, simd_abi::scalar>,
-                             simd<T, simd_abi::scalar>> {
+class const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
+                             basic_simd<T, simd_abi::scalar>> {
  public:
   using abi_type   = simd_abi::scalar;
-  using value_type = simd<T, abi_type>;
-  using mask_type  = simd_mask<T, abi_type>;
+  using value_type = basic_simd<T, abi_type>;
+  using mask_type  = basic_simd_mask<T, abi_type>;
 
  protected:
   value_type& m_value;
@@ -321,7 +327,8 @@ class const_where_expression<simd_mask<T, simd_abi::scalar>,
   }
   template <class Integral>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<std::is_integral_v<Integral>>
-  scatter_to(T* mem, simd<Integral, simd_abi::scalar> const& index) const {
+  scatter_to(T* mem,
+             basic_simd<Integral, simd_abi::scalar> const& index) const {
     if (static_cast<bool>(m_mask))
       mem[static_cast<Integral>(index)] = static_cast<T>(m_value);
   }
@@ -338,18 +345,18 @@ class const_where_expression<simd_mask<T, simd_abi::scalar>,
 };
 
 template <class T>
-class where_expression<simd_mask<T, simd_abi::scalar>,
-                       simd<T, simd_abi::scalar>>
-    : public const_where_expression<simd_mask<T, simd_abi::scalar>,
-                                    simd<T, simd_abi::scalar>> {
-  using base_type = const_where_expression<simd_mask<T, simd_abi::scalar>,
-                                           simd<T, simd_abi::scalar>>;
+class where_expression<basic_simd_mask<T, simd_abi::scalar>,
+                       basic_simd<T, simd_abi::scalar>>
+    : public const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
+                                    basic_simd<T, simd_abi::scalar>> {
+  using base_type = const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
+                                           basic_simd<T, simd_abi::scalar>>;
 
  public:
   using typename base_type::value_type;
   KOKKOS_FORCEINLINE_FUNCTION
-  where_expression(simd_mask<T, simd_abi::scalar> const& mask_arg,
-                   simd<T, simd_abi::scalar>& value_arg)
+  where_expression(basic_simd_mask<T, simd_abi::scalar> const& mask_arg,
+                   basic_simd<T, simd_abi::scalar>& value_arg)
       : base_type(mask_arg, value_arg) {}
   KOKKOS_FORCEINLINE_FUNCTION
   void copy_from(T const* mem, element_aligned_tag) {
@@ -361,62 +368,63 @@ class where_expression<simd_mask<T, simd_abi::scalar>,
   }
   template <class Integral>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<std::is_integral_v<Integral>>
-  gather_from(T const* mem, simd<Integral, simd_abi::scalar> const& index) {
+  gather_from(T const* mem,
+              basic_simd<Integral, simd_abi::scalar> const& index) {
     if (static_cast<bool>(this->m_mask))
       this->m_value = mem[static_cast<Integral>(index)];
   }
-  template <class U, std::enable_if_t<
-                         std::is_convertible_v<U, simd<T, simd_abi::scalar>>,
-                         bool> = false>
+  template <class U, std::enable_if_t<std::is_convertible_v<
+                                          U, basic_simd<T, simd_abi::scalar>>,
+                                      bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION void operator=(U&& x) {
     if (static_cast<bool>(this->m_mask))
       this->m_value =
-          static_cast<simd<T, simd_abi::scalar>>(std::forward<U>(x));
+          static_cast<basic_simd<T, simd_abi::scalar>>(std::forward<U>(x));
   }
 };
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION
-    where_expression<simd_mask<T, Kokkos::Experimental::simd_abi::scalar>,
-                     simd<T, Kokkos::Experimental::simd_abi::scalar>>
-    where(typename simd<
+    where_expression<basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>,
+                     basic_simd<T, Kokkos::Experimental::simd_abi::scalar>>
+    where(typename basic_simd<
               T, Kokkos::Experimental::simd_abi::scalar>::mask_type const& mask,
-          simd<T, Kokkos::Experimental::simd_abi::scalar>& value) {
+          basic_simd<T, Kokkos::Experimental::simd_abi::scalar>& value) {
   return where_expression(mask, value);
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION
-    const_where_expression<simd_mask<T, Kokkos::Experimental::simd_abi::scalar>,
-                           simd<T, Kokkos::Experimental::simd_abi::scalar>>
-    where(typename simd<
-              T, Kokkos::Experimental::simd_abi::scalar>::mask_type const& mask,
-          simd<T, Kokkos::Experimental::simd_abi::scalar> const& value) {
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION const_where_expression<
+    basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>,
+    basic_simd<T, Kokkos::Experimental::simd_abi::scalar>>
+where(typename basic_simd<
+          T, Kokkos::Experimental::simd_abi::scalar>::mask_type const& mask,
+      basic_simd<T, Kokkos::Experimental::simd_abi::scalar> const& value) {
   return const_where_expression(mask, value);
 }
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION bool all_of(
-    simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const& a) {
-  return a == simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(true);
+    basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const& a) {
+  return a == basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(true);
 }
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION bool any_of(
-    simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const& a) {
-  return a != simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(false);
+    basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const& a) {
+  return a != basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(false);
 }
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION bool none_of(
-    simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const& a) {
-  return a == simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(false);
+    basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const& a) {
+  return a == basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(false);
 }
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
-reduce(const_where_expression<simd_mask<T, simd_abi::scalar>,
-                              simd<T, simd_abi::scalar>> const& x,
+reduce(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
+                              basic_simd<T, simd_abi::scalar>> const& x,
        T identity_element, std::plus<>) {
   return static_cast<bool>(x.impl_get_mask())
              ? static_cast<T>(x.impl_get_value())
@@ -425,8 +433,8 @@ reduce(const_where_expression<simd_mask<T, simd_abi::scalar>,
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
-hmax(const_where_expression<simd_mask<T, simd_abi::scalar>,
-                            simd<T, simd_abi::scalar>> const& x) {
+hmax(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
+                            basic_simd<T, simd_abi::scalar>> const& x) {
   return static_cast<bool>(x.impl_get_mask())
              ? static_cast<T>(x.impl_get_value())
              : Kokkos::reduction_identity<T>::max();
@@ -434,8 +442,8 @@ hmax(const_where_expression<simd_mask<T, simd_abi::scalar>,
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
-hmin(const_where_expression<simd_mask<T, simd_abi::scalar>,
-                            simd<T, simd_abi::scalar>> const& x) {
+hmin(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
+                            basic_simd<T, simd_abi::scalar>> const& x) {
   return static_cast<bool>(x.impl_get_mask())
              ? static_cast<T>(x.impl_get_value())
              : Kokkos::reduction_identity<T>::min();

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -44,14 +44,15 @@ class kokkos_checker {
 
 template <class T, class Abi>
 inline void host_check_equality(
-    Kokkos::Experimental::simd<T, Abi> const& expected_result,
-    Kokkos::Experimental::simd<T, Abi> const& computed_result,
+    Kokkos::Experimental::basic_simd<T, Abi> const& expected_result,
+    Kokkos::Experimental::basic_simd<T, Abi> const& computed_result,
     std::size_t nlanes) {
   gtest_checker checker;
   for (std::size_t i = 0; i < nlanes; ++i) {
     checker.equality(expected_result[i], computed_result[i]);
   }
-  using mask_type = typename Kokkos::Experimental::simd<T, Abi>::mask_type;
+  using mask_type =
+      typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
   mask_type mask(false);
   for (std::size_t i = 0; i < nlanes; ++i) {
     mask[i] = true;
@@ -61,14 +62,15 @@ inline void host_check_equality(
 
 template <class T, class Abi>
 KOKKOS_INLINE_FUNCTION void device_check_equality(
-    Kokkos::Experimental::simd<T, Abi> const& expected_result,
-    Kokkos::Experimental::simd<T, Abi> const& computed_result,
+    Kokkos::Experimental::basic_simd<T, Abi> const& expected_result,
+    Kokkos::Experimental::basic_simd<T, Abi> const& computed_result,
     std::size_t nlanes) {
   kokkos_checker checker;
   for (std::size_t i = 0; i < nlanes; ++i) {
     checker.equality(expected_result[i], computed_result[i]);
   }
-  using mask_type = typename Kokkos::Experimental::simd<T, Abi>::mask_type;
+  using mask_type =
+      typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
   mask_type mask(false);
   for (std::size_t i = 0; i < nlanes; ++i) {
     mask[i] = true;
@@ -78,8 +80,8 @@ KOKKOS_INLINE_FUNCTION void device_check_equality(
 
 template <typename T, typename Abi>
 KOKKOS_INLINE_FUNCTION void check_equality(
-    Kokkos::Experimental::simd<T, Abi> const& expected_result,
-    Kokkos::Experimental::simd<T, Abi> const& computed_result,
+    Kokkos::Experimental::basic_simd<T, Abi> const& expected_result,
+    Kokkos::Experimental::basic_simd<T, Abi> const& computed_result,
     std::size_t nlanes) {
   KOKKOS_IF_ON_HOST(
       (host_check_equality(expected_result, computed_result, nlanes);))
@@ -91,7 +93,7 @@ class load_element_aligned {
  public:
   template <class T, class Abi>
   bool host_load(T const* mem, std::size_t n,
-                 Kokkos::Experimental::simd<T, Abi>& result) const {
+                 Kokkos::Experimental::basic_simd<T, Abi>& result) const {
     if (n < result.size()) return false;
     result.copy_from(mem, Kokkos::Experimental::simd_flag_default);
     return true;
@@ -99,7 +101,7 @@ class load_element_aligned {
   template <class T, class Abi>
   KOKKOS_INLINE_FUNCTION bool device_load(
       T const* mem, std::size_t n,
-      Kokkos::Experimental::simd<T, Abi>& result) const {
+      Kokkos::Experimental::basic_simd<T, Abi>& result) const {
     if (n < result.size()) return false;
     result.copy_from(mem, Kokkos::Experimental::simd_flag_default);
     return true;
@@ -110,7 +112,7 @@ class load_vector_aligned {
  public:
   template <class T, class Abi>
   bool host_load(T const* mem, std::size_t n,
-                 Kokkos::Experimental::simd<T, Abi>& result) const {
+                 Kokkos::Experimental::basic_simd<T, Abi>& result) const {
     if (n < result.size()) return false;
     result.copy_from(mem, Kokkos::Experimental::simd_flag_aligned);
     return true;
@@ -118,7 +120,7 @@ class load_vector_aligned {
   template <class T, class Abi>
   KOKKOS_INLINE_FUNCTION bool device_load(
       T const* mem, std::size_t n,
-      Kokkos::Experimental::simd<T, Abi>& result) const {
+      Kokkos::Experimental::basic_simd<T, Abi>& result) const {
     if (n < result.size()) return false;
     result.copy_from(mem, Kokkos::Experimental::simd_flag_aligned);
     return true;
@@ -129,8 +131,9 @@ class load_masked {
  public:
   template <class T, class Abi>
   bool host_load(T const* mem, std::size_t n,
-                 Kokkos::Experimental::simd<T, Abi>& result) const {
-    using mask_type = typename Kokkos::Experimental::simd<T, Abi>::mask_type;
+                 Kokkos::Experimental::basic_simd<T, Abi>& result) const {
+    using mask_type =
+        typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
     mask_type mask(false);
     for (std::size_t i = 0; i < n; ++i) {
       mask[i] = true;
@@ -142,8 +145,9 @@ class load_masked {
   template <class T, class Abi>
   KOKKOS_INLINE_FUNCTION bool device_load(
       T const* mem, std::size_t n,
-      Kokkos::Experimental::simd<T, Abi>& result) const {
-    using mask_type = typename Kokkos::Experimental::simd<T, Abi>::mask_type;
+      Kokkos::Experimental::basic_simd<T, Abi>& result) const {
+    using mask_type =
+        typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
     mask_type mask(false);
     for (std::size_t i = 0; i < n; ++i) {
       mask[i] = true;
@@ -158,7 +162,7 @@ class load_as_scalars {
  public:
   template <class T, class Abi>
   bool host_load(T const* mem, std::size_t n,
-                 Kokkos::Experimental::simd<T, Abi>& result) const {
+                 Kokkos::Experimental::basic_simd<T, Abi>& result) const {
     for (std::size_t i = 0; i < n; ++i) {
       result[i] = mem[i];
     }
@@ -170,7 +174,7 @@ class load_as_scalars {
   template <class T, class Abi>
   KOKKOS_INLINE_FUNCTION bool device_load(
       T const* mem, std::size_t n,
-      Kokkos::Experimental::simd<T, Abi>& result) const {
+      Kokkos::Experimental::basic_simd<T, Abi>& result) const {
     for (std::size_t i = 0; i < n; ++i) {
       result[i] = mem[i];
     }

--- a/simd/unit_tests/include/TestSIMD_Condition.hpp
+++ b/simd/unit_tests/include/TestSIMD_Condition.hpp
@@ -22,8 +22,8 @@
 
 template <typename Abi, typename DataType>
 inline void host_check_condition() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
-    using simd_type = typename Kokkos::Experimental::simd<DataType, Abi>;
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
+    using simd_type = typename Kokkos::Experimental::basic_simd<DataType, Abi>;
     using mask_type = typename simd_type::mask_type;
 
     auto condition_op = [](mask_type const& mask, simd_type const& a,
@@ -56,8 +56,8 @@ inline void host_check_condition_all_abis(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_condition() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
-    using simd_type = typename Kokkos::Experimental::simd<DataType, Abi>;
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
+    using simd_type = typename Kokkos::Experimental::basic_simd<DataType, Abi>;
     using mask_type = typename simd_type::mask_type;
     kokkos_checker checker;
 

--- a/simd/unit_tests/include/TestSIMD_Construction.hpp
+++ b/simd/unit_tests/include/TestSIMD_Construction.hpp
@@ -22,7 +22,7 @@
 
 template <typename Abi, typename DataType>
 inline void host_test_simd_traits() {
-  using simd_type = Kokkos::Experimental::simd<DataType, Abi>;
+  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
 
   static_assert(std::is_nothrow_default_constructible_v<simd_type>);
   static_assert(std::is_nothrow_copy_assignable_v<simd_type>);
@@ -41,7 +41,7 @@ inline void host_test_simd_traits() {
 
 template <typename Abi, typename DataType>
 inline void host_test_mask_traits() {
-  using mask_type = Kokkos::Experimental::simd_mask<DataType, Abi>;
+  using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
 
   static_assert(std::is_nothrow_default_constructible_v<mask_type>);
   static_assert(std::is_nothrow_copy_assignable_v<mask_type>);
@@ -60,7 +60,7 @@ inline void host_test_mask_traits() {
 
 template <typename Abi, typename DataType>
 inline void host_check_construction() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
     host_test_simd_traits<Abi, DataType>();
     host_test_mask_traits<Abi, DataType>();
   }
@@ -81,7 +81,7 @@ inline void host_check_construction_all_abis(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_test_simd_traits() {
-  using simd_type = Kokkos::Experimental::simd<DataType, Abi>;
+  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
 
   simd_type default_simd, result;
   simd_type test_simd(KOKKOS_LAMBDA(std::size_t i) { return (i % 2 == 0); });
@@ -96,7 +96,7 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_traits() {
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_test_mask_traits() {
-  using mask_type = Kokkos::Experimental::simd_mask<DataType, Abi>;
+  using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
 
   mask_type default_mask, result;
   mask_type test_mask(KOKKOS_LAMBDA(std::size_t i) { return (i % 2 == 0); });
@@ -111,7 +111,7 @@ KOKKOS_INLINE_FUNCTION void device_test_mask_traits() {
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_construction() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
     device_test_simd_traits<Abi, DataType>();
     device_test_mask_traits<Abi, DataType>();
   }

--- a/simd/unit_tests/include/TestSIMD_Construction.hpp
+++ b/simd/unit_tests/include/TestSIMD_Construction.hpp
@@ -59,10 +59,37 @@ inline void host_test_mask_traits() {
 }
 
 template <typename Abi, typename DataType>
+inline void host_test_simd_alias() {
+  using basic_simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  using native_fixed_abi =
+      Kokkos::Experimental::simd_abi::Impl::native_fixed_abi<>;
+  using native_abi =
+      Kokkos::Experimental::simd_abi::Impl::native_abi<basic_simd_type::size()>;
+
+  if constexpr (std::is_same_v<Abi, native_fixed_abi>) {
+    using simd_type      = Kokkos::Experimental::simd<DataType>;
+    using simd_mask_type = Kokkos::Experimental::simd_mask<DataType>;
+    static_assert(std::is_same_v<basic_simd_type, simd_type>);
+    static_assert(
+        std::is_same_v<typename basic_simd_type::mask_type, simd_mask_type>);
+  }
+  if constexpr (std::is_same_v<Abi, native_abi>) {
+    using simd_type =
+        Kokkos::Experimental::simd<DataType, basic_simd_type::size()>;
+    using simd_mask_type =
+        Kokkos::Experimental::simd_mask<DataType, basic_simd_type::size()>;
+    static_assert(std::is_same_v<basic_simd_type, simd_type>);
+    static_assert(
+        std::is_same_v<typename basic_simd_type::mask_type, simd_mask_type>);
+  }
+}
+
+template <typename Abi, typename DataType>
 inline void host_check_construction() {
   if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
     host_test_simd_traits<Abi, DataType>();
     host_test_mask_traits<Abi, DataType>();
+    host_test_simd_alias<Abi, DataType>();
   }
 }
 

--- a/simd/unit_tests/include/TestSIMD_Conversions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Conversions.hpp
@@ -22,40 +22,40 @@
 
 template <typename Abi>
 inline void host_check_conversions() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<uint64_t, Abi>>) {
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<uint64_t, Abi>>) {
     {
-      auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
-      auto b = Kokkos::Experimental::simd<std::int64_t, Abi>(a);
+      auto a = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(1);
+      auto b = Kokkos::Experimental::basic_simd<std::int64_t, Abi>(a);
       EXPECT_TRUE(all_of(b == decltype(b)(1)));
     }
     {
-      auto a = Kokkos::Experimental::simd<std::int32_t, Abi>(1);
-      auto b = Kokkos::Experimental::simd<std::uint64_t, Abi>(a);
+      auto a = Kokkos::Experimental::basic_simd<std::int32_t, Abi>(1);
+      auto b = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(a);
       EXPECT_TRUE(all_of(b == decltype(b)(1)));
     }
     {
-      auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
-      auto b = Kokkos::Experimental::simd<std::int32_t, Abi>(a);
+      auto a = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(1);
+      auto b = Kokkos::Experimental::basic_simd<std::int32_t, Abi>(a);
       EXPECT_TRUE(all_of(b == decltype(b)(1)));
     }
     {
-      auto a = Kokkos::Experimental::simd_mask<double, Abi>(true);
-      auto b = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(a);
+      auto a = Kokkos::Experimental::basic_simd_mask<double, Abi>(true);
+      auto b = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(a);
       EXPECT_TRUE(b == decltype(b)(true));
     }
     {
-      auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-      auto b = Kokkos::Experimental::simd_mask<std::uint64_t, Abi>(a);
+      auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
+      auto b = Kokkos::Experimental::basic_simd_mask<std::uint64_t, Abi>(a);
       EXPECT_TRUE(b == decltype(b)(true));
     }
     {
-      auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-      auto b = Kokkos::Experimental::simd_mask<std::int64_t, Abi>(a);
+      auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
+      auto b = Kokkos::Experimental::basic_simd_mask<std::int64_t, Abi>(a);
       EXPECT_TRUE(b == decltype(b)(true));
     }
     {
-      auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-      auto b = Kokkos::Experimental::simd_mask<double, Abi>(a);
+      auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
+      auto b = Kokkos::Experimental::basic_simd_mask<double, Abi>(a);
       EXPECT_TRUE(b == decltype(b)(true));
     }
   }
@@ -69,41 +69,41 @@ inline void host_check_conversions_all_abis(
 
 template <typename Abi>
 KOKKOS_INLINE_FUNCTION void device_check_conversions() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<uint64_t, Abi>>) {
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<uint64_t, Abi>>) {
     kokkos_checker checker;
     {
-      auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
-      auto b = Kokkos::Experimental::simd<std::int64_t, Abi>(a);
+      auto a = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(1);
+      auto b = Kokkos::Experimental::basic_simd<std::int64_t, Abi>(a);
       checker.truth(all_of(b == decltype(b)(1)));
     }
     {
-      auto a = Kokkos::Experimental::simd<std::int32_t, Abi>(1);
-      auto b = Kokkos::Experimental::simd<std::uint64_t, Abi>(a);
+      auto a = Kokkos::Experimental::basic_simd<std::int32_t, Abi>(1);
+      auto b = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(a);
       checker.truth(all_of(b == decltype(b)(1)));
     }
     {
-      auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
-      auto b = Kokkos::Experimental::simd<std::int32_t, Abi>(a);
+      auto a = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(1);
+      auto b = Kokkos::Experimental::basic_simd<std::int32_t, Abi>(a);
       checker.truth(all_of(b == decltype(b)(1)));
     }
     {
-      auto a = Kokkos::Experimental::simd_mask<double, Abi>(true);
-      auto b = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(a);
+      auto a = Kokkos::Experimental::basic_simd_mask<double, Abi>(true);
+      auto b = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(a);
       checker.truth(b == decltype(b)(true));
     }
     {
-      auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-      auto b = Kokkos::Experimental::simd_mask<std::uint64_t, Abi>(a);
+      auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
+      auto b = Kokkos::Experimental::basic_simd_mask<std::uint64_t, Abi>(a);
       checker.truth(b == decltype(b)(true));
     }
     {
-      auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-      auto b = Kokkos::Experimental::simd_mask<std::int64_t, Abi>(a);
+      auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
+      auto b = Kokkos::Experimental::basic_simd_mask<std::int64_t, Abi>(a);
       checker.truth(b == decltype(b)(true));
     }
     {
-      auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-      auto b = Kokkos::Experimental::simd_mask<double, Abi>(a);
+      auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
+      auto b = Kokkos::Experimental::basic_simd_mask<double, Abi>(a);
       checker.truth(b == decltype(b)(true));
     }
   }

--- a/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
+++ b/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
@@ -22,9 +22,9 @@
 
 template <typename Abi, typename DataType>
 inline void host_check_gen_ctor() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
-    using simd_type             = Kokkos::Experimental::simd<DataType, Abi>;
-    using mask_type             = typename simd_type::mask_type;
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
+    using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+    using mask_type = typename simd_type::mask_type;
     constexpr std::size_t lanes = simd_type::size();
 
     DataType init[lanes];
@@ -84,9 +84,9 @@ inline void host_check_gen_ctors_all_abis(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_gen_ctor() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
-    using simd_type             = Kokkos::Experimental::simd<DataType, Abi>;
-    using mask_type             = typename simd_type::mask_type;
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
+    using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+    using mask_type = typename simd_type::mask_type;
     constexpr std::size_t lanes = simd_type::size();
 
     DataType init[lanes];

--- a/simd/unit_tests/include/TestSIMD_MaskOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MaskOps.hpp
@@ -22,8 +22,8 @@
 
 template <typename Abi, typename DataType>
 inline void host_check_mask_ops() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
-    using mask_type = Kokkos::Experimental::simd_mask<DataType, Abi>;
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
+    using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
 
     EXPECT_FALSE(none_of(mask_type(true)));
     EXPECT_TRUE(none_of(mask_type(false)));
@@ -62,8 +62,8 @@ inline void host_check_mask_ops_all_abis(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_mask_ops() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
-    using mask_type = Kokkos::Experimental::simd_mask<DataType, Abi>;
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
+    using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
     kokkos_checker checker;
     checker.truth(!none_of(mask_type(true)));
     checker.truth(none_of(mask_type(false)));

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -24,7 +24,7 @@ template <class Abi, class Loader, class BinaryOp, class T>
 void host_check_math_op_one_loader(BinaryOp binary_op, std::size_t n,
                                    T const* first_args, T const* second_args) {
   Loader loader;
-  using simd_type             = Kokkos::Experimental::simd<T, Abi>;
+  using simd_type             = Kokkos::Experimental::basic_simd<T, Abi>;
   constexpr std::size_t width = simd_type::size();
   for (std::size_t i = 0; i < n; i += width) {
     std::size_t const nremaining = n - i;
@@ -53,7 +53,7 @@ template <class Abi, class Loader, class UnaryOp, class T>
 void host_check_math_op_one_loader(UnaryOp unary_op, std::size_t n,
                                    T const* args) {
   Loader loader;
-  using simd_type             = Kokkos::Experimental::simd<T, Abi>;
+  using simd_type             = Kokkos::Experimental::basic_simd<T, Abi>;
   constexpr std::size_t width = simd_type::size();
   for (std::size_t i = 0; i < n; i += width) {
     std::size_t const nremaining = n - i;
@@ -114,16 +114,17 @@ inline void host_check_all_math_ops(const DataType (&first_args)[n],
 
 template <typename Abi, typename DataType>
 inline void host_check_abi_size() {
-  using simd_type = Kokkos::Experimental::simd<DataType, Abi>;
+  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
   using mask_type = typename simd_type::mask_type;
   static_assert(simd_type::size() == mask_type::size());
 }
 
 template <typename Abi, typename DataType>
 inline void host_check_math_ops() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
     constexpr size_t alignment =
-        Kokkos::Experimental::simd<DataType, Abi>::size() * sizeof(DataType);
+        Kokkos::Experimental::basic_simd<DataType, Abi>::size() *
+        sizeof(DataType);
 
     host_check_abi_size<Abi, DataType>();
 
@@ -171,7 +172,7 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_one_loader(
     BinaryOp binary_op, std::size_t n, T const* first_args,
     T const* second_args) {
   Loader loader;
-  using simd_type             = Kokkos::Experimental::simd<T, Abi>;
+  using simd_type             = Kokkos::Experimental::basic_simd<T, Abi>;
   constexpr std::size_t width = simd_type::size();
   for (std::size_t i = 0; i < n; i += width) {
     std::size_t const nremaining = n - i;
@@ -199,7 +200,7 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_one_loader(UnaryOp unary_op,
                                                             std::size_t n,
                                                             T const* args) {
   Loader loader;
-  using simd_type             = Kokkos::Experimental::simd<T, Abi>;
+  using simd_type             = Kokkos::Experimental::basic_simd<T, Abi>;
   constexpr std::size_t width = simd_type::size();
   for (std::size_t i = 0; i < n; i += width) {
     std::size_t const nremaining = n - i;
@@ -249,14 +250,14 @@ KOKKOS_INLINE_FUNCTION void device_check_all_math_ops(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_abi_size() {
-  using simd_type = Kokkos::Experimental::simd<DataType, Abi>;
+  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
   using mask_type = typename simd_type::mask_type;
   static_assert(simd_type::size() == mask_type::size());
 }
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_math_ops() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
     device_check_abi_size<Abi, DataType>();
 
     if constexpr (!std::is_integral_v<DataType>) {

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -24,8 +24,9 @@ template <typename Abi, typename Loader, typename ReductionOp, typename T>
 inline void host_check_reduction_one_loader(ReductionOp reduce_op,
                                             std::size_t n, T const* args) {
   Loader loader;
-  using simd_type = Kokkos::Experimental::simd<T, Abi>;
-  using mask_type = typename Kokkos::Experimental::simd<T, Abi>::mask_type;
+  using simd_type = Kokkos::Experimental::basic_simd<T, Abi>;
+  using mask_type =
+      typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
   constexpr std::size_t width = simd_type::size();
 
   for (std::size_t i = 0; i < n; i += width) {
@@ -65,7 +66,7 @@ inline void host_check_all_reductions(const DataType (&args)[n]) {
 
 template <typename Abi, typename DataType>
 inline void host_check_reductions() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
     constexpr size_t n = 16;
 
     if constexpr (std::is_signed_v<DataType>) {
@@ -97,8 +98,9 @@ template <typename Abi, typename Loader, typename ReductionOp, typename T>
 KOKKOS_INLINE_FUNCTION void device_check_reduction_one_loader(
     ReductionOp reduce_op, std::size_t n, T const* args) {
   Loader loader;
-  using simd_type = Kokkos::Experimental::simd<T, Abi>;
-  using mask_type = typename Kokkos::Experimental::simd<T, Abi>::mask_type;
+  using simd_type = Kokkos::Experimental::basic_simd<T, Abi>;
+  using mask_type =
+      typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
   constexpr std::size_t width = simd_type::size();
 
   for (std::size_t i = 0; i < n; i += width) {
@@ -139,7 +141,7 @@ KOKKOS_INLINE_FUNCTION void device_check_all_reductions(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_reductions() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
     constexpr size_t n = 16;
 
     if constexpr (std::is_signed_v<DataType>) {

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -24,7 +24,7 @@ template <typename Abi, typename Loader, typename ShiftOp, typename DataType>
 inline void host_check_shift_on_one_loader(ShiftOp shift_op,
                                            DataType test_vals[],
                                            DataType shift_by[], std::size_t n) {
-  using simd_type             = Kokkos::Experimental::simd<DataType, Abi>;
+  using simd_type             = Kokkos::Experimental::basic_simd<DataType, Abi>;
   constexpr std::size_t width = simd_type::size();
   Loader loader;
 
@@ -53,8 +53,8 @@ inline void host_check_shift_on_one_loader(ShiftOp shift_op,
 template <typename Abi, typename Loader, typename ShiftOp, typename DataType>
 inline void host_check_shift_by_lanes_on_one_loader(
     ShiftOp shift_op, DataType test_vals[],
-    Kokkos::Experimental::simd<DataType, Abi>& shift_by) {
-  using simd_type             = Kokkos::Experimental::simd<DataType, Abi>;
+    Kokkos::Experimental::basic_simd<DataType, Abi>& shift_by) {
+  using simd_type             = Kokkos::Experimental::basic_simd<DataType, Abi>;
   constexpr std::size_t width = simd_type::size();
   Loader loader;
 
@@ -88,7 +88,7 @@ inline void host_check_shift_op_all_loaders(ShiftOp shift_op,
   host_check_shift_on_one_loader<Abi, load_vector_aligned>(shift_op, test_vals,
                                                            shift_by, n);
 
-  Kokkos::Experimental::simd<DataType, Abi> shift_by_lanes;
+  Kokkos::Experimental::basic_simd<DataType, Abi> shift_by_lanes;
   shift_by_lanes.copy_from(shift_by, Kokkos::Experimental::simd_flag_default);
 
   host_check_shift_by_lanes_on_one_loader<Abi, load_element_aligned>(
@@ -103,13 +103,14 @@ inline void host_check_shift_op_all_loaders(ShiftOp shift_op,
 
 template <typename Abi, typename DataType>
 inline void host_check_shift_ops() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
     if constexpr (std::is_integral_v<DataType>) {
-      using simd_type             = Kokkos::Experimental::simd<DataType, Abi>;
-      constexpr std::size_t width = simd_type::size();
+      using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+      constexpr std::size_t width     = simd_type::size();
       constexpr std::size_t num_cases = 16;
       constexpr size_t alignment =
-          Kokkos::Experimental::simd<DataType, Abi>::size() * sizeof(DataType);
+          Kokkos::Experimental::basic_simd<DataType, Abi>::size() *
+          sizeof(DataType);
 
       DataType max = std::numeric_limits<DataType>::max();
 
@@ -153,7 +154,7 @@ template <typename Abi, typename Loader, typename ShiftOp, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_shift_on_one_loader(
     ShiftOp shift_op, DataType test_vals[], DataType shift_by[],
     std::size_t n) {
-  using simd_type             = Kokkos::Experimental::simd<DataType, Abi>;
+  using simd_type             = Kokkos::Experimental::basic_simd<DataType, Abi>;
   constexpr std::size_t width = simd_type::size();
   Loader loader;
 
@@ -180,8 +181,8 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_on_one_loader(
 template <typename Abi, typename Loader, typename ShiftOp, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_shift_by_lanes_on_one_loader(
     ShiftOp shift_op, DataType test_vals[],
-    Kokkos::Experimental::simd<DataType, Abi>& shift_by) {
-  using simd_type             = Kokkos::Experimental::simd<DataType, Abi>;
+    Kokkos::Experimental::basic_simd<DataType, Abi>& shift_by) {
+  using simd_type             = Kokkos::Experimental::basic_simd<DataType, Abi>;
   constexpr std::size_t width = simd_type::size();
   Loader loader;
   simd_type simd_vals;
@@ -210,7 +211,7 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_op_all_loaders(
   device_check_shift_on_one_loader<Abi, load_vector_aligned>(
       shift_op, test_vals, shift_by, n);
 
-  Kokkos::Experimental::simd<DataType, Abi> shift_by_lanes;
+  Kokkos::Experimental::basic_simd<DataType, Abi> shift_by_lanes;
   shift_by_lanes.copy_from(shift_by, Kokkos::Experimental::simd_flag_default);
 
   device_check_shift_by_lanes_on_one_loader<Abi, load_element_aligned>(
@@ -225,10 +226,10 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_op_all_loaders(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_shift_ops() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
     if constexpr (std::is_integral_v<DataType>) {
-      using simd_type             = Kokkos::Experimental::simd<DataType, Abi>;
-      constexpr std::size_t width = simd_type::size();
+      using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+      constexpr std::size_t width     = simd_type::size();
       constexpr std::size_t num_cases = 16;
 
       DataType max = Kokkos::reduction_identity<DataType>::max();

--- a/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
+++ b/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
@@ -22,9 +22,9 @@
 
 template <typename Abi, typename DataType>
 inline void host_check_where_expr_scatter_to() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
-    using simd_type  = Kokkos::Experimental::simd<DataType, Abi>;
-    using index_type = Kokkos::Experimental::simd<std::int32_t, Abi>;
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
+    using simd_type  = Kokkos::Experimental::basic_simd<DataType, Abi>;
+    using index_type = Kokkos::Experimental::basic_simd<std::int32_t, Abi>;
     using mask_type  = typename simd_type::mask_type;
 
     std::size_t nlanes = simd_type::size();
@@ -57,9 +57,9 @@ inline void host_check_where_expr_scatter_to() {
 
 template <typename Abi, typename DataType>
 inline void host_check_where_expr_gather_from() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
-    using simd_type  = Kokkos::Experimental::simd<DataType, Abi>;
-    using index_type = Kokkos::Experimental::simd<std::int32_t, Abi>;
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
+    using simd_type  = Kokkos::Experimental::basic_simd<DataType, Abi>;
+    using index_type = Kokkos::Experimental::basic_simd<std::int32_t, Abi>;
     using mask_type  = typename simd_type::mask_type;
 
     std::size_t nlanes = simd_type::size();
@@ -106,9 +106,9 @@ inline void host_check_where_expr_all_abis(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_where_expr_scatter_to() {
-  if constexpr (is_type_v<Kokkos::Experimental::simd<DataType, Abi>>) {
-    using simd_type  = Kokkos::Experimental::simd<DataType, Abi>;
-    using index_type = Kokkos::Experimental::simd<std::int32_t, Abi>;
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
+    using simd_type  = Kokkos::Experimental::basic_simd<DataType, Abi>;
+    using index_type = Kokkos::Experimental::basic_simd<std::int32_t, Abi>;
     using mask_type  = typename simd_type::mask_type;
 
     std::size_t nlanes = simd_type::size();
@@ -141,8 +141,8 @@ KOKKOS_INLINE_FUNCTION void device_check_where_expr_scatter_to() {
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_where_expr_gather_from() {
-  using simd_type  = Kokkos::Experimental::simd<DataType, Abi>;
-  using index_type = Kokkos::Experimental::simd<std::int32_t, Abi>;
+  using simd_type  = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  using index_type = Kokkos::Experimental::basic_simd<std::int32_t, Abi>;
   using mask_type  = typename simd_type::mask_type;
 
   std::size_t nlanes = simd_type::size();


### PR DESCRIPTION
This PR makes following changes in kokkos simd to keep its interface more aligned with [P1928R12](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r12.pdf):

- Renames `simd` classes to `basic_simd` (Section 1.6)
- Renames `simd_mask` classes to `basic_simd_mask` (Section 1.6)
- Hides/deprecates `simd` interface that exposes `simd_abi` (Section 4.1)
- Introduces a `simd<T, N>` type alias where `T` is data type and `N` is vector size (Section 4.1)

- Replaced the type alias `Kokkos::Experimental::simd<T, simd_abi>` with `Kokkos::Experimental::simd<T, N>`