### PR TITLE
Fix Kokkos::realloc for View of Views

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -958,6 +958,71 @@ void contiguous_fill_or_memset(
 
   contiguous_fill_or_memset(exec_space_type(), dst, value);
 }
+
+template <class ViewType, class ValueType, int Dim = 0>
+struct ViewSequentialHostFill {
+  const ViewType& dst;
+  const ValueType& value;
+
+  template <class... Indices>
+  void apply(Indices... idx) const {
+    if constexpr (Dim == int(ViewType::rank)) {
+      if constexpr (ViewType::rank == 0) {
+        dst() = value;
+      } else {
+        dst(idx...) = value;
+      }
+    } else {
+      for (size_t i = 0; i < dst.extent(Dim); ++i) {
+        ViewSequentialHostFill<ViewType, ValueType, Dim + 1>{dst, value}.apply(
+            idx..., i);
+      }
+    }
+  }
+
+  void operator()() const { apply(); }
+};
+
+template <class ViewType>
+void sequential_host_fill(const ViewType& dst,
+                          const typename ViewType::const_value_type& value) {
+  static_assert(
+      Kokkos::SpaceAccessibility<Kokkos::HostSpace,
+                                 typename ViewType::memory_space>::accessible,
+      "sequential_host_fill requires host-accessible memory");
+  static_assert(std::is_same_v<typename ViewType::non_const_value_type,
+                               typename ViewType::value_type>,
+                "deep_copy requires non-const destination type");
+
+  if (dst.data() == nullptr || dst.span() == 0) {
+    return;
+  }
+
+  if constexpr (ViewType::rank == 0) {
+    dst() = value;
+    return;
+  }
+
+  if (dst.span_is_contiguous() && !ViewType::traits::impl_is_customized) {
+    using value_type      = typename ViewType::value_type;
+    value_type* const ptr = dst.data();
+    const size_t n        = dst.span();
+    if constexpr (std::is_trivially_copyable_v<value_type>) {
+      if (has_all_zero_bits(value)) {
+        std::memset(static_cast<void*>(ptr), 0, n * sizeof(value_type));
+        return;
+      }
+    }
+    for (size_t i = 0; i < n; ++i) {
+      ptr[i] = value;
+    }
+    return;
+  }
+
+  ViewSequentialHostFill<ViewType, typename ViewType::const_value_type> fill{
+      dst, value};
+  fill();
+}
 }  // namespace Impl
 
 /** \brief  Deep copy a value from Host memory into a view.  */
