### PR TITLE
simd: add compound assignments and update reductions

### DIFF
--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -35,6 +35,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=20 \
             -DKokkos_ENABLE_CUDA=ON \
             -DKokkos_ARCH_HOPPER90=ON \
+            -DKokkos_ARCH_NATIVE=ON \
             -DCMAKE_CXX_EXTENSIONS=OFF \
             -DBUILD_SHARED_LIBS=OFF \
             -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF \

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -217,13 +217,11 @@ using native = ForSpace<Kokkos::DefaultExecutionSpace>;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class T>
-using native_simd KOKKOS_DEPRECATED_WITH_COMMENT(
-    "native_simd is deprecated. Use simd<T> instead") =
+using native_simd KOKKOS_DEPRECATED_WITH_COMMENT("Use simd<T> instead") =
     basic_simd<T, simd_abi::native<T>>;
 template <class T>
 using native_simd_mask KOKKOS_DEPRECATED_WITH_COMMENT(
-    "native_simd_mask is deprecated. Use simd_mask<T> instead") =
-    basic_simd_mask<T, simd_abi::native<T>>;
+    "Use simd_mask<T> instead") = basic_simd_mask<T, simd_abi::native<T>>;
 #endif
 
 template <class T, int N = 0>

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -538,6 +538,11 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
                                gen(std::integral_constant<std::size_t, 2>()),
                                gen(std::integral_constant<std::size_t, 3>()))) {
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
     value_type tmp[size()];
@@ -811,6 +816,11 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
                             gen(std::integral_constant<std::size_t, 1>()),
                             gen(std::integral_constant<std::size_t, 2>()),
                             gen(std::integral_constant<std::size_t, 3>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m128 const& value_in)
       : m_value(value_in) {}
@@ -1074,6 +1084,11 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
                                gen(std::integral_constant<std::size_t, 5>()),
                                gen(std::integral_constant<std::size_t, 6>()),
                                gen(std::integral_constant<std::size_t, 7>()))) {
+  }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256 const& value_in)
@@ -1342,6 +1357,11 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
                                gen(std::integral_constant<std::size_t, 2>()),
                                gen(std::integral_constant<std::size_t, 3>()))) {
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m128i const& value_in)
       : m_value(value_in) {}
@@ -1555,6 +1575,11 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256i const& value_in)
       : m_value(value_in) {}
@@ -1767,6 +1792,11 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
             gen(std::integral_constant<std::size_t, 1>()),
             gen(std::integral_constant<std::size_t, 2>()),
             gen(std::integral_constant<std::size_t, 3>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256i const& value_in)
       : m_value(value_in) {}
