### PR TITLE
Switch jenkins ROCm 5.6 config to ROCm 5.7

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -70,12 +70,12 @@ pipeline {
                         }
                     }
                 }
-                stage('HIP-ROCm-5.6-C++20') {
+                stage('HIP-ROCm-5.7-C++20') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.hipcc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-22.04:5.6-complete@sha256:578a310fb1037d9c5e23fded2564f239acf6dc7231ff4742d2e7279fe7cc5c4a'
+                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-22.04:5.7.1-complete@sha256:fc6abb843a4cb2b3e5d8e9225ed0db1450e063dbcc347f44b43252264134485d'
                             label 'rocm-docker'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
                         }


### PR DESCRIPTION
ROCm 5.7 is the default version of ROCm on Frontier. Let's use that version instead of ROCm 5.7