### PR TITLE
Add test for Cuda stream semantics

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -253,7 +253,7 @@ CudaInternal &CudaInternal::singleton() {
   return self;
 }
 void CudaInternal::fence(const std::string &name) const {
-  Impl::cuda_stream_synchronize(get_stream(), this, name);
+  Impl::cuda_stream_synchronize(m_stream, this, name);
 }
 void CudaInternal::fence() const {
   fence("Kokkos::CudaInternal::fence(): Unnamed Instance Fence");

--- a/core/unit_test/TestMultiGPU.hpp
+++ b/core/unit_test/TestMultiGPU.hpp
@@ -189,7 +189,7 @@ __global__ void accumulate_kernel(int *value) {
   }
 }
 
-__global__ void set_equal_kernel(int *check, const int *value) {
+__global__ void copy_kernel(int *check, const int *value) {
   check[0] = value[0];
 }
 }  // namespace

--- a/core/unit_test/TestMultiGPU.hpp
+++ b/core/unit_test/TestMultiGPU.hpp
@@ -182,9 +182,6 @@ void test_scratch(TEST_EXECSPACE exec0, TEST_EXECSPACE exec1) {
   ASSERT_EQ(error1, 0);
 }
 
-// Test that stream synchronization behavior for various GPU APIs matches the
-// assumptions made in Kokkos for multi gpu support, namely, that any stream (no
-// matter which device it is created on) can be synced from any device.
 struct AccumulateTag {};
 struct CheckTag {};
 
@@ -230,5 +227,16 @@ void test_stream_sync(TEST_EXECSPACE exec0, TEST_EXECSPACE exec1,
 
   // Check the value observed on dev1 matches the complete computation on dev0
   ASSERT_EQ(check(), N);
+}
+
+template <int N>
+__global__ void accumulate_kernel(int *value) {
+  for (int i = 0; i < N; ++i) {
+    Kokkos::atomic_inc(value);
+  }
+}
+
+__global__ void set_equal_kernel(int *check, const int *value) {
+  check[0] = value[0];
 }
 }  // namespace

