### PR TITLE
oneDPL: Mark comparators as device-copyable

### DIFF
--- a/algorithms/unit_tests/TestSortByKey.hpp
+++ b/algorithms/unit_tests/TestSortByKey.hpp
@@ -28,6 +28,10 @@ namespace Test {
 namespace SortImpl {
 
 struct Less {
+  // Make sure that the comparator isn't device copyable, this caused problems
+  // with SYCL/oneDPL
+  Kokkos::View<int *> dummy;
+
   template <class ValueType>
   KOKKOS_INLINE_FUNCTION bool operator()(const ValueType &lhs,
                                          const ValueType &rhs) const {
@@ -36,6 +40,10 @@ struct Less {
 };
 
 struct Greater {
+  // Make sure that the comparator isn't device copyable, this caused problems
+  // with SYCL/oneDPL
+  Kokkos::View<int *> dummy;
+
   template <class ValueType>
   KOKKOS_INLINE_FUNCTION bool operator()(const ValueType &lhs,
                                          const ValueType &rhs) const {

--- a/algorithms/unit_tests/TestSortCustomComp.hpp
+++ b/algorithms/unit_tests/TestSortCustomComp.hpp
@@ -62,6 +62,10 @@ auto create_random_view_and_host_clone(
 
 template <class T>
 struct MyComp {
+  // Make sure that the comparator isn't device copyable, this caused problems
+  // with SYCL/oneDPL
+  Kokkos::View<T*> dummy;
+
   KOKKOS_FUNCTION
   bool operator()(T a, T b) const {
     // we return a>b on purpose here, rather than doing a<b


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/6939 and needs https://github.com/oneapi-src/oneDPL/pull/1932.