### PR TITLE
core(openmp): don't forget to properly clean the `OpenMPInternal` singleton

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -55,19 +55,17 @@ void OpenMPInternal::clear_thread_data() {
 
   OpenMP::memory_space space;
 
-#pragma omp parallel num_threads(m_pool_size)
-  {
-    const int rank = omp_get_thread_num();
-
+  for (int rank = 0; rank < m_pool_size; ++rank) {
     if (nullptr != m_pool[rank]) {
       m_pool[rank]->disband_pool();
+
+      m_pool[rank]->~HostThreadTeamData();
 
       space.deallocate(m_pool[rank], old_alloc_bytes);
 
       m_pool[rank] = nullptr;
     }
   }
-  /* END #pragma omp parallel */
 }
 
 void OpenMPInternal::resize_thread_data(size_t pool_reduce_bytes,
@@ -140,12 +138,8 @@ void OpenMPInternal::resize_thread_data(size_t pool_reduce_bytes,
 }
 
 OpenMPInternal &OpenMPInternal::singleton() {
-  static OpenMPInternal *self = nullptr;
-  if (self == nullptr) {
-    self = new OpenMPInternal(get_current_max_threads());
-  }
-
-  return *self;
+  static OpenMPInternal self(get_current_max_threads());
+  return self;
 }
 
 int OpenMPInternal::get_current_max_threads() noexcept {
@@ -308,6 +302,8 @@ void OpenMPInternal::finalize() {
     *it = all_instances.back();
     all_instances.pop_back();
   }
+
+  clear_thread_data();
 }
 
 void OpenMPInternal::print_configuration(std::ostream &s) const {

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -62,7 +62,9 @@ class OpenMPInternal {
     }
   }
 
-  ~OpenMPInternal() { clear_thread_data(); }
+  OpenMPInternal()                                 = delete;
+  OpenMPInternal(const OpenMPInternal&)            = delete;
+  OpenMPInternal& operator=(const OpenMPInternal&) = delete;
 
   static int get_current_max_threads() noexcept;
 


### PR DESCRIPTION
### Summary

Running `Kokkos` with the `OpenMP` backend leads to leaks in `OpenMPInternal`.

~~I think the changes speak for themselves. But I don't know if the way I did it is OK with you.~~

~~Forgetting to do so leads to `OpenMPInternal::clear_thread_data` not being called, thereby leaking the whole `OpenMPInternal::m_pool`.~~

~~Note that the singleton has to be a pointer, because `OpenMPInternal::clear_thread_data` calls `Kokkos` code to free memory, so we must be able to do it during finalization.~~

### Related

- #5056