### PR TITLE
URGENT: Fix CI

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -383,7 +383,6 @@ pipeline {
                     post {
                         always {
                             sh 'ccache --show-stats'
-                            xunit([CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)])
                         }
                     }
                 }


### PR DESCRIPTION
The last commit of https://github.com/kokkos/kokkos/pull/7470 broke the CI. Note that this change doesn't matter because it is applied to a configuration that is commented (openmp-target + rocm)