### PR TITLE
Remove `Impl::DynRankViewFill`

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1020,57 +1020,6 @@ KOKKOS_INLINE_FUNCTION bool operator!=(const DynRankView<LT, LP...>& lhs,
 namespace Kokkos {
 namespace Impl {
 
-template <class OutputView, class Enable = void>
-struct DynRankViewFill {
-  using const_value_type = typename OutputView::traits::const_value_type;
-
-  const OutputView output;
-  const_value_type input;
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t i0) const {
-    const size_t n1 = output.extent(1);
-    const size_t n2 = output.extent(2);
-    const size_t n3 = output.extent(3);
-    const size_t n4 = output.extent(4);
-    const size_t n5 = output.extent(5);
-    const size_t n6 = output.extent(6);
-
-    for (size_t i1 = 0; i1 < n1; ++i1) {
-      for (size_t i2 = 0; i2 < n2; ++i2) {
-        for (size_t i3 = 0; i3 < n3; ++i3) {
-          for (size_t i4 = 0; i4 < n4; ++i4) {
-            for (size_t i5 = 0; i5 < n5; ++i5) {
-              for (size_t i6 = 0; i6 < n6; ++i6) {
-                output.access(i0, i1, i2, i3, i4, i5, i6) = input;
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  DynRankViewFill(const OutputView& arg_out, const_value_type& arg_in)
-      : output(arg_out), input(arg_in) {
-    using execution_space = typename OutputView::execution_space;
-    using Policy          = Kokkos::RangePolicy<execution_space>;
-
-    Kokkos::parallel_for("Kokkos::DynRankViewFill", Policy(0, output.extent(0)),
-                         *this);
-  }
-};
-
-template <class OutputView>
-struct DynRankViewFill<OutputView, std::enable_if_t<OutputView::rank == 0>> {
-  DynRankViewFill(const OutputView& dst,
-                  const typename OutputView::const_value_type& src) {
-    Kokkos::Impl::DeepCopy<typename OutputView::memory_space,
-                           Kokkos::HostSpace>(
-        dst.data(), &src, sizeof(typename OutputView::const_value_type));
-  }
-};
-
 template <class OutputView, class InputView,
           class ExecSpace = typename OutputView::execution_space>
 struct DynRankViewRemap {


### PR DESCRIPTION
This PR is a refactor that removes the `Impl::DynRankViewFill` structs, as they are neither tested, nor used in the project.

Only Sacado in Trilinos seems to use it.