@@ -1199,13 +1264,15 @@ inline void deep_copy(
 template <class DT, class... DP, class ST, class... SP>
 inline void deep_copy(
     const View<DT, DP...>& dst, const View<ST, SP...>& src,
-    std::enable_if_t<
-        (std::is_void_v<typename ViewTraits<DT, DP...>::specialize> &&
-         std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
-         (is_view_v<typename View<DT, DP...>::value_type> ==
-          is_view_v<typename View<ST, SP...>::value_type>)&&  //
-         (unsigned(ViewTraits<DT, DP...>::rank) != 0 ||
-          unsigned(ViewTraits<ST, SP...>::rank) != 0))>* = nullptr) {
+    std::enable_if_t<(
+        std::is_void_v<typename ViewTraits<DT, DP...>::specialize> &&
+        std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
+        (is_view_v<typename View<DT, DP...>::value_type> ==
+         is_view_v<typename View<
+             ST, SP...>::value_type>)&&(unsigned(ViewTraits<DT, DP...>::rank) !=
+                                            0 ||
+                                        unsigned(ViewTraits<ST, SP...>::rank) !=
+                                            0))>* = nullptr) {
   Impl::check_deep_copy_view_arguments_are_distinct(std::addressof(dst),
                                                     std::addressof(src));
 
@@ -2408,14 +2475,16 @@ template <class ExecSpace, class DT, class... DP, class ST, class... SP>
 inline void deep_copy(
     const ExecSpace& exec_space, const View<DT, DP...>& dst,
     const View<ST, SP...>& src,
-    std::enable_if_t<
-        (Kokkos::is_execution_space<ExecSpace>::value &&
-         std::is_void_v<typename ViewTraits<DT, DP...>::specialize> &&
-         std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
-         (is_view_v<typename View<DT, DP...>::value_type> ==
-          is_view_v<typename View<ST, SP...>::value_type>)&&  //
-         (unsigned(ViewTraits<DT, DP...>::rank) != 0 ||
-          unsigned(ViewTraits<ST, SP...>::rank) != 0))>* = nullptr) {
+    std::enable_if_t<(
+        Kokkos::is_execution_space<ExecSpace>::value &&
+        std::is_void_v<typename ViewTraits<DT, DP...>::specialize> &&
+        std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
+        (is_view_v<typename View<DT, DP...>::value_type> ==
+         is_view_v<typename View<
+             ST, SP...>::value_type>)&&(unsigned(ViewTraits<DT, DP...>::rank) !=
+                                            0 ||
+                                        unsigned(ViewTraits<ST, SP...>::rank) !=
+                                            0))>* = nullptr) {
   Impl::check_deep_copy_view_arguments_are_distinct(std::addressof(dst),
                                                     std::addressof(src));
 
@@ -2888,12 +2957,16 @@ impl_realloc(Kokkos::View<T, P...>& v, const size_t n0, const size_t n1,
   }
 
   if constexpr (alloc_prop_input::initialize) {
-    if constexpr (alloc_prop_input::has_execution_space) {
+    const typename view_type::value_type fill_value{};
+    if constexpr (alloc_prop_input::sequential_host_init) {
+      Impl::sequential_host_fill(v, fill_value);
+    } else if constexpr (alloc_prop_input::has_execution_space) {
       const auto& exec_space =
           Impl::get_property<Impl::ExecutionSpaceTag>(arg_prop);
-      Kokkos::deep_copy(exec_space, v, typename view_type::value_type{});
-    } else
-      Kokkos::deep_copy(v, typename view_type::value_type{});
+      Kokkos::deep_copy(exec_space, v, fill_value);
+    } else {
+      Kokkos::deep_copy(v, fill_value);
+    }
   }
 }
 
@@ -2986,12 +3059,16 @@ impl_realloc(Kokkos::View<T, P...>& v,
   }
 
   if constexpr (alloc_prop_input::initialize) {
-    if constexpr (alloc_prop_input::has_execution_space) {
+    const typename view_type::value_type fill_value{};
+    if constexpr (alloc_prop_input::sequential_host_init) {
+      Impl::sequential_host_fill(v, fill_value);
+    } else if constexpr (alloc_prop_input::has_execution_space) {
       const auto& exec_space =
           Impl::get_property<Impl::ExecutionSpaceTag>(arg_prop);
-      Kokkos::deep_copy(exec_space, v, typename view_type::value_type{});
-    } else
-      Kokkos::deep_copy(v, typename view_type::value_type{});
+      Kokkos::deep_copy(exec_space, v, fill_value);
+    } else {
+      Kokkos::deep_copy(v, fill_value);
+    }
   }
 }
 

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1202,6 +1202,8 @@ inline void deep_copy(
     std::enable_if_t<
         (std::is_void_v<typename ViewTraits<DT, DP...>::specialize> &&
          std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
+         (is_view_v<typename View<DT, DP...>::value_type> ==
+          is_view_v<typename View<ST, SP...>::value_type>)&&  //
          (unsigned(ViewTraits<DT, DP...>::rank) != 0 ||
           unsigned(ViewTraits<ST, SP...>::rank) != 0))>* = nullptr) {
   Impl::check_deep_copy_view_arguments_are_distinct(std::addressof(dst),
@@ -2410,6 +2412,8 @@ inline void deep_copy(
         (Kokkos::is_execution_space<ExecSpace>::value &&
          std::is_void_v<typename ViewTraits<DT, DP...>::specialize> &&
          std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
+         (is_view_v<typename View<DT, DP...>::value_type> ==
+          is_view_v<typename View<ST, SP...>::value_type>)&&  //
          (unsigned(ViewTraits<DT, DP...>::rank) != 0 ||
           unsigned(ViewTraits<ST, SP...>::rank) != 0))>* = nullptr) {
   Impl::check_deep_copy_view_arguments_are_distinct(std::addressof(dst),

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -968,14 +968,14 @@ struct ViewSequentialHostFill {
   void apply(Indices... idx) const {
     if constexpr (ViewType::rank == 0)
       dst() = value;
-    else if constexpr (Dim == int(ViewType::rank))
-      dst(idx...) = value;
-    else {
-      ViewSequentialHostFill<ViewType, ValueType, Dim + 1>
-          view_sequential_host_fill{dst, value};
-      for (size_t i = 0; i < dst.extent(Dim); ++i)
-        view_sequential_host_fill.apply(idx..., i);
-    }
+    else
+      for (size_t i = 0; i < dst.extent(Dim); ++i) {
+        if constexpr (Dim + 1 == int(ViewType::rank))
+          dst(idx..., i) = value;
+        else
+          ViewSequentialHostFill<ViewType, ValueType, Dim + 1>{dst, value}
+              .apply(idx..., i);
+      }
   }
 };
 
@@ -1010,7 +1010,9 @@ void sequential_host_fill(const ViewType& dst,
     return;
   }
 
-  ViewSequentialHostFill{dst, value}.apply();
+  ViewSequentialHostFill<ViewType, typename ViewType::const_value_type>{dst,
+                                                                        value}
+      .apply();
 }
 }  // namespace Impl
 

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -966,21 +966,17 @@ struct ViewSequentialHostFill {
 
   template <class... Indices>
   void apply(Indices... idx) const {
-    if constexpr (Dim == int(ViewType::rank)) {
-      if constexpr (ViewType::rank == 0) {
-        dst() = value;
-      } else {
-        dst(idx...) = value;
-      }
-    } else {
-      for (size_t i = 0; i < dst.extent(Dim); ++i) {
-        ViewSequentialHostFill<ViewType, ValueType, Dim + 1>{dst, value}.apply(
-            idx..., i);
-      }
+    if constexpr (ViewType::rank == 0)
+      dst() = value;
+    else if constexpr (Dim == int(ViewType::rank))
+      dst(idx...) = value;
+    else {
+      ViewSequentialHostFill<ViewType, ValueType, Dim + 1>
+          view_sequential_host_fill{dst, value};
+      for (size_t i = 0; i < dst.extent(Dim); ++i)
+        view_sequential_host_fill.apply(idx..., i);
     }
   }
-
-  void operator()() const { apply(); }
 };
 
 template <class ViewType>
@@ -995,11 +991,6 @@ void sequential_host_fill(const ViewType& dst,
                 "deep_copy requires non-const destination type");
 
   if (dst.data() == nullptr || dst.span() == 0) {
-    return;
-  }
-
-  if constexpr (ViewType::rank == 0) {
-    dst() = value;
     return;
   }
 
@@ -1019,9 +1010,7 @@ void sequential_host_fill(const ViewType& dst,
     return;
   }
 
-  ViewSequentialHostFill<ViewType, typename ViewType::const_value_type> fill{
-      dst, value};
-  fill();
+  ViewSequentialHostFill{dst, value}.apply();
 }
 }  // namespace Impl
 
@@ -1264,15 +1253,11 @@ inline void deep_copy(
 template <class DT, class... DP, class ST, class... SP>
 inline void deep_copy(
     const View<DT, DP...>& dst, const View<ST, SP...>& src,
-    std::enable_if_t<(
-        std::is_void_v<typename ViewTraits<DT, DP...>::specialize> &&
-        std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
-        (is_view_v<typename View<DT, DP...>::value_type> ==
-         is_view_v<typename View<
-             ST, SP...>::value_type>)&&(unsigned(ViewTraits<DT, DP...>::rank) !=
-                                            0 ||
-                                        unsigned(ViewTraits<ST, SP...>::rank) !=
-                                            0))>* = nullptr) {
+    std::enable_if_t<
+        (std::is_void_v<typename ViewTraits<DT, DP...>::specialize> &&
+         std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
+         (unsigned(ViewTraits<DT, DP...>::rank) != 0 ||
+          unsigned(ViewTraits<ST, SP...>::rank) != 0))>* = nullptr) {
   Impl::check_deep_copy_view_arguments_are_distinct(std::addressof(dst),
                                                     std::addressof(src));
 
@@ -2475,16 +2460,12 @@ template <class ExecSpace, class DT, class... DP, class ST, class... SP>
 inline void deep_copy(
     const ExecSpace& exec_space, const View<DT, DP...>& dst,
     const View<ST, SP...>& src,
-    std::enable_if_t<(
-        Kokkos::is_execution_space<ExecSpace>::value &&
-        std::is_void_v<typename ViewTraits<DT, DP...>::specialize> &&
-        std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
-        (is_view_v<typename View<DT, DP...>::value_type> ==
-         is_view_v<typename View<
-             ST, SP...>::value_type>)&&(unsigned(ViewTraits<DT, DP...>::rank) !=
-                                            0 ||
-                                        unsigned(ViewTraits<ST, SP...>::rank) !=
-                                            0))>* = nullptr) {
+    std::enable_if_t<
+        (Kokkos::is_execution_space<ExecSpace>::value &&
+         std::is_void_v<typename ViewTraits<DT, DP...>::specialize> &&
+         std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
+         (unsigned(ViewTraits<DT, DP...>::rank) != 0 ||
+          unsigned(ViewTraits<ST, SP...>::rank) != 0))>* = nullptr) {
   Impl::check_deep_copy_view_arguments_are_distinct(std::addressof(dst),
                                                     std::addressof(src));
 

--- a/core/unit_test/TestViewOfViews.hpp
+++ b/core/unit_test/TestViewOfViews.hpp
@@ -65,7 +65,7 @@ void test_view_of_views_realloc_sequential_host_init_rank_impl(
     std::index_sequence<Is...>) {
   using VoV = ViewOfViews<V, Rank>;
 
-  // Same-size realloc to reinitialize via deep_copy(v, value_type{})
+  // Same-size realloc reinitializes each inner View via value_type{}.
   {
     VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit),
             (static_cast<void>(Is), 2u)...);

--- a/core/unit_test/TestViewOfViews.hpp
+++ b/core/unit_test/TestViewOfViews.hpp
@@ -56,17 +56,10 @@ void test_view_of_views_default() {
   vov(0, 0) = a;
   vov(1, 0) = a;
   vov(0, 1) = b;
-
 #ifndef KOKKOS_ENABLE_IMPL_VIEW_OF_VIEWS_DESTRUCTOR_PRECONDITION_VIOLATION_WORKAROUND
   vov(0, 0) = V();
   vov(1, 0) = V();
   vov(0, 1) = V();
-#endif
-
-  Kokkos::realloc(vov, 1, 1);
-  vov(0, 0) = a;
-#ifndef KOKKOS_ENABLE_IMPL_VIEW_OF_VIEWS_DESTRUCTOR_PRECONDITION_VIOLATION_WORKAROUND
-  vov(0, 0) = V();
 #endif
 }
 
@@ -81,21 +74,12 @@ void test_view_of_views_without_initializing() {
   new (&vov(0, 0)) V(a);
   new (&vov(1, 0)) V(a);
   new (&vov(0, 1)) V(b);
-
 #ifndef KOKKOS_ENABLE_IMPL_VIEW_OF_VIEWS_DESTRUCTOR_PRECONDITION_VIOLATION_WORKAROUND
   vov(0, 0).~V();
   vov(1, 0).~V();
   vov(0, 1).~V();
 #else
   // leaks memory
-#endif
-
-  Kokkos::realloc(Kokkos::view_alloc(Kokkos::WithoutInitializing), vov, 1, 1);
-  new (&vov(0, 0)) V(a);
-#ifndef KOKKOS_ENABLE_IMPL_VIEW_OF_VIEWS_DESTRUCTOR_PRECONDITION_VIOLATION_WORKAROUND
-  vov(0, 0).~V();
-#else
-// leaks memory
 #endif
 }
 
@@ -110,9 +94,6 @@ void test_view_of_views_sequential_host_init() {
   vov(0, 0) = a;
   vov(1, 0) = a;
   vov(0, 1) = b;
-
-  Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1);
-  vov(0, 0) = a;
 }
 
 TEST(TEST_CATEGORY, view_of_views_default) {
@@ -137,6 +118,109 @@ TEST(TEST_CATEGORY, test_view_of_views_sequential_host_init) {
   test_view_of_views_sequential_host_init<
       S<Kokkos::View<float, TEST_EXECSPACE>>>();
   test_view_of_views_sequential_host_init<
+      H<Kokkos::View<int, TEST_EXECSPACE>>>();
+}
+
+template <class V>
+void test_view_of_views_realloc_sequential_host_init() {
+  {
+    using VoV = Kokkos::View<V*, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2);
+    {
+      V a("a");
+      vov(0) = a;
+    }
+    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+  {
+    using VoV = Kokkos::View<V**, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2);
+    {
+      V a("a");
+      vov(0, 0) = a;
+    }
+    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+  {
+    using VoV = Kokkos::View<V***, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2);
+    {
+      V a("a");
+      vov(0, 0, 0) = a;
+    }
+    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1,
+                    1);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+  {
+    using VoV = Kokkos::View<V****, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2);
+    {
+      V a("a");
+      vov(0, 0, 0, 0) = a;
+    }
+    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1,
+                    1, 1);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+  {
+    using VoV = Kokkos::View<V*****, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2,
+            2);
+    {
+      V a("a");
+      vov(0, 0, 0, 0, 0) = a;
+    }
+    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1,
+                    1, 1, 1);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+  {
+    using VoV = Kokkos::View<V******, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2,
+            2, 2);
+    {
+      V a("a");
+      vov(0, 0, 0, 0, 0, 0) = a;
+    }
+    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1,
+                    1, 1, 1, 1);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+  {
+    using VoV = Kokkos::View<V*******, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2,
+            2, 2, 2);
+    {
+      V a("a");
+      vov(0, 0, 0, 0, 0, 0, 0) = a;
+    }
+    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1,
+                    1, 1, 1, 1, 1);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+  {
+    using VoV = Kokkos::View<V********, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2,
+            2, 2, 2, 2);
+    {
+      V a("a");
+      vov(0, 0, 0, 0, 0, 0, 0, 0) = a;
+    }
+    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1,
+                    1, 1, 1, 1, 1, 1);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+}
+
+TEST(TEST_CATEGORY, test_view_of_views_realloc_sequential_host_init) {
+  test_view_of_views_realloc_sequential_host_init<
+      Kokkos::View<int, TEST_EXECSPACE>>();
+  test_view_of_views_realloc_sequential_host_init<
+      S<Kokkos::View<float, TEST_EXECSPACE>>>();
+  test_view_of_views_realloc_sequential_host_init<
       H<Kokkos::View<int, TEST_EXECSPACE>>>();
 }
 

