### PR TITLE
Fix DynRankView performance by re-introducing shortcut operators

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -524,7 +524,10 @@ class DynRankView : private View<DataType*******, Properties...> {
         std::is_same_v<typename traits::array_layout, Kokkos::LayoutStride>,
 
     is_default_map = std::is_void_v<typename traits::specialize> &&
-                     (is_layout_left || is_layout_right || is_layout_stride)
+                     (is_layout_left || is_layout_right || is_layout_stride),
+
+    is_default_access =
+        is_default_map && std::is_same_v<reference_type, element_type&>
   };
 
 // Bounds checking macros
@@ -574,10 +577,98 @@ class DynRankView : private View<DataType*******, Properties...> {
   using view_type::stride_7;            // FIXME: not tested
   using view_type::use_count;
 
-  KOKKOS_FUNCTION reference_type
-  operator()(index_type i0 = 0, index_type i1 = 0, index_type i2 = 0,
-             index_type i3 = 0, index_type i4 = 0, index_type i5 = 0,
-             index_type i6 = 0) const {
+  // Adding shortcut operators for rank-0 to rank-3 for default layouts
+  // and access modalities.
+  // This removes performance overhead for always using rank-7 mapping.
+  // See https://github.com/kokkos/kokkos/issues/7604
+  // When boundschecking is enabled we still go through the underlying
+  // rank-7 View to leverage the error checks there.
+
+  KOKKOS_FUNCTION reference_type operator()() const {
+#ifdef KOKKOS_ENABLE_DEBUG
+    if (rank() != 0u)
+      Kokkos::abort(
+          "DynRankView operator() called with invalid number of arguments.");
+#endif
+#ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
+    if constexpr (is_default_access) {
+      return view_type::data()[0];
+    } else
+#endif
+      return view_type::operator()(0, 0, 0, 0, 0, 0, 0);
+  }
+
+  KOKKOS_FUNCTION reference_type operator()(index_type i0) const {
+#ifdef KOKKOS_ENABLE_DEBUG
+    if (rank() != 1u)
+      Kokkos::abort(
+          "DynRankView operator() called with invalid number of arguments.");
+#endif
+#ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
+    if constexpr (is_default_access) {
+      if constexpr (is_layout_stride) {
+        return view_type::data()[i0 * view_type::stride(0)];
+      } else {
+        return view_type::data()[i0];
+      }
+    } else
+#endif
+      return view_type::operator()(i0, 0, 0, 0, 0, 0, 0);
+  }
+
+  KOKKOS_FUNCTION reference_type operator()(index_type i0,
+                                            index_type i1) const {
+#ifdef KOKKOS_ENABLE_DEBUG
+    if (rank() != 2u)
+      Kokkos::abort(
+          "DynRankView operator() called with invalid number of arguments.");
+#endif
+#ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
+    if constexpr (is_default_access) {
+      if constexpr (is_layout_left) {
+        return view_type::data()[i0 + i1 * view_type::stride(1)];
+      } else if constexpr (is_layout_right) {
+        return view_type::data()[i0 * view_type::extent(1) + i1];
+      } else {
+        return view_type::data()[i0 * view_type::stride(0) +
+                                 i1 * view_type::stride(1)];
+      }
+    } else
+#endif
+      return view_type::operator()(i0, i1, 0, 0, 0, 0, 0);
+  }
+
+  KOKKOS_FUNCTION reference_type operator()(index_type i0, index_type i1,
+                                            index_type i2) const {
+#ifdef KOKKOS_ENABLE_DEBUG
+    if (rank() != 3u)
+      Kokkos::abort(
+          "DynRankView operator() called with invalid number of arguments.");
+#endif
+#ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
+    if constexpr (is_default_access) {
+      if constexpr (is_layout_left) {
+        return view_type::data()[i0 + view_type::stride(1) *
+                                          (i1 + i2 * view_type::extent(1))];
+      } else if constexpr (is_layout_right) {
+        return view_type::data()[(i0 * view_type::extent(1) + i1) *
+                                     view_type::extent(2) +
+                                 i2];
+      } else {
+        return view_type::data()[i0 * view_type::stride(0) +
+                                 i1 * view_type::stride(1) +
+                                 i2 * view_type::stride(2)];
+      }
+    } else
+#endif
+      return view_type::operator()(i0, i1, i2, 0, 0, 0, 0);
+  }
+
+  KOKKOS_FUNCTION reference_type operator()(index_type i0, index_type i1,
+                                            index_type i2, index_type i3,
+                                            index_type i4 = 0,
+                                            index_type i5 = 0,
+                                            index_type i6 = 0) const {
     return view_type::operator()(i0, i1, i2, i3, i4, i5, i6);
   }
 


### PR DESCRIPTION
This addresses perf issues documented in #7604