### PR TITLE
Use cmake-format on the 'cmake.in' files

### DIFF
--- a/cmake/KokkosConfig.cmake.in
+++ b/cmake/KokkosConfig.cmake.in
@@ -2,65 +2,71 @@
 # loaded by include() and find_package() commands except when invoked with
 # the NO_POLICY_SCOPE option
 # CMP0057 + NEW -> IN_LIST operator in IF(...)
-CMAKE_POLICY(SET CMP0057 NEW)
+cmake_policy(SET CMP0057 NEW)
 
 # Compute paths
 @PACKAGE_INIT@
 
 #Find dependencies
-INCLUDE(CMakeFindDependencyMacro)
+include(CMakeFindDependencyMacro)
 
 #This needs to go above the KokkosTargets in case
 #the Kokkos targets depend in some way on the TPL imports
 @KOKKOS_TPL_EXPORTS@
 
-GET_FILENAME_COMPONENT(Kokkos_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-INCLUDE("${Kokkos_CMAKE_DIR}/KokkosTargets.cmake")
-INCLUDE("${Kokkos_CMAKE_DIR}/KokkosConfigCommon.cmake")
-UNSET(Kokkos_CMAKE_DIR)
+get_filename_component(Kokkos_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+include("${Kokkos_CMAKE_DIR}/KokkosTargets.cmake")
+include("${Kokkos_CMAKE_DIR}/KokkosConfigCommon.cmake")
+unset(Kokkos_CMAKE_DIR)
 
 # check for conflicts
-IF("launch_compiler" IN_LIST Kokkos_FIND_COMPONENTS AND
-    "separable_compilation" IN_LIST Kokkos_FIND_COMPONENTS)
-    MESSAGE(STATUS "'launch_compiler' implies global redirection of targets depending on Kokkos to appropriate compiler.")
-    MESSAGE(STATUS "'separable_compilation' implies explicitly defining where redirection occurs via 'kokkos_compilation(PROJECT|TARGET|SOURCE|DIRECTORY ...)'")
-    MESSAGE(FATAL_ERROR "Conflicting COMPONENTS: 'launch_compiler' and 'separable_compilation'")
-ENDIF()
+if("launch_compiler" IN_LIST Kokkos_FIND_COMPONENTS AND "separable_compilation" IN_LIST Kokkos_FIND_COMPONENTS)
+  message(STATUS "'launch_compiler' implies global redirection of targets depending on Kokkos to appropriate compiler.")
+  message(
+    STATUS
+      "'separable_compilation' implies explicitly defining where redirection occurs via 'kokkos_compilation(PROJECT|TARGET|SOURCE|DIRECTORY ...)'"
+  )
+  message(FATAL_ERROR "Conflicting COMPONENTS: 'launch_compiler' and 'separable_compilation'")
+endif()
 
-IF("launch_compiler" IN_LIST Kokkos_FIND_COMPONENTS)
-    #
-    # if find_package(Kokkos COMPONENTS launch_compiler) then rely on the
-    # RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK to always redirect to the
-    # appropriate compiler for Kokkos
-    #
+if("launch_compiler" IN_LIST Kokkos_FIND_COMPONENTS)
+  #
+  # if find_package(Kokkos COMPONENTS launch_compiler) then rely on the
+  # RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK to always redirect to the
+  # appropriate compiler for Kokkos
+  #
 
-    MESSAGE(STATUS "kokkos_launch_compiler is enabled globally. C++ compiler commands with -DKOKKOS_DEPENDENCE will be redirected to the appropriate compiler for Kokkos")
-    kokkos_compilation(
-        GLOBAL
-        CHECK_CUDA_COMPILES)
+  message(
+    STATUS
+      "kokkos_launch_compiler is enabled globally. C++ compiler commands with -DKOKKOS_DEPENDENCE will be redirected to the appropriate compiler for Kokkos"
+  )
+  kokkos_compilation(GLOBAL CHECK_CUDA_COMPILES)
 
-ELSEIF(@Kokkos_ENABLE_CUDA@
-    AND NOT @KOKKOS_COMPILE_LANGUAGE@ STREQUAL CUDA
-    AND NOT "separable_compilation" IN_LIST Kokkos_FIND_COMPONENTS)
-    #
-    # if CUDA was enabled, the compilation language was not set to CUDA, and separable compilation was not
-    # specified, then set the RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK globally and
-    # kokkos_launch_compiler will re-direct to the compiler used to compile CUDA code during installation.
-    # kokkos_launch_compiler will re-direct if ${CMAKE_CXX_COMPILER} and -DKOKKOS_DEPENDENCE is present,
-    # otherwise, the original command will be executed
-    #
+elseif(@Kokkos_ENABLE_CUDA@ AND NOT @KOKKOS_COMPILE_LANGUAGE@ STREQUAL CUDA AND NOT "separable_compilation" IN_LIST
+                                                                                Kokkos_FIND_COMPONENTS
+)
+  #
+  # if CUDA was enabled, the compilation language was not set to CUDA, and separable compilation was not
+  # specified, then set the RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK globally and
+  # kokkos_launch_compiler will re-direct to the compiler used to compile CUDA code during installation.
+  # kokkos_launch_compiler will re-direct if ${CMAKE_CXX_COMPILER} and -DKOKKOS_DEPENDENCE is present,
+  # otherwise, the original command will be executed
+  #
 
-    # run test to see if CMAKE_CXX_COMPILER=nvcc_wrapper
-    kokkos_compiler_is_nvcc(IS_NVCC ${CMAKE_CXX_COMPILER})
+  # run test to see if CMAKE_CXX_COMPILER=nvcc_wrapper
+  kokkos_compiler_is_nvcc(IS_NVCC ${CMAKE_CXX_COMPILER})
 
-    # if not nvcc_wrapper and Kokkos_LAUNCH_COMPILER was not set to OFF
-    IF(NOT IS_NVCC AND (NOT DEFINED Kokkos_LAUNCH_COMPILER OR Kokkos_LAUNCH_COMPILER))
-        MESSAGE(STATUS "kokkos_launch_compiler is enabled globally. C++ compiler commands with -DKOKKOS_DEPENDENCE will be redirected to the appropriate compiler for Kokkos")
-        kokkos_compilation(GLOBAL)
-    ENDIF()
+  # if not nvcc_wrapper and Kokkos_LAUNCH_COMPILER was not set to OFF
+  if(NOT IS_NVCC AND (NOT DEFINED Kokkos_LAUNCH_COMPILER OR Kokkos_LAUNCH_COMPILER))
+    message(
+      STATUS
+        "kokkos_launch_compiler is enabled globally. C++ compiler commands with -DKOKKOS_DEPENDENCE will be redirected to the appropriate compiler for Kokkos"
+    )
+    kokkos_compilation(GLOBAL)
+  endif()
 
-    # be mindful of the environment, pollution is bad
-    UNSET(IS_NVCC)
-ENDIF()
+  # be mindful of the environment, pollution is bad
+  unset(IS_NVCC)
+endif()
 
 set(Kokkos_COMPILE_LANGUAGE @KOKKOS_COMPILE_LANGUAGE@)

--- a/cmake/KokkosConfigCommon.cmake.in
+++ b/cmake/KokkosConfigCommon.cmake.in
@@ -1,65 +1,67 @@
-SET(Kokkos_DEVICES @KOKKOS_ENABLED_DEVICES@)
-SET(Kokkos_OPTIONS @KOKKOS_ENABLED_OPTIONS@)
-SET(Kokkos_TPLS @KOKKOS_ENABLED_TPLS@)
-SET(Kokkos_ARCH @KOKKOS_ENABLED_ARCH_LIST@)
-SET(Kokkos_CXX_COMPILER "@CMAKE_CXX_COMPILER@")
-SET(Kokkos_CXX_COMPILER_ID "@KOKKOS_CXX_COMPILER_ID@")
-SET(Kokkos_CXX_COMPILER_VERSION "@KOKKOS_CXX_COMPILER_VERSION@")
-SET(Kokkos_CXX_STANDARD @KOKKOS_CXX_STANDARD@)
+set(Kokkos_DEVICES @KOKKOS_ENABLED_DEVICES@)
+set(Kokkos_OPTIONS @KOKKOS_ENABLED_OPTIONS@)
+set(Kokkos_TPLS @KOKKOS_ENABLED_TPLS@)
+set(Kokkos_ARCH @KOKKOS_ENABLED_ARCH_LIST@)
+set(Kokkos_CXX_COMPILER "@CMAKE_CXX_COMPILER@")
+set(Kokkos_CXX_COMPILER_ID "@KOKKOS_CXX_COMPILER_ID@")
+set(Kokkos_CXX_COMPILER_VERSION "@KOKKOS_CXX_COMPILER_VERSION@")
+set(Kokkos_CXX_STANDARD @KOKKOS_CXX_STANDARD@)
 
 # Required to be a TriBITS-compliant external package
-IF(NOT TARGET Kokkos::all_libs)
+if(NOT TARGET Kokkos::all_libs)
   # CMake Error at <prefix>/lib/cmake/Kokkos/KokkosConfigCommon.cmake:10 (ADD_LIBRARY):
   #   ADD_LIBRARY cannot create ALIAS target "Kokkos::all_libs" because target
   #   "Kokkos::kokkos" is imported but not globally visible.
-  IF(CMAKE_VERSION VERSION_LESS "3.18")
-    SET_TARGET_PROPERTIES(Kokkos::kokkos PROPERTIES IMPORTED_GLOBAL ON)
-  ENDIF()
-  ADD_LIBRARY(Kokkos::all_libs ALIAS Kokkos::kokkos)
-ENDIF()
+  if(CMAKE_VERSION VERSION_LESS "3.18")
+    set_target_properties(Kokkos::kokkos PROPERTIES IMPORTED_GLOBAL ON)
+  endif()
+  add_library(Kokkos::all_libs ALIAS Kokkos::kokkos)
+endif()
 
 # Export Kokkos_ENABLE_<BACKEND> for each backend that was enabled.
 # NOTE: "Devices" is a little bit of a misnomer here.  These are really
 # backends, e.g. Kokkos_ENABLE_OPENMP, Kokkos_ENABLE_CUDA, Kokkos_ENABLE_HIP,
 # or Kokkos_ENABLE_SYCL.
-FOREACH(DEV ${Kokkos_DEVICES})
-  SET(Kokkos_ENABLE_${DEV} ON)
-ENDFOREACH()
+foreach(DEV ${Kokkos_DEVICES})
+  set(Kokkos_ENABLE_${DEV} ON)
+endforeach()
 # Export relevant Kokkos_ENABLE<OPTION> variables, e.g.
 # Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE, Kokkos_ENABLE_DEBUG, etc.
-FOREACH(OPT ${Kokkos_OPTIONS})
-  SET(Kokkos_ENABLE_${OPT} ON)
-ENDFOREACH()
+foreach(OPT ${Kokkos_OPTIONS})
+  set(Kokkos_ENABLE_${OPT} ON)
+endforeach()
 
-IF(Kokkos_ENABLE_CUDA)
-  SET(Kokkos_CUDA_ARCHITECTURES @KOKKOS_CUDA_ARCHITECTURES@)
-ENDIF()
+if(Kokkos_ENABLE_CUDA)
+  set(Kokkos_CUDA_ARCHITECTURES @KOKKOS_CUDA_ARCHITECTURES@)
+endif()
 
-IF(Kokkos_ENABLE_HIP)
-  SET(Kokkos_HIP_ARCHITECTURES @KOKKOS_HIP_ARCHITECTURES@)
-ENDIF()
+if(Kokkos_ENABLE_HIP)
+  set(Kokkos_HIP_ARCHITECTURES @KOKKOS_HIP_ARCHITECTURES@)
+endif()
 
-IF(NOT Kokkos_FIND_QUIETLY)
-  MESSAGE(STATUS "Enabled Kokkos devices: ${Kokkos_DEVICES}")
-ENDIF()
+if(NOT Kokkos_FIND_QUIETLY)
+  message(STATUS "Enabled Kokkos devices: ${Kokkos_DEVICES}")
+endif()
 
-IF (Kokkos_ENABLE_CUDA)
+if(Kokkos_ENABLE_CUDA)
   # If we are building CUDA, we have tricked CMake because we declare a CXX project
   # If the default C++ standard for a given compiler matches the requested
   # standard, then CMake just omits the -std flag in later versions of CMake
   # This breaks CUDA compilation (CUDA compiler can have a different default
   # -std then the underlying host compiler by itself). Setting this variable
   # forces CMake to always add the -std flag even if it thinks it doesn't need it
-  SET(CMAKE_CXX_STANDARD_DEFAULT 98 CACHE INTERNAL "" FORCE)
-ENDIF()
+  set(CMAKE_CXX_STANDARD_DEFAULT 98 CACHE INTERNAL "" FORCE)
+endif()
 
-SET(KOKKOS_USE_CXX_EXTENSIONS @KOKKOS_USE_CXX_EXTENSIONS@)
-IF (NOT DEFINED CMAKE_CXX_EXTENSIONS OR CMAKE_CXX_EXTENSIONS)
-  IF (NOT KOKKOS_USE_CXX_EXTENSIONS)
-    MESSAGE(WARNING "The installed Kokkos configuration does not support CXX extensions. Forcing -DCMAKE_CXX_EXTENSIONS=Off")
-    SET(CMAKE_CXX_EXTENSIONS OFF CACHE BOOL "" FORCE)
-  ENDIF()
-ENDIF()
+set(KOKKOS_USE_CXX_EXTENSIONS @KOKKOS_USE_CXX_EXTENSIONS@)
+if(NOT DEFINED CMAKE_CXX_EXTENSIONS OR CMAKE_CXX_EXTENSIONS)
+  if(NOT KOKKOS_USE_CXX_EXTENSIONS)
+    message(
+      WARNING "The installed Kokkos configuration does not support CXX extensions. Forcing -DCMAKE_CXX_EXTENSIONS=Off"
+    )
+    set(CMAKE_CXX_EXTENSIONS OFF CACHE BOOL "" FORCE)
+  endif()
+endif()
 
 include(FindPackageHandleStandardArgs)
 
@@ -93,8 +95,8 @@ function(kokkos_check)
     # the Kokkos install.
     foreach(requested ${KOKKOS_CHECK_${arg}})
       foreach(provided ${Kokkos_${arg}})
-        STRING(TOUPPER ${requested} REQUESTED_UC)
-        STRING(TOUPPER ${provided}  PROVIDED_UC)
+        string(TOUPPER ${requested} REQUESTED_UC)
+        string(TOUPPER ${provided} PROVIDED_UC)
         if(PROVIDED_UC STREQUAL REQUESTED_UC)
           string(REPLACE ";" " " ${requested} "${KOKKOS_CHECK_${arg}}")
         endif()
@@ -104,11 +106,10 @@ function(kokkos_check)
     # use it to check that there are variables defined for all required
     # arguments. Success or failure messages will be displayed but we are
     # responsible for signaling failure and skip the build system generation.
-    if (KOKKOS_CHECK_RETURN_VALUE)
+    if(KOKKOS_CHECK_RETURN_VALUE)
       set(Kokkos_${arg}_FIND_QUIETLY ON)
     endif()
-    find_package_handle_standard_args("Kokkos_${arg}" DEFAULT_MSG
-            ${KOKKOS_CHECK_${arg}})
+    find_package_handle_standard_args("Kokkos_${arg}" DEFAULT_MSG ${KOKKOS_CHECK_${arg}})
     if(NOT Kokkos_${arg}_FOUND)
       set(KOKKOS_CHECK_SUCCESS FALSE)
     endif()
@@ -122,32 +123,35 @@ endfunction()
 
 # A test to check whether a downstream project set the C++ compiler to NVCC or not
 # this is called only when Kokkos was installed with Kokkos_ENABLE_CUDA=ON
-FUNCTION(kokkos_compiler_is_nvcc VAR COMPILER)
-    # Check if the compiler is nvcc (which really means nvcc_wrapper).
-    EXECUTE_PROCESS(COMMAND ${COMPILER} ${ARGN} --version
-                    OUTPUT_VARIABLE INTERNAL_COMPILER_VERSION
-                    OUTPUT_STRIP_TRAILING_WHITESPACE
-                    RESULT_VARIABLE RET)
-    # something went wrong
-    IF(RET GREATER 0)
-        SET(${VAR} false PARENT_SCOPE)
-    ELSE()
-        STRING(REPLACE "\n" " - " INTERNAL_COMPILER_VERSION_ONE_LINE ${INTERNAL_COMPILER_VERSION} )
-        STRING(FIND ${INTERNAL_COMPILER_VERSION_ONE_LINE} "nvcc" INTERNAL_COMPILER_VERSION_CONTAINS_NVCC)
-        STRING(REGEX REPLACE "^ +" "" INTERNAL_HAVE_COMPILER_NVCC "${INTERNAL_HAVE_COMPILER_NVCC}")
-        IF(${INTERNAL_COMPILER_VERSION_CONTAINS_NVCC} GREATER -1)
-            SET(${VAR} true PARENT_SCOPE)
-        ELSE()
-            SET(${VAR} false PARENT_SCOPE)
-        ENDIF()
-    ENDIF()
-ENDFUNCTION()
+function(kokkos_compiler_is_nvcc VAR COMPILER)
+  # Check if the compiler is nvcc (which really means nvcc_wrapper).
+  execute_process(
+    COMMAND ${COMPILER} ${ARGN} --version
+    OUTPUT_VARIABLE INTERNAL_COMPILER_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE RET
+  )
+  # something went wrong
+  if(RET GREATER 0)
+    set(${VAR} false PARENT_SCOPE)
+  else()
+    string(REPLACE "\n" " - " INTERNAL_COMPILER_VERSION_ONE_LINE ${INTERNAL_COMPILER_VERSION})
+    string(FIND ${INTERNAL_COMPILER_VERSION_ONE_LINE} "nvcc" INTERNAL_COMPILER_VERSION_CONTAINS_NVCC)
+    string(REGEX REPLACE "^ +" "" INTERNAL_HAVE_COMPILER_NVCC "${INTERNAL_HAVE_COMPILER_NVCC}")
+    if(${INTERNAL_COMPILER_VERSION_CONTAINS_NVCC} GREATER -1)
+      set(${VAR} true PARENT_SCOPE)
+    else()
+      set(${VAR} false PARENT_SCOPE)
+    endif()
+  endif()
+endfunction()
 
 # this function checks whether the current CXX compiler supports building CUDA
-FUNCTION(kokkos_cxx_compiler_cuda_test _VAR _COMPILER)
+function(kokkos_cxx_compiler_cuda_test _VAR _COMPILER)
 
-    FILE(WRITE ${PROJECT_BINARY_DIR}/compile_tests/compiles_cuda.cu
-"
+  file(
+    WRITE ${PROJECT_BINARY_DIR}/compile_tests/compiles_cuda.cu
+    "
 #include <cuda.h>
 #include <cstdlib>
 
@@ -171,34 +175,39 @@ int main()
     cudaDeviceSynchronize();
     return EXIT_SUCCESS;
 }
-")
+"
+  )
 
+  # save the command for debugging
+  set(_COMMANDS "${_COMPILER} ${ARGN} -c ${PROJECT_BINARY_DIR}/compile_tests/compiles_cuda.cu")
+
+  # use execute_process instead of try compile because we want to set custom compiler
+  execute_process(
+    COMMAND ${_COMPILER} ${ARGN} -c ${PROJECT_BINARY_DIR}/compile_tests/compiles_cuda.cu
+    RESULT_VARIABLE _RET
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/compile_tests
+    TIMEOUT 15
+    OUTPUT_QUIET ERROR_QUIET
+  )
+
+  if(NOT _RET EQUAL 0)
     # save the command for debugging
-    SET(_COMMANDS "${_COMPILER} ${ARGN} -c ${PROJECT_BINARY_DIR}/compile_tests/compiles_cuda.cu")
+    set(_COMMANDS
+        "${_COMMAND}\n${_COMPILER} --cuda-gpu-arch=sm_35 ${ARGN} -c ${PROJECT_BINARY_DIR}/compile_tests/compiles_cuda.cu"
+    )
+    # try the compile test again with clang arguments
+    execute_process(
+      COMMAND ${_COMPILER} --cuda-gpu-arch=sm_35 -c ${PROJECT_BINARY_DIR}/compile_tests/compiles_cuda.cu
+      RESULT_VARIABLE _RET
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/compile_tests
+      TIMEOUT 15
+      OUTPUT_QUIET ERROR_QUIET
+    )
+  endif()
 
-    # use execute_process instead of try compile because we want to set custom compiler
-    EXECUTE_PROCESS(COMMAND ${_COMPILER} ${ARGN} -c ${PROJECT_BINARY_DIR}/compile_tests/compiles_cuda.cu
-        RESULT_VARIABLE     _RET
-        WORKING_DIRECTORY   ${PROJECT_BINARY_DIR}/compile_tests
-        TIMEOUT             15
-        OUTPUT_QUIET
-        ERROR_QUIET)
-
-    IF(NOT _RET EQUAL 0)
-        # save the command for debugging
-        SET(_COMMANDS "${_COMMAND}\n${_COMPILER} --cuda-gpu-arch=sm_35 ${ARGN} -c ${PROJECT_BINARY_DIR}/compile_tests/compiles_cuda.cu")
-        # try the compile test again with clang arguments
-        EXECUTE_PROCESS(COMMAND ${_COMPILER} --cuda-gpu-arch=sm_35 -c ${PROJECT_BINARY_DIR}/compile_tests/compiles_cuda.cu
-            RESULT_VARIABLE     _RET
-            WORKING_DIRECTORY   ${PROJECT_BINARY_DIR}/compile_tests
-            TIMEOUT             15
-            OUTPUT_QUIET
-            ERROR_QUIET)
-    ENDIF()
-
-    SET(${_VAR}_COMMANDS "${_COMMANDS}" PARENT_SCOPE)
-    SET(${_VAR} ${_RET} PARENT_SCOPE)
-ENDFUNCTION()
+  set(${_VAR}_COMMANDS "${_COMMANDS}" PARENT_SCOPE)
+  set(${_VAR} ${_RET} PARENT_SCOPE)
+endfunction()
 
 # this function is provided to easily select which files use the same compiler as Kokkos
 # when it was installed (or nvcc_wrapper):
@@ -215,94 +224,107 @@ ENDFUNCTION()
 #
 # Use CHECK_CUDA_COMPILES to run a check when CUDA is enabled
 #
-FUNCTION(kokkos_compilation)
-    CMAKE_PARSE_ARGUMENTS(COMP
-        "GLOBAL;PROJECT;CHECK_CUDA_COMPILES"
-        "COMPILER"
-        "DIRECTORY;TARGET;SOURCE;COMMAND_PREFIX"
-        ${ARGN})
+function(kokkos_compilation)
+  cmake_parse_arguments(
+    COMP "GLOBAL;PROJECT;CHECK_CUDA_COMPILES" "COMPILER" "DIRECTORY;TARGET;SOURCE;COMMAND_PREFIX" ${ARGN}
+  )
 
-    # if built w/o CUDA support, we want to basically make this a no-op
-    SET(_Kokkos_ENABLE_CUDA @Kokkos_ENABLE_CUDA@)
+  # if built w/o CUDA support, we want to basically make this a no-op
+  set(_Kokkos_ENABLE_CUDA @Kokkos_ENABLE_CUDA@)
 
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+    set(MAYBE_CURRENT_INSTALLATION_ROOT "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../../..")
+  endif()
 
-    IF(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
-      SET(MAYBE_CURRENT_INSTALLATION_ROOT "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../../..")
-    ENDIF()
+  # search relative first and then absolute
+  set(_HINTS "${MAYBE_CURRENT_INSTALLATION_ROOT}" "@CMAKE_INSTALL_PREFIX@")
 
-    # search relative first and then absolute
-    SET(_HINTS "${MAYBE_CURRENT_INSTALLATION_ROOT}" "@CMAKE_INSTALL_PREFIX@")
+  # find kokkos_launch_compiler
+  find_program(
+    Kokkos_COMPILE_LAUNCHER
+    NAMES kokkos_launch_compiler
+    HINTS ${_HINTS}
+    PATHS ${_HINTS}
+    PATH_SUFFIXES bin
+  )
 
-    # find kokkos_launch_compiler
-    FIND_PROGRAM(Kokkos_COMPILE_LAUNCHER
-        NAMES           kokkos_launch_compiler
-        HINTS           ${_HINTS}
-        PATHS           ${_HINTS}
-        PATH_SUFFIXES   bin)
+  if(NOT Kokkos_COMPILE_LAUNCHER)
+    message(
+      FATAL_ERROR
+        "Kokkos could not find 'kokkos_launch_compiler'. Please set '-DKokkos_COMPILE_LAUNCHER=/path/to/launcher'"
+    )
+  endif()
 
-    IF(NOT Kokkos_COMPILE_LAUNCHER)
-        MESSAGE(FATAL_ERROR "Kokkos could not find 'kokkos_launch_compiler'. Please set '-DKokkos_COMPILE_LAUNCHER=/path/to/launcher'")
-    ENDIF()
+  # if COMPILER was not specified, assume Kokkos_CXX_COMPILER
+  if(NOT COMP_COMPILER)
+    set(COMP_COMPILER ${Kokkos_CXX_COMPILER})
+    if(_Kokkos_ENABLE_CUDA AND Kokkos_CXX_COMPILER_ID STREQUAL NVIDIA)
+      # find nvcc_wrapper
+      find_program(
+        Kokkos_NVCC_WRAPPER
+        NAMES nvcc_wrapper
+        HINTS ${_HINTS}
+        PATHS ${_HINTS}
+        PATH_SUFFIXES bin
+      )
+      # fatal if we can't nvcc_wrapper
+      if(NOT Kokkos_NVCC_WRAPPER)
+        message(
+          FATAL_ERROR "Kokkos could not find nvcc_wrapper. Please set '-DKokkos_NVCC_WRAPPER=/path/to/nvcc_wrapper'"
+        )
+      endif()
+      set(COMP_COMPILER ${Kokkos_NVCC_WRAPPER})
+    endif()
+  endif()
 
-    # if COMPILER was not specified, assume Kokkos_CXX_COMPILER
-    IF(NOT COMP_COMPILER)
-        SET(COMP_COMPILER ${Kokkos_CXX_COMPILER})
-        IF(_Kokkos_ENABLE_CUDA AND Kokkos_CXX_COMPILER_ID STREQUAL NVIDIA)
-            # find nvcc_wrapper
-            FIND_PROGRAM(Kokkos_NVCC_WRAPPER
-                NAMES           nvcc_wrapper
-                HINTS           ${_HINTS}
-                PATHS           ${_HINTS}
-                PATH_SUFFIXES   bin)
-            # fatal if we can't nvcc_wrapper
-            IF(NOT Kokkos_NVCC_WRAPPER)
-                MESSAGE(FATAL_ERROR "Kokkos could not find nvcc_wrapper. Please set '-DKokkos_NVCC_WRAPPER=/path/to/nvcc_wrapper'")
-            ENDIF()
-            SET(COMP_COMPILER ${Kokkos_NVCC_WRAPPER})
-        ENDIF()
-    ENDIF()
+  # check that the original compiler still exists!
+  if(NOT EXISTS ${COMP_COMPILER})
+    message(FATAL_ERROR "Kokkos could not find original compiler: '${COMP_COMPILER}'")
+  endif()
 
-    # check that the original compiler still exists!
-    IF(NOT EXISTS ${COMP_COMPILER})
-        MESSAGE(FATAL_ERROR "Kokkos could not find original compiler: '${COMP_COMPILER}'")
-    ENDIF()
+  # try to ensure that compiling cuda code works!
+  if(_Kokkos_ENABLE_CUDA AND COMP_CHECK_CUDA_COMPILES)
 
-    # try to ensure that compiling cuda code works!
-    IF(_Kokkos_ENABLE_CUDA AND COMP_CHECK_CUDA_COMPILES)
+    # this may fail if kokkos_compiler launcher was used during install
+    kokkos_cxx_compiler_cuda_test(_COMPILES_CUDA ${Kokkos_COMPILE_LAUNCHER} ${COMP_COMPILER} ${CMAKE_CXX_COMPILER})
 
-        # this may fail if kokkos_compiler launcher was used during install
-        kokkos_cxx_compiler_cuda_test(_COMPILES_CUDA
-            ${Kokkos_COMPILE_LAUNCHER} ${COMP_COMPILER} ${CMAKE_CXX_COMPILER})
+    # if above failed, throw an error
+    if(NOT _COMPILES_CUDA)
+      message(FATAL_ERROR "kokkos_cxx_compiler_cuda_test failed! Test commands:\n${_COMPILES_CUDA_COMMANDS}")
+    endif()
+  endif()
 
-        # if above failed, throw an error
-        IF(NOT _COMPILES_CUDA)
-            MESSAGE(FATAL_ERROR "kokkos_cxx_compiler_cuda_test failed! Test commands:\n${_COMPILES_CUDA_COMMANDS}")
-        ENDIF()
-    ENDIF()
+  if(COMP_COMMAND_PREFIX)
+    set(_PREFIX "${COMP_COMMAND_PREFIX}")
+    string(REPLACE ";" " " _PREFIX "${COMP_COMMAND_PREFIX}")
+    set(Kokkos_COMPILER_LAUNCHER "${_PREFIX} ${Kokkos_COMPILE_LAUNCHER}")
+  endif()
 
-    IF(COMP_COMMAND_PREFIX)
-        SET(_PREFIX "${COMP_COMMAND_PREFIX}")
-        STRING(REPLACE ";" " " _PREFIX "${COMP_COMMAND_PREFIX}")
-        SET(Kokkos_COMPILER_LAUNCHER "${_PREFIX} ${Kokkos_COMPILE_LAUNCHER}")
-    ENDIF()
-
-    IF(COMP_GLOBAL)
-        # if global, don't bother setting others
-        SET_PROPERTY(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${Kokkos_COMPILE_LAUNCHER} ${COMP_COMPILER} ${CMAKE_CXX_COMPILER}")
-        SET_PROPERTY(GLOBAL PROPERTY RULE_LAUNCH_LINK "${Kokkos_COMPILE_LAUNCHER} ${COMP_COMPILER} ${CMAKE_CXX_COMPILER}")
-    ELSE()
-        FOREACH(_TYPE PROJECT DIRECTORY TARGET SOURCE)
-            # make project/subproject scoping easy, e.g. KokkosCompilation(PROJECT) after project(...)
-            IF("${_TYPE}" STREQUAL "PROJECT" AND COMP_${_TYPE})
-                LIST(APPEND COMP_DIRECTORY ${PROJECT_SOURCE_DIR})
-                UNSET(COMP_${_TYPE})
-            ENDIF()
-            # set the properties if defined
-            IF(COMP_${_TYPE})
-                # MESSAGE(STATUS "Using ${COMP_COMPILER} :: ${_TYPE} :: ${COMP_${_TYPE}}")
-                SET_PROPERTY(${_TYPE} ${COMP_${_TYPE}} PROPERTY RULE_LAUNCH_COMPILE "${Kokkos_COMPILE_LAUNCHER} ${COMP_COMPILER} ${CMAKE_CXX_COMPILER}")
-                SET_PROPERTY(${_TYPE} ${COMP_${_TYPE}} PROPERTY RULE_LAUNCH_LINK "${Kokkos_COMPILE_LAUNCHER} ${COMP_COMPILER} ${CMAKE_CXX_COMPILER}")
-            ENDIF()
-        ENDFOREACH()
-    ENDIF()
-ENDFUNCTION()
+  if(COMP_GLOBAL)
+    # if global, don't bother setting others
+    set_property(
+      GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${Kokkos_COMPILE_LAUNCHER} ${COMP_COMPILER} ${CMAKE_CXX_COMPILER}"
+    )
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${Kokkos_COMPILE_LAUNCHER} ${COMP_COMPILER} ${CMAKE_CXX_COMPILER}")
+  else()
+    foreach(_TYPE PROJECT DIRECTORY TARGET SOURCE)
+      # make project/subproject scoping easy, e.g. KokkosCompilation(PROJECT) after project(...)
+      if("${_TYPE}" STREQUAL "PROJECT" AND COMP_${_TYPE})
+        list(APPEND COMP_DIRECTORY ${PROJECT_SOURCE_DIR})
+        unset(COMP_${_TYPE})
+      endif()
+      # set the properties if defined
+      if(COMP_${_TYPE})
+        # MESSAGE(STATUS "Using ${COMP_COMPILER} :: ${_TYPE} :: ${COMP_${_TYPE}}")
+        set_property(
+          ${_TYPE} ${COMP_${_TYPE}} PROPERTY RULE_LAUNCH_COMPILE
+                                             "${Kokkos_COMPILE_LAUNCHER} ${COMP_COMPILER} ${CMAKE_CXX_COMPILER}"
+        )
+        set_property(
+          ${_TYPE} ${COMP_${_TYPE}} PROPERTY RULE_LAUNCH_LINK
+                                             "${Kokkos_COMPILE_LAUNCHER} ${COMP_COMPILER} ${CMAKE_CXX_COMPILER}"
+        )
+      endif()
+    endforeach()
+  endif()
+endfunction()


### PR DESCRIPTION
Pure formatting change by running `cmake-format --config-files .cmake-format.py --in-place cmake/KokkosConfig.cmake.in cmake/KokkosConfigCommon.cmake.in`

If we want to check the format in our CI we would need to fork the action repository and add the 'cmake.in' files to the 'entrypoint.sh'. Or we suggest a pull request to the original author allowing to control this with command line options or environment variables.

I am not sure if we actually want to go this far for two files