### PR TITLE
Fix HIP clang-tidy warning in unit_tests

### DIFF
--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -817,7 +817,7 @@ TEST(TEST_CATEGORY, scatterview_devicetype) {
   using device_memory_space    = Kokkos::HIPSpace;
   using host_accessible_space  = Kokkos::HIPManagedSpace;
 #endif
-  if (std::is_same<TEST_EXECSPACE, device_execution_space>::value) {
+  if (std::is_same_v<TEST_EXECSPACE, device_execution_space>) {
     using device_device_type =
         Kokkos::Device<device_execution_space, device_memory_space>;
     test_scatter_view<device_device_type, Kokkos::Experimental::ScatterSum,

--- a/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
+++ b/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
@@ -247,7 +247,7 @@ TEST(TEST_CATEGORY, host_shared_ptr_tracking) {
                                             Kokkos::SYCLSharedUSMSpace>();
 #endif
 #ifdef KOKKOS_ENABLE_HIP
-  if (std::is_same<TEST_EXECSPACE, Kokkos::HIP>::value) {
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::HIP>) {
     host_shared_ptr_test_reference_counting<Kokkos::HIPHostPinnedSpace,
                                             Kokkos::HIPHostPinnedSpace>();
     host_shared_ptr_test_reference_counting<Kokkos::HIPManagedSpace,

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -350,7 +350,7 @@ TEST(TEST_CATEGORY, team_broadcast_float) {
 #endif
     // FIXME_HIP
 #ifdef KOKKOS_ENABLE_HIP
-      if (!std::is_same<TEST_EXECSPACE, Kokkos::HIP>::value)
+      if (!std::is_same_v<TEST_EXECSPACE, Kokkos::HIP>)
 #endif
       {
         TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
@@ -384,7 +384,7 @@ TEST(TEST_CATEGORY, team_broadcast_double) {
 #endif
     // FIXME_HIP
 #ifdef KOKKOS_ENABLE_HIP
-      if (!std::is_same<TEST_EXECSPACE, Kokkos::HIP>::value)
+      if (!std::is_same_v<TEST_EXECSPACE, Kokkos::HIP>)
 #endif
       {
         TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,

--- a/core/unit_test/hip/TestHIP_ScanUnit.cpp
+++ b/core/unit_test/hip/TestHIP_ScanUnit.cpp
@@ -53,8 +53,8 @@ void test_intra_block_scan() {
 }
 
 TEST(TEST_CATEGORY, scan_unit) {
-  if (std::is_same<TEST_EXECSPACE,
-                   typename Kokkos::HIPSpace::execution_space>::value) {
+  if (std::is_same_v<TEST_EXECSPACE,
+                     typename Kokkos::HIPSpace::execution_space>) {
     test_intra_block_scan<1>();
     test_intra_block_scan<2>();
     test_intra_block_scan<4>();

--- a/core/unit_test/hip/TestHIP_Spaces.cpp
+++ b/core/unit_test/hip/TestHIP_Spaces.cpp
@@ -171,22 +171,24 @@ TEST(hip, space_access) {
                                  Kokkos::HIPManagedSpace>::accessible);
 
 #if !defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
-  static_assert(std::is_same<Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Space,
-                             Kokkos::HostSpace>::value);
+  static_assert(
+      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Space,
+                     Kokkos::HostSpace>);
 #else
-  static_assert(std::is_same<Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Space,
-                             Kokkos::Device<Kokkos::HostSpace::execution_space,
-                                            Kokkos::HIPSpace>>::value);
+  static_assert(
+      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Space,
+                     Kokkos::Device<Kokkos::HostSpace::execution_space,
+                                    Kokkos::HIPSpace>>);
 #endif
 
-  static_assert(
-      std::is_same<Kokkos::Impl::HostMirror<Kokkos::HIPHostPinnedSpace>::Space,
-                   Kokkos::HIPHostPinnedSpace>::value);
+  static_assert(std::is_same_v<
+                Kokkos::Impl::HostMirror<Kokkos::HIPHostPinnedSpace>::Space,
+                Kokkos::HIPHostPinnedSpace>);
 
   static_assert(
-      std::is_same<Kokkos::Impl::HostMirror<Kokkos::HIPManagedSpace>::Space,
-                   Kokkos::Device<Kokkos::HostSpace::execution_space,
-                                  Kokkos::HIPManagedSpace>>::value);
+      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::HIPManagedSpace>::Space,
+                     Kokkos::Device<Kokkos::HostSpace::execution_space,
+                                    Kokkos::HIPManagedSpace>>);
 
   static_assert(
       Kokkos::SpaceAccessibility<Kokkos::Impl::HostMirror<Kokkos::HIP>::Space,


### PR DESCRIPTION
The clang-tidy in ROCm 6.2 emits more warnings than the clang-tidy in ROCm 6.0, so our nightly tests failed on Frontier even though the CI passed. ROCm 6.3 has just been released, if the Docker image includes clang-tidy, I will update our CI.