### PR TITLE
Cleanup archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 .appveyor.yml export-ignore
 .*gitlab-ci.yml export-ignore
 scripts/ export-ignore
+LICENSE_FILE_HEADER export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 .clang* export-ignore
+.cmake* export-ignore
 .git* export-ignore
 .jenkins* export-ignore
 .appveyor.yml export-ignore


### PR DESCRIPTION
To be cherry-picked into the 4.5 release candidate
We forgot to mark the `.cmake-format.py` file to exclude it
Drive-by change, also ignore the license file header (used to check that source file start with it in the CI)