--- a/core/unit_test/TestViewOfViews.hpp
+++ b/core/unit_test/TestViewOfViews.hpp
@@ -46,6 +46,72 @@ class H {  // constructible and destructible only from on the host side
   ~H() {}
 };
 
+template <class T, int N>
+struct AddPointer {
+  using type = typename AddPointer<T, N - 1>::type*;
+};
+
+template <class T>
+struct AddPointer<T, 0> {
+  using type = T;
+};
+
+template <class V, int Rank>
+using ViewOfViews =
+    Kokkos::View<typename AddPointer<V, Rank>::type, Kokkos::HostSpace>;
+
+template <class V, int Rank, std::size_t... Is>
+void test_view_of_views_realloc_sequential_host_init_rank_impl(
+    std::index_sequence<Is...>) {
+  using VoV = ViewOfViews<V, Rank>;
+
+  // Same-size realloc to reinitialize via deep_copy(v, value_type{})
+  {
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit),
+            (static_cast<void>(Is), 2u)...);
+    {
+      V a("a");
+      vov((static_cast<void>(Is), 0u)...) = a;
+    }
+    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov,
+                    (static_cast<void>(Is), 2u)...);
+    for (unsigned dim = 0; dim < Rank; ++dim) {
+      ASSERT_EQ(vov.extent(dim), 2u);
+    }
+  }
+
+  // Size change reconstructs the view
+  {
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit),
+            (static_cast<void>(Is), 2u)...);
+    {
+      V a("a");
+      vov((static_cast<void>(Is), 0u)...) = a;
+    }
+    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov,
+                    (static_cast<void>(Is), 1u)...);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+}
+
+template <class V, int Rank>
+void test_view_of_views_realloc_sequential_host_init_rank() {
+  test_view_of_views_realloc_sequential_host_init_rank_impl<V, Rank>(
+      std::make_index_sequence<static_cast<std::size_t>(Rank)>{});
+}
+
+template <class V>
+void test_view_of_views_realloc_sequential_host_init() {
+  test_view_of_views_realloc_sequential_host_init_rank<V, 1>();
+  test_view_of_views_realloc_sequential_host_init_rank<V, 2>();
+  test_view_of_views_realloc_sequential_host_init_rank<V, 3>();
+  test_view_of_views_realloc_sequential_host_init_rank<V, 4>();
+  test_view_of_views_realloc_sequential_host_init_rank<V, 5>();
+  test_view_of_views_realloc_sequential_host_init_rank<V, 6>();
+  test_view_of_views_realloc_sequential_host_init_rank<V, 7>();
+  test_view_of_views_realloc_sequential_host_init_rank<V, 8>();
+}
+
 template <class V>
 void test_view_of_views_default() {
   // assigning a default-constructed view to destruct the inner objects
@@ -119,100 +185,6 @@ TEST(TEST_CATEGORY, test_view_of_views_sequential_host_init) {
       S<Kokkos::View<float, TEST_EXECSPACE>>>();
   test_view_of_views_sequential_host_init<
       H<Kokkos::View<int, TEST_EXECSPACE>>>();
-}
-
-template <class V>
-void test_view_of_views_realloc_sequential_host_init() {
-  {
-    using VoV = Kokkos::View<V*, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2);
-    {
-      V a("a");
-      vov(0) = a;
-    }
-    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1);
-    ASSERT_EQ(vov.size(), 1u);
-  }
-  {
-    using VoV = Kokkos::View<V**, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2);
-    {
-      V a("a");
-      vov(0, 0) = a;
-    }
-    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1);
-    ASSERT_EQ(vov.size(), 1u);
-  }
-  {
-    using VoV = Kokkos::View<V***, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2);
-    {
-      V a("a");
-      vov(0, 0, 0) = a;
-    }
-    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1,
-                    1);
-    ASSERT_EQ(vov.size(), 1u);
-  }
-  {
-    using VoV = Kokkos::View<V****, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2);
-    {
-      V a("a");
-      vov(0, 0, 0, 0) = a;
-    }
-    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1,
-                    1, 1);
-    ASSERT_EQ(vov.size(), 1u);
-  }
-  {
-    using VoV = Kokkos::View<V*****, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2,
-            2);
-    {
-      V a("a");
-      vov(0, 0, 0, 0, 0) = a;
-    }
-    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1,
-                    1, 1, 1);
-    ASSERT_EQ(vov.size(), 1u);
-  }
-  {
-    using VoV = Kokkos::View<V******, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2,
-            2, 2);
-    {
-      V a("a");
-      vov(0, 0, 0, 0, 0, 0) = a;
-    }
-    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1,
-                    1, 1, 1, 1);
-    ASSERT_EQ(vov.size(), 1u);
-  }
-  {
-    using VoV = Kokkos::View<V*******, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2,
-            2, 2, 2);
-    {
-      V a("a");
-      vov(0, 0, 0, 0, 0, 0, 0) = a;
-    }
-    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1,
-                    1, 1, 1, 1, 1);
-    ASSERT_EQ(vov.size(), 1u);
-  }
-  {
-    using VoV = Kokkos::View<V********, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2,
-            2, 2, 2, 2);
-    {
-      V a("a");
-      vov(0, 0, 0, 0, 0, 0, 0, 0) = a;
-    }
-    Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1,
-                    1, 1, 1, 1, 1, 1);
-    ASSERT_EQ(vov.size(), 1u);
-  }
 }
 
 TEST(TEST_CATEGORY, test_view_of_views_realloc_sequential_host_init) {

--- a/core/unit_test/TestViewOfViews.hpp
+++ b/core/unit_test/TestViewOfViews.hpp
@@ -56,10 +56,17 @@ void test_view_of_views_default() {
   vov(0, 0) = a;
   vov(1, 0) = a;
   vov(0, 1) = b;
+
 #ifndef KOKKOS_ENABLE_IMPL_VIEW_OF_VIEWS_DESTRUCTOR_PRECONDITION_VIOLATION_WORKAROUND
   vov(0, 0) = V();
   vov(1, 0) = V();
   vov(0, 1) = V();
+#endif
+
+  Kokkos::realloc(vov, 1, 1);
+  vov(0, 0) = a;
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_OF_VIEWS_DESTRUCTOR_PRECONDITION_VIOLATION_WORKAROUND
+  vov(0, 0) = V();
 #endif
 }
 
@@ -74,12 +81,21 @@ void test_view_of_views_without_initializing() {
   new (&vov(0, 0)) V(a);
   new (&vov(1, 0)) V(a);
   new (&vov(0, 1)) V(b);
+
 #ifndef KOKKOS_ENABLE_IMPL_VIEW_OF_VIEWS_DESTRUCTOR_PRECONDITION_VIOLATION_WORKAROUND
   vov(0, 0).~V();
   vov(1, 0).~V();
   vov(0, 1).~V();
 #else
   // leaks memory
+#endif
+
+  Kokkos::realloc(Kokkos::view_alloc(Kokkos::WithoutInitializing), vov, 1, 1);
+  new (&vov(0, 0)) V(a);
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_OF_VIEWS_DESTRUCTOR_PRECONDITION_VIOLATION_WORKAROUND
+  vov(0, 0).~V();
+#else
+// leaks memory
 #endif
 }
 
@@ -94,6 +110,9 @@ void test_view_of_views_sequential_host_init() {
   vov(0, 0) = a;
   vov(1, 0) = a;
   vov(0, 1) = b;
+
+  Kokkos::realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1);
+  vov(0, 0) = a;
 }
 
 TEST(TEST_CATEGORY, view_of_views_default) {


### PR DESCRIPTION
Fixes #7466 partly. We must make sure to select the overload copying from/to a scalar for
```
deep_copy(View<View<Scalar>>, View<Scalar>);
```
and not the ones copying from one view to another view of a similar type. 