### PR TITLE
Revert 6683:  simd: add compound assignments and reductions

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -751,11 +751,6 @@ class simd<double, simd_abi::avx2_fixed_size<4>> {
                                gen(std::integral_constant<std::size_t, 2>()),
                                gen(std::integral_constant<std::size_t, 3>()))) {
   }
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -1016,11 +1011,6 @@ class simd<float, simd_abi::avx2_fixed_size<4>> {
                             gen(std::integral_constant<std::size_t, 1>()),
                             gen(std::integral_constant<std::size_t, 2>()),
                             gen(std::integral_constant<std::size_t, 3>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m128 const& value_in)
       : m_value(value_in) {}
@@ -1272,11 +1262,6 @@ class simd<float, simd_abi::avx2_fixed_size<8>> {
                                gen(std::integral_constant<std::size_t, 5>()),
                                gen(std::integral_constant<std::size_t, 6>()),
                                gen(std::integral_constant<std::size_t, 7>()))) {
-  }
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m256 const& value_in)
@@ -1533,11 +1518,6 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
                                gen(std::integral_constant<std::size_t, 2>()),
                                gen(std::integral_constant<std::size_t, 3>()))) {
   }
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m128i const& value_in)
       : m_value(value_in) {}
@@ -1741,11 +1721,6 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m256i const& value_in)
       : m_value(value_in) {}
@@ -1945,11 +1920,6 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
             gen(std::integral_constant<std::size_t, 1>()),
             gen(std::integral_constant<std::size_t, 2>()),
             gen(std::integral_constant<std::size_t, 3>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m256i const& value_in)
       : m_value(value_in) {}
