### PR TITLE
core(graph): capture

### DIFF
--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -30,6 +30,27 @@
 namespace Kokkos {
 namespace Impl {
 
+template <typename Functor>
+struct GraphNodeCaptureImpl<Kokkos::HIP, Functor> {
+  Functor m_functor;
+  hipGraphNode_t m_node = nullptr;
+
+  void capture(const Kokkos::HIP& exec, hipGraph_t graph) {
+    KOKKOS_IMPL_HIP_SAFE_CALL(
+        hipStreamBeginCapture(exec.hip_stream(), hipStreamCaptureModeGlobal));
+
+    m_functor(exec);
+
+    hipGraph_t captured_subgraph(nullptr);
+
+    KOKKOS_IMPL_HIP_SAFE_CALL(
+        hipStreamEndCapture(exec.hip_stream(), &captured_subgraph));
+
+    KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphAddChildGraphNode(&m_node, graph, nullptr,
+                                                        0, captured_subgraph));
+  }
+};
+
 template <typename PolicyType, typename Functor, typename PatternTag,
           typename... Args>
 class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -57,7 +57,8 @@ class GraphNodeRef {
       "Invalid execution space template parameter given to GraphNodeRef");
 
   static_assert(std::is_same_v<Predecessor, TypeErasedTag> ||
-                    Kokkos::Impl::is_graph_kernel<Kernel>::value,
+                    Kokkos::Impl::is_graph_kernel<Kernel>::value ||
+                    Kokkos::Impl::is_graph_capture<Kernel>::value,
                 "Invalid kernel template parameter given to GraphNodeRef");
 
   static_assert(!Kokkos::Impl::is_more_type_erased<Kernel, Predecessor>::value,
@@ -154,7 +155,7 @@ class GraphNodeRef {
     // Add the node itself to the backend's graph data structure, now that
     // everything is set up.
     graph_ptr->add_node(rv.m_node_impl);
-    // Add the predecessaor we stored in the constructor above in the backend's
+    // Add the predecessor we stored in the constructor above in the backend's
     // data structure, now that everything is set up.
     graph_ptr->add_predecessor(rv.m_node_impl, *this);
     KOKKOS_ENSURES(bool(rv.m_node_impl))
@@ -245,6 +246,51 @@ class GraphNodeRef {
     return this->then(std::forward<Label>(label), ExecutionSpace{},
                       std::forward<Functor>(functor));
   }
+
+#if defined(KOKKOS_ENABLE_CUDA) ||                                           \
+    (defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)) || \
+    (defined(KOKKOS_ENABLE_SYCL) && defined(SYCL_EXT_ONEAPI_GRAPH))
+  template <class Functor,
+            typename = std::enable_if_t<std::is_invocable_r_v<
+                void, const Kokkos::Impl::remove_cvref_t<Functor>,
+                const ExecutionSpace&>>>
+#if defined(KOKKOS_ENABLE_CUDA)
+  auto cuda_capture(const ExecutionSpace& exec, Functor&& functor) const {
+    if constexpr (std::is_same_v<ExecutionSpace, Kokkos::Cuda>) {
+#elif defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
+  auto hip_capture(const ExecutionSpace& exec, Functor&& functor) const {
+    if constexpr (std::is_same_v<ExecutionSpace, Kokkos::HIP>) {
+#elif defined(KOKKOS_ENABLE_SYCL) && defined(SYCL_EXT_ONEAPI_GRAPH)
+  auto sycl_capture(const ExecutionSpace& exec, Functor&& functor) const {
+    if constexpr (std::is_same_v<ExecutionSpace, Kokkos::SYCL>) {
+#endif
+      using capture_t = Kokkos::Impl::GraphNodeCaptureImpl<
+          ExecutionSpace, Kokkos::Impl::remove_cvref_t<Functor>>;
+      using return_t = GraphNodeRef<ExecutionSpace, capture_t, GraphNodeRef>;
+
+      auto graph_ptr = m_graph_impl.lock();
+      KOKKOS_EXPECTS(bool(graph_ptr))
+
+      auto rv = Kokkos::Impl::GraphAccess::make_graph_node_ref(
+          m_graph_impl,
+          Kokkos::Impl::GraphAccess::make_node_shared_ptr<
+              typename return_t::node_impl_t>(
+              m_node_impl->execution_space_instance(),
+              Kokkos::Impl::_graph_node_capture_ctor_tag{},
+              std::forward<Functor>(functor),
+              Kokkos::Impl::_graph_node_predecessor_ctor_tag{}, *this));
+
+      // Add the node itself to the backend's graph data structure, now that
+      // everything is set up.
+      graph_ptr->add_node(exec, rv.m_node_impl);
+      // Add the predecessor we stored in the constructor above in the
+      // backend's data structure, now that everything is set up.
+      graph_ptr->add_predecessor(rv.m_node_impl, *this);
+      KOKKOS_ENSURES(bool(rv.m_node_impl))
+      return rv;
+    }
+  }
+#endif
 
   template <
       class Policy, class Functor,

--- a/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
@@ -64,7 +64,12 @@ class GraphImpl<Kokkos::SYCL> {
   template <class NodeImpl>
   std::enable_if_t<
       Kokkos::Impl::is_graph_kernel_v<typename NodeImpl::kernel_type>>
-  add_node(std::shared_ptr<NodeImpl> const& arg_node_ptr);
+  add_node(std::shared_ptr<NodeImpl> arg_node_ptr);
+
+  template <class NodeImpl>
+  std::enable_if_t<
+      Kokkos::Impl::is_graph_capture_v<typename NodeImpl::kernel_type>>
+  add_node(const Kokkos::SYCL& exec, std::shared_ptr<NodeImpl> arg_node_ptr);
 
   template <class NodeImplPtr, class PredecessorRef>
   void add_predecessor(NodeImplPtr arg_node_ptr, PredecessorRef arg_pred_ref);
@@ -119,8 +124,7 @@ inline void GraphImpl<Kokkos::SYCL>::add_node(
 template <class NodeImpl>
 inline std::enable_if_t<
     Kokkos::Impl::is_graph_kernel_v<typename NodeImpl::kernel_type>>
-GraphImpl<Kokkos::SYCL>::add_node(
-    std::shared_ptr<NodeImpl> const& arg_node_ptr) {
+GraphImpl<Kokkos::SYCL>::add_node(std::shared_ptr<NodeImpl> arg_node_ptr) {
   static_assert(Kokkos::Impl::is_specialization_of_v<NodeImpl, GraphNodeImpl>);
   KOKKOS_EXPECTS(arg_node_ptr);
   // The Kernel launch from the execute() method has been shimmed to insert
@@ -132,7 +136,22 @@ GraphImpl<Kokkos::SYCL>::add_node(
   kernel.set_sycl_graph_node_ptr(&node);
   kernel.execute();
   KOKKOS_ENSURES(node);
-  m_nodes.push_back(arg_node_ptr);
+  m_nodes.push_back(std::move(arg_node_ptr));
+}
+
+template <class NodeImpl>
+std::enable_if_t<
+    Kokkos::Impl::is_graph_capture_v<typename NodeImpl::kernel_type>>
+GraphImpl<Kokkos::SYCL>::add_node(const Kokkos::SYCL& exec,
+                                  std::shared_ptr<NodeImpl> arg_node_ptr) {
+  static_assert(Kokkos::Impl::is_specialization_of_v<NodeImpl, GraphNodeImpl>);
+  KOKKOS_EXPECTS(arg_node_ptr);
+
+  auto& kernel = arg_node_ptr->get_kernel();
+  kernel.capture(exec, m_graph);
+  static_cast<node_details_t*>(arg_node_ptr.get())->node = kernel.m_node;
+
+  m_nodes.push_back(std::move(arg_node_ptr));
 }
 
 // Requires PredecessorRef is a specialization of GraphNodeRef that has

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -31,6 +31,12 @@
 namespace Kokkos {
 namespace Impl {
 
+template <typename T>
+struct is_graph_capture<
+    T, std::enable_if_t<
+           Kokkos::Impl::is_specialization_of_v<T, GraphNodeCaptureImpl>>>
+    : public std::true_type {};
+
 struct GraphAccess {
   template <class ExecutionSpace>
   static Kokkos::Experimental::Graph<ExecutionSpace> construct_graph(

--- a/core/src/impl/Kokkos_GraphImpl_fwd.hpp
+++ b/core/src/impl/Kokkos_GraphImpl_fwd.hpp
@@ -35,7 +35,17 @@ class GraphNodeKernelImpl;
 template <class ExecutionSpace, class Functor>
 struct GraphNodeThenImpl;
 
+template <typename ExecutionSpace, typename Functor>
+struct GraphNodeCaptureImpl;
+
+template <typename T, class Enable = void>
+struct is_graph_capture : public std::false_type {};
+
+template <typename T>
+inline constexpr bool is_graph_capture_v = is_graph_capture<T>::value;
+
 struct _graph_node_kernel_ctor_tag {};
+struct _graph_node_capture_ctor_tag {};
 struct _graph_node_predecessor_ctor_tag {};
 struct _graph_node_is_root_ctor_tag {};
 


### PR DESCRIPTION
## Summary

This PR introduces the *capture* node. Capture is only supported for the following backends:
- `Cuda`
- `HIP`
- `SYCL` (though in `SYCL` native language it's called this *recording*)

As the capture mechanism is backend-specific, the API has been prefixed with the backend.

It's been documented in:
- https://github.com/kokkos/kokkos-core-wiki/pull/652

### `Cuda` capture

The user passes a callable. We call it with a stream for which capture is enabled, and add the captured nodes as a sub-graph:
```c++
auto my_captured_node = predecessor.cuda_capture(
    exec,
    [data = data](const Kokkos::Cuda& exec_) { ... }
);
```

### `HIP` capture

The user passes a callable. We call it with a stream for which capture is enabled, and add the captured nodes as a sub-graph:
```c++
auto my_captured_node = predecessor.hip_capture(
    exec,
    [data = data](const Kokkos::HIP& exec_) { ... }
);
```

### `SYCL` recording

The user passes a callable. We call it with a queue for which recording was enabled, and add the recorded (executable) graph as a sub-graph:

```c++
auto my_captured_node = predecessor.sycl_capture(
    exec,
    [data = data](const Kokkos::SYCL& exec_) { ... }
);
```

<details>

<summary>

:warning: This is the old PR description. Kept for the record only. :older_man: 

</summary>

## Summary

This PR introduces the `then` node type for `Kokkos::Graph`.

The idea of the `then` node type is to allow users to add workloads that **are not defined through a `Kokkos` parallel construct** through the public API.

A formal definition could be:
> A `then` node places its workloads in a graph-ordered execution stack.
How workloads are actually defined and stored is backend-specific to best match the available backend execution models.

## Description

### What it does

The behavior of the `then` node varies:
* For `Cuda`, `HIP` and `SYCL`, a `then` node is equivalent to adding workloads through *graph capture* to the underlying native graph.
* For backends using the defaulted graph implementation, a `then` node stores the workload in a functor and calls this functor when calling `submit` (much like `Kokkos::Impl::ParallelFor` would do for instance).

In both cases, the users gives a functor and in both cases it is stored:
* For graph capturing backends, the functor is called once to capture workloads, and must be stored to keep any data alive.
* For others, it is obviously stored to be called on `submit`.

### Example

I've added a test in `core/unit_test/TestGraph.hpp` that should be the reference example. This is a code example:
```c++
auto node_then = other_node.then(
    [data = data] -> void (const Kokkos::Cuda& exec){
        my_external_kernel<<<..., ..., ..., exec.cuda_stream()>>>(data);
});
```

</details>