### PR TITLE
Fix some clang-tidy complaints

### DIFF
--- a/.github/workflows/continuous-integration-linux-hpx.yml
+++ b/.github/workflows/continuous-integration-linux-hpx.yml
@@ -60,6 +60,8 @@ jobs:
         if: steps.cache-hpx.outputs.cache-hit != 'true'
         working-directory: hpx/build
         run: ninja -j2 install
+      - name: install clang-tidy
+        run: sudo apt-get install -y clang-tidy
 
       - name: configure kokkos
         run: |
@@ -69,6 +71,7 @@ jobs:
             -GNinja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_INSTALL_PREFIX=$PWD/../install \
+            -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*" \
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_CXX_FLAGS="-Werror" \
             -DHPX_ROOT=$PWD/../../hpx/install \

--- a/.github/workflows/continuous-integration-linux.yml
+++ b/.github/workflows/continuous-integration-linux.yml
@@ -19,6 +19,7 @@ jobs:
         cxx_extra_flags: ['']
         cmake_build_type: ['Release', 'Debug']
         backend: ['OPENMP']
+        clang-tidy: ['-DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*"']
         stdcxx: [17]
         include:
           - distro: 'ubuntu:intel'
@@ -26,12 +27,14 @@ jobs:
             cxx_extra_flags: '-diag-disable=177,1478,1786,10441'
             cmake_build_type: 'Release'
             backend: 'OPENMP'
+            clang-tidy: ''
             stdcxx: '17'
           - distro: 'ubuntu:intel'
             cxx: 'icpc'
             cxx_extra_flags: '-diag-disable=177,1478,1786,10441'
             cmake_build_type: 'Debug'
             backend: 'OPENMP'
+            clang-tidy: ''
             stdcxx: '17'
           - distro: 'ubuntu:intel'
             cxx: 'icpx'
@@ -39,12 +42,14 @@ jobs:
             extra_linker_flags: '-fsanitize=address,undefined -fno-sanitize=function -fno-sanitize=vptr -fno-sanitize-recover=all'
             cmake_build_type: 'Release'
             backend: 'OPENMP'
+            clang-tidy: ''
             stdcxx: '17'
           - distro: 'ubuntu:intel'
             cxx: 'icpx'
             cxx_extra_flags: '-fp-model=precise -Wno-pass-failed'
             cmake_build_type: 'Debug'
             backend: 'OPENMP'
+            clang-tidy: ''
             stdcxx: '20'
           - distro: 'ubuntu:latest'
             cxx: 'clang++'
@@ -107,7 +112,7 @@ jobs:
         run: |
           cmake -B builddir \
             -DCMAKE_INSTALL_PREFIX=/usr \
-            -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*" \
+            ${{ matrix.clang-tidy }} \
             -DBUILD_SHARED_LIBS=ON \
             -Ddesul_ROOT=/usr/desul-install/ \
             -DKokkos_ENABLE_DESUL_ATOMICS_EXTERNAL=ON \

--- a/.github/workflows/continuous-integration-linux.yml
+++ b/.github/workflows/continuous-integration-linux.yml
@@ -19,7 +19,6 @@ jobs:
         cxx_extra_flags: ['']
         cmake_build_type: ['Release', 'Debug']
         backend: ['OPENMP']
-        clang-tidy: ['']
         stdcxx: [17]
         include:
           - distro: 'ubuntu:intel'
@@ -53,7 +52,6 @@ jobs:
             extra_linker_flags: '-fsanitize=address,undefined -fno-sanitize=function -fno-sanitize=vptr -fno-sanitize-recover=all'
             cmake_build_type: 'RelWithDebInfo'
             backend: 'THREADS'
-            clang-tidy: '-DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*"'
             stdcxx: '23'
           - distro: 'ubuntu:latest'
             cxx: 'clang++'
@@ -99,14 +97,17 @@ jobs:
       - name: maybe_use_external_gtest
         if: ${{ matrix.distro == 'ubuntu:latest' }}
         run: sudo apt-get update && sudo apt-get install -y libgtest-dev
-      - name: maybe_install_clang_tidy
-        if: ${{ matrix.clang-tidy != '' }}
+      - name: maybe_install_clang_tidy_fedora
+        if: ${{ startsWith(matrix.distro,'fedora:') }}
+        run: sudo yum update -y && sudo yum install -y clang-tools-extra
+      - name: maybe_install_clang_tidy_ubuntu
+        if: ${{ startsWith(matrix.distro,'ubuntu:') }}
         run: sudo apt-get update && sudo apt-get install -y clang-tidy
       - name: Configure Kokkos
         run: |
           cmake -B builddir \
             -DCMAKE_INSTALL_PREFIX=/usr \
-            ${{ matrix.clang-tidy }} \
+            -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*" \
             -DBUILD_SHARED_LIBS=ON \
             -Ddesul_ROOT=/usr/desul-install/ \
             -DKokkos_ENABLE_DESUL_ATOMICS_EXTERNAL=ON \

