### PR TITLE
Fix Zen3 flag for NVHPC

### DIFF
--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -404,7 +404,7 @@ if(KOKKOS_ARCH_ZEN3)
     MSVC
     /arch:AVX2
     NVHPC
-    -tp=zen2
+    -tp=zen3
     DEFAULT
     -march=znver3
     -mtune=znver3


### PR DESCRIPTION
I couldn't find any discussion about consciously using `-tp=zen2` for Zen3 with NVHPC.