### PR TITLE
simd: Initialize simd values to suppress gcc's uninitialized var warnings

### DIFF
--- a/simd/unit_tests/include/TestSIMD_Construction.hpp
+++ b/simd/unit_tests/include/TestSIMD_Construction.hpp
@@ -30,7 +30,8 @@ inline void host_test_simd_traits() {
   static_assert(std::is_nothrow_move_assignable_v<simd_type>);
   static_assert(std::is_nothrow_move_constructible_v<simd_type>);
 
-  simd_type default_simd, result;
+  simd_type default_simd(zero_init<simd_type>()),
+      result(zero_init<simd_type>());
   simd_type test_simd(KOKKOS_LAMBDA(std::size_t i) { return (i % 2 == 0); });
   simd_type copy_simd(test_simd);
   simd_type move_simd(std::move(copy_simd));
@@ -83,7 +84,8 @@ template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_test_simd_traits() {
   using simd_type = Kokkos::Experimental::simd<DataType, Abi>;
 
-  simd_type default_simd, result;
+  simd_type default_simd(zero_init<simd_type>()),
+      result(zero_init<simd_type>());
   simd_type test_simd(KOKKOS_LAMBDA(std::size_t i) { return (i % 2 == 0); });
   simd_type copy_simd(test_simd);
   simd_type move_simd(std::move(copy_simd));

--- a/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
+++ b/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
@@ -37,10 +37,10 @@ inline void host_check_gen_ctor() {
       expected[i] = (init_mask[i]) ? init[i] * 9 : init[i];
     }
 
-    simd_type rhs;
+    simd_type rhs(zero_init<simd_type>());
     rhs.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
-    simd_type blend;
+    simd_type blend(zero_init<simd_type>());
     blend.copy_from(expected, Kokkos::Experimental::simd_flag_default);
 
 #if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
@@ -100,7 +100,7 @@ KOKKOS_INLINE_FUNCTION void device_check_gen_ctor() {
     }
 
     simd_type basic(KOKKOS_LAMBDA(std::size_t i) { return init[i]; });
-    simd_type rhs;
+    simd_type rhs(zero_init<simd_type>());
     rhs.copy_from(init, Kokkos::Experimental::simd_flag_default);
     device_check_equality(basic, rhs, lanes);
 
@@ -108,7 +108,7 @@ KOKKOS_INLINE_FUNCTION void device_check_gen_ctor() {
     simd_type result(
         KOKKOS_LAMBDA(std::size_t i) { return (mask[i]) ? lhs[i] : rhs[i]; });
 
-    simd_type blend;
+    simd_type blend(zero_init<simd_type>());
     blend.copy_from(expected, Kokkos::Experimental::simd_flag_default);
     device_check_equality(result, blend, lanes);
   }

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -31,7 +31,7 @@ inline void host_check_reduction_one_loader(ReductionOp reduce_op,
   for (std::size_t i = 0; i < n; i += width) {
     std::size_t const nremaining = n - i;
     std::size_t const nlanes     = Kokkos::min(nremaining, width);
-    simd_type arg;
+    simd_type arg(zero_init<simd_type>());
     bool const loaded_arg = loader.host_load(args + i, nlanes, arg);
     if (!loaded_arg) continue;
 
@@ -109,7 +109,7 @@ KOKKOS_INLINE_FUNCTION void device_check_reduction_one_loader(
   for (std::size_t i = 0; i < n; i += width) {
     std::size_t const nremaining = n - i;
     std::size_t const nlanes     = Kokkos::min(nremaining, width);
-    simd_type arg;
+    simd_type arg(zero_init<simd_type>());
     bool const loaded_arg = loader.device_load(args + i, nlanes, arg);
     if (!loaded_arg) continue;
 

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -29,13 +29,13 @@ inline void host_check_shift_on_one_loader(ShiftOp shift_op,
   Loader loader;
 
   for (std::size_t i = 0; i < n; ++i) {
-    simd_type simd_vals;
+    simd_type simd_vals(zero_init<simd_type>());
     bool const loaded_arg = loader.host_load(test_vals, width, simd_vals);
     if (!loaded_arg) {
       continue;
     }
 
-    simd_type expected_result;
+    simd_type expected_result(zero_init<simd_type>());
 
     for (std::size_t lane = 0; lane < width; ++lane) {
       DataType value = simd_vals[lane];
@@ -57,11 +57,11 @@ inline void host_check_shift_by_lanes_on_one_loader(
   constexpr std::size_t width = simd_type::size();
   Loader loader;
 
-  simd_type simd_vals;
+  simd_type simd_vals(zero_init<simd_type>());
   bool const loaded_arg = loader.host_load(test_vals, width, simd_vals);
   ASSERT_TRUE(loaded_arg);
 
-  simd_type expected_result;
+  simd_type expected_result(zero_init<simd_type>());
 
   for (std::size_t lane = 0; lane < width; ++lane) {
     DataType value = simd_vals[lane];
@@ -163,13 +163,13 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_on_one_loader(
   Loader loader;
 
   for (std::size_t i = 0; i < n; ++i) {
-    simd_type simd_vals;
+    simd_type simd_vals(zero_init<simd_type>());
     bool const loaded_arg = loader.device_load(test_vals, width, simd_vals);
     if (!loaded_arg) {
       continue;
     }
 
-    simd_type expected_result;
+    simd_type expected_result(zero_init<simd_type>());
 
     for (std::size_t lane = 0; lane < width; ++lane) {
       DataType value = simd_vals[lane];
@@ -189,10 +189,10 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_by_lanes_on_one_loader(
   using simd_type             = Kokkos::Experimental::simd<DataType, Abi>;
   constexpr std::size_t width = simd_type::size();
   Loader loader;
-  simd_type simd_vals;
+  simd_type simd_vals(zero_init<simd_type>());
   loader.device_load(test_vals, width, simd_vals);
 
-  simd_type expected_result;
+  simd_type expected_result(zero_init<simd_type>());
 
   for (std::size_t lane = 0; lane < width; ++lane) {
     DataType value = simd_vals[lane];

--- a/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
+++ b/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
@@ -30,7 +30,7 @@ inline void host_check_where_expr_scatter_to() {
     std::size_t nlanes = simd_type::size();
     DataType init[]    = {11, 13, 17, 19, 23, 29, 31, 37,
                           53, 71, 79, 83, 89, 93, 97, 103};
-    simd_type src;
+    simd_type src(zero_init<simd_type>());
     src.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
     for (std::size_t idx = 0; idx < nlanes; ++idx) {
@@ -39,7 +39,7 @@ inline void host_check_where_expr_scatter_to() {
 
       DataType dst[simd_type::size()] = {0};
       index_type index;
-      simd_type expected_result;
+      simd_type expected_result(zero_init<simd_type>());
       for (std::size_t i = 0; i < nlanes; ++i) {
         dst[i]             = (2 + (i * 2));
         index[i]           = i;
@@ -47,7 +47,7 @@ inline void host_check_where_expr_scatter_to() {
       }
       where(mask, src).scatter_to(dst, index);
 
-      simd_type dst_simd;
+      simd_type dst_simd(zero_init<simd_type>());
       dst_simd.copy_from(dst, Kokkos::Experimental::simd_flag_default);
 
       host_check_equality(expected_result, dst_simd, nlanes);
@@ -70,9 +70,9 @@ inline void host_check_where_expr_gather_from() {
       mask_type mask(true);
       mask[idx] = false;
 
-      simd_type dst;
+      simd_type dst(zero_init<simd_type>());
       index_type index;
-      simd_type expected_result;
+      simd_type expected_result(zero_init<simd_type>());
       for (std::size_t i = 0; i < nlanes; ++i) {
         dst[i]             = (2 + (i * 2));
         index[i]           = i;
@@ -114,7 +114,7 @@ KOKKOS_INLINE_FUNCTION void device_check_where_expr_scatter_to() {
     std::size_t nlanes = simd_type::size();
     DataType init[]    = {11, 13, 17, 19, 23, 29, 31, 37,
                           53, 71, 79, 83, 89, 93, 97, 103};
-    simd_type src;
+    simd_type src(zero_init<simd_type>());
     src.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
     for (std::size_t idx = 0; idx < nlanes; ++idx) {
@@ -123,7 +123,7 @@ KOKKOS_INLINE_FUNCTION void device_check_where_expr_scatter_to() {
 
       DataType dst[simd_type::size()] = {0};
       index_type index;
-      simd_type expected_result;
+      simd_type expected_result(zero_init<simd_type>());
       for (std::size_t i = 0; i < nlanes; ++i) {
         dst[i]             = (2 + (i * 2));
         index[i]           = i;
@@ -153,9 +153,9 @@ KOKKOS_INLINE_FUNCTION void device_check_where_expr_gather_from() {
     mask_type mask(true);
     mask[idx] = false;
 
-    simd_type dst;
+    simd_type dst(zero_init<simd_type>());
     index_type index;
-    simd_type expected_result;
+    simd_type expected_result(zero_init<simd_type>());
     for (std::size_t i = 0; i < nlanes; ++i) {
       dst[i]             = (2 + (i * 2));
       index[i]           = i;


### PR DESCRIPTION
This PR initializes default constructed simd variables in simd unit tests to mitigate gcc's uninitialized variable warnings on simd variables that were initialized using intrinsics.

Co-authored-by: Christian Trott (crtrott@sandia.gov)