### PR TITLE
core(graph): clarifying that an aggregate is not a kernel

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -103,9 +103,7 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
   auto get_driver_storage() const { return m_driver_storage; }
 };
 
-struct CudaGraphNodeAggregateKernel {
-  using graph_kernel = CudaGraphNodeAggregateKernel;
-};
+struct CudaGraphNodeAggregate {};
 
 template <class KernelType,
           class Tag =

--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -74,9 +74,9 @@ struct GraphImpl<Kokkos::Cuda> {
   using root_node_impl_t =
       GraphNodeImpl<Kokkos::Cuda, Kokkos::Experimental::TypeErasedTag,
                     Kokkos::Experimental::TypeErasedTag>;
-  using aggregate_kernel_impl_t = CudaGraphNodeAggregateKernel;
+  using aggregate_impl_t = CudaGraphNodeAggregate;
   using aggregate_node_impl_t =
-      GraphNodeImpl<Kokkos::Cuda, aggregate_kernel_impl_t,
+      GraphNodeImpl<Kokkos::Cuda, aggregate_impl_t,
                     Kokkos::Experimental::TypeErasedTag>;
 
   // Not movable or copyable; it spends its whole life as a shared_ptr in the
@@ -204,8 +204,7 @@ struct GraphImpl<Kokkos::Cuda> {
     // each predecessor ref, so all we need to do here is create the (trivial)
     // aggregate node.
     return std::make_shared<aggregate_node_impl_t>(
-        m_execution_space, _graph_node_kernel_ctor_tag{},
-        aggregate_kernel_impl_t{});
+        m_execution_space, _graph_node_kernel_ctor_tag{}, aggregate_impl_t{});
   }
 
   cudaGraph_t cuda_graph() { return m_graph; }

--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -93,9 +93,7 @@ class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
   std::string label;
 };
 
-struct HIPGraphNodeAggregateKernel {
-  using graph_kernel = HIPGraphNodeAggregateKernel;
-};
+struct HIPGraphNodeAggregate {};
 
 template <typename KernelType,
           typename Tag =

--- a/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
@@ -35,9 +35,9 @@ class GraphImpl<Kokkos::HIP> {
   using root_node_impl_t =
       GraphNodeImpl<Kokkos::HIP, Kokkos::Experimental::TypeErasedTag,
                     Kokkos::Experimental::TypeErasedTag>;
-  using aggregate_kernel_impl_t = HIPGraphNodeAggregateKernel;
+  using aggregate_impl_t = HIPGraphNodeAggregate;
   using aggregate_node_impl_t =
-      GraphNodeImpl<Kokkos::HIP, aggregate_kernel_impl_t,
+      GraphNodeImpl<Kokkos::HIP, aggregate_impl_t,
                     Kokkos::Experimental::TypeErasedTag>;
 
   // Not movable or copyable; it spends its whole life as a shared_ptr in the
@@ -190,9 +190,8 @@ inline auto GraphImpl<Kokkos::HIP>::create_aggregate_ptr(PredecessorRefs&&...) {
   // in the generic layer, which calls through to add_predecessor for
   // each predecessor ref, so all we need to do here is create the (trivial)
   // aggregate node.
-  return std::make_shared<aggregate_node_impl_t>(m_execution_space,
-                                                 _graph_node_kernel_ctor_tag{},
-                                                 aggregate_kernel_impl_t{});
+  return std::make_shared<aggregate_node_impl_t>(
+      m_execution_space, _graph_node_kernel_ctor_tag{}, aggregate_impl_t{});
 }
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/SYCL/Kokkos_SYCL_GraphNodeKernel.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_GraphNodeKernel.hpp
@@ -87,9 +87,7 @@ class GraphNodeKernelImpl<Kokkos::SYCL, PolicyType, Functor, PatternTag,
       m_graph_node_ptr = nullptr;
 };
 
-struct SYCLGraphNodeAggregateKernel {
-  using graph_kernel = SYCLGraphNodeAggregateKernel;
-};
+struct SYCLGraphNodeAggregate {};
 
 template <typename KernelType,
           typename Tag =

