### PR TITLE
Update jenkins CI from ROCm 5.2 to ROCm 5.3

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -296,12 +296,12 @@ pipeline {
                         }
                     }
                 }
-                stage('HIP-ROCm-5.2') {
+                stage('HIP-ROCm-5.3') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.hipcc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:5.2-complete@sha256:4030c8af0c06c286174758523dabe4b3850bf72d4a8c1ef275d3ec69aa475f65'
+                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:5.3.3-complete@sha256:bac114b9d09e61d88b45fbeb40a15a315c2a78a203223c9b4ed7263b05ff3977'
                             label 'rocm-docker '
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
                         }

--- a/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
@@ -101,6 +101,9 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 
   ASSERT_EQ(num_nodes, 2u);
 
+  // hipGraphDebugDotPrint was introduced in ROCm 5.5
+#if (HIP_VERSION_MAJOR > 5) || \
+    ((HIP_VERSION_MAJOR > 5) && (HIP_VERSION_MINOR >= 5))
   const auto dot = std::filesystem::temp_directory_path() / "hip_graph.dot";
 
   KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphDebugDotPrint(
@@ -121,6 +124,7 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
   ASSERT_TRUE(std::regex_search(buffer.str(), std::regex(expected)))
       << "Could not find expected signature regex " << std::quoted(expected)
       << " in " << dot;
+#endif
 #endif
 }
 


### PR DESCRIPTION
We cannot build Docker images based on ROCm 5.2 anymore because AMD removed an external repository need to build the image. We need to bump the version from 5.2 to 5.3. ROCm 5.3 is also the oldest version on Frontier.