### PR TITLE
Workaround bogus icpc -Werror

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
@@ -137,6 +137,9 @@ class RandomAccessIterator<::Kokkos::View<DataType, Args...>> {
       return *(m_data + n);
     else
       return *(m_data + n * m_stride);
+#ifdef KOKKOS_COMPILER_INTEL
+    __builtin_unreachable();
+#endif
   }
 
   KOKKOS_FUNCTION
@@ -177,6 +180,9 @@ class RandomAccessIterator<::Kokkos::View<DataType, Args...>> {
       return m_data - it.m_data;
     else
       return (m_data - it.m_data) / m_stride;
+#ifdef KOKKOS_COMPILER_INTEL
+    __builtin_unreachable();
+#endif
   }
 
   KOKKOS_FUNCTION


### PR DESCRIPTION
Workaround error # 1011: missing return statement at end of non-void function

Picked up in nightly intel/19.0.5 jobs