### PR TITLE
Use absolute value of delta in conversion test for b16

### DIFF
--- a/core/unit_test/TestHalfConversion.hpp
+++ b/core/unit_test/TestHalfConversion.hpp
@@ -24,7 +24,7 @@ void test_half_conversion_type() {
   T base                         = static_cast<T>(3.3);
   Kokkos::Experimental::half_t a = Kokkos::Experimental::cast_to_half(base);
   T b                            = Kokkos::Experimental::cast_from_half<T>(a);
-  ASSERT_LT((double(b - base) / double(base)), epsilon);
+  ASSERT_LT(abs(double(b - base) / double(base)), epsilon);
 
   Kokkos::View<T> b_v("b_v");
   Kokkos::parallel_for(
@@ -35,7 +35,7 @@ void test_half_conversion_type() {
       });
 
   Kokkos::deep_copy(b, b_v);
-  ASSERT_LT((double(b - base) / double(base)), epsilon);
+  ASSERT_LT(abs(double(b - base) / double(base)), epsilon);
 }
 
 template <class T>
@@ -44,7 +44,7 @@ void test_bhalf_conversion_type() {
   T base         = static_cast<T>(3.3);
   Kokkos::Experimental::bhalf_t a = Kokkos::Experimental::cast_to_bhalf(base);
   T b                             = Kokkos::Experimental::cast_from_bhalf<T>(a);
-  ASSERT_LT((double(b - base) / double(base)), epsilon);
+  ASSERT_LT(abs(double(b - base) / double(base)), epsilon);
 
   Kokkos::View<T> b_v("b_v");
   Kokkos::parallel_for(
@@ -55,7 +55,7 @@ void test_bhalf_conversion_type() {
       });
 
   Kokkos::deep_copy(b, b_v);
-  ASSERT_LT((double(b - base) / double(base)), epsilon);
+  ASSERT_LT(abs(double(b - base) / double(base)), epsilon);
 }
 
 void test_half_conversion() {

--- a/core/unit_test/TestHalfConversion.hpp
+++ b/core/unit_test/TestHalfConversion.hpp
@@ -22,7 +22,7 @@ template <class T>
 void test_half_conversion_type() {
   // When truncating mantissa to 10bits (like f16), 3.3 becomes 3.298828125
   // 3.3 - 3.298828125 < 1.1719-3, so conversion error should be smaller
-  double epsilon                 = KOKKOS_HALF_T_IS_FLOAT ? 3E-7 : 1.1719E-3;
+  double epsilon                 = KOKKOS_HALF_T_IS_FLOAT ? 3e-7 : 1.1719e-3;
   T base                         = static_cast<T>(3.3);
   Kokkos::Experimental::half_t a = Kokkos::Experimental::cast_to_half(base);
   T b                            = Kokkos::Experimental::cast_from_half<T>(a);
@@ -44,8 +44,8 @@ template <class T>
 void test_bhalf_conversion_type() {
   // When truncating mantissa to 7bits (like b16), 3.3 becomes 3.296875
   // 3.3 - 3.296875 < 3.125E-3, so conversion error should be smaller
-  double epsilon = KOKKOS_BHALF_T_IS_FLOAT ? 3E-7 : 3.125E-3;
-  T base         = static_cast<T>(3.3);
+  double epsilon                  = KOKKOS_BHALF_T_IS_FLOAT ? 3e-7 : 3.125e-3;
+  T base                          = static_cast<T>(3.3);
   Kokkos::Experimental::bhalf_t a = Kokkos::Experimental::cast_to_bhalf(base);
   T b                             = Kokkos::Experimental::cast_from_bhalf<T>(a);
   ASSERT_NEAR(b, base, epsilon);

--- a/core/unit_test/TestHalfConversion.hpp
+++ b/core/unit_test/TestHalfConversion.hpp
@@ -21,7 +21,7 @@ namespace Test {
 template <class T>
 void test_half_conversion_type() {
   // When truncating mantissa to 10bits (like f16), 3.3 becomes 3.298828125
-  // 3.3 - 3.298828125 < 1.1719-3, so conversion error should be smaller
+  // 3.3 - 3.298828125 < 1.1719e-3, so conversion error should be smaller
   double epsilon                 = KOKKOS_HALF_T_IS_FLOAT ? 3e-7 : 1.1719e-3;
   T base                         = static_cast<T>(3.3);
   Kokkos::Experimental::half_t a = Kokkos::Experimental::cast_to_half(base);
@@ -43,7 +43,7 @@ void test_half_conversion_type() {
 template <class T>
 void test_bhalf_conversion_type() {
   // When truncating mantissa to 7bits (like b16), 3.3 becomes 3.296875
-  // 3.3 - 3.296875 < 3.125E-3, so conversion error should be smaller
+  // 3.3 - 3.296875 < 3.125e-3, so conversion error should be smaller
   double epsilon                  = KOKKOS_BHALF_T_IS_FLOAT ? 3e-7 : 3.125e-3;
   T base                          = static_cast<T>(3.3);
   Kokkos::Experimental::bhalf_t a = Kokkos::Experimental::cast_to_bhalf(base);

--- a/core/unit_test/TestHalfConversion.hpp
+++ b/core/unit_test/TestHalfConversion.hpp
@@ -20,11 +20,13 @@ namespace Test {
 
 template <class T>
 void test_half_conversion_type() {
-  double epsilon                 = KOKKOS_HALF_T_IS_FLOAT ? 0.0000003 : 0.0003;
+  // When truncating mantissa to 10bits (like f16), 3.3 becomes 3.298828125
+  // 3.3 - 3.298828125 < 1.1719-3, so conversion error should be smaller
+  double epsilon                 = KOKKOS_HALF_T_IS_FLOAT ? 3E-7 : 1.1719E-3;
   T base                         = static_cast<T>(3.3);
   Kokkos::Experimental::half_t a = Kokkos::Experimental::cast_to_half(base);
   T b                            = Kokkos::Experimental::cast_from_half<T>(a);
-  ASSERT_LT(abs(double(b - base) / double(base)), epsilon);
+  ASSERT_NEAR(b, base, epsilon);
 
   Kokkos::View<T> b_v("b_v");
   Kokkos::parallel_for(
@@ -35,16 +37,18 @@ void test_half_conversion_type() {
       });
 
   Kokkos::deep_copy(b, b_v);
-  ASSERT_LT(abs(double(b - base) / double(base)), epsilon);
+  ASSERT_NEAR(b, base, epsilon);
 }
 
 template <class T>
 void test_bhalf_conversion_type() {
-  double epsilon = KOKKOS_BHALF_T_IS_FLOAT ? 0.0000003 : 0.0003;
+  // When truncating mantissa to 7bits (like b16), 3.3 becomes 3.296875
+  // 3.3 - 3.296875 < 3.125E-3, so conversion error should be smaller
+  double epsilon = KOKKOS_BHALF_T_IS_FLOAT ? 3E-7 : 3.125E-3;
   T base         = static_cast<T>(3.3);
   Kokkos::Experimental::bhalf_t a = Kokkos::Experimental::cast_to_bhalf(base);
   T b                             = Kokkos::Experimental::cast_from_bhalf<T>(a);
-  ASSERT_LT(abs(double(b - base) / double(base)), epsilon);
+  ASSERT_NEAR(b, base, epsilon);
 
   Kokkos::View<T> b_v("b_v");
   Kokkos::parallel_for(
@@ -55,7 +59,7 @@ void test_bhalf_conversion_type() {
       });
 
   Kokkos::deep_copy(b, b_v);
-  ASSERT_LT(abs(double(b - base) / double(base)), epsilon);
+  ASSERT_NEAR(b, base, epsilon);
 }
 
 void test_half_conversion() {


### PR DESCRIPTION
Test for conversion to and from b16/f16 only checked that the delta between the expected value and the result of the conversion was below some bound.
Since this delta was negative on backends that have access to native b16 (CUDA for instance), the test used to pass despite the error being bigger than the margin.

This commit adds a call to the abs function but does nothing to make the test pass since I am unsure of whether we should just increase the margin of error or if the failure reveals a deeper bug with b16 conversion.