--- a/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
@@ -37,9 +37,9 @@ class GraphImpl<Kokkos::SYCL> {
   using root_node_impl_t =
       GraphNodeImpl<Kokkos::SYCL, Kokkos::Experimental::TypeErasedTag,
                     Kokkos::Experimental::TypeErasedTag>;
-  using aggregate_kernel_impl_t = SYCLGraphNodeAggregateKernel;
+  using aggregate_impl_t = SYCLGraphNodeAggregate;
   using aggregate_node_impl_t =
-      GraphNodeImpl<Kokkos::SYCL, aggregate_kernel_impl_t,
+      GraphNodeImpl<Kokkos::SYCL, aggregate_impl_t,
                     Kokkos::Experimental::TypeErasedTag>;
 
   // Not movable or copyable; it spends its whole life as a shared_ptr in the
@@ -170,9 +170,8 @@ inline auto GraphImpl<Kokkos::SYCL>::create_aggregate_ptr(
   // in the generic layer, which calls through to add_predecessor for
   // each predecessor ref, so all we need to do here is create the (trivial)
   // aggregate node.
-  return std::make_shared<aggregate_node_impl_t>(m_execution_space,
-                                                 _graph_node_kernel_ctor_tag{},
-                                                 aggregate_kernel_impl_t{});
+  return std::make_shared<aggregate_node_impl_t>(
+      m_execution_space, _graph_node_kernel_ctor_tag{}, aggregate_impl_t{});
 }
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_Default_GraphNodeKernel.hpp
+++ b/core/src/impl/Kokkos_Default_GraphNodeKernel.hpp
@@ -89,9 +89,8 @@ class GraphNodeKernelImpl
 //==============================================================================
 
 template <class ExecutionSpace>
-struct GraphNodeAggregateKernelDefaultImpl
+struct GraphNodeAggregateDefaultImpl
     : GraphNodeKernelDefaultImpl<ExecutionSpace> {
-  using graph_kernel = GraphNodeAggregateKernelDefaultImpl;
   void execute_kernel() override final {}
 };
 

--- a/core/src/impl/Kokkos_Default_GraphNode_Impl.hpp
+++ b/core/src/impl/Kokkos_Default_GraphNode_Impl.hpp
@@ -38,8 +38,8 @@ struct GraphNodeBackendSpecificDetails {
   using execution_space_instance_storage_t =
       ExecutionSpaceInstanceStorage<ExecutionSpace>;
   using default_kernel_impl_t = GraphNodeKernelDefaultImpl<ExecutionSpace>;
-  using default_aggregate_kernel_impl_t =
-      GraphNodeAggregateKernelDefaultImpl<ExecutionSpace>;
+  using default_aggregate_impl_t =
+      GraphNodeAggregateDefaultImpl<ExecutionSpace>;
 
   std::vector<std::shared_ptr<GraphNodeBackendSpecificDetails<ExecutionSpace>>>
       m_predecessors = {};
@@ -86,7 +86,7 @@ struct GraphNodeBackendSpecificDetails {
     m_kernel_ptr = &arg_kernel;
   }
 
-  void set_kernel(default_aggregate_kernel_impl_t& arg_kernel) {
+  void set_kernel(default_aggregate_impl_t& arg_kernel) {
     KOKKOS_EXPECTS(m_kernel_ptr == nullptr)
     m_kernel_ptr   = &arg_kernel;
     m_is_aggregate = true;

--- a/core/src/impl/Kokkos_Default_Graph_Impl.hpp
+++ b/core/src/impl/Kokkos_Default_Graph_Impl.hpp
@@ -45,6 +45,8 @@ struct GraphImpl : private ExecutionSpaceInstanceStorage<ExecutionSpace> {
       GraphNodeImpl<ExecutionSpace, Kokkos::Experimental::TypeErasedTag,
                     Kokkos::Experimental::TypeErasedTag>;
 
+  using aggregate_impl_t = GraphNodeAggregateDefaultImpl<ExecutionSpace>;
+
  private:
   using execution_space_instance_storage_base_t =
       ExecutionSpaceInstanceStorage<ExecutionSpace>;
@@ -119,14 +121,12 @@ struct GraphImpl : private ExecutionSpaceInstanceStorage<ExecutionSpace> {
     // in the generic layer, which calls through to add_predecessor for
     // each predecessor ref, so all we need to do here is create the (trivial)
     // aggregate node.
-    using aggregate_kernel_impl_t =
-        GraphNodeAggregateKernelDefaultImpl<ExecutionSpace>;
     using aggregate_node_impl_t =
-        GraphNodeImpl<ExecutionSpace, aggregate_kernel_impl_t,
+        GraphNodeImpl<ExecutionSpace, aggregate_impl_t,
                       Kokkos::Experimental::TypeErasedTag>;
     return GraphAccess::make_node_shared_ptr<aggregate_node_impl_t>(
         this->execution_space_instance(), _graph_node_kernel_ctor_tag{},
-        aggregate_kernel_impl_t{});
+        aggregate_impl_t{});
   }
 
   auto create_root_node_ptr() {

--- a/core/src/impl/Kokkos_Default_Graph_fwd.hpp
+++ b/core/src/impl/Kokkos_Default_Graph_fwd.hpp
@@ -26,7 +26,7 @@ template <class ExecutionSpace>
 struct GraphNodeKernelDefaultImpl;
 
 template <class ExecutionSpace>
-struct GraphNodeAggregateKernelDefaultImpl;
+struct GraphNodeAggregateDefaultImpl;
 
 }  // end namespace Impl
 }  // end namespace Kokkos

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -739,4 +739,62 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), end_of_submit_control_flow) {
             value_A + 2 * value_B + value_C + value_D + value_E + value_F);
 }
 
