### PR TITLE
Deprecate StaticCrsGraph

### DIFF
--- a/containers/src/Kokkos_StaticCrsGraph.hpp
+++ b/containers/src/Kokkos_StaticCrsGraph.hpp
@@ -37,10 +37,6 @@ static auto do_not_include = emit_warning_kokkos_static_crs_graph_deprecated();
 #error "Deprecated <Kokkos_StaticCrsGraph.hpp> header is included"
 #endif
 
-#define KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD \
-  KOKKOS_DEPRECATED_WITH_COMMENT(                        \
-      "Moved to KokkosKernels into KokkosSparse namespace")
-
 #include <string>
 #include <vector>
 
@@ -164,7 +160,7 @@ struct StaticCrsGraphBalancerFunctor {
 /// is used by CrsMatrix), but may be greater than one for other
 /// sparse matrix storage formats (e.g., ELLPACK or jagged diagonal).
 template <class GraphType>
-struct KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD GraphRowViewConst {
+struct GraphRowViewConst {
   //! The type of the column indices in the row.
   using ordinal_type = const typename GraphType::data_type;
 
@@ -277,7 +273,7 @@ template <class DataType, class Arg1Type, class Arg2Type = void,
           class Arg3Type    = void,
           typename SizeType = typename ViewTraits<DataType*, Arg1Type, Arg2Type,
                                                   Arg3Type>::size_type>
-class KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD StaticCrsGraph {
+class StaticCrsGraph {
  private:
   using traits = ViewTraits<DataType*, Arg1Type, Arg2Type, Arg3Type>;
 
@@ -411,35 +407,33 @@ class KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD StaticCrsGraph {
 //----------------------------------------------------------------------------
 
 template <class StaticCrsGraphType, class InputSizeType>
-KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD
-    typename StaticCrsGraphType::staticcrsgraph_type
-    create_staticcrsgraph(const std::string& label,
-                          const std::vector<InputSizeType>& input);
+
+typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
+    const std::string& label, const std::vector<InputSizeType>& input);
 
 template <class StaticCrsGraphType, class InputSizeType>
-KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD
-    typename StaticCrsGraphType::staticcrsgraph_type
-    create_staticcrsgraph(
-        const std::string& label,
-        const std::vector<std::vector<InputSizeType> >& input);
+
+typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
+    const std::string& label,
+    const std::vector<std::vector<InputSizeType> >& input);
 
 //----------------------------------------------------------------------------
 
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
-KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD
-    typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                            SizeType>::HostMirror
-    create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type,
-                                            Arg3Type, SizeType>& input);
+
+typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
+                        SizeType>::HostMirror
+create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
+                                        SizeType>& input);
 
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
-KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD
-    typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                            SizeType>::HostMirror
-    create_mirror(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                                       SizeType>& input);
+
+typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
+                        SizeType>::HostMirror
+create_mirror(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
+                                   SizeType>& input);
 
 }  // namespace Kokkos
 
@@ -481,9 +475,8 @@ struct StaticCrsGraphMaximumEntry {
 
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
-KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD DataType maximum_entry(
-    const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type, SizeType>&
-        graph) {
+DataType maximum_entry(const StaticCrsGraph<DataType, Arg1Type, Arg2Type,
+                                            Arg3Type, SizeType>& graph) {
   using GraphType =
       StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type, SizeType>;
   using FunctorType = Impl::StaticCrsGraphMaximumEntry<GraphType>;
@@ -499,7 +492,7 @@ KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD DataType maximum_entry(
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-#undef KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD
+#undef
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_STATICCRSGRAPH
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE

--- a/containers/src/Kokkos_StaticCrsGraph.hpp
+++ b/containers/src/Kokkos_StaticCrsGraph.hpp
@@ -24,7 +24,8 @@
 #include <Kokkos_Macros.hpp>
 
 #if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
-#if defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
+#if defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS) && \
+    !defined(KOKKOS_IMPL_DO_NOT_WARN_INCLUDE_STATIC_CRS_GRAPH)
 namespace {
 [[deprecated("Deprecated <Kokkos_StaticCrsGraph.hpp> header is included")]] int
 emit_warning_kokkos_static_crs_graph_deprecated() {

--- a/containers/src/Kokkos_StaticCrsGraph.hpp
+++ b/containers/src/Kokkos_StaticCrsGraph.hpp
@@ -21,6 +21,26 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_STATICCRSGRAPH
 #endif
 
+#include <Kokkos_Macros.hpp>
+
+#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
+#if defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
+namespace {
+[[deprecated("Deprecated <Kokkos_StaticCrsGraph.hpp> header is included")]] int
+emit_warning_kokkos_static_crs_graph_deprecated() {
+  return 0;
+}
+static auto do_not_include = emit_warning_kokkos_static_crs_graph_deprecated();
+}  // namespace
+#endif
+#else
+#error "Deprecated <Kokkos_StaticCrsGraph.hpp> header is included"
+#endif
+
+#define KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD \
+  KOKKOS_DEPRECATED_WITH_COMMENT(                        \
+      "Moved to KokkosKernels into KokkosSparse namespace")
+
 #include <string>
 #include <vector>
 
@@ -144,7 +164,7 @@ struct StaticCrsGraphBalancerFunctor {
 /// is used by CrsMatrix), but may be greater than one for other
 /// sparse matrix storage formats (e.g., ELLPACK or jagged diagonal).
 template <class GraphType>
-struct GraphRowViewConst {
+struct KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD GraphRowViewConst {
   //! The type of the column indices in the row.
   using ordinal_type = const typename GraphType::data_type;
 
@@ -257,7 +277,7 @@ template <class DataType, class Arg1Type, class Arg2Type = void,
           class Arg3Type    = void,
           typename SizeType = typename ViewTraits<DataType*, Arg1Type, Arg2Type,
                                                   Arg3Type>::size_type>
-class StaticCrsGraph {
+class KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD StaticCrsGraph {
  private:
   using traits = ViewTraits<DataType*, Arg1Type, Arg2Type, Arg3Type>;
 
@@ -391,29 +411,35 @@ class StaticCrsGraph {
 //----------------------------------------------------------------------------
 
 template <class StaticCrsGraphType, class InputSizeType>
-typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
-    const std::string& label, const std::vector<InputSizeType>& input);
+KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD
+    typename StaticCrsGraphType::staticcrsgraph_type
+    create_staticcrsgraph(const std::string& label,
+                          const std::vector<InputSizeType>& input);
 
 template <class StaticCrsGraphType, class InputSizeType>
-typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
-    const std::string& label,
-    const std::vector<std::vector<InputSizeType> >& input);
+KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD
+    typename StaticCrsGraphType::staticcrsgraph_type
+    create_staticcrsgraph(
+        const std::string& label,
+        const std::vector<std::vector<InputSizeType> >& input);
 
 //----------------------------------------------------------------------------
 
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
-typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                        SizeType>::HostMirror
-create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                                        SizeType>& input);
+KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD
+    typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
+                            SizeType>::HostMirror
+    create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type,
+                                            Arg3Type, SizeType>& input);
 
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
-typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                        SizeType>::HostMirror
-create_mirror(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                                   SizeType>& input);
+KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD
+    typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
+                            SizeType>::HostMirror
+    create_mirror(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
+                                       SizeType>& input);
 
 }  // namespace Kokkos
 
@@ -455,8 +481,9 @@ struct StaticCrsGraphMaximumEntry {
 
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
-DataType maximum_entry(const StaticCrsGraph<DataType, Arg1Type, Arg2Type,
-                                            Arg3Type, SizeType>& graph) {
+KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD DataType maximum_entry(
+    const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type, SizeType>&
+        graph) {
   using GraphType =
       StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type, SizeType>;
   using FunctorType = Impl::StaticCrsGraphMaximumEntry<GraphType>;
@@ -471,6 +498,8 @@ DataType maximum_entry(const StaticCrsGraph<DataType, Arg1Type, Arg2Type,
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
+
+#undef KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_STATICCRSGRAPH
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE

--- a/containers/src/Kokkos_StaticCrsGraph.hpp
+++ b/containers/src/Kokkos_StaticCrsGraph.hpp
@@ -407,12 +407,10 @@ class StaticCrsGraph {
 //----------------------------------------------------------------------------
 
 template <class StaticCrsGraphType, class InputSizeType>
-
 typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
     const std::string& label, const std::vector<InputSizeType>& input);
 
 template <class StaticCrsGraphType, class InputSizeType>
-
 typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
     const std::string& label,
     const std::vector<std::vector<InputSizeType> >& input);
@@ -421,7 +419,6 @@ typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
 
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
-
 typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
                         SizeType>::HostMirror
 create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
@@ -429,7 +426,6 @@ create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
 
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
-
 typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
                         SizeType>::HostMirror
 create_mirror(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
@@ -491,8 +487,6 @@ DataType maximum_entry(const StaticCrsGraph<DataType, Arg1Type, Arg2Type,
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
-
-#undef
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_STATICCRSGRAPH
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE

--- a/containers/src/impl/Kokkos_StaticCrsGraph_factory.hpp
+++ b/containers/src/impl/Kokkos_StaticCrsGraph_factory.hpp
@@ -26,8 +26,8 @@ namespace Kokkos {
 
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
-KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD inline typename StaticCrsGraph<
-    DataType, Arg1Type, Arg2Type, Arg3Type, SizeType>::HostMirror
+inline typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
+                               SizeType>::HostMirror
 create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
                                         SizeType>& view,
                    std::enable_if_t<ViewTraits<DataType, Arg1Type, Arg2Type,
@@ -37,11 +37,10 @@ create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
 
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
-KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD inline
-    typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                            SizeType>::HostMirror
-    create_mirror(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                                       SizeType>& view) {
+inline typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
+                               SizeType>::HostMirror
+create_mirror(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
+                                   SizeType>& view) {
   // Force copy:
   // using alloc = Impl::ViewAssignment<Impl::ViewDefault>; // unused
   using staticcrsgraph_type =
@@ -69,8 +68,8 @@ KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD inline
 
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
-KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD inline typename StaticCrsGraph<
-    DataType, Arg1Type, Arg2Type, Arg3Type, SizeType>::HostMirror
+inline typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
+                               SizeType>::HostMirror
 create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
                                         SizeType>& view,
                    std::enable_if_t<!ViewTraits<DataType, Arg1Type, Arg2Type,
@@ -85,10 +84,8 @@ create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
 namespace Kokkos {
 
 template <class StaticCrsGraphType, class InputSizeType>
-KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD inline
-    typename StaticCrsGraphType::staticcrsgraph_type
-    create_staticcrsgraph(const std::string& label,
-                          const std::vector<InputSizeType>& input) {
+inline typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
+    const std::string& label, const std::vector<InputSizeType>& input) {
   using output_type  = StaticCrsGraphType;
   using entries_type = typename output_type::entries_type;
   using work_type    = View<
@@ -124,11 +121,9 @@ KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD inline
 //----------------------------------------------------------------------------
 
 template <class StaticCrsGraphType, class InputSizeType>
-KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD inline
-    typename StaticCrsGraphType::staticcrsgraph_type
-    create_staticcrsgraph(
-        const std::string& label,
-        const std::vector<std::vector<InputSizeType> >& input) {
+inline typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
+    const std::string& label,
+    const std::vector<std::vector<InputSizeType> >& input) {
   using output_type  = StaticCrsGraphType;
   using entries_type = typename output_type::entries_type;
 

--- a/containers/src/impl/Kokkos_StaticCrsGraph_factory.hpp
+++ b/containers/src/impl/Kokkos_StaticCrsGraph_factory.hpp
@@ -26,8 +26,8 @@ namespace Kokkos {
 
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
-inline typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                               SizeType>::HostMirror
+KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD inline typename StaticCrsGraph<
+    DataType, Arg1Type, Arg2Type, Arg3Type, SizeType>::HostMirror
 create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
                                         SizeType>& view,
                    std::enable_if_t<ViewTraits<DataType, Arg1Type, Arg2Type,
@@ -37,10 +37,11 @@ create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
 
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
-inline typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                               SizeType>::HostMirror
-create_mirror(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                                   SizeType>& view) {
+KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD inline
+    typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
+                            SizeType>::HostMirror
+    create_mirror(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
+                                       SizeType>& view) {
   // Force copy:
   // using alloc = Impl::ViewAssignment<Impl::ViewDefault>; // unused
   using staticcrsgraph_type =
@@ -68,8 +69,8 @@ create_mirror(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
 
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
-inline typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                               SizeType>::HostMirror
+KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD inline typename StaticCrsGraph<
+    DataType, Arg1Type, Arg2Type, Arg3Type, SizeType>::HostMirror
 create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
                                         SizeType>& view,
                    std::enable_if_t<!ViewTraits<DataType, Arg1Type, Arg2Type,
@@ -84,8 +85,10 @@ create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
 namespace Kokkos {
 
 template <class StaticCrsGraphType, class InputSizeType>
-inline typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
-    const std::string& label, const std::vector<InputSizeType>& input) {
+KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD inline
+    typename StaticCrsGraphType::staticcrsgraph_type
+    create_staticcrsgraph(const std::string& label,
+                          const std::vector<InputSizeType>& input) {
   using output_type  = StaticCrsGraphType;
   using entries_type = typename output_type::entries_type;
   using work_type    = View<
@@ -121,9 +124,11 @@ inline typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
 //----------------------------------------------------------------------------
 
 template <class StaticCrsGraphType, class InputSizeType>
-inline typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
-    const std::string& label,
-    const std::vector<std::vector<InputSizeType> >& input) {
+KOKKOS_IMPL_DEPRECATED_USE_KOKKOS_SPARSE_INSTEAD inline
+    typename StaticCrsGraphType::staticcrsgraph_type
+    create_staticcrsgraph(
+        const std::string& label,
+        const std::vector<std::vector<InputSizeType> >& input) {
   using output_type  = StaticCrsGraphType;
   using entries_type = typename output_type::entries_type;
 

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -28,8 +28,8 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
       Vector
       ViewCtorPropEmbeddedDim
     )
-      if(NOT Kokkos_ENABLE_DEPRECATED_CODE_4 AND NOT Name IN_LIST "Vector,StaticCrsGraph" )
-        continue() # skip Kokkos::vector test if deprecated code 4 is not enabled
+      if(NOT Kokkos_ENABLE_DEPRECATED_CODE_4 AND NOT Name IN_LIST "Vector,StaticCrsGraph")
+        continue() # skip Kokkos::{vector,StaticCrsGraph} tests if deprecated code 4 is not enabled
       endif()
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -28,7 +28,7 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
       Vector
       ViewCtorPropEmbeddedDim
     )
-      if(NOT Kokkos_ENABLE_DEPRECATED_CODE_4 AND Name STREQUAL "Vector")
+      if(NOT Kokkos_ENABLE_DEPRECATED_CODE_4 AND NOT Name IN_LIST "Vector,StaticCrsGraph" )
         continue() # skip Kokkos::vector test if deprecated code 4 is not enabled
       endif()
       # Write to a temporary intermediate file and call configure_file to avoid

--- a/containers/unit_tests/Makefile
+++ b/containers/unit_tests/Makefile
@@ -31,7 +31,7 @@ KOKKOS_CXXFLAGS += -I$(GTEST_PATH) -I${KOKKOS_PATH}/containers/unit_tests -I${KO
 TEST_TARGETS =
 TARGETS =
 
-TESTS = Bitset DualView DynamicView DynViewAPI_generic DynViewAPI_rank12345 DynViewAPI_rank67 ErrorReporter OffsetView ScatterView StaticCrsGraph UnorderedMap ViewCtorPropEmbeddedDim
+TESTS = Bitset DualView DynamicView DynViewAPI_generic DynViewAPI_rank12345 DynViewAPI_rank67 ErrorReporter OffsetView ScatterView UnorderedMap ViewCtorPropEmbeddedDim
 tmp := $(foreach device, $(KOKKOS_DEVICELIST), \
   tmp2 := $(foreach test, $(TESTS), \
     $(if $(filter Test$(device)_$(test).cpp, $(shell ls Test$(device)_$(test).cpp 2>/dev/null)),,\
@@ -52,7 +52,6 @@ ifeq ($(KOKKOS_INTERNAL_USE_CUDA), 1)
 	OBJ_CUDA += TestCuda_ErrorReporter.o
 	OBJ_CUDA += TestCuda_OffsetView.o
 	OBJ_CUDA += TestCuda_ScatterView.o
-	OBJ_CUDA += TestCuda_StaticCrsGraph.o
 	OBJ_CUDA += TestCuda_UnorderedMap.o
 	OBJ_CUDA += TestCuda_ViewCtorPropEmbeddedDim.o
 	TARGETS += KokkosContainers_UnitTest_Cuda
@@ -70,7 +69,6 @@ ifeq ($(KOKKOS_INTERNAL_USE_THREADS), 1)
 	OBJ_THREADS += TestThreads_ErrorReporter.o
 	OBJ_THREADS += TestThreads_OffsetView.o
 	OBJ_THREADS += TestThreads_ScatterView.o
-	OBJ_THREADS += TestThreads_StaticCrsGraph.o
 	OBJ_THREADS += TestThreads_UnorderedMap.o
 	OBJ_THREADS += TestThreads_ViewCtorPropEmbeddedDim.o
 	TARGETS += KokkosContainers_UnitTest_Threads
@@ -88,7 +86,6 @@ ifeq ($(KOKKOS_INTERNAL_USE_OPENMP), 1)
 	OBJ_OPENMP += TestOpenMP_ErrorReporter.o
 	OBJ_OPENMP += TestOpenMP_OffsetView.o
 	OBJ_OPENMP += TestOpenMP_ScatterView.o
-	OBJ_OPENMP += TestOpenMP_StaticCrsGraph.o
 	OBJ_OPENMP += TestOpenMP_UnorderedMap.o
 	OBJ_OPENMP += TestOpenMP_ViewCtorPropEmbeddedDim.o
 	TARGETS += KokkosContainers_UnitTest_OpenMP
@@ -106,7 +103,6 @@ ifeq ($(KOKKOS_INTERNAL_USE_HPX), 1)
 	OBJ_HPX += TestHPX_ErrorReporter.o
 	OBJ_HPX += TestHPX_OffsetView.o
 	OBJ_HPX += TestHPX_ScatterView.o
-	OBJ_HPX += TestHPX_StaticCrsGraph.o
 	OBJ_HPX += TestHPX_UnorderedMap.o
 	OBJ_HPX += TestHPX_ViewCtorPropEmbeddedDim.o
 	TARGETS += KokkosContainers_UnitTest_HPX
@@ -124,7 +120,6 @@ ifeq ($(KOKKOS_INTERNAL_USE_SERIAL), 1)
 	OBJ_SERIAL += TestSerial_ErrorReporter.o
 	OBJ_SERIAL += TestSerial_OffsetView.o
 	OBJ_SERIAL += TestSerial_ScatterView.o
-	OBJ_SERIAL += TestSerial_StaticCrsGraph.o
 	OBJ_SERIAL += TestSerial_UnorderedMap.o
 	OBJ_SERIAL += TestSerial_ViewCtorPropEmbeddedDim.o
 	TARGETS += KokkosContainers_UnitTest_Serial

--- a/containers/unit_tests/TestStaticCrsGraph.hpp
+++ b/containers/unit_tests/TestStaticCrsGraph.hpp
@@ -18,7 +18,9 @@
 
 #include <vector>
 
+#define KOKKOS_IMPL_DO_NOT_WARN_INCLUDE_STATIC_CRS_GRAPH
 #include <Kokkos_StaticCrsGraph.hpp>
+#undef KOKKOS_IMPL_DO_NOT_WARN_INCLUDE_STATIC_CRS_GRAPH
 #include <Kokkos_Core.hpp>
 
 /*--------------------------------------------------------------------------*/

--- a/containers/unit_tests/TestStaticCrsGraph.hpp
+++ b/containers/unit_tests/TestStaticCrsGraph.hpp
@@ -18,11 +18,6 @@
 
 #include <vector>
 
-#include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
-#endif
-
 #include <Kokkos_StaticCrsGraph.hpp>
 #include <Kokkos_Core.hpp>
 

--- a/containers/unit_tests/TestStaticCrsGraph.hpp
+++ b/containers/unit_tests/TestStaticCrsGraph.hpp
@@ -18,6 +18,11 @@
 
 #include <vector>
 
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
+#endif
+
 #include <Kokkos_StaticCrsGraph.hpp>
 #include <Kokkos_Core.hpp>
 

--- a/core/unit_test/headers_self_contained/CMakeLists.txt
+++ b/core/unit_test/headers_self_contained/CMakeLists.txt
@@ -9,7 +9,7 @@ file(GLOB KOKKOS_ALGORITHMS_HEADERS RELATIVE ${BASE_DIR}/algorithms/src ${BASE_D
 
 # erroring out when deprecated code is disabled and raising warnings that are treated as errors in the CI otherwise
 if(NOT Kokkos_ENABLE_DEPRECATED_CODE_4 OR Kokkos_ENABLE_DEPRECATION_WARNINGS)
-  list(REMOVE_ITEM KOKKOS_CONTAINERS_HEADERS "Kokkos_Vector.hpp")
+  list(REMOVE_ITEM KOKKOS_CONTAINERS_HEADERS "Kokkos_Vector.hpp" "Kokkos_StaticCrsGraph.hpp")
   list(REMOVE_ITEM KOKKOS_CORE_HEADERS "Kokkos_Future.hpp" "Kokkos_TaskScheduler.hpp")
 endif()
 


### PR DESCRIPTION
Transitioning it to KokkosKernels, in the KokkosSparse:: namespace

Compagnon to kokkos/kokkos-kernels#2419