### PR TITLE
Fix wrong use of m_reducer

### DIFF
--- a/core/src/Threads/Kokkos_Threads_Instance.hpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.hpp
@@ -225,7 +225,7 @@ class ThreadsInternal {
     //  to inactive triggers another thread to exit a spinwait
     //  and read the 'reduce_memory'.
     //  Must 'memory_fence()' to guarantee that storing the update to
-    //  'reduce_memory()' will complete before storing the the update to
+    //  'reduce_memory()' will complete before storing the update to
     //  'm_pool_state'.
 
     memory_fence();

--- a/core/src/Threads/Kokkos_Threads_ParallelReduce_MDRange.hpp
+++ b/core/src/Threads/Kokkos_Threads_ParallelReduce_MDRange.hpp
@@ -91,8 +91,8 @@ class ParallelReduce<CombinedFunctorReducerType,
     long work_index = instance.get_work_index();
 
     const ReducerType &reducer = self.m_iter.m_func.get_reducer();
-    reference_type update      = self.m_reducer.init(
-        static_cast<pointer_type>(instance.reduce_memory()));
+    reference_type update =
+        reducer.init(static_cast<pointer_type>(instance.reduce_memory()));
     while (work_index != -1) {
       const Member begin = static_cast<Member>(work_index);
       const Member end   = begin + 1 < num_tiles ? begin + 1 : num_tiles;
@@ -100,7 +100,7 @@ class ParallelReduce<CombinedFunctorReducerType,
       work_index = instance.get_work_index();
     }
 
-    instance.fan_in_reduce(self.m_reducer);
+    instance.fan_in_reduce(reducer);
   }
 
  public:

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -571,20 +571,37 @@ TEST(TEST_CATEGORY, mdrange_combined_reduce) {
   constexpr uint64_t nw = 1000;
 
   uint64_t nsum = (nw / 2) * (nw + 1);
+  {
+    int64_t result1 = 0;
+    int64_t result2 = 0;
+    int64_t result3 = 0;
 
-  int64_t result1 = 0;
-  int64_t result2 = 0;
-  int64_t result3 = 0;
+    Kokkos::parallel_reduce(
+        "int_combined_reduce_mdrange",
+        Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<3>>({{0, 0, 0}},
+                                                               {{nw, 1, 1}}),
+        functor_type(nw), result1, result2, result3);
 
-  Kokkos::parallel_reduce(
-      "int_combined_reduce_mdrange",
-      Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<3>>({{0, 0, 0}},
-                                                             {{nw, 1, 1}}),
-      functor_type(nw), result1, result2, result3);
+    ASSERT_EQ(nw, uint64_t(result1));
+    ASSERT_EQ(nsum, uint64_t(result2));
+    ASSERT_EQ(nsum, uint64_t(result3));
+  }
+  {
+    int64_t result1 = 0;
+    int64_t result2 = 0;
+    int64_t result3 = 0;
 
-  ASSERT_EQ(nw, uint64_t(result1));
-  ASSERT_EQ(nsum, uint64_t(result2));
-  ASSERT_EQ(nsum, uint64_t(result3));
+    Kokkos::parallel_reduce(
+        "int_combined_reduce_mdrange",
+        Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<3>,
+                              Kokkos::Schedule<Kokkos::Dynamic>>({{0, 0, 0}},
+                                                                 {{nw, 1, 1}}),
+        functor_type(nw), result1, result2, result3);
+
+    ASSERT_EQ(nw, uint64_t(result1));
+    ASSERT_EQ(nsum, uint64_t(result2));
+    ASSERT_EQ(nsum, uint64_t(result3));
+  }
 }
 
 TEST(TEST_CATEGORY, int_combined_reduce_mixed) {


### PR DESCRIPTION
Probably an oversight. Not sure why we did not catch this.

`In file included from ::/Users/jciesko/RAndD/kokkos/core/src/Kokkos_Core.hpp :/Users/jciesko/RAndD/kokkos/core/src/Threads/Kokkos_Threads_ParallelReduce_MDRange.hpp45 :error: no member named 'm_reducer' in 'ParallelReduce<type-parameter-0-0, MDRangePolicy<type-parameter-0-1...>, Kokkos::Threads>'`

Reproducer: 
`Apple M1, clang version 19.1.2 `
`cmake .. -DCMAKE_CXX_COMPILER=clang++ -DKokkos_ENABLE_THREADS=On -DKokkos_ENABLE_TESTS=On && make`