--- a/core/unit_test/TestMultiGPU.hpp
+++ b/core/unit_test/TestMultiGPU.hpp
@@ -203,7 +203,7 @@ struct StreamSyncFunctor {
 };
 
 void test_stream_sync(TEST_EXECSPACE exec0, TEST_EXECSPACE exec1,
-                      const std::function<void()> &set_to_device_1) {
+                      const std::function<void(TEST_EXECSPACE &)> &set_device) {
   // Create data in host pinned space
   Kokkos::View<int, Kokkos::SharedHostPinnedSpace> value("value"),
       check("check");
@@ -217,7 +217,7 @@ void test_stream_sync(TEST_EXECSPACE exec0, TEST_EXECSPACE exec1,
       Kokkos::RangePolicy<TEST_EXECSPACE, AccumulateTag>(exec0, 0, 1), f);
 
   // Force set internal device to dev1
-  set_to_device_1();
+  set_device(exec1);
 
   // Sync dev0
   exec0.fence();

--- a/core/unit_test/TestMultiGPU.hpp
+++ b/core/unit_test/TestMultiGPU.hpp
@@ -182,7 +182,7 @@ void test_scratch(TEST_EXECSPACE exec0, TEST_EXECSPACE exec1) {
   ASSERT_EQ(error1, 0);
 }
 
-// Test that stream synchronization behavoir for various GPU APIs matches the
+// Test that stream synchronization behavior for various GPU APIs matches the
 // assumptions made in Kokkos for multi gpu support, namely, that any stream (no
 // matter which device it is created on) can be synced from any device.
 struct AccumulateTag {};

--- a/core/unit_test/TestMultiGPU.hpp
+++ b/core/unit_test/TestMultiGPU.hpp
@@ -182,23 +182,6 @@ void test_scratch(TEST_EXECSPACE exec0, TEST_EXECSPACE exec1) {
   ASSERT_EQ(error1, 0);
 }
 
-struct AccumulateTag {};
-struct CheckTag {};
-
-template <int N>
-struct StreamSyncFunctor {
-  int *value;
-  int *check;
-
-  KOKKOS_FUNCTION
-  void operator()(const AccumulateTag &, const int) const {
-    for (int i = 0; i < N; ++i) Kokkos::atomic_inc(value);
-  }
-
-  KOKKOS_FUNCTION
-  void operator()(const CheckTag &, const int) const { check[0] = value[0]; }
-};
-
 template <int N>
 __global__ void accumulate_kernel(int *value) {
   for (int i = 0; i < N; ++i) {

--- a/core/unit_test/TestMultiGPU.hpp
+++ b/core/unit_test/TestMultiGPU.hpp
@@ -182,6 +182,7 @@ void test_scratch(TEST_EXECSPACE exec0, TEST_EXECSPACE exec1) {
   ASSERT_EQ(error1, 0);
 }
 
+#ifdef KOKKOS_ENABLE_CUDA
 template <int N>
 __global__ void accumulate_kernel(int *value) {
   for (int i = 0; i < N; ++i) {
@@ -192,4 +193,5 @@ __global__ void accumulate_kernel(int *value) {
 __global__ void copy_kernel(int *check, const int *value) {
   check[0] = value[0];
 }
+#endif
 }  // namespace

--- a/core/unit_test/TestMultiGPU.hpp
+++ b/core/unit_test/TestMultiGPU.hpp
@@ -181,4 +181,15 @@ void test_scratch(TEST_EXECSPACE exec0, TEST_EXECSPACE exec1) {
   ASSERT_EQ(error0, 0);
   ASSERT_EQ(error1, 0);
 }
+
+template <int N>
+__global__ void accumulate_kernel(int *value) {
+  for (int i = 0; i < N; ++i) {
+    Kokkos::atomic_inc(value);
+  }
+}
+
+__global__ void set_equal_kernel(int *check, const int *value) {
+  check[0] = value[0];
+}
 }  // namespace

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -128,4 +128,41 @@ TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), stream_sync_semantics) {
   }
 }
 
+TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), stream_sync_semantics_raw_cuda) {
+  // Test that stream synchronization behavior for various GPU APIs matches the
+  // assumptions made in Kokkos for multi gpu support, namely, that any stream
+  // (no matter which device it is created on) can be synced from any device.
+
+  StreamsAndDevices streams_and_devices;
+  {
+    auto streams = streams_and_devices.streams;
+    auto devices = streams_and_devices.devices;
+
+    // Allocate data.
+    int *value;
+    int *check;
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        cudaMallocHost(reinterpret_cast<void **>(&value), 1 * sizeof(int)));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        cudaMallocHost(reinterpret_cast<void **>(&check), 1 * sizeof(int)));
+
+    // Launch "long" kernel on device 0.
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(devices[0]));
+    constexpr size_t size = 10000;
+    accumulate_kernel<size><<<1, 1, 0, streams[0]>>>(value);
+
+    // Wait for the kernel running on device 0 while we are on device 1, then
+    // check the value.
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(devices[1]));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamSynchronize(streams[0]));
+    set_equal_kernel<<<1, 1, 0, streams[1]>>>(check, value);
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamSynchronize(streams[1]));
+    ASSERT_EQ(check[0], size);
+
+    // Cleanup.
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeHost(value));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeHost(check));
+  }
+}
+
 }  // namespace

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -105,4 +105,40 @@ TEST(cuda_multi_gpu, scratch_space) {
     test_scratch(execs[0], execs[1]);
   }
 }
