### PR TITLE
Clean up resize-relevant implementations in Kokkos_Views.hpp

### DIFF
--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -873,7 +873,7 @@ inline void deep_copy(const Kokkos::Experimental::DynamicView<T, DP...>& dst,
 namespace Impl {
 template <class Arg0, class... DP, class... SP>
 struct CommonSubview<Kokkos::Experimental::DynamicView<DP...>,
-                     Kokkos::Experimental::DynamicView<SP...>, 1, Arg0> {
+                     Kokkos::Experimental::DynamicView<SP...>, Arg0> {
   using DstType          = Kokkos::Experimental::DynamicView<DP...>;
   using SrcType          = Kokkos::Experimental::DynamicView<SP...>;
   using dst_subview_type = DstType;
@@ -885,8 +885,7 @@ struct CommonSubview<Kokkos::Experimental::DynamicView<DP...>,
 };
 
 template <class... DP, class SrcType, class Arg0>
-struct CommonSubview<Kokkos::Experimental::DynamicView<DP...>, SrcType, 1,
-                     Arg0> {
+struct CommonSubview<Kokkos::Experimental::DynamicView<DP...>, SrcType, Arg0> {
   using DstType          = Kokkos::Experimental::DynamicView<DP...>;
   using dst_subview_type = DstType;
   using src_subview_type = typename Kokkos::Subview<SrcType, Arg0>;
@@ -897,8 +896,7 @@ struct CommonSubview<Kokkos::Experimental::DynamicView<DP...>, SrcType, 1,
 };
 
 template <class DstType, class... SP, class Arg0>
-struct CommonSubview<DstType, Kokkos::Experimental::DynamicView<SP...>, 1,
-                     Arg0> {
+struct CommonSubview<DstType, Kokkos::Experimental::DynamicView<SP...>, Arg0> {
   using SrcType          = Kokkos::Experimental::DynamicView<SP...>;
   using dst_subview_type = typename Kokkos::Subview<DstType, Arg0>;
   using src_subview_type = SrcType;

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -544,14 +544,10 @@ void view_copy(const ExecutionSpace& space, const DstType& dst,
   using dst_memory_space = typename DstType::memory_space;
   using src_memory_space = typename SrcType::memory_space;
 
-  enum {
-    ExecCanAccessSrc =
-        Kokkos::SpaceAccessibility<ExecutionSpace, src_memory_space>::accessible
-  };
-  enum {
-    ExecCanAccessDst =
-        Kokkos::SpaceAccessibility<ExecutionSpace, dst_memory_space>::accessible
-  };
+  constexpr bool ExecCanAccessSrc =
+      Kokkos::SpaceAccessibility<ExecutionSpace, src_memory_space>::accessible;
+  constexpr bool ExecCanAccessDst =
+      Kokkos::SpaceAccessibility<ExecutionSpace, dst_memory_space>::accessible;
 
   if (!(ExecCanAccessSrc && ExecCanAccessDst)) {
     Kokkos::Impl::throw_runtime_exception(
@@ -618,17 +614,13 @@ void view_copy(const DstType& dst, const SrcType& src) {
   using dst_memory_space    = typename DstType::memory_space;
   using src_memory_space    = typename SrcType::memory_space;
 
-  enum {
-    DstExecCanAccessSrc =
-        Kokkos::SpaceAccessibility<dst_execution_space,
-                                   src_memory_space>::accessible
-  };
+  constexpr bool DstExecCanAccessSrc =
+      Kokkos::SpaceAccessibility<dst_execution_space,
+                                 src_memory_space>::accessible;
 
-  enum {
-    SrcExecCanAccessDst =
-        Kokkos::SpaceAccessibility<src_execution_space,
-                                   dst_memory_space>::accessible
-  };
+  constexpr bool SrcExecCanAccessDst =
+      Kokkos::SpaceAccessibility<src_execution_space,
+                                 dst_memory_space>::accessible;
 
   if (!DstExecCanAccessSrc && !SrcExecCanAccessDst) {
     std::ostringstream ss;
@@ -2402,23 +2394,15 @@ inline void deep_copy(
     // Copying data between views in accessible memory spaces and either
     // non-contiguous or incompatible shape.
 
-    enum {
-      ExecCanAccessSrcDst =
-          Kokkos::SpaceAccessibility<ExecSpace, dst_memory_space>::accessible &&
-          Kokkos::SpaceAccessibility<ExecSpace, src_memory_space>::accessible
-    };
-
-    enum {
-      DstExecCanAccessSrc =
-          Kokkos::SpaceAccessibility<dst_execution_space,
-                                     src_memory_space>::accessible
-    };
-
-    enum {
-      SrcExecCanAccessDst =
-          Kokkos::SpaceAccessibility<src_execution_space,
-                                     dst_memory_space>::accessible
-    };
+    constexpr bool ExecCanAccessSrcDst =
+        Kokkos::SpaceAccessibility<ExecSpace, dst_memory_space>::accessible &&
+        Kokkos::SpaceAccessibility<ExecSpace, src_memory_space>::accessible;
+    constexpr bool DstExecCanAccessSrc =
+        Kokkos::SpaceAccessibility<dst_execution_space,
+                                   src_memory_space>::accessible;
+    constexpr bool SrcExecCanAccessDst =
+        Kokkos::SpaceAccessibility<src_execution_space,
+                                   dst_memory_space>::accessible;
 
     if constexpr (ExecCanAccessSrcDst) {
       Impl::view_copy(exec_space, dst, src);
@@ -2909,10 +2893,8 @@ struct MirrorViewType {
   // The memory space for the mirror view
   using memory_space = typename Space::memory_space;
   // Check whether it is the same memory space
-  enum {
-    is_same_memspace =
-        std::is_same_v<memory_space, typename src_view_type::memory_space>
-  };
+  static constexpr bool is_same_memspace =
+      std::is_same_v<memory_space, typename src_view_type::memory_space>;
   // The array_layout
   using array_layout = typename src_view_type::array_layout;
   // The data type (we probably want it non-const since otherwise we can't even

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -727,128 +727,14 @@ void view_copy(const DstType& dst, const SrcType& src) {
   }
 }
 
-template <class DstType, class SrcType, int Rank, class... Args>
-struct CommonSubview;
-
-template <class DstType, class SrcType, class Arg0, class... Args>
-struct CommonSubview<DstType, SrcType, 1, Arg0, Args...> {
-  using dst_subview_type = typename Kokkos::Subview<DstType, Arg0>;
-  using src_subview_type = typename Kokkos::Subview<SrcType, Arg0>;
+template <class DstType, class SrcType, class... Args>
+struct CommonSubview {
+  using dst_subview_type = typename Kokkos::Subview<DstType, Args...>;
+  using src_subview_type = typename Kokkos::Subview<SrcType, Args...>;
   dst_subview_type dst_sub;
   src_subview_type src_sub;
-  CommonSubview(const DstType& dst, const SrcType& src, const Arg0& arg0,
-                Args...)
-      : dst_sub(dst, arg0), src_sub(src, arg0) {}
-};
-
-template <class DstType, class SrcType, class Arg0, class Arg1, class... Args>
-struct CommonSubview<DstType, SrcType, 2, Arg0, Arg1, Args...> {
-  using dst_subview_type = typename Kokkos::Subview<DstType, Arg0, Arg1>;
-  using src_subview_type = typename Kokkos::Subview<SrcType, Arg0, Arg1>;
-  dst_subview_type dst_sub;
-  src_subview_type src_sub;
-  CommonSubview(const DstType& dst, const SrcType& src, const Arg0& arg0,
-                const Arg1& arg1, Args...)
-      : dst_sub(dst, arg0, arg1), src_sub(src, arg0, arg1) {}
-};
-
-template <class DstType, class SrcType, class Arg0, class Arg1, class Arg2,
-          class... Args>
-struct CommonSubview<DstType, SrcType, 3, Arg0, Arg1, Arg2, Args...> {
-  using dst_subview_type = typename Kokkos::Subview<DstType, Arg0, Arg1, Arg2>;
-  using src_subview_type = typename Kokkos::Subview<SrcType, Arg0, Arg1, Arg2>;
-  dst_subview_type dst_sub;
-  src_subview_type src_sub;
-  CommonSubview(const DstType& dst, const SrcType& src, const Arg0& arg0,
-                const Arg1& arg1, const Arg2& arg2, Args...)
-      : dst_sub(dst, arg0, arg1, arg2), src_sub(src, arg0, arg1, arg2) {}
-};
-
-template <class DstType, class SrcType, class Arg0, class Arg1, class Arg2,
-          class Arg3, class... Args>
-struct CommonSubview<DstType, SrcType, 4, Arg0, Arg1, Arg2, Arg3, Args...> {
-  using dst_subview_type =
-      typename Kokkos::Subview<DstType, Arg0, Arg1, Arg2, Arg3>;
-  using src_subview_type =
-      typename Kokkos::Subview<SrcType, Arg0, Arg1, Arg2, Arg3>;
-  dst_subview_type dst_sub;
-  src_subview_type src_sub;
-  CommonSubview(const DstType& dst, const SrcType& src, const Arg0& arg0,
-                const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
-                const Args...)
-      : dst_sub(dst, arg0, arg1, arg2, arg3),
-        src_sub(src, arg0, arg1, arg2, arg3) {}
-};
-
-template <class DstType, class SrcType, class Arg0, class Arg1, class Arg2,
-          class Arg3, class Arg4, class... Args>
-struct CommonSubview<DstType, SrcType, 5, Arg0, Arg1, Arg2, Arg3, Arg4,
-                     Args...> {
-  using dst_subview_type =
-      typename Kokkos::Subview<DstType, Arg0, Arg1, Arg2, Arg3, Arg4>;
-  using src_subview_type =
-      typename Kokkos::Subview<SrcType, Arg0, Arg1, Arg2, Arg3, Arg4>;
-  dst_subview_type dst_sub;
-  src_subview_type src_sub;
-  CommonSubview(const DstType& dst, const SrcType& src, const Arg0& arg0,
-                const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
-                const Arg4& arg4, const Args...)
-      : dst_sub(dst, arg0, arg1, arg2, arg3, arg4),
-        src_sub(src, arg0, arg1, arg2, arg3, arg4) {}
-};
-
-template <class DstType, class SrcType, class Arg0, class Arg1, class Arg2,
-          class Arg3, class Arg4, class Arg5, class... Args>
-struct CommonSubview<DstType, SrcType, 6, Arg0, Arg1, Arg2, Arg3, Arg4, Arg5,
-                     Args...> {
-  using dst_subview_type =
-      typename Kokkos::Subview<DstType, Arg0, Arg1, Arg2, Arg3, Arg4, Arg5>;
-  using src_subview_type =
-      typename Kokkos::Subview<SrcType, Arg0, Arg1, Arg2, Arg3, Arg4, Arg5>;
-  dst_subview_type dst_sub;
-  src_subview_type src_sub;
-  CommonSubview(const DstType& dst, const SrcType& src, const Arg0& arg0,
-                const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
-                const Arg4& arg4, const Arg5& arg5, const Args...)
-      : dst_sub(dst, arg0, arg1, arg2, arg3, arg4, arg5),
-        src_sub(src, arg0, arg1, arg2, arg3, arg4, arg5) {}
-};
-
-template <class DstType, class SrcType, class Arg0, class Arg1, class Arg2,
-          class Arg3, class Arg4, class Arg5, class Arg6, class... Args>
-struct CommonSubview<DstType, SrcType, 7, Arg0, Arg1, Arg2, Arg3, Arg4, Arg5,
-                     Arg6, Args...> {
-  using dst_subview_type = typename Kokkos::Subview<DstType, Arg0, Arg1, Arg2,
-                                                    Arg3, Arg4, Arg5, Arg6>;
-  using src_subview_type = typename Kokkos::Subview<SrcType, Arg0, Arg1, Arg2,
-                                                    Arg3, Arg4, Arg5, Arg6>;
-  dst_subview_type dst_sub;
-  src_subview_type src_sub;
-  CommonSubview(const DstType& dst, const SrcType& src, const Arg0& arg0,
-                const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
-                const Arg4& arg4, const Arg5& arg5, const Arg6& arg6, Args...)
-      : dst_sub(dst, arg0, arg1, arg2, arg3, arg4, arg5, arg6),
-        src_sub(src, arg0, arg1, arg2, arg3, arg4, arg5, arg6) {}
-};
-
-template <class DstType, class SrcType, class Arg0, class Arg1, class Arg2,
-          class Arg3, class Arg4, class Arg5, class Arg6, class Arg7>
-struct CommonSubview<DstType, SrcType, 8, Arg0, Arg1, Arg2, Arg3, Arg4, Arg5,
-                     Arg6, Arg7> {
-  using dst_subview_type =
-      typename Kokkos::Subview<DstType, Arg0, Arg1, Arg2, Arg3, Arg4, Arg5,
-                               Arg6, Arg7>;
-  using src_subview_type =
-      typename Kokkos::Subview<SrcType, Arg0, Arg1, Arg2, Arg3, Arg4, Arg5,
-                               Arg6, Arg7>;
-  dst_subview_type dst_sub;
-  src_subview_type src_sub;
-  CommonSubview(const DstType& dst, const SrcType& src, const Arg0& arg0,
-                const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
-                const Arg4& arg4, const Arg5& arg5, const Arg6& arg6,
-                const Arg7& arg7)
-      : dst_sub(dst, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7),
-        src_sub(src, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) {}
+  CommonSubview(const DstType& dst, const SrcType& src, const Args&... args)
+      : dst_sub(dst, args...), src_sub(src, args...) {}
 };
 
 template <class DstType, class SrcType,
@@ -871,8 +757,7 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 1> {
       view_copy(exec_space..., dst, src);
     } else {
       p_type ext0(0, std::min(dst.extent(0), src.extent(0)));
-      using sv_adapter_type = CommonSubview<DstType, SrcType, 1, p_type>;
-      sv_adapter_type common_subview(dst, src, ext0);
+      CommonSubview common_subview(dst, src, ext0);
       view_copy(exec_space..., common_subview.dst_sub, common_subview.src_sub);
     }
   }
@@ -894,26 +779,20 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 2> {
         view_copy(exec_space..., dst, src);
       } else {
         p_type ext1(0, std::min(dst.extent(1), src.extent(1)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 2, Kokkos::ALL_t, p_type>;
-        sv_adapter_type common_subview(dst, src, Kokkos::ALL, ext1);
+        CommonSubview common_subview(dst, src, Kokkos::ALL, ext1);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       }
     } else {
       if (dst.extent(1) == src.extent(1)) {
         p_type ext0(0, std::min(dst.extent(0), src.extent(0)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 2, p_type, Kokkos::ALL_t>;
-        sv_adapter_type common_subview(dst, src, ext0, Kokkos::ALL);
+        CommonSubview common_subview(dst, src, ext0, Kokkos::ALL);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       } else {
         p_type ext0(0, std::min(dst.extent(0), src.extent(0)));
         p_type ext1(0, std::min(dst.extent(1), src.extent(1)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 2, p_type, p_type>;
-        sv_adapter_type common_subview(dst, src, ext0, ext1);
+        CommonSubview common_subview(dst, src, ext0, ext1);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       }
@@ -935,19 +814,13 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 3> {
     if (dst.extent(0) == src.extent(0)) {
       if (dst.extent(2) == src.extent(2)) {
         p_type ext1(0, std::min(dst.extent(1), src.extent(1)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 3, Kokkos::ALL_t, p_type,
-                          Kokkos::ALL_t>;
-        sv_adapter_type common_subview(dst, src, Kokkos::ALL, ext1,
-                                       Kokkos::ALL);
+        CommonSubview common_subview(dst, src, Kokkos::ALL, ext1, Kokkos::ALL);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       } else {
         p_type ext1(0, std::min(dst.extent(1), src.extent(1)));
         p_type ext2(0, std::min(dst.extent(2), src.extent(2)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 3, Kokkos::ALL_t, p_type, p_type>;
-        sv_adapter_type common_subview(dst, src, Kokkos::ALL, ext1, ext2);
+        CommonSubview common_subview(dst, src, Kokkos::ALL, ext1, ext2);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       }
@@ -955,18 +828,14 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 3> {
       if (dst.extent(2) == src.extent(2)) {
         p_type ext0(0, std::min(dst.extent(0), src.extent(0)));
         p_type ext1(0, std::min(dst.extent(1), src.extent(1)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 3, p_type, p_type, Kokkos::ALL_t>;
-        sv_adapter_type common_subview(dst, src, ext0, ext1, Kokkos::ALL);
+        CommonSubview common_subview(dst, src, ext0, ext1, Kokkos::ALL);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       } else {
         p_type ext0(0, std::min(dst.extent(0), src.extent(0)));
         p_type ext1(0, std::min(dst.extent(1), src.extent(1)));
         p_type ext2(0, std::min(dst.extent(2), src.extent(2)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 3, p_type, p_type, p_type>;
-        sv_adapter_type common_subview(dst, src, ext0, ext1, ext2);
+        CommonSubview common_subview(dst, src, ext0, ext1, ext2);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       }
@@ -989,21 +858,15 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 4> {
       if (dst.extent(3) == src.extent(3)) {
         p_type ext1(0, std::min(dst.extent(1), src.extent(1)));
         p_type ext2(0, std::min(dst.extent(2), src.extent(2)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 4, Kokkos::ALL_t, p_type, p_type,
-                          Kokkos::ALL_t>;
-        sv_adapter_type common_subview(dst, src, Kokkos::ALL, ext1, ext2,
-                                       Kokkos::ALL);
+        CommonSubview common_subview(dst, src, Kokkos::ALL, ext1, ext2,
+                                     Kokkos::ALL);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       } else {
         p_type ext1(0, std::min(dst.extent(1), src.extent(1)));
         p_type ext2(0, std::min(dst.extent(2), src.extent(2)));
         p_type ext3(0, std::min(dst.extent(3), src.extent(3)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 4, Kokkos::ALL_t, p_type, p_type,
-                          p_type>;
-        sv_adapter_type common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3);
+        CommonSubview common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       }
@@ -1012,9 +875,7 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 4> {
         p_type ext0(0, std::min(dst.extent(0), src.extent(0)));
         p_type ext1(0, std::min(dst.extent(1), src.extent(1)));
         p_type ext2(0, std::min(dst.extent(2), src.extent(2)));
-        using sv_adapter_type = CommonSubview<DstType, SrcType, 4, p_type,
-                                              p_type, p_type, Kokkos::ALL_t>;
-        sv_adapter_type common_subview(dst, src, ext0, ext1, ext2, Kokkos::ALL);
+        CommonSubview common_subview(dst, src, ext0, ext1, ext2, Kokkos::ALL);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       } else {
@@ -1022,9 +883,7 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 4> {
         p_type ext1(0, std::min(dst.extent(1), src.extent(1)));
         p_type ext2(0, std::min(dst.extent(2), src.extent(2)));
         p_type ext3(0, std::min(dst.extent(3), src.extent(3)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 4, p_type, p_type, p_type, p_type>;
-        sv_adapter_type common_subview(dst, src, ext0, ext1, ext2, ext3);
+        CommonSubview common_subview(dst, src, ext0, ext1, ext2, ext3);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       }
@@ -1048,11 +907,8 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 5> {
         p_type ext1(0, std::min(dst.extent(1), src.extent(1)));
         p_type ext2(0, std::min(dst.extent(2), src.extent(2)));
         p_type ext3(0, std::min(dst.extent(3), src.extent(3)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 5, Kokkos::ALL_t, p_type, p_type,
-                          p_type, Kokkos::ALL_t>;
-        sv_adapter_type common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3,
-                                       Kokkos::ALL);
+        CommonSubview common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3,
+                                     Kokkos::ALL);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       } else {
@@ -1060,11 +916,8 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 5> {
         p_type ext2(0, std::min(dst.extent(2), src.extent(2)));
         p_type ext3(0, std::min(dst.extent(3), src.extent(3)));
         p_type ext4(0, std::min(dst.extent(4), src.extent(4)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 5, Kokkos::ALL_t, p_type, p_type,
-                          p_type, p_type>;
-        sv_adapter_type common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3,
-                                       ext4);
+        CommonSubview common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3,
+                                     ext4);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       }
@@ -1074,11 +927,8 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 5> {
         p_type ext1(0, std::min(dst.extent(1), src.extent(1)));
         p_type ext2(0, std::min(dst.extent(2), src.extent(2)));
         p_type ext3(0, std::min(dst.extent(3), src.extent(3)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 5, p_type, p_type, p_type, p_type,
-                          Kokkos::ALL_t>;
-        sv_adapter_type common_subview(dst, src, ext0, ext1, ext2, ext3,
-                                       Kokkos::ALL);
+        CommonSubview common_subview(dst, src, ext0, ext1, ext2, ext3,
+                                     Kokkos::ALL);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       } else {
@@ -1087,9 +937,7 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 5> {
         p_type ext2(0, std::min(dst.extent(2), src.extent(2)));
         p_type ext3(0, std::min(dst.extent(3), src.extent(3)));
         p_type ext4(0, std::min(dst.extent(4), src.extent(4)));
-        using sv_adapter_type = CommonSubview<DstType, SrcType, 5, p_type,
-                                              p_type, p_type, p_type, p_type>;
-        sv_adapter_type common_subview(dst, src, ext0, ext1, ext2, ext3, ext4);
+        CommonSubview common_subview(dst, src, ext0, ext1, ext2, ext3, ext4);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       }
@@ -1113,11 +961,8 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 6> {
         p_type ext2(0, std::min(dst.extent(2), src.extent(2)));
         p_type ext3(0, std::min(dst.extent(3), src.extent(3)));
         p_type ext4(0, std::min(dst.extent(4), src.extent(4)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 6, Kokkos::ALL_t, p_type, p_type,
-                          p_type, p_type, Kokkos::ALL_t>;
-        sv_adapter_type common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3,
-                                       ext4, Kokkos::ALL);
+        CommonSubview common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3,
+                                     ext4, Kokkos::ALL);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       } else {
@@ -1126,11 +971,8 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 6> {
         p_type ext3(0, std::min(dst.extent(3), src.extent(3)));
         p_type ext4(0, std::min(dst.extent(4), src.extent(4)));
         p_type ext5(0, std::min(dst.extent(5), src.extent(5)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 6, Kokkos::ALL_t, p_type, p_type,
-                          p_type, p_type, p_type>;
-        sv_adapter_type common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3,
-                                       ext4, ext5);
+        CommonSubview common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3,
+                                     ext4, ext5);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       }
@@ -1142,11 +984,8 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 6> {
         p_type ext3(0, std::min(dst.extent(3), src.extent(3)));
         p_type ext4(0, std::min(dst.extent(4), src.extent(4)));
 
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 6, p_type, p_type, p_type, p_type,
-                          p_type, Kokkos::ALL_t>;
-        sv_adapter_type common_subview(dst, src, ext0, ext1, ext2, ext3, ext4,
-                                       Kokkos::ALL);
+        CommonSubview common_subview(dst, src, ext0, ext1, ext2, ext3, ext4,
+                                     Kokkos::ALL);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       } else {
@@ -1157,11 +996,8 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 6> {
         p_type ext4(0, std::min(dst.extent(4), src.extent(4)));
         p_type ext5(0, std::min(dst.extent(5), src.extent(5)));
 
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 6, p_type, p_type, p_type, p_type,
-                          p_type, p_type>;
-        sv_adapter_type common_subview(dst, src, ext0, ext1, ext2, ext3, ext4,
-                                       ext5);
+        CommonSubview common_subview(dst, src, ext0, ext1, ext2, ext3, ext4,
+                                     ext5);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       }
@@ -1187,11 +1023,8 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 7> {
         p_type ext3(0, std::min(dst.extent(3), src.extent(3)));
         p_type ext4(0, std::min(dst.extent(4), src.extent(4)));
         p_type ext5(0, std::min(dst.extent(5), src.extent(5)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 7, Kokkos::ALL_t, p_type, p_type,
-                          p_type, p_type, p_type, Kokkos::ALL_t>;
-        sv_adapter_type common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3,
-                                       ext4, ext5, Kokkos::ALL);
+        CommonSubview common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3,
+                                     ext4, ext5, Kokkos::ALL);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       } else {
@@ -1201,11 +1034,8 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 7> {
         p_type ext4(0, std::min(dst.extent(4), src.extent(4)));
         p_type ext5(0, std::min(dst.extent(5), src.extent(5)));
         p_type ext6(0, std::min(dst.extent(6), src.extent(6)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 7, Kokkos::ALL_t, p_type, p_type,
-                          p_type, p_type, p_type, p_type>;
-        sv_adapter_type common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3,
-                                       ext4, ext5, ext6);
+        CommonSubview common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3,
+                                     ext4, ext5, ext6);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       }
@@ -1217,11 +1047,8 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 7> {
         p_type ext3(0, std::min(dst.extent(3), src.extent(3)));
         p_type ext4(0, std::min(dst.extent(4), src.extent(4)));
         p_type ext5(0, std::min(dst.extent(5), src.extent(5)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 7, p_type, p_type, p_type, p_type,
-                          p_type, p_type, Kokkos::ALL_t>;
-        sv_adapter_type common_subview(dst, src, ext0, ext1, ext2, ext3, ext4,
-                                       ext5, Kokkos::ALL);
+        CommonSubview common_subview(dst, src, ext0, ext1, ext2, ext3, ext4,
+                                     ext5, Kokkos::ALL);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       } else {
@@ -1232,11 +1059,8 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 7> {
         p_type ext4(0, std::min(dst.extent(4), src.extent(4)));
         p_type ext5(0, std::min(dst.extent(5), src.extent(5)));
         p_type ext6(0, std::min(dst.extent(6), src.extent(6)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 7, p_type, p_type, p_type, p_type,
-                          p_type, p_type, p_type>;
-        sv_adapter_type common_subview(dst, src, ext0, ext1, ext2, ext3, ext4,
-                                       ext5, ext6);
+        CommonSubview common_subview(dst, src, ext0, ext1, ext2, ext3, ext4,
+                                     ext5, ext6);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       }
@@ -1263,11 +1087,8 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 8> {
         p_type ext4(0, std::min(dst.extent(4), src.extent(4)));
         p_type ext5(0, std::min(dst.extent(5), src.extent(5)));
         p_type ext6(0, std::min(dst.extent(6), src.extent(6)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 8, Kokkos::ALL_t, p_type, p_type,
-                          p_type, p_type, p_type, p_type, Kokkos::ALL_t>;
-        sv_adapter_type common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3,
-                                       ext4, ext5, ext6, Kokkos::ALL);
+        CommonSubview common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3,
+                                     ext4, ext5, ext6, Kokkos::ALL);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       } else {
@@ -1278,11 +1099,8 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 8> {
         p_type ext5(0, std::min(dst.extent(5), src.extent(5)));
         p_type ext6(0, std::min(dst.extent(6), src.extent(6)));
         p_type ext7(0, std::min(dst.extent(7), src.extent(7)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 8, Kokkos::ALL_t, p_type, p_type,
-                          p_type, p_type, p_type, p_type, p_type>;
-        sv_adapter_type common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3,
-                                       ext4, ext5, ext6, ext7);
+        CommonSubview common_subview(dst, src, Kokkos::ALL, ext1, ext2, ext3,
+                                     ext4, ext5, ext6, ext7);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       }
@@ -1295,11 +1113,8 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 8> {
         p_type ext4(0, std::min(dst.extent(4), src.extent(4)));
         p_type ext5(0, std::min(dst.extent(5), src.extent(5)));
         p_type ext6(0, std::min(dst.extent(6), src.extent(6)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 8, p_type, p_type, p_type, p_type,
-                          p_type, p_type, p_type, Kokkos::ALL_t>;
-        sv_adapter_type common_subview(dst, src, ext0, ext1, ext2, ext3, ext4,
-                                       ext5, ext6, Kokkos::ALL);
+        CommonSubview common_subview(dst, src, ext0, ext1, ext2, ext3, ext4,
+                                     ext5, ext6, Kokkos::ALL);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       } else {
@@ -1311,11 +1126,8 @@ struct ViewRemap<DstType, SrcType, ExecSpace, 8> {
         p_type ext5(0, std::min(dst.extent(5), src.extent(5)));
         p_type ext6(0, std::min(dst.extent(6), src.extent(6)));
         p_type ext7(0, std::min(dst.extent(7), src.extent(7)));
-        using sv_adapter_type =
-            CommonSubview<DstType, SrcType, 8, p_type, p_type, p_type, p_type,
-                          p_type, p_type, p_type, p_type>;
-        sv_adapter_type common_subview(dst, src, ext0, ext1, ext2, ext3, ext4,
-                                       ext5, ext6, ext7);
+        CommonSubview common_subview(dst, src, ext0, ext1, ext2, ext3, ext4,
+                                     ext5, ext6, ext7);
         view_copy(exec_space..., common_subview.dst_sub,
                   common_subview.src_sub);
       }


### PR DESCRIPTION
Prerequisite for https://github.com/kokkos/kokkos/pull/7514.

We can remove a lot of lines of code by avoiding explicitly specializing `CommonSubView` and `ViewRemap` for all dimensions.
Minor changes:
- introduce `get_iteration_order` avoiding duplicated code
- replacing unnamed enums for clarity and saving a couple lines
-  shortening `view_copy` by using `std::conditional_t` for determining the execution space