### PR TITLE
Enable bugprone-implicit-widening-of-multiplication-result check with ClangTidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,3 @@
-Checks: '-*,kokkos-*,modernize-type-traits,modernize-use-using,modernize-use-nullptr,cppcoreguidelines-pro-type-cstyle-cast'
+Checks: '-*,kokkos-*,modernize-type-traits,modernize-use-using,modernize-use-nullptr,cppcoreguidelines-pro-type-cstyle-cast,bugprone-implicit-widening-of-multiplication-result'
 FormatStyle: file
 HeaderFilterRegex: '(algorithms|benchmarks|containers|core|example|simd).*\.hpp'

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -587,11 +587,13 @@ struct Random_XorShift1024_State<false> {
                                             int state_idx)
       : state_(&v(state_idx, 0)), stride_(v.stride_1()) {}
 
+  // NOLINTBEGIN(bugprone-implicit-widening-of-multiplication-result)
   KOKKOS_FUNCTION
-  uint64_t operator[](size_t i) const { return state_[i * stride_]; }
+  uint64_t operator[](int i) const { return state_[i * stride_]; }
 
   KOKKOS_FUNCTION
-  uint64_t& operator[](size_t i) { return state_[i * stride_]; }
+  uint64_t& operator[](int i) { return state_[i * stride_]; }
+  // NOLINTEND(bugprone-implicit-widening-of-multiplication-result)
 };
 
 template <class ExecutionSpace>

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -588,10 +588,10 @@ struct Random_XorShift1024_State<false> {
       : state_(&v(state_idx, 0)), stride_(v.stride_1()) {}
 
   KOKKOS_FUNCTION
-  uint64_t operator[](const int i) const { return state_[i * stride_]; }
+  uint64_t operator[](size_t i) const { return state_[i * stride_]; }
 
   KOKKOS_FUNCTION
-  uint64_t& operator[](const int i) { return state_[i * stride_]; }
+  uint64_t& operator[](size_t i) { return state_[i * stride_]; }
 };
 
 template <class ExecutionSpace>

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -589,10 +589,10 @@ struct Random_XorShift1024_State<false> {
 
   // NOLINTBEGIN(bugprone-implicit-widening-of-multiplication-result)
   KOKKOS_FUNCTION
-  uint64_t operator[](int i) const { return state_[i * stride_]; }
+  uint64_t operator[](const int i) const { return state_[i * stride_]; }
 
   KOKKOS_FUNCTION
-  uint64_t& operator[](int i) { return state_[i * stride_]; }
+  uint64_t& operator[](const int i) { return state_[i * stride_]; }
   // NOLINTEND(bugprone-implicit-widening-of-multiplication-result)
 };
 

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -99,6 +99,7 @@ void test_dynamic_view_sort_impl(unsigned int n) {
       Kokkos::Experimental::DynamicView<KeyType*, ExecutionSpace>;
   using KeyViewType = Kokkos::View<KeyType*, ExecutionSpace>;
 
+  // NOLINTNEXTLINE(bugprone-implicit-widening-of-multiplication-result)
   const size_t upper_bound    = 2 * n;
   const size_t min_chunk_size = 1024;
 

--- a/algorithms/unit_tests/TestStdAlgorithmsConstraints.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsConstraints.cpp
@@ -173,6 +173,7 @@ TEST(std_algorithms_DeathTest, expect_no_overlap) {
 
   KE::Impl::expect_no_overlap(sub_first_d0, sub_last_d0, sub_first_d1);
 
+  // NOLINTNEXTLINE(bugprone-implicit-widening-of-multiplication-result)
   Kokkos::LayoutStride layout2d{2, 3, extent0, 2 * 3};
   Kokkos::View<value_type**, Kokkos::LayoutStride> strided_view_2d{
       "std-algo-test-2d-contiguous-view-strided", layout2d};

--- a/containers/src/impl/Kokkos_Functional_impl.hpp
+++ b/containers/src/impl/Kokkos_Functional_impl.hpp
@@ -75,6 +75,7 @@ uint32_t MurmurHash3_x86_32(const void* key, int len, uint32_t seed) {
   //----------
   // tail
 
+  // NOLINTNEXTLINE(bugprone-implicit-widening-of-multiplication-result)
   const uint8_t* tail = (const uint8_t*)(data + nblocks * 4);
 
   uint32_t k1 = 0;

--- a/containers/unit_tests/TestDynRankView_TeamScratch.hpp
+++ b/containers/unit_tests/TestDynRankView_TeamScratch.hpp
@@ -27,7 +27,7 @@ void test_dyn_rank_view_team_scratch() {
   using policy_type     = Kokkos::TeamPolicy<execution_space>;
   using team_type       = policy_type::member_type;
 
-  int N0 = 10, N1 = 4, N2 = 3;
+  size_t N0 = 10, N1 = 4, N2 = 3;
   size_t shmem_size = drv_type::shmem_size(N0, N1, N2);
   ASSERT_GE(shmem_size, N0 * N1 * N2 * sizeof(int));
 
@@ -40,9 +40,9 @@ void test_dyn_rank_view_team_scratch() {
         drv_type scr(team.team_scratch(0), N0, N1, N2);
         // Control that the code ran at all
         if (scr.rank() != 3) errors() |= 1u;
-        if (scr.extent_int(0) != N0) errors() |= 2u;
-        if (scr.extent_int(1) != N1) errors() |= 4u;
-        if (scr.extent_int(2) != N2) errors() |= 8u;
+        if (scr.extent(0) != N0) errors() |= 2u;
+        if (scr.extent(1) != N1) errors() |= 4u;
+        if (scr.extent(2) != N2) errors() |= 8u;
         Kokkos::parallel_for(
             Kokkos::TeamThreadMDRange(team, N0, N1, N2),
             [=](int i, int j, int k) { scr(i, j, k) = i * 100 + j * 10 + k; });

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -196,8 +196,10 @@ void HIPInternal::initialize(hipStream_t stream) {
     const unsigned reduce_block_count =
         maxWarpCount * Impl::HIPTraits::WarpSize;
 
-    (void)scratch_flags(reduce_block_count * 2 * sizeof(size_type));
-    (void)scratch_space(reduce_block_count * 16 * sizeof(size_type));
+    (void)scratch_flags(static_cast<size_t>(reduce_block_count * 2) *
+                        sizeof(size_type));
+    (void)scratch_space(static_cast<size_t>(reduce_block_count * 16) *
+                        sizeof(size_type));
   }
 
   m_num_scratch_locks = concurrency();

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Team.hpp
@@ -88,9 +88,11 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>, HIP> {
          league_rank += gridDim.x) {
       this->template exec_team<work_tag>(typename Policy::member_type(
           kokkos_impl_hip_shared_memory<void>(), m_shmem_begin, m_shmem_size,
-          static_cast<void*>(static_cast<char*>(m_scratch_ptr[1]) +
-                             ptrdiff_t(threadid / (blockDim.x * blockDim.y)) *
-                                 m_scratch_size[1]),
+          static_cast<void*>(
+              static_cast<char*>(m_scratch_ptr[1]) +
+              ptrdiff_t(threadid /
+                        static_cast<size_t>(blockDim.x * blockDim.y)) *
+                  m_scratch_size[1]),
           m_scratch_size[1], league_rank, m_league_size));
     }
     if (m_scratch_size[1] > 0) {

--- a/core/src/Kokkos_BitManipulation.hpp
+++ b/core/src/Kokkos_BitManipulation.hpp
@@ -47,7 +47,7 @@ KOKKOS_FUNCTION constexpr T byteswap_fallback(T x) {
       lo_mask <<= CHAR_BIT;
       hi_mask >>= CHAR_BIT;
 
-      shift -= 2 * CHAR_BIT;
+      shift -= size_t{2} * CHAR_BIT;
     }
     return val;
   }

--- a/core/src/Kokkos_BitManipulation.hpp
+++ b/core/src/Kokkos_BitManipulation.hpp
@@ -47,7 +47,7 @@ KOKKOS_FUNCTION constexpr T byteswap_fallback(T x) {
       lo_mask <<= CHAR_BIT;
       hi_mask >>= CHAR_BIT;
 
-      shift -= size_t{2} * CHAR_BIT;
+      shift -= static_cast<size_t>(2) * CHAR_BIT;
     }
     return val;
   }

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -29,6 +29,7 @@ static_assert(false,
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>
 
+// NOLINTBEGIN(bugprone-implicit-widening-of-multiplication-result)
 namespace Kokkos {
 namespace Impl {
 /* Report violation of size constraints:
@@ -791,5 +792,6 @@ class MemoryPool {
 };
 
 }  // namespace Kokkos
+   // NOLINTEND(bugprone-implicit-widening-of-multiplication-result)
 
 #endif /* #ifndef KOKKOS_MEMORYPOOL_HPP */

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -240,9 +240,9 @@ void OpenMPInternal::initialize(int thread_count) {
 
     // New, unified host thread team data:
     {
-      size_t pool_reduce_bytes  = 32 * thread_count;
-      size_t team_reduce_bytes  = 32 * thread_count;
-      size_t team_shared_bytes  = 1024 * thread_count;
+      size_t pool_reduce_bytes  = static_cast<size_t>(32) * thread_count;
+      size_t team_reduce_bytes  = static_cast<size_t>(32) * thread_count;
+      size_t team_shared_bytes  = static_cast<size_t>(1024) * thread_count;
       size_t thread_local_bytes = 1024;
 
       instance.resize_thread_data(pool_reduce_bytes, team_reduce_bytes,

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
@@ -84,11 +84,12 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::OpenMP, QueueType>> {
     std::lock_guard<std::mutex> lock(instance->m_instance_mutex);
 
     // TODO @tasking @new_feature DSH allow team sizes other than 1
-    const int team_size = 1;                      // Threads per core
-    instance->resize_thread_data(0,               /* global reduce buffer */
-                                 512 * team_size, /* team reduce buffer */
-                                 0,               /* team shared buffer */
-                                 0                /* thread local buffer */
+    const int team_size = 1;  // Threads per core
+    instance->resize_thread_data(
+        0,                                    /* global reduce buffer */
+        static_cast<size_t>(512) * team_size, /* team reduce buffer */
+        0,                                    /* team shared buffer */
+        0                                     /* thread local buffer */
     );
     assert(pool_size % team_size == 0);
 
@@ -246,14 +247,15 @@ class TaskQueueSpecializationConstrained<
     // Serialize kernels on the same execution space instance
     std::lock_guard<std::mutex> lock(instance->m_instance_mutex);
 
-    const int team_size = 1;       // Threads per core
-    instance->resize_thread_data(0 /* global reduce buffer */
-                                 ,
-                                 512 * team_size /* team reduce buffer */
-                                 ,
-                                 0 /* team shared buffer */
-                                 ,
-                                 0 /* thread local buffer */
+    const int team_size = 1;  // Threads per core
+    instance->resize_thread_data(
+        0 /* global reduce buffer */
+        ,
+        static_cast<size_t>(512) * team_size /* team reduce buffer */
+        ,
+        0 /* team shared buffer */
+        ,
+        0 /* thread local buffer */
     );
     assert(pool_size % team_size == 0);
 

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
@@ -106,7 +106,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
 #endif
       cgh.parallel_for(
           sycl::nd_range<2>(
-              sycl::range<2>(m_team_size, m_league_size * final_vector_size),
+              sycl::range<2>(m_team_size, static_cast<size_t>(m_league_size) *
+                                              final_vector_size),
               sycl::range<2>(m_team_size, final_vector_size)),
           lambda);
     };

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
@@ -153,7 +153,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
       // maximum number of work groups, also see
       // https://github.com/intel/llvm/blob/756ba2616111235bba073e481b7f1c8004b34ee6/sycl/source/detail/reduction.cpp#L51-L62
       size_t max_work_groups =
-          2 * q.get_device().get_info<sycl::info::device::max_compute_units>();
+          static_cast<size_t>(2) *
+          q.get_device().get_info<sycl::info::device::max_compute_units>();
       int values_per_thread = 1;
       size_t n_wgroups      = n_tiles;
       while (n_wgroups > max_work_groups) {

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
@@ -295,7 +295,7 @@ class Kokkos::Impl::ParallelReduce<
         // maximum number of work groups, also see
         // https://github.com/intel/llvm/blob/756ba2616111235bba073e481b7f1c8004b34ee6/sycl/source/detail/reduction.cpp#L51-L62
         size_t max_work_groups =
-            2 *
+            static_cast<size_t>(2) *
             q.get_device().get_info<sycl::info::device::max_compute_units>();
         int values_per_thread = 1;
         size_t n_wgroups      = (size + wgroup_size - 1) / wgroup_size;

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -335,7 +335,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                 sizeof(value_type) * std::max(value_count, 1u) * init_size));
 
         size_t max_work_groups =
-            2 *
+            static_cast<size_t>(2) *
             q.get_device().get_info<sycl::info::device::max_compute_units>();
         int values_per_thread = 1;
         size_t n_wgroups      = m_league_size;

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -766,7 +766,7 @@ class TeamPolicyInternal<Kokkos::Threads, Properties...>
  private:
   /** \brief finalize chunk_size if it was set to AUTO*/
   inline void set_auto_chunk_size() {
-    int64_t concurrency = space().concurrency() / m_team_alloc;
+    int concurrency = space().concurrency() / m_team_alloc;
     if (concurrency == 0) concurrency = 1;
 
     if (m_chunk_size > 0) {

--- a/core/src/View/Kokkos_ViewMapping.hpp
+++ b/core/src/View/Kokkos_ViewMapping.hpp
@@ -1027,8 +1027,8 @@ struct ViewOffset<
     KOKKOS_INLINE_FUNCTION
     static constexpr size_t stride(size_t const N) {
       return ((align != 0) &&
-              ((static_cast<int>(Kokkos::Impl::MEMORY_ALIGNMENT_THRESHOLD) *
-                static_cast<int>(align)) < N) &&
+              ((static_cast<size_t>(Kokkos::Impl::MEMORY_ALIGNMENT_THRESHOLD) *
+                align) < N) &&
               ((N % div_ok) != 0))
                  ? N + align - (N % div_ok)
                  : N;
@@ -1713,8 +1713,8 @@ struct ViewOffset<
     KOKKOS_INLINE_FUNCTION
     static constexpr size_t stride(size_t const N) {
       return ((align != 0) &&
-              ((static_cast<int>(Kokkos::Impl::MEMORY_ALIGNMENT_THRESHOLD) *
-                static_cast<int>(align)) < N) &&
+              ((static_cast<size_t>(Kokkos::Impl::MEMORY_ALIGNMENT_THRESHOLD) *
+                align) < N) &&
               ((N % div_ok) != 0))
                  ? N + align - (N % div_ok)
                  : N;

--- a/core/unit_test/TestSharedSpace.cpp
+++ b/core/unit_test/TestSharedSpace.cpp
@@ -118,9 +118,9 @@ TEST(defaultdevicetype, shared_space) {
 
   const unsigned int numRepetitions      = 10;
   const unsigned int numDeviceHostCycles = 3;
-  double threshold                       = 1.5;
-  unsigned int numPages                  = 100;
-  size_t numBytes                        = numPages * getBytesPerPage();
+  const double threshold                 = 1.5;
+  const size_t numPages                  = 100;
+  const size_t numBytes                  = numPages * getBytesPerPage();
 
   using DeviceExecutionSpace = Kokkos::DefaultExecutionSpace;
   using HostExecutionSpace   = Kokkos::DefaultHostExecutionSpace;

--- a/core/unit_test/TestTaskScheduler_single.hpp
+++ b/core/unit_test/TestTaskScheduler_single.hpp
@@ -19,8 +19,8 @@ namespace Test {
 TEST(TEST_CATEGORY, KOKKOS_TEST_WITH_SUFFIX(task_fib, TEST_SCHEDULER_SUFFIX)) {
   const int N = 27;
   for (int i = 0; i < N; ++i) {
-    TestTaskScheduler::TestFib<TEST_SCHEDULER>::run(i,
-                                                    (i + 1) * (i + 1) * 64000);
+    TestTaskScheduler::TestFib<TEST_SCHEDULER>::run(
+        i, static_cast<size_t>(i + 1) * (i + 1) * 64000);
   }
 }
 

--- a/core/unit_test/TestView_64bit.hpp
+++ b/core/unit_test/TestView_64bit.hpp
@@ -84,7 +84,7 @@ void test_64bit() {
   {
 // We are running out of device memory on Intel GPUs
 #ifdef KOKKOS_ENABLE_SYCL
-    int64_t N0 = 1024 * 1024 * 900;
+    int N0 = 1024 * 1024 * 900;
 #else
     int N0 = 1024 * 1024 * 1500;
 #endif

--- a/core/unit_test/hip/TestHIP_UnifiedMemory_ZeroMemset.cpp
+++ b/core/unit_test/hip/TestHIP_UnifiedMemory_ZeroMemset.cpp
@@ -28,8 +28,8 @@ TEST(hip, unified_memory_zero_memset) {
       << "this test should only be run with HIP unified memory enabled";
 #endif
 
-  constexpr size_t N = 1024 * 1024;  // size doesn't matter
-  std::vector<int> v(N, 1);          // initialize to non-zero
+  constexpr size_t N = static_cast<size_t>(1024 * 1024);  // size doesn't matter
+  std::vector<int> v(N, 1);  // initialize to non-zero
   Kokkos::View<int*, Kokkos::HIPSpace> a(v.data(), N);
 
   // zero with deep_copy (this is where the error occurs)


### PR DESCRIPTION
We recently fixed a number of vulnerability reports regarding multiplication result converted to larger type
(see
#7543
#7463
#7454
#7430
and #7429)

There is a [`bugprone-implicit-widening-of-multiplication-result` ClangTidy check](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/implicit-widening-of-multiplication-result.html) that is able to detect these.
I propose we enable it.

I suggested fixes for all the warnings I could see on my local build.
I anticipate more will show up in other builds.
I would welcome help to find all issues and resolve them.
Please feel free to push my branch.  Don't hesitate to reach out if you are unsure about how to tackle any of them.
