### PR TITLE
Fixing Threads backend on ARM - use std::atomic for thread coordination

### DIFF
--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -67,8 +67,9 @@ std::pair<unsigned, unsigned>
 
 int s_thread_pool_size[3] = {0, 0, 0};
 
-void (*volatile s_current_function)(ThreadsInternal &, const void *);
-const void *volatile s_current_function_arg = nullptr;
+using s_current_function_type = void (*)(ThreadsInternal &, const void *);
+std::atomic<s_current_function_type> s_current_function;
+std::atomic<const void *> s_current_function_arg = nullptr;
 
 inline unsigned fan_size(const unsigned rank, const unsigned size) {
   const unsigned rank_rev = size - (rank + 1);
@@ -79,7 +80,7 @@ inline unsigned fan_size(const unsigned rank, const unsigned size) {
   return count;
 }
 
-void wait_yield(volatile ThreadState &flag, const ThreadState value) {
+void wait_yield(std::atomic<ThreadState> &flag, const ThreadState value) {
   while (value == flag) {
     std::this_thread::yield();
   }
@@ -135,11 +136,12 @@ ThreadsInternal::ThreadsInternal()
     ThreadsInternal *const nil = nullptr;
 
     // Which entry in 's_threads_exec', possibly determined from hwloc binding
-    const int entry = reinterpret_cast<size_t>(s_current_function_arg) <
-                              size_t(s_thread_pool_size[0])
-                          ? reinterpret_cast<size_t>(s_current_function_arg)
-                          : size_t(Kokkos::hwloc::bind_this_thread(
-                                s_thread_pool_size[0], s_threads_coord));
+    const int entry =
+        reinterpret_cast<size_t>(s_current_function_arg.load()) <
+                size_t(s_thread_pool_size[0])
+            ? reinterpret_cast<size_t>(s_current_function_arg.load())
+            : size_t(Kokkos::hwloc::bind_this_thread(s_thread_pool_size[0],
+                                                     s_threads_coord));
 
     // Given a good entry set this thread in the 's_threads_exec' array
     if (entry < s_thread_pool_size[0] &&

--- a/core/src/Threads/Kokkos_Threads_Instance.hpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.hpp
@@ -60,7 +60,7 @@ class ThreadsInternal {
   int m_pool_rank_rev;
   int m_pool_size;
   int m_pool_fan_size;
-  ThreadState volatile m_pool_state;  ///< State for global synchronizations
+  std::atomic<ThreadState> m_pool_state;  ///< State for global synchronizations
 
   // Members for dynamic scheduling
   // Which thread am I stealing from currently
@@ -96,7 +96,7 @@ class ThreadsInternal {
     return reinterpret_cast<unsigned char *>(m_scratch) + m_scratch_reduce_end;
   }
 
-  KOKKOS_INLINE_FUNCTION ThreadState volatile &state() { return m_pool_state; }
+  KOKKOS_INLINE_FUNCTION auto &state() { return m_pool_state; }
   KOKKOS_INLINE_FUNCTION ThreadsInternal *const *pool_base() const {
     return m_pool_base;
   }

--- a/core/src/Threads/Kokkos_Threads_Spinwait.cpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.cpp
@@ -108,7 +108,7 @@ void host_thread_yield(const uint32_t i, const WaitMode mode) {
 #endif /* defined( KOKKOS_ENABLE_ASM ) */
 }
 
-void spinwait_while_equal(ThreadState const volatile& flag,
+void spinwait_while_equal(std::atomic<ThreadState> const& flag,
                           ThreadState const value) {
   Kokkos::store_fence();
   uint32_t i = 0;

--- a/core/src/Threads/Kokkos_Threads_Spinwait.hpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.hpp
@@ -20,6 +20,7 @@
 #include <Threads/Kokkos_Threads_State.hpp>
 
 #include <cstdint>
+#include <atomic>
 
 namespace Kokkos {
 namespace Impl {
@@ -34,7 +35,7 @@ enum class WaitMode : int {
 
 void host_thread_yield(const uint32_t i, const WaitMode mode);
 
-void spinwait_while_equal(ThreadState const volatile& flag,
+void spinwait_while_equal(std::atomic<ThreadState> const& flag,
                           ThreadState const value);
 
 }  // namespace Impl


### PR DESCRIPTION
Fixes threads backend failures on ARM.
This approach seems to be most consistently to fix the issues. I suspect that largely that is due to inserting seqcst load/stores in critical places.

I did some performance testing and didn't see any obvious bad things. In fact this is as fast as develop, while the other PR #7493 show significant slowdowns for this code:

```c++
#include<Kokkos_Core.hpp>

int main(int argc, char* argv[]) {
  Kokkos::initialize(argc, argv);
  {

    int N = 100000;
    int R = 100;
    Kokkos::View<double**> A("A",N, R);

    Kokkos::Timer timer;
    Kokkos::parallel_for(Kokkos::TeamPolicy<>(N, 4), KOKKOS_LAMBDA(const typename Kokkos::TeamPolicy<>::member_type& team) {
      for(int r=0; r<R; r++) {
        double result;
        Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, 0, 100), [&](int i, double& lres) {
          lres += i%r;
        },result);
        A(team.league_rank(), r) = result;
      }
    });
    double time = timer.seconds();
    printf("%lf %lf\n",A(1,1),time);
  }
  Kokkos::finalize();
}
```