### PR TITLE
Fix bugprone-throw-keyword-missing

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,7 +22,6 @@ Checks: >
   -bugprone-suspicious-memory-comparison,
   -bugprone-suspicious-string-compare,
   -bugprone-switch-missing-default-case,
-  -bugprone-throw-keyword-missing,
   -bugprone-unchecked-optional-access,
   -bugprone-undefined-memory-manipulation,
   -bugprone-unhandled-exception-at-new,

--- a/core/unit_test/UnitTest_ScopeGuard.cpp
+++ b/core/unit_test/UnitTest_ScopeGuard.cpp
@@ -145,11 +145,11 @@ TEST_F(scope_guard_DeathTest, destroy_after_finalize) {
  */
 
 // Test scope guard is not copyable.
-static_assert(!std::is_copy_assignable<Kokkos::ScopeGuard>());
-static_assert(!std::is_copy_constructible<Kokkos::ScopeGuard>());
+static_assert(!std::is_copy_assignable_v<Kokkos::ScopeGuard>);
+static_assert(!std::is_copy_constructible_v<Kokkos::ScopeGuard>);
 
 // Test scope guard is not movable.
-static_assert(!std::is_move_assignable<Kokkos::ScopeGuard>());
-static_assert(!std::is_move_constructible<Kokkos::ScopeGuard>());
+static_assert(!std::is_move_assignable_v<Kokkos::ScopeGuard>);
+static_assert(!std::is_move_constructible_v<Kokkos::ScopeGuard>);
 
 }  // namespace


### PR DESCRIPTION
Following #7572, try to fix unexpected bugprone-throw-keyword-missing in HPX build.