### PR TITLE
Fix Kokkos::resize with View of Views

### DIFF
--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -768,8 +768,7 @@ inline void deep_copy(const Kokkos::Experimental::DynamicView<T, DP...>& dst,
                                  dst_memory_space>::accessible;
 
   if (DstExecCanAccessSrc || SrcExecCanAccessDst)
-    Kokkos::Impl::ViewRemap</* SequentialHostInit */ false, dst_type, src_type>(
-        dst, src);
+    Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
   else
     src.impl_get_chunks().deep_copy_to(dst_execution_space{},
                                        dst.impl_get_chunks());
@@ -797,8 +796,7 @@ inline void deep_copy(const ExecutionSpace& exec,
 
   // FIXME use execution space
   if (DstExecCanAccessSrc || SrcExecCanAccessDst)
-    Kokkos::Impl::ViewRemap</* SequentialHostInit */ false, dst_type, src_type>(
-        dst, src);
+    Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
   else
     src.impl_get_chunks().deep_copy_to(exec, dst.impl_get_chunks());
 }
@@ -821,8 +819,7 @@ inline void deep_copy(const View<T, DP...>& dst,
 
   // Copying data between views in accessible memory spaces and either
   // non-contiguous or incompatible shape.
-  Kokkos::Impl::ViewRemap</* SequentialHostInit */ false, dst_type, src_type>(
-      dst, src);
+  Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
   Kokkos::fence("Kokkos::deep_copy(DynamicView)");
 }
 
@@ -844,8 +841,7 @@ inline void deep_copy(const Kokkos::Experimental::DynamicView<T, DP...>& dst,
 
   // Copying data between views in accessible memory spaces and either
   // non-contiguous or incompatible shape.
-  Kokkos::Impl::ViewRemap</* SequentialHostInit */ false, dst_type, src_type>(
-      dst, src);
+  Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
   Kokkos::fence("Kokkos::deep_copy(DynamicView)");
 }
 
@@ -887,8 +883,7 @@ struct CommonSubview<DstType, Kokkos::Experimental::DynamicView<SP...>, Arg0> {
 
 template <class... DP, class ViewTypeB, class Layout, class ExecSpace,
           typename iType>
-struct ViewCopy</* SequentialHostInit */ false,
-                Kokkos::Experimental::DynamicView<DP...>, ViewTypeB, Layout,
+struct ViewCopy<Kokkos::Experimental::DynamicView<DP...>, ViewTypeB, Layout,
                 ExecSpace, 1, iType> {
   Kokkos::Experimental::DynamicView<DP...> a;
   ViewTypeB b;
@@ -908,9 +903,9 @@ struct ViewCopy</* SequentialHostInit */ false,
 
 template <class... DP, class... SP, class Layout, class ExecSpace,
           typename iType>
-struct ViewCopy<
-    /* SequentialHostInit */ false, Kokkos::Experimental::DynamicView<DP...>,
-    Kokkos::Experimental::DynamicView<SP...>, Layout, ExecSpace, 1, iType> {
+struct ViewCopy<Kokkos::Experimental::DynamicView<DP...>,
+                Kokkos::Experimental::DynamicView<SP...>, Layout, ExecSpace, 1,
+                iType> {
   Kokkos::Experimental::DynamicView<DP...> a;
   Kokkos::Experimental::DynamicView<SP...> b;
 

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -768,7 +768,7 @@ inline void deep_copy(const Kokkos::Experimental::DynamicView<T, DP...>& dst,
                                  dst_memory_space>::accessible;
 
   if (DstExecCanAccessSrc || SrcExecCanAccessDst)
-    Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
+    Kokkos::Impl::ViewRemap</* SequentialHostInit */ false, dst_type, src_type>(dst, src);
   else
     src.impl_get_chunks().deep_copy_to(dst_execution_space{},
                                        dst.impl_get_chunks());
@@ -796,7 +796,7 @@ inline void deep_copy(const ExecutionSpace& exec,
 
   // FIXME use execution space
   if (DstExecCanAccessSrc || SrcExecCanAccessDst)
-    Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
+    Kokkos::Impl::ViewRemap</* SequentialHostInit */ false, dst_type, src_type>(dst, src);
   else
     src.impl_get_chunks().deep_copy_to(exec, dst.impl_get_chunks());
 }
@@ -819,7 +819,8 @@ inline void deep_copy(const View<T, DP...>& dst,
 
   // Copying data between views in accessible memory spaces and either
   // non-contiguous or incompatible shape.
-  Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
+  Kokkos::Impl::ViewRemap</* SequentialHostInit */ false, dst_type, src_type>(
+      dst, src);
   Kokkos::fence("Kokkos::deep_copy(DynamicView)");
 }
 
@@ -841,7 +842,8 @@ inline void deep_copy(const Kokkos::Experimental::DynamicView<T, DP...>& dst,
 
   // Copying data between views in accessible memory spaces and either
   // non-contiguous or incompatible shape.
-  Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
+  Kokkos::Impl::ViewRemap</* SequentialHostInit */ false, dst_type, src_type>(
+      dst, src);
   Kokkos::fence("Kokkos::deep_copy(DynamicView)");
 }
 
@@ -883,7 +885,8 @@ struct CommonSubview<DstType, Kokkos::Experimental::DynamicView<SP...>, Arg0> {
 
 template <class... DP, class ViewTypeB, class Layout, class ExecSpace,
           typename iType>
-struct ViewCopy<Kokkos::Experimental::DynamicView<DP...>, ViewTypeB, Layout,
+struct ViewCopy</* SequentialHostInit */ false,
+                Kokkos::Experimental::DynamicView<DP...>, ViewTypeB, Layout,
                 ExecSpace, 1, iType> {
   Kokkos::Experimental::DynamicView<DP...> a;
   ViewTypeB b;
@@ -903,9 +906,9 @@ struct ViewCopy<Kokkos::Experimental::DynamicView<DP...>, ViewTypeB, Layout,
 
 template <class... DP, class... SP, class Layout, class ExecSpace,
           typename iType>
-struct ViewCopy<Kokkos::Experimental::DynamicView<DP...>,
-                Kokkos::Experimental::DynamicView<SP...>, Layout, ExecSpace, 1,
-                iType> {
+struct ViewCopy<
+    /* SequentialHostInit */ false, Kokkos::Experimental::DynamicView<DP...>,
+    Kokkos::Experimental::DynamicView<SP...>, Layout, ExecSpace, 1, iType> {
   Kokkos::Experimental::DynamicView<DP...> a;
   Kokkos::Experimental::DynamicView<SP...> b;
 

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -768,7 +768,8 @@ inline void deep_copy(const Kokkos::Experimental::DynamicView<T, DP...>& dst,
                                  dst_memory_space>::accessible;
 
   if (DstExecCanAccessSrc || SrcExecCanAccessDst)
-    Kokkos::Impl::ViewRemap</* SequentialHostInit */ false, dst_type, src_type>(dst, src);
+    Kokkos::Impl::ViewRemap</* SequentialHostInit */ false, dst_type, src_type>(
+        dst, src);
   else
     src.impl_get_chunks().deep_copy_to(dst_execution_space{},
                                        dst.impl_get_chunks());
@@ -796,7 +797,8 @@ inline void deep_copy(const ExecutionSpace& exec,
 
   // FIXME use execution space
   if (DstExecCanAccessSrc || SrcExecCanAccessDst)
-    Kokkos::Impl::ViewRemap</* SequentialHostInit */ false, dst_type, src_type>(dst, src);
+    Kokkos::Impl::ViewRemap</* SequentialHostInit */ false, dst_type, src_type>(
+        dst, src);
   else
     src.impl_get_chunks().deep_copy_to(exec, dst.impl_get_chunks());
 }

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -314,9 +314,10 @@ struct ViewFill<ViewType, Layout, ExecSpace, 8, iType> {
   }
 };
 
-template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
-          typename iType>
-struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 1, iType> {
+template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
+          class Layout, class ExecSpace, typename iType>
+struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 1,
+                iType> {
   ViewTypeA a;
   ViewTypeB b;
 
@@ -341,9 +342,10 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 1, iType> {
   }
 };
 
-template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
-          typename iType>
-struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 2, iType> {
+template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
+          class Layout, class ExecSpace, typename iType>
+struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 2,
+                iType> {
   ViewTypeA a;
   ViewTypeB b;
   static const Kokkos::Iterate outer_iteration_pattern =
@@ -378,9 +380,10 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 2, iType> {
   }
 };
 
-template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
-          typename iType>
-struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 3, iType> {
+template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
+          class Layout, class ExecSpace, typename iType>
+struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 3,
+                iType> {
   ViewTypeA a;
   ViewTypeB b;
 
@@ -417,9 +420,10 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 3, iType> {
   }
 };
 
-template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
-          typename iType>
-struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 4, iType> {
+template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
+          class Layout, class ExecSpace, typename iType>
+struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 4,
+                iType> {
   ViewTypeA a;
   ViewTypeB b;
 
@@ -451,9 +455,10 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 4, iType> {
   }
 };
 
-template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
-          typename iType>
-struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 5, iType> {
+template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
+          class Layout, class ExecSpace, typename iType>
+struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 5,
+                iType> {
   ViewTypeA a;
   ViewTypeB b;
 
@@ -485,9 +490,10 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 5, iType> {
   }
 };
 
-template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
-          typename iType>
-struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 6, iType> {
+template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
+          class Layout, class ExecSpace, typename iType>
+struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 6,
+                iType> {
   ViewTypeA a;
   ViewTypeB b;
 
@@ -519,9 +525,10 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 6, iType> {
   }
 };
 
-template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
-          typename iType>
-struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 7, iType> {
+template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
+          class Layout, class ExecSpace, typename iType>
+struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 7,
+                iType> {
   ViewTypeA a;
   ViewTypeB b;
 
@@ -556,9 +563,10 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 7, iType> {
   }
 };
 
-template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
-          typename iType>
-struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 8, iType> {
+template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
+          class Layout, class ExecSpace, typename iType>
+struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 8,
+                iType> {
   ViewTypeA a;
   ViewTypeB b;
 
@@ -626,7 +634,8 @@ Kokkos::Iterate get_iteration_order(const DstType& dst) {
   return iterate;
 }
 
-template <class ExecutionSpace, class DstType, class SrcType>
+template <bool SequentialHostInit, class ExecutionSpace, class DstType,
+          class SrcType>
 void view_copy(const ExecutionSpace& space, const DstType& dst,
                const SrcType& src) {
   using dst_memory_space = typename DstType::memory_space;
@@ -648,12 +657,14 @@ void view_copy(const ExecutionSpace& space, const DstType& dst,
         (src.span() >= size_t(std::numeric_limits<int>::max()))) {
       if (iterate == Kokkos::Iterate::Right)
         Kokkos::Impl::ViewCopy<
+            SequentialHostInit,
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
             Kokkos::LayoutRight, ExecutionSpace, DstType::rank, int64_t>(
             dst, src, space);
       else
         Kokkos::Impl::ViewCopy<
+            SequentialHostInit,
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
             Kokkos::LayoutLeft, ExecutionSpace, DstType::rank, int64_t>(
@@ -661,12 +672,14 @@ void view_copy(const ExecutionSpace& space, const DstType& dst,
     } else {
       if (iterate == Kokkos::Iterate::Right)
         Kokkos::Impl::ViewCopy<
+            SequentialHostInit,
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
             Kokkos::LayoutRight, ExecutionSpace, DstType::rank, int>(dst, src,
                                                                      space);
       else
         Kokkos::Impl::ViewCopy<
+            SequentialHostInit,
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
             Kokkos::LayoutLeft, ExecutionSpace, DstType::rank, int>(dst, src,
@@ -675,7 +688,7 @@ void view_copy(const ExecutionSpace& space, const DstType& dst,
   }
 }
 
-template <class DstType, class SrcType>
+template <bool SequentialHostInit, class DstType, class SrcType>
 void view_copy(const DstType& dst, const SrcType& src) {
   using dst_execution_space = typename DstType::execution_space;
   using src_execution_space = typename SrcType::execution_space;
@@ -715,24 +728,24 @@ void view_copy(const DstType& dst, const SrcType& src) {
       (src.span() >= size_t(std::numeric_limits<int>::max()))) {
     if (iterate == Kokkos::Iterate::Right)
       Kokkos::Impl::ViewCopy<
-          typename DstType::uniform_runtime_nomemspace_type,
+          SequentialHostInit, typename DstType::uniform_runtime_nomemspace_type,
           typename SrcType::uniform_runtime_const_nomemspace_type,
           Kokkos::LayoutRight, ExecutionSpace, DstType::rank, int64_t>(dst,
                                                                        src);
     else
       Kokkos::Impl::ViewCopy<
-          typename DstType::uniform_runtime_nomemspace_type,
+          SequentialHostInit, typename DstType::uniform_runtime_nomemspace_type,
           typename SrcType::uniform_runtime_const_nomemspace_type,
           Kokkos::LayoutLeft, ExecutionSpace, DstType::rank, int64_t>(dst, src);
   } else {
     if (iterate == Kokkos::Iterate::Right)
       Kokkos::Impl::ViewCopy<
-          typename DstType::uniform_runtime_nomemspace_type,
+          SequentialHostInit, typename DstType::uniform_runtime_nomemspace_type,
           typename SrcType::uniform_runtime_const_nomemspace_type,
           Kokkos::LayoutRight, ExecutionSpace, DstType::rank, int>(dst, src);
     else
       Kokkos::Impl::ViewCopy<
-          typename DstType::uniform_runtime_nomemspace_type,
+          SequentialHostInit, typename DstType::uniform_runtime_nomemspace_type,
           typename SrcType::uniform_runtime_const_nomemspace_type,
           Kokkos::LayoutLeft, ExecutionSpace, DstType::rank, int>(dst, src);
   }
@@ -748,11 +761,12 @@ struct CommonSubview {
       : dst_sub(dst, args...), src_sub(src, args...) {}
 };
 
-template <class DstType, class SrcType, int Rank = DstType::rank>
+template <bool SequentialHostInit, class DstType, class SrcType,
+          int Rank        = DstType::rank>
 struct ViewRemap;
 
-template <class DstType, class SrcType>
-struct ViewRemap<DstType, SrcType, 1> {
+template <bool SequentialHostInit, class DstType, class SrcType>
+struct ViewRemap<SequentialHostInit, DstType, SrcType, 1> {
   using p_type = Kokkos::pair<int64_t, int64_t>;
 
   template <typename... OptExecSpace>
@@ -763,11 +777,12 @@ struct ViewRemap<DstType, SrcType, 1> {
         "OptExecSpace must be either empty or be an execution space!");
 
     if (dst.extent(0) == src.extent(0)) {
-      view_copy(exec_space..., dst, src);
+      view_copy<SequentialHostInit>(exec_space..., dst, src);
     } else {
       p_type ext0(0, std::min(dst.extent(0), src.extent(0)));
       CommonSubview common_subview(dst, src, ext0);
-      view_copy(exec_space..., common_subview.dst_sub, common_subview.src_sub);
+      view_copy<SequentialHostInit>(exec_space..., common_subview.dst_sub,
+                                    common_subview.src_sub);
     }
   }
 };
@@ -813,7 +828,8 @@ auto create_common_subview_no_match(const DstType& dst, const SrcType& src,
   return common_subview;
 }
 
-template <class DstType, class SrcType, int Rank>
+template <bool SequentialHostInit, class DstType, class SrcType,
+          int Rank>
 struct ViewRemap {
   using p_type = Kokkos::pair<int64_t, int64_t>;
 
@@ -827,30 +843,30 @@ struct ViewRemap {
     if (dst.extent(0) == src.extent(0)) {
       if (dst.extent(Rank - 1) == src.extent(Rank - 1)) {
         if constexpr (Rank < 3)
-          view_copy(exec_space..., dst, src);
+          view_copy<SequentialHostInit>(exec_space..., dst, src);
         else {
           auto common_subview = create_common_subview_first_and_last_match(
               dst, src, std::make_index_sequence<Rank - 2>{});
-          view_copy(exec_space..., common_subview.dst_sub,
-                    common_subview.src_sub);
+          view_copy<SequentialHostInit>(exec_space..., common_subview.dst_sub,
+                                        common_subview.src_sub);
         }
       } else {
         auto common_subview = create_common_subview_first_match(
             dst, src, std::make_index_sequence<Rank - 1>{});
-        view_copy(exec_space..., common_subview.dst_sub,
-                  common_subview.src_sub);
+        view_copy<SequentialHostInit>(exec_space..., common_subview.dst_sub,
+                                      common_subview.src_sub);
       }
     } else {
       if (dst.extent(Rank - 1) == src.extent(Rank - 1)) {
         auto common_subview = create_common_subview_last_match(
             dst, src, std::make_index_sequence<Rank - 1>{});
-        view_copy(exec_space..., common_subview.dst_sub,
-                  common_subview.src_sub);
+        view_copy<SequentialHostInit>(exec_space..., common_subview.dst_sub,
+                                      common_subview.src_sub);
       } else {
         auto common_subview = create_common_subview_no_match(
             dst, src, std::make_index_sequence<Rank>{});
-        view_copy(exec_space..., common_subview.dst_sub,
-                  common_subview.src_sub);
+        view_copy<SequentialHostInit>(exec_space..., common_subview.dst_sub,
+                                      common_subview.src_sub);
       }
     }
   }
@@ -1352,7 +1368,7 @@ inline void deep_copy(
   } else {
     Kokkos::fence(
         "Kokkos::deep_copy: copy between contiguous views, pre copy fence");
-    Impl::view_copy(dst, src);
+    Impl::view_copy</* SequentialHostInit */ false>(dst, src);
     Kokkos::fence(
         "Kokkos::deep_copy: copy between contiguous views, post copy fence");
   }
@@ -2544,7 +2560,7 @@ inline void deep_copy(
                                    dst_memory_space>::accessible;
 
     if constexpr (ExecCanAccessSrcDst) {
-      Impl::view_copy(exec_space, dst, src);
+      Impl::view_copy</* SequentialHostInit */ false>(exec_space, dst, src);
     } else if constexpr (DstExecCanAccessSrc || SrcExecCanAccessDst) {
       using cpy_exec_space =
           std::conditional_t<DstExecCanAccessSrc, dst_execution_space,
@@ -2552,7 +2568,8 @@ inline void deep_copy(
       exec_space.fence(
           "Kokkos::deep_copy: view-to-view noncontiguous copy on space, pre "
           "copy");
-      Impl::view_copy(cpy_exec_space(), dst, src);
+      Impl::view_copy</* SequentialHostInit */ false>(cpy_exec_space(), dst,
+                                                      src);
       cpy_exec_space().fence(
           "Kokkos::deep_copy: view-to-view noncontiguous copy on space, post "
           "copy");
@@ -2674,10 +2691,12 @@ impl_resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
 #endif
 
     if constexpr (alloc_prop_input::has_execution_space)
-      Kokkos::Impl::ViewRemap<view_type, view_type>(
+      Kokkos::Impl::ViewRemap<alloc_prop_input::sequential_host_init, view_type,
+                              view_type>(
           v_resized, v, Impl::get_property<Impl::ExecutionSpaceTag>(prop_copy));
     else {
-      Kokkos::Impl::ViewRemap<view_type, view_type>(v_resized, v);
+      Kokkos::Impl::ViewRemap<alloc_prop_input::sequential_host_init, view_type,
+                              view_type>(v_resized, v);
       Kokkos::fence("Kokkos::resize(View)");
     }
 
@@ -2771,10 +2790,12 @@ impl_resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
     view_type v_resized(prop_copy, layout);
 
     if constexpr (alloc_prop_input::has_execution_space)
-      Kokkos::Impl::ViewRemap<view_type, view_type>(
+      Kokkos::Impl::ViewRemap<alloc_prop_input::sequential_host_init, view_type,
+                              view_type>(
           v_resized, v, Impl::get_property<Impl::ExecutionSpaceTag>(arg_prop));
     else {
-      Kokkos::Impl::ViewRemap<view_type, view_type>(v_resized, v);
+      Kokkos::Impl::ViewRemap<alloc_prop_input::sequential_host_init, view_type,
+                              view_type>(v_resized, v);
       Kokkos::fence("Kokkos::resize(View)");
     }
 
@@ -2816,10 +2837,12 @@ impl_resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
   view_type v_resized(prop_copy, layout);
 
   if constexpr (alloc_prop_input::has_execution_space)
-    Kokkos::Impl::ViewRemap<view_type, view_type>(
+    Kokkos::Impl::ViewRemap<alloc_prop_input::sequential_host_init, view_type,
+                            view_type>(
         v_resized, v, Impl::get_property<Impl::ExecutionSpaceTag>(arg_prop));
   else {
-    Kokkos::Impl::ViewRemap<view_type, view_type>(v_resized, v);
+    Kokkos::Impl::ViewRemap<alloc_prop_input::sequential_host_init, view_type,
+                            view_type>(v_resized, v);
     Kokkos::fence("Kokkos::resize(View)");
   }
 

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -355,7 +355,7 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 1,
       uint64_t kpID        = 0;
       const auto& response = Kokkos::Tools::Impl::begin_parallel_for(
           policy, *this, "Kokkos::ViewCopy-1D", kpID);
-      for (iType i = 0; i < a.extent(0); ++i) operator()(i);
+      for (iType i = 0; i < static_cast<iType>(a.extent(0)); ++i) operator()(i);
       Kokkos::Tools::Impl::end_parallel_for(response.policy, *this,
                                             "Kokkos::ViewCopy-1D", kpID);
     } else

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -863,8 +863,8 @@ template <class DstType, class SrcType, bool SequentialHostInit = false,
           int Rank = DstType::rank>
 struct ViewRemap;
 
-template <bool SequentialHostInit, class DstType, class SrcType>
-struct ViewRemap<DstType, SrcType, 1, SequentialHostInit> {
+template <class DstType, class SrcType, bool SequentialHostInit>
+struct ViewRemap<DstType, SrcType, SequentialHostInit, 1> {
   using p_type = Kokkos::pair<int64_t, int64_t>;
 
   template <typename... OptExecSpace>

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -861,7 +861,7 @@ struct CommonSubview {
 };
 
 template <bool SequentialHostInit, class DstType, class SrcType,
-          int Rank        = DstType::rank>
+          int Rank = DstType::rank>
 struct ViewRemap;
 
 template <bool SequentialHostInit, class DstType, class SrcType>
@@ -927,8 +927,7 @@ auto create_common_subview_no_match(const DstType& dst, const SrcType& src,
   return common_subview;
 }
 
-template <bool SequentialHostInit, class DstType, class SrcType,
-          int Rank>
+template <bool SequentialHostInit, class DstType, class SrcType, int Rank>
 struct ViewRemap {
   using p_type = Kokkos::pair<int64_t, int64_t>;
 

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -60,6 +60,8 @@ KOKKOS_INLINE_FUNCTION constexpr bool view_equal_strides(
 namespace Kokkos {
 namespace Impl {
 
+struct SequentialHostTag {};
+
 template <typename MDRangePolicy, typename Functor>
 void execute_mdrange_parallel_for_sequentially(
     const std::string& str, const MDRangePolicy& mdrange_policy,
@@ -72,8 +74,8 @@ void execute_mdrange_parallel_for_sequentially(
   const auto& inner_policy = response.policy;
 
   using Policy = typename MDRangePolicy::impl_range_policy;
-  const HostIterateTile<MDRangePolicy, Functor> host_iterate(inner_policy,
-                                                             functor);
+  const HostIterateTile<MDRangePolicy, Functor, SequentialHostTag> host_iterate(
+      inner_policy, functor);
 
   const typename Policy::member_type e = host_iterate.m_rp.m_num_tiles;
   for (typename Policy::member_type i = 0; i < e; ++i) {
@@ -355,11 +357,16 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 1,
       uint64_t kpID        = 0;
       const auto& response = Kokkos::Tools::Impl::begin_parallel_for(
           policy, *this, "Kokkos::ViewCopy-1D", kpID);
-      for (iType i = 0; i < static_cast<iType>(a.extent(0)); ++i) operator()(i);
+      for (iType i = 0; i < static_cast<iType>(a.extent(0)); ++i)
+        operator()(SequentialHostTag{}, i);
       Kokkos::Tools::Impl::end_parallel_for(response.policy, *this,
                                             "Kokkos::ViewCopy-1D", kpID);
     } else
       Kokkos::parallel_for("Kokkos::ViewCopy-1D", policy, *this);
+  }
+
+  void operator()(SequentialHostTag, const iType& i0) const {
+    a(i0) = static_cast<value_type>(b(i0));
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -400,6 +407,10 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 2,
                                                 *this);
     else
       Kokkos::parallel_for("Kokkos::ViewCopy-2D", policy, *this);
+  }
+
+  void operator()(SequentialHostTag, const iType& i0, const iType& i1) const {
+    a(i0, i1) = static_cast<value_type>(b(i0, i1));
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -445,6 +456,11 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 3,
       Kokkos::parallel_for("Kokkos::ViewCopy-3D", policy, *this);
   }
 
+  void operator()(SequentialHostTag, const iType& i0, const iType& i1,
+                  const iType& i2) const {
+    a(i0, i1, i2) = static_cast<value_type>(b(i0, i1, i2));
+  }
+
   KOKKOS_INLINE_FUNCTION
   void operator()(const iType& i0, const iType& i1, const iType& i2) const {
     // backwards compatible fix for allowing deep_copy between
@@ -488,6 +504,12 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 4,
   }
 
   KOKKOS_INLINE_FUNCTION
+  void operator()(SequentialHostTag, const iType& i0, const iType& i1,
+                  const iType& i2, const iType& i3) const {
+    a(i0, i1, i2, i3) = b(i0, i1, i2, i3);
+  }
+
+  KOKKOS_INLINE_FUNCTION
   void operator()(const iType& i0, const iType& i1, const iType& i2,
                   const iType& i3) const {
     a(i0, i1, i2, i3) = b(i0, i1, i2, i3);
@@ -523,6 +545,11 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 5,
                                                 *this);
     else
       Kokkos::parallel_for("Kokkos::ViewCopy-5D", policy, *this);
+  }
+
+  void operator()(SequentialHostTag, const iType& i0, const iType& i1,
+                  const iType& i2, const iType& i3, const iType& i4) const {
+    a(i0, i1, i2, i3, i4) = b(i0, i1, i2, i3, i4);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -561,6 +588,12 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 6,
                                                 *this);
     else
       Kokkos::parallel_for("Kokkos::ViewCopy-6D", policy, *this);
+  }
+
+  void operator()(SequentialHostTag, const iType& i0, const iType& i1,
+                  const iType& i2, const iType& i3, const iType& i4,
+                  const iType& i5) const {
+    a(i0, i1, i2, i3, i4, i5) = b(i0, i1, i2, i3, i4, i5);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -603,6 +636,13 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 7,
       Kokkos::parallel_for("Kokkos::ViewCopy-7D", policy, *this);
   }
 
+  void operator()(SequentialHostTag, const iType& i0, const iType& i1,
+                  const iType& i3, const iType& i4, const iType& i5,
+                  const iType& i6) const {
+    for (iType i2 = 0; i2 < iType(a.extent(2)); i2++)
+      a(i0, i1, i2, i3, i4, i5, i6) = b(i0, i1, i2, i3, i4, i5, i6);
+  }
+
   KOKKOS_INLINE_FUNCTION
   void operator()(const iType& i0, const iType& i1, const iType& i3,
                   const iType& i4, const iType& i5, const iType& i6) const {
@@ -642,6 +682,14 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 8,
                                                 *this);
     else
       Kokkos::parallel_for("Kokkos::ViewCopy-8D", policy, *this);
+  }
+
+  void operator()(SequentialHostTag, const iType& i0, const iType& i1,
+                  const iType& i3, const iType& i5, const iType& i6,
+                  const iType& i7) const {
+    for (iType i2 = 0; i2 < iType(a.extent(2)); i2++)
+      for (iType i4 = 0; i4 < iType(a.extent(4)); i4++)
+        a(i0, i1, i2, i3, i4, i5, i6, i7) = b(i0, i1, i2, i3, i4, i5, i6, i7);
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -60,6 +60,29 @@ KOKKOS_INLINE_FUNCTION constexpr bool view_equal_strides(
 namespace Kokkos {
 namespace Impl {
 
+template <typename MDRangePolicy, typename Functor>
+void execute_mdrange_parallel_for_sequentially(
+    const std::string& str, const MDRangePolicy& mdrange_policy,
+    const Functor& functor) {
+  uint64_t kpID = 0;
+
+  /** Request a tuned policy from the tools subsystem */
+  const auto& response = Kokkos::Tools::Impl::begin_parallel_for(
+      mdrange_policy, functor, str, kpID);
+  const auto& inner_policy = response.policy;
+
+  using Policy = typename MDRangePolicy::impl_range_policy;
+  const HostIterateTile<MDRangePolicy, Functor> host_iterate(inner_policy,
+                                                             functor);
+
+  const typename Policy::member_type e = host_iterate.m_rp.m_num_tiles;
+  for (typename Policy::member_type i = 0; i < e; ++i) {
+    host_iterate(i);
+  }
+
+  Kokkos::Tools::Impl::end_parallel_for(inner_policy, functor, str, kpID);
+}
+
 template <class ViewType, class Layout, class ExecSpace, typename iType>
 struct ViewFill<ViewType, Layout, ExecSpace, 0, iType> {
   ViewType a;
@@ -327,8 +350,16 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 1,
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_,
            const ExecSpace space = ExecSpace())
       : a(a_), b(b_) {
-    Kokkos::parallel_for("Kokkos::ViewCopy-1D",
-                         policy_type(space, 0, a.extent(0)), *this);
+    policy_type policy(space, 0, a.extent(0));
+    if constexpr (SequentialHostInit) {
+      uint64_t kpID        = 0;
+      const auto& response = Kokkos::Tools::Impl::begin_parallel_for(
+          policy, *this, "Kokkos::ViewCopy-1D", kpID);
+      for (iType i = 0; i < a.extent(0); ++i) operator()(i);
+      Kokkos::Tools::Impl::end_parallel_for(response.policy, *this,
+                                            "Kokkos::ViewCopy-1D", kpID);
+    } else
+      Kokkos::parallel_for("Kokkos::ViewCopy-1D", policy, *this);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -363,9 +394,12 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 2,
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_,
            const ExecSpace space = ExecSpace())
       : a(a_), b(b_) {
-    Kokkos::parallel_for("Kokkos::ViewCopy-2D",
-                         policy_type(space, {0, 0}, {a.extent(0), a.extent(1)}),
-                         *this);
+    policy_type policy(space, {0, 0}, {a.extent(0), a.extent(1)});
+    if constexpr (SequentialHostInit)
+      execute_mdrange_parallel_for_sequentially("Kokkos::ViewCopy-2D", policy,
+                                                *this);
+    else
+      Kokkos::parallel_for("Kokkos::ViewCopy-2D", policy, *this);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -402,10 +436,13 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 3,
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_,
            const ExecSpace space = ExecSpace())
       : a(a_), b(b_) {
-    Kokkos::parallel_for(
-        "Kokkos::ViewCopy-3D",
-        policy_type(space, {0, 0, 0}, {a.extent(0), a.extent(1), a.extent(2)}),
-        *this);
+    policy_type policy(space, {0, 0, 0},
+                       {a.extent(0), a.extent(1), a.extent(2)});
+    if constexpr (SequentialHostInit)
+      execute_mdrange_parallel_for_sequentially("Kokkos::ViewCopy-3D", policy,
+                                                *this);
+    else
+      Kokkos::parallel_for("Kokkos::ViewCopy-3D", policy, *this);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -441,11 +478,13 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 4,
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_,
            const ExecSpace space = ExecSpace())
       : a(a_), b(b_) {
-    Kokkos::parallel_for(
-        "Kokkos::ViewCopy-4D",
-        policy_type(space, {0, 0, 0, 0},
-                    {a.extent(0), a.extent(1), a.extent(2), a.extent(3)}),
-        *this);
+    policy_type policy(space, {0, 0, 0, 0},
+                       {a.extent(0), a.extent(1), a.extent(2), a.extent(3)});
+    if constexpr (SequentialHostInit)
+      execute_mdrange_parallel_for_sequentially("Kokkos::ViewCopy-4D", policy,
+                                                *this);
+    else
+      Kokkos::parallel_for("Kokkos::ViewCopy-4D", policy, *this);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -476,11 +515,14 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 5,
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_,
            const ExecSpace space = ExecSpace())
       : a(a_), b(b_) {
-    Kokkos::parallel_for("Kokkos::ViewCopy-5D",
-                         policy_type(space, {0, 0, 0, 0, 0},
-                                     {a.extent(0), a.extent(1), a.extent(2),
-                                      a.extent(3), a.extent(4)}),
-                         *this);
+    policy_type policy(
+        space, {0, 0, 0, 0, 0},
+        {a.extent(0), a.extent(1), a.extent(2), a.extent(3), a.extent(4)});
+    if constexpr (SequentialHostInit)
+      execute_mdrange_parallel_for_sequentially("Kokkos::ViewCopy-5D", policy,
+                                                *this);
+    else
+      Kokkos::parallel_for("Kokkos::ViewCopy-5D", policy, *this);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -511,11 +553,14 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 6,
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_,
            const ExecSpace space = ExecSpace())
       : a(a_), b(b_) {
-    Kokkos::parallel_for("Kokkos::ViewCopy-6D",
-                         policy_type(space, {0, 0, 0, 0, 0, 0},
-                                     {a.extent(0), a.extent(1), a.extent(2),
-                                      a.extent(3), a.extent(4), a.extent(5)}),
-                         *this);
+    policy_type policy(space, {0, 0, 0, 0, 0, 0},
+                       {a.extent(0), a.extent(1), a.extent(2), a.extent(3),
+                        a.extent(4), a.extent(5)});
+    if constexpr (SequentialHostInit)
+      execute_mdrange_parallel_for_sequentially("Kokkos::ViewCopy-6D", policy,
+                                                *this);
+    else
+      Kokkos::parallel_for("Kokkos::ViewCopy-6D", policy, *this);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -548,11 +593,14 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 7,
       : a(a_), b(b_) {
     // MDRangePolicy is not supported for 7D views
     // Iterate separately over extent(2)
-    Kokkos::parallel_for("Kokkos::ViewCopy-7D",
-                         policy_type(space, {0, 0, 0, 0, 0, 0},
-                                     {a.extent(0), a.extent(1), a.extent(3),
-                                      a.extent(4), a.extent(5), a.extent(6)}),
-                         *this);
+    policy_type policy(space, {0, 0, 0, 0, 0, 0},
+                       {a.extent(0), a.extent(1), a.extent(3), a.extent(4),
+                        a.extent(5), a.extent(6)});
+    if constexpr (SequentialHostInit)
+      execute_mdrange_parallel_for_sequentially("Kokkos::ViewCopy-7D", policy,
+                                                *this);
+    else
+      Kokkos::parallel_for("Kokkos::ViewCopy-7D", policy, *this);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -586,11 +634,14 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 8,
       : a(a_), b(b_) {
     // MDRangePolicy is not supported for 8D views
     // Iterate separately over extent(2) and extent(4)
-    Kokkos::parallel_for("Kokkos::ViewCopy-8D",
-                         policy_type(space, {0, 0, 0, 0, 0, 0},
-                                     {a.extent(0), a.extent(1), a.extent(3),
-                                      a.extent(5), a.extent(6), a.extent(7)}),
-                         *this);
+    policy_type policy(space, {0, 0, 0, 0, 0, 0},
+                       {a.extent(0), a.extent(1), a.extent(3), a.extent(5),
+                        a.extent(6), a.extent(7)});
+    if constexpr (SequentialHostInit)
+      execute_mdrange_parallel_for_sequentially("Kokkos::ViewCopy-8D", policy,
+                                                *this);
+    else
+      Kokkos::parallel_for("Kokkos::ViewCopy-8D", policy, *this);
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -339,10 +339,10 @@ struct ViewFill<ViewType, Layout, ExecSpace, 8, iType> {
   }
 };
 
-template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
-          class Layout, class ExecSpace, typename iType>
-struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 1,
-                iType> {
+template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
+          typename iType, bool SequentialHostInit>
+struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 1, iType,
+                SequentialHostInit> {
   ViewTypeA a;
   ViewTypeB b;
 
@@ -382,8 +382,8 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 1,
 
 template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
           class Layout, class ExecSpace, typename iType>
-struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 2,
-                iType> {
+struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 2, iType,
+                SequentialHostInit> {
   ViewTypeA a;
   ViewTypeB b;
   static const Kokkos::Iterate outer_iteration_pattern =
@@ -427,8 +427,8 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 2,
 
 template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
           class Layout, class ExecSpace, typename iType>
-struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 3,
-                iType> {
+struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 3, iType,
+                SequentialHostInit> {
   ViewTypeA a;
   ViewTypeB b;
 
@@ -475,8 +475,8 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 3,
 
 template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
           class Layout, class ExecSpace, typename iType>
-struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 4,
-                iType> {
+struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 4, iType,
+                SequentialHostInit> {
   ViewTypeA a;
   ViewTypeB b;
 
@@ -518,8 +518,8 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 4,
 
 template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
           class Layout, class ExecSpace, typename iType>
-struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 5,
-                iType> {
+struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 5, iType,
+                SequentialHostInit> {
   ViewTypeA a;
   ViewTypeB b;
 
@@ -561,8 +561,8 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 5,
 
 template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
           class Layout, class ExecSpace, typename iType>
-struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 6,
-                iType> {
+struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 6, iType,
+                SequentialHostInit> {
   ViewTypeA a;
   ViewTypeB b;
 
@@ -605,8 +605,8 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 6,
 
 template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
           class Layout, class ExecSpace, typename iType>
-struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 7,
-                iType> {
+struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 7, iType,
+                SequentialHostInit> {
   ViewTypeA a;
   ViewTypeB b;
 
@@ -653,8 +653,8 @@ struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 7,
 
 template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
           class Layout, class ExecSpace, typename iType>
-struct ViewCopy<SequentialHostInit, ViewTypeA, ViewTypeB, Layout, ExecSpace, 8,
-                iType> {
+struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 8, iType,
+                SequentialHostInit> {
   ViewTypeA a;
   ViewTypeB b;
 
@@ -756,33 +756,29 @@ void view_copy(const ExecutionSpace& space, const DstType& dst,
         (src.span() >= size_t(std::numeric_limits<int>::max()))) {
       if (iterate == Kokkos::Iterate::Right)
         Kokkos::Impl::ViewCopy<
-            SequentialHostInit,
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
-            Kokkos::LayoutRight, ExecutionSpace, DstType::rank, int64_t>(
-            dst, src, space);
+            Kokkos::LayoutRight, ExecutionSpace, DstType::rank, int64_t,
+            SequentialHostInit>(dst, src, space);
       else
         Kokkos::Impl::ViewCopy<
-            SequentialHostInit,
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
-            Kokkos::LayoutLeft, ExecutionSpace, DstType::rank, int64_t>(
-            dst, src, space);
+            Kokkos::LayoutLeft, ExecutionSpace, DstType::rank, int64_t,
+            SequentialHostInit>(dst, src, space);
     } else {
       if (iterate == Kokkos::Iterate::Right)
         Kokkos::Impl::ViewCopy<
-            SequentialHostInit,
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
-            Kokkos::LayoutRight, ExecutionSpace, DstType::rank, int>(dst, src,
-                                                                     space);
+            Kokkos::LayoutRight, ExecutionSpace, DstType::rank, int,
+            SequentialHostInit>(dst, src, space);
       else
         Kokkos::Impl::ViewCopy<
-            SequentialHostInit,
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
-            Kokkos::LayoutLeft, ExecutionSpace, DstType::rank, int>(dst, src,
-                                                                    space);
+            Kokkos::LayoutLeft, ExecutionSpace, DstType::rank, int,
+            SequentialHostInit>(dst, src, space);
     }
   }
 }
@@ -827,26 +823,29 @@ void view_copy(const DstType& dst, const SrcType& src) {
       (src.span() >= size_t(std::numeric_limits<int>::max()))) {
     if (iterate == Kokkos::Iterate::Right)
       Kokkos::Impl::ViewCopy<
-          SequentialHostInit, typename DstType::uniform_runtime_nomemspace_type,
+          typename DstType::uniform_runtime_nomemspace_type,
           typename SrcType::uniform_runtime_const_nomemspace_type,
-          Kokkos::LayoutRight, ExecutionSpace, DstType::rank, int64_t>(dst,
-                                                                       src);
+          Kokkos::LayoutRight, ExecutionSpace, DstType::rank, int64_t,
+          SequentialHostInit>(dst, src);
     else
       Kokkos::Impl::ViewCopy<
-          SequentialHostInit, typename DstType::uniform_runtime_nomemspace_type,
+          typename DstType::uniform_runtime_nomemspace_type,
           typename SrcType::uniform_runtime_const_nomemspace_type,
-          Kokkos::LayoutLeft, ExecutionSpace, DstType::rank, int64_t>(dst, src);
+          Kokkos::LayoutLeft, ExecutionSpace, DstType::rank, int64_t,
+          SequentialHostInit>(dst, src);
   } else {
     if (iterate == Kokkos::Iterate::Right)
       Kokkos::Impl::ViewCopy<
-          SequentialHostInit, typename DstType::uniform_runtime_nomemspace_type,
+          typename DstType::uniform_runtime_nomemspace_type,
           typename SrcType::uniform_runtime_const_nomemspace_type,
-          Kokkos::LayoutRight, ExecutionSpace, DstType::rank, int>(dst, src);
+          Kokkos::LayoutRight, ExecutionSpace, DstType::rank, int,
+          SequentialHostInit>(dst, src);
     else
       Kokkos::Impl::ViewCopy<
-          SequentialHostInit, typename DstType::uniform_runtime_nomemspace_type,
+          typename DstType::uniform_runtime_nomemspace_type,
           typename SrcType::uniform_runtime_const_nomemspace_type,
-          Kokkos::LayoutLeft, ExecutionSpace, DstType::rank, int>(dst, src);
+          Kokkos::LayoutLeft, ExecutionSpace, DstType::rank, int,
+          SequentialHostInit>(dst, src);
   }
 }
 
@@ -860,12 +859,12 @@ struct CommonSubview {
       : dst_sub(dst, args...), src_sub(src, args...) {}
 };
 
-template <bool SequentialHostInit, class DstType, class SrcType,
+template <class DstType, class SrcType, bool SequentialHostInit = false,
           int Rank = DstType::rank>
 struct ViewRemap;
 
 template <bool SequentialHostInit, class DstType, class SrcType>
-struct ViewRemap<SequentialHostInit, DstType, SrcType, 1> {
+struct ViewRemap<DstType, SrcType, 1, SequentialHostInit> {
   using p_type = Kokkos::pair<int64_t, int64_t>;
 
   template <typename... OptExecSpace>
@@ -927,7 +926,7 @@ auto create_common_subview_no_match(const DstType& dst, const SrcType& src,
   return common_subview;
 }
 
-template <bool SequentialHostInit, class DstType, class SrcType, int Rank>
+template <class DstType, class SrcType, bool SequentialHostInit, int Rank>
 struct ViewRemap {
   using p_type = Kokkos::pair<int64_t, int64_t>;
 
@@ -2789,12 +2788,13 @@ impl_resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
 #endif
 
     if constexpr (alloc_prop_input::has_execution_space)
-      Kokkos::Impl::ViewRemap<alloc_prop_input::sequential_host_init, view_type,
-                              view_type>(
+      Kokkos::Impl::ViewRemap<view_type, view_type,
+                              alloc_prop_input::sequential_host_init>(
           v_resized, v, Impl::get_property<Impl::ExecutionSpaceTag>(prop_copy));
     else {
-      Kokkos::Impl::ViewRemap<alloc_prop_input::sequential_host_init, view_type,
-                              view_type>(v_resized, v);
+      Kokkos::Impl::ViewRemap<view_type, view_type,
+                              alloc_prop_input::sequential_host_init>(v_resized,
+                                                                      v);
       Kokkos::fence("Kokkos::resize(View)");
     }
 
@@ -2888,12 +2888,13 @@ impl_resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
     view_type v_resized(prop_copy, layout);
 
     if constexpr (alloc_prop_input::has_execution_space)
-      Kokkos::Impl::ViewRemap<alloc_prop_input::sequential_host_init, view_type,
-                              view_type>(
+      Kokkos::Impl::ViewRemap<view_type, view_type,
+                              alloc_prop_input::sequential_host_init>(
           v_resized, v, Impl::get_property<Impl::ExecutionSpaceTag>(arg_prop));
     else {
-      Kokkos::Impl::ViewRemap<alloc_prop_input::sequential_host_init, view_type,
-                              view_type>(v_resized, v);
+      Kokkos::Impl::ViewRemap<view_type, view_type,
+                              alloc_prop_input::sequential_host_init>(v_resized,
+                                                                      v);
       Kokkos::fence("Kokkos::resize(View)");
     }
 
@@ -2935,12 +2936,13 @@ impl_resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
   view_type v_resized(prop_copy, layout);
 
   if constexpr (alloc_prop_input::has_execution_space)
-    Kokkos::Impl::ViewRemap<alloc_prop_input::sequential_host_init, view_type,
-                            view_type>(
+    Kokkos::Impl::ViewRemap<view_type, view_type,
+                            alloc_prop_input::sequential_host_init>(
         v_resized, v, Impl::get_property<Impl::ExecutionSpaceTag>(arg_prop));
   else {
-    Kokkos::Impl::ViewRemap<alloc_prop_input::sequential_host_init, view_type,
-                            view_type>(v_resized, v);
+    Kokkos::Impl::ViewRemap<view_type, view_type,
+                            alloc_prop_input::sequential_host_init>(v_resized,
+                                                                    v);
     Kokkos::fence("Kokkos::resize(View)");
   }
 

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -269,8 +269,8 @@ template <class ViewType, class Layout = typename ViewType::array_layout,
           int Rank = ViewType::rank, typename iType = int64_t>
 struct ViewFill;
 
-template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
-          int Rank, typename iType>
+template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
+          class Layout, class ExecSpace, int Rank, typename iType>
 struct ViewCopy;
 
 template <class Functor, class Policy>

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -269,8 +269,8 @@ template <class ViewType, class Layout = typename ViewType::array_layout,
           int Rank = ViewType::rank, typename iType = int64_t>
 struct ViewFill;
 
-template <bool SequentialHostInit, class ViewTypeA, class ViewTypeB,
-          class Layout, class ExecSpace, int Rank, typename iType>
+template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
+          int Rank, typename iType, bool SequentialHostInit = false>
 struct ViewCopy;
 
 template <class Functor, class Policy>

--- a/core/unit_test/TestViewOfViews.hpp
+++ b/core/unit_test/TestViewOfViews.hpp
@@ -59,6 +59,57 @@ class H {  // constructible and destructible only from on the host side
   ~H() {}
 };
 
+template <class T, int N>
+struct AddPointer {
+  using type = typename AddPointer<T, N - 1>::type*;
+};
+
+template <class T>
+struct AddPointer<T, 0> {
+  using type = T;
+};
+
+template <class V, int Rank>
+using ViewOfViews =
+    Kokkos::View<typename AddPointer<V, Rank>::type, Kokkos::HostSpace>;
+
+template <class V, int Rank, std::size_t... Is>
+void test_view_of_views_resize_sequential_host_init_rank_impl(
+    std::index_sequence<Is...>) {
+  using VoV = ViewOfViews<V, Rank>;
+
+  // Size change reconstructs the view and remaps overlapping data.
+  {
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit),
+            (static_cast<void>(Is), 2u)...);
+    {
+      V a("a");
+      vov((static_cast<void>(Is), 0u)...) = a;
+    }
+    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov,
+                   (static_cast<void>(Is), 1u)...);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+}
+
+template <class V, int Rank>
+void test_view_of_views_resize_sequential_host_init_rank() {
+  test_view_of_views_resize_sequential_host_init_rank_impl<V, Rank>(
+      std::make_index_sequence<static_cast<std::size_t>(Rank)>{});
+}
+
+template <class V>
+void test_view_of_views_resize_sequential_host_init() {
+  test_view_of_views_resize_sequential_host_init_rank<V, 1>();
+  test_view_of_views_resize_sequential_host_init_rank<V, 2>();
+  test_view_of_views_resize_sequential_host_init_rank<V, 3>();
+  test_view_of_views_resize_sequential_host_init_rank<V, 4>();
+  test_view_of_views_resize_sequential_host_init_rank<V, 5>();
+  test_view_of_views_resize_sequential_host_init_rank<V, 6>();
+  test_view_of_views_resize_sequential_host_init_rank<V, 7>();
+  test_view_of_views_resize_sequential_host_init_rank<V, 8>();
+}
+
 template <class V>
 void test_view_of_views_default() {
   // assigning a default-constructed view to destruct the inner objects
@@ -134,100 +185,6 @@ TEST(TEST_CATEGORY, test_view_of_views_sequential_host_init) {
       DA<Kokkos::View<double, TEST_EXECSPACE>>>();
   test_view_of_views_sequential_host_init<
       H<Kokkos::View<int, TEST_EXECSPACE>>>();
-}
-
-template <class V>
-void test_view_of_views_resize_sequential_host_init() {
-  {
-    using VoV = Kokkos::View<V*, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2);
-    {
-      V a("a");
-      vov(0) = a;
-    }
-    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1);
-    ASSERT_EQ(vov.size(), 1u);
-  }
-  {
-    using VoV = Kokkos::View<V**, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2);
-    {
-      V a("a");
-      vov(0, 0) = a;
-    }
-    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1);
-    ASSERT_EQ(vov.size(), 1u);
-  }
-  {
-    using VoV = Kokkos::View<V***, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2);
-    {
-      V a("a");
-      vov(0, 0, 0) = a;
-    }
-    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1,
-                   1);
-    ASSERT_EQ(vov.size(), 1u);
-  }
-  {
-    using VoV = Kokkos::View<V****, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2);
-    {
-      V a("a");
-      vov(0, 0, 0, 0) = a;
-    }
-    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1, 1,
-                   1);
-    ASSERT_EQ(vov.size(), 1u);
-  }
-  {
-    using VoV = Kokkos::View<V*****, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2,
-            2);
-    {
-      V a("a");
-      vov(0, 0, 0, 0, 0) = a;
-    }
-    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1, 1,
-                   1, 1);
-    ASSERT_EQ(vov.size(), 1u);
-  }
-  {
-    using VoV = Kokkos::View<V******, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2,
-            2, 2);
-    {
-      V a("a");
-      vov(0, 0, 0, 0, 0, 0) = a;
-    }
-    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1, 1,
-                   1, 1, 1);
-    ASSERT_EQ(vov.size(), 1u);
-  }
-  {
-    using VoV = Kokkos::View<V*******, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2,
-            2, 2, 2);
-    {
-      V a("a");
-      vov(0, 0, 0, 0, 0, 0, 0) = a;
-    }
-    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1, 1,
-                   1, 1, 1, 1);
-    ASSERT_EQ(vov.size(), 1u);
-  }
-  {
-    using VoV = Kokkos::View<V********, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2,
-            2, 2, 2, 2);
-    {
-      V a("a");
-      vov(0, 0, 0, 0, 0, 0, 0, 0) = a;
-    }
-    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1, 1,
-                   1, 1, 1, 1, 1);
-    ASSERT_EQ(vov.size(), 1u);
-  }
 }
 
 TEST(TEST_CATEGORY, test_view_of_views_resize_sequential_host_init) {

--- a/core/unit_test/TestViewOfViews.hpp
+++ b/core/unit_test/TestViewOfViews.hpp
@@ -25,6 +25,19 @@ class S {
   KOKKOS_DEFAULTED_FUNCTION S() = default;
 };
 
+// User-defined types with a View data member that allocates in the default
+// constructor
+template <class V>
+class DA {
+  V v_ = V("v", 5);
+
+ public:
+  template <class... Extents>
+  DA(std::string label, Extents... extents)
+      : v_(std::move(label), extents...) {}
+  DA() = default;
+};
+
 template <class V>
 class N {  // not default constructible
   V v_;
@@ -87,13 +100,34 @@ template <class V>
 void test_view_of_views_sequential_host_init() {
   // inner views value-initialized sequentially on the host, and also
   // sequentially destructed on the host, without the need to cleanup
-  using VoV = Kokkos::View<V**, Kokkos::HostSpace>;
-  VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 3);
-  V a("a");
-  V b("b");
-  vov(0, 0) = a;
-  vov(1, 0) = a;
-  vov(0, 1) = b;
+  {
+    using VoV = Kokkos::View<V*, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 3);
+    {
+      V a("a");
+      V b("b");
+      vov(0) = a;
+      vov(1) = b;
+    }
+
+    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1);
+    ASSERT_EQ(vov.extent(0), 1u);
+  }
+  {
+    using VoV = Kokkos::View<V**, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 3);
+    {
+      V a("a");
+      V b("b");
+      vov(0, 0) = a;
+      vov(1, 0) = a;
+      vov(0, 1) = b;
+    }
+
+    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1);
+    ASSERT_EQ(vov.extent(0), 1u);
+    ASSERT_EQ(vov.extent(1), 1u);
+  }
 }
 
 TEST(TEST_CATEGORY, view_of_views_default) {
@@ -117,6 +151,8 @@ TEST(TEST_CATEGORY, test_view_of_views_sequential_host_init) {
   test_view_of_views_sequential_host_init<Kokkos::View<int, TEST_EXECSPACE>>();
   test_view_of_views_sequential_host_init<
       S<Kokkos::View<float, TEST_EXECSPACE>>>();
+  test_view_of_views_sequential_host_init<
+      DA<Kokkos::View<double, TEST_EXECSPACE>>>();
   test_view_of_views_sequential_host_init<
       H<Kokkos::View<int, TEST_EXECSPACE>>>();
 }

--- a/core/unit_test/TestViewOfViews.hpp
+++ b/core/unit_test/TestViewOfViews.hpp
@@ -100,34 +100,13 @@ template <class V>
 void test_view_of_views_sequential_host_init() {
   // inner views value-initialized sequentially on the host, and also
   // sequentially destructed on the host, without the need to cleanup
-  {
-    using VoV = Kokkos::View<V*, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 3);
-    {
-      V a("a");
-      V b("b");
-      vov(0) = a;
-      vov(1) = b;
-    }
-
-    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1);
-    ASSERT_EQ(vov.extent(0), 1u);
-  }
-  {
-    using VoV = Kokkos::View<V**, Kokkos::HostSpace>;
-    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 3);
-    {
-      V a("a");
-      V b("b");
-      vov(0, 0) = a;
-      vov(1, 0) = a;
-      vov(0, 1) = b;
-    }
-
-    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1);
-    ASSERT_EQ(vov.extent(0), 1u);
-    ASSERT_EQ(vov.extent(1), 1u);
-  }
+  using VoV = Kokkos::View<V**, Kokkos::HostSpace>;
+  VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 3);
+  V a("a");
+  V b("b");
+  vov(0, 0) = a;
+  vov(1, 0) = a;
+  vov(0, 1) = b;
 }
 
 TEST(TEST_CATEGORY, view_of_views_default) {
@@ -154,6 +133,111 @@ TEST(TEST_CATEGORY, test_view_of_views_sequential_host_init) {
   test_view_of_views_sequential_host_init<
       DA<Kokkos::View<double, TEST_EXECSPACE>>>();
   test_view_of_views_sequential_host_init<
+      H<Kokkos::View<int, TEST_EXECSPACE>>>();
+}
+
+template <class V>
+void test_view_of_views_resize_sequential_host_init() {
+  {
+    using VoV = Kokkos::View<V*, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2);
+    {
+      V a("a");
+      vov(0) = a;
+    }
+    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+  {
+    using VoV = Kokkos::View<V**, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2);
+    {
+      V a("a");
+      vov(0, 0) = a;
+    }
+    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+  {
+    using VoV = Kokkos::View<V***, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2);
+    {
+      V a("a");
+      vov(0, 0, 0) = a;
+    }
+    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1,
+                   1);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+  {
+    using VoV = Kokkos::View<V****, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2);
+    {
+      V a("a");
+      vov(0, 0, 0, 0) = a;
+    }
+    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1, 1,
+                   1);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+  {
+    using VoV = Kokkos::View<V*****, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2,
+            2);
+    {
+      V a("a");
+      vov(0, 0, 0, 0, 0) = a;
+    }
+    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1, 1,
+                   1, 1);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+  {
+    using VoV = Kokkos::View<V******, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2,
+            2, 2);
+    {
+      V a("a");
+      vov(0, 0, 0, 0, 0, 0) = a;
+    }
+    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1, 1,
+                   1, 1, 1);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+  {
+    using VoV = Kokkos::View<V*******, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2,
+            2, 2, 2);
+    {
+      V a("a");
+      vov(0, 0, 0, 0, 0, 0, 0) = a;
+    }
+    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1, 1,
+                   1, 1, 1, 1);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+  {
+    using VoV = Kokkos::View<V********, Kokkos::HostSpace>;
+    VoV vov(Kokkos::view_alloc("vov", Kokkos::SequentialHostInit), 2, 2, 2, 2,
+            2, 2, 2, 2);
+    {
+      V a("a");
+      vov(0, 0, 0, 0, 0, 0, 0, 0) = a;
+    }
+    Kokkos::resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), vov, 1, 1, 1,
+                   1, 1, 1, 1, 1);
+    ASSERT_EQ(vov.size(), 1u);
+  }
+}
+
+TEST(TEST_CATEGORY, test_view_of_views_resize_sequential_host_init) {
+  test_view_of_views_resize_sequential_host_init<
+      Kokkos::View<int, TEST_EXECSPACE>>();
+  test_view_of_views_resize_sequential_host_init<
+      S<Kokkos::View<float, TEST_EXECSPACE>>>();
+  test_view_of_views_resize_sequential_host_init<
+      DA<Kokkos::View<double, TEST_EXECSPACE>>>();
+  test_view_of_views_resize_sequential_host_init<
       H<Kokkos::View<int, TEST_EXECSPACE>>>();
 }
 

--- a/core/unit_test/TestViewOfViews.hpp
+++ b/core/unit_test/TestViewOfViews.hpp
@@ -29,7 +29,7 @@ class S {
 // constructor
 template <class V>
 class DA {
-  V v_ = V("v", 5);
+  V v_ = V("v");
 
  public:
   template <class... Extents>


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/7466.
As discussed in the meeting last week (https://github.com/kokkos/kokkos/issues/7466#issuecomment-2447610652), this pull request runs the copy operation sequentially on the host. To be able to use the existing infrastructure for using MDRangePolicy/HostIterateTile the attribute needs to be propagated to a number of layers. To make this feasible, about half of the commits simplify classes in `Kokkos_CopyViews.hpp`. These changes can, of course, be merged first independently if preferred.