### PR TITLE
Update mdspan tpl to commit cb3bd4284dc3bcdfd8b7779a62ada1504fefd6a4

### DIFF
--- a/tpls/mdspan/include/experimental/__p0009_bits/config.hpp
+++ b/tpls/mdspan/include/experimental/__p0009_bits/config.hpp
@@ -240,7 +240,13 @@ static_assert(_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or 
 
 #ifndef MDSPAN_USE_BRACKET_OPERATOR
 #  if defined(__cpp_multidimensional_subscript)
-#    define MDSPAN_USE_BRACKET_OPERATOR 1
+// The following if/else is necessary to workaround a clang issue
+// relative to using a parameter pack inside a bracket operator in C++2b/C++23 mode
+#    if defined(_MDSPAN_COMPILER_CLANG) && ((__clang_major__ == 15) || (__clang_major__ == 16))
+#      define MDSPAN_USE_BRACKET_OPERATOR 0
+#    else
+#      define MDSPAN_USE_BRACKET_OPERATOR 1
+#    endif
 #  else
 #    define MDSPAN_USE_BRACKET_OPERATOR 0
 #  endif

--- a/tpls/mdspan/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/tpls/mdspan/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -252,7 +252,7 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(
                         *this, inv_map,
 // HIP needs deduction guides to have markups so we need to be explicit
 // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
-// the issue But Clang-CUDA also doesn't accept the use of deduction guide so
+// the issue but Clang-CUDA also doesn't accept the use of deduction guide so
 // disable it for CUDA altogether
 #if defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_CUDA)
                         detail::tuple<decltype(detail::stride_of(slices))...>{
@@ -330,7 +330,7 @@ MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_left_padded<PaddingValue>::mapping<Extent
                         *this, inv_map,
 // HIP needs deduction guides to have markups so we need to be explicit
 // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
-// the issue But Clang-CUDA also doesn't accept the use of deduction guide so
+// the issue but Clang-CUDA also doesn't accept the use of deduction guide so
 // disable it for CUDA alltogether
 #if defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_CUDA)
                         MDSPAN_IMPL_STANDARD_NAMESPACE::detail::tuple<decltype(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::stride_of(slices))...>{
@@ -485,7 +485,7 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
                         *this, inv_map,
 // HIP needs deduction guides to have markups so we need to be explicit
 // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
-// the issue But Clang-CUDA also doesn't accept the use of deduction guide so
+// the issue but Clang-CUDA also doesn't accept the use of deduction guide so
 // disable it for CUDA altogether
 #if defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_CUDA)
                         MDSPAN_IMPL_STANDARD_NAMESPACE::detail::tuple<decltype(detail::stride_of(slices))...>{
@@ -555,7 +555,7 @@ MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_right_padded<PaddingValue>::mapping<Exten
                         *this, inv_map,
 // HIP needs deduction guides to have markups so we need to be explicit
 // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
-// the issue But Clang-CUDA also doesn't accept the use of deduction guide so
+// the issue but Clang-CUDA also doesn't accept the use of deduction guide so
 // disable it for CUDA alltogether
 #if defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_CUDA)
                         MDSPAN_IMPL_STANDARD_NAMESPACE::detail::tuple<decltype(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::stride_of(slices))...>{
@@ -603,12 +603,11 @@ layout_stride::mapping<Extents>::submdspan_mapping_impl(
                       *this, inv_map,
 // HIP needs deduction guides to have markups so we need to be explicit
 // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
-// the issue
-#if defined(_MDSPAN_HAS_HIP) ||                                                \
-    (defined(__NVCC__) &&                                                      \
-     (__CUDACC_VER_MAJOR__ * 100 + __CUDACC_VER_MINOR__ * 10) < 1120)
+// the issue but Clang-CUDA also doesn't accept the use of deduction guide so
+// disable it for CUDA alltogether
+#if defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_CUDA)
                       MDSPAN_IMPL_STANDARD_NAMESPACE::detail::tuple<decltype(detail::stride_of(slices))...>(
-                          detail::stride_of(slices)...).values)),
+                          detail::stride_of(slices)...)).values),
 #else
                       MDSPAN_IMPL_STANDARD_NAMESPACE::detail::tuple(detail::stride_of(slices)...)).values),
 #endif


### PR DESCRIPTION
This is a copy/paste of the directories `mdspan/include/experimental` and `mdspan/include/mdspan` of the commit https://github.com/kokkos/mdspan/commit/cb3bd4284dc3bcdfd8b7779a62ada1504fefd6a4.

It brings:
- a typo fix in submdspan,
- a workaround for the clang compilers 15 and 16 related to the bracket operator.

I would like we consider this PR as a candidate for a 4.5.1 patch release.