### PR TITLE
[ci skip] Use C++23 for ROCm 6.3 MI210 nightly and add MI100 RDC config

### DIFF
--- a/.jenkins_nightly
+++ b/.jenkins_nightly
@@ -131,6 +131,7 @@ pipeline {
                                 -DKokkos_ENABLE_DEPRECATED_CODE_4=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_BENCHMARKS=ON \
+                                -DKokkos_ENABLE_EXAMPLES=ON \
                                 -DKokkos_ENABLE_HIP=ON \
                               .. && \
                               make -j8 && ctest --no-compress-output -T Test --verbose'''

--- a/.jenkins_nightly
+++ b/.jenkins_nightly
@@ -104,7 +104,46 @@ pipeline {
                         }
                     }
                 }
-                stage('HIP-ROCM-6.3') {
+                stage('HIP-ROCM-6.3-MI100-RDC') {
+                    agent {
+                        dockerfile {
+                            filename 'Dockerfile.hipcc'
+                            dir 'scripts/docker'
+                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-22.04:6.3-complete'
+                            label 'rocm-docker && AMD_Radeon_Instinct_MI100'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
+                        }
+                    }
+                    environment {
+                        // FIXME Test returns a wrong value
+                        GTEST_FILTER = '-hip_hostpinned.view_allocation_large_rank'
+                    }
+                    steps {
+                        sh 'ccache --zero-stats'
+                        sh '''rm -rf build && mkdir -p build && cd build && \
+                              cmake \
+                                -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                                -DCMAKE_CXX_COMPILER=hipcc \
+                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument" \
+                                -DKokkos_ENABLE_HIP_RELOCATABLE_DEVICE_CODE=ON \
+                                -DKokkos_ARCH_NATIVE=ON \
+                                -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
+                                -DKokkos_ENABLE_DEPRECATED_CODE_4=ON \
+                                -DKokkos_ENABLE_TESTS=ON \
+                                -DKokkos_ENABLE_BENCHMARKS=ON \
+                                -DKokkos_ENABLE_HIP=ON \
+                              .. && \
+                              make -j8 && ctest --no-compress-output -T Test --verbose'''
+                    }
+                    post {
+                        always {
+                            sh 'ccache --show-stats'
+                            xunit([CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)])
+                        }
+                    }
+                }
+            }
+                stage('HIP-ROCM-6.3-MI210-CXX23') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.hipcc'
@@ -125,7 +164,7 @@ pipeline {
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                                 -DCMAKE_CXX_COMPILER=hipcc \
                                 -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument" \
-                                -DCMAKE_CXX_STANDARD=20 \
+                                -DCMAKE_CXX_STANDARD=23 \
                                 -DKokkos_ARCH_NATIVE=ON \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_DEPRECATED_CODE_4=ON \


### PR DESCRIPTION
 - We did not test C++23 with ROCm -> update the C++ standard from C++20 to C++23 in the nightly test 
 - Add MI100 RDC to make sure that we always have a built on MI100 (OLCF had a machine that uses MI100) and one built with RDC. Compiling with RDC is slower, so put it in the nightly.