### PR TITLE
Use absolute paths for CXX compiler in launcher script

### DIFF
--- a/bin/kokkos_launch_compiler
+++ b/bin/kokkos_launch_compiler
@@ -62,7 +62,7 @@ KOKKOS_COMPILER=${1}
 shift
 
 # store the expected C++ compiler
-CXX_COMPILER=${1}
+CXX_COMPILER=$(which "${1}")
 
 # remove the expected C++ compiler from the arguments
 shift
@@ -84,7 +84,7 @@ shift
 #       kokkos_launch_compiler ${KOKKOS_COMPILER} g++ g++ -c file.cpp -o file.o
 # results in this command being executed:
 #       ${KOKKOS_COMPILER} -c file.cpp -o file.o
-if [[ "${KOKKOS_DEPENDENCE}" -eq "0" || "${CXX_COMPILER}" != "${1}" ]]; then
+if [[ "${KOKKOS_DEPENDENCE}" -eq "0" || "${CXX_COMPILER}" != $(which "${1}") ]]; then
     debug-message "$@"
     # the command does not depend on Kokkos so just execute the command w/o re-directing to ${KOKKOS_COMPILER}
     exec "$@"


### PR DESCRIPTION
This PR uses absolute paths for the CXX compiler and the third argument of the compiler launcher script.

Before, the following would not choose the `nvcc_wrapper`:
```
kokkos_launch_compiler nvcc_wrapper /usr/bin/g++ g++
```
even though `$(which g++) == /usr/bin/g++`.