+template <typename Exec>
+struct GraphNodeTypes {
+  // Type of a kernel node built using a Kokkos parallel construct.
+  using kernel_t =
+      Kokkos::Impl::GraphNodeKernelImpl<Exec, Kokkos::RangePolicy<Exec>,
+                                        CountTestFunctor<Exec>,
+                                        Kokkos::ParallelForTag>;
+
+  // Type of an aggregate node.
+  using aggregate_t = typename Kokkos::Impl::GraphImpl<Exec>::aggregate_impl_t;
+};
+
+constexpr bool test_is_graph_kernel() {
+  using types = GraphNodeTypes<TEST_EXECSPACE>;
+  static_assert(Kokkos::Impl::is_graph_kernel_v<types::kernel_t>);
+  static_assert(!Kokkos::Impl::is_graph_kernel_v<types::aggregate_t>);
+  return true;
+}
+static_assert(test_is_graph_kernel());
+
+// This test checks the node types before/after a 'when_all'.
+TEST(TEST_CATEGORY, when_all_type) {
+  using kernel_functor_t = CountTestFunctor<TEST_EXECSPACE>;
+  using graph_t          = Kokkos::Experimental::Graph<TEST_EXECSPACE>;
+  using graph_impl_t     = Kokkos::Impl::GraphImpl<TEST_EXECSPACE>;
+  using node_ref_root_t =
+      Kokkos::Experimental::GraphNodeRef<TEST_EXECSPACE,
+                                         Kokkos::Experimental::TypeErasedTag,
+                                         Kokkos::Experimental::TypeErasedTag>;
+  using node_kernel_impl_t = Kokkos::Impl::GraphNodeKernelImpl<
+      TEST_EXECSPACE,
+      Kokkos::RangePolicy<TEST_EXECSPACE, Kokkos::Impl::IsGraphKernelTag>,
+      kernel_functor_t, Kokkos::ParallelForTag>;
+  using node_ref_first_layer_t =
+      Kokkos::Experimental::GraphNodeRef<TEST_EXECSPACE, node_kernel_impl_t,
+                                         node_ref_root_t>;
+  using node_ref_agg_t = Kokkos::Experimental::GraphNodeRef<
+      TEST_EXECSPACE, typename graph_impl_t::aggregate_impl_t,
+      Kokkos::Experimental::TypeErasedTag>;
+  using node_ref_tail_t =
+      Kokkos::Experimental::GraphNodeRef<TEST_EXECSPACE, node_kernel_impl_t,
+                                         node_ref_agg_t>;
+
+  auto graph  = Kokkos::Experimental::create_graph(TEST_EXECSPACE{});
+  auto root   = Kokkos::Impl::GraphAccess::create_root_ref(graph);
+  auto node_A = root.then_parallel_for(1, kernel_functor_t{});
+  auto node_B = root.then_parallel_for(1, kernel_functor_t{});
+  auto agg    = Kokkos::Experimental::when_all(node_A, node_B);
+  auto tail   = agg.then_parallel_for(1, kernel_functor_t{});
+
+  static_assert(std::is_same_v<decltype(graph), graph_t>);
+  static_assert(std::is_same_v<decltype(root), node_ref_root_t>);
+  static_assert(std::is_same_v<decltype(node_A), node_ref_first_layer_t>);
+  static_assert(std::is_same_v<decltype(node_B), node_ref_first_layer_t>);
+  static_assert(std::is_same_v<decltype(agg), node_ref_agg_t>);
+  static_assert(std::is_same_v<decltype(tail), node_ref_tail_t>);
+}
+
 }  // end namespace Test


### PR DESCRIPTION
## Summary

This PR makes it clear that an aggregate node is **never** a kernel node.

We now clearly differentiate between 2 types of nodes:
1. kernel (built from a `Kokkos` parallel construct)
2. aggregate (built from a `when_all`)

In #7552 we will introduce a 3rd type (`then`).

Discussion triggered by https://github.com/kokkos/kokkos/pull/7552#discussion_r1875592277.

## Details

- clear distinction between a kernel and an aggregate node type
- make `aggregate_impl_t` a public member of **all** `Kokkos::Impl::GraphImpl` (it was not the case for the default implementation before this PR)
- add a test for `is_graph_kernel_v`
- add a test for the node types when using `when_all`

## Related

- followup of #7537