### PR TITLE
Make `build_cmake_installed_kk_as_language` example backend agnostic

### DIFF
--- a/example/build_cmake_installed_kk_as_language/CMakeLists.txt
+++ b/example/build_cmake_installed_kk_as_language/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.19)
 project(Example CXX Fortran)
 
 # Look for an installed Kokkos
-find_package(Kokkos COMPONENTS)
+find_package(Kokkos)
 enable_language(${Kokkos_COMPILE_LANGUAGE})
 
 #the language has to be set on the files

--- a/example/build_cmake_installed_kk_as_language/CMakeLists.txt
+++ b/example/build_cmake_installed_kk_as_language/CMakeLists.txt
@@ -4,14 +4,19 @@ cmake_minimum_required(VERSION 3.19)
 
 # Projects can safely mix languages - must have C++ support
 # Kokkos flags will only apply to C++ files
-project(Example CXX Fortran CUDA)
+project(Example CXX Fortran)
 
 # Look for an installed Kokkos
-find_package(Kokkos COMPONENTS separable_compilation)
-set_source_files_properties(cmake_example.cpp PROPERTIES LANGUAGE CUDA)
+find_package(Kokkos COMPONENTS)
+enable_language(${Kokkos_COMPILE_LANGUAGE})
+
+#the language has to be set on the files
+set_source_files_properties(cmake_example.cpp PROPERTIES LANGUAGE ${Kokkos_COMPILE_LANGUAGE})
 add_executable(example cmake_example.cpp bar.cpp foo.f)
 
-# This is the only thing required to set up compiler/linker flags
+# The architectures and std have to be set on the target
+set_target_properties(example PROPERTIES ${Kokkos_COMPILE_LANGUAGE}_ARCHITECTURES ${Kokkos_${Kokkos_COMPILE_LANGUAGE}_ARCHITECTURES})
+set_target_properties(example PROPERTIES ${Kokkos_COMPILE_LANGUAGE}_STANDARD ${Kokkos_CXX_STANDARD})
 target_link_libraries(example Kokkos::kokkos)
 
 enable_testing()

--- a/example/build_cmake_installed_kk_as_language/CMakeLists.txt
+++ b/example/build_cmake_installed_kk_as_language/CMakeLists.txt
@@ -15,10 +15,10 @@ set_source_files_properties(cmake_example.cpp PROPERTIES LANGUAGE ${Kokkos_COMPI
 add_executable(example cmake_example.cpp bar.cpp foo.f)
 
 # The architectures and std have to be set on the target
-set_target_properties(
-  example PROPERTIES ${Kokkos_COMPILE_LANGUAGE}_ARCHITECTURES ${Kokkos_${Kokkos_COMPILE_LANGUAGE}_ARCHITECTURES}
+set_property(
+  TARGET example PROPERTY ${Kokkos_COMPILE_LANGUAGE}_ARCHITECTURES ${Kokkos_${Kokkos_COMPILE_LANGUAGE}_ARCHITECTURES}
 )
-set_target_properties(example PROPERTIES ${Kokkos_COMPILE_LANGUAGE}_STANDARD ${Kokkos_CXX_STANDARD})
+set_property(TARGET example PROPERTY ${Kokkos_COMPILE_LANGUAGE}_STANDARD ${Kokkos_${Kokkos_COMPILE_LANGUAGE}_STANDARD})
 target_link_libraries(example Kokkos::kokkos)
 
 enable_testing()

--- a/example/build_cmake_installed_kk_as_language/CMakeLists.txt
+++ b/example/build_cmake_installed_kk_as_language/CMakeLists.txt
@@ -15,7 +15,9 @@ set_source_files_properties(cmake_example.cpp PROPERTIES LANGUAGE ${Kokkos_COMPI
 add_executable(example cmake_example.cpp bar.cpp foo.f)
 
 # The architectures and std have to be set on the target
-set_target_properties(example PROPERTIES ${Kokkos_COMPILE_LANGUAGE}_ARCHITECTURES ${Kokkos_${Kokkos_COMPILE_LANGUAGE}_ARCHITECTURES})
+set_target_properties(
+  example PROPERTIES ${Kokkos_COMPILE_LANGUAGE}_ARCHITECTURES ${Kokkos_${Kokkos_COMPILE_LANGUAGE}_ARCHITECTURES}
+)
 set_target_properties(example PROPERTIES ${Kokkos_COMPILE_LANGUAGE}_STANDARD ${Kokkos_CXX_STANDARD})
 target_link_libraries(example Kokkos::kokkos)
 


### PR DESCRIPTION
I tried to use the vars we export to make it agnostic (at least for `CUDA` and `HIP`).
We also should specify the std and architectures Kokkos was configured for on the target. Otherwise we end up with the std one depending on the toolkit which might not provide stuff we use inside kokkos