### PR TITLE
Only use public `deep_copy` inside containers

### DIFF
--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -400,10 +400,7 @@ void deep_copy(Bitset<DstDevice>& dst, Bitset<SrcDevice> const& src) {
     Kokkos::Impl::throw_runtime_exception(
         "Error: Cannot deep_copy bitsets of different sizes!");
   }
-
-  Kokkos::fence("Bitset::deep_copy: fence before copy operation");
   Kokkos::deep_copy(dst.m_blocks, src.m_blocks);
-  Kokkos::fence("Bitset::deep_copy: fence after copy operation");
 }
 
 template <typename DstDevice, typename SrcDevice>
@@ -412,10 +409,7 @@ void deep_copy(Bitset<DstDevice>& dst, ConstBitset<SrcDevice> const& src) {
     Kokkos::Impl::throw_runtime_exception(
         "Error: Cannot deep_copy bitsets of different sizes!");
   }
-
-  Kokkos::fence("Bitset::deep_copy: fence before copy operation");
   Kokkos::deep_copy(dst.m_blocks, src.m_blocks);
-  Kokkos::fence("Bitset::deep_copy: fence after copy operation");
 }
 
 template <typename DstDevice, typename SrcDevice>
@@ -424,10 +418,7 @@ void deep_copy(ConstBitset<DstDevice>& dst, ConstBitset<SrcDevice> const& src) {
     Kokkos::Impl::throw_runtime_exception(
         "Error: Cannot deep_copy bitsets of different sizes!");
   }
-
-  Kokkos::fence("Bitset::deep_copy: fence before copy operation");
   Kokkos::deep_copy(dst.m_blocks, src.m_blocks);
-  Kokkos::fence("Bitset::deep_copy: fence after copy operation");
 }
 
 }  // namespace Kokkos

--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -135,9 +135,9 @@ class Bitset {
 
     if (m_last_block_mask) {
       // clear the unused bits in the last block
-      Kokkos::Impl::DeepCopy<typename Device::memory_space, Kokkos::HostSpace>(
-          m_blocks.data() + (m_blocks.extent(0) - 1u), &m_last_block_mask,
-          sizeof(unsigned));
+      auto last_block = Kokkos::subview(m_blocks, m_blocks.extent(0) - 1u);
+      Kokkos::deep_copy(typename Device::execution_space{}, last_block,
+                        m_last_block_mask);
       Kokkos::fence(
           "Bitset::set: fence after clearing unused bits copying from "
           "HostSpace");
@@ -402,10 +402,7 @@ void deep_copy(Bitset<DstDevice>& dst, Bitset<SrcDevice> const& src) {
   }
 
   Kokkos::fence("Bitset::deep_copy: fence before copy operation");
-  Kokkos::Impl::DeepCopy<typename DstDevice::memory_space,
-                         typename SrcDevice::memory_space>(
-      dst.m_blocks.data(), src.m_blocks.data(),
-      sizeof(unsigned) * src.m_blocks.extent(0));
+  Kokkos::deep_copy(dst.m_blocks, src.m_blocks);
   Kokkos::fence("Bitset::deep_copy: fence after copy operation");
 }
 
@@ -417,10 +414,7 @@ void deep_copy(Bitset<DstDevice>& dst, ConstBitset<SrcDevice> const& src) {
   }
 
   Kokkos::fence("Bitset::deep_copy: fence before copy operation");
-  Kokkos::Impl::DeepCopy<typename DstDevice::memory_space,
-                         typename SrcDevice::memory_space>(
-      dst.m_blocks.data(), src.m_blocks.data(),
-      sizeof(unsigned) * src.m_blocks.extent(0));
+  Kokkos::deep_copy(dst.m_blocks, src.m_blocks);
   Kokkos::fence("Bitset::deep_copy: fence after copy operation");
 }
 
@@ -432,10 +426,7 @@ void deep_copy(ConstBitset<DstDevice>& dst, ConstBitset<SrcDevice> const& src) {
   }
 
   Kokkos::fence("Bitset::deep_copy: fence before copy operation");
