### PR TITLE
Remove build directory when using gcc 14

### DIFF
--- a/.jenkins_nightly
+++ b/.jenkins_nightly
@@ -82,7 +82,7 @@ pipeline {
                           wget https://github.com/Kitware/CMake/releases/download/v3.30.0/cmake-3.30.0-linux-x86_64.sh && \
                           chmod +x cmake-3.30.0-linux-x86_64.sh && ./cmake-3.30.0-linux-x86_64.sh --skip-license --prefix=/usr
 
-                          mkdir -p build && cd build && \
+                          rm -rf build && mkdir -p build && cd build && \
                           cmake \
                             -DCMAKE_BUILD_TYPE=Release \
                             -DCMAKE_CXX_STANDARD=26 \


### PR DESCRIPTION
https://github.com/kokkos/kokkos/pull/7470 broke the nightly. For the gcc 14 configuration, we don't remove the build directory and so, we started to accumulate xunit outputs which confuses jenkins.