### PR TITLE
Restrict nightly CEA build to original repo

### DIFF
--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   build_and_test:
+    # only run on original repo
+    if: ${{ github.repository == "kokkos/kokkos" }}
+
     env:
       build_jobs: 40
 


### PR DESCRIPTION
Forks started to try running the nightly CEA build, but failed since no self-hosted runners were available. This PR fixes that by restricting the nightly test to only run for the original repo.