-  Kokkos::Impl::DeepCopy<typename DstDevice::memory_space,
-                         typename SrcDevice::memory_space>(
-      dst.m_blocks.data(), src.m_blocks.data(),
-      sizeof(unsigned) * src.m_blocks.extent(0));
+  Kokkos::deep_copy(dst.m_blocks, src.m_blocks);
   Kokkos::fence("Bitset::deep_copy: fence after copy operation");
 }
 

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -195,11 +195,13 @@ struct ChunkedArrayManager {
   void deep_copy_to(
       const ExecutionSpace& exec_space,
       ChunkedArrayManager<OtherMemorySpace, ValueType> const& other) const {
-    if (other.m_chunks != m_chunks) {
-      Kokkos::Impl::DeepCopy<OtherMemorySpace, MemorySpace, ExecutionSpace>(
-          exec_space, other.m_chunks, m_chunks,
-          sizeof(pointer_type) * (m_chunk_max + 2));
-    }
+    // use of ad-hoc unmanaged views
+    Kokkos::deep_copy(
+        exec_space,
+        Kokkos::View<uintptr_t*, OtherMemorySpace>(
+            reinterpret_cast<uintptr_t*>(other.m_chunks), m_chunk_max + 2),
+        Kokkos::View<uintptr_t*, MemorySpace>(
+            reinterpret_cast<uintptr_t*>(m_chunks), m_chunk_max + 2));
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -874,22 +874,16 @@ class UnorderedMap {
     if (m_hash_lists.data() != src.m_hash_lists.data()) {
       Kokkos::deep_copy(m_available_indexes, src.m_available_indexes);
 
-      using raw_deep_copy =
-          Kokkos::Impl::DeepCopy<typename device_type::memory_space,
-                                 typename SDevice::memory_space>;
+      // do the other deep copies asynchronously if possible
+      typename device_type::execution_space exec_space{};
 
-      raw_deep_copy(m_hash_lists.data(), src.m_hash_lists.data(),
-                    sizeof(size_type) * src.m_hash_lists.extent(0));
-      raw_deep_copy(m_next_index.data(), src.m_next_index.data(),
-                    sizeof(size_type) * src.m_next_index.extent(0));
-      raw_deep_copy(m_keys.data(), src.m_keys.data(),
-                    sizeof(key_type) * src.m_keys.extent(0));
+      Kokkos::deep_copy(exec_space, m_hash_lists, src.m_hash_lists);
+      Kokkos::deep_copy(exec_space, m_next_index, src.m_next_index);
+      Kokkos::deep_copy(exec_space, m_keys, src.m_keys);
       if (!is_set) {
-        raw_deep_copy(m_values.data(), src.m_values.data(),
-                      sizeof(impl_value_type) * src.m_values.extent(0));
+        Kokkos::deep_copy(exec_space, m_values, src.m_values);
       }
-      raw_deep_copy(m_scalars.data(), src.m_scalars.data(),
-                    sizeof(int) * num_scalars);
+      Kokkos::deep_copy(exec_space, m_scalars, src.m_scalars);
 
       Kokkos::fence(
           "Kokkos::UnorderedMap::deep_copy_view: fence after copy to dst.");
@@ -901,33 +895,27 @@ class UnorderedMap {
   bool modified() const { return get_flag(modified_idx); }
 
   void set_flag(int flag) const {
-    using raw_deep_copy =
-        Kokkos::Impl::DeepCopy<typename device_type::memory_space,
-                               Kokkos::HostSpace>;
-    const int true_ = true;
-    raw_deep_copy(m_scalars.data() + flag, &true_, sizeof(int));
+    auto scalar = Kokkos::subview(m_scalars, flag);
+    Kokkos::deep_copy(typename device_type::execution_space{}, scalar,
+                      static_cast<int>(true));
     Kokkos::fence(
         "Kokkos::UnorderedMap::set_flag: fence after copying flag from "
         "HostSpace");
   }
 
   void reset_flag(int flag) const {
-    using raw_deep_copy =
-        Kokkos::Impl::DeepCopy<typename device_type::memory_space,
-                               Kokkos::HostSpace>;
-    const int false_ = false;
-    raw_deep_copy(m_scalars.data() + flag, &false_, sizeof(int));
+    auto scalar = Kokkos::subview(m_scalars, flag);
+    Kokkos::deep_copy(typename device_type::execution_space{}, scalar,
+                      static_cast<int>(false));
     Kokkos::fence(
         "Kokkos::UnorderedMap::reset_flag: fence after copying flag from "
         "HostSpace");
   }
 
   bool get_flag(int flag) const {
-    using raw_deep_copy =
-        Kokkos::Impl::DeepCopy<Kokkos::HostSpace,
-                               typename device_type::memory_space>;
-    int result = false;
-    raw_deep_copy(&result, m_scalars.data() + flag, sizeof(int));
+    const auto scalar = Kokkos::subview(m_scalars, flag);
+    int result;
+    Kokkos::deep_copy(typename device_type::execution_space{}, result, scalar);
     Kokkos::fence(
         "Kokkos::UnorderedMap::get_flag: fence after copy to return value in "
         "HostSpace");


### PR DESCRIPTION
This PR is a refactor which is part of a greater effort to simplify the use of `Impl::DeepCopy`.

It replaces the `Impl::DeepCopy` used in containers by the public `deep_copy`.