+
+// Test that stream synchronization behavoir for CudaAPI matches the assumptions
+// made in Kokkos for multi gpu support, namely, that any stream (no matter
+// which device it is created on) can be synced from any device.
+TEST(cuda_multi_gpu, stream_sync_semantics) {
+  StreamsAndDevices streams_and_devices;
+  {
+    auto streams = streams_and_devices.streams;
+
+    // Allocate data.
+    int *value;
+    int *check;
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        cudaMallocHost(reinterpret_cast<void **>(&value), 1 * sizeof(int)));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        cudaMallocHost(reinterpret_cast<void **>(&check), 1 * sizeof(int)));
+
+    // Launch "long" kernel on device 0.
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(0));
+    constexpr size_t size = 1000;
+    accumulate_kernel<size><<<1, 1, 0, streams[0]>>>(value);
+
+    // Wait for the kernel running on device 0 while we are on device 1, then
+    // check the value.
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(1));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamSynchronize(streams[0]));
+    set_equal_kernel<<<1, 1, 0, streams[1]>>>(check, value);
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamSynchronize(streams[1]));
+    ASSERT_EQ(check[0], size);
+
+    // Cleanup.
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeHost(value));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeHost(check));
+  }
+}
+
 }  // namespace

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -45,6 +45,13 @@ struct StreamsAndDevices {
 
 std::array<TEST_EXECSPACE, 2> get_execution_spaces(
     const StreamsAndDevices &streams_and_devices) {
+  // Must return void to use GTEST_SKIP
+  [&]() {
+    if (streams_and_devices.devices[0] == streams_and_devices.devices[1])
+      GTEST_SKIP() << "Skipping Cuda multi-gpu testing since current machine "
+                      "only contains a single GPU.\n";
+  }();
+
   TEST_EXECSPACE exec0(streams_and_devices.streams[0]);
   TEST_EXECSPACE exec1(streams_and_devices.streams[1]);
 

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -112,8 +112,8 @@ TEST(cuda_multi_gpu, stream_sync_semantics) {
     std::array<TEST_EXECSPACE, 2> execs =
         get_execution_spaces(streams_and_devices);
 
-    test_stream_sync(execs[0], execs[1], [&execs]() {
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(execs[1].cuda_device()));
+    test_stream_sync(execs[0], execs[1], [](const Kokkos::Cuda &exec_space) {
+      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(exec_space.cuda_device()));
     });
   }
 }

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -58,10 +58,10 @@ std::array<TEST_EXECSPACE, 2> get_execution_spaces(
 }
 
 struct TEST_CATEGORY_FIXTURE(MultiGPU) : public ::testing::Test {
-  StreamsAndDevices streams_and_devices;
+  StreamsAndDevices sd;
 
   void SetUp() override {
-    if (streams_and_devices.devices[0] == streams_and_devices.devices[1])
+    if (sd.devices[0] == sd.devices[1])
       GTEST_SKIP() << "Skipping Cuda multi-gpu testing since current machine "
                       "only contains a single GPU.\n";
   }

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -143,7 +143,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), stream_sync_semantics_raw_cuda) {
     // check the value.
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(devices[1]));
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamSynchronize(streams[0]));
-    set_equal_kernel<<<1, 1, 0, streams[1]>>>(check, value);
+    copy_kernel<<<1, 1, 0, streams[1]>>>(check, value);
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamSynchronize(streams[1]));
     ASSERT_EQ(check[0], size);
 

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -45,13 +45,6 @@ struct StreamsAndDevices {
 
 std::array<TEST_EXECSPACE, 2> get_execution_spaces(
     const StreamsAndDevices &streams_and_devices) {
-  // Must return void to use GTEST_SKIP
-  [&]() {
-    if (streams_and_devices.devices[0] == streams_and_devices.devices[1])
-      GTEST_SKIP() << "Skipping Cuda multi-gpu testing since current machine "
-                      "only contains a single GPU.\n";
-  }();
-
   TEST_EXECSPACE exec0(streams_and_devices.streams[0]);
   TEST_EXECSPACE exec1(streams_and_devices.streams[1]);
 
@@ -64,7 +57,17 @@ std::array<TEST_EXECSPACE, 2> get_execution_spaces(
   return {exec0, exec1};
 }
 
-TEST(cuda_multi_gpu, managed_views) {
+struct TEST_CATEGORY_FIXTURE(MultiGPU) : public ::testing::Test {
+  StreamsAndDevices streams_and_devices;
+
+  void SetUp() override {
+    if (streams_and_devices.devices[0] == streams_and_devices.devices[1])
+      GTEST_SKIP() << "Skipping Cuda multi-gpu testing since current machine "
+                      "only contains a single GPU.\n";
+  }
+};
+
+TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), managed_views) {
   StreamsAndDevices streams_and_devices;
   {
     std::array<TEST_EXECSPACE, 2> execs =
@@ -79,7 +82,7 @@ TEST(cuda_multi_gpu, managed_views) {
   }
 }
 
-TEST(cuda_multi_gpu, unmanaged_views) {
+TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), unmanaged_views) {
   StreamsAndDevices streams_and_devices;
   {
     std::array<TEST_EXECSPACE, 2> execs =
@@ -103,7 +106,7 @@ TEST(cuda_multi_gpu, unmanaged_views) {
   }
 }
 
-TEST(cuda_multi_gpu, scratch_space) {
+TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), scratch_space) {
   StreamsAndDevices streams_and_devices;
   {
     std::array<TEST_EXECSPACE, 2> execs =
@@ -113,7 +116,7 @@ TEST(cuda_multi_gpu, scratch_space) {
   }
 }
 
-TEST(cuda_multi_gpu, stream_sync_semantics) {
+TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), stream_sync_semantics) {
   StreamsAndDevices streams_and_devices;
   {
     std::array<TEST_EXECSPACE, 2> execs =

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -57,7 +57,7 @@ std::array<TEST_EXECSPACE, 2> get_execution_spaces(
   return {exec0, exec1};
 }
 
-struct TEST_CATEGORY_FIXTURE(MultiGPU) : public ::testing::Test {
+struct TEST_CATEGORY_FIXTURE(multi_gpu) : public ::testing::Test {
   StreamsAndDevices sd;
 
   void SetUp() override {
@@ -67,7 +67,7 @@ struct TEST_CATEGORY_FIXTURE(MultiGPU) : public ::testing::Test {
   }
 };
 
-TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), managed_views) {
+TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), managed_views) {
   StreamsAndDevices streams_and_devices;
   {
     std::array<TEST_EXECSPACE, 2> execs =
@@ -82,7 +82,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), managed_views) {
   }
 }
 
-TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), unmanaged_views) {
+TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), unmanaged_views) {
   StreamsAndDevices streams_and_devices;
   {
     std::array<TEST_EXECSPACE, 2> execs =
@@ -106,7 +106,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), unmanaged_views) {
   }
 }
 
-TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), scratch_space) {
+TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), scratch_space) {
   StreamsAndDevices streams_and_devices;
   {
     std::array<TEST_EXECSPACE, 2> execs =
@@ -116,7 +116,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), scratch_space) {
   }
 }
 
-TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), stream_sync_semantics_raw_cuda) {
+TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), stream_sync_semantics_raw_cuda) {
   // Test that stream synchronization behavior for various GPU APIs matches the
   // assumptions made in Kokkos for multi gpu support, namely, that any stream
   // (no matter which device it is created on) can be synced from any device.

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -116,18 +116,6 @@ TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), scratch_space) {
   }
 }
 
-TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), stream_sync_semantics) {
-  StreamsAndDevices streams_and_devices;
-  {
-    std::array<TEST_EXECSPACE, 2> execs =
-        get_execution_spaces(streams_and_devices);
-
-    test_stream_sync(execs[0], execs[1], [](const Kokkos::Cuda &exec_space) {
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(exec_space.cuda_device()));
-    });
-  }
-}
-
 TEST_F(TEST_CATEGORY_FIXTURE(MultiGPU), stream_sync_semantics_raw_cuda) {
   // Test that stream synchronization behavior for various GPU APIs matches the
   // assumptions made in Kokkos for multi gpu support, namely, that any stream

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -112,19 +112,9 @@ TEST(cuda_multi_gpu, stream_sync_semantics) {
     std::array<TEST_EXECSPACE, 2> execs =
         get_execution_spaces(streams_and_devices);
 
-    int *value;
-    int *check;
-    KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaMallocHost(reinterpret_cast<void **>(&value), 1 * sizeof(int)));
-    KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaMallocHost(reinterpret_cast<void **>(&check), 1 * sizeof(int)));
-
-    test_stream_sync(execs[0], execs[1], value, check, [&execs]() {
+    test_stream_sync(execs[0], execs[1], [&execs]() {
       KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(execs[1].cuda_device()));
     });
-
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeHost(value));
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeHost(check));
   }
 }
 


### PR DESCRIPTION
Test that Kokkos' assumption for cuda stream sync is correct, namely, any stream can be sync when on any cuda device, so therefore no need to set device beforehand.

Requested in https://github.com/kokkos/kokkos/pull/7569. Test from @romintomasetti.