### PR TITLE
Print value of all relevant SYCL_EXT_ONEAPI* macros

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -119,6 +119,17 @@ void SYCL::print_configuration(std::ostream& os, bool verbose) const {
 #else
   os << "macro  SYCL_EXT_ONEAPI_GRAPH : undefined\n";
 #endif
+#ifdef SYCL_EXT_ONEAPI_BFLOAT16
+  os << "macro  SYCL_EXT_ONEAPI_BFLOAT16 : defined\n";
+#else
+  os << "macro  SYCL_EXT_ONEAPI_BFLOAT16 : undefined\n";
+#endif
+#ifdef SYCL_EXT_ONEAPI_AUTO_LOCAL_RANGE
+  os << "macro  SYCL_EXT_ONEAPI_AUTO_LOCAL_RANGE : defined\n";
+#else
+  os << "macro  SYCL_EXT_ONEAPI_AUTO_LOCAL_RANGE : undefined\n";
+#endif
+
 #ifdef SYCL_EXT_INTEL_QUEUE_IMMEDIATE_COMMAND_LIST
   if (sycl_queue()
           .has_property<


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/pull/6496#discussion_r1865979749.