### PR TITLE
Apply `cmake-format` on `.cmake.in` files in CI

### DIFF
--- a/.github/workflows/cmake-format-check.yml
+++ b/.github/workflows/cmake-format-check.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: cmake-format lint action
-      uses: puneetmatharu/cmake-format-lint-action@efbb497b2a8badd2c9dc638faaf8ef4a9aa71bc8 # v1.0.4
+      uses: puneetmatharu/cmake-format-lint-action@2ac346e79e7ceac958bc637c1391285fb335ed7c # v1.0.5
       with:
         args: --config-files .cmake-format.py --in-place
         file_regex: '(.*\.cmake$|.*\.cmake\.in$|CMakeLists.txt$)'

--- a/.github/workflows/cmake-format-check.yml
+++ b/.github/workflows/cmake-format-check.yml
@@ -14,5 +14,6 @@ jobs:
       uses: puneetmatharu/cmake-format-lint-action@efbb497b2a8badd2c9dc638faaf8ef4a9aa71bc8 # v1.0.4
       with:
         args: --config-files .cmake-format.py --in-place
+        file_regex: '(.*\.cmake$|.*\.cmake\.in$|CMakeLists.txt$)'
     - name: check
       run: git diff --exit-code

--- a/.github/workflows/cmake-format-check.yml
+++ b/.github/workflows/cmake-format-check.yml
@@ -14,6 +14,6 @@ jobs:
       uses: puneetmatharu/cmake-format-lint-action@2ac346e79e7ceac958bc637c1391285fb335ed7c # v1.0.5
       with:
         args: --config-files .cmake-format.py --in-place
-        file_regex: '(.*\.cmake$|.*\.cmake\.in$|CMakeLists.txt$)'
+        file-regex: '(.*\.cmake$|.*\.cmake\.in$|CMakeLists.txt$)'
     - name: check
       run: git diff --exit-code


### PR DESCRIPTION
Fixes #7594
~~Depends on https://github.com/puneetmatharu/cmake-format-lint-action/pull/9/files~~
Depends on v1.0.5 of https://github.com/puneetmatharu/cmake-format-lint-action

- [x] This might lead to the action bumping version which needs to be included here