### PR TITLE
Skip hip_hostpinned.view_allocation_large_rank test for ROCm 6.0

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -350,6 +350,10 @@ pipeline {
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
                         }
                     }
+                    environment {
+                        // FIXME Test returns a wrong value
+                        GTEST_FILTER = '-hip_hostpinned.view_allocation_large_rank'
+                    }
                     steps {
                         sh 'ccache --zero-stats'
                         sh '''rm -rf build && mkdir -p build && cd build && \


### PR DESCRIPTION
The test hip_hostpinned.view_allocation_large_rank fails with ROCm 6.0. We have the same issue with ROCm 6.2 in the nightly. This PR disable the test in Jenkins. The test passes on Frontier, it's only our CI where it fails.