@@ -2168,11 +2138,6 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
             gen(std::integral_constant<std::size_t, 1>()),
             gen(std::integral_constant<std::size_t, 2>()),
             gen(std::integral_constant<std::size_t, 3>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m256i const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -298,11 +298,6 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
                                gen(std::integral_constant<std::size_t, 6>()),
                                gen(std::integral_constant<std::size_t, 7>()))) {
   }
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -593,11 +588,6 @@ class simd<float, simd_abi::avx512_fixed_size<8>> {
                                gen(std::integral_constant<std::size_t, 6>()),
                                gen(std::integral_constant<std::size_t, 7>()))) {
   }
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -873,11 +863,6 @@ class simd<float, simd_abi::avx512_fixed_size<16>> {
                            gen(std::integral_constant<std::size_t, 13>()),
                            gen(std::integral_constant<std::size_t, 14>()),
                            gen(std::integral_constant<std::size_t, 15>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -1149,11 +1134,6 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -1369,11 +1349,6 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
             gen(std::integral_constant<std::size_t, 13>()),
             gen(std::integral_constant<std::size_t, 14>()),
             gen(std::integral_constant<std::size_t, 15>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -1584,11 +1559,6 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -1799,11 +1769,6 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
             gen(std::integral_constant<std::size_t, 13>()),
             gen(std::integral_constant<std::size_t, 14>()),
             gen(std::integral_constant<std::size_t, 15>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -2005,11 +1970,6 @@ class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m512i const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
@@ -2219,11 +2179,6 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
       simd<std::int64_t, abi_type> const& other)
       : m_value(static_cast<__m512i>(other)) {}
@@ -3231,437 +3186,39 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
   }
 };
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    std::int32_t
-    hmax(const_where_expression<
-         simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-         simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
-  if (none_of(x.impl_get_mask())) {
-    return Kokkos::reduction_identity<std::int32_t>::max();
-  }
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t hmax(
+    const_where_expression<
+        simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+        simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   return _mm512_mask_reduce_max_epi32(
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
-#endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
-reduce_max(
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
-    simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<std::int32_t>::max();
-  }
-  return _mm512_mask_reduce_max_epi32(
-      static_cast<__mmask8>(m),
-      _mm512_castsi256_si512(static_cast<__m256i>(v)));
-}
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    std::int32_t
-    hmin(const_where_expression<
-         simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-         simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
-  if (none_of(x.impl_get_mask())) {
-    return Kokkos::reduction_identity<std::int32_t>::min();
-  }
-  return _mm512_mask_reduce_min_epi32(
-      static_cast<__mmask8>(x.impl_get_mask()),
-      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
-}
-#endif
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
-reduce_min(
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
-    simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<std::int32_t>::min();
-  }
-  return _mm512_mask_reduce_min_epi32(
-      static_cast<__mmask8>(m),
-      _mm512_castsi256_si512(static_cast<__m256i>(v)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
-reduce_max(simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
-           simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
-               m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<std::int32_t>::max();
-  }
-  return _mm512_mask_reduce_max_epi32(static_cast<__mmask16>(m),
-                                      static_cast<__m512i>(v));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
-reduce_min(simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
-           simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
-               m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<std::int32_t>::min();
-  }
-  return _mm512_mask_reduce_min_epi32(static_cast<__mmask16>(m),
-                                      static_cast<__m512i>(v));
-}
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    std::uint32_t
-    hmax(const_where_expression<
-         simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
-         simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
-  if (none_of(x.impl_get_mask())) {
-    return Kokkos::reduction_identity<std::uint32_t>::max();
-  }
-  return _mm512_mask_reduce_max_epu32(
-      static_cast<__mmask8>(x.impl_get_mask()),
-      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
-}
-#endif
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
-reduce_max(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& v,
-           simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
-               m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<std::uint32_t>::max();
-  }
-  return _mm512_mask_reduce_max_epu32(
-      static_cast<__mmask8>(m),
-      _mm512_castsi256_si512(static_cast<__m256i>(v)));
-}
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    std::uint32_t
-    hmin(const_where_expression<
-         simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
-         simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
-  if (none_of(x.impl_get_mask())) {
-    return Kokkos::reduction_identity<std::uint32_t>::min();
-  }
-  return _mm512_mask_reduce_min_epu32(
-      static_cast<__mmask8>(x.impl_get_mask()),
-      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
-}
-#endif
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
-reduce_min(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& v,
-           simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
-               m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<std::uint32_t>::min();
-  }
-  return _mm512_mask_reduce_min_epu32(
-      static_cast<__mmask8>(m),
-      _mm512_castsi256_si512(static_cast<__m256i>(v)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
-reduce_max(simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& v,
-           simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
-               m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<std::uint32_t>::max();
-  }
-  return _mm512_mask_reduce_max_epu32(static_cast<__mmask16>(m),
-                                      static_cast<__m512i>(v));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
-reduce_min(simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& v,
-           simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
-               m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<std::uint32_t>::min();
-  }
-  return _mm512_mask_reduce_min_epu32(static_cast<__mmask16>(m),
-                                      static_cast<__m512i>(v));
-}
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    std::int64_t
-    hmax(const_where_expression<
-         simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-         simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
-  if (none_of(x.impl_get_mask())) {
-    return Kokkos::reduction_identity<std::int64_t>::max();
-  }
-  return _mm512_mask_reduce_max_epi64(static_cast<__mmask8>(x.impl_get_mask()),
-                                      static_cast<__m512i>(x.impl_get_value()));
-}
-#endif
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int64_t
-reduce_max(
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
-    simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<std::int64_t>::max();
-  }
-  return _mm512_mask_reduce_max_epi64(static_cast<__mmask8>(m),
-                                      static_cast<__m512i>(v));
-}
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    std::int64_t
-    hmin(const_where_expression<
-         simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-         simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
-  if (none_of(x.impl_get_mask())) {
-    return Kokkos::reduction_identity<std::int64_t>::min();
-  }
-  return _mm512_mask_reduce_min_epi64(static_cast<__mmask8>(x.impl_get_mask()),
-                                      static_cast<__m512i>(x.impl_get_value()));
-}
-#endif
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int64_t
-reduce_min(
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
-    simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<std::int64_t>::min();
-  }
-  return _mm512_mask_reduce_min_epi64(static_cast<__mmask8>(m),
-                                      static_cast<__m512i>(v));
-}
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    std::uint64_t
-    hmax(const_where_expression<
-         simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
-         simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
-  if (none_of(x.impl_get_mask())) {
-    return Kokkos::reduction_identity<std::uint64_t>::max();
-  }
-  return _mm512_mask_reduce_max_epu64(static_cast<__mmask8>(x.impl_get_mask()),
-                                      static_cast<__m512i>(x.impl_get_value()));
-}
-#endif
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint64_t
-reduce_max(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& v,
-           simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
-               m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<std::uint64_t>::max();
-  }
-  return _mm512_mask_reduce_max_epu64(static_cast<__mmask8>(m),
-                                      static_cast<__m512i>(v));
-}
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    std::uint64_t
-    hmin(const_where_expression<
-         simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
-         simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
-  if (none_of(x.impl_get_mask())) {
-    return Kokkos::reduction_identity<std::uint64_t>::min();
-  }
-  return _mm512_mask_reduce_min_epu64(static_cast<__mmask8>(x.impl_get_mask()),
-                                      static_cast<__m512i>(x.impl_get_value()));
-}
-#endif
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint64_t
-reduce_min(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& v,
-           simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
-               m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<std::uint64_t>::min();
-  }
-  return _mm512_mask_reduce_min_epu64(static_cast<__mmask8>(m),
-                                      static_cast<__m512i>(v));
-}
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double
-hmax(const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-                            simd<double, simd_abi::avx512_fixed_size<8>>> const&
-         x) {
-  if (none_of(x.impl_get_mask())) {
-    return Kokkos::reduction_identity<double>::max();
-  }
-  return _mm512_mask_reduce_max_pd(static_cast<__mmask8>(x.impl_get_mask()),
-                                   static_cast<__m512d>(x.impl_get_value()));
-}
-#endif
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr double reduce_max(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& v,
-    simd_mask<double, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<double>::max();
-  }
-  return _mm512_mask_reduce_max_pd(static_cast<__mmask8>(m),
-                                   static_cast<__m512d>(v));
-}
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double
-hmin(const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-                            simd<double, simd_abi::avx512_fixed_size<8>>> const&
-         x) {
-  if (none_of(x.impl_get_mask())) {
-    return Kokkos::reduction_identity<double>::min();
-  }
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double hmin(
+    const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+                           simd<double, simd_abi::avx512_fixed_size<8>>> const&
+        x) {
   return _mm512_mask_reduce_min_pd(static_cast<__mmask8>(x.impl_get_mask()),
                                    static_cast<__m512d>(x.impl_get_value()));
 }
-#endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr double reduce_min(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& v,
-    simd_mask<double, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<double>::min();
-  }
-  return _mm512_mask_reduce_min_pd(static_cast<__mmask8>(m),
-                                   static_cast<__m512d>(v));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce(
+    const_where_expression<
+        simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+        simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x,
+    std::int64_t, std::plus<>) {
+  return _mm512_mask_reduce_add_epi64(static_cast<__mmask8>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
 }
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
-hmax(const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-                            simd<float, simd_abi::avx512_fixed_size<8>>> const&
-         x) {
-  if (none_of(x.impl_get_mask())) {
-    return Kokkos::reduction_identity<float>::max();
-  }
-  return _mm512_mask_reduce_max_ps(
-      static_cast<__mmask8>(x.impl_get_mask()),
-      _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
-}
-#endif
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float reduce_max(
-    simd<float, simd_abi::avx512_fixed_size<8>> const& v,
-    simd_mask<float, simd_abi::avx512_fixed_size<8>> m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<float>::max();
-  }
-  return _mm512_mask_reduce_max_ps(
-      static_cast<__mmask8>(m), _mm512_castps256_ps512(static_cast<__m256>(v)));
-}
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
-hmin(const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-                            simd<float, simd_abi::avx512_fixed_size<8>>> const&
-         x) {
-  if (none_of(x.impl_get_mask())) {
-    return Kokkos::reduction_identity<float>::min();
-  }
-  return _mm512_mask_reduce_min_ps(
-      static_cast<__mmask8>(x.impl_get_mask()),
-      _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
-}
-#endif
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float reduce_min(
-    simd<float, simd_abi::avx512_fixed_size<8>> const& v,
-    simd_mask<float, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<float>::min();
-  }
-  return _mm512_mask_reduce_min_ps(
-      static_cast<__mmask8>(m), _mm512_castps256_ps512(static_cast<__m256>(v)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float reduce_max(
-    simd<float, simd_abi::avx512_fixed_size<16>> const& v,
-    simd_mask<float, simd_abi::avx512_fixed_size<16>> m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<float>::max();
-  }
-  return _mm512_mask_reduce_max_ps(static_cast<__mmask16>(m),
-                                   static_cast<__m512>(v));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float reduce_min(
-    simd<float, simd_abi::avx512_fixed_size<16>> const& v,
-    simd_mask<float, simd_abi::avx512_fixed_size<16>> const& m) noexcept {
-  if (none_of(m)) {
-    return Kokkos::reduction_identity<float>::min();
-  }
-  return _mm512_mask_reduce_min_ps(static_cast<__mmask16>(m),
-                                   static_cast<__m512>(v));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
-reduce(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
-       simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& m,
-       std::int32_t identity, std::plus<>) noexcept {
-  if (none_of(m)) {
-    return identity;
-  }
-  return _mm512_mask_reduce_add_epi32(
-      static_cast<__mmask8>(m),
-      _mm512_castsi256_si512(static_cast<__m256i>(v)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
-reduce(simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
-       simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& m,
-       std::int32_t identity, std::plus<>) noexcept {
-  if (none_of(m)) {
-    return identity;
-  }
-  return _mm512_mask_reduce_add_epi32(static_cast<__mmask16>(m),
-                                      static_cast<__m512i>(v));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int64_t
-reduce(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
-       simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& m,
-       std::int64_t identity, std::plus<>) noexcept {
-  if (none_of(m)) {
-    return identity;
-  }
-  return _mm512_mask_reduce_add_epi64(static_cast<__mmask8>(m),
-                                      static_cast<__m512i>(v));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr double reduce(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& v,
-    simd_mask<double, simd_abi::avx512_fixed_size<8>> const& m, double identity,
-    std::plus<>) noexcept {
-  if (none_of(m)) {
-    return identity;
-  }
-  return _mm512_mask_reduce_add_pd(static_cast<__mmask8>(m),
-                                   static_cast<__m512d>(v));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float reduce(
-    simd<float, simd_abi::avx512_fixed_size<8>> const& v,
-    simd_mask<float, simd_abi::avx512_fixed_size<8>> const& m, float identity,
-    std::plus<>) noexcept {
-  if (none_of(m)) {
-    return identity;
-  }
-  return _mm512_mask_reduce_add_ps(
-      static_cast<__mmask8>(m), _mm512_castps256_ps512(static_cast<__m256>(v)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float reduce(
-    simd<float, simd_abi::avx512_fixed_size<16>> const& v,
-    simd_mask<float, simd_abi::avx512_fixed_size<16>> const& m, float identity,
-    std::plus<>) noexcept {
-  if (none_of(m)) {
-    return identity;
-  }
-  return _mm512_mask_reduce_add_ps(static_cast<__mmask16>(m),
-                                   static_cast<__m512>(v));
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
+    const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+                           simd<double, simd_abi::avx512_fixed_size<8>>> const&
+        x,
+    double, std::plus<>) {
+  return _mm512_mask_reduce_add_pd(static_cast<__mmask8>(x.impl_get_mask()),
+                                   static_cast<__m512d>(x.impl_get_value()));
 }
 
 }  // namespace Experimental

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -25,10 +25,6 @@ namespace Kokkos {
 
 namespace Experimental {
 
-namespace simd_abi {
-class scalar;
-}
-
 template <class T, class Abi>
 class simd;
 
@@ -138,7 +134,7 @@ template <class T>
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator+(
     Experimental::simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] + rhs);
   return Experimental::simd<result_member, Abi>(lhs) +
@@ -147,18 +143,16 @@ template <class T, class U, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator+(
     U lhs, Experimental::simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs + rhs[0]);
   return Experimental::simd<result_member, Abi>(lhs) +
          Experimental::simd<result_member, Abi>(rhs);
 }
 
-template <
-    class T, class U, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi>& operator+=(
-    simd<T, Abi>& lhs, U&& rhs) {
+template <class T, class U, class Abi>
+KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>& operator+=(simd<T, Abi>& lhs,
+                                                     U&& rhs) {
   lhs = lhs + std::forward<U>(rhs);
   return lhs;
 }
@@ -172,7 +166,7 @@ KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator+=(
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator-(
     Experimental::simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] - rhs);
   return Experimental::simd<result_member, Abi>(lhs) -
@@ -181,24 +175,22 @@ template <class T, class U, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator-(
     U lhs, Experimental::simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs - rhs[0]);
   return Experimental::simd<result_member, Abi>(lhs) -
          Experimental::simd<result_member, Abi>(rhs);
 }
 
-template <
-    class T, class U, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi>& operator-=(
-    simd<T, Abi>& lhs, U&& rhs) {
+template <class T, class U, class Abi>
+KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>& operator-=(simd<T, Abi>& lhs,
+                                                     U&& rhs) {
   lhs = lhs - std::forward<U>(rhs);
   return lhs;
 }
 
 template <class M, class T, class U>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION where_expression<M, T>& operator-=(
+KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator-=(
     where_expression<M, T>& lhs, U&& rhs) {
   lhs = lhs.value() - std::forward<U>(rhs);
   return lhs;
@@ -206,7 +198,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION where_expression<M, T>& operator-=(
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator*(
     Experimental::simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] * rhs);
   return Experimental::simd<result_member, Abi>(lhs) *
@@ -215,41 +207,30 @@ template <class T, class U, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator*(
     U lhs, Experimental::simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs * rhs[0]);
   return Experimental::simd<result_member, Abi>(lhs) *
          Experimental::simd<result_member, Abi>(rhs);
 }
 
-template <
-    class T, class U, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi>& operator*=(
-    simd<T, Abi>& lhs, U&& rhs) {
+template <class T, class U, class Abi>
+KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>& operator*=(simd<T, Abi>& lhs,
+                                                     U&& rhs) {
   lhs = lhs * std::forward<U>(rhs);
   return lhs;
 }
 
 template <class M, class T, class U>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION where_expression<M, T>& operator*=(
+KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator*=(
     where_expression<M, T>& lhs, U&& rhs) {
   lhs = lhs.value() * std::forward<U>(rhs);
   return lhs;
 }
 
-template <class T, class Abi,
-          std::enable_if_t<std::is_integral_v<T>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
-    Experimental::simd<T, Abi> const& lhs,
-    Experimental::simd<T, Abi> const& rhs) {
-  return Experimental::simd<T, Abi>(
-      [&](std::size_t i) { return lhs[i] / rhs[i]; });
-}
-
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator/(
     Experimental::simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] / rhs);
   return Experimental::simd<result_member, Abi>(lhs) /
@@ -258,44 +239,24 @@ template <class T, class U, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator/(
     U lhs, Experimental::simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs / rhs[0]);
   return Experimental::simd<result_member, Abi>(lhs) /
          Experimental::simd<result_member, Abi>(rhs);
 }
 
-template <
-    class T, class U, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi>& operator/=(
-    simd<T, Abi>& lhs, U&& rhs) {
+template <class T, class U, class Abi>
+KOKKOS_FORCEINLINE_FUNCTION simd<T, Abi>& operator/=(simd<T, Abi>& lhs,
+                                                     U&& rhs) {
   lhs = lhs / std::forward<U>(rhs);
   return lhs;
 }
 
 template <class M, class T, class U>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION where_expression<M, T>& operator/=(
+KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator/=(
     where_expression<M, T>& lhs, U&& rhs) {
   lhs = lhs.value() / std::forward<U>(rhs);
-  return lhs;
-}
-
-template <
-    class T, class U, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi>& operator>>=(
-    simd<T, Abi>& lhs, U&& rhs) {
-  lhs = lhs >> std::forward<U>(rhs);
-  return lhs;
-}
-
-template <
-    class T, class U, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi>& operator<<=(
-    simd<T, Abi>& lhs, U&& rhs) {
-  lhs = lhs << std::forward<U>(rhs);
   return lhs;
 }
 
@@ -317,19 +278,19 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi>& operator<<=(
 // fallback implementations of reductions across simd_mask:
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr bool all_of(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool all_of(
     simd_mask<T, Abi> const& a) {
   return a == simd_mask<T, Abi>(true);
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr bool any_of(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool any_of(
     simd_mask<T, Abi> const& a) {
   return a != simd_mask<T, Abi>(false);
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr bool none_of(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool none_of(
     simd_mask<T, Abi> const& a) {
   return a == simd_mask<T, Abi>(false);
 }
@@ -346,26 +307,6 @@ template <typename T>
     return (rem == 0) ? ceil : floor;
   }
   return Kokkos::round(x);
-}
-
-// common implementations of host only simd reductions:
-template <class T, class Abi, class BinaryOperation = std::plus<>>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
-    const simd<T, Abi>& x, BinaryOperation binary_op = {}) {
-  return reduce(x, simd<T, Abi>::mask_type(true), T(0), binary_op);
-}
-
-template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_min(
-    const simd<T, Abi>& x) noexcept {
-  return reduce_min(x, simd<T, Abi>::mask_type(true));
-}
-
-template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_max(
-    const simd<T, Abi>& x) noexcept {
-  auto v = where(true, x);
-  return reduce_max(x, simd<T, Abi>::mask_type(true));
 }
 
 }  // namespace Experimental

--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -23,10 +23,6 @@ namespace Kokkos {
 
 namespace Experimental {
 
-namespace simd_abi {
-class scalar;
-}
-
 template <class T, class Abi>
 class simd;
 
@@ -36,9 +32,8 @@ class simd_mask;
 template <class M, class T>
 class const_where_expression;
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <typename T, typename Abi>
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 hmin(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
   auto const& v = x.impl_get_value();
   auto const& m = x.impl_get_mask();
@@ -50,7 +45,7 @@ hmin(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 hmax(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
   auto const& v = x.impl_get_value();
   auto const& m = x.impl_get_mask();
@@ -60,44 +55,16 @@ hmax(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
   }
   return result;
 }
-#endif
 
-template <
-    typename T, typename Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_min(
-    simd<T, Abi> const& v, typename simd<T, Abi>::mask_type const& m) {
-  auto result = Kokkos::reduction_identity<T>::min();
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+reduce(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x, T,
+       std::plus<>) {
+  auto const& v = x.impl_get_value();
+  auto const& m = x.impl_get_mask();
+  auto result   = Kokkos::reduction_identity<T>::sum();
   for (std::size_t i = 0; i < v.size(); ++i) {
-    if (m[i]) result = Kokkos::min(result, v[i]);
-  }
-  return result;
-}
-
-template <
-    class T, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce_max(
-    simd<T, Abi> const& v, typename simd<T, Abi>::mask_type const& m) {
-  auto result = Kokkos::reduction_identity<T>::max();
-  for (std::size_t i = 0; i < v.size(); ++i) {
-    if (m[i]) result = Kokkos::max(result, v[i]);
-  }
-  return result;
-}
-
-template <
-    class T, class Abi, class BinaryOperation = std::plus<>,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr T reduce(
-    simd<T, Abi> const& v, typename simd<T, Abi>::mask_type const& m,
-    T identity, BinaryOperation op = {}) {
-  if (none_of(m)) {
-    return identity;
-  }
-  auto result = v[0];
-  for (std::size_t i = 1; i < v.size(); ++i) {
-    if (m[i]) result = op(result, v[i]);
+    if (m[i]) result += v[i];
   }
   return result;
 }

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -492,11 +492,6 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
     m_value = vsetq_lane_f64(gen(std::integral_constant<std::size_t, 1>()),
                              m_value, 1);
   }
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       float64x2_t const& value_in)
       : m_value(value_in) {}
@@ -749,11 +744,6 @@ class simd<float, simd_abi::neon_fixed_size<2>> {
     m_value = vset_lane_f32(gen(std::integral_constant<std::size_t, 1>()),
                             m_value, 1);
   }
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       float32x2_t const& value_in)
       : m_value(value_in) {}
@@ -1004,11 +994,6 @@ class simd<float, simd_abi::neon_fixed_size<4>> {
     m_value = vsetq_lane_f32(gen(std::integral_constant<std::size_t, 3>()),
                              m_value, 3);
   }
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       float32x4_t const& value_in)
       : m_value(value_in) {}
@@ -1252,11 +1237,6 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
     m_value = vset_lane_s32(gen(std::integral_constant<std::size_t, 1>()),
                             m_value, 1);
   }
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       int32x2_t const& value_in)
       : m_value(value_in) {}
@@ -1477,11 +1457,6 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
     m_value = vsetq_lane_s32(gen(std::integral_constant<std::size_t, 3>()),
                              m_value, 3);
   }
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       int32x4_t const& value_in)
       : m_value(value_in) {}
@@ -1694,11 +1669,6 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
     m_value = vsetq_lane_s64(gen(std::integral_constant<std::size_t, 1>()),
                              m_value, 1);
   }
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       int64x2_t const& value_in)
       : m_value(value_in) {}
@@ -1909,11 +1879,6 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
                              m_value, 0);
     m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 1>()),
                              m_value, 1);
-  }
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      value_type const* ptr, FlagType flag) {
-    copy_from(ptr, flag);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       uint64x2_t const& value_in)
@@ -2721,196 +2686,6 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
                   static_cast<uint64x2_t>(m_value)));
   }
 };
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
-// reduce_min(
-//         simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& v,
-//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& m)
-//         noexcept {
-//   return vminv_s32(static_cast<int32x2_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
-// reduce_max(
-//         simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& v,
-//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& m)
-//         noexcept {
-//   return vmaxv_s32(static_cast<int32x2_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
-// reduce(
-//         simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& v,
-//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& m,
-//     std::int32_t identity, std::plus<>) noexcept {
-//   if (none_of(m)) return identity;
-//   return vaddv_s32(static_cast<int32x2_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
-// reduce_min(
-//         simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& v,
-//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& m)
-//         noexcept {
-//   return vminvq_s32(static_cast<int32x4_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
-// reduce_max(
-//         simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& v,
-//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> m) noexcept {
-//   return vmaxvq_s32(static_cast<int32x4_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int32_t
-// reduce(
-//         simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& v,
-//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& m,
-//     std::int32_t identity, std::plus<>) noexcept {
-//   if (none_of(m)) return identity;
-//   return vaddvq_s32(static_cast<int32x4_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
-// reduce_min(
-//         simd<std::uint32_t, simd_abi::neon_fixed_size<2>> const& v,
-//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>> const& m)
-//         noexcept {
-//   return vminv_u32(static_cast<uint32x2_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
-// reduce_max(
-//         simd<std::uint32_t, simd_abi::neon_fixed_size<2>> const& v,
-//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>> const& m)
-//         noexcept {
-//   return vmaxv_u32(static_cast<uint32x2_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
-// reduce(
-//         simd<std::uint32_t, simd_abi::neon_fixed_size<2>> const& v,
-//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>> const& m,
-//     std::uint32_t identity, std::plus<>) noexcept {
-//   if (none_of(m)) return identity;
-//   return vaddv_u32(static_cast<uint32x2_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
-// reduce_min(
-//         simd<std::uint32_t, simd_abi::neon_fixed_size<4>> const& v,
-//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>> const& m)
-//         noexcept {
-//   return vminvq_u32(static_cast<uint32x4_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
-// reduce_max(
-//         simd<std::uint32_t, simd_abi::neon_fixed_size<4>> const& v,
-//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>> const& m)
-//         noexcept {
-//   return vmaxvq_u32(static_cast<uint32x4_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint32_t
-// reduce(
-//         simd<std::uint32_t, simd_abi::neon_fixed_size<4>> const& v,
-//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>> const& m,
-//     std::uint32_t identity, std::plus<>) noexcept {
-//   if (none_of(m)) return identity;
-//   return vaddvq_u32(static_cast<uint32x4_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::int64_t
-// reduce(
-//         simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& v,
-//         simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& m,
-//     std::int64_t identity, std::plus<>) noexcept {
-//   if (none_of(m)) return identity;
-//   return vaddvq_s64(static_cast<int64x2_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr std::uint64_t
-// reduce(
-//         simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& v,
-//         simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& m,
-//     std::uint64_t identity, std::plus<>) noexcept {
-//   return vaddvq_u64(static_cast<uint64x2_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr double
-// reduce_min(
-//     simd < double, simd_abi::neon_fixed_size < 2 >> const& v,
-//     simd_mask<double, simd_abi::neon_fixed_size<2>> const& m) noexcept {
-//   return vminvq_f64(static_cast<float64x2_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr double
-// reduce_max(
-//                            simd<double, simd_abi::neon_fixed_size<2>> const&
-//                            v,
-//     simd_mask<double, simd_abi::neon_fixed_size<2>> const& m) noexcept {
-//   return vmaxvq_f64(static_cast<float64x2_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr double reduce(
-//                            simd<double, simd_abi::neon_fixed_size<2>> const&
-//                            v,
-//     simd_mask<double, simd_abi::neon_fixed_size<2>> const& m,
-//     double identity, std::plus<>) noexcept {
-//   if (none_of(m)) return identity;
-//   return vaddvq_f64(static_cast<float64x2_t>(x.impl_get_value()));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float
-// reduce_min(
-//                            simd<float, simd_abi::neon_fixed_size<2>> const&
-//                            v,
-//     simd_mask<float, simd_abi::neon_fixed_size<2>> const& m) noexcept {
-//   return vminv_f32(static_cast<float32x2_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float
-// reduce_max(
-//                            simd<float, simd_abi::neon_fixed_size<2>> const&
-//                            v,
-//     simd_mask<float, simd_abi::neon_fixed_size<2>> const& m) noexcept {
-//   return vmaxv_f32(static_cast<float32x2_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float reduce(
-//                            simd<float, simd_abi::neon_fixed_size<2>> const&
-//                            v,
-//     simd_mask<float, simd_abi::neon_fixed_size<2>> const& m,
-//     float identity, std::plus<>) noexcept {
-//   if (none_of(m)) return identity;
-//   return vaddv_f32(static_cast<float32x2_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float
-// reduce_min(
-//                            simd<float, simd_abi::neon_fixed_size<4>> const&
-//                            v,
-//     simd_mask<float, simd_abi::neon_fixed_size<4>> const& m) noexcept {
-//   return vminvq_f32(static_cast<float32x4_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float
-// reduce_max(
-//                            simd<float, simd_abi::neon_fixed_size<4>> const&
-//                            const& v
-//     simd_mask<float, simd_abi::neon_fixed_size<4>> const& m) noexcept {
-//   return vmaxvq_f32(static_cast<float32x4_t>(v));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr float reduce(
-//                            simd<float, simd_abi::neon_fixed_size<4>> const&
-//                            v,
-//     simd_mask<float, simd_abi::neon_fixed_size<4>> const& m,
-//     float identity, std::plus<>) noexcept {
-//   if (none_of(m)) return identity;
-//   return vaddvq_f32(static_cast<float32x4_t>(v));
-// }
 
 }  // namespace Experimental
 }  // namespace Kokkos

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -120,9 +120,6 @@ class simd<T, simd_abi::scalar> {
                 bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit simd(G&& gen) noexcept
       : m_value(gen(0)) {}
-  template <typename FlagType>
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit simd(T const* ptr, FlagType)
-      : m_value(*ptr) {}
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator T() const {
     return m_value;
   }
@@ -154,37 +151,17 @@ class simd<T, simd_abi::scalar> {
       simd const& lhs, simd const& rhs) noexcept {
     return simd(lhs.m_value * rhs.m_value);
   }
-  template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator*(
-      simd const& lhs, U rhs) {
-    return lhs.m_value * simd(rhs);
-  }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator/(
       simd const& lhs, simd const& rhs) noexcept {
     return simd(lhs.m_value / rhs.m_value);
-  }
-  template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator/(
-      simd const& lhs, U rhs) {
-    return lhs.m_value / simd(rhs);
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator+(
       simd const& lhs, simd const& rhs) noexcept {
     return simd(lhs.m_value + rhs.m_value);
   }
-  template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator+(
-      simd const& lhs, U rhs) {
-    return lhs.m_value + simd(rhs);
-  }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator-(
       simd const& lhs, simd const& rhs) noexcept {
     return simd(lhs.m_value - rhs.m_value);
-  }
-  template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator-(
-      simd const& lhs, U rhs) {
-    return lhs.m_value - simd(rhs);
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator>>(
       simd const& lhs, int rhs) noexcept {
@@ -209,36 +186,6 @@ class simd<T, simd_abi::scalar> {
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator|(
       simd const& lhs, simd const& rhs) noexcept {
     return lhs.m_value | rhs.m_value;
-  }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator+=(
-      simd& lhs, simd const& rhs) noexcept {
-    lhs = lhs + rhs;
-    return lhs;
-  }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator-=(
-      simd& lhs, simd const& rhs) noexcept {
-    lhs = lhs - rhs;
-    return lhs;
-  }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator*=(
-      simd& lhs, simd const& rhs) noexcept {
-    lhs = lhs * rhs;
-    return lhs;
-  }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator/=(
-      simd& lhs, simd const& rhs) noexcept {
-    lhs = lhs / rhs;
-    return lhs;
-  }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator>>=(
-      simd& lhs, simd const& rhs) noexcept {
-    lhs = lhs >> rhs;
-    return lhs;
-  }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator<<=(
-      simd& lhs, simd const& rhs) noexcept {
-    lhs = lhs << rhs;
-    return lhs;
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
   operator<(simd const& lhs, simd const& rhs) noexcept {
@@ -345,58 +292,6 @@ KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> condition(
     simd<T, simd_abi::scalar> const& b, simd<T, simd_abi::scalar> const& c) {
   return simd<T, simd_abi::scalar>(static_cast<bool>(a) ? static_cast<T>(b)
                                                         : static_cast<T>(c));
-}
-
-template <class T, class BinaryOperation>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
-    Experimental::simd<T, Experimental::simd_abi::scalar> const& x,
-    Experimental::simd_mask<T, Experimental::simd_abi::scalar> const& mask,
-    T identity, BinaryOperation) noexcept {
-  if (!mask) return identity;
-  return x[0];
-}
-
-template <class T, class BinaryOperation>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
-    Experimental::simd<T, Experimental::simd_abi::scalar> const& x,
-    BinaryOperation binary_op) noexcept {
-  return reduce(
-      x, Experimental::simd<T, Experimental::simd_abi::scalar>::mask_type(true),
-      T(0), binary_op);
-}
-
-template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
-    Experimental::simd<T, Experimental::simd_abi::scalar> const& x,
-    Experimental::simd_mask<T, Experimental::simd_abi::scalar> const&
-        mask) noexcept {
-  if (!mask) return Kokkos::reduction_identity<T>::min();
-  return x[0];
-}
-
-template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
-    Experimental::simd<T, Experimental::simd_abi::scalar> const& x) noexcept {
-  return reduce_min(
-      x,
-      Experimental::simd<T, Experimental::simd_abi::scalar>::mask_type(true));
-}
-
-template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
-    Experimental::simd<T, Experimental::simd_abi::scalar> const& x,
-    Experimental::simd_mask<T, Experimental::simd_abi::scalar> const&
-        mask) noexcept {
-  if (!mask) return Kokkos::reduction_identity<T>::max();
-  return x[0];
-}
-
-template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
-    Experimental::simd<T, Experimental::simd_abi::scalar> const& x) noexcept {
-  return reduce_max(
-      x,
-      Experimental::simd<T, Experimental::simd_abi::scalar>::mask_type(true));
 }
 
 template <class T>
@@ -518,41 +413,29 @@ template <class T>
   return a == simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(false);
 }
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class T>
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION T
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
+reduce(const_where_expression<simd_mask<T, simd_abi::scalar>,
+                              simd<T, simd_abi::scalar>> const& x,
+       T identity_element, std::plus<>) {
+  return static_cast<bool>(x.impl_get_mask())
+             ? static_cast<T>(x.impl_get_value())
+             : identity_element;
+}
+
+template <class T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
 hmax(const_where_expression<simd_mask<T, simd_abi::scalar>,
                             simd<T, simd_abi::scalar>> const& x) {
   return static_cast<bool>(x.impl_get_mask())
              ? static_cast<T>(x.impl_get_value())
              : Kokkos::reduction_identity<T>::max();
 }
-#endif
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
-reduce_max(const_where_expression<simd_mask<T, simd_abi::scalar>,
-                                  simd<T, simd_abi::scalar>> const& x) {
-  return static_cast<bool>(x.impl_get_mask())
-             ? static_cast<T>(x.impl_get_value())
-             : Kokkos::reduction_identity<T>::max();
-}
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-template <class T>
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION T
 hmin(const_where_expression<simd_mask<T, simd_abi::scalar>,
                             simd<T, simd_abi::scalar>> const& x) {
-  return static_cast<bool>(x.impl_get_mask())
-             ? static_cast<T>(x.impl_get_value())
-             : Kokkos::reduction_identity<T>::min();
-}
-#endif
-
-template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
-reduce_min(const_where_expression<simd_mask<T, simd_abi::scalar>,
-                                  simd<T, simd_abi::scalar>> const& x) {
   return static_cast<bool>(x.impl_get_mask())
              ? static_cast<T>(x.impl_get_value())
              : Kokkos::reduction_identity<T>::min();

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -31,18 +31,6 @@ class plus {
   }
 };
 
-class plus_eq {
- public:
-  template <class T>
-  auto on_host(T&& a, T&& b) const {
-    return a += b;
-  }
-  template <class T>
-  KOKKOS_INLINE_FUNCTION auto on_device(T&& a, T&& b) const {
-    return a += b;
-  }
-};
-
 class minus {
  public:
   template <class T>
@@ -52,18 +40,6 @@ class minus {
   template <class T>
   KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
     return a - b;
-  }
-};
-
-class minus_eq {
- public:
-  template <class T>
-  auto on_host(T&& a, T&& b) const {
-    return a -= b;
-  }
-  template <class T>
-  KOKKOS_INLINE_FUNCTION auto on_device(T&& a, T&& b) const {
-    return a -= b;
   }
 };
 
@@ -79,18 +55,6 @@ class multiplies {
   }
 };
 
-class multiplies_eq {
- public:
-  template <class T>
-  auto on_host(T&& a, T&& b) const {
-    return a *= b;
-  }
-  template <class T>
-  KOKKOS_INLINE_FUNCTION auto on_device(T&& a, T&& b) const {
-    return a *= b;
-  }
-};
-
 class divides {
  public:
   template <class T>
@@ -100,18 +64,6 @@ class divides {
   template <class T>
   KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
     return a / b;
-  }
-};
-
-class divides_eq {
- public:
-  template <class T>
-  auto on_host(T&& a, T&& b) const {
-    return a /= b;
-  }
-  template <class T>
-  KOKKOS_INLINE_FUNCTION auto on_device(T&& a, T&& b) const {
-    return a /= b;
   }
 };
 
@@ -251,18 +203,6 @@ class shift_right {
   }
 };
 
-class shift_right_eq {
- public:
-  template <typename T, typename U>
-  auto on_host(T&& a, U&& b) const {
-    return a >>= b;
-  }
-  template <typename T, typename U>
-  KOKKOS_INLINE_FUNCTION auto on_device(T&& a, U&& b) const {
-    return a >>= b;
-  }
-};
-
 class shift_left {
  public:
   template <typename T, typename U>
@@ -272,18 +212,6 @@ class shift_left {
   template <typename T, typename U>
   KOKKOS_INLINE_FUNCTION auto on_device(T&& a, U&& b) const {
     return a << b;
-  }
-};
-
-class shift_left_eq {
- public:
-  template <typename T, typename U>
-  auto on_host(T&& a, U&& b) const {
-    return a <<= b;
-  }
-  template <typename T, typename U>
-  KOKKOS_INLINE_FUNCTION auto on_device(T&& a, U&& b) const {
-    return a <<= b;
   }
 };
 
@@ -335,133 +263,114 @@ class log_op {
   }
 };
 
-class reduce_min {
+class hmin {
  public:
-  template <typename T, typename U, typename MaskType>
-  auto on_host(T const& a, U, MaskType mask) const {
-    return Kokkos::Experimental::reduce_min(a, mask);
+  template <typename T>
+  auto on_host(T const& a) const {
+    return Kokkos::Experimental::hmin(a);
   }
-  template <typename T, typename U, typename MaskType>
-  auto on_host_serial(T const& a, U, MaskType mask) const {
-    if (Kokkos::Experimental::none_of(mask))
-      return Kokkos::reduction_identity<U>::min();
-    auto w        = Kokkos::Experimental::where(mask, a);
-    auto const& v = w.impl_get_value();
-    auto const& m = w.impl_get_mask();
-    auto result   = v[0];
-    for (std::size_t i = 1; i < v.size(); ++i) {
+  template <typename T>
+  auto on_host_serial(T const& a) const {
+    using DataType = typename T::value_type::value_type;
+
+    auto const& v = a.impl_get_value();
+    auto const& m = a.impl_get_mask();
+    auto result   = Kokkos::reduction_identity<DataType>::min();
+    for (std::size_t i = 0; i < v.size(); ++i) {
       if (m[i]) result = Kokkos::min(result, v[i]);
     }
     return result;
   }
 
-  template <typename T, typename U, typename MaskType>
-  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, U, MaskType mask) const {
-    return Kokkos::Experimental::reduce_min(a, mask);
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a) const {
+    return Kokkos::Experimental::hmin(a);
   }
-  template <typename T, typename U, typename MaskType>
-  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a, U,
-                                               MaskType mask) const {
-    if (Kokkos::Experimental::none_of(mask))
-      return Kokkos::reduction_identity<U>::min();
-    auto w        = Kokkos::Experimental::where(mask, a);
-    auto const& v = w.impl_get_value();
-    auto const& m = w.impl_get_mask();
-    auto result   = v[0];
-    for (std::size_t i = 1; i < v.size(); ++i) {
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a) const {
+    using DataType = typename T::value_type::value_type;
+
+    auto const& v = a.impl_get_value();
+    auto const& m = a.impl_get_mask();
+    auto result   = Kokkos::reduction_identity<DataType>::min();
+    for (std::size_t i = 0; i < v.size(); ++i) {
       if (m[i]) result = Kokkos::min(result, v[i]);
     }
     return result;
   }
 };
 
-class reduce_max {
+class hmax {
  public:
-  template <typename T, typename U, typename MaskType>
-  auto on_host(T const& a, U, MaskType mask) const {
-    return Kokkos::Experimental::reduce_max(a, mask);
+  template <typename T>
+  auto on_host(T const& a) const {
+    return Kokkos::Experimental::hmax(a);
   }
-  template <typename T, typename U, typename MaskType>
-  auto on_host_serial(T const& a, U, MaskType mask) const {
-    if (Kokkos::Experimental::none_of(mask))
-      return Kokkos::reduction_identity<U>::max();
-    auto w        = Kokkos::Experimental::where(mask, a);
-    auto const& v = w.impl_get_value();
-    auto const& m = w.impl_get_mask();
-    auto result   = v[0];
-    for (std::size_t i = 1; i < v.size(); ++i) {
+  template <typename T>
+  auto on_host_serial(T const& a) const {
+    using DataType = typename T::value_type::value_type;
+
+    auto const& v = a.impl_get_value();
+    auto const& m = a.impl_get_mask();
+    auto result   = Kokkos::reduction_identity<DataType>::max();
+    for (std::size_t i = 0; i < v.size(); ++i) {
       if (m[i]) result = Kokkos::max(result, v[i]);
     }
     return result;
   }
 
-  template <typename T, typename U, typename MaskType>
-  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, U, MaskType mask) const {
-    return Kokkos::Experimental::reduce_max(a, mask);
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a) const {
+    return Kokkos::Experimental::hmax(a);
   }
-  template <typename T, typename U, typename MaskType>
-  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a, U,
-                                               MaskType mask) const {
-    if (Kokkos::Experimental::none_of(mask))
-      return Kokkos::reduction_identity<U>::max();
-    auto w        = Kokkos::Experimental::where(mask, a);
-    auto const& v = w.impl_get_value();
-    auto const& m = w.impl_get_mask();
-    auto result   = v[0];
-    for (std::size_t i = 1; i < v.size(); ++i) {
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a) const {
+    using DataType = typename T::value_type::value_type;
+
+    auto const& v = a.impl_get_value();
+    auto const& m = a.impl_get_mask();
+    auto result   = Kokkos::reduction_identity<DataType>::max();
+    for (std::size_t i = 0; i < v.size(); ++i) {
       if (m[i]) result = Kokkos::max(result, v[i]);
     }
     return result;
   }
 };
 
-template <typename BinaryOperation = std::plus<>>
 class reduce {
  public:
-  template <typename T, typename U, typename MaskType>
-  auto on_host(T const& a, U const& identity, MaskType mask) const {
-    return Kokkos::Experimental::reduce(a, mask, identity, BinaryOperation());
+  template <typename T>
+  auto on_host(T const& a) const {
+    using DataType = typename T::value_type::value_type;
+    return Kokkos::Experimental::reduce(a, DataType(0), std::plus<>());
   }
-  template <typename T, typename U, typename MaskType>
-  auto on_host_serial(T const& a, U const& identity, MaskType mask) const {
-    if (Kokkos::Experimental::none_of(mask)) return identity;
-    auto w        = Kokkos::Experimental::where(mask, a);
-    auto const& v = w.impl_get_value();
-    auto const& m = w.impl_get_mask();
-    auto result   = v[0];
-    for (std::size_t i = 1; i < v.size(); ++i) {
-      if (m[i]) result = BinaryOperation()(result, v[i]);
+  template <typename T>
+  auto on_host_serial(T const& a) const {
+    using DataType = typename T::value_type::value_type;
+
+    auto const& v = a.impl_get_value();
+    auto const& m = a.impl_get_mask();
+    auto result   = Kokkos::reduction_identity<DataType>::sum();
+    for (std::size_t i = 0; i < v.size(); ++i) {
+      if (m[i]) result += v[i];
     }
     return result;
   }
 
-  template <typename T, typename U, typename MaskType>
-  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, U const& identity,
-                                        MaskType mask) const {
-    return Kokkos::Experimental::reduce(a, mask, identity, BinaryOperation());
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a) const {
+    using DataType = typename T::value_type::value_type;
+    return Kokkos::Experimental::reduce(a, DataType(0), std::plus<>());
   }
-  template <typename T, typename U, typename MaskType>
-  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a, U const& identity,
-                                               MaskType mask) const {
-    if (Kokkos::Experimental::none_of(mask)) return identity;
-    auto w        = Kokkos::Experimental::where(mask, a);
-    auto const& v = w.impl_get_value();
-    auto const& m = w.impl_get_mask();
-    auto result   = v[0];
-    for (std::size_t i = 1; i < v.size(); ++i) {
-      if constexpr (std::is_same_v<BinaryOperation, std::plus<>>) {
-        if (m[i]) result = result + v[i];
-      } else if constexpr (std::is_same_v<BinaryOperation, std::multiplies<>>) {
-        if (m[i]) result = result * v[i];
-      } else if constexpr (std::is_same_v<BinaryOperation, std::bit_and<>>) {
-        if (m[i]) result = result & v[i];
-      } else if constexpr (std::is_same_v<BinaryOperation, std::bit_or<>>) {
-        if (m[i]) result = result | v[i];
-      } else if constexpr (std::is_same_v<BinaryOperation, std::bit_xor<>>) {
-        if (m[i]) result = result ^ v[i];
-      } else {
-        Kokkos::abort("Unsupported reduce operation");
-      }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a) const {
+    using DataType = typename T::value_type::value_type;
+
+    auto const& v = a.impl_get_value();
+    auto const& m = a.impl_get_mask();
+    auto result   = Kokkos::reduction_identity<DataType>::sum();
+    for (std::size_t i = 0; i < v.size(); ++i) {
+      if (m[i]) result += v[i];
     }
     return result;
   }

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -29,9 +29,6 @@ void host_check_math_op_one_loader(BinaryOp binary_op, std::size_t n,
   for (std::size_t i = 0; i < n; i += width) {
     std::size_t const nremaining = n - i;
     std::size_t const nlanes     = Kokkos::min(nremaining, width);
-    if ((std::is_same_v<BinaryOp, divides> ||
-         std::is_same_v<BinaryOp, divides_eq>)&&nremaining < width)
-      continue;
     simd_type first_arg;
     bool const loaded_first_arg =
         loader.host_load(first_args + i, nlanes, first_arg);
@@ -47,7 +44,6 @@ void host_check_math_op_one_loader(BinaryOp binary_op, std::size_t n,
         expected_result[lane] =
             binary_op.on_host(T(first_arg[lane]), T(second_arg[lane]));
     }
-    loader.host_load(first_args + i, nlanes, first_arg);
     simd_type const computed_result = binary_op.on_host(first_arg, second_arg);
     host_check_equality(expected_result, computed_result, nlanes);
   }
@@ -94,14 +90,8 @@ template <typename Abi, typename DataType, size_t n>
 inline void host_check_all_math_ops(const DataType (&first_args)[n],
                                     const DataType (&second_args)[n]) {
   host_check_math_op_all_loaders<Abi>(plus(), n, first_args, second_args);
-  host_check_math_op_all_loaders<Abi>(plus_eq(), n, first_args, second_args);
   host_check_math_op_all_loaders<Abi>(minus(), n, first_args, second_args);
-  host_check_math_op_all_loaders<Abi>(minus_eq(), n, first_args, second_args);
   host_check_math_op_all_loaders<Abi>(multiplies(), n, first_args, second_args);
-  host_check_math_op_all_loaders<Abi>(multiplies_eq(), n, first_args,
-                                      second_args);
-  host_check_math_op_all_loaders<Abi>(divides(), n, first_args, second_args);
-  host_check_math_op_all_loaders<Abi>(divides_eq(), n, first_args, second_args);
   host_check_math_op_all_loaders<Abi>(absolutes(), n, first_args);
 
   host_check_math_op_all_loaders<Abi>(floors(), n, first_args);
@@ -111,6 +101,8 @@ inline void host_check_all_math_ops(const DataType (&first_args)[n],
 
   // TODO: Place fallback implementations for all simd integer types
   if constexpr (std::is_floating_point_v<DataType>) {
+    host_check_math_op_all_loaders<Abi>(divides(), n, first_args, second_args);
+
 #if defined(__INTEL_COMPILER) && \
     (defined(KOKKOS_ARCH_AVX2) || defined(KOKKOS_ARCH_AVX512XEON))
     host_check_math_op_all_loaders<Abi>(cbrt_op(), n, first_args);
@@ -184,9 +176,6 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_one_loader(
   for (std::size_t i = 0; i < n; i += width) {
     std::size_t const nremaining = n - i;
     std::size_t const nlanes     = Kokkos::min(nremaining, width);
-    if ((std::is_same_v<BinaryOp, divides> ||
-         std::is_same_v<BinaryOp, divides_eq>)&&nremaining < width)
-      continue;
     simd_type first_arg;
     bool const loaded_first_arg =
         loader.device_load(first_args + i, nlanes, first_arg);
@@ -199,7 +188,6 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_one_loader(
       expected_result[lane] =
           binary_op.on_device(first_arg[lane], second_arg[lane]);
     }
-    loader.device_load(first_args + i, nlanes, first_arg);
     simd_type const computed_result =
         binary_op.on_device(first_arg, second_arg);
     device_check_equality(expected_result, computed_result, nlanes);
@@ -243,15 +231,8 @@ template <typename Abi, typename DataType, size_t n>
 KOKKOS_INLINE_FUNCTION void device_check_all_math_ops(
     const DataType (&first_args)[n], const DataType (&second_args)[n]) {
   device_check_math_op_all_loaders<Abi>(plus(), n, first_args, second_args);
-  device_check_math_op_all_loaders<Abi>(plus_eq(), n, first_args, second_args);
   device_check_math_op_all_loaders<Abi>(minus(), n, first_args, second_args);
-  device_check_math_op_all_loaders<Abi>(minus_eq(), n, first_args, second_args);
   device_check_math_op_all_loaders<Abi>(multiplies(), n, first_args,
-                                        second_args);
-  device_check_math_op_all_loaders<Abi>(multiplies_eq(), n, first_args,
-                                        second_args);
-  device_check_math_op_all_loaders<Abi>(divides(), n, first_args, second_args);
-  device_check_math_op_all_loaders<Abi>(divides_eq(), n, first_args,
                                         second_args);
   device_check_math_op_all_loaders<Abi>(absolutes(), n, first_args);
 
@@ -259,6 +240,11 @@ KOKKOS_INLINE_FUNCTION void device_check_all_math_ops(
   device_check_math_op_all_loaders<Abi>(ceils(), n, first_args);
   device_check_math_op_all_loaders<Abi>(rounds(), n, first_args);
   device_check_math_op_all_loaders<Abi>(truncates(), n, first_args);
+
+  if constexpr (std::is_floating_point_v<DataType>) {
+    device_check_math_op_all_loaders<Abi>(divides(), n, first_args,
+                                          second_args);
+  }
 }
 
 template <typename Abi, typename DataType>

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -36,16 +36,12 @@ inline void host_check_reduction_one_loader(ReductionOp reduce_op,
     if (!loaded_arg) continue;
 
     mask_type mask(false);
-    T identity    = 12;
-    auto expected = reduce_op.on_host_serial(arg, identity, mask);
-    auto computed = reduce_op.on_host(arg, identity, mask);
-    gtest_checker().equality(expected, computed);
-
     for (std::size_t j = 0; j < n; ++j) {
       mask[j] = true;
     }
-    expected = reduce_op.on_host_serial(arg, identity, mask);
-    computed = reduce_op.on_host(arg, identity, mask);
+    auto value    = where(mask, arg);
+    auto expected = reduce_op.on_host_serial(value);
+    auto computed = reduce_op.on_host(value);
 
     gtest_checker().equality(expected, computed);
   }
@@ -62,10 +58,9 @@ inline void host_check_reduction_all_loaders(ReductionOp reduce_op,
 
 template <typename Abi, typename DataType, size_t n>
 inline void host_check_all_reductions(const DataType (&args)[n]) {
-  host_check_reduction_all_loaders<Abi>(reduce_min(), n, args);
-  host_check_reduction_all_loaders<Abi>(reduce_max(), n, args);
-  host_check_reduction_all_loaders<Abi>(reduce<std::plus<>>(), n, args);
-  host_check_reduction_all_loaders<Abi>(reduce<std::multiplies<>>(), n, args);
+  host_check_reduction_all_loaders<Abi>(hmin(), n, args);
+  host_check_reduction_all_loaders<Abi>(hmax(), n, args);
+  host_check_reduction_all_loaders<Abi>(reduce(), n, args);
 }
 
 template <typename Abi, typename DataType>
@@ -114,16 +109,12 @@ KOKKOS_INLINE_FUNCTION void device_check_reduction_one_loader(
     if (!loaded_arg) continue;
 
     mask_type mask(false);
-    T identity    = 12;
-    auto expected = reduce_op.on_device_serial(arg, identity, mask);
-    auto computed = reduce_op.on_device(arg, identity, mask);
-    kokkos_checker().equality(expected, computed);
-
     for (std::size_t j = 0; j < n; ++j) {
       mask[j] = true;
     }
-    expected = reduce_op.on_device_serial(arg, identity, mask);
-    computed = reduce_op.on_device(arg, identity, mask);
+    auto value    = where(mask, arg);
+    auto expected = reduce_op.on_device_serial(value);
+    auto computed = reduce_op.on_device(value);
 
     kokkos_checker().equality(expected, computed);
   }
@@ -141,10 +132,9 @@ KOKKOS_INLINE_FUNCTION void device_check_reduction_all_loaders(
 template <typename Abi, typename DataType, size_t n>
 KOKKOS_INLINE_FUNCTION void device_check_all_reductions(
     const DataType (&args)[n]) {
-  device_check_reduction_all_loaders<Abi>(reduce_min(), n, args);
-  device_check_reduction_all_loaders<Abi>(reduce_max(), n, args);
-  device_check_reduction_all_loaders<Abi>(reduce<std::plus<>>(), n, args);
-  device_check_reduction_all_loaders<Abi>(reduce<std::multiplies<>>(), n, args);
+  device_check_reduction_all_loaders<Abi>(hmin(), n, args);
+  device_check_reduction_all_loaders<Abi>(hmax(), n, args);
+  device_check_reduction_all_loaders<Abi>(reduce(), n, args);
 }
 
 template <typename Abi, typename DataType>

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -43,6 +43,7 @@ inline void host_check_shift_on_one_loader(ShiftOp shift_op,
           shift_op.on_host(value, static_cast<int>(shift_by[i]));
       EXPECT_EQ(value, value);
     }
+
     simd_type const computed_result =
         shift_op.on_host(simd_vals, static_cast<int>(shift_by[i]));
     host_check_equality(expected_result, computed_result, width);
@@ -123,19 +124,13 @@ inline void host_check_shift_ops() {
 
       host_check_shift_op_all_loaders<Abi>(shift_right(), test_vals, shift_by,
                                            num_cases);
-      host_check_shift_op_all_loaders<Abi>(shift_right_eq(), test_vals,
-                                           shift_by, num_cases);
       host_check_shift_op_all_loaders<Abi>(shift_left(), test_vals, shift_by,
-                                           num_cases);
-      host_check_shift_op_all_loaders<Abi>(shift_left_eq(), test_vals, shift_by,
                                            num_cases);
 
       if constexpr (std::is_signed_v<DataType>) {
         for (std::size_t i = 0; i < width; ++i) test_vals[i] *= -1;
         host_check_shift_op_all_loaders<Abi>(shift_right(), test_vals, shift_by,
                                              num_cases);
-        host_check_shift_op_all_loaders<Abi>(shift_right_eq(), test_vals,
-                                             shift_by, num_cases);
       }
     }
   }
@@ -172,10 +167,10 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_on_one_loader(
     simd_type expected_result;
 
     for (std::size_t lane = 0; lane < width; ++lane) {
-      DataType value = simd_vals[lane];
-      expected_result[lane] =
-          shift_op.on_device(value, static_cast<int>(shift_by[i]));
+      expected_result[lane] = shift_op.on_device(DataType(simd_vals[lane]),
+                                                 static_cast<int>(shift_by[i]));
     }
+
     simd_type const computed_result =
         shift_op.on_device(simd_vals, static_cast<int>(shift_by[i]));
     device_check_equality(expected_result, computed_result, width);
@@ -195,9 +190,8 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_by_lanes_on_one_loader(
   simd_type expected_result;
 
   for (std::size_t lane = 0; lane < width; ++lane) {
-    DataType value = simd_vals[lane];
-    expected_result[lane] =
-        shift_op.on_device(value, static_cast<int>(shift_by[lane]));
+    expected_result[lane] = shift_op.on_device(
+        DataType(simd_vals[lane]), static_cast<int>(shift_by[lane]));
   }
   simd_type const computed_result = shift_op.on_device(simd_vals, shift_by);
   device_check_equality(expected_result, computed_result, width);
@@ -251,18 +245,12 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_ops() {
 
       device_check_shift_op_all_loaders<Abi>(shift_right(), test_vals, shift_by,
                                              num_cases);
-      device_check_shift_op_all_loaders<Abi>(shift_right_eq(), test_vals,
-                                             shift_by, num_cases);
       device_check_shift_op_all_loaders<Abi>(shift_left(), test_vals, shift_by,
                                              num_cases);
-      device_check_shift_op_all_loaders<Abi>(shift_left_eq(), test_vals,
-                                             shift_by, num_cases);
 
       if constexpr (std::is_signed_v<DataType>) {
         for (std::size_t i = 0; i < width; ++i) test_vals[i] *= -1;
         device_check_shift_op_all_loaders<Abi>(shift_right(), test_vals,
-                                               shift_by, num_cases);
-        device_check_shift_op_all_loaders<Abi>(shift_right_eq(), test_vals,
                                                shift_by, num_cases);
       }
     }


### PR DESCRIPTION
Testing with AVX512 is currebtly broken and it seems to make sense to revert, add consistent AVX512 testing (see #7477), and fix then again.