### PR TITLE
Fix DynRankView in ScratchSpace

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -846,34 +846,19 @@ class DynRankView : private View<DataType*******, Properties...> {
   //----------------------------------------
   // Shared scratch memory constructor
 
-  static inline size_t shmem_size(const size_t arg_N0 = KOKKOS_INVALID_INDEX,
-                                  const size_t arg_N1 = KOKKOS_INVALID_INDEX,
-                                  const size_t arg_N2 = KOKKOS_INVALID_INDEX,
-                                  const size_t arg_N3 = KOKKOS_INVALID_INDEX,
-                                  const size_t arg_N4 = KOKKOS_INVALID_INDEX,
-                                  const size_t arg_N5 = KOKKOS_INVALID_INDEX,
-                                  const size_t arg_N6 = KOKKOS_INVALID_INDEX,
-                                  const size_t arg_N7 = KOKKOS_INVALID_INDEX) {
-    return size_t(1) * (arg_N0 != KOKKOS_INVALID_INDEX ? arg_N0 : 1) *
-           (arg_N1 != KOKKOS_INVALID_INDEX ? arg_N1 : 1) *
-           (arg_N2 != KOKKOS_INVALID_INDEX ? arg_N2 : 1) *
-           (arg_N3 != KOKKOS_INVALID_INDEX ? arg_N3 : 1) *
-           (arg_N4 != KOKKOS_INVALID_INDEX ? arg_N4 : 1) *
-           (arg_N5 != KOKKOS_INVALID_INDEX ? arg_N5 : 1) *
-           (arg_N6 != KOKKOS_INVALID_INDEX ? arg_N6 : 1) *
-           (arg_N7 != KOKKOS_INVALID_INDEX ? arg_N7 : 1);
+  static inline size_t shmem_size(
+      const size_t arg_N0 = 1, const size_t arg_N1 = 1, const size_t arg_N2 = 1,
+      const size_t arg_N3 = 1, const size_t arg_N4 = 1, const size_t arg_N5 = 1,
+      const size_t arg_N6 = 1, const size_t arg_N7 = KOKKOS_INVALID_INDEX) {
+    return view_type::shmem_size(arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5,
+                                 arg_N6, arg_N7);
   }
 
   explicit KOKKOS_FUNCTION DynRankView(
       const typename traits::execution_space::scratch_memory_space& arg_space,
       const typename traits::array_layout& arg_layout)
-      : DynRankView(
-            Kokkos::Impl::ViewCtorProp<typename view_type::pointer_type>(
-                reinterpret_cast<typename view_type::pointer_type>(
-                    arg_space.get_shmem(view_type::required_allocation_size(
-                        Impl::DynRankDimTraits<typename traits::specialize>::
-                            createLayout(arg_layout))))),
-            arg_layout) {}
+      : view_type(arg_space, drdtraits::createLayout(arg_layout)),
+        m_rank(drdtraits::computeRank(arg_layout)) {}
 
   explicit KOKKOS_FUNCTION DynRankView(
       const typename traits::execution_space::scratch_memory_space& arg_space,
@@ -886,16 +871,9 @@ class DynRankView : private View<DataType*******, Properties...> {
       const size_t arg_N6 = KOKKOS_INVALID_INDEX,
       const size_t arg_N7 = KOKKOS_INVALID_INDEX)
 
-      : DynRankView(
-            Kokkos::Impl::ViewCtorProp<typename view_type::pointer_type>(
-                reinterpret_cast<typename view_type::pointer_type>(
-                    arg_space.get_shmem(view_type::required_allocation_size(
-                        Impl::DynRankDimTraits<typename traits::specialize>::
-                            createLayout(typename traits::array_layout(
-                                arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5,
-                                arg_N6, arg_N7)))))),
-            typename traits::array_layout(arg_N0, arg_N1, arg_N2, arg_N3,
-                                          arg_N4, arg_N5, arg_N6, arg_N7)) {}
+      : DynRankView(arg_space, typename traits::array_layout(
+                                   arg_N0, arg_N1, arg_N2, arg_N3, arg_N4,
+                                   arg_N5, arg_N6, arg_N7)) {}
 
   KOKKOS_FUNCTION constexpr auto layout() const {
     switch (rank()) {

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -846,6 +846,7 @@ class DynRankView : private View<DataType*******, Properties...> {
   //----------------------------------------
   // Shared scratch memory constructor
 
+  // Note: We must pass 7 valid args since view_type is rank 7
   static inline size_t shmem_size(
       const size_t arg_N0 = 1, const size_t arg_N1 = 1, const size_t arg_N2 = 1,
       const size_t arg_N3 = 1, const size_t arg_N4 = 1, const size_t arg_N5 = 1,

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -19,6 +19,7 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
       DynViewAPI_generic
       DynViewAPI_rank12345
       DynViewAPI_rank67
+      DynRankView_TeamScratch
       ErrorReporter
       OffsetView
       ScatterView

--- a/containers/unit_tests/TestDynRankView_TeamScratch.hpp
+++ b/containers/unit_tests/TestDynRankView_TeamScratch.hpp
@@ -14,6 +14,8 @@
 //
 //@HEADER
 
+#include <gtest/gtest.h>
+
 #include <Kokkos_DynRankView.hpp>
 
 namespace {

--- a/containers/unit_tests/TestDynRankView_TeamScratch.hpp
+++ b/containers/unit_tests/TestDynRankView_TeamScratch.hpp
@@ -40,9 +40,9 @@ void test_dyn_rank_view_team_scratch() {
         drv_type scr(team.team_scratch(0), N0, N1, N2);
         // Control that the code ran at all
         if (scr.rank() != 3) errors() |= 1u;
-        if (scr.extent(0) != N0) errors() |= 2u;
-        if (scr.extent(1) != N1) errors() |= 4u;
-        if (scr.extent(2) != N2) errors() |= 8u;
+        if (scr.extent_int(0) != N0) errors() |= 2u;
+        if (scr.extent_int(1) != N1) errors() |= 4u;
+        if (scr.extent_int(2) != N2) errors() |= 8u;
         Kokkos::parallel_for(
             Kokkos::TeamThreadMDRange(team, N0, N1, N2),
             [=](int i, int j, int k) { scr(i, j, k) = i * 100 + j * 10 + k; });

--- a/containers/unit_tests/TestDynRankView_TeamScratch.hpp
+++ b/containers/unit_tests/TestDynRankView_TeamScratch.hpp
@@ -1,0 +1,70 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_DynRankView.hpp>
+
+namespace Test {
+
+void test_dyn_rank_view_team_scratch() {
+  using execution_space = TEST_EXECSPACE;
+  using memspace_type   = execution_space::scratch_memory_space;
+  using drv_type        = Kokkos::DynRankView<int, memspace_type>;
+  using policy_type     = Kokkos::TeamPolicy<execution_space>;
+  using team_type       = policy_type::member_type;
+
+  int N0 = 10, N1 = 4, N2 = 3;
+  size_t shmem_size = drv_type::shmem_size(N0, N1, N2);
+  ASSERT_GE(shmem_size, N0 * N1 * N2 * sizeof(int));
+
+  Kokkos::View<unsigned, execution_space, Kokkos::MemoryTraits<Kokkos::Atomic>>
+      errors("errors");
+  auto policy = policy_type(1, Kokkos::AUTO)
+                    .set_scratch_size(0, Kokkos::PerTeam(shmem_size));
+  Kokkos::parallel_for(
+      policy, KOKKOS_LAMBDA(const team_type& team) {
+        drv_type scr(team.team_scratch(0), N0, N1, N2);
+        // Control that the code ran at all
+        if (scr.rank() != 3) errors() |= 1u;
+        if (scr.extent(0) != N0) errors() |= 2u;
+        if (scr.extent(1) != N1) errors() |= 4u;
+        if (scr.extent(2) != N2) errors() |= 8u;
+        Kokkos::parallel_for(
+            Kokkos::TeamThreadMDRange(team, N0, N1, N2),
+            [=](int i, int j, int k) { scr(i, j, k) = i * 100 + j * 10 + k; });
+        team.team_barrier();
+        Kokkos::parallel_for(Kokkos::TeamThreadMDRange(team, N0, N1, N2),
+                             [=](int i, int j, int k) {
+                               if (scr(i, j, k) != i * 100 + j * 10 + k)
+                                 errors() &= 16u;
+                             });
+        errors() |= 256u;
+      });
+  unsigned h_errors = 0;
+  Kokkos::deep_copy(h_errors, errors);
+
+  ASSERT_EQ((h_errors & 1u), 0u) << "Rank mismatch";
+  ASSERT_EQ((h_errors & 2u), 0u) << "extent 0 mismatch";
+  ASSERT_EQ((h_errors & 4u), 0u) << "extent 1 mismatch";
+  ASSERT_EQ((h_errors & 8u), 0u) << "extent 2 mismatch";
+  ASSERT_EQ((h_errors & 16u), 0u) << "data access incorrect";
+  ASSERT_EQ(h_errors, 256u);
+}
+
+TEST(TEST_CATEGORY, dyn_rank_view_team_scratch) {
+  test_dyn_rank_view_team_scratch();
+}
+
+}  // namespace Test

--- a/containers/unit_tests/TestDynRankView_TeamScratch.hpp
+++ b/containers/unit_tests/TestDynRankView_TeamScratch.hpp
@@ -50,7 +50,7 @@ void test_dyn_rank_view_team_scratch() {
         Kokkos::parallel_for(Kokkos::TeamThreadMDRange(team, N0, N1, N2),
                              [=](int i, int j, int k) {
                                if (scr(i, j, k) != i * 100 + j * 10 + k)
-                                 errors() &= 16u;
+                                 errors() |= 16u;
                              });
         errors() |= 256u;
       });

--- a/containers/unit_tests/TestDynRankView_TeamScratch.hpp
+++ b/containers/unit_tests/TestDynRankView_TeamScratch.hpp
@@ -22,8 +22,8 @@ namespace {
 
 void test_dyn_rank_view_team_scratch() {
   using execution_space = TEST_EXECSPACE;
-  using memspace_type   = execution_space::scratch_memory_space;
-  using drv_type        = Kokkos::DynRankView<int, memspace_type>;
+  using memory_space    = execution_space::scratch_memory_space;
+  using drv_type        = Kokkos::DynRankView<int, memory_space>;
   using policy_type     = Kokkos::TeamPolicy<execution_space>;
   using team_type       = policy_type::member_type;
 

--- a/containers/unit_tests/TestDynRankView_TeamScratch.hpp
+++ b/containers/unit_tests/TestDynRankView_TeamScratch.hpp
@@ -16,7 +16,7 @@
 
 #include <Kokkos_DynRankView.hpp>
 
-namespace Test {
+namespace {
 
 void test_dyn_rank_view_team_scratch() {
   using execution_space = TEST_EXECSPACE;
@@ -67,4 +67,4 @@ TEST(TEST_CATEGORY, dyn_rank_view_team_scratch) {
   test_dyn_rank_view_team_scratch();
 }
 
-}  // namespace Test
+}  // namespace


### PR DESCRIPTION
This fixes using DynRankView in scratch space. Two issues are fixed:

* `shmem_size` didn't report correct size.
* ctor taking scratch space called host only function.