--- a/algorithms/src/sorting/Kokkos_BinOpsPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_BinOpsPublicAPI.hpp
@@ -45,7 +45,7 @@ struct BinOp1D {
     // For integral types the number of bins may be larger than the range
     // in which case we can exactly have one unique value per bin
     // and then don't need to sort bins.
-    if (std::is_integral<typename KeyViewType::const_value_type>::value &&
+    if (std::is_integral_v<typename KeyViewType::const_value_type> &&
         (static_cast<double>(max) - static_cast<double>(min)) <=
             static_cast<double>(max_bins)) {
       mul_ = 1.;

--- a/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
@@ -171,7 +171,7 @@ struct VerifyData {
         create_mirror_view_and_copy(Kokkos::HostSpace(), test_view_dc);
     if (test_view_h.extent(0) > 0) {
       for (std::size_t i = 0; i < test_view_h.extent(0); ++i) {
-        if (std::is_same<gold_view_value_type, int>::value) {
+        if (std::is_same_v<gold_view_value_type, int>) {
           ASSERT_EQ(gold_h(i), test_view_h(i));
         } else {
           const auto error =

--- a/algorithms/unit_tests/TestStdAlgorithmsInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsInclusiveScan.cpp
@@ -184,7 +184,7 @@ struct VerifyData {
     const auto ext = test_view_h.extent(0);
     if (ext > 0) {
       for (std::size_t i = 0; i < ext; ++i) {
-        if (std::is_same<gold_view_value_type, int>::value) {
+        if (std::is_same_v<gold_view_value_type, int>) {
           ASSERT_EQ(gold_h(i), test_view_h(i));
         } else {
           const auto error =

--- a/algorithms/unit_tests/TestStdAlgorithmsModOps.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsModOps.cpp
@@ -70,7 +70,7 @@ struct StdAlgoModSeqOpsTestMove {
   void operator()(const int index) const {
     typename ViewType::value_type a{11};
     using move_t = decltype(std::move(a));
-    static_assert(std::is_rvalue_reference<move_t>::value);
+    static_assert(std::is_rvalue_reference_v<move_t>);
     m_view(index) = std::move(a);
   }
 

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -172,7 +172,7 @@ if(KOKKOS_ENABLE_COMPILER_WARNINGS)
     list(APPEND COMMON_WARNINGS "-Wimplicit-fallthrough")
   endif()
 
-  set(GNU_WARNINGS "-Wempty-body" "-Wclobbered" "-Wignored-qualifiers" ${COMMON_WARNINGS})
+  set(GNU_WARNINGS "-Wempty-body" "-Wignored-qualifiers" ${COMMON_WARNINGS})
   if(KOKKOS_CXX_COMPILER_ID STREQUAL GNU)
     list(APPEND GNU_WARNINGS "-Wimplicit-fallthrough")
   endif()

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -615,8 +615,8 @@ class DualView : public ViewTraits<DataType, Properties...> {
         impl_report_host_sync();
       }
     }
-    if constexpr (std::is_same<typename t_host::memory_space,
-                               typename t_dev::memory_space>::value) {
+    if constexpr (std::is_same_v<typename t_host::memory_space,
+                                 typename t_dev::memory_space>) {
       typename t_dev::execution_space().fence(
           "Kokkos::DualView<>::sync: fence after syncing DualView");
       typename t_host::execution_space().fence(
@@ -687,8 +687,8 @@ class DualView : public ViewTraits<DataType, Properties...> {
   // deliberately passing args by cref as they're used multiple times
   template <typename... Args>
   void sync_host_impl(Args const&... args) {
-    if (!std::is_same<typename traits::data_type,
-                      typename traits::non_const_data_type>::value)
+    if (!std::is_same_v<typename traits::data_type,
+                        typename traits::non_const_data_type>)
       Impl::throw_runtime_exception(
           "Calling sync_host on a DualView with a const datatype.");
     if (modified_flags.data() == nullptr) return;
@@ -718,8 +718,8 @@ class DualView : public ViewTraits<DataType, Properties...> {
   // deliberately passing args by cref as they're used multiple times
   template <typename... Args>
   void sync_device_impl(Args const&... args) {
-    if (!std::is_same<typename traits::data_type,
-                      typename traits::non_const_data_type>::value)
+    if (!std::is_same_v<typename traits::data_type,
+                        typename traits::non_const_data_type>)
       Impl::throw_runtime_exception(
           "Calling sync_device on a DualView with a const datatype.");
     if (modified_flags.data() == nullptr) return;

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -651,8 +651,8 @@ class OffsetView : public View<DataType, Properties...> {
       m_begins[i] = minIndices.begin()[i];
     }
     static_assert(
-        std::is_same<pointer_type, typename Kokkos::Impl::ViewCtorProp<
-                                       P...>::pointer_type>::value,
+        std::is_same_v<pointer_type,
+                       typename Kokkos::Impl::ViewCtorProp<P...>::pointer_type>,
         "When constructing OffsetView to wrap user memory, you must supply "
         "matching pointer type");
   }

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -788,7 +788,7 @@ class ScatterView<DataType, Layout, DeviceType, Op, ScatterNonDuplicated,
   void contribute_into(execution_space const& exec_space,
                        View<DT, RP...> const& dest) const {
     using dest_type = View<DT, RP...>;
-    static_assert(std::is_same<typename dest_type::array_layout, Layout>::value,
+    static_assert(std::is_same_v<typename dest_type::array_layout, Layout>,
                   "ScatterView contribute destination has different layout");
     static_assert(
         Kokkos::SpaceAccessibility<
@@ -1071,9 +1071,9 @@ class ScatterView<DataType, Kokkos::LayoutRight, DeviceType, Op,
   void contribute_into(execution_space const& exec_space,
                        View<DT, RP...> const& dest) const {
     using dest_type = View<DT, RP...>;
-    static_assert(std::is_same<typename dest_type::array_layout,
-                               Kokkos::LayoutRight>::value,
-                  "ScatterView deep_copy destination has different layout");
+    static_assert(
+        std::is_same_v<typename dest_type::array_layout, Kokkos::LayoutRight>,
+        "ScatterView deep_copy destination has different layout");
     static_assert(
         Kokkos::SpaceAccessibility<
             execution_space, typename dest_type::memory_space>::accessible,
@@ -1351,12 +1351,12 @@ class ScatterView<DataType, Kokkos::LayoutLeft, DeviceType, Op,
                        View<RP...> const& dest) const {
     using dest_type = View<RP...>;
     static_assert(
-        std::is_same<typename dest_type::value_type,
-                     typename original_view_type::non_const_value_type>::value,
+        std::is_same_v<typename dest_type::value_type,
+                       typename original_view_type::non_const_value_type>,
         "ScatterView deep_copy destination has wrong value_type");
-    static_assert(std::is_same<typename dest_type::array_layout,
-                               Kokkos::LayoutLeft>::value,
-                  "ScatterView deep_copy destination has different layout");
+    static_assert(
+        std::is_same_v<typename dest_type::array_layout, Kokkos::LayoutLeft>,
+        "ScatterView deep_copy destination has different layout");
     static_assert(
         Kokkos::SpaceAccessibility<
             execution_space, typename dest_type::memory_space>::accessible,

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -772,12 +772,12 @@ TEST(TEST_CATEGORY, scatterview) {
 
 #if defined(KOKKOS_ENABLE_SERIAL) || defined(KOKKOS_ENABLE_OPENMP)
 #if defined(KOKKOS_ENABLE_SERIAL)
-  bool is_serial = std::is_same<TEST_EXECSPACE, Kokkos::Serial>::value;
+  bool is_serial = std::is_same_v<TEST_EXECSPACE, Kokkos::Serial>;
 #else
   bool is_serial = false;
 #endif
 #if defined(KOKKOS_ENABLE_OPENMP)
-  bool is_openmp = std::is_same<TEST_EXECSPACE, Kokkos::OpenMP>::value;
+  bool is_openmp = std::is_same_v<TEST_EXECSPACE, Kokkos::OpenMP>;
 #else
   bool is_openmp = false;
 #endif

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -2021,7 +2021,7 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
   using closure_value_type = typename Kokkos::Impl::FunctorAnalysis<
       Kokkos::Impl::FunctorPatternInterface::SCAN, void, FunctorType,
       void>::value_type;
-  static_assert(std::is_same<closure_value_type, ValueType>::value,
+  static_assert(std::is_same_v<closure_value_type, ValueType>,
                 "Non-matching value types of closure and return type");
 
   ValueType accum;

--- a/core/src/HPX/Kokkos_HPX_Task.hpp
+++ b/core/src/HPX/Kokkos_HPX_Task.hpp
@@ -128,8 +128,8 @@ class TaskQueueSpecialization<
 template <class Scheduler>
 class TaskQueueSpecializationConstrained<
     Scheduler,
-    std::enable_if_t<std::is_same<typename Scheduler::execution_space,
-                                  Kokkos::Experimental::HPX>::value>> {
+    std::enable_if_t<std::is_same_v<typename Scheduler::execution_space,
+                                    Kokkos::Experimental::HPX>>> {
  public:
   void setup() const {
     const int num_worker_threads = Kokkos::Experimental::HPX().concurrency();

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -109,9 +109,8 @@ struct Array {
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION constexpr reference operator[](const iType& i) {
-    static_assert(
-        (std::is_integral<iType>::value || std::is_enum<iType>::value),
-        "Must be integral argument");
+    static_assert((std::is_integral_v<iType> || std::is_enum_v<iType>),
+                  "Must be integral argument");
     KOKKOS_ARRAY_BOUNDS_CHECK(i, N);
     return m_internal_implementation_private_member_data[i];
   }
@@ -119,9 +118,8 @@ struct Array {
   template <typename iType>
   KOKKOS_INLINE_FUNCTION constexpr const_reference operator[](
       const iType& i) const {
-    static_assert(
-        (std::is_integral<iType>::value || std::is_enum<iType>::value),
-        "Must be integral argument");
+    static_assert((std::is_integral_v<iType> || std::is_enum_v<iType>),
+                  "Must be integral argument");
     KOKKOS_ARRAY_BOUNDS_CHECK(i, N);
     return m_internal_implementation_private_member_data[i];
   }
@@ -179,18 +177,16 @@ struct Array<T, 0> {
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION reference operator[](const iType&) {
-    static_assert(
-        (std::is_integral<iType>::value || std::is_enum<iType>::value),
-        "Must be integer argument");
+    static_assert((std::is_integral_v<iType> || std::is_enum_v<iType>),
+                  "Must be integer argument");
     Kokkos::abort("Unreachable code");
     return *reinterpret_cast<pointer>(-1);
   }
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION const_reference operator[](const iType&) const {
-    static_assert(
-        (std::is_integral<iType>::value || std::is_enum<iType>::value),
-        "Must be integer argument");
+    static_assert((std::is_integral_v<iType> || std::is_enum_v<iType>),
+                  "Must be integer argument");
     Kokkos::abort("Unreachable code");
     return *reinterpret_cast<const_pointer>(-1);
   }
@@ -248,18 +244,16 @@ struct KOKKOS_DEPRECATED
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION reference operator[](const iType& i) {
-    static_assert(
-        (std::is_integral<iType>::value || std::is_enum<iType>::value),
-        "Must be integral argument");
+    static_assert((std::is_integral_v<iType> || std::is_enum_v<iType>),
+                  "Must be integral argument");
     KOKKOS_ARRAY_BOUNDS_CHECK(i, m_size);
     return m_elem[i];
   }
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION const_reference operator[](const iType& i) const {
-    static_assert(
-        (std::is_integral<iType>::value || std::is_enum<iType>::value),
-        "Must be integral argument");
+    static_assert((std::is_integral_v<iType> || std::is_enum_v<iType>),
+                  "Must be integral argument");
     KOKKOS_ARRAY_BOUNDS_CHECK(i, m_size);
     return m_elem[i];
   }
@@ -318,18 +312,16 @@ struct KOKKOS_DEPRECATED
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION reference operator[](const iType& i) {
-    static_assert(
-        (std::is_integral<iType>::value || std::is_enum<iType>::value),
-        "Must be integral argument");
+    static_assert((std::is_integral_v<iType> || std::is_enum_v<iType>),
+                  "Must be integral argument");
     KOKKOS_ARRAY_BOUNDS_CHECK(i, m_size);
     return m_elem[i * m_stride];
   }
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION const_reference operator[](const iType& i) const {
-    static_assert(
-        (std::is_integral<iType>::value || std::is_enum<iType>::value),
-        "Must be integral argument");
+    static_assert((std::is_integral_v<iType> || std::is_enum_v<iType>),
+                  "Must be integral argument");
     KOKKOS_ARRAY_BOUNDS_CHECK(i, m_size);
     return m_elem[i * m_stride];
   }

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -685,17 +685,18 @@ class TeamPolicy
 
  public:
   inline TeamPolicy& set_chunk_size(int chunk) {
-    static_assert(std::is_same<decltype(internal_policy::set_chunk_size(chunk)),
-                               internal_policy&>::value,
-                  "internal set_chunk_size should return a reference");
+    static_assert(
+        std::is_same_v<decltype(internal_policy::set_chunk_size(chunk)),
+                       internal_policy&>,
+        "internal set_chunk_size should return a reference");
     return static_cast<TeamPolicy&>(internal_policy::set_chunk_size(chunk));
   }
 
   inline TeamPolicy& set_scratch_size(const int& level,
                                       const Impl::PerTeamValue& per_team) {
-    static_assert(std::is_same<decltype(internal_policy::set_scratch_size(
-                                   level, per_team)),
-                               internal_policy&>::value,
+    static_assert(std::is_same_v<decltype(internal_policy::set_scratch_size(
+                                     level, per_team)),
+                                 internal_policy&>,
                   "internal set_chunk_size should return a reference");
 
     team_policy_check_valid_storage_level_argument(level);

--- a/core/src/Kokkos_Future.hpp
+++ b/core/src/Kokkos_Future.hpp
@@ -144,13 +144,12 @@ class KOKKOS_DEPRECATED
   KOKKOS_INLINE_FUNCTION BasicFuture(
       BasicFuture<T, S>&& rhs) noexcept  // NOLINT(google-explicit-constructor)
       : m_task(std::move(rhs.m_task)) {
-    static_assert(std::is_void<scheduler_type>::value ||
-                      std::is_same<scheduler_type, S>::value,
-                  "Moved Futures must have the same scheduler");
-
     static_assert(
-        std::is_void<value_type>::value || std::is_same<value_type, T>::value,
-        "Moved Futures must have the same value_type");
+        std::is_void_v<scheduler_type> || std::is_same_v<scheduler_type, S>,
+        "Moved Futures must have the same scheduler");
+
+    static_assert(std::is_void_v<value_type> || std::is_same_v<value_type, T>,
+                  "Moved Futures must have the same value_type");
 
     // reference counts are unchanged, since this is a move
     rhs.m_task = nullptr;
@@ -161,13 +160,12 @@ class KOKKOS_DEPRECATED
       BasicFuture<T, S> const& rhs)  // NOLINT(google-explicit-constructor)
                                      //: m_task(rhs.m_task)
       : m_task(nullptr) {
-    static_assert(std::is_void<scheduler_type>::value ||
-                      std::is_same<scheduler_type, S>::value,
-                  "Copied Futures must have the same scheduler");
-
     static_assert(
-        std::is_void<value_type>::value || std::is_same<value_type, T>::value,
-        "Copied Futures must have the same value_type");
+        std::is_void_v<scheduler_type> || std::is_same_v<scheduler_type, S>,
+        "Copied Futures must have the same scheduler");
+
+    static_assert(std::is_void_v<value_type> || std::is_same_v<value_type, T>,
+                  "Copied Futures must have the same value_type");
 
     *static_cast<task_base_type* volatile*>(&m_task) = rhs.m_task;
     if (m_task) m_task->increment_reference_count();
@@ -175,13 +173,12 @@ class KOKKOS_DEPRECATED
 
   template <class T, class S>
   KOKKOS_INLINE_FUNCTION BasicFuture& operator=(BasicFuture<T, S> const& rhs) {
-    static_assert(std::is_void<scheduler_type>::value ||
-                      std::is_same<scheduler_type, S>::value,
-                  "Assigned Futures must have the same scheduler");
-
     static_assert(
-        std::is_void<value_type>::value || std::is_same<value_type, T>::value,
-        "Assigned Futures must have the same value_type");
+        std::is_void_v<scheduler_type> || std::is_same_v<scheduler_type, S>,
+        "Assigned Futures must have the same scheduler");
+
+    static_assert(std::is_void_v<value_type> || std::is_same_v<value_type, T>,
+                  "Assigned Futures must have the same value_type");
 
     if (m_task != rhs.m_task) {
       clear();
@@ -196,13 +193,12 @@ class KOKKOS_DEPRECATED
 
   template <class T, class S>
   KOKKOS_INLINE_FUNCTION BasicFuture& operator=(BasicFuture<T, S>&& rhs) {
-    static_assert(std::is_void<scheduler_type>::value ||
-                      std::is_same<scheduler_type, S>::value,
-                  "Assigned Futures must have the same scheduler");
-
     static_assert(
-        std::is_void<value_type>::value || std::is_same<value_type, T>::value,
-        "Assigned Futures must have the same value_type");
+        std::is_void_v<scheduler_type> || std::is_same_v<scheduler_type, S>,
+        "Assigned Futures must have the same scheduler");
+
+    static_assert(std::is_void_v<value_type> || std::is_same_v<value_type, T>,
+                  "Assigned Futures must have the same value_type");
 
     if (m_task != rhs.m_task) {
       clear();
@@ -350,13 +346,12 @@ class KOKKOS_DEPRECATED BasicFuture {
   KOKKOS_INLINE_FUNCTION BasicFuture(
       BasicFuture<T, S>&& rhs) noexcept  // NOLINT(google-explicit-constructor)
       : m_task(rhs.m_task) {
-    static_assert(std::is_void<scheduler_type>::value ||
-                      std::is_same<scheduler_type, S>::value,
-                  "Assigned Futures must have the same scheduler");
-
     static_assert(
-        std::is_void<value_type>::value || std::is_same<value_type, T>::value,
-        "Assigned Futures must have the same value_type");
+        std::is_void_v<scheduler_type> || std::is_same_v<scheduler_type, S>,
+        "Assigned Futures must have the same scheduler");
+
+    static_assert(std::is_void_v<value_type> || std::is_same_v<value_type, T>,
+                  "Assigned Futures must have the same value_type");
 
     rhs.m_task = 0;
   }
@@ -365,26 +360,24 @@ class KOKKOS_DEPRECATED BasicFuture {
   KOKKOS_INLINE_FUNCTION BasicFuture(
       BasicFuture<T, S> const& rhs)  // NOLINT(google-explicit-constructor)
       : m_task(nullptr) {
-    static_assert(std::is_void<scheduler_type>::value ||
-                      std::is_same<scheduler_type, S>::value,
-                  "Assigned Futures must have the same scheduler");
-
     static_assert(
-        std::is_void<value_type>::value || std::is_same<value_type, T>::value,
-        "Assigned Futures must have the same value_type");
+        std::is_void_v<scheduler_type> || std::is_same_v<scheduler_type, S>,
+        "Assigned Futures must have the same scheduler");
+
+    static_assert(std::is_void_v<value_type> || std::is_same_v<value_type, T>,
+                  "Assigned Futures must have the same value_type");
 
     if (rhs.m_task) queue_type::assign(&m_task, rhs.m_task);
   }
 
   template <class T, class S>
   KOKKOS_INLINE_FUNCTION BasicFuture& operator=(BasicFuture<T, S> const& rhs) {
-    static_assert(std::is_void<scheduler_type>::value ||
-                      std::is_same<scheduler_type, S>::value,
-                  "Assigned Futures must have the same scheduler");
-
     static_assert(
-        std::is_void<value_type>::value || std::is_same<value_type, T>::value,
-        "Assigned Futures must have the same value_type");
+        std::is_void_v<scheduler_type> || std::is_same_v<scheduler_type, S>,
+        "Assigned Futures must have the same scheduler");
+
+    static_assert(std::is_void_v<value_type> || std::is_same_v<value_type, T>,
+                  "Assigned Futures must have the same value_type");
 
     if (m_task || rhs.m_task) queue_type::assign(&m_task, rhs.m_task);
     return *this;
@@ -392,13 +385,12 @@ class KOKKOS_DEPRECATED BasicFuture {
 
   template <class T, class S>
   KOKKOS_INLINE_FUNCTION BasicFuture& operator=(BasicFuture<T, S>&& rhs) {
-    static_assert(std::is_void<scheduler_type>::value ||
-                      std::is_same<scheduler_type, S>::value,
-                  "Assigned Futures must have the same scheduler");
-
     static_assert(
-        std::is_void<value_type>::value || std::is_same<value_type, T>::value,
-        "Assigned Futures must have the same value_type");
+        std::is_void_v<scheduler_type> || std::is_same_v<scheduler_type, S>,
+        "Assigned Futures must have the same scheduler");
+
+    static_assert(std::is_void_v<value_type> || std::is_same_v<value_type, T>,
+                  "Assigned Futures must have the same value_type");
 
     clear();
     m_task     = rhs.m_task;

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -251,8 +251,7 @@ class GraphNodeRef {
     using policy_t = Kokkos::Impl::remove_cvref_t<Policy>;
     // constraint check: same execution space type (or defaulted, maybe?)
     static_assert(
-        std::is_same<typename policy_t::execution_space,
-                     execution_space>::value,
+        std::is_same_v<typename policy_t::execution_space, execution_space>,
         // TODO @graph make defaulted execution space work
         //|| policy_t::execution_space_is_defaulted,
         "Execution Space mismatch between execution policy and graph");
@@ -328,8 +327,7 @@ class GraphNodeRef {
 
     using policy_t = std::remove_cv_t<std::remove_reference_t<Policy>>;
     static_assert(
-        std::is_same<typename policy_t::execution_space,
-                     execution_space>::value,
+        std::is_same_v<typename policy_t::execution_space, execution_space>,
         // TODO @graph make defaulted execution space work
         // || policy_t::execution_space_is_defaulted,
         "Execution Space mismatch between execution policy and graph");
@@ -394,9 +392,9 @@ class GraphNodeRef {
 
     using passed_reducer_type = typename return_value_adapter::reducer_type;
 
-    using reducer_selector = Kokkos::Impl::if_c<
-        std::is_same<InvalidType, passed_reducer_type>::value, functor_type,
-        passed_reducer_type>;
+    using reducer_selector =
+        Kokkos::Impl::if_c<std::is_same_v<InvalidType, passed_reducer_type>,
+                           functor_type, passed_reducer_type>;
     using analysis = Kokkos::Impl::FunctorAnalysis<
         Kokkos::Impl::FunctorPatternInterface::REDUCE, Policy,
         typename reducer_selector::type,

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -129,9 +129,10 @@ void OpenMPInternal::resize_thread_data(size_t pool_reduce_bytes,
 
       m_pool[rank] = new (ptr) HostThreadTeamData();
 
-      m_pool[rank]->scratch_assign(((char *)ptr) + member_bytes, alloc_bytes,
-                                   pool_reduce_bytes, team_reduce_bytes,
-                                   team_shared_bytes, thread_local_bytes);
+      m_pool[rank]->scratch_assign(static_cast<char *>(ptr) + member_bytes,
+                                   alloc_bytes, pool_reduce_bytes,
+                                   team_reduce_bytes, team_shared_bytes,
+                                   thread_local_bytes);
     }
 
     HostThreadTeamData::organize_pool(m_pool, m_pool_size);

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -136,7 +136,7 @@ template <typename T>
 inline std::vector<OpenMP> create_OpenMP_instances(
     OpenMP const& main_instance, std::vector<T> const& weights) {
   static_assert(
-      std::is_arithmetic<T>::value,
+      std::is_arithmetic_v<T>,
       "Kokkos Error: partitioning arguments must be integers or floats");
   if (weights.size() == 0) {
     Kokkos::abort("Kokkos::abort: Partition weights vector is empty.");

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel_For.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel_For.hpp
@@ -60,22 +60,22 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::OpenMP> {
   }
 
   template <class Enable = WorkTag>
-  inline static std::enable_if_t<std::is_void<WorkTag>::value &&
-                                 std::is_same<Enable, WorkTag>::value>
+  inline static std::enable_if_t<std::is_void_v<WorkTag> &&
+                                 std::is_same_v<Enable, WorkTag>>
   exec_work(const FunctorType& functor, const Member iwork) {
     functor(iwork);
   }
 
   template <class Enable = WorkTag>
-  inline static std::enable_if_t<!std::is_void<WorkTag>::value &&
-                                 std::is_same<Enable, WorkTag>::value>
+  inline static std::enable_if_t<!std::is_void_v<WorkTag> &&
+                                 std::is_same_v<Enable, WorkTag>>
   exec_work(const FunctorType& functor, const Member iwork) {
     functor(WorkTag{}, iwork);
   }
 
   template <class Policy>
-  std::enable_if_t<std::is_same<typename Policy::schedule_type::type,
-                                Kokkos::Dynamic>::value>
+  std::enable_if_t<
+      std::is_same_v<typename Policy::schedule_type::type, Kokkos::Dynamic>>
   execute_parallel() const {
     // prevent bug in NVHPC 21.9/CUDA 11.4 (entering zero iterations loop)
     if (m_policy.begin() >= m_policy.end()) return;
@@ -88,8 +88,8 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::OpenMP> {
   }
 
   template <class Policy>
-  std::enable_if_t<!std::is_same<typename Policy::schedule_type::type,
-                                 Kokkos::Dynamic>::value>
+  std::enable_if_t<
+      !std::is_same_v<typename Policy::schedule_type::type, Kokkos::Dynamic>>
   execute_parallel() const {
 // Specifying an chunksize with GCC compiler leads to performance regression
 // with static schedule.
@@ -179,8 +179,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   }
 
   template <class Policy>
-  typename std::enable_if_t<std::is_same<typename Policy::schedule_type::type,
-                                         Kokkos::Dynamic>::value>
+  typename std::enable_if_t<
+      std::is_same_v<typename Policy::schedule_type::type, Kokkos::Dynamic>>
   execute_parallel() const {
 #pragma omp parallel for schedule(dynamic, 1) \
     num_threads(m_instance->thread_pool_size())
@@ -191,8 +191,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   }
 
   template <class Policy>
-  typename std::enable_if<!std::is_same<typename Policy::schedule_type::type,
-                                        Kokkos::Dynamic>::value>::type
+  std::enable_if_t<
+      !std::is_same_v<typename Policy::schedule_type::type, Kokkos::Dynamic>>
   execute_parallel() const {
 #pragma omp parallel for schedule(static, 1) \
     num_threads(m_instance->thread_pool_size())
@@ -292,7 +292,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   const size_t m_shmem_size;
 
   template <class TagType>
-  inline static std::enable_if_t<(std::is_void<TagType>::value)> exec_team(
+  inline static std::enable_if_t<(std::is_void_v<TagType>)> exec_team(
       const FunctorType& functor, HostThreadTeamData& data,
       const int league_rank_begin, const int league_rank_end,
       const int league_size) {
@@ -310,7 +310,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
   template <class TagType>
-  inline static std::enable_if_t<(!std::is_void<TagType>::value)> exec_team(
+  inline static std::enable_if_t<(!std::is_void_v<TagType>)> exec_team(
       const FunctorType& functor, HostThreadTeamData& data,
       const int league_rank_begin, const int league_rank_end,
       const int league_size) {
@@ -331,7 +331,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
  public:
   inline void execute() const {
-    enum { is_dynamic = std::is_same<SchedTag, Kokkos::Dynamic>::value };
+    enum { is_dynamic = std::is_same_v<SchedTag, Kokkos::Dynamic> };
 
     const size_t pool_reduce_size  = 0;  // Never shrinks
     const size_t team_reduce_size  = TEAM_REDUCE_SIZE * m_policy.team_size();

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel_Reduce.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel_Reduce.hpp
@@ -47,7 +47,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   const pointer_type m_result_ptr;
 
   template <class TagType>
-  inline static std::enable_if_t<std::is_void<TagType>::value> exec_range(
+  inline static std::enable_if_t<std::is_void_v<TagType>> exec_range(
       const FunctorType& functor, const Member ibeg, const Member iend,
       reference_type update) {
     for (Member iwork = ibeg; iwork < iend; ++iwork) {
@@ -56,7 +56,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   }
 
   template <class TagType>
-  inline static std::enable_if_t<!std::is_void<TagType>::value> exec_range(
+  inline static std::enable_if_t<!std::is_void_v<TagType>> exec_range(
       const FunctorType& functor, const Member ibeg, const Member iend,
       reference_type update) {
     const TagType t{};
@@ -77,8 +77,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
       return;
     }
     enum {
-      is_dynamic = std::is_same<typename Policy::schedule_type::type,
-                                Kokkos::Dynamic>::value
+      is_dynamic =
+          std::is_same_v<typename Policy::schedule_type::type, Kokkos::Dynamic>
     };
 
     const size_t pool_reduce_bytes = reducer.value_size();
@@ -247,8 +247,8 @@ class ParallelReduce<CombinedFunctorReducerType,
 #endif
 
     enum {
-      is_dynamic = std::is_same<typename Policy::schedule_type::type,
-                                Kokkos::Dynamic>::value
+      is_dynamic =
+          std::is_same_v<typename Policy::schedule_type::type, Kokkos::Dynamic>
     };
 
     const int pool_size = m_instance->thread_pool_size();
@@ -355,7 +355,7 @@ class ParallelReduce<CombinedFunctorReducerType,
   const int m_shmem_size;
 
   template <class TagType>
-  inline static std::enable_if_t<(std::is_void<TagType>::value)> exec_team(
+  inline static std::enable_if_t<(std::is_void_v<TagType>)> exec_team(
       const FunctorType& functor, HostThreadTeamData& data,
       reference_type& update, const int league_rank_begin,
       const int league_rank_end, const int league_size) {
@@ -373,7 +373,7 @@ class ParallelReduce<CombinedFunctorReducerType,
   }
 
   template <class TagType>
-  inline static std::enable_if_t<(!std::is_void<TagType>::value)> exec_team(
+  inline static std::enable_if_t<(!std::is_void_v<TagType>)> exec_team(
       const FunctorType& functor, HostThreadTeamData& data,
       reference_type& update, const int league_rank_begin,
       const int league_rank_end, const int league_size) {
@@ -394,7 +394,7 @@ class ParallelReduce<CombinedFunctorReducerType,
 
  public:
   inline void execute() const {
-    enum { is_dynamic = std::is_same<SchedTag, Kokkos::Dynamic>::value };
+    enum { is_dynamic = std::is_same_v<SchedTag, Kokkos::Dynamic> };
 
     const ReducerType& reducer = m_functor_reducer.get_reducer();
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel_Scan.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel_Scan.hpp
@@ -47,7 +47,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
   const Policy m_policy;
 
   template <class TagType>
-  inline static std::enable_if_t<std::is_void<TagType>::value> exec_range(
+  inline static std::enable_if_t<std::is_void_v<TagType>> exec_range(
       const FunctorType& functor, const Member ibeg, const Member iend,
       reference_type update, const bool final) {
     for (Member iwork = ibeg; iwork < iend; ++iwork) {
@@ -56,7 +56,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
   }
 
   template <class TagType>
-  inline static std::enable_if_t<!std::is_void<TagType>::value> exec_range(
+  inline static std::enable_if_t<!std::is_void_v<TagType>> exec_range(
       const FunctorType& functor, const Member ibeg, const Member iend,
       reference_type update, const bool final) {
     const TagType t{};
@@ -173,7 +173,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
   const pointer_type m_result_ptr;
 
   template <class TagType>
-  inline static std::enable_if_t<std::is_void<TagType>::value> exec_range(
+  inline static std::enable_if_t<std::is_void_v<TagType>> exec_range(
       const FunctorType& functor, const Member ibeg, const Member iend,
       reference_type update, const bool final) {
     for (Member iwork = ibeg; iwork < iend; ++iwork) {
@@ -182,7 +182,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
   }
 
   template <class TagType>
-  inline static std::enable_if_t<!std::is_void<TagType>::value> exec_range(
+  inline static std::enable_if_t<!std::is_void_v<TagType>> exec_range(
       const FunctorType& functor, const Member ibeg, const Member iend,
       reference_type update, const bool final) {
     const TagType t{};

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
@@ -178,9 +178,8 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::OpenMP, QueueType>> {
 
 template <class Scheduler>
 class TaskQueueSpecializationConstrained<
-    Scheduler,
-    std::enable_if_t<std::is_same<typename Scheduler::execution_space,
-                                  Kokkos::OpenMP>::value>> {
+    Scheduler, std::enable_if_t<std::is_same_v<
+                   typename Scheduler::execution_space, Kokkos::OpenMP>>> {
  public:
   using execution_space = Kokkos::OpenMP;
   using scheduler_type  = Scheduler;

--- a/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
@@ -32,13 +32,13 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
   FunctorType m_functor;
 
   template <class TagType>
-  std::enable_if_t<std::is_void<TagType>::value> exec_one(
+  std::enable_if_t<std::is_void_v<TagType>> exec_one(
       const std::int32_t w) const noexcept {
     m_functor(w);
   }
 
   template <class TagType>
-  std::enable_if_t<!std::is_void<TagType>::value> exec_one(
+  std::enable_if_t<!std::is_void_v<TagType>> exec_one(
       const std::int32_t w) const noexcept {
     const TagType t{};
     m_functor(t, w);

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -426,9 +426,10 @@ class ThreadsExecTeamMember {
         m_instance->set_work_range(m_league_rank, m_league_end, m_chunk_size);
         m_instance->reset_steal_target(m_team_size);
       }
-      if (std::is_same<typename TeamPolicyInternal<
-                           Kokkos::Threads, Properties...>::schedule_type::type,
-                       Kokkos::Dynamic>::value) {
+      if (std::is_same_v<
+              typename TeamPolicyInternal<Kokkos::Threads,
+                                          Properties...>::schedule_type::type,
+              Kokkos::Dynamic>) {
         m_instance->barrier();
       }
     } else {

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -1031,8 +1031,8 @@ class View : public ViewTraits<DataType, Properties...> {
       const std::string& alloc_name =
           Impl::get_property<Impl::LabelTag>(prop_copy);
       Impl::runtime_check_rank(
-          *this, std::is_same<typename traits::specialize, void>::value, i0, i1,
-          i2, i3, i4, i5, i6, i7, alloc_name.c_str());
+          *this, std::is_same_v<typename traits::specialize, void>, i0, i1, i2,
+          i3, i4, i5, i6, i7, alloc_name.c_str());
     }
 #endif
 
@@ -1059,8 +1059,8 @@ class View : public ViewTraits<DataType, Properties...> {
         ,
         m_map(arg_prop, arg_layout) {
     static_assert(
-        std::is_same<pointer_type,
-                     typename Impl::ViewCtorProp<P...>::pointer_type>::value,
+        std::is_same_v<pointer_type,
+                       typename Impl::ViewCtorProp<P...>::pointer_type>,
         "Constructing View to wrap user memory must supply matching pointer "
         "type");
 
@@ -1081,8 +1081,8 @@ class View : public ViewTraits<DataType, Properties...> {
       size_t i7 = arg_layout.dimension[7];
 
       Impl::runtime_check_rank(
-          *this, std::is_same<typename traits::specialize, void>::value, i0, i1,
-          i2, i3, i4, i5, i6, i7, "UNMANAGED");
+          *this, std::is_same_v<typename traits::specialize, void>, i0, i1, i2,
+          i3, i4, i5, i6, i7, "UNMANAGED");
     }
 #endif
   }

--- a/core/src/impl/Kokkos_LIFO.hpp
+++ b/core/src/impl/Kokkos_LIFO.hpp
@@ -139,7 +139,7 @@ class LockBasedLIFO : private LockBasedLIFOCommon<T> {
   KOKKOS_INLINE_FUNCTION
   OptionalRef<T> pop(bool abort_on_locked = false) {
     // Put this in here to avoid requiring value_type to be complete until now.
-    static_assert(std::is_base_of<intrusive_node_base_type, value_type>::value,
+    static_assert(std::is_base_of_v<intrusive_node_base_type, value_type>,
                   "Intrusive linked-list value_type must be derived from "
                   "intrusive_node_base_type");
 

--- a/core/src/impl/Kokkos_SimpleTaskScheduler.hpp
+++ b/core/src/impl/Kokkos_SimpleTaskScheduler.hpp
@@ -289,10 +289,10 @@ class SimpleTaskScheduler
                                       scheduler_type>
   spawn(Impl::TaskPolicyWithPredecessor<TaskEnum, DepFutureType>&& arg_policy,
         FunctorType&& arg_functor) {
-    static_assert(std::is_same<typename DepFutureType::scheduler_type,
-                               scheduler_type>::value,
-                  "Can't create a task policy from a scheduler and a future "
-                  "from a different scheduler");
+    static_assert(
+        std::is_same_v<typename DepFutureType::scheduler_type, scheduler_type>,
+        "Can't create a task policy from a scheduler and a future "
+        "from a different scheduler");
 
     using task_type = runnable_task_type<FunctorType>;
     typename task_type::function_type const ptr = task_type::apply;
@@ -417,8 +417,8 @@ class SimpleTaskScheduler
                   "when_all function must return a Kokkos future (an instance "
                   "of Kokkos::BasicFuture)");
     static_assert(
-        std::is_base_of<scheduler_type,
-                        typename generated_type::scheduler_type>::value,
+        std::is_base_of_v<scheduler_type,
+                          typename generated_type::scheduler_type>,
         "when_all function must return a Kokkos::BasicFuture of a compatible "
         "scheduler type");
 

--- a/core/src/impl/Kokkos_TaskQueueCommon.hpp
+++ b/core/src/impl/Kokkos_TaskQueueCommon.hpp
@@ -307,9 +307,8 @@ class TaskQueueCommonMixin {
     using task_scheduling_info_type =
         typename Derived::task_scheduling_info_type;
     using team_scheduler_info_type = typename Derived::team_scheduler_info_type;
-    static_assert(
-        std::is_same<TeamSchedulerInfo, team_scheduler_info_type>::value,
-        "SchedulingInfo type mismatch!");
+    static_assert(std::is_same_v<TeamSchedulerInfo, team_scheduler_info_type>,
+                  "SchedulingInfo type mismatch!");
 
     bool incomplete_dependence_found = false;
 

--- a/core/src/impl/Kokkos_TaskQueueMemoryManager.hpp
+++ b/core/src/impl/Kokkos_TaskQueueMemoryManager.hpp
@@ -93,7 +93,7 @@ class TaskQueueMemoryManager : public TaskQueueBase {
   KOKKOS_INLINE_FUNCTION T* _do_contruct(void* allocated,
                                          allocation_size_type allocated_size,
                                          Args&&... args) {
-    static_assert(std::is_base_of<PoolAllocatedObjectBase<int32_t>, T>::value,
+    static_assert(std::is_base_of_v<PoolAllocatedObjectBase<int32_t>, T>,
                   "TaskQueueMemoryManager can only allocate objects with "
                   "PoolAllocatedObjectBase base class");
 
@@ -151,7 +151,7 @@ class TaskQueueMemoryManager : public TaskQueueBase {
   //     && std::is_constructible_v<T, allocation_size_type, Args&&...>
   {
     static_assert(
-        std::is_base_of<ObjectWithVLAEmulation<T, VLAValueType>, T>::value,
+        std::is_base_of_v<ObjectWithVLAEmulation<T, VLAValueType>, T>,
         "Can't append emulated variable length array of type with greater "
         "alignment than"
         "  the type to which the VLA is being appended");

--- a/core/src/impl/Kokkos_VLAEmulation.hpp
+++ b/core/src/impl/Kokkos_VLAEmulation.hpp
@@ -157,7 +157,7 @@ struct ObjectWithVLAEmulation {
 
     // Note: We can't do this at class scope because it unnecessarily requires
     // vla_value_type to be a complete type
-    static_assert(!std::is_abstract<vla_value_type>::value,
+    static_assert(!std::is_abstract_v<vla_value_type>,
                   "Can't use abstract type with VLA emulation");
 
     KOKKOS_EXPECTS(num_entries >= 0);

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -294,7 +294,7 @@ struct Functor_TestHalfOperators {
     d_lhs        = static_cast<double>(h_lhs);
     d_rhs        = static_cast<double>(h_rhs);
 
-    if (std::is_same<view_type, ViewTypeHost>::value) {
+    if (std::is_same_v<view_type, ViewTypeHost>) {
       auto run_on_host = *this;
       run_on_host(Batch0{}, 0);
       run_on_host(Batch1{}, 0);
@@ -331,13 +331,13 @@ struct Functor_TestHalfOperators {
     auto sum = static_cast<LhsType>(h_lhs) + static_cast<RhsType>(h_rhs);
     actual_lhs(op_test_idx) = static_cast<double>(sum);
 
-    if (std::is_same<RhsType, half_type>::value &&
-        std::is_same<LhsType, half_type>::value) {
+    if (std::is_same_v<RhsType, half_type> &&
+        std::is_same_v<LhsType, half_type>) {
       expected_lhs(op_test_idx) = d_lhs + d_rhs;
     } else {
-      if (std::is_same<LhsType, half_type>::value)
+      if (std::is_same_v<LhsType, half_type>)
         expected_lhs(op_test_idx) = d_lhs + static_cast<RhsType>(d_rhs);
-      if (std::is_same<RhsType, half_type>::value)
+      if (std::is_same_v<RhsType, half_type>)
         expected_lhs(op_test_idx) = static_cast<LhsType>(d_lhs) + d_rhs;
     }
 
@@ -351,13 +351,13 @@ struct Functor_TestHalfOperators {
     auto result = static_cast<LhsType>(h_lhs) - static_cast<RhsType>(h_rhs);
     actual_lhs(op_test_idx) = static_cast<double>(result);
 
-    if (std::is_same<RhsType, half_type>::value &&
-        std::is_same<LhsType, half_type>::value) {
+    if (std::is_same_v<RhsType, half_type> &&
+        std::is_same_v<LhsType, half_type>) {
       expected_lhs(op_test_idx) = d_lhs - d_rhs;
     } else {
-      if (std::is_same<LhsType, half_type>::value)
+      if (std::is_same_v<LhsType, half_type>)
         expected_lhs(op_test_idx) = d_lhs - static_cast<RhsType>(d_rhs);
-      if (std::is_same<RhsType, half_type>::value)
+      if (std::is_same_v<RhsType, half_type>)
         expected_lhs(op_test_idx) = static_cast<LhsType>(d_lhs) - d_rhs;
     }
 
@@ -371,13 +371,13 @@ struct Functor_TestHalfOperators {
     auto result = static_cast<LhsType>(h_lhs) * static_cast<RhsType>(h_rhs);
     actual_lhs(op_test_idx) = static_cast<double>(result);
 
-    if (std::is_same<RhsType, half_type>::value &&
-        std::is_same<LhsType, half_type>::value) {
+    if (std::is_same_v<RhsType, half_type> &&
+        std::is_same_v<LhsType, half_type>) {
       expected_lhs(op_test_idx) = d_lhs * d_rhs;
     } else {
-      if (std::is_same<LhsType, half_type>::value)
+      if (std::is_same_v<LhsType, half_type>)
         expected_lhs(op_test_idx) = d_lhs * static_cast<RhsType>(d_rhs);
-      if (std::is_same<RhsType, half_type>::value)
+      if (std::is_same_v<RhsType, half_type>)
         expected_lhs(op_test_idx) = static_cast<LhsType>(d_lhs) * d_rhs;
     }
 
@@ -391,13 +391,13 @@ struct Functor_TestHalfOperators {
     auto result = static_cast<LhsType>(h_lhs) / static_cast<RhsType>(h_rhs);
     actual_lhs(op_test_idx) = static_cast<double>(result);
 
-    if (std::is_same<RhsType, half_type>::value &&
-        std::is_same<LhsType, half_type>::value) {
+    if (std::is_same_v<RhsType, half_type> &&
+        std::is_same_v<LhsType, half_type>) {
       expected_lhs(op_test_idx) = d_lhs / d_rhs;
     } else {
-      if (std::is_same<LhsType, half_type>::value)
+      if (std::is_same_v<LhsType, half_type>)
         expected_lhs(op_test_idx) = d_lhs / static_cast<RhsType>(d_rhs);
-      if (std::is_same<RhsType, half_type>::value)
+      if (std::is_same_v<RhsType, half_type>)
         expected_lhs(op_test_idx) = static_cast<LhsType>(d_lhs) / d_rhs;
     }
 

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1329,10 +1329,10 @@ struct TestAbsoluteValueFunction {
     static_assert(std::is_same_v<decltype(abs(1)), int>);
     static_assert(std::is_same_v<decltype(abs(2l)), long>);
     static_assert(std::is_same_v<decltype(abs(3ll)), long long>);
-    static_assert(std::is_same<decltype(abs(static_cast<KE::half_t>(4.f))),
-                               KE::half_t>::value);
-    static_assert(std::is_same<decltype(abs(static_cast<KE::bhalf_t>(4.f))),
-                               KE::bhalf_t>::value);
+    static_assert(std::is_same_v<decltype(abs(static_cast<KE::half_t>(4.f))),
+                                 KE::half_t>);
+    static_assert(std::is_same_v<decltype(abs(static_cast<KE::bhalf_t>(4.f))),
+                                 KE::bhalf_t>);
     static_assert(std::is_same_v<decltype(abs(4.f)), float>);
     static_assert(std::is_same_v<decltype(abs(5.)), double>);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
@@ -1387,10 +1387,10 @@ struct TestFloatingPointAbsoluteValueFunction {
       Kokkos::printf("failed fabs(floating_point) special values\n");
     }
 
-    static_assert(std::is_same<decltype(fabs(static_cast<KE::half_t>(4.f))),
-                               KE::half_t>::value);
-    static_assert(std::is_same<decltype(fabs(static_cast<KE::bhalf_t>(4.f))),
-                               KE::bhalf_t>::value);
+    static_assert(std::is_same_v<decltype(fabs(static_cast<KE::half_t>(4.f))),
+                                 KE::half_t>);
+    static_assert(std::is_same_v<decltype(fabs(static_cast<KE::bhalf_t>(4.f))),
+                                 KE::bhalf_t>);
     static_assert(std::is_same_v<decltype(fabs(4.f)), float>);
     static_assert(std::is_same_v<decltype(fabs(5.)), double>);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
@@ -1456,12 +1456,12 @@ struct TestFloatingPointRemainderFunction : FloatingPointComparison {
       Kokkos::printf("failed fmod(floating_point) special values\n");
     }
 
-    static_assert(std::is_same<decltype(fmod(static_cast<KE::half_t>(4.f),
-                                             static_cast<KE::half_t>(4.f))),
-                               KE::half_t>::value);
-    static_assert(std::is_same<decltype(fmod(static_cast<KE::bhalf_t>(4.f),
-                                             static_cast<KE::bhalf_t>(4.f))),
-                               KE::bhalf_t>::value);
+    static_assert(std::is_same_v<decltype(fmod(static_cast<KE::half_t>(4.f),
+                                               static_cast<KE::half_t>(4.f))),
+                                 KE::half_t>);
+    static_assert(std::is_same_v<decltype(fmod(static_cast<KE::bhalf_t>(4.f),
+                                               static_cast<KE::bhalf_t>(4.f))),
+                                 KE::bhalf_t>);
     static_assert(std::is_same_v<decltype(fmod(4.f, 4.f)), float>);
     static_assert(std::is_same_v<decltype(fmod(5., 5.)), double>);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -58,7 +58,7 @@ struct TestTeamPolicy {
 
     m_flags(member.team_rank(), member.league_rank()) = tid;
     static_assert(
-        (std::is_same<typename team_member::execution_space, ExecSpace>::value),
+        (std::is_same_v<typename team_member::execution_space, ExecSpace>),
         "TeamMember::execution_space is not the same as "
         "TeamPolicy<>::execution_space");
   }

--- a/core/unit_test/TestTeamScan.hpp
+++ b/core/unit_test/TestTeamScan.hpp
@@ -92,7 +92,7 @@ struct TestTeamScan {
       for (int32_t j = 0; j < N; ++j) {
         scan_ref += a_i(i, j);
         scan_calc = a_o(i, j);
-        if (std::is_integral<value_type>::value) {
+        if (std::is_integral_v<value_type>) {
           ASSERT_EQ(scan_ref, scan_calc)
               << test_id
               << " calculated scan output value differs from reference at "
@@ -214,7 +214,7 @@ struct TestTeamScanRetVal {
       for (int32_t j = 0; j < N; ++j) {
         scan_ref += a_i(i, j);
         scan_calc = a_o(i, j);
-        if (std::is_integral<value_type>::value) {
+        if (std::is_integral_v<value_type>) {
           ASSERT_EQ(scan_ref, scan_calc)
               << test_id
               << " calculated scan output value differs from reference at "
@@ -230,7 +230,7 @@ struct TestTeamScanRetVal {
         }
       }
       // Validate return value from parallel_scan
-      if (std::is_integral<value_type>::value) {
+      if (std::is_integral_v<value_type>) {
         ASSERT_EQ(scan_ref, a_os(i));
       } else {
         ASSERT_NEAR(scan_ref, a_os(i), abs_err);

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -802,7 +802,7 @@ class TestTripleNestedReduce {
 
 #ifdef KOKKOS_ENABLE_HPX
     team_size = 1;
-    if (!std::is_same<execution_space, Kokkos::Experimental::HPX>::value) {
+    if (!std::is_same_v<execution_space, Kokkos::Experimental::HPX>) {
       team_size = 1;
     }
 #endif

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -1108,11 +1108,10 @@ struct TestViewMapOperator {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(size_t i, int64_t& error_count) const {
-    if (std::is_same<typename ViewType::array_layout,
-                     Kokkos::LayoutLeft>::value) {
+    if (std::is_same_v<typename ViewType::array_layout, Kokkos::LayoutLeft>) {
       test_left(i, error_count);
-    } else if (std::is_same<typename ViewType::array_layout,
-                            Kokkos::LayoutRight>::value) {
+    } else if (std::is_same_v<typename ViewType::array_layout,
+                              Kokkos::LayoutRight>) {
       test_right(i, error_count);
     }
   }

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -1020,11 +1020,11 @@ struct CheckSubviewCorrectness_2D_3D {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int& ii, int& e) const {
-    const int i1 = std::is_same<layout, Kokkos::LayoutLeft>::value
+    const int i1 = std::is_same_v<layout, Kokkos::LayoutLeft>
                        ? ii % b.extent(0)
                        : ii / b.extent(1);
 
-    const int i2 = std::is_same<layout, Kokkos::LayoutLeft>::value
+    const int i2 = std::is_same_v<layout, Kokkos::LayoutLeft>
                        ? ii / b.extent(0)
                        : ii % b.extent(1);
 
@@ -1055,15 +1055,15 @@ struct CheckSubviewCorrectness_3D_3D {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int& ii, int& e) const {
-    const int i0 = std::is_same<layout, Kokkos::LayoutLeft>::value
+    const int i0 = std::is_same_v<layout, Kokkos::LayoutLeft>
                        ? ii % b.extent(0)
                        : ii / (b.extent(1) * b.extent(2));
 
-    const int i1 = std::is_same<layout, Kokkos::LayoutLeft>::value
+    const int i1 = std::is_same_v<layout, Kokkos::LayoutLeft>
                        ? (ii / b.extent(0)) % b.extent(1)
                        : (ii / b.extent(2)) % b.extent(1);
 
-    const int i2 = std::is_same<layout, Kokkos::LayoutLeft>::value
+    const int i2 = std::is_same_v<layout, Kokkos::LayoutLeft>
                        ? ii / (b.extent(0) * b.extent(1))
                        : ii % b.extent(2);
 
@@ -1094,21 +1094,21 @@ struct CheckSubviewCorrectness_3D_4D {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int& ii, int& e) const {
-    const int i = std::is_same<layout, Kokkos::LayoutLeft>::value
+    const int i = std::is_same_v<layout, Kokkos::LayoutLeft>
                       ? ii % b.extent(0)
                       : ii / (b.extent(1) * b.extent(2));
 
-    const int j = std::is_same<layout, Kokkos::LayoutLeft>::value
+    const int j = std::is_same_v<layout, Kokkos::LayoutLeft>
                       ? (ii / b.extent(0)) % b.extent(1)
                       : (ii / b.extent(2)) % b.extent(1);
 
-    const int k = std::is_same<layout, Kokkos::LayoutLeft>::value
+    const int k = std::is_same_v<layout, Kokkos::LayoutLeft>
                       ? ii / (b.extent(0) * b.extent(1))
                       : ii % b.extent(2);
 
     int i0, i1, i2, i3;
 
-    if (std::is_same<layout, Kokkos::LayoutLeft>::value) {
+    if (std::is_same_v<layout, Kokkos::LayoutLeft>) {
       i0 = i + offset_0;
       i1 = j;
       i2 = k + offset_2;
@@ -1152,15 +1152,15 @@ struct CheckSubviewCorrectness_3D_5D {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int& ii, int& e) const {
-    const int i2 = std::is_same<layout, Kokkos::LayoutLeft>::value
+    const int i2 = std::is_same_v<layout, Kokkos::LayoutLeft>
                        ? ii % b.extent(0)
                        : ii / (b.extent(1) * b.extent(2));
 
-    const int i3 = std::is_same<layout, Kokkos::LayoutLeft>::value
+    const int i3 = std::is_same_v<layout, Kokkos::LayoutLeft>
                        ? (ii / b.extent(0)) % b.extent(1)
                        : (ii / b.extent(2)) % b.extent(1);
 
-    const int i4 = std::is_same<layout, Kokkos::LayoutLeft>::value
+    const int i4 = std::is_same_v<layout, Kokkos::LayoutLeft>
                        ? ii / (b.extent(0) * b.extent(1))
                        : ii % b.extent(2);
 

--- a/core/unit_test/incremental/Test01_execspace.hpp
+++ b/core/unit_test/incremental/Test01_execspace.hpp
@@ -33,10 +33,10 @@ template <class ExecSpace>
 struct TestIncrExecSpaceTypedef {
   void testit() {
     const bool passed =
-        (!std::is_void<typename ExecSpace::memory_space>::value) &&
-        std::is_same<ExecSpace, typename ExecSpace::execution_space>::value &&
-        !std::is_void<typename ExecSpace::scratch_memory_space>::value &&
-        !std::is_void<typename ExecSpace::array_layout>::value;
+        (!std::is_void_v<typename ExecSpace::memory_space>)&&std::is_same_v<
+            ExecSpace, typename ExecSpace::execution_space> &&
+        !std::is_void_v<typename ExecSpace::scratch_memory_space> &&
+        !std::is_void_v<typename ExecSpace::array_layout>;
     static_assert(passed == true,
                   "The memory and execution spaces are defined");
   }
@@ -50,8 +50,8 @@ struct TestIncrExecSpace {
     using execution_space = typename device_type::execution_space;
 
     const bool passed =
-        std::is_same<device_type,
-                     Kokkos::Device<execution_space, memory_space>>::value;
+        std::is_same_v<device_type,
+                       Kokkos::Device<execution_space, memory_space>>;
 
     static_assert(passed == true,
                   "Checking if the is_execution_space is evaluated correctly");


### PR DESCRIPTION
Looking at https://github.com/kokkos/kokkos/pull/7430#discussion_r1800001727, I noticed that I am still seeing `clang-tidy` complaints locally. This pull request fixes those when compiling with `HPX`, `Threads`, `OpenMP` and `Serial`.