### PR TITLE
core(graph): cleaning `is_graph_kernel`

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -105,12 +105,6 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
 
 struct CudaGraphNodeAggregateKernel {
   using graph_kernel = CudaGraphNodeAggregateKernel;
-
-  // Aggregates don't need a policy, but for the purposes of checking the static
-  // assertions about graph kerenls,
-  struct Policy {
-    using is_graph_kernel = std::true_type;
-  };
 };
 
 template <class KernelType,

--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -121,10 +121,11 @@ struct GraphImpl<Kokkos::Cuda> {
   }
 
   template <class NodeImpl>
-  //  requires NodeImplPtr is a shared_ptr to specialization of GraphNodeImpl
-  //  Also requires that the kernel has the graph node tag in its policy
-  void add_node(std::shared_ptr<NodeImpl> const& arg_node_ptr) {
-    static_assert(NodeImpl::kernel_type::Policy::is_graph_kernel::value);
+  std::enable_if_t<
+      Kokkos::Impl::is_graph_kernel_v<typename NodeImpl::kernel_type>>
+  add_node(std::shared_ptr<NodeImpl> const& arg_node_ptr) {
+    static_assert(
+        Kokkos::Impl::is_specialization_of_v<NodeImpl, GraphNodeImpl>);
     KOKKOS_EXPECTS(bool(arg_node_ptr));
     // The Kernel launch from the execute() method has been shimmed to insert
     // the node into the graph

--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -95,12 +95,6 @@ class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
 
 struct HIPGraphNodeAggregateKernel {
   using graph_kernel = HIPGraphNodeAggregateKernel;
-
-  // Aggregates don't need a policy, but for the purposes of checking the static
-  // assertions about graph kernels,
-  struct Policy {
-    using is_graph_kernel = std::true_type;
-  };
 };
 
 template <typename KernelType,

--- a/core/src/SYCL/Kokkos_SYCL_GraphNodeKernel.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_GraphNodeKernel.hpp
@@ -89,12 +89,6 @@ class GraphNodeKernelImpl<Kokkos::SYCL, PolicyType, Functor, PatternTag,
 
 struct SYCLGraphNodeAggregateKernel {
   using graph_kernel = SYCLGraphNodeAggregateKernel;
-
-  // Aggregates don't need a policy, but for the purposes of checking the static
-  // assertions about graph kernels,
-  struct Policy {
-    using is_graph_kernel = std::true_type;
-  };
 };
 
 template <typename KernelType,

--- a/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
@@ -57,7 +57,9 @@ class GraphImpl<Kokkos::SYCL> {
   void add_node(std::shared_ptr<aggregate_node_impl_t> const& arg_node_ptr);
 
   template <class NodeImpl>
-  void add_node(std::shared_ptr<NodeImpl> const& arg_node_ptr);
+  std::enable_if_t<
+      Kokkos::Impl::is_graph_kernel_v<typename NodeImpl::kernel_type>>
+  add_node(std::shared_ptr<NodeImpl> const& arg_node_ptr);
 
   template <class NodeImplPtr, class PredecessorRef>
   void add_predecessor(NodeImplPtr arg_node_ptr, PredecessorRef arg_pred_ref);
@@ -104,12 +106,12 @@ inline void GraphImpl<Kokkos::SYCL>::add_node(
   arg_node_ptr->node_details_t::node = m_graph.add();
 }
 
-// Requires NodeImplPtr is a shared_ptr to specialization of GraphNodeImpl
-// Also requires that the kernel has the graph node tag in its policy
 template <class NodeImpl>
-inline void GraphImpl<Kokkos::SYCL>::add_node(
+inline std::enable_if_t<
+    Kokkos::Impl::is_graph_kernel_v<typename NodeImpl::kernel_type>>
+GraphImpl<Kokkos::SYCL>::add_node(
     std::shared_ptr<NodeImpl> const& arg_node_ptr) {
-  static_assert(NodeImpl::kernel_type::Policy::is_graph_kernel::value);
+  static_assert(Kokkos::Impl::is_specialization_of_v<NodeImpl, GraphNodeImpl>);
   KOKKOS_EXPECTS(arg_node_ptr);
   // The Kernel launch from the execute() method has been shimmed to insert
   // the node into the graph

--- a/core/src/impl/Kokkos_Default_GraphNodeKernel.hpp
+++ b/core/src/impl/Kokkos_Default_GraphNodeKernel.hpp
@@ -91,11 +91,6 @@ class GraphNodeKernelImpl
 template <class ExecutionSpace>
 struct GraphNodeAggregateKernelDefaultImpl
     : GraphNodeKernelDefaultImpl<ExecutionSpace> {
-  // Aggregates don't need a policy, but for the purposes of checking the static
-  // assertions about graph kernels,
-  struct Policy {
-    using is_graph_kernel = std::true_type;
-  };
   using graph_kernel = GraphNodeAggregateKernelDefaultImpl;
   void execute_kernel() override final {}
 };

--- a/core/src/impl/Kokkos_Default_Graph_Impl.hpp
+++ b/core/src/impl/Kokkos_Default_Graph_Impl.hpp
@@ -80,9 +80,9 @@ struct GraphImpl : private ExecutionSpaceInstanceStorage<ExecutionSpace> {
   // <editor-fold desc="required customizations"> {{{2
 
   template <class NodeImpl>
-  //  requires NodeImplPtr is a shared_ptr to specialization of GraphNodeImpl
   void add_node(std::shared_ptr<NodeImpl> const& arg_node_ptr) {
-    static_assert(NodeImpl::kernel_type::Policy::is_graph_kernel::value);
+    static_assert(
+        Kokkos::Impl::is_specialization_of_v<NodeImpl, GraphNodeImpl>);
     // Since this is always called before any calls to add_predecessor involving
     // it, we can treat this node as a sink until we discover otherwise.
     arg_node_ptr->node_details_t::set_kernel(arg_node_ptr->get_kernel());

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -120,6 +120,10 @@ struct is_specialization_of : std::false_type {};
 template <template <class...> class Template, class... Args>
 struct is_specialization_of<Template<Args...>, Template> : std::true_type {};
 
+template <typename T, template <typename...> class U>
+inline constexpr bool is_specialization_of_v =
+    is_specialization_of<T, U>::value;
+
 // </editor-fold> end is_specialization_of }}}1
 //==============================================================================
 


### PR DESCRIPTION
This PR cleans `is_graph_kernel`.

Changes are twofold:
1. For specialized graph implementations, the aggregate node type is now much simpler, because it does not need to define a policy. This change also makes sense, because an aggregate node does not do any work, so it should not have a policy, nor should it be defined as a "graph kernel".
2. `GraphImpl::add_node` is now better constrained. Note that `add_node` is **not** part of the user-facing API, so we don't need to make a nice error message. Also note that I'm strengthening the constraints on this function because I'll introduce a new type of node in a followup PR, requiring `add_node` to be specialized.