### PR TITLE
core(cuda): set device not needed for stream synchronization

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -161,10 +161,7 @@ void cuda_stream_synchronize(const cudaStream_t stream, const CudaInternal *ptr,
       name,
       Kokkos::Tools::Experimental::Impl::DirectFenceIDHandle{
           ptr->impl_get_instance_id()},
-      [&]() {
-        KOKKOS_IMPL_CUDA_SAFE_CALL(
-            (ptr->cuda_stream_synchronize_wrapper(stream)));
-      });
+      [stream] { KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamSynchronize(stream)); });
 }
 
 void cuda_internal_error_throw(cudaError e, const char *name, const char *file,

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -414,12 +414,6 @@ class CudaInternal {
     return cudaStreamDestroy(stream);
   }
 
-  template <bool setCudaDevice = true>
-  cudaError_t cuda_stream_synchronize_wrapper(cudaStream_t stream) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaStreamSynchronize(stream);
-  }
-
   // C++ API routines
   template <typename T, bool setCudaDevice = true>
   cudaError_t cuda_func_get_attributes_wrapper(cudaFuncAttributes* attr,


### PR DESCRIPTION
### Summary

`Cuda` stream synchronization in a multi-GPU context can be called whatever the current device is.

### Description

As per [`Cuda` documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#stream-and-event-behavior):
> `cudaEventSynchronize()` and `cudaEventQuery()` will succeed even if the input event is associated to a device that is different from the current device.
> `cudaStreamWaitEvent()` will succeed even if the input stream and input event are associated to different devices. `cudaStreamWaitEvent()` can therefore be used to synchronize multiple devices with each other.

:warning: I don't have access to a multi-GPU `Cuda` machine, so either we trust the documentation or someone can test it.

### Related

- This addresses partly #7562.