@@ -1995,6 +2025,11 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
             gen(std::integral_constant<std::size_t, 1>()),
             gen(std::integral_constant<std::size_t, 2>()),
             gen(std::integral_constant<std::size_t, 3>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
       __m256i const& value_in)
       : m_value(value_in) {}

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -3284,8 +3284,8 @@ class where_expression<
 };
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    std::int32_t
+[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
     hmax(const_where_expression<
          basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
@@ -3311,8 +3311,8 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    std::int32_t
+[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
     hmin(const_where_expression<
          basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
@@ -3360,8 +3360,8 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    std::uint32_t
+[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
     hmax(const_where_expression<
          basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
          basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
@@ -3387,8 +3387,8 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    std::uint32_t
+[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
     hmin(const_where_expression<
          basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
          basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
@@ -3436,8 +3436,8 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    std::int64_t
+[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t
     hmax(const_where_expression<
          basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
          basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
@@ -3461,8 +3461,8 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    std::int64_t
+[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t
     hmin(const_where_expression<
          basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
          basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
@@ -3486,8 +3486,8 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    std::uint64_t
+[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t
     hmax(const_where_expression<
          basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
          basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
@@ -3511,8 +3511,8 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    std::uint64_t
+[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t
     hmin(const_where_expression<
          basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
          basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
@@ -3536,10 +3536,11 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double
-hmax(const_where_expression<
-     basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-     basic_simd<double, simd_abi::avx512_fixed_size<8>>> const& x) {
+[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    double hmax(const_where_expression<
+                basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+                basic_simd<double, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<double>::max();
   }
@@ -3559,10 +3560,11 @@ hmax(const_where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double
-hmin(const_where_expression<
-     basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-     basic_simd<double, simd_abi::avx512_fixed_size<8>>> const& x) {
+[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    double hmin(const_where_expression<
+                basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+                basic_simd<double, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<double>::min();
   }
@@ -3582,10 +3584,11 @@ hmin(const_where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
-hmax(const_where_expression<
-     basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-     basic_simd<float, simd_abi::avx512_fixed_size<8>>> const& x) {
+[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    float hmax(const_where_expression<
+               basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+               basic_simd<float, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<float>::max();
   }
@@ -3606,10 +3609,11 @@ hmax(const_where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
-hmin(const_where_expression<
-     basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-     basic_simd<float, simd_abi::avx512_fixed_size<8>>> const& x) {
+[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    float hmin(const_where_expression<
+               basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+               basic_simd<float, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<float>::min();
   }

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -281,6 +281,11 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
                                gen(std::integral_constant<std::size_t, 6>()),
                                gen(std::integral_constant<std::size_t, 7>()))) {
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
     auto index = _mm512_set1_epi32(i);
@@ -570,6 +575,11 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
                                gen(std::integral_constant<std::size_t, 6>()),
                                gen(std::integral_constant<std::size_t, 7>()))) {
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
     auto index = _mm256_set1_epi32(i);
@@ -844,6 +854,11 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
                            gen(std::integral_constant<std::size_t, 13>()),
                            gen(std::integral_constant<std::size_t, 14>()),
                            gen(std::integral_constant<std::size_t, 15>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
     auto index = _mm512_set1_epi32(i);
@@ -1114,6 +1129,11 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
 // _mm256_cvtsi256_si32 was not added in GCC until 11
@@ -1338,6 +1358,11 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
             gen(std::integral_constant<std::size_t, 13>()),
             gen(std::integral_constant<std::size_t, 14>()),
             gen(std::integral_constant<std::size_t, 15>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
 // _mm512_cvtsi512_si32 was not added in GCC until 11
@@ -1557,6 +1582,11 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
 // _mm256_cvtsi256_si32 was not added in GCC until 11
@@ -1776,6 +1806,11 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
             gen(std::integral_constant<std::size_t, 13>()),
             gen(std::integral_constant<std::size_t, 14>()),
             gen(std::integral_constant<std::size_t, 15>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
 // _mm512_cvtsi512_si32 was not added in GCC until 11
@@ -1985,6 +2020,11 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
       __m512i const& value_in)
       : m_value(value_in) {}
@@ -2197,6 +2237,11 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int64_t, abi_type> const& other)
       : m_value(static_cast<__m512i>(other)) {}
@@ -3238,39 +3283,437 @@ class where_expression<
   }
 };
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t hmax(
-    const_where_expression<
-        basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-        basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    std::int32_t
+    hmax(const_where_expression<
+         basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+         basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<std::int32_t>::max();
+  }
   return _mm512_mask_reduce_max_epi32(
       static_cast<__mmask8>(x.impl_get_mask()),
       _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
 }
+#endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double hmin(
-    const_where_expression<
-        basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-        basic_simd<double, simd_abi::avx512_fixed_size<8>>> const& x) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+        m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::int32_t>::max();
+  }
+  return _mm512_mask_reduce_max_epi32(
+      static_cast<__mmask8>(m),
+      _mm512_castsi256_si512(static_cast<__m256i>(v)));
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    std::int32_t
+    hmin(const_where_expression<
+         basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+         basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<std::int32_t>::min();
+  }
+  return _mm512_mask_reduce_min_epi32(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
+}
+#endif
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+        m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::int32_t>::min();
+  }
+  return _mm512_mask_reduce_min_epi32(
+      static_cast<__mmask8>(m),
+      _mm512_castsi256_si512(static_cast<__m256i>(v)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
+    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
+        m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::int32_t>::max();
+  }
+  return _mm512_mask_reduce_max_epi32(static_cast<__mmask16>(m),
+                                      static_cast<__m512i>(v));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
+    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
+        m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::int32_t>::min();
+  }
+  return _mm512_mask_reduce_min_epi32(static_cast<__mmask16>(m),
+                                      static_cast<__m512i>(v));
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    std::uint32_t
+    hmax(const_where_expression<
+         basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+         basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<std::uint32_t>::max();
+  }
+  return _mm512_mask_reduce_max_epu32(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
+}
+#endif
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+        m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::uint32_t>::max();
+  }
+  return _mm512_mask_reduce_max_epu32(
+      static_cast<__mmask8>(m),
+      _mm512_castsi256_si512(static_cast<__m256i>(v)));
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    std::uint32_t
+    hmin(const_where_expression<
+         basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+         basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<std::uint32_t>::min();
+  }
+  return _mm512_mask_reduce_min_epu32(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castsi256_si512(static_cast<__m256i>(x.impl_get_value())));
+}
+#endif
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+        m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::uint32_t>::min();
+  }
+  return _mm512_mask_reduce_min_epu32(
+      static_cast<__mmask8>(m),
+      _mm512_castsi256_si512(static_cast<__m256i>(v)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& v,
+    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
+        m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::uint32_t>::max();
+  }
+  return _mm512_mask_reduce_max_epu32(static_cast<__mmask16>(m),
+                                      static_cast<__m512i>(v));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& v,
+    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
+        m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::uint32_t>::min();
+  }
+  return _mm512_mask_reduce_min_epu32(static_cast<__mmask16>(m),
+                                      static_cast<__m512i>(v));
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    std::int64_t
+    hmax(const_where_expression<
+         basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+         basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<std::int64_t>::max();
+  }
+  return _mm512_mask_reduce_max_epi64(static_cast<__mmask8>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
+}
+#endif
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce_max(
+    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+        m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::int64_t>::max();
+  }
+  return _mm512_mask_reduce_max_epi64(static_cast<__mmask8>(m),
+                                      static_cast<__m512i>(v));
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    std::int64_t
+    hmin(const_where_expression<
+         basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+         basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<std::int64_t>::min();
+  }
+  return _mm512_mask_reduce_min_epi64(static_cast<__mmask8>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
+}
+#endif
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce_min(
+    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+        m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::int64_t>::min();
+  }
+  return _mm512_mask_reduce_min_epi64(static_cast<__mmask8>(m),
+                                      static_cast<__m512i>(v));
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    std::uint64_t
+    hmax(const_where_expression<
+         basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+         basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<std::uint64_t>::max();
+  }
+  return _mm512_mask_reduce_max_epu64(static_cast<__mmask8>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
+}
+#endif
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce_max(
+    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+        m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::uint64_t>::max();
+  }
+  return _mm512_mask_reduce_max_epu64(static_cast<__mmask8>(m),
+                                      static_cast<__m512i>(v));
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    std::uint64_t
+    hmin(const_where_expression<
+         basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+         basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<std::uint64_t>::min();
+  }
+  return _mm512_mask_reduce_min_epu64(static_cast<__mmask8>(x.impl_get_mask()),
+                                      static_cast<__m512i>(x.impl_get_value()));
+}
+#endif
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce_min(
+    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+        m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<std::uint64_t>::min();
+  }
+  return _mm512_mask_reduce_min_epu64(static_cast<__mmask8>(m),
+                                      static_cast<__m512i>(v));
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double
+hmax(const_where_expression<
+     basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+     basic_simd<double, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<double>::max();
+  }
+  return _mm512_mask_reduce_max_pd(static_cast<__mmask8>(x.impl_get_mask()),
+                                   static_cast<__m512d>(x.impl_get_value()));
+}
+#endif
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_max(
+    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<double>::max();
+  }
+  return _mm512_mask_reduce_max_pd(static_cast<__mmask8>(m),
+                                   static_cast<__m512d>(v));
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double
+hmin(const_where_expression<
+     basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+     basic_simd<double, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<double>::min();
+  }
   return _mm512_mask_reduce_min_pd(static_cast<__mmask8>(x.impl_get_mask()),
                                    static_cast<__m512d>(x.impl_get_value()));
 }
+#endif
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_min(
+    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<double>::min();
+  }
+  return _mm512_mask_reduce_min_pd(static_cast<__mmask8>(m),
+                                   static_cast<__m512d>(v));
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
+hmax(const_where_expression<
+     basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+     basic_simd<float, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<float>::max();
+  }
+  return _mm512_mask_reduce_max_ps(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
+}
+#endif
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
+    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<float>::max();
+  }
+  return _mm512_mask_reduce_max_ps(
+      static_cast<__mmask8>(m), _mm512_castps256_ps512(static_cast<__m256>(v)));
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
+hmin(const_where_expression<
+     basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+     basic_simd<float, simd_abi::avx512_fixed_size<8>>> const& x) {
+  if (none_of(x.impl_get_mask())) {
+    return Kokkos::reduction_identity<float>::min();
+  }
+  return _mm512_mask_reduce_min_ps(
+      static_cast<__mmask8>(x.impl_get_mask()),
+      _mm512_castps256_ps512(static_cast<__m256>(x.impl_get_value())));
+}
+#endif
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
+    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<float>::min();
+  }
+  return _mm512_mask_reduce_min_ps(
+      static_cast<__mmask8>(m), _mm512_castps256_ps512(static_cast<__m256>(v)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
+    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& v,
+    basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<float>::max();
+  }
+  return _mm512_mask_reduce_max_ps(static_cast<__mmask16>(m),
+                                   static_cast<__m512>(v));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
+    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& v,
+    basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& m) noexcept {
+  if (none_of(m)) {
+    return Kokkos::reduction_identity<float>::min();
+  }
+  return _mm512_mask_reduce_min_ps(static_cast<__mmask16>(m),
+                                   static_cast<__m512>(v));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& m,
+    std::int32_t identity, std::plus<>) noexcept {
+  if (none_of(m)) {
+    return identity;
+  }
+  return _mm512_mask_reduce_add_epi32(
+      static_cast<__mmask8>(m),
+      _mm512_castsi256_si512(static_cast<__m256i>(v)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
+    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& m,
+    std::int32_t identity, std::plus<>) noexcept {
+  if (none_of(m)) {
+    return identity;
+  }
+  return _mm512_mask_reduce_add_epi32(static_cast<__mmask16>(m),
+                                      static_cast<__m512i>(v));
+}
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce(
-    const_where_expression<
-        basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-        basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x,
-    std::int64_t, std::plus<>) {
-  return _mm512_mask_reduce_add_epi64(static_cast<__mmask8>(x.impl_get_mask()),
-                                      static_cast<__m512i>(x.impl_get_value()));
+    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& m,
+    std::int64_t identity, std::plus<>) noexcept {
+  if (none_of(m)) {
+    return identity;
+  }
+  return _mm512_mask_reduce_add_epi64(static_cast<__mmask8>(m),
+                                      static_cast<__m512i>(v));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
-    const_where_expression<
-        basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-        basic_simd<double, simd_abi::avx512_fixed_size<8>>> const& x,
-    double, std::plus<>) {
-  return _mm512_mask_reduce_add_pd(static_cast<__mmask8>(x.impl_get_mask()),
-                                   static_cast<__m512d>(x.impl_get_value()));
+    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& m,
+    double identity, std::plus<>) noexcept {
+  if (none_of(m)) {
+    return identity;
+  }
+  return _mm512_mask_reduce_add_pd(static_cast<__mmask8>(m),
+                                   static_cast<__m512d>(v));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
+    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& m,
+    float identity, std::plus<>) noexcept {
+  if (none_of(m)) {
+    return identity;
+  }
+  return _mm512_mask_reduce_add_ps(
+      static_cast<__mmask8>(m), _mm512_castps256_ps512(static_cast<__m256>(v)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
+    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& v,
+    basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& m,
+    float identity, std::plus<>) noexcept {
+  if (none_of(m)) {
+    return identity;
+  }
+  return _mm512_mask_reduce_add_ps(static_cast<__mmask16>(m),
+                                   static_cast<__m512>(v));
 }
 
 }  // namespace Experimental

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -25,6 +25,10 @@ namespace Kokkos {
 
 namespace Experimental {
 
+namespace simd_abi {
+class scalar;
+}
+
 template <class T, class Abi>
 class basic_simd;
 
@@ -135,7 +139,7 @@ template <class T>
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator+(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
     Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] + rhs);
   return Experimental::basic_simd<result_member, Abi>(lhs) +
@@ -144,15 +148,17 @@ template <class T, class U, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator+(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
     U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs + rhs[0]);
   return Experimental::basic_simd<result_member, Abi>(lhs) +
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
-template <class T, class U, class Abi>
-KOKKOS_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator+=(
+template <
+    class T, class U, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator+=(
     basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs + std::forward<U>(rhs);
   return lhs;
@@ -167,7 +173,7 @@ KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator+=(
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator-(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
     Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] - rhs);
   return Experimental::basic_simd<result_member, Abi>(lhs) -
@@ -176,22 +182,24 @@ template <class T, class U, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator-(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
     U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs - rhs[0]);
   return Experimental::basic_simd<result_member, Abi>(lhs) -
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
-template <class T, class U, class Abi>
-KOKKOS_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator-=(
+template <
+    class T, class U, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator-=(
     basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs - std::forward<U>(rhs);
   return lhs;
 }
 
 template <class M, class T, class U>
-KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator-=(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION where_expression<M, T>& operator-=(
     where_expression<M, T>& lhs, U&& rhs) {
   lhs = lhs.value() - std::forward<U>(rhs);
   return lhs;
@@ -199,7 +207,7 @@ KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator-=(
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator*(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
     Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] * rhs);
   return Experimental::basic_simd<result_member, Abi>(lhs) *
@@ -208,30 +216,41 @@ template <class T, class U, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator*(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
     U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs * rhs[0]);
   return Experimental::basic_simd<result_member, Abi>(lhs) *
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
-template <class T, class U, class Abi>
-KOKKOS_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator*=(
+template <
+    class T, class U, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator*=(
     basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs * std::forward<U>(rhs);
   return lhs;
 }
 
 template <class M, class T, class U>
-KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator*=(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION where_expression<M, T>& operator*=(
     where_expression<M, T>& lhs, U&& rhs) {
   lhs = lhs.value() * std::forward<U>(rhs);
   return lhs;
 }
 
+template <class T, class Abi,
+          std::enable_if_t<std::is_integral_v<T>, bool> = false>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
+    Experimental::basic_simd<T, Abi> const& lhs,
+    Experimental::basic_simd<T, Abi> const& rhs) {
+  return Experimental::basic_simd<T, Abi>(
+      [&](std::size_t i) { return lhs[i] / rhs[i]; });
+}
+
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator/(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
     Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] / rhs);
   return Experimental::basic_simd<result_member, Abi>(lhs) /
@@ -240,41 +259,55 @@ template <class T, class U, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto operator/(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
     U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs / rhs[0]);
   return Experimental::basic_simd<result_member, Abi>(lhs) /
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
-template <class T, class U, class Abi>
-KOKKOS_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator/=(
+template <
+    class T, class U, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator/=(
     basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs / std::forward<U>(rhs);
   return lhs;
 }
 
 template <class M, class T, class U>
-KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator/=(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION where_expression<M, T>& operator/=(
     where_expression<M, T>& lhs, U&& rhs) {
   lhs = lhs.value() / std::forward<U>(rhs);
+  return lhs;
+}
+
+template <
+    class T, class U, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator>>=(
+    basic_simd<T, Abi>& lhs, U&& rhs) {
+  lhs = lhs >> std::forward<U>(rhs);
+  return lhs;
+}
+
+template <
+    class T, class U, class Abi,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator<<=(
+    basic_simd<T, Abi>& lhs, U&& rhs) {
+  lhs = lhs << std::forward<U>(rhs);
   return lhs;
 }
 
 // implement mask reductions for type bool to allow generic code to accept
 // both basic_simd<double, Abi> and just double
 
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr bool all_of(bool a) {
-  return a;
-}
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION bool all_of(bool a) { return a; }
 
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr bool any_of(bool a) {
-  return a;
-}
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION bool any_of(bool a) { return a; }
 
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr bool none_of(bool a) {
-  return !a;
-}
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION bool none_of(bool a) { return !a; }
 
 // fallback implementations of reductions across basic_simd_mask:
 
@@ -308,6 +341,51 @@ template <typename T>
     return (rem == 0) ? ceil : floor;
   }
   return Kokkos::round(x);
+}
+
+namespace Impl {
+
+template <class T, class BinaryOperation>
+struct Identity {
+  KOKKOS_FORCEINLINE_FUNCTION
+  operator T() {
+    if constexpr (std::is_same_v<BinaryOperation, std::plus<>>) {
+      return T();
+    } else if constexpr (std::is_same_v<BinaryOperation, std::multiplies<>>) {
+      return T(1);
+    } else if constexpr (std::is_same_v<BinaryOperation, std::bit_and<>>) {
+      return T(~T());
+    } else if constexpr (std::is_same_v<BinaryOperation, std::bit_or<>>) {
+      return T();
+    } else if constexpr (std::is_same_v<BinaryOperation, std::bit_xor<>>) {
+      return T();
+    } else {
+      return T();
+    }
+  }
+};
+
+}  // namespace Impl
+
+// common implementations of host only simd reductions:
+template <class T, class Abi, class BinaryOperation = std::plus<>>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+reduce(const basic_simd<T, Abi>& x, BinaryOperation binary_op = {}) {
+  return reduce(x, basic_simd<T, Abi>::mask_type(true),
+                Impl::Identity<T, BinaryOperation>(), binary_op);
+}
+
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+reduce_min(const basic_simd<T, Abi>& x) noexcept {
+  return reduce_min(x, basic_simd<T, Abi>::mask_type(true));
+}
+
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+reduce_max(const basic_simd<T, Abi>& x) noexcept {
+  auto v = where(true, x);
+  return reduce_max(x, basic_simd<T, Abi>::mask_type(true));
 }
 
 }  // namespace Experimental

--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -38,8 +38,7 @@ class const_where_expression;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <typename T, typename Abi>
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT(
-    "hmin has been deprecated. Please use reduce_min instead")
+[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead")
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
     hmin(const_where_expression<basic_simd_mask<T, Abi>,
                                 basic_simd<T, Abi>> const& x) {
@@ -53,8 +52,7 @@ template <typename T, typename Abi>
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT(
-    "hmax has been deprecated. Please use reduce_max instead")
+[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead")
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
     hmax(const_where_expression<basic_simd_mask<T, Abi>,
                                 basic_simd<T, Abi>> const& x) {

--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -102,8 +102,8 @@ reduce(basic_simd<T, Abi> const& v,
   if (none_of(m)) {
     return identity;
   }
-  auto result = v[0];
-  for (std::size_t i = 1; i < v.size(); ++i) {
+  T result = Impl::Identity<T, BinaryOperation>();
+  for (std::size_t i = 0; i < v.size(); ++i) {
     if (m[i]) result = op(result, v[i]);
   }
   return result;

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -385,6 +385,11 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
     m_value = vsetq_lane_f64(gen(std::integral_constant<std::size_t, 1>()),
                              m_value, 1);
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       float64x2_t const& value_in)
       : m_value(value_in) {}
@@ -626,6 +631,11 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
     m_value = vset_lane_f32(gen(std::integral_constant<std::size_t, 1>()),
                             m_value, 1);
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       float32x2_t const& value_in)
       : m_value(value_in) {}
@@ -860,6 +870,11 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
     m_value = vsetq_lane_f32(gen(std::integral_constant<std::size_t, 3>()),
                              m_value, 3);
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       float32x4_t const& value_in)
       : m_value(value_in) {}
@@ -1093,6 +1108,11 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
     m_value = vset_lane_s32(gen(std::integral_constant<std::size_t, 1>()),
                             m_value, 1);
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       int32x2_t const& value_in)
       : m_value(value_in) {}
@@ -1289,6 +1309,11 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
     m_value = vsetq_lane_s32(gen(std::integral_constant<std::size_t, 3>()),
                              m_value, 3);
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       int32x4_t const& value_in)
       : m_value(value_in) {}
@@ -1483,6 +1508,11 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
     m_value = vsetq_lane_s64(gen(std::integral_constant<std::size_t, 1>()),
                              m_value, 1);
   }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       int64x2_t const& value_in)
       : m_value(value_in) {}
@@ -1673,6 +1703,11 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
                              m_value, 0);
     m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 1>()),
                              m_value, 1);
+  }
+  template <typename FlagType>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      value_type const* ptr, FlagType flag) {
+    copy_from(ptr, flag);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       uint64x2_t const& value_in)
@@ -2494,6 +2529,196 @@ class where_expression<
                       static_cast<uint64x2_t>(m_value)));
   }
 };
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
+// reduce_min(
+//         simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& v,
+//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& m)
+//         noexcept {
+//   return vminv_s32(static_cast<int32x2_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
+// reduce_max(
+//         simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& v,
+//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& m)
+//         noexcept {
+//   return vmaxv_s32(static_cast<int32x2_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
+// reduce(
+//         simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& v,
+//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& m,
+//     std::int32_t identity, std::plus<>) noexcept {
+//   if (none_of(m)) return identity;
+//   return vaddv_s32(static_cast<int32x2_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
+// reduce_min(
+//         simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& v,
+//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& m)
+//         noexcept {
+//   return vminvq_s32(static_cast<int32x4_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
+// reduce_max(
+//         simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& v,
+//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> m) noexcept {
+//   return vmaxvq_s32(static_cast<int32x4_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
+// reduce(
+//         simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& v,
+//         simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& m,
+//     std::int32_t identity, std::plus<>) noexcept {
+//   if (none_of(m)) return identity;
+//   return vaddvq_s32(static_cast<int32x4_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
+// reduce_min(
+//         simd<std::uint32_t, simd_abi::neon_fixed_size<2>> const& v,
+//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>> const& m)
+//         noexcept {
+//   return vminv_u32(static_cast<uint32x2_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
+// reduce_max(
+//         simd<std::uint32_t, simd_abi::neon_fixed_size<2>> const& v,
+//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>> const& m)
+//         noexcept {
+//   return vmaxv_u32(static_cast<uint32x2_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
+// reduce(
+//         simd<std::uint32_t, simd_abi::neon_fixed_size<2>> const& v,
+//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>> const& m,
+//     std::uint32_t identity, std::plus<>) noexcept {
+//   if (none_of(m)) return identity;
+//   return vaddv_u32(static_cast<uint32x2_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
+// reduce_min(
+//         simd<std::uint32_t, simd_abi::neon_fixed_size<4>> const& v,
+//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>> const& m)
+//         noexcept {
+//   return vminvq_u32(static_cast<uint32x4_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
+// reduce_max(
+//         simd<std::uint32_t, simd_abi::neon_fixed_size<4>> const& v,
+//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>> const& m)
+//         noexcept {
+//   return vmaxvq_u32(static_cast<uint32x4_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
+// reduce(
+//         simd<std::uint32_t, simd_abi::neon_fixed_size<4>> const& v,
+//         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>> const& m,
+//     std::uint32_t identity, std::plus<>) noexcept {
+//   if (none_of(m)) return identity;
+//   return vaddvq_u32(static_cast<uint32x4_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t
+// reduce(
+//         simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& v,
+//         simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& m,
+//     std::int64_t identity, std::plus<>) noexcept {
+//   if (none_of(m)) return identity;
+//   return vaddvq_s64(static_cast<int64x2_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t
+// reduce(
+//         simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& v,
+//         simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& m,
+//     std::uint64_t identity, std::plus<>) noexcept {
+//   return vaddvq_u64(static_cast<uint64x2_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double
+// reduce_min(
+//     simd < double, simd_abi::neon_fixed_size < 2 >> const& v,
+//     simd_mask<double, simd_abi::neon_fixed_size<2>> const& m) noexcept {
+//   return vminvq_f64(static_cast<float64x2_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double
+// reduce_max(
+//                            simd<double, simd_abi::neon_fixed_size<2>> const&
+//                            v,
+//     simd_mask<double, simd_abi::neon_fixed_size<2>> const& m) noexcept {
+//   return vmaxvq_f64(static_cast<float64x2_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
+//                            simd<double, simd_abi::neon_fixed_size<2>> const&
+//                            v,
+//     simd_mask<double, simd_abi::neon_fixed_size<2>> const& m,
+//     double identity, std::plus<>) noexcept {
+//   if (none_of(m)) return identity;
+//   return vaddvq_f64(static_cast<float64x2_t>(x.impl_get_value()));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
+// reduce_min(
+//                            simd<float, simd_abi::neon_fixed_size<2>> const&
+//                            v,
+//     simd_mask<float, simd_abi::neon_fixed_size<2>> const& m) noexcept {
+//   return vminv_f32(static_cast<float32x2_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
+// reduce_max(
+//                            simd<float, simd_abi::neon_fixed_size<2>> const&
+//                            v,
+//     simd_mask<float, simd_abi::neon_fixed_size<2>> const& m) noexcept {
+//   return vmaxv_f32(static_cast<float32x2_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
+//                            simd<float, simd_abi::neon_fixed_size<2>> const&
+//                            v,
+//     simd_mask<float, simd_abi::neon_fixed_size<2>> const& m,
+//     float identity, std::plus<>) noexcept {
+//   if (none_of(m)) return identity;
+//   return vaddv_f32(static_cast<float32x2_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
+// reduce_min(
+//                            simd<float, simd_abi::neon_fixed_size<4>> const&
+//                            v,
+//     simd_mask<float, simd_abi::neon_fixed_size<4>> const& m) noexcept {
+//   return vminvq_f32(static_cast<float32x4_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
+// reduce_max(
+//                            simd<float, simd_abi::neon_fixed_size<4>> const&
+//                            const& v
+//     simd_mask<float, simd_abi::neon_fixed_size<4>> const& m) noexcept {
+//   return vmaxvq_f32(static_cast<float32x4_t>(v));
+// }
+
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
+//                            simd<float, simd_abi::neon_fixed_size<4>> const&
+//                            v,
+//     simd_mask<float, simd_abi::neon_fixed_size<4>> const& m,
+//     float identity, std::plus<>) noexcept {
+//   if (none_of(m)) return identity;
+//   return vaddvq_f32(static_cast<float32x4_t>(v));
+// }
 
 }  // namespace Experimental
 }  // namespace Kokkos

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -525,9 +525,10 @@ template <class T>
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class T>
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION T
-hmax(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
-                            basic_simd<T, simd_abi::scalar>> const& x) {
+[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead")
+    KOKKOS_FORCEINLINE_FUNCTION T
+    hmax(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
+                                basic_simd<T, simd_abi::scalar>> const& x) {
   return static_cast<bool>(x.impl_get_mask())
              ? static_cast<T>(x.impl_get_value())
              : Kokkos::reduction_identity<T>::max();
@@ -555,9 +556,10 @@ reduce_max(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class T>
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION T
-hmin(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
-                            basic_simd<T, simd_abi::scalar>> const& x) {
+[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead")
+    KOKKOS_FORCEINLINE_FUNCTION T
+    hmin(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
+                                basic_simd<T, simd_abi::scalar>> const& x) {
   return static_cast<bool>(x.impl_get_mask())
              ? static_cast<T>(x.impl_get_value())
              : Kokkos::reduction_identity<T>::min();

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -379,9 +379,7 @@ template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
 reduce_min(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const&
                x) noexcept {
-  return reduce_min(
-      x, Experimental::basic_simd<T, Experimental::simd_abi::scalar>::mask_type(
-             true));
+  return x[0];
 }
 
 template <class T>
@@ -397,9 +395,7 @@ template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
 reduce_max(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const&
                x) noexcept {
-  return reduce_max(
-      x, Experimental::basic_simd<T, Experimental::simd_abi::scalar>::mask_type(
-             true));
+  return x[0];
 }
 
 template <class T>

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -348,8 +348,8 @@ class reduce_min {
     auto w        = Kokkos::Experimental::where(mask, a);
     auto const& v = w.impl_get_value();
     auto const& m = w.impl_get_mask();
-    auto result   = v[0];
-    for (std::size_t i = 1; i < v.size(); ++i) {
+    auto result   = Kokkos::reduction_identity<U>::min();
+    for (std::size_t i = 0; i < v.size(); ++i) {
       if (m[i]) result = Kokkos::min(result, v[i]);
     }
     return result;
@@ -367,8 +367,8 @@ class reduce_min {
     auto w        = Kokkos::Experimental::where(mask, a);
     auto const& v = w.impl_get_value();
     auto const& m = w.impl_get_mask();
-    auto result   = v[0];
-    for (std::size_t i = 1; i < v.size(); ++i) {
+    auto result   = Kokkos::reduction_identity<U>::min();
+    for (std::size_t i = 0; i < v.size(); ++i) {
       if (m[i]) result = Kokkos::min(result, v[i]);
     }
     return result;
@@ -388,8 +388,8 @@ class reduce_max {
     auto w        = Kokkos::Experimental::where(mask, a);
     auto const& v = w.impl_get_value();
     auto const& m = w.impl_get_mask();
-    auto result   = v[0];
-    for (std::size_t i = 1; i < v.size(); ++i) {
+    auto result   = Kokkos::reduction_identity<U>::max();
+    for (std::size_t i = 0; i < v.size(); ++i) {
       if (m[i]) result = Kokkos::max(result, v[i]);
     }
     return result;
@@ -407,8 +407,8 @@ class reduce_max {
     auto w        = Kokkos::Experimental::where(mask, a);
     auto const& v = w.impl_get_value();
     auto const& m = w.impl_get_mask();
-    auto result   = v[0];
-    for (std::size_t i = 1; i < v.size(); ++i) {
+    auto result   = Kokkos::reduction_identity<U>::max();
+    for (std::size_t i = 0; i < v.size(); ++i) {
       if (m[i]) result = Kokkos::max(result, v[i]);
     }
     return result;
@@ -428,8 +428,8 @@ class reduce {
     auto w        = Kokkos::Experimental::where(mask, a);
     auto const& v = w.impl_get_value();
     auto const& m = w.impl_get_mask();
-    auto result   = v[0];
-    for (std::size_t i = 1; i < v.size(); ++i) {
+    U result      = Kokkos::Experimental::Impl::Identity<U, BinaryOperation>();
+    for (std::size_t i = 0; i < v.size(); ++i) {
       if (m[i]) result = BinaryOperation()(result, v[i]);
     }
     return result;
@@ -447,8 +447,9 @@ class reduce {
     auto w        = Kokkos::Experimental::where(mask, a);
     auto const& v = w.impl_get_value();
     auto const& m = w.impl_get_mask();
-    auto result   = v[0];
-    for (std::size_t i = 1; i < v.size(); ++i) {
+    U result      = Kokkos::Experimental::Impl::Identity<U, BinaryOperation>();
+    ;
+    for (std::size_t i = 0; i < v.size(); ++i) {
       if constexpr (std::is_same_v<BinaryOperation, std::plus<>>) {
         if (m[i]) result = result + v[i];
       } else if constexpr (std::is_same_v<BinaryOperation, std::multiplies<>>) {

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -31,6 +31,18 @@ class plus {
   }
 };
 
+class plus_eq {
+ public:
+  template <class T>
+  auto on_host(T&& a, T&& b) const {
+    return a += b;
+  }
+  template <class T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T&& a, T&& b) const {
+    return a += b;
+  }
+};
+
 class minus {
  public:
   template <class T>
@@ -40,6 +52,18 @@ class minus {
   template <class T>
   KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
     return a - b;
+  }
+};
+
+class minus_eq {
+ public:
+  template <class T>
+  auto on_host(T&& a, T&& b) const {
+    return a -= b;
+  }
+  template <class T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T&& a, T&& b) const {
+    return a -= b;
   }
 };
 
@@ -55,6 +79,18 @@ class multiplies {
   }
 };
 
+class multiplies_eq {
+ public:
+  template <class T>
+  auto on_host(T&& a, T&& b) const {
+    return a *= b;
+  }
+  template <class T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T&& a, T&& b) const {
+    return a *= b;
+  }
+};
+
 class divides {
  public:
   template <class T>
@@ -64,6 +100,18 @@ class divides {
   template <class T>
   KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
     return a / b;
+  }
+};
+
+class divides_eq {
+ public:
+  template <class T>
+  auto on_host(T&& a, T&& b) const {
+    return a /= b;
+  }
+  template <class T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T&& a, T&& b) const {
+    return a /= b;
   }
 };
 
@@ -203,6 +251,18 @@ class shift_right {
   }
 };
 
+class shift_right_eq {
+ public:
+  template <typename T, typename U>
+  auto on_host(T&& a, U&& b) const {
+    return a >>= b;
+  }
+  template <typename T, typename U>
+  KOKKOS_INLINE_FUNCTION auto on_device(T&& a, U&& b) const {
+    return a >>= b;
+  }
+};
+
 class shift_left {
  public:
   template <typename T, typename U>
@@ -212,6 +272,18 @@ class shift_left {
   template <typename T, typename U>
   KOKKOS_INLINE_FUNCTION auto on_device(T&& a, U&& b) const {
     return a << b;
+  }
+};
+
+class shift_left_eq {
+ public:
+  template <typename T, typename U>
+  auto on_host(T&& a, U&& b) const {
+    return a <<= b;
+  }
+  template <typename T, typename U>
+  KOKKOS_INLINE_FUNCTION auto on_device(T&& a, U&& b) const {
+    return a <<= b;
   }
 };
 
@@ -263,114 +335,133 @@ class log_op {
   }
 };
 
-class hmin {
+class reduce_min {
  public:
-  template <typename T>
-  auto on_host(T const& a) const {
-    return Kokkos::Experimental::hmin(a);
+  template <typename T, typename U, typename MaskType>
+  auto on_host(T const& a, U, MaskType mask) const {
+    return Kokkos::Experimental::reduce_min(a, mask);
   }
-  template <typename T>
-  auto on_host_serial(T const& a) const {
-    using DataType = typename T::value_type::value_type;
-
-    auto const& v = a.impl_get_value();
-    auto const& m = a.impl_get_mask();
-    auto result   = Kokkos::reduction_identity<DataType>::min();
-    for (std::size_t i = 0; i < v.size(); ++i) {
+  template <typename T, typename U, typename MaskType>
+  auto on_host_serial(T const& a, U, MaskType mask) const {
+    if (Kokkos::Experimental::none_of(mask))
+      return Kokkos::reduction_identity<U>::min();
+    auto w        = Kokkos::Experimental::where(mask, a);
+    auto const& v = w.impl_get_value();
+    auto const& m = w.impl_get_mask();
+    auto result   = v[0];
+    for (std::size_t i = 1; i < v.size(); ++i) {
       if (m[i]) result = Kokkos::min(result, v[i]);
     }
     return result;
   }
 
-  template <typename T>
-  KOKKOS_INLINE_FUNCTION auto on_device(T const& a) const {
-    return Kokkos::Experimental::hmin(a);
+  template <typename T, typename U, typename MaskType>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, U, MaskType mask) const {
+    return Kokkos::Experimental::reduce_min(a, mask);
   }
-  template <typename T>
-  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a) const {
-    using DataType = typename T::value_type::value_type;
-
-    auto const& v = a.impl_get_value();
-    auto const& m = a.impl_get_mask();
-    auto result   = Kokkos::reduction_identity<DataType>::min();
-    for (std::size_t i = 0; i < v.size(); ++i) {
+  template <typename T, typename U, typename MaskType>
+  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a, U,
+                                               MaskType mask) const {
+    if (Kokkos::Experimental::none_of(mask))
+      return Kokkos::reduction_identity<U>::min();
+    auto w        = Kokkos::Experimental::where(mask, a);
+    auto const& v = w.impl_get_value();
+    auto const& m = w.impl_get_mask();
+    auto result   = v[0];
+    for (std::size_t i = 1; i < v.size(); ++i) {
       if (m[i]) result = Kokkos::min(result, v[i]);
     }
     return result;
   }
 };
 
-class hmax {
+class reduce_max {
  public:
-  template <typename T>
-  auto on_host(T const& a) const {
-    return Kokkos::Experimental::hmax(a);
+  template <typename T, typename U, typename MaskType>
+  auto on_host(T const& a, U, MaskType mask) const {
+    return Kokkos::Experimental::reduce_max(a, mask);
   }
-  template <typename T>
-  auto on_host_serial(T const& a) const {
-    using DataType = typename T::value_type::value_type;
-
-    auto const& v = a.impl_get_value();
-    auto const& m = a.impl_get_mask();
-    auto result   = Kokkos::reduction_identity<DataType>::max();
-    for (std::size_t i = 0; i < v.size(); ++i) {
+  template <typename T, typename U, typename MaskType>
+  auto on_host_serial(T const& a, U, MaskType mask) const {
+    if (Kokkos::Experimental::none_of(mask))
+      return Kokkos::reduction_identity<U>::max();
+    auto w        = Kokkos::Experimental::where(mask, a);
+    auto const& v = w.impl_get_value();
+    auto const& m = w.impl_get_mask();
+    auto result   = v[0];
+    for (std::size_t i = 1; i < v.size(); ++i) {
       if (m[i]) result = Kokkos::max(result, v[i]);
     }
     return result;
   }
 
-  template <typename T>
-  KOKKOS_INLINE_FUNCTION auto on_device(T const& a) const {
-    return Kokkos::Experimental::hmax(a);
+  template <typename T, typename U, typename MaskType>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, U, MaskType mask) const {
+    return Kokkos::Experimental::reduce_max(a, mask);
   }
-  template <typename T>
-  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a) const {
-    using DataType = typename T::value_type::value_type;
-
-    auto const& v = a.impl_get_value();
-    auto const& m = a.impl_get_mask();
-    auto result   = Kokkos::reduction_identity<DataType>::max();
-    for (std::size_t i = 0; i < v.size(); ++i) {
+  template <typename T, typename U, typename MaskType>
+  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a, U,
+                                               MaskType mask) const {
+    if (Kokkos::Experimental::none_of(mask))
+      return Kokkos::reduction_identity<U>::max();
+    auto w        = Kokkos::Experimental::where(mask, a);
+    auto const& v = w.impl_get_value();
+    auto const& m = w.impl_get_mask();
+    auto result   = v[0];
+    for (std::size_t i = 1; i < v.size(); ++i) {
       if (m[i]) result = Kokkos::max(result, v[i]);
     }
     return result;
   }
 };
 
+template <typename BinaryOperation = std::plus<>>
 class reduce {
  public:
-  template <typename T>
-  auto on_host(T const& a) const {
-    using DataType = typename T::value_type::value_type;
-    return Kokkos::Experimental::reduce(a, DataType(0), std::plus<>());
+  template <typename T, typename U, typename MaskType>
+  auto on_host(T const& a, U const& identity, MaskType mask) const {
+    return Kokkos::Experimental::reduce(a, mask, identity, BinaryOperation());
   }
-  template <typename T>
-  auto on_host_serial(T const& a) const {
-    using DataType = typename T::value_type::value_type;
-
-    auto const& v = a.impl_get_value();
-    auto const& m = a.impl_get_mask();
-    auto result   = Kokkos::reduction_identity<DataType>::sum();
-    for (std::size_t i = 0; i < v.size(); ++i) {
-      if (m[i]) result += v[i];
+  template <typename T, typename U, typename MaskType>
+  auto on_host_serial(T const& a, U const& identity, MaskType mask) const {
+    if (Kokkos::Experimental::none_of(mask)) return identity;
+    auto w        = Kokkos::Experimental::where(mask, a);
+    auto const& v = w.impl_get_value();
+    auto const& m = w.impl_get_mask();
+    auto result   = v[0];
+    for (std::size_t i = 1; i < v.size(); ++i) {
+      if (m[i]) result = BinaryOperation()(result, v[i]);
     }
     return result;
   }
 
-  template <typename T>
-  KOKKOS_INLINE_FUNCTION auto on_device(T const& a) const {
-    using DataType = typename T::value_type::value_type;
-    return Kokkos::Experimental::reduce(a, DataType(0), std::plus<>());
+  template <typename T, typename U, typename MaskType>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, U const& identity,
+                                        MaskType mask) const {
+    return Kokkos::Experimental::reduce(a, mask, identity, BinaryOperation());
   }
-  template <typename T>
-  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a) const {
-    using DataType = typename T::value_type::value_type;
-
-    auto const& v = a.impl_get_value();
-    auto const& m = a.impl_get_mask();
-    auto result   = Kokkos::reduction_identity<DataType>::sum();
-    for (std::size_t i = 0; i < v.size(); ++i) {
-      if (m[i]) result += v[i];
+  template <typename T, typename U, typename MaskType>
+  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a, U const& identity,
+                                               MaskType mask) const {
+    if (Kokkos::Experimental::none_of(mask)) return identity;
+    auto w        = Kokkos::Experimental::where(mask, a);
+    auto const& v = w.impl_get_value();
+    auto const& m = w.impl_get_mask();
+    auto result   = v[0];
+    for (std::size_t i = 1; i < v.size(); ++i) {
+      if constexpr (std::is_same_v<BinaryOperation, std::plus<>>) {
+        if (m[i]) result = result + v[i];
+      } else if constexpr (std::is_same_v<BinaryOperation, std::multiplies<>>) {
+        if (m[i]) result = result * v[i];
+      } else if constexpr (std::is_same_v<BinaryOperation, std::bit_and<>>) {
+        if (m[i]) result = result & v[i];
+      } else if constexpr (std::is_same_v<BinaryOperation, std::bit_or<>>) {
+        if (m[i]) result = result | v[i];
+      } else if constexpr (std::is_same_v<BinaryOperation, std::bit_xor<>>) {
+        if (m[i]) result = result ^ v[i];
+      } else {
+        Kokkos::abort("Unsupported reduce operation");
+      }
     }
     return result;
   }

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -448,7 +448,6 @@ class reduce {
     auto const& v = w.impl_get_value();
     auto const& m = w.impl_get_mask();
     U result      = Kokkos::Experimental::Impl::Identity<U, BinaryOperation>();
-    ;
     for (std::size_t i = 0; i < v.size(); ++i) {
       if constexpr (std::is_same_v<BinaryOperation, std::plus<>>) {
         if (m[i]) result = result + v[i];

--- a/simd/unit_tests/include/TestSIMD_Construction.hpp
+++ b/simd/unit_tests/include/TestSIMD_Construction.hpp
@@ -49,7 +49,8 @@ inline void host_test_mask_traits() {
   static_assert(std::is_nothrow_move_assignable_v<mask_type>);
   static_assert(std::is_nothrow_move_constructible_v<mask_type>);
 
-  mask_type default_mask, result;
+  mask_type default_mask(false);
+  mask_type result(false);
   mask_type test_mask(KOKKOS_LAMBDA(std::size_t i) { return (i % 2 == 0); });
   mask_type copy_mask(test_mask);
   mask_type move_mask(std::move(copy_mask));
@@ -125,7 +126,8 @@ template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_test_mask_traits() {
   using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
 
-  mask_type default_mask, result;
+  mask_type default_mask(false);
+  mask_type result(false);
   mask_type test_mask(KOKKOS_LAMBDA(std::size_t i) { return (i % 2 == 0); });
   mask_type copy_mask(test_mask);
   mask_type move_mask(std::move(copy_mask));

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -37,19 +37,29 @@ inline void host_check_reduction_one_loader(ReductionOp reduce_op,
     if (!loaded_arg) continue;
 
     if constexpr (std::is_same_v<Abi, Kokkos::Experimental::simd_abi::scalar>) {
+      mask_type mask_false(false);
+      T identity    = 12;
+      auto expected = reduce_op.on_host_serial(arg, identity, mask_false);
+      auto computed = reduce_op.on_host(arg, identity, mask_false);
+      gtest_checker().equality(expected, computed);
+
       mask_type mask(KOKKOS_LAMBDA(std::size_t j) { return j < nlanes; });
 
-      auto value    = where(mask, arg);
-      auto expected = reduce_op.on_host_serial(value);
-      auto computed = reduce_op.on_host(value);
+      expected = reduce_op.on_host_serial(arg, identity, mask);
+      computed = reduce_op.on_host(arg, identity, mask);
 
       gtest_checker().equality(expected, computed);
     } else {
+      mask_type mask_false(false);
+      T identity    = 12;
+      auto expected = reduce_op.on_host_serial(arg, identity, mask_false);
+      auto computed = reduce_op.on_host(arg, identity, mask_false);
+      gtest_checker().equality(expected, computed);
+
       mask_type mask([=](std::size_t j) { return j < nlanes; });
 
-      auto value    = where(mask, arg);
-      auto expected = reduce_op.on_host_serial(value);
-      auto computed = reduce_op.on_host(value);
+      expected = reduce_op.on_host_serial(arg, identity, mask);
+      computed = reduce_op.on_host(arg, identity, mask);
 
       gtest_checker().equality(expected, computed);
     }
@@ -67,9 +77,10 @@ inline void host_check_reduction_all_loaders(ReductionOp reduce_op,
 
 template <typename Abi, typename DataType, size_t n>
 inline void host_check_all_reductions(const DataType (&args)[n]) {
-  host_check_reduction_all_loaders<Abi>(hmin(), n, args);
-  host_check_reduction_all_loaders<Abi>(hmax(), n, args);
-  host_check_reduction_all_loaders<Abi>(reduce(), n, args);
+  host_check_reduction_all_loaders<Abi>(reduce_min(), n, args);
+  host_check_reduction_all_loaders<Abi>(reduce_max(), n, args);
+  host_check_reduction_all_loaders<Abi>(reduce<std::plus<>>(), n, args);
+  host_check_reduction_all_loaders<Abi>(reduce<std::multiplies<>>(), n, args);
 }
 
 template <typename Abi, typename DataType>
@@ -118,12 +129,15 @@ KOKKOS_INLINE_FUNCTION void device_check_reduction_one_loader(
     bool const loaded_arg = loader.device_load(args + i, nlanes, arg);
     if (!loaded_arg) continue;
 
+    mask_type mask_false(false);
+    T identity    = 12;
+    auto expected = reduce_op.on_device_serial(arg, identity, mask_false);
+    auto computed = reduce_op.on_device(arg, identity, mask_false);
+    kokkos_checker().equality(expected, computed);
+
     mask_type mask(KOKKOS_LAMBDA(std::size_t j) { return j < nlanes; });
-
-    auto value    = where(mask, arg);
-    auto expected = reduce_op.on_device_serial(value);
-    auto computed = reduce_op.on_device(value);
-
+    expected = reduce_op.on_device_serial(arg, identity, mask);
+    computed = reduce_op.on_device(arg, identity, mask);
     kokkos_checker().equality(expected, computed);
   }
 }
@@ -140,9 +154,10 @@ KOKKOS_INLINE_FUNCTION void device_check_reduction_all_loaders(
 template <typename Abi, typename DataType, size_t n>
 KOKKOS_INLINE_FUNCTION void device_check_all_reductions(
     const DataType (&args)[n]) {
-  device_check_reduction_all_loaders<Abi>(hmin(), n, args);
-  device_check_reduction_all_loaders<Abi>(hmax(), n, args);
-  device_check_reduction_all_loaders<Abi>(reduce(), n, args);
+  device_check_reduction_all_loaders<Abi>(reduce_min(), n, args);
+  device_check_reduction_all_loaders<Abi>(reduce_max(), n, args);
+  device_check_reduction_all_loaders<Abi>(reduce<std::plus<>>(), n, args);
+  device_check_reduction_all_loaders<Abi>(reduce<std::multiplies<>>(), n, args);
 }
 
 template <typename Abi, typename DataType>

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -43,10 +43,9 @@ inline void host_check_reduction_one_loader(ReductionOp reduce_op,
       auto computed = reduce_op.on_host(arg, identity, mask_false);
       gtest_checker().equality(expected, computed);
 
-      mask_type mask(KOKKOS_LAMBDA(std::size_t j) { return j < nlanes; });
-
-      expected = reduce_op.on_host_serial(arg, identity, mask);
-      computed = reduce_op.on_host(arg, identity, mask);
+      mask_type mask_true(true);
+      expected = reduce_op.on_host_serial(arg, identity, mask_true);
+      computed = reduce_op.on_host(arg, identity, mask_true);
 
       gtest_checker().equality(expected, computed);
     } else {
@@ -56,12 +55,12 @@ inline void host_check_reduction_one_loader(ReductionOp reduce_op,
       auto computed = reduce_op.on_host(arg, identity, mask_false);
       gtest_checker().equality(expected, computed);
 
-      mask_type mask([=](std::size_t j) { return j < nlanes; });
-
-      expected = reduce_op.on_host_serial(arg, identity, mask);
-      computed = reduce_op.on_host(arg, identity, mask);
-
-      gtest_checker().equality(expected, computed);
+      for (std::size_t j = 0; j < mask_type::size(); ++j) {
+        mask_type mask([=](std::size_t idx) { return idx >= j; });
+        expected = reduce_op.on_host_serial(arg, identity, mask);
+        computed = reduce_op.on_host(arg, identity, mask);
+        gtest_checker().equality(expected, computed);
+      }
     }
   }
 }
@@ -135,10 +134,12 @@ KOKKOS_INLINE_FUNCTION void device_check_reduction_one_loader(
     auto computed = reduce_op.on_device(arg, identity, mask_false);
     kokkos_checker().equality(expected, computed);
 
-    mask_type mask(KOKKOS_LAMBDA(std::size_t j) { return j < nlanes; });
-    expected = reduce_op.on_device_serial(arg, identity, mask);
-    computed = reduce_op.on_device(arg, identity, mask);
-    kokkos_checker().equality(expected, computed);
+    for (std::size_t j = 0; j < mask_type::size(); ++j) {
+      mask_type mask(KOKKOS_LAMBDA(std::size_t idx) { return idx >= j; });
+      expected = reduce_op.on_device_serial(arg, identity, mask);
+      computed = reduce_op.on_device(arg, identity, mask);
+      kokkos_checker().equality(expected, computed);
+    }
   }
 }
 

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -48,14 +48,6 @@ inline void host_check_shift_on_one_loader(ShiftOp shift_op,
     simd_type const computed_result =
         shift_op.on_host(simd_vals, static_cast<int>(shift_by[i]));
 
-    // gcc build with cxxflag of -g and -O2 or above doesn't seem to properly
-    // load values into simd vectors until simd values are directly accessed.
-    // Placing a memory fence to ensure that simd values are fully loaded
-    // before executing simd instructions.
-#if defined(KOKKOS_COMPILER_GNU) && defined(NDEBUG)
-    __sync_synchronize();
-#endif
-
     host_check_equality(expected_result, computed_result, width);
   }
 }
@@ -83,14 +75,6 @@ inline void host_check_shift_by_lanes_on_one_loader(
                             Kokkos::Experimental::simd_flag_default);
 
   simd_type const computed_result = shift_op.on_host(simd_vals, shift_by);
-
-  // gcc build with cxxflag of -g and -O2 or above doesn't seem to properly
-  // load values into simd vectors until simd values are directly accessed.
-  // Placing a memory fence to ensure that simd values are fully loaded
-  // before executing simd instructions.
-#if defined(KOKKOS_COMPILER_GNU) && defined(NDEBUG)
-  __sync_synchronize();
-#endif
 
   host_check_equality(expected_result, computed_result, width);
 }

--- a/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
+++ b/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
@@ -33,6 +33,14 @@ inline void host_check_where_expr_scatter_to() {
     simd_type src;
     src.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
+    // gcc build with cxxflag of -g and -O2 or above doesn't seem to properly
+    // load values into simd vectors until simd values are directly accessed.
+    // Placing a memory fence to ensure that simd values are fully loaded
+    // before executing simd instructions.
+#if defined(KOKKOS_COMPILER_GNU) && defined(NDEBUG)
+    __sync_synchronize();
+#endif
+
     for (std::size_t idx = 0; idx < nlanes; ++idx) {
       if constexpr (std::is_same_v<Abi,
                                    Kokkos::Experimental::simd_abi::scalar>) {

--- a/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
+++ b/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
@@ -33,14 +33,6 @@ inline void host_check_where_expr_scatter_to() {
     simd_type src;
     src.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
-    // gcc build with cxxflag of -g and -O2 or above doesn't seem to properly
-    // load values into simd vectors until simd values are directly accessed.
-    // Placing a memory fence to ensure that simd values are fully loaded
-    // before executing simd instructions.
-#if defined(KOKKOS_COMPILER_GNU) && defined(NDEBUG)
-    __sync_synchronize();
-#endif
-
     for (std::size_t idx = 0; idx < nlanes; ++idx) {
       if constexpr (std::is_same_v<Abi,
                                    Kokkos::Experimental::simd_abi::scalar>) {


### PR DESCRIPTION
This is a clone of a reverted PR: #6683.

Descriptions from the original PR:

This PR adds following functions described in P1928

- Compound assignments
    - `simd<T, Abi>& operator/=(simd<T, Abi>& lhs, U&& rhs)` (enabled)
    - `simd<T, Abi>& operator>>=(simd<T, Abi>& lhs, U&& rhs)` (added)
    - `simd<T, Abi>& operator<<=(simd<T, Abi>& lhs, U&& rhs)` (added)

- Constructor that accepts a pointer to the src memory
    - `constexpr explicit simd(value_type const* ptr, FlagType flag)`

- Fallback simd reducers
    - `T reduce(const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask, T identity_element, BinaryOperation binary_op)`
    - `T reduce(const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask, std::plus<> binary_op = {}) noexcept`
    - `T reduce(const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask, std::bit_and<> binary_op) noexcept`
    - `T reduce(const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask, std::bit_or<> binary_op) noexcept`
    - `T reduce(const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask, std::bit_xor<> binary_op) noexcept`
    - `T reduce_min(const simd<T, Abi>& x) noexcept`
    - `T reduce_min(const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask) noexcept`
    - `T reduce_max(const simd<T, Abi>& x) noexcept`
    - `T reduce_max(const simd<T, Abi>& x, const typename simd<T, Abi>::mask_type& mask) noexcept`

- `Max`, `Min`, `Sum` reducers for AVX512
    - `T reduce_min(const simd<T, Abi>& x)`
    - `T reduce_max(const simd<T, Abi>& x)`
    - `T reduce(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x, T, std::plus<>)`

- Deprecated `hmin` and `hmax` in favor of `reduce_min` and `reduce_max`