### PR TITLE
core(graph): `then` node

### DIFF
--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -216,6 +216,7 @@ decltype(auto) Graph<ExecutionSpace>::native_graph_exec() {
 #include <Kokkos_GraphNode.hpp>
 
 #include <impl/Kokkos_GraphNodeImpl.hpp>
+#include <impl/Kokkos_GraphNodeThenImpl.hpp>
 #include <impl/Kokkos_Default_Graph_Impl.hpp>
 #include <Cuda/Kokkos_Cuda_Graph_Impl.hpp>
 #if defined(KOKKOS_ENABLE_HIP)

--- a/core/src/impl/Kokkos_GraphImpl_fwd.hpp
+++ b/core/src/impl/Kokkos_GraphImpl_fwd.hpp
@@ -32,6 +32,9 @@ template <class ExecutionSpace, class Policy, class Functor,
           class KernelTypeTag, class... Args>
 class GraphNodeKernelImpl;
 
+template <class ExecutionSpace, class Functor>
+struct GraphNodeThenImpl;
+
 struct _graph_node_kernel_ctor_tag {};
 struct _graph_node_predecessor_ctor_tag {};
 struct _graph_node_is_root_ctor_tag {};

--- a/core/src/impl/Kokkos_GraphNodeThenImpl.hpp
+++ b/core/src/impl/Kokkos_GraphNodeThenImpl.hpp
@@ -1,0 +1,58 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_IMPL_KOKKOS_GRAPHNODETHENIMPL_HPP
+#define KOKKOS_IMPL_KOKKOS_GRAPHNODETHENIMPL_HPP
+
+#include <Kokkos_ExecPolicy.hpp>
+#include <impl/Kokkos_GraphImpl_fwd.hpp>
+
+namespace Kokkos::Impl {
+
+// Helper for the 'then', such that the user can indeed pass a callable that
+// takes no argument.
+template <typename Functor>
+struct ThenWrapper {
+  Functor functor;
+  template <typename T>
+  KOKKOS_FUNCTION void operator()(const T) const {
+    functor();
+  }
+};
+
+template <typename ExecutionSpace, typename Functor>
+struct GraphNodeThenImpl
+    : public GraphNodeKernelImpl<
+          ExecutionSpace, Kokkos::RangePolicy<ExecutionSpace, IsGraphKernelTag>,
+          ThenWrapper<Functor>, ParallelForTag> {
+  using base_t =
+      GraphNodeKernelImpl<ExecutionSpace,
+                          Kokkos::RangePolicy<ExecutionSpace, IsGraphKernelTag>,
+                          ThenWrapper<Functor>, ParallelForTag>;
+  using wrapper_t = ThenWrapper<Functor>;
+
+  template <typename Label, typename T>
+  GraphNodeThenImpl(Label&& label_, const ExecutionSpace& exec, T&& functor)
+      : base_t(
+            std::forward<Label>(label_), exec,
+            wrapper_t{std::forward<T>(functor)},
+            Kokkos::RangePolicy<ExecutionSpace, IsGraphKernelTag>(exec, 0, 1)) {
+  }
+};
+
+}  // namespace Kokkos::Impl
+
+#endif  // KOKKOS_IMPL_KOKKOS_GRAPHNODETHENIMPL_HPP


### PR DESCRIPTION
## Summary

This PR adds a `then` node to `Kokkos::Graph`.

## Description

The idea is that this `then` node mimics the `then` in [P2300](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html#design-sender-adaptor-then).

In essence, you pass a functor to the `then` and it's guaranteed to be executed at each graph submission, in the graph topology ordering.

```c++
auto my_then_node = predecessor.then(
    "label",
    KOKKOS_FUNCTION{... do some stuff with some data ...}
);
```

Things to be noted from the above code snippet:
1. The functor passed to the `then` must be callable without any argument, marked with `KOKKOS_FUNCTION`.
2. The `then` is nothing else then a kernel launch, done through one of `Kokkos` drivers.
3. It adds exactly one node in the `Kokkos` graph and one node in the backend graph.

:warning: For now, I've implemented it as a parallel-for from 0 to 1, but I think we can do better than that (in the future).

## Related

- extracted from #7552 