### PR TITLE
Fixing a compiler segfault for MSVC/CUDA and failing test

### DIFF
--- a/core/unit_test/TestAtomicViews.hpp
+++ b/core/unit_test/TestAtomicViews.hpp
@@ -1065,13 +1065,10 @@ T AndEqualAtomicViewCheck(const int64_t input_length) {
   const int64_t N = input_length;
   T result[2]     = {1};
   for (int64_t i = 0; i < N; ++i) {
-    if (N % 2 == 0) {
-      result[0] &= (T)i;
-    } else {
-      result[1] &= (T)i;
-    }
+    int64_t idx = N % 2;
+    result[idx] &= (T)i;
   }
-
+  
   return (result[0]);
 }
 

--- a/core/unit_test/TestViewBadAlloc.hpp
+++ b/core/unit_test/TestViewBadAlloc.hpp
@@ -66,6 +66,12 @@ TEST(TEST_CATEGORY, view_bad_alloc) {
   }
 #endif
 
+#if defined(_WIN32) && defined(KOKKOS_ENABLE_CUDA)
+  if (std::is_same_v<ExecutionSpace, Kokkos::Cuda>) {
+    GTEST_SKIP() << "MSVC/CUDA segfaults when allocating too much memory";
+  }
+#endif
+
   test_view_bad_alloc<MemorySpace>();
 
   constexpr bool execution_space_is_device =


### PR DESCRIPTION
The code actually simplifies slightly. Its a mystery to me how this could possibley have gone wrong. Also skipping bad-alloc test which doesn't behave as expected on MSVC+CUDA