### PR TITLE
 Fix compiling with recent clang 

### DIFF
--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -340,22 +340,26 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), repeat_chain) {
     GTEST_SKIP() << "The graph requires the reduction targets like 'bugs_host' "
                     "to be accessible by the execution space.";
   } else {
-    auto graph = Kokkos::Experimental::create_graph(
-        ex, [&, count_host = count_host](auto root) {
-          // FIXME_CLANG Recent clang versions would still trigger a similar
-          // static_assert without the additional if constexpr
-          if constexpr (!result_not_accessible_by_exec) {
-            //----------------------------------------
-            root.then_parallel_for(1, set_functor{count, 0})
-                .then_parallel_for(1, count_functor{count, bugs, 0, 0})
-                .then_parallel_for(1, count_functor{count, bugs, 1, 1})
-                .then_parallel_reduce(1, set_result_functor{count}, count_host)
-                .then_parallel_reduce(
-                    1, set_result_functor{bugs},
-                    Kokkos::Sum<int, Kokkos::HostSpace>{bugs_host});
-            //----------------------------------------
-          }
-        });
+    auto graph = Kokkos::Experimental::create_graph(ex, [&, count_host =
+                                                                count_host](
+                                                            auto root) {
+      // FIXME_CLANG Recent clang versions would still trigger a similar
+      // static_assert without the additional if constexpr
+      constexpr bool result_not_accessible_by_exec_copy =
+          !Kokkos::SpaceAccessibility<
+              TEST_EXECSPACE, decltype(bugs_host)::memory_space>::accessible;
+      if constexpr (!result_not_accessible_by_exec_copy) {
+        //----------------------------------------
+        root.then_parallel_for(1, set_functor{count, 0})
+            .then_parallel_for(1, count_functor{count, bugs, 0, 0})
+            .then_parallel_for(1, count_functor{count, bugs, 1, 1})
+            .then_parallel_reduce(1, set_result_functor{count}, count_host)
+            .then_parallel_reduce(
+                1, set_result_functor{bugs},
+                Kokkos::Sum<int, Kokkos::HostSpace>{bugs_host});
+        //----------------------------------------
+      }
+    });
 
     //----------------------------------------
     constexpr int repeats = 10;


### PR DESCRIPTION
With a preview of oneAPI 2025.0.0, I am seeing the following on the Aurora testbeds:
```
In file included from /home/darndt/kokkos_new/build/core/unit_test/sycl/TestSYCL_Graph.cpp:2:
In file included from /home/darndt/kokkos_new/core/unit_test/TestGraph.hpp:18:
In file included from /home/darndt/kokkos_new/core/src/Kokkos_Graph.hpp:216:
/home/darndt/kokkos_new/core/src/Kokkos_GraphNode.hpp:371:11: error: static assertion failed due to requirement 'Kokkos::SpaceAccessibility<Kokkos::SYCL, Kokkos::HostSpace>::accessible': The reduction target must be accessible by the graph execution space.
  371 |           Kokkos::SpaceAccessibility<
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~
  372 |               ExecutionSpace,
      |               ~~~~~~~~~~~~~~~
  373 |               typename return_type_remove_cvref::memory_space>::accessible,
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/darndt/kokkos_new/core/src/Kokkos_GraphNode.hpp:442:18: note: in instantiation of function template specialization 'Kokkos::Experimental::GraphNodeRef<Kokkos::SYCL, Kokkos::Impl::GraphNodeKernelImpl<Kokkos::SYCL, Kokkos::RangePolicy<Kokkos::SYCL, Kokkos::Impl::IsGraphKernelTag>, Test::CountTestFunctor<Kokkos::SYCL>, Kokkos::ParallelForTag>, Kokkos::Experimental::GraphNodeRef<Kokkos::SYCL, Kokkos::Impl::GraphNodeKernelImpl<Kokkos::SYCL, Kokkos::RangePolicy<Kokkos::SYCL, Kokkos::Impl::IsGraphKernelTag>, Test::CountTestFunctor<Kokkos::SYCL>, Kokkos::ParallelForTag>, Kokkos::Experimental::GraphNodeRef<Kokkos::SYCL, Kokkos::Impl::GraphNodeKernelImpl<Kokkos::SYCL, Kokkos::RangePolicy<Kokkos::SYCL, Kokkos::Impl::IsGraphKernelTag>, Test::SetViewToValueFunctor<Kokkos::SYCL, int>, Kokkos::ParallelForTag>, Kokkos::Experimental::GraphNodeRef<Kokkos::SYCL>>>>::then_parallel_reduce<Kokkos::RangePolicy<Kokkos::SYCL>, Test::SetResultToViewFunctor<Kokkos::SYCL, int>, const Kokkos::View<int, Kokkos::HostSpace> &, 0>' requested here
  442 |     return this->then_parallel_reduce(
      |                  ^
/home/darndt/kokkos_new/core/src/Kokkos_GraphNode.hpp:451:18: note: in instantiation of function template specialization 'Kokkos::Experimental::GraphNodeRef<Kokkos::SYCL, Kokkos::Impl::GraphNodeKernelImpl<Kokkos::SYCL, Kokkos::RangePolicy<Kokkos::SYCL, Kokkos::Impl::IsGraphKernelTag>, Test::CountTestFunctor<Kokkos::SYCL>, Kokkos::ParallelForTag>, Kokkos::Experimental::GraphNodeRef<Kokkos::SYCL, Kokkos::Impl::GraphNodeKernelImpl<Kokkos::SYCL, Kokkos::RangePolicy<Kokkos::SYCL, Kokkos::Impl::IsGraphKernelTag>, Test::CountTestFunctor<Kokkos::SYCL>, Kokkos::ParallelForTag>, Kokkos::Experimental::GraphNodeRef<Kokkos::SYCL, Kokkos::Impl::GraphNodeKernelImpl<Kokkos::SYCL, Kokkos::RangePolicy<Kokkos::SYCL, Kokkos::Impl::IsGraphKernelTag>, Test::SetViewToValueFunctor<Kokkos::SYCL, int>, Kokkos::ParallelForTag>, Kokkos::Experimental::GraphNodeRef<Kokkos::SYCL>>>>::then_parallel_reduce<Test::SetResultToViewFunctor<Kokkos::SYCL, int>, const Kokkos::View<int, Kokkos::HostSpace> &>' requested here
  451 |     return this->then_parallel_reduce("", idx_end, (Functor&&)functor,
      |                  ^
/home/darndt/kokkos_new/core/unit_test/TestGraph.hpp:349:16: note: in instantiation of function template specialization 'Kokkos::Experimental::GraphNodeRef<Kokkos::SYCL, Kokkos::Impl::GraphNodeKernelImpl<Kokkos::SYCL, Kokkos::RangePolicy<Kokkos::SYCL, Kokkos::Impl::IsGraphKernelTag>, Test::CountTestFunctor<Kokkos::SYCL>, Kokkos::ParallelForTag>, Kokkos::Experimental::GraphNodeRef<Kokkos::SYCL, Kokkos::Impl::GraphNodeKernelImpl<Kokkos::SYCL, Kokkos::RangePolicy<Kokkos::SYCL, Kokkos::Impl::IsGraphKernelTag>, Test::CountTestFunctor<Kokkos::SYCL>, Kokkos::ParallelForTag>, Kokkos::Experimental::GraphNodeRef<Kokkos::SYCL, Kokkos::Impl::GraphNodeKernelImpl<Kokkos::SYCL, Kokkos::RangePolicy<Kokkos::SYCL, Kokkos::Impl::IsGraphKernelTag>, Test::SetViewToValueFunctor<Kokkos::SYCL, int>, Kokkos::ParallelForTag>, Kokkos::Experimental::GraphNodeRef<Kokkos::SYCL>>>>::then_parallel_reduce<Test::SetResultToViewFunctor<Kokkos::SYCL, int>, const Kokkos::View<int, Kokkos::HostSpace> &>' requested here
  349 |               .then_parallel_reduce(1, set_result_functor{count}, count_host)
      |                ^
/home/darndt/kokkos_new/core/src/Kokkos_Graph.hpp:149:3: note: in instantiation of function template specialization 'Test::sycl_graph_repeat_chain_Test::TestBody()::(anonymous class)::operator()<Kokkos::Experimental::GraphNodeRef<Kokkos::SYCL>>' requested here
  149 |   ((Closure&&)arg_closure)(Kokkos::Impl::GraphAccess::create_root_ref(rv));
      |   ^
/home/darndt/kokkos_new/core/unit_test/TestGraph.hpp:343:40: note: in instantiation of function template specialization 'Kokkos::Experimental::create_graph<Kokkos::SYCL, (lambda at /home/darndt/kokkos_new/core/unit_test/TestGraph.hpp:344:13)>' requested here
  343 |     auto graph = Kokkos::Experimental::create_graph(
      |                                        ^
In file included from /home/darndt/kokkos_new/build/core/unit_test/sycl/TestSYCL_Graph.cpp:2:
In file included from /home/darndt/kokkos_new/core/unit_test/TestGraph.hpp:18:
In file included from /home/darndt/kokkos_new/core/src/Kokkos_Graph.hpp:216:
```
For some reason, the functor for `Kokkos::Experimental::create_graph` gets instantiated in the `if constexpr(false)` branch causing the `static_assert` referenced to fail. Note that pretty much all functions and classes involved are templated so that the `static_assert` in question is not ill-formed in the context used AFAICT. The code compiles fine with, e.g., oneAPI 2024.2.1.
@rgayatri23 Saw the same error on his side using a recent clang compiler version.

It seems that adding another `if constexpr` check inside the lambda provides a workaround.