### PR TITLE
HIP: prefer smaller block size

### DIFF
--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -140,8 +140,7 @@ unsigned hip_internal_get_block_size(const HIPInternal *hip_instance,
           tperb >= HIPTraits::ConservativeThreadsPerBlock) {
         min_block_size = block_size;
       } else if ((min_block_size == 0) && (tperb_shmem)) {
-        min_block_size = block_size;
-        break;
+        return block_size;
       }
     }
     block_size >>= 1;

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_Range.hpp
@@ -241,7 +241,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
       dim3 block(1, block_size, 1);
       // use a slightly less constrained, but still well bounded limit for
       // scratch
-      int nblocks = (nwork + block.y - 1) / block.y;
+      index_type nblocks = (nwork + block.y - 1) / block.y;
       // Heuristic deciding the value of nblocks.
       // The general idea here is we want to:
       //    1. Not undersubscribe the device (i.e., we want at least
@@ -265,7 +265,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
         if (items_per_thread < 4) {
           int ratio = std::min(
               (nblocks + preferred_block_min - 1) / preferred_block_min,
-              (4 + items_per_thread - 1) / items_per_thread);
+              static_cast<index_type>(4 + items_per_thread - 1) /
+                  items_per_thread);
           nblocks /= ratio;
         }
       }


### PR DESCRIPTION
This PR fixes an issue reported by AMD and the AthenaK team. Unlike the CUDA backend, in the HIP backend we prefer larger block size. Because of this when people use a TeamPolicy with `Kokkos::AUTO`, we also prefer large team size and we end up launching too many threads. This PR changes the behavior to prefer smaller block size, similar to what is done in CUDA. 