### PR TITLE
graph(fix): nodes must be stored by the graph, whatever the backend

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -51,10 +51,7 @@ struct GraphImpl<Kokkos::Cuda> {
 
   using node_details_t = GraphNodeBackendSpecificDetails<Kokkos::Cuda>;
 
-  // Store drivers for the kernel nodes that launch in global memory.
-  // This is required as lifetime of drivers must be bounded to this instance's
-  // lifetime.
-  std::vector<std::shared_ptr<void>> m_driver_storage;
+  std::vector<std::shared_ptr<node_details_t>> m_nodes;
 
  public:
   void instantiate() {
@@ -137,8 +134,7 @@ struct GraphImpl<Kokkos::Cuda> {
     kernel.set_cuda_graph_node_ptr(&cuda_node);
     kernel.execute();
     KOKKOS_ENSURES(bool(cuda_node));
-    if (std::shared_ptr<void> tmp = kernel.get_driver_storage())
-      m_driver_storage.push_back(std::move(tmp));
+    m_nodes.push_back(arg_node_ptr);
   }
 
   template <class NodeImplPtr, class PredecessorRef>

--- a/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
@@ -89,10 +89,7 @@ class GraphImpl<Kokkos::HIP> {
   hipGraph_t m_graph          = nullptr;
   hipGraphExec_t m_graph_exec = nullptr;
 
-  // Store drivers for the kernel nodes that launch in global memory.
-  // This is required as lifetime of drivers must be bounded to this instance's
-  // lifetime.
-  std::vector<std::shared_ptr<void>> m_driver_storage;
+  std::vector<std::shared_ptr<node_details_t>> m_nodes;
 };
 
 inline GraphImpl<Kokkos::HIP>::~GraphImpl() {
@@ -135,8 +132,7 @@ GraphImpl<Kokkos::HIP>::add_node(
   kernel.set_hip_graph_node_ptr(&node);
   kernel.execute();
   KOKKOS_ENSURES(node);
-  if (std::shared_ptr<void> tmp = kernel.get_driver_storage())
-    m_driver_storage.push_back(std::move(tmp));
+  m_nodes.push_back(arg_node_ptr);
 }
 
 // Requires PredecessorRef is a specialization of GraphNodeRef that has

--- a/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
@@ -89,6 +89,8 @@ class GraphImpl<Kokkos::SYCL> {
   std::optional<sycl::ext::oneapi::experimental::command_graph<
       sycl::ext::oneapi::experimental::graph_state::executable>>
       m_graph_exec;
+
+  std::vector<std::shared_ptr<node_details_t>> m_nodes;
 };
 
 inline GraphImpl<Kokkos::SYCL>::~GraphImpl() {
@@ -122,6 +124,7 @@ GraphImpl<Kokkos::SYCL>::add_node(
   kernel.set_sycl_graph_node_ptr(&node);
   kernel.execute();
   KOKKOS_ENSURES(node);
+  m_nodes.push_back(arg_node_ptr);
 }
 
 // Requires PredecessorRef is a specialization of GraphNodeRef that has


### PR DESCRIPTION
As discussed with @crtrott and @dalg24, the node must be stored by the graph. Otherwise, the lifetime of captured things is not bound to the node's lifetime and undefined behavior might happen.

Namely, adding a node to a graph within a scope should be allowed:
```c++
auto graph = ... create graph ....;
{
   auto buffer = Kokkos::View<...>(...);
   auto scoped = pred.then_ ...(... do something with buffer ...);
}
// Anything needed by the workload defined by 'scoped' must still be alive,
// e.g. 'buffer' must be kept alive.
```