### PR TITLE
Fix last vulnerability reports in benchmarks and perf tests

### DIFF
--- a/benchmarks/policy_performance/main.cpp
+++ b/benchmarks/policy_performance/main.cpp
@@ -120,11 +120,12 @@ int main(int argc, char* argv[]) {
   // view appropriately for test and should obey first-touch etc Second call to
   // test is the one we actually care about and time
   view_type_1d v_1(Kokkos::view_alloc(Kokkos::WithoutInitializing, "v_1"),
-                   team_range * team_size);
+                   static_cast<size_t>(team_range) * team_size);
   view_type_2d v_2(Kokkos::view_alloc(Kokkos::WithoutInitializing, "v_2"),
-                   team_range * team_size, thread_range);
+                   static_cast<size_t>(team_range) * team_size, thread_range);
   view_type_3d v_3(Kokkos::view_alloc(Kokkos::WithoutInitializing, "v_3"),
-                   team_range * team_size, thread_range, vector_range);
+                   static_cast<size_t>(team_range) * team_size, thread_range,
+                   vector_range);
 
   double result_computed = 0.0;
   double result_expect   = 0.0;

--- a/benchmarks/policy_performance/policy_perf_test.hpp
+++ b/benchmarks/policy_performance/policy_perf_test.hpp
@@ -367,7 +367,7 @@ void test_policy(int team_range, int thread_range, int vector_range,
     // parallel_for RangePolicy: range = team_size*team_range
     if (test_type == 300) {
       Kokkos::parallel_for(
-          "300 outer for", team_size * team_range,
+          "300 outer for", static_cast<size_t>(team_size) * team_range,
           KOKKOS_LAMBDA(const int idx) {
             v1(idx) = idx;
             // prevent compiler from optimizing away the loop
@@ -376,14 +376,15 @@ void test_policy(int team_range, int thread_range, int vector_range,
     // parallel_reduce RangePolicy: range = team_size*team_range
     if (test_type == 400) {
       Kokkos::parallel_reduce(
-          "400 outer reduce", team_size * team_range,
+          "400 outer reduce", static_cast<size_t>(team_size) * team_range,
           KOKKOS_LAMBDA(const int idx, double& val) { val += idx; }, result);
       result_expect =
           0.5 * (team_size * team_range) * (team_size * team_range - 1);
     }
     // parallel_scan RangePolicy: range = team_size*team_range
     if (test_type == 500) {
-      Kokkos::parallel_scan("500 outer scan", team_size * team_range,
+      Kokkos::parallel_scan("500 outer scan",
+                            static_cast<size_t>(team_size) * team_range,
                             ParallelScanFunctor<ViewType1>(v1)
 #if 0
         // This does not compile with pre Cuda 8.0 - see Github Issue #913 for explanation

--- a/core/perf_test/PerfTest_CustomReduction.cpp
+++ b/core/perf_test/PerfTest_CustomReduction.cpp
@@ -107,8 +107,8 @@ int get_R(benchmark::State& state) {
 
 template <class Scalar>
 static void CustomReduction(benchmark::State& state) {
-  int N = get_N(state);
-  int R = get_R(state);
+  size_t N = get_N(state);
+  size_t R = get_R(state);
 
   for (auto _ : state) {
     auto results = custom_reduction_test<double>(N, R);

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -323,7 +323,7 @@ class ArrayReduceTeamFunctor {
     const int thread_size = team.team_size() * team.league_size();
     const int chunk       = (nwork + thread_size - 1) / thread_size;
 
-    size_type iwork           = chunk * thread_rank;
+    size_type iwork           = static_cast<size_type>(chunk) * thread_rank;
     const size_type iwork_end = iwork + chunk < nwork ? iwork + chunk : nwork;
 
     for (; iwork < iwork_end; ++iwork) {


### PR DESCRIPTION
Resolving a few more "Multiplication result converted to larger type" warnings in benchmarks and perf tests (plus one stray warning in unit tests)

https://github.com/kokkos/kokkos/security/code-scanning/66
https://github.com/kokkos/kokkos/security/code-scanning/65
https://github.com/kokkos/kokkos/security/code-scanning/64
https://github.com/kokkos/kokkos/security/code-scanning/63
https://github.com/kokkos/kokkos/security/code-scanning/62
https://github.com/kokkos/kokkos/security/code-scanning/61
https://github.com/kokkos/kokkos/security/code-scanning/25
https://github.com/kokkos/kokkos/security/code-scanning/22
