### PR TITLE
Fix ViewCtorProp specialization for SequentialHostInit

### DIFF
--- a/core/src/View/Kokkos_ViewCtor.hpp
+++ b/core/src/View/Kokkos_ViewCtor.hpp
@@ -147,6 +147,26 @@ struct ViewCtorProp<void, T *> {
   type value;
 };
 
+// For some reason I don't understand I needed this specialization explicitly
+// for NVCC/MSVC
+template <typename T>
+struct ViewCtorProp<T *> : public ViewCtorProp<void, T *> {
+  static constexpr bool has_memory_space     = false;
+  static constexpr bool has_execution_space  = false;
+  static constexpr bool has_pointer          = true;
+  static constexpr bool has_label            = false;
+  static constexpr bool allow_padding        = false;
+  static constexpr bool initialize           = true;
+  static constexpr bool sequential_host_init = false;
+
+  using memory_space    = void;
+  using execution_space = void;
+  using pointer_type    = T *;
+
+  KOKKOS_FUNCTION ViewCtorProp(const pointer_type arg)
+      : ViewCtorProp<void, pointer_type>(arg) {}
+};
+
 // If we use `ViewCtorProp<Args...>` and `ViewCtorProp<void, Args>...` directly
 // in the parameter lists and base class initializers, respectively, as far as
 // we can tell MSVC 16.5.5+CUDA 10.2 thinks that `ViewCtorProp` refers to the

--- a/core/src/View/Kokkos_ViewCtor.hpp
+++ b/core/src/View/Kokkos_ViewCtor.hpp
@@ -147,25 +147,6 @@ struct ViewCtorProp<void, T *> {
   type value;
 };
 
-// For some reason I don't understand I needed this specialization explicitly
-// for NVCC/MSVC
-template <typename T>
-struct ViewCtorProp<T *> : public ViewCtorProp<void, T *> {
-  static constexpr bool has_memory_space    = false;
-  static constexpr bool has_execution_space = false;
-  static constexpr bool has_pointer         = true;
-  static constexpr bool has_label           = false;
-  static constexpr bool allow_padding       = false;
-  static constexpr bool initialize          = true;
-
-  using memory_space    = void;
-  using execution_space = void;
-  using pointer_type    = T *;
-
-  KOKKOS_FUNCTION ViewCtorProp(const pointer_type arg)
-      : ViewCtorProp<void, pointer_type>(arg) {}
-};
-
 // If we use `ViewCtorProp<Args...>` and `ViewCtorProp<void, Args>...` directly
 // in the parameter lists and base class initializers, respectively, as far as
 // we can tell MSVC 16.5.5+CUDA 10.2 thinks that `ViewCtorProp` refers to the

--- a/core/unit_test/TestViewCtorProp.hpp
+++ b/core/unit_test/TestViewCtorProp.hpp
@@ -92,4 +92,13 @@ TEST(TEST_CATEGORY, vcp_label_copy_constructor) {
             "our label");
 }
 
+TEST(TEST_CATEGORY, vcp_pointer_add_property) {
+  double dummy        = 1.;
+  auto properties     = Kokkos::view_wrap(&dummy);
+  auto new_properties = Kokkos::Impl::with_properties_if_unset(
+      properties, std::string("our label"));
+  ASSERT_EQ(Kokkos::Impl::get_property<Kokkos::Impl::LabelTag>(new_properties),
+            "our label");
+}
+
 }  // namespace


### PR DESCRIPTION
Extracted from https://github.com/kokkos/kokkos/pull/7480/files#r1821082227. Basically, the specialization is missing to define a `sequential_host_init` alias. Let's see if we can just remove the specialization and if not we'll add the missing alias.