### PR TITLE
GitLab CI: Test MI300A

### DIFF
--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -54,7 +54,7 @@ AMD-MI300A:
       -DKokkos_ENABLE_HIP=ON
       -DKokkos_ARCH_AMD_GFX942_APU=ON
       -DKokkos_ARCH_NATIVE=ON
-      -DKokkos_ENABLE_ROCTHRUST=OFF
+      -Drocthrust_ROOT=/opt/rocm-6.2.4
       -DKokkos_ENABLE_TESTS=ON
       -DCMAKE_CXX_FLAGS='-Werror'
       -DKokkos_ENABLE_COMPILER_WARNINGS=ON

--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -57,6 +57,7 @@ AMD-MI300A:
       -DKokkos_ENABLE_ROCTHRUST=OFF
       -DKokkos_ENABLE_TESTS=ON
       -DCMAKE_CXX_FLAGS='-Werror'
+      -DKokkos_ENABLE_COMPILER_WARNINGS=ON
     - cmake --build build -j48 --verbose
     - cd build
     - ctest -V --output-junit result_mi300a.xml

--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -39,3 +39,30 @@ INTEL-DATA-CENTER-MAX-1100:
       - build/result_pvc1100.xml
     reports:
       junit: build/result_pvc1100.xml
+
+AMD-MI300A:
+  stage: test
+  tags: [uo-gpu, odyssey, amd-mi300]
+  image: rocm/dev-ubuntu-24.04:6.2.4-complete
+  script:
+    - sudo apt-get update && sudo apt-get install -y cmake
+    - export GTEST_FILTER=-hip.unified_memory_zero_memset
+    - cmake
+      -B build
+      -DCMAKE_BUILD_TYPE=Release
+      -DCMAKE_CXX_COMPILER=hipcc
+      -DKokkos_ENABLE_HIP=ON
+      -DKokkos_ARCH_AMD_GFX942_APU=ON
+      -DKokkos_ARCH_NATIVE=ON
+      -DKokkos_ENABLE_ROCTHRUST=OFF
+      -DKokkos_ENABLE_TESTS=ON
+      -DCMAKE_CXX_FLAGS='-Werror'
+    - cmake --build build -j48 --verbose
+    - cd build
+    - ctest -V --output-junit result_mi300a.xml
+  artifacts:
+    when: always
+    paths:
+      - build/result_mi300a.xml
+    reports:
+      junit: build/result_mi300a.xml


### PR DESCRIPTION
This pull requets adds a GitLab CI build running on https://systems.nic.uoregon.edu/internal-wiki/index.php?title=Compute:_Odyssey. The image used doesn't seem to contain `rocthrust` so it's disabled for now and I was seeing
```
[ RUN      ] hip.unified_memory_zero_memset
5: Memory access fault by GPU node-4 (Agent handle: 0x628b250) on address 0x97f1000. Reason: Unknown.
```
so that test is skipped for now as well.