### PR TITLE
simd: Remove subscript operators returning by reference

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1354,10 +1354,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       case 1: return _mm_extract_epi32(m_value, 0x1);
       case 2: return _mm_extract_epi32(m_value, 0x2);
       case 3: return _mm_extract_epi32(m_value, 0x3);
-      default:
-        Kokkos::Impl::throw_runtime_exception(
-            std::string("Index out of bound"));
-        break;
+      default: Kokkos::abort("Index out of bound"); break;
     }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
@@ -1785,10 +1782,7 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       case 1: return _mm256_extract_epi64(m_value, 0x1);
       case 2: return _mm256_extract_epi64(m_value, 0x2);
       case 3: return _mm256_extract_epi64(m_value, 0x3);
-      default:
-        Kokkos::Impl::throw_runtime_exception(
-            std::string("Index out of bound"));
-        break;
+      default: Kokkos::abort("Index out of bound"); break;
     }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
@@ -2017,10 +2011,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
       case 1: return _mm256_extract_epi64(m_value, 0x1);
       case 2: return _mm256_extract_epi64(m_value, 0x2);
       case 3: return _mm256_extract_epi64(m_value, 0x3);
-      default:
-        Kokkos::Impl::throw_runtime_exception(
-            std::string("Index out of bound"));
-        break;
+      default: Kokkos::abort("Index out of bound"); break;
     }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -2238,13 +2238,23 @@ class where_expression<basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, element_aligned_tag) {
+#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
+    __m256d tmp = _mm256_loadu_pd(mem);
+    m_value = value_type(_mm256_and_si256(tmp, static_cast<__m256d>(m_mask)));
+#else
     m_value = value_type(_mm256_maskload_pd(
         mem, _mm256_castpd_si256(static_cast<__m256d>(m_mask))));
+#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, vector_aligned_tag) {
+#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
+    __m256d tmp = _mm256_load_pd(mem);
+    m_value = value_type(_mm256_and_si256(tmp, static_cast<__m256d>(m_mask)));
+#else
     m_value = value_type(_mm256_maskload_pd(
         mem, _mm256_castpd_si256(static_cast<__m256d>(m_mask))));
+#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
@@ -2329,13 +2339,23 @@ class where_expression<basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
+#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
+    __m128 tmp = _mm_loadu_ps(mem);
+    m_value    = value_type(_mm_and_ps(tmp, static_cast<__m128>(m_mask)));
+#else
     m_value = value_type(
         _mm_maskload_ps(mem, _mm_castps_si128(static_cast<__m128>(m_mask))));
+#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, vector_aligned_tag) {
+#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
+    __m128 tmp = _mm_load_ps(mem);
+    m_value    = value_type(_mm_and_ps(tmp, static_cast<__m128>(m_mask)));
+#else
     m_value = value_type(
         _mm_maskload_ps(mem, _mm_castps_si128(static_cast<__m128>(m_mask))));
+#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
@@ -2420,12 +2440,22 @@ class where_expression<basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
+#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
+    __m256 tmp = _mm256_loadu_ps(mem);
+    m_value    = value_type(_mm256_and_ps(tmp, static_cast<__m256>(m_mask)));
+#else
     m_value = value_type(_mm256_maskload_ps(
         mem, _mm256_castps_si256(static_cast<__m256>(m_mask))));
+#endif
   }
   void copy_from(float const* mem, vector_aligned_tag) {
+#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
+    __m256 tmp = _mm256_load_ps(mem);
+    m_value    = value_type(_mm256_and_ps(tmp, static_cast<__m256>(m_mask)));
+#else
     m_value = value_type(_mm256_maskload_ps(
         mem, _mm256_castps_si256(static_cast<__m256>(m_mask))));
+#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -54,32 +54,6 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
   __m256d m_value;
 
  public:
-  class reference {
-    __m256d& m_mask;
-    int m_lane;
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __m256d bit_mask() const {
-      return _mm256_castsi256_pd(_mm256_setr_epi64x(
-          -std::int64_t(m_lane == 0), -std::int64_t(m_lane == 1),
-          -std::int64_t(m_lane == 2), -std::int64_t(m_lane == 3)));
-    }
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(__m256d& mask_arg,
-                                                    int lane_arg)
-        : m_mask(mask_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(bool value) const {
-      if (value) {
-        m_mask = _mm256_or_pd(bit_mask(), m_mask);
-      } else {
-        m_mask = _mm256_andnot_pd(bit_mask(), m_mask);
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      return (_mm256_movemask_pd(m_mask) & (1 << m_lane)) != 0;
-    }
-  };
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
@@ -112,13 +86,9 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return static_cast<value_type>(
-        reference(const_cast<__m256d&>(m_value), int(i)));
+    return (_mm256_movemask_pd(m_value) & (1 << i)) != 0;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
   operator||(basic_simd_mask const& other) const {
@@ -147,32 +117,6 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
   __m128 m_value;
 
  public:
-  class reference {
-    __m128& m_mask;
-    int m_lane;
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __m128 bit_mask() const {
-      return _mm_castsi128_ps(_mm_setr_epi32(
-          -std::int32_t(m_lane == 0), -std::int32_t(m_lane == 1),
-          -std::int32_t(m_lane == 2), -std::int32_t(m_lane == 3)));
-    }
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(__m128& mask_arg,
-                                                    int lane_arg)
-        : m_mask(mask_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(bool value) const {
-      if (value) {
-        m_mask = _mm_or_ps(bit_mask(), m_mask);
-      } else {
-        m_mask = _mm_andnot_ps(bit_mask(), m_mask);
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      return (_mm_movemask_ps(m_mask) & (1 << m_lane)) != 0;
-    }
-  };
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
@@ -201,13 +145,9 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return static_cast<value_type>(
-        reference(const_cast<__m128&>(m_value), int(i)));
+    return (_mm_movemask_ps(m_value) & (1 << i)) != 0;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
   operator||(basic_simd_mask const& other) const {
@@ -236,40 +176,6 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
   __m256 m_value;
 
  public:
-  class reference {
-    __m256& m_mask;
-    int m_lane;
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __m256 bit_mask() const {
-      // FIXME_HIP ROCm 5.6, 5.7, and 6.0 can't compile with the intrinsic used
-      // here.
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-      return _mm256_cvtepi32_ps(_mm256_setr_epi32(
-#else
-      return _mm256_castsi256_ps(_mm256_setr_epi32(
-#endif
-          -std::int32_t(m_lane == 0), -std::int32_t(m_lane == 1),
-          -std::int32_t(m_lane == 2), -std::int32_t(m_lane == 3),
-          -std::int32_t(m_lane == 4), -std::int32_t(m_lane == 5),
-          -std::int32_t(m_lane == 6), -std::int32_t(m_lane == 7)));
-    }
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(__m256& mask_arg,
-                                                    int lane_arg)
-        : m_mask(mask_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(bool value) const {
-      if (value) {
-        m_mask = _mm256_or_ps(bit_mask(), m_mask);
-      } else {
-        m_mask = _mm256_andnot_ps(bit_mask(), m_mask);
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      return (_mm256_movemask_ps(m_mask) & (1 << m_lane)) != 0;
-    }
-  };
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
@@ -302,13 +208,9 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return static_cast<value_type>(
-        reference(const_cast<__m256&>(m_value), int(i)));
+    return (_mm256_movemask_ps(m_value) & (1 << i)) != 0;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
   operator||(basic_simd_mask const& other) const {
@@ -337,32 +239,6 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   __m128i m_value;
 
  public:
-  class reference {
-    __m128i& m_mask;
-    int m_lane;
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __m128i bit_mask() const {
-      return _mm_setr_epi32(
-          -std::int32_t(m_lane == 0), -std::int32_t(m_lane == 1),
-          -std::int32_t(m_lane == 2), -std::int32_t(m_lane == 3));
-    }
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(__m128i& mask_arg,
-                                                    int lane_arg)
-        : m_mask(mask_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(bool value) const {
-      if (value) {
-        m_mask = _mm_or_si128(bit_mask(), m_mask);
-      } else {
-        m_mask = _mm_andnot_si128(bit_mask(), m_mask);
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      return (_mm_movemask_ps(_mm_castsi128_ps(m_mask)) & (1 << m_lane)) != 0;
-    }
-  };
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
@@ -390,19 +266,16 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
       basic_simd_mask<U, abi_type> const& other) {
-    for (std::size_t i = 0; i < size(); ++i) (*this)[i] = other[i];
+    m_value = _mm_setr_epi32(-std::int32_t(other[0]), -std::int32_t(other[1]),
+                             -std::int32_t(other[2]), -std::int32_t(other[3]));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128i()
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return static_cast<value_type>(
-        reference(const_cast<__m128i&>(m_value), int(i)));
+    return (_mm_movemask_ps(_mm_castsi128_ps(m_value)) & (1 << i)) != 0;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
   operator||(basic_simd_mask const& other) const {
@@ -432,35 +305,6 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
   __m256i m_value;
 
  public:
-  class reference {
-    __m256i& m_mask;
-    int m_lane;
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __m256i bit_mask() const {
-      return _mm256_setr_epi32(
-          -std::int32_t(m_lane == 0), -std::int32_t(m_lane == 1),
-          -std::int32_t(m_lane == 2), -std::int32_t(m_lane == 3),
-          -std::int32_t(m_lane == 4), -std::int32_t(m_lane == 5),
-          -std::int32_t(m_lane == 6), -std::int32_t(m_lane == 7));
-    }
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(__m256i& mask_arg,
-                                                    int lane_arg)
-        : m_mask(mask_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(bool value) const {
-      if (value) {
-        m_mask = _mm256_or_si256(bit_mask(), m_mask);
-      } else {
-        m_mask = _mm256_andnot_si256(bit_mask(), m_mask);
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      return (_mm256_movemask_ps(_mm256_castsi256_ps(m_mask)) &
-              (1 << m_lane)) != 0;
-    }
-  };
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
@@ -498,13 +342,9 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return static_cast<value_type>(
-        reference(const_cast<__m256i&>(m_value), int(i)));
+    return (_mm256_movemask_ps(_mm256_castsi256_ps(m_value)) & (1 << i)) != 0;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
   operator||(basic_simd_mask const& other) const {
@@ -534,33 +374,6 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   __m256i m_value;
 
  public:
-  class reference {
-    __m256i& m_mask;
-    int m_lane;
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __m256i bit_mask() const {
-      return _mm256_setr_epi64x(
-          -std::int64_t(m_lane == 0), -std::int64_t(m_lane == 1),
-          -std::int64_t(m_lane == 2), -std::int64_t(m_lane == 3));
-    }
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(__m256i& mask_arg,
-                                                    int lane_arg)
-        : m_mask(mask_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(bool value) const {
-      if (value) {
-        m_mask = _mm256_or_si256(bit_mask(), m_mask);
-      } else {
-        m_mask = _mm256_andnot_si256(bit_mask(), m_mask);
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      return (_mm256_movemask_pd(_mm256_castsi256_pd(m_mask)) &
-              (1 << m_lane)) != 0;
-    }
-  };
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
@@ -592,13 +405,9 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return static_cast<value_type>(
-        reference(const_cast<__m256i&>(m_value), int(i)));
+    return (_mm256_movemask_pd(_mm256_castsi256_pd(m_value)) & (1 << i)) != 0;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
   operator||(basic_simd_mask const& other) const {
@@ -628,33 +437,6 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   __m256i m_value;
 
  public:
-  class reference {
-    __m256i& m_mask;
-    int m_lane;
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __m256i bit_mask() const {
-      return _mm256_setr_epi64x(
-          -std::int64_t(m_lane == 0), -std::int64_t(m_lane == 1),
-          -std::int64_t(m_lane == 2), -std::int64_t(m_lane == 3));
-    }
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(__m256i& mask_arg,
-                                                    int lane_arg)
-        : m_mask(mask_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(bool value) const {
-      if (value) {
-        m_mask = _mm256_or_si256(bit_mask(), m_mask);
-      } else {
-        m_mask = _mm256_andnot_si256(bit_mask(), m_mask);
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      return (_mm256_movemask_pd(_mm256_castsi256_pd(m_mask)) &
-              (1 << m_lane)) != 0;
-    }
-  };
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
@@ -686,13 +468,9 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return static_cast<value_type>(
-        reference(const_cast<__m256i&>(m_value), int(i)));
+    return (_mm256_movemask_pd(_mm256_castsi256_pd(m_value)) & (1 << i)) != 0;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
   operator||(basic_simd_mask const& other) const {
@@ -731,7 +509,6 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
   using value_type = double;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -761,12 +538,11 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
                                gen(std::integral_constant<std::size_t, 2>()),
                                gen(std::integral_constant<std::size_t, 3>()))) {
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
+    value_type tmp[size()];
+    _mm256_storeu_pd(tmp, m_value);
+    return tmp[i];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1011,7 +787,6 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
   using value_type = float;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -1039,12 +814,11 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m128 const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
+    auto index = _mm_cvtsi32_si128(i);
+    auto tmp   = _mm_permutevar_ps(m_value, index);
+    return _mm_cvtss_f32(tmp);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1272,7 +1046,6 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
   using value_type = float;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -1305,12 +1078,11 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256 const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
+    auto index = _mm256_set1_epi32(i);
+    auto tmp   = _mm256_permutevar8x32_ps(m_value, index);
+    return _mm256_cvtss_f32(tmp);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1544,7 +1316,6 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -1576,12 +1347,18 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other);
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
+    switch (i) {
+      case 0: return _mm_extract_epi32(m_value, 0x0);
+      case 1: return _mm_extract_epi32(m_value, 0x1);
+      case 2: return _mm_extract_epi32(m_value, 0x2);
+      case 3: return _mm_extract_epi32(m_value, 0x3);
+      default:
+        Kokkos::Impl::throw_runtime_exception(
+            std::string("Index out of bound"));
+        break;
+    }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1590,7 +1367,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
 #ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
     m_value = _mm_loadu_si128(reinterpret_cast<__m128i const*>(ptr));
 #else
-    m_value = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask_type(true)));
+    m_value    = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask_type(true)));
 #endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
@@ -1599,7 +1376,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
 #ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
     m_value = _mm_load_si128(reinterpret_cast<__m128i const*>(ptr));
 #else
-    m_value = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask_type(true)));
+    m_value    = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask_type(true)));
 #endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
@@ -1751,7 +1528,6 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -1785,12 +1561,18 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256i const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
+// _mm256_cvtsi256_si32 was not added in GCC until 11
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
+    value_type tmp[size()];
+    _mm256_maskstore_epi32(tmp, static_cast<__m256i>(mask_type(true)), m_value);
+    return tmp[i];
+#else
+    auto index = _mm256_set1_epi32(i);
+    auto tmp   = _mm256_permutevar8x32_epi32(m_value, index);
+    return _mm256_cvtsi256_si32(tmp);
+#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1962,7 +1744,6 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   using value_type = std::int64_t;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -1997,12 +1778,18 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
       basic_simd<std::int32_t, abi_type> const& other)
       : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
+    switch (i) {
+      case 0: return _mm256_extract_epi64(m_value, 0x0);
+      case 1: return _mm256_extract_epi64(m_value, 0x1);
+      case 2: return _mm256_extract_epi64(m_value, 0x2);
+      case 3: return _mm256_extract_epi64(m_value, 0x3);
+      default:
+        Kokkos::Impl::throw_runtime_exception(
+            std::string("Index out of bound"));
+        break;
+    }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -2187,7 +1974,6 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   using value_type = std::uint64_t;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -2224,12 +2010,18 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int64_t, abi_type> const& other)
       : m_value(static_cast<__m256i>(other)) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
+    switch (i) {
+      case 0: return _mm256_extract_epi64(m_value, 0x0);
+      case 1: return _mm256_extract_epi64(m_value, 0x1);
+      case 2: return _mm256_extract_epi64(m_value, 0x2);
+      case 3: return _mm256_extract_epi64(m_value, 0x3);
+      default:
+        Kokkos::Impl::throw_runtime_exception(
+            std::string("Index out of bound"));
+        break;
+    }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -2388,9 +2180,11 @@ namespace Experimental {
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
     basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other) {
+  std::int32_t arr[4];
   for (std::size_t i = 0; i < 4; ++i) {
-    (*this)[i] = std::int32_t(other[i]);
+    arr[i] = std::int32_t(other[i]);
   }
+  this->copy_from(arr, element_aligned_tag{});
 }
 
 template <>

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -45,30 +45,6 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<8>> {
   __mmask8 m_value;
 
  public:
-  class reference {
-    __mmask8& m_mask;
-    int m_lane;
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __mmask8 bit_mask() const {
-      return __mmask8(std::int16_t(1 << m_lane));
-    }
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(__mmask8& mask_arg,
-                                                    int lane_arg)
-        : m_mask(mask_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(bool value) const {
-      if (value) {
-        m_mask |= bit_mask();
-      } else {
-        m_mask &= ~bit_mask();
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      return (m_mask & bit_mask()) != 0;
-    }
-  };
   using value_type                                        = bool;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
@@ -85,22 +61,30 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<8>> {
                 bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(G&& gen)
       : m_value(false) {
-    reference(m_value, int(0)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 0>()));
-    reference(m_value, int(1)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 1>()));
-    reference(m_value, int(2)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 2>()));
-    reference(m_value, int(3)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 3>()));
-    reference(m_value, int(4)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 4>()));
-    reference(m_value, int(5)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 5>()));
-    reference(m_value, int(6)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 6>()));
-    reference(m_value, int(7)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 7>()));
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 0>())))
+                  ? m_value | 0x01
+                  : m_value;
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 1>())))
+                  ? m_value | 0x02
+                  : m_value;
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 2>())))
+                  ? m_value | 0x04
+                  : m_value;
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 3>())))
+                  ? m_value | 0x08
+                  : m_value;
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 4>())))
+                  ? m_value | 0x10
+                  : m_value;
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 5>())))
+                  ? m_value | 0x20
+                  : m_value;
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 6>())))
+                  ? m_value | 0x40
+                  : m_value;
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 7>())))
+                  ? m_value | 0x80
+                  : m_value;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
@@ -111,9 +95,6 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __mmask8()
       const {
     return m_value;
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
@@ -148,30 +129,6 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<16>> {
   __mmask16 m_value;
 
  public:
-  class reference {
-    __mmask16& m_mask;
-    int m_lane;
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __mmask16 bit_mask() const {
-      return __mmask16(std::int32_t(1 << m_lane));
-    }
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(__mmask16& mask_arg,
-                                                    int lane_arg)
-        : m_mask(mask_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(bool value) const {
-      if (value) {
-        m_mask |= bit_mask();
-      } else {
-        m_mask &= ~bit_mask();
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      return (m_mask & bit_mask()) != 0;
-    }
-  };
   using value_type                                        = bool;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
@@ -188,38 +145,60 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<16>> {
                 bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(G&& gen)
       : m_value(false) {
-    reference(m_value, int(0)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 0>()));
-    reference(m_value, int(1)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 1>()));
-    reference(m_value, int(2)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 2>()));
-    reference(m_value, int(3)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 3>()));
-    reference(m_value, int(4)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 4>()));
-    reference(m_value, int(5)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 5>()));
-    reference(m_value, int(6)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 6>()));
-    reference(m_value, int(7)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 7>()));
-    reference(m_value, int(8)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 8>()));
-    reference(m_value, int(9)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 9>()));
-    reference(m_value, int(10)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 10>()));
-    reference(m_value, int(11)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 11>()));
-    reference(m_value, int(12)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 12>()));
-    reference(m_value, int(13)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 13>()));
-    reference(m_value, int(14)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 14>()));
-    reference(m_value, int(15)) =
-        static_cast<bool>(gen(std::integral_constant<std::size_t, 15>()));
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 0>())))
+                  ? m_value | 0x0001
+                  : m_value;
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 1>())))
+                  ? m_value | 0x0002
+                  : m_value;
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 2>())))
+                  ? m_value | 0x0004
+                  : m_value;
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 3>())))
+                  ? m_value | 0x0008
+                  : m_value;
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 4>())))
+                  ? m_value | 0x0010
+                  : m_value;
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 5>())))
+                  ? m_value | 0x0020
+                  : m_value;
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 6>())))
+                  ? m_value | 0x0040
+                  : m_value;
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 7>())))
+                  ? m_value | 0x0080
+                  : m_value;
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 8>())))
+                  ? m_value | 0x0100
+                  : m_value;
+    m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 9>())))
+                  ? m_value | 0x0200
+                  : m_value;
+    m_value =
+        (static_cast<bool>(gen(std::integral_constant<std::size_t, 10>())))
+            ? m_value | 0x0400
+            : m_value;
+    m_value =
+        (static_cast<bool>(gen(std::integral_constant<std::size_t, 11>())))
+            ? m_value | 0x0800
+            : m_value;
+    m_value =
+        (static_cast<bool>(gen(std::integral_constant<std::size_t, 12>())))
+            ? m_value | 0x1000
+            : m_value;
+    m_value =
+        (static_cast<bool>(gen(std::integral_constant<std::size_t, 13>())))
+            ? m_value | 0x2000
+            : m_value;
+    m_value =
+        (static_cast<bool>(gen(std::integral_constant<std::size_t, 14>())))
+            ? m_value | 0x4000
+            : m_value;
+    m_value =
+        (static_cast<bool>(gen(std::integral_constant<std::size_t, 15>())))
+            ? m_value | 0x8000
+            : m_value;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 16;
@@ -230,9 +209,6 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<16>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __mmask16()
       const {
     return m_value;
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
@@ -270,7 +246,6 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
   using value_type = double;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -306,12 +281,11 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
                                gen(std::integral_constant<std::size_t, 6>()),
                                gen(std::integral_constant<std::size_t, 7>()))) {
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
+    auto index = _mm512_set1_epi32(i);
+    auto tmp   = _mm512_permutexvar_pd(index, m_value);
+    return _mm512_cvtsd_f64(tmp);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -564,7 +538,6 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
   using value_type = float;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -597,12 +570,11 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
                                gen(std::integral_constant<std::size_t, 6>()),
                                gen(std::integral_constant<std::size_t, 7>()))) {
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
+    auto index = _mm256_set1_epi32(i);
+    auto tmp   = _mm256_permutexvar_ps(index, m_value);
+    return _mm256_cvtss_f32(tmp);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -832,7 +804,6 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
   using value_type = float;
   using abi_type   = simd_abi::avx512_fixed_size<16>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -873,12 +844,11 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
                            gen(std::integral_constant<std::size_t, 13>()),
                            gen(std::integral_constant<std::size_t, 14>()),
                            gen(std::integral_constant<std::size_t, 15>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
+    auto index = _mm512_set1_epi32(i);
+    auto tmp   = _mm512_permutexvar_ps(index, m_value);
+    return _mm512_cvtss_f32(tmp);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1107,7 +1077,6 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -1145,12 +1114,19 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
+// _mm256_cvtsi256_si32 was not added in GCC until 11
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
+    value_type tmp[size()];
+    _mm256_mask_storeu_epi32(tmp, static_cast<__mmask8>(mask_type(true)),
+                             m_value);
+    return tmp[i];
+#else
+    auto index = _mm256_set1_epi32(i);
+    auto tmp   = _mm256_permutevar8x32_epi32(m_value, index);
+    return _mm256_cvtsi256_si32(tmp);
+#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1317,7 +1293,6 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx512_fixed_size<16>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -1363,12 +1338,19 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
             gen(std::integral_constant<std::size_t, 13>()),
             gen(std::integral_constant<std::size_t, 14>()),
             gen(std::integral_constant<std::size_t, 15>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
+// _mm512_cvtsi512_si32 was not added in GCC until 11
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
+    value_type tmp[size()];
+    _mm512_mask_store_epi32(tmp, static_cast<__mmask16>(mask_type(true)),
+                            m_value);
+    return tmp[i];
+#else
+    auto index = _mm512_set1_epi32(i);
+    auto tmp   = _mm512_permutexvar_epi32(index, m_value);
+    return _mm512_cvtsi512_si32(tmp);
+#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
@@ -1536,7 +1518,6 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
   using value_type = std::uint32_t;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -1576,12 +1557,19 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 5>()),
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
+// _mm256_cvtsi256_si32 was not added in GCC until 11
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
+    value_type tmp[size()];
+    _mm256_mask_storeu_epi32(tmp, static_cast<__mmask8>(mask_type(true)),
+                             m_value);
+    return tmp[i];
+#else
+    auto index = _mm256_set1_epi32(i);
+    auto tmp   = _mm256_permutevar8x32_epi32(m_value, index);
+    return _mm256_cvtsi256_si32(tmp);
+#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
@@ -1741,7 +1729,6 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
   using value_type = std::uint32_t;
   using abi_type   = simd_abi::avx512_fixed_size<16>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -1789,12 +1776,19 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
             gen(std::integral_constant<std::size_t, 13>()),
             gen(std::integral_constant<std::size_t, 14>()),
             gen(std::integral_constant<std::size_t, 15>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
+// _mm512_cvtsi512_si32 was not added in GCC until 11
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
+    value_type tmp[size()];
+    _mm512_mask_store_epi32(tmp, static_cast<__mmask16>(mask_type(true)),
+                            m_value);
+    return tmp[i];
+#else
+    auto index = _mm512_set1_epi32(i);
+    auto tmp   = _mm512_permutexvar_epi32(index, m_value);
+    return _mm512_cvtsi512_si32(tmp);
+#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1954,7 +1948,6 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
   using value_type = std::int64_t;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -1995,12 +1988,11 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
       __m512i const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
+    value_type tmp[size()];
+    _mm512_storeu_si512(tmp, m_value);
+    return tmp[i];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -2166,7 +2158,6 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   using value_type = std::uint64_t;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -2209,12 +2200,11 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int64_t, abi_type> const& other)
       : m_value(static_cast<__m512i>(other)) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
+    value_type tmp[size()];
+    _mm512_storeu_si512(tmp, m_value);
+    return tmp[i];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -1343,8 +1343,8 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
 // _mm512_cvtsi512_si32 was not added in GCC until 11
 #if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
     value_type tmp[size()];
-    _mm512_mask_store_epi32(tmp, static_cast<__mmask16>(mask_type(true)),
-                            m_value);
+    _mm512_mask_storeu_epi32(tmp, static_cast<__mmask16>(mask_type(true)),
+                             m_value);
     return tmp[i];
 #else
     auto index = _mm512_set1_epi32(i);
@@ -1781,8 +1781,8 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
 // _mm512_cvtsi512_si32 was not added in GCC until 11
 #if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
     value_type tmp[size()];
-    _mm512_mask_store_epi32(tmp, static_cast<__mmask16>(mask_type(true)),
-                            m_value);
+    _mm512_mask_storeu_epi32(tmp, static_cast<__mmask16>(mask_type(true)),
+                             m_value);
     return tmp[i];
 #else
     auto index = _mm512_set1_epi32(i);

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -50,38 +50,6 @@ class neon_mask<Derived, 64, 2> {
   uint64x2_t m_value;
 
  public:
-  class reference {
-    uint64x2_t& m_mask;
-    int m_lane;
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(uint64x2_t& mask_arg,
-                                                    int lane_arg)
-        : m_mask(mask_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(bool value) const {
-      // this switch statement is needed because the lane argument has to be a
-      // constant
-      switch (m_lane) {
-        case 0:
-          m_mask = vsetq_lane_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0, m_mask, 0);
-          break;
-        case 1:
-          m_mask = vsetq_lane_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0, m_mask, 1);
-          break;
-        default: Kokkos::abort("unreachable");
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      switch (m_lane) {
-        case 0: return vgetq_lane_u64(m_mask, 0) != 0;
-        case 1: return vgetq_lane_u64(m_mask, 1) != 0;
-        default: Kokkos::abort("unreachable");
-      }
-      return false;
-    }
-  };
   using value_type          = bool;
   using abi_type            = simd_abi::neon_fixed_size<2>;
   using implementation_type = uint64x2_t;
@@ -124,13 +92,13 @@ class neon_mask<Derived, 64, 2> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return static_cast<value_type>(
-        reference(const_cast<uint64x2_t&>(m_value), int(i)));
+    switch (i) {
+      case 0: return vgetq_lane_u64(m_value, 0) != 0;
+      case 1: return vgetq_lane_u64(m_value, 1) != 0;
+    }
+    return false;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Derived
   operator||(neon_mask const& other) const {
@@ -165,36 +133,6 @@ class neon_mask<Derived, 32, 2> {
   uint32x2_t m_value;
 
  public:
-  class reference {
-    uint32x2_t& m_mask;
-    int m_lane;
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(uint32x2_t& mask_arg,
-                                                    int lane_arg)
-        : m_mask(mask_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(bool value) const {
-      switch (m_lane) {
-        case 0:
-          m_mask = vset_lane_u32(value ? 0xFFFFFFFFU : 0, m_mask, 0);
-          break;
-        case 1:
-          m_mask = vset_lane_u32(value ? 0xFFFFFFFFU : 0, m_mask, 1);
-          break;
-        default: Kokkos::abort("unreachable");
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      switch (m_lane) {
-        case 0: return vget_lane_u32(m_mask, 0) != 0;
-        case 1: return vget_lane_u32(m_mask, 1) != 0;
-        default: Kokkos::abort("unreachable");
-      }
-      return false;
-    }
-  };
   using value_type          = bool;
   using abi_type            = simd_abi::neon_fixed_size<2>;
   using implementation_type = uint32x2_t;
@@ -233,13 +171,13 @@ class neon_mask<Derived, 32, 2> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return static_cast<value_type>(
-        reference(const_cast<uint32x2_t&>(m_value), int(i)));
+    switch (i) {
+      case 0: return vget_lane_u32(m_value, 0) != 0;
+      case 1: return vget_lane_u32(m_value, 1) != 0;
+    }
+    return false;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Derived
   operator||(neon_mask const& other) const {
@@ -272,44 +210,6 @@ class neon_mask<Derived, 32, 4> {
   uint32x4_t m_value;
 
  public:
-  class reference {
-    uint32x4_t& m_mask;
-    int m_lane;
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(uint32x4_t& mask_arg,
-                                                    int lane_arg)
-        : m_mask(mask_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(bool value) const {
-      switch (m_lane) {
-        case 0:
-          m_mask = vsetq_lane_u32(value ? 0xFFFFFFFFU : 0, m_mask, 0);
-          break;
-        case 1:
-          m_mask = vsetq_lane_u32(value ? 0xFFFFFFFFU : 0, m_mask, 1);
-          break;
-        case 2:
-          m_mask = vsetq_lane_u32(value ? 0xFFFFFFFFU : 0, m_mask, 2);
-          break;
-        case 3:
-          m_mask = vsetq_lane_u32(value ? 0xFFFFFFFFU : 0, m_mask, 3);
-          break;
-        default: Kokkos::abort("unreachable");
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      switch (m_lane) {
-        case 0: return vgetq_lane_u32(m_mask, 0) != 0;
-        case 1: return vgetq_lane_u32(m_mask, 1) != 0;
-        case 2: return vgetq_lane_u32(m_mask, 2) != 0;
-        case 3: return vgetq_lane_u32(m_mask, 3) != 0;
-        default: Kokkos::abort("unreachable");
-      }
-      return false;
-    }
-  };
   using value_type          = bool;
   using abi_type            = simd_abi::neon_fixed_size<4>;
   using implementation_type = uint32x4_t;
@@ -346,13 +246,15 @@ class neon_mask<Derived, 32, 4> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return static_cast<value_type>(
-        reference(const_cast<uint32x4_t&>(m_value), int(i)));
+    switch (i) {
+      case 0: return vgetq_lane_u32(m_value, 0) != 0;
+      case 1: return vgetq_lane_u32(m_value, 1) != 0;
+      case 2: return vgetq_lane_u32(m_value, 2) != 0;
+      case 3: return vgetq_lane_u32(m_value, 3) != 0;
+    }
+    return false;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Derived
   operator||(neon_mask const& other) const {
@@ -450,32 +352,6 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
   using value_type = double;
   using abi_type   = simd_abi::neon_fixed_size<2>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  class reference {
-    float64x2_t& m_value;
-    int m_lane;
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(float64x2_t& mask_arg,
-                                                    int lane_arg)
-        : m_value(mask_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(double value) const {
-      switch (m_lane) {
-        case 0: m_value = vsetq_lane_f64(value, m_value, 0); break;
-        case 1: m_value = vsetq_lane_f64(value, m_value, 1); break;
-        default: Kokkos::abort("unreachable");
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator double() const {
-      switch (m_lane) {
-        case 0: return vgetq_lane_f64(m_value, 0);
-        case 1: return vgetq_lane_f64(m_value, 1);
-        default: Kokkos::abort("unreachable");
-      }
-      return 0;
-    }
-  };
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -507,12 +383,16 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       float64x2_t const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reference(const_cast<basic_simd*>(this)->m_value, int(i));
+    switch (i) {
+      case 0: return vgetq_lane_f64(m_value, 0);
+      case 1: return vgetq_lane_f64(m_value, 1);
+      default:
+        Kokkos::Impl::throw_runtime_exception(
+            std::string("Index out of bound"));
+        break;
+    }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -719,32 +599,6 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
   using value_type = float;
   using abi_type   = simd_abi::neon_fixed_size<2>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  class reference {
-    float32x2_t& m_value;
-    int m_lane;
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(float32x2_t& value_arg,
-                                                    int lane_arg)
-        : m_value(value_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(float value) const {
-      switch (m_lane) {
-        case 0: m_value = vset_lane_f32(value, m_value, 0); break;
-        case 1: m_value = vset_lane_f32(value, m_value, 1); break;
-        default: Kokkos::abort("unreachable");
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator float() const {
-      switch (m_lane) {
-        case 0: return vget_lane_f32(m_value, 0);
-        case 1: return vget_lane_f32(m_value, 1);
-        default: Kokkos::abort("unreachable");
-      }
-      return 0;
-    }
-  };
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -773,12 +627,16 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       float32x2_t const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reference(const_cast<basic_simd*>(this)->m_value, int(i));
+    switch (i) {
+      case 0: return vget_lane_f32(m_value, 0);
+      case 1: return vget_lane_f32(m_value, 1);
+      default:
+        Kokkos::Impl::throw_runtime_exception(
+            std::string("Index out of bound"));
+        break;
+    }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -974,36 +832,6 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
   using value_type = float;
   using abi_type   = simd_abi::neon_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  class reference {
-    float32x4_t& m_value;
-    int m_lane;
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(float32x4_t& value_arg,
-                                                    int lane_arg)
-        : m_value(value_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(float value) const {
-      switch (m_lane) {
-        case 0: m_value = vsetq_lane_f32(value, m_value, 0); break;
-        case 1: m_value = vsetq_lane_f32(value, m_value, 1); break;
-        case 2: m_value = vsetq_lane_f32(value, m_value, 2); break;
-        case 3: m_value = vsetq_lane_f32(value, m_value, 3); break;
-        default: Kokkos::abort("unreachable");
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator float() const {
-      switch (m_lane) {
-        case 0: return vgetq_lane_f32(m_value, 0);
-        case 1: return vgetq_lane_f32(m_value, 1);
-        case 2: return vgetq_lane_f32(m_value, 2);
-        case 3: return vgetq_lane_f32(m_value, 3);
-        default: Kokkos::abort("unreachable");
-      }
-      return 0;
-    }
-  };
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -1036,12 +864,19 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       float32x4_t const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reference(const_cast<basic_simd*>(this)->m_value, int(i));
+    switch (i) {
+      case 0: return vgetq_lane_f32(m_value, 0);
+      case 1: return vgetq_lane_f32(m_value, 1);
+      case 2: return vgetq_lane_f32(m_value, 2);
+      case 3: return vgetq_lane_f32(m_value, 3);
+      default:
+
+        Kokkos::Impl::throw_runtime_exception(
+            std::string("Index out of bound"));
+        break;
+    }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1237,32 +1072,6 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
   using value_type = std::int32_t;
   using abi_type   = simd_abi::neon_fixed_size<2>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  class reference {
-    int32x2_t& m_value;
-    int m_lane;
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(int32x2_t& value_arg,
-                                                    int lane_arg)
-        : m_value(value_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(std::int32_t value) const {
-      switch (m_lane) {
-        case 0: m_value = vset_lane_s32(value, m_value, 0); break;
-        case 1: m_value = vset_lane_s32(value, m_value, 1); break;
-        default: Kokkos::abort("unreachable");
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator std::int32_t() const {
-      switch (m_lane) {
-        case 0: return vget_lane_s32(m_value, 0);
-        case 1: return vget_lane_s32(m_value, 1);
-        default: Kokkos::abort("unreachable");
-      }
-      return 0;
-    }
-  };
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -1294,12 +1103,16 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other);
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reference(const_cast<basic_simd*>(this)->m_value, int(i));
+    switch (i) {
+      case 0: return vget_lane_s32(m_value, 0);
+      case 1: return vget_lane_s32(m_value, 1);
+      default:
+        Kokkos::Impl::throw_runtime_exception(
+            std::string("Index out of bound"));
+        break;
+    }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1454,36 +1267,6 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
   using value_type = std::int32_t;
   using abi_type   = simd_abi::neon_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  class reference {
-    int32x4_t& m_value;
-    int m_lane;
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(int32x4_t& value_arg,
-                                                    int lane_arg)
-        : m_value(value_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(std::int32_t value) const {
-      switch (m_lane) {
-        case 0: m_value = vsetq_lane_s32(value, m_value, 0); break;
-        case 1: m_value = vsetq_lane_s32(value, m_value, 1); break;
-        case 2: m_value = vsetq_lane_s32(value, m_value, 2); break;
-        case 3: m_value = vsetq_lane_s32(value, m_value, 3); break;
-        default: Kokkos::abort("unreachable");
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator std::int32_t() const {
-      switch (m_lane) {
-        case 0: return vgetq_lane_s32(m_value, 0);
-        case 1: return vgetq_lane_s32(m_value, 1);
-        case 2: return vgetq_lane_s32(m_value, 2);
-        case 3: return vgetq_lane_s32(m_value, 3);
-        default: Kokkos::abort("unreachable");
-      }
-      return 0;
-    }
-  };
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -1519,12 +1302,18 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other);
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reference(const_cast<basic_simd*>(this)->m_value, int(i));
+    switch (i) {
+      case 0: return vgetq_lane_s32(m_value, 0);
+      case 1: return vgetq_lane_s32(m_value, 1);
+      case 2: return vgetq_lane_s32(m_value, 2);
+      case 3: return vgetq_lane_s32(m_value, 3);
+      default:
+        Kokkos::Impl::throw_runtime_exception(
+            std::string("Index out of bound"));
+        break;
+    }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1679,32 +1468,6 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
   using value_type = std::int64_t;
   using abi_type   = simd_abi::neon_fixed_size<2>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  class reference {
-    int64x2_t& m_value;
-    int m_lane;
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(int64x2_t& value_arg,
-                                                    int lane_arg)
-        : m_value(value_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(std::int64_t value) const {
-      switch (m_lane) {
-        case 0: m_value = vsetq_lane_s64(value, m_value, 0); break;
-        case 1: m_value = vsetq_lane_s64(value, m_value, 1); break;
-        default: Kokkos::abort("unreachable");
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator std::int64_t() const {
-      switch (m_lane) {
-        case 0: return vgetq_lane_s64(m_value, 0);
-        case 1: return vgetq_lane_s64(m_value, 1);
-        default: Kokkos::abort("unreachable");
-      }
-      return 0;
-    }
-  };
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -1736,12 +1499,16 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const&);
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reference(const_cast<basic_simd*>(this)->m_value, int(i));
+    switch (i) {
+      case 0: return vgetq_lane_s64(m_value, 0);
+      case 1: return vgetq_lane_s64(m_value, 1);
+      default:
+        Kokkos::Impl::throw_runtime_exception(
+            std::string("Index out of bound"));
+        break;
+    }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1895,32 +1662,6 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   using value_type = std::uint64_t;
   using abi_type   = simd_abi::neon_fixed_size<2>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  class reference {
-    uint64x2_t& m_value;
-    int m_lane;
-
-   public:
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(uint64x2_t& value_arg,
-                                                    int lane_arg)
-        : m_value(value_arg), m_lane(lane_arg) {}
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
-    operator=(std::uint64_t value) const {
-      switch (m_lane) {
-        case 0: m_value = vsetq_lane_u64(value, m_value, 0); break;
-        case 1: m_value = vsetq_lane_u64(value, m_value, 1); break;
-        default: Kokkos::abort("unreachable");
-      }
-      return *this;
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator std::uint64_t() const {
-      switch (m_lane) {
-        case 0: return vgetq_lane_u64(m_value, 0);
-        case 1: return vgetq_lane_u64(m_value, 1);
-        default: Kokkos::abort("unreachable");
-      }
-      return 0;
-    }
-  };
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
@@ -1954,12 +1695,16 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
       basic_simd<std::int32_t, abi_type> const& other)
       : m_value(
             vreinterpretq_u64_s64(vmovl_s32(static_cast<int32x2_t>(other)))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reference(m_value, int(i));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reference(const_cast<basic_simd*>(this)->m_value, int(i));
+    switch (i) {
+      case 0: return vgetq_lane_u64(m_value, 0);
+      case 1: return vgetq_lane_u64(m_value, 1);
+      default:
+        Kokkos::Impl::throw_runtime_exception(
+            std::string("Index out of bound"));
+        break;
+    }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -75,8 +75,8 @@ class neon_mask<Derived, 64, 2> {
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(
       neon_mask<U, 32, 2> const& other) {
-    operator[](0) = bool(other[0]);
-    operator[](1) = bool(other[1]);
+    m_value = vsetq_lane_u64( (other[0] ? 0xFFFFFFFFFFFFFFFFULL : 0), m_value, 0);
+    m_value = vsetq_lane_u64( (other[1] ? 0xFFFFFFFFFFFFFFFFULL : 0), m_value, 1);
   }
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(
@@ -1904,20 +1904,17 @@ class where_expression<basic_simd_mask<double, simd_abi::neon_fixed_size<2>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, element_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, vector_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       double const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
-    if (m_mask[0]) m_value[0] = mem[index[0]];
-    if (m_mask[1]) m_value[1] = mem[index[1]];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[index[i]] : m_value[i]; });
   }
   template <
       class U,
@@ -1994,19 +1991,16 @@ class where_expression<basic_simd_mask<float, simd_abi::neon_fixed_size<2>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   void copy_from(float const* mem, vector_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
-    if (m_mask[0]) m_value[0] = mem[index[0]];
-    if (m_mask[1]) m_value[1] = mem[index[1]];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[index[i]] : m_value[i]; });
   }
   template <
       class U,
@@ -2089,26 +2083,17 @@ class where_expression<basic_simd_mask<float, simd_abi::neon_fixed_size<4>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
-    if (m_mask[2]) m_value[2] = mem[2];
-    if (m_mask[3]) m_value[3] = mem[3];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, vector_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
-    if (m_mask[2]) m_value[2] = mem[2];
-    if (m_mask[3]) m_value[3] = mem[3];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) {
-    if (m_mask[0]) m_value[0] = mem[index[0]];
-    if (m_mask[1]) m_value[1] = mem[index[1]];
-    if (m_mask[2]) m_value[2] = mem[index[2]];
-    if (m_mask[3]) m_value[3] = mem[index[3]];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[index[i]] : m_value[i]; });
   }
   template <
       class U,
@@ -2188,21 +2173,18 @@ class where_expression<
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, vector_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
-    if (m_mask[0]) m_value[0] = mem[index[0]];
-    if (m_mask[1]) m_value[1] = mem[index[1]];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[index[i]] : m_value[i]; });
   }
 
   template <class U,
@@ -2288,26 +2270,17 @@ class where_expression<
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
-    if (m_mask[2]) m_value[2] = mem[2];
-    if (m_mask[3]) m_value[3] = mem[3];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, vector_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
-    if (m_mask[2]) m_value[2] = mem[2];
-    if (m_mask[3]) m_value[3] = mem[3];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) {
-    if (m_mask[0]) m_value[0] = mem[index[0]];
-    if (m_mask[1]) m_value[1] = mem[index[1]];
-    if (m_mask[2]) m_value[2] = mem[index[2]];
-    if (m_mask[3]) m_value[3] = mem[index[3]];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[index[i]] : m_value[i]; });
   }
   template <class U,
             std::enable_if_t<
@@ -2387,21 +2360,18 @@ class where_expression<
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int64_t const* mem, element_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int64_t const* mem, vector_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int64_t const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
-    if (m_mask[0]) m_value[0] = mem[index[0]];
-    if (m_mask[1]) m_value[1] = mem[index[1]];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[index[i]] : m_value[i]; });
   }
 
   template <class U,
@@ -2483,21 +2453,18 @@ class where_expression<
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::uint64_t const* mem, element_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::uint64_t const* mem, vector_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint64_t const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
-    if (m_mask[0]) m_value[0] = mem[index[0]];
-    if (m_mask[1]) m_value[1] = mem[index[1]];
+    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[index[i]] : m_value[i]; });
   }
 
   template <class U,

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -390,10 +390,7 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
     switch (i) {
       case 0: return vgetq_lane_f64(m_value, 0);
       case 1: return vgetq_lane_f64(m_value, 1);
-      default:
-        Kokkos::Impl::throw_runtime_exception(
-            std::string("Index out of bound"));
-        break;
+      default: Kokkos::abort("Index out of bound"); break;
     }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
@@ -634,10 +631,7 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
     switch (i) {
       case 0: return vget_lane_f32(m_value, 0);
       case 1: return vget_lane_f32(m_value, 1);
-      default:
-        Kokkos::Impl::throw_runtime_exception(
-            std::string("Index out of bound"));
-        break;
+      default: Kokkos::abort("Index out of bound"); break;
     }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
@@ -873,11 +867,7 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
       case 1: return vgetq_lane_f32(m_value, 1);
       case 2: return vgetq_lane_f32(m_value, 2);
       case 3: return vgetq_lane_f32(m_value, 3);
-      default:
-
-        Kokkos::Impl::throw_runtime_exception(
-            std::string("Index out of bound"));
-        break;
+      default: Kokkos::abort("Index out of bound"); break;
     }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
@@ -1110,10 +1100,7 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
     switch (i) {
       case 0: return vget_lane_s32(m_value, 0);
       case 1: return vget_lane_s32(m_value, 1);
-      default:
-        Kokkos::Impl::throw_runtime_exception(
-            std::string("Index out of bound"));
-        break;
+      default: Kokkos::abort("Index out of bound"); break;
     }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
@@ -1311,10 +1298,7 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
       case 1: return vgetq_lane_s32(m_value, 1);
       case 2: return vgetq_lane_s32(m_value, 2);
       case 3: return vgetq_lane_s32(m_value, 3);
-      default:
-        Kokkos::Impl::throw_runtime_exception(
-            std::string("Index out of bound"));
-        break;
+      default: Kokkos::abort("Index out of bound"); break;
     }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
@@ -1506,10 +1490,7 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
     switch (i) {
       case 0: return vgetq_lane_s64(m_value, 0);
       case 1: return vgetq_lane_s64(m_value, 1);
-      default:
-        Kokkos::Impl::throw_runtime_exception(
-            std::string("Index out of bound"));
-        break;
+      default: Kokkos::abort("Index out of bound"); break;
     }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
@@ -1702,10 +1683,7 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
     switch (i) {
       case 0: return vgetq_lane_u64(m_value, 0);
       case 1: return vgetq_lane_u64(m_value, 1);
-      default:
-        Kokkos::Impl::throw_runtime_exception(
-            std::string("Index out of bound"));
-        break;
+      default: Kokkos::abort("Index out of bound"); break;
     }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -75,8 +75,10 @@ class neon_mask<Derived, 64, 2> {
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(
       neon_mask<U, 32, 2> const& other) {
-    m_value = vsetq_lane_u64( (other[0] ? 0xFFFFFFFFFFFFFFFFULL : 0), m_value, 0);
-    m_value = vsetq_lane_u64( (other[1] ? 0xFFFFFFFFFFFFFFFFULL : 0), m_value, 1);
+    m_value =
+        vsetq_lane_u64((other[0] ? 0xFFFFFFFFFFFFFFFFULL : 0), m_value, 0);
+    m_value =
+        vsetq_lane_u64((other[1] ? 0xFFFFFFFFFFFFFFFFULL : 0), m_value, 1);
   }
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(
@@ -1904,17 +1906,21 @@ class where_expression<basic_simd_mask<double, simd_abi::neon_fixed_size<2>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, element_aligned_tag) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type(
+        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, vector_aligned_tag) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type(
+        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       double const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[index[i]] : m_value[i]; });
+    m_value = value_type([=](std::size_t i) {
+      return (m_mask[i]) ? mem[index[i]] : m_value[i];
+    });
   }
   template <
       class U,
@@ -1991,16 +1997,20 @@ class where_expression<basic_simd_mask<float, simd_abi::neon_fixed_size<2>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type(
+        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   void copy_from(float const* mem, vector_aligned_tag) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type(
+        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[index[i]] : m_value[i]; });
+    m_value = value_type([=](std::size_t i) {
+      return (m_mask[i]) ? mem[index[i]] : m_value[i];
+    });
   }
   template <
       class U,
@@ -2083,17 +2093,21 @@ class where_expression<basic_simd_mask<float, simd_abi::neon_fixed_size<4>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type(
+        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, vector_aligned_tag) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type(
+        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[index[i]] : m_value[i]; });
+    m_value = value_type([=](std::size_t i) {
+      return (m_mask[i]) ? mem[index[i]] : m_value[i];
+    });
   }
   template <
       class U,
@@ -2173,18 +2187,22 @@ class where_expression<
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type(
+        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, vector_aligned_tag) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type(
+        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[index[i]] : m_value[i]; });
+    m_value = value_type([=](std::size_t i) {
+      return (m_mask[i]) ? mem[index[i]] : m_value[i];
+    });
   }
 
   template <class U,
@@ -2270,17 +2288,21 @@ class where_expression<
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type(
+        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, vector_aligned_tag) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type(
+        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[index[i]] : m_value[i]; });
+    m_value = value_type([=](std::size_t i) {
+      return (m_mask[i]) ? mem[index[i]] : m_value[i];
+    });
   }
   template <class U,
             std::enable_if_t<
@@ -2360,18 +2382,22 @@ class where_expression<
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int64_t const* mem, element_aligned_tag) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type(
+        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int64_t const* mem, vector_aligned_tag) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type(
+        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int64_t const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[index[i]] : m_value[i]; });
+    m_value = value_type([=](std::size_t i) {
+      return (m_mask[i]) ? mem[index[i]] : m_value[i];
+    });
   }
 
   template <class U,
@@ -2453,18 +2479,22 @@ class where_expression<
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::uint64_t const* mem, element_aligned_tag) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type(
+        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::uint64_t const* mem, vector_aligned_tag) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type(
+        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint64_t const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
-    m_value = value_type([=](std::size_t i) { return (m_mask[i]) ? mem[index[i]] : m_value[i]; });
+    m_value = value_type([=](std::size_t i) {
+      return (m_mask[i]) ? mem[index[i]] : m_value[i];
+    });
   }
 
   template <class U,

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -45,7 +45,6 @@ class basic_simd_mask<T, simd_abi::scalar> {
   using value_type                            = bool;
   using simd_type                             = basic_simd<T, simd_abi::scalar>;
   using abi_type                              = simd_abi::scalar;
-  using reference                             = value_type&;
   KOKKOS_DEFAULTED_FUNCTION basic_simd_mask() = default;
   KOKKOS_FORCEINLINE_FUNCTION static constexpr std::size_t size() { return 1; }
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(value_type value)
@@ -63,9 +62,6 @@ class basic_simd_mask<T, simd_abi::scalar> {
       basic_simd_mask<U, simd_abi::scalar> const& other)
       : m_value(static_cast<bool>(other)) {}
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator bool() const {
-    return m_value;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION reference operator[](std::size_t) {
     return m_value;
   }
   KOKKOS_FORCEINLINE_FUNCTION value_type operator[](std::size_t) const {
@@ -100,7 +96,6 @@ class basic_simd<T, simd_abi::scalar> {
   using value_type                       = T;
   using abi_type                         = simd_abi::scalar;
   using mask_type                        = basic_simd_mask<T, abi_type>;
-  using reference                        = value_type&;
   KOKKOS_DEFAULTED_FUNCTION basic_simd() = default;
   KOKKOS_DEFAULTED_FUNCTION basic_simd(basic_simd const&)            = default;
   KOKKOS_DEFAULTED_FUNCTION basic_simd(basic_simd&&)                 = default;
@@ -139,10 +134,6 @@ class basic_simd<T, simd_abi::scalar> {
   }
   KOKKOS_FORCEINLINE_FUNCTION void copy_to(T* ptr, vector_aligned_tag) const {
     *ptr = m_value;
-  }
-
-  KOKKOS_FORCEINLINE_FUNCTION reference operator[](std::size_t) {
-    return m_value;
   }
   KOKKOS_FORCEINLINE_FUNCTION value_type operator[](std::size_t) const {
     return m_value;

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -53,10 +53,7 @@ inline void host_check_equality(
   }
   using mask_type =
       typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
-  mask_type mask(false);
-  for (std::size_t i = 0; i < nlanes; ++i) {
-    mask[i] = true;
-  }
+  mask_type mask([=](std::size_t i) { return (i < nlanes); });
   checker.equality((expected_result == computed_result) && mask, mask);
 }
 
@@ -71,10 +68,7 @@ KOKKOS_INLINE_FUNCTION void device_check_equality(
   }
   using mask_type =
       typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
-  mask_type mask(false);
-  for (std::size_t i = 0; i < nlanes; ++i) {
-    mask[i] = true;
-  }
+  mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return (i < nlanes); });
   checker.equality((expected_result == computed_result) && mask, mask);
 }
 
@@ -134,10 +128,7 @@ class load_masked {
                  Kokkos::Experimental::basic_simd<T, Abi>& result) const {
     using mask_type =
         typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
-    mask_type mask(false);
-    for (std::size_t i = 0; i < n; ++i) {
-      mask[i] = true;
-    }
+    mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return i < n; });
     result = T(0);
     where(mask, result).copy_from(mem, Kokkos::Experimental::simd_flag_default);
     return true;
@@ -148,10 +139,7 @@ class load_masked {
       Kokkos::Experimental::basic_simd<T, Abi>& result) const {
     using mask_type =
         typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
-    mask_type mask(false);
-    for (std::size_t i = 0; i < n; ++i) {
-      mask[i] = true;
-    }
+    mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return i < n; });
     where(mask, result).copy_from(mem, Kokkos::Experimental::simd_flag_default);
     where(!mask, result) = T(0);
     return true;
@@ -163,24 +151,20 @@ class load_as_scalars {
   template <class T, class Abi>
   bool host_load(T const* mem, std::size_t n,
                  Kokkos::Experimental::basic_simd<T, Abi>& result) const {
-    for (std::size_t i = 0; i < n; ++i) {
-      result[i] = mem[i];
-    }
-    for (std::size_t i = n; i < result.size(); ++i) {
-      result[i] = T(0);
-    }
+    Kokkos::Experimental::basic_simd<T, Abi> init(
+        KOKKOS_LAMBDA(std::size_t i) { return (i < n) ? mem[i] : T(0); });
+    result = init;
+
     return true;
   }
   template <class T, class Abi>
   KOKKOS_INLINE_FUNCTION bool device_load(
       T const* mem, std::size_t n,
       Kokkos::Experimental::basic_simd<T, Abi>& result) const {
-    for (std::size_t i = 0; i < n; ++i) {
-      result[i] = mem[i];
-    }
-    for (std::size_t i = n; i < result.size(); ++i) {
-      result[i] = T(0);
-    }
+    Kokkos::Experimental::basic_simd<T, Abi> init(
+        KOKKOS_LAMBDA(std::size_t i) { return (i < n) ? mem[i] : T(0); });
+
+    result = init;
     return true;
   }
 };

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -53,8 +53,13 @@ inline void host_check_equality(
   }
   using mask_type =
       typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
-  mask_type mask([=](std::size_t i) { return (i < nlanes); });
-  checker.equality((expected_result == computed_result) && mask, mask);
+  if constexpr (std::is_same_v<Abi, Kokkos::Experimental::simd_abi::scalar>) {
+    mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return (i < nlanes); });
+    checker.equality((expected_result == computed_result) && mask, mask);
+  } else {
+    mask_type mask([=](std::size_t i) { return (i < nlanes); });
+    checker.equality((expected_result == computed_result) && mask, mask);
+  }
 }
 
 template <class T, class Abi>

--- a/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
+++ b/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
@@ -29,12 +29,12 @@ inline void host_check_gen_ctor() {
 
     DataType init[lanes];
     DataType expected[lanes];
-    mask_type init_mask(false);
+    bool init_mask[lanes];
 
     for (std::size_t i = 0; i < lanes; ++i) {
-      if (i % 3 == 0) init_mask[i] = true;
-      init[i]     = 7;
-      expected[i] = (init_mask[i]) ? init[i] * 9 : init[i];
+      init_mask[i] = (i % 2 == 0);
+      init[i]      = i + 1;
+      expected[i]  = (init_mask[i]) ? init[i] * 10 : init[i];
     }
 
     simd_type rhs;
@@ -48,7 +48,7 @@ inline void host_check_gen_ctor() {
       simd_type basic(KOKKOS_LAMBDA(std::size_t i) { return init[i]; });
       host_check_equality(basic, rhs, lanes);
 
-      simd_type lhs(KOKKOS_LAMBDA(std::size_t i) { return init[i] * 9; });
+      simd_type lhs(KOKKOS_LAMBDA(std::size_t i) { return init[i] * 10; });
       mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return init_mask[i]; });
       simd_type result(
           KOKKOS_LAMBDA(std::size_t i) { return (mask[i]) ? lhs[i] : rhs[i]; });
@@ -58,11 +58,10 @@ inline void host_check_gen_ctor() {
       simd_type basic([=](std::size_t i) { return init[i]; });
       host_check_equality(basic, rhs, lanes);
 
-      simd_type lhs([=](std::size_t i) { return init[i] * 9; });
+      simd_type lhs([=](std::size_t i) { return init[i] * 10; });
       mask_type mask([=](std::size_t i) { return init_mask[i]; });
       simd_type result(
           [=](std::size_t i) { return (mask[i]) ? lhs[i] : rhs[i]; });
-
       host_check_equality(blend, result, lanes);
     }
 #endif
@@ -91,13 +90,18 @@ KOKKOS_INLINE_FUNCTION void device_check_gen_ctor() {
 
     DataType init[lanes];
     DataType expected[lanes];
-    mask_type mask(false);
+    bool init_mask[lanes];
 
     for (std::size_t i = 0; i < lanes; ++i) {
-      if (i % 3 == 0) mask[i] = true;
+      if (i % 3 == 0) {
+        init_mask[i] = true;
+      } else {
+        init_mask[i] = false;
+      }
       init[i]     = 7;
-      expected[i] = (mask[i]) ? init[i] * 9 : init[i];
+      expected[i] = (init_mask[i]) ? init[i] * 9 : init[i];
     }
+    mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return init_mask[i]; });
 
     simd_type basic(KOKKOS_LAMBDA(std::size_t i) { return init[i]; });
     simd_type rhs;

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -37,9 +37,15 @@ void host_check_math_op_one_loader(BinaryOp binary_op, std::size_t n,
         loader.host_load(second_args + i, nlanes, second_arg);
     if (!(loaded_first_arg && loaded_second_arg)) continue;
 
-    simd_type expected_result(KOKKOS_LAMBDA(std::size_t lane) {
-      return binary_op.on_host(T(first_arg[lane]), T(second_arg[lane]));
-    });
+    T expected_val[width];
+    for (std::size_t lane = 0; lane < width; ++lane) {
+      expected_val[lane] =
+          binary_op.on_host(T(first_arg[lane]), T(second_arg[lane]));
+    }
+
+    simd_type expected_result;
+    expected_result.copy_from(expected_val,
+                              Kokkos::Experimental::simd_flag_default);
 
     simd_type const computed_result = binary_op.on_host(first_arg, second_arg);
     host_check_equality(expected_result, computed_result, nlanes);
@@ -59,15 +65,18 @@ void host_check_math_op_one_loader(UnaryOp unary_op, std::size_t n,
     bool const loaded_arg = loader.host_load(args + i, nlanes, arg);
     if (!loaded_arg) continue;
 
-    decltype(unary_op.on_host(arg)) expected_result(
-        KOKKOS_LAMBDA(std::size_t lane) {
-          if constexpr (std::is_same_v<UnaryOp, cbrt_op> ||
-                        std::is_same_v<UnaryOp, exp_op> ||
-                        std::is_same_v<UnaryOp, log_op>)
-            arg[lane] = Kokkos::abs(arg[lane]);
+    typename decltype(unary_op.on_host(arg))::value_type expected_val[width];
+    for (std::size_t lane = 0; lane < width; ++lane) {
+      if constexpr (std::is_same_v<UnaryOp, cbrt_op> ||
+                    std::is_same_v<UnaryOp, exp_op> ||
+                    std::is_same_v<UnaryOp, log_op>)
+        arg[lane] = Kokkos::abs(arg[lane]);
+      expected_val[lane] = unary_op.on_host_serial(T(arg[lane]));
+    }
 
-          return unary_op.on_host_serial(T(arg[lane]));
-        });
+    decltype(unary_op.on_host(arg)) expected_result;
+    expected_result.copy_from(expected_val,
+                              Kokkos::Experimental::simd_flag_default);
 
     auto computed_result = unary_op.on_host(arg);
     host_check_equality(expected_result, computed_result, nlanes);

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -36,14 +36,11 @@ void host_check_math_op_one_loader(BinaryOp binary_op, std::size_t n,
     bool const loaded_second_arg =
         loader.host_load(second_args + i, nlanes, second_arg);
     if (!(loaded_first_arg && loaded_second_arg)) continue;
-    simd_type expected_result;
-    // gcc 8.4.0 warns if using nlanes as upper bound about first_arg and/or
-    // second_arg being uninitialized
-    for (std::size_t lane = 0; lane < simd_type::size(); ++lane) {
-      if (lane < nlanes)
-        expected_result[lane] =
-            binary_op.on_host(T(first_arg[lane]), T(second_arg[lane]));
-    }
+
+    simd_type expected_result(KOKKOS_LAMBDA(std::size_t lane) {
+      return binary_op.on_host(T(first_arg[lane]), T(second_arg[lane]));
+    });
+
     simd_type const computed_result = binary_op.on_host(first_arg, second_arg);
     host_check_equality(expected_result, computed_result, nlanes);
   }
@@ -62,16 +59,16 @@ void host_check_math_op_one_loader(UnaryOp unary_op, std::size_t n,
     bool const loaded_arg = loader.host_load(args + i, nlanes, arg);
     if (!loaded_arg) continue;
 
-    decltype(unary_op.on_host(arg)) expected_result;
-    for (std::size_t lane = 0; lane < simd_type::size(); ++lane) {
-      if (lane < nlanes) {
-        if constexpr (std::is_same_v<UnaryOp, cbrt_op> ||
-                      std::is_same_v<UnaryOp, exp_op> ||
-                      std::is_same_v<UnaryOp, log_op>)
-          arg[lane] = Kokkos::abs(arg[lane]);
-        expected_result[lane] = unary_op.on_host_serial(T(arg[lane]));
-      }
-    }
+    decltype(unary_op.on_host(arg)) expected_result(
+        KOKKOS_LAMBDA(std::size_t lane) {
+          if constexpr (std::is_same_v<UnaryOp, cbrt_op> ||
+                        std::is_same_v<UnaryOp, exp_op> ||
+                        std::is_same_v<UnaryOp, log_op>)
+            arg[lane] = Kokkos::abs(arg[lane]);
+
+          return unary_op.on_host_serial(T(arg[lane]));
+        });
+
     auto computed_result = unary_op.on_host(arg);
     host_check_equality(expected_result, computed_result, nlanes);
   }
@@ -184,11 +181,11 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_one_loader(
     bool const loaded_second_arg =
         loader.device_load(second_args + i, nlanes, second_arg);
     if (!(loaded_first_arg && loaded_second_arg)) continue;
-    simd_type expected_result;
-    for (std::size_t lane = 0; lane < nlanes; ++lane) {
-      expected_result[lane] =
-          binary_op.on_device(first_arg[lane], second_arg[lane]);
-    }
+
+    simd_type expected_result(KOKKOS_LAMBDA(std::size_t lane) {
+      return binary_op.on_device(first_arg[lane], second_arg[lane]);
+    });
+
     simd_type const computed_result =
         binary_op.on_device(first_arg, second_arg);
     device_check_equality(expected_result, computed_result, nlanes);
@@ -210,10 +207,10 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_one_loader(UnaryOp unary_op,
     if (!loaded_arg) continue;
     auto computed_result = unary_op.on_device(arg);
 
-    decltype(computed_result) expected_result;
-    for (std::size_t lane = 0; lane < nlanes; ++lane) {
-      expected_result[lane] = unary_op.on_device_serial(arg[lane]);
-    }
+    decltype(computed_result) expected_result(KOKKOS_LAMBDA(std::size_t lane) {
+      return unary_op.on_device_serial(arg[lane]);
+    });
+
     device_check_equality(expected_result, computed_result, nlanes);
   }
 }

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -37,7 +37,7 @@ inline void host_check_reduction_one_loader(ReductionOp reduce_op,
     if (!loaded_arg) continue;
 
     if constexpr (std::is_same_v<Abi, Kokkos::Experimental::simd_abi::scalar>) {
-      mask_type mask(KOKKOS_LAMBDA(std::size_t) { return true; });
+      mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return i < nlanes; });
 
       auto value    = where(mask, arg);
       auto expected = reduce_op.on_host_serial(value);
@@ -45,7 +45,7 @@ inline void host_check_reduction_one_loader(ReductionOp reduce_op,
 
       gtest_checker().equality(expected, computed);
     } else {
-      mask_type mask([=](std::size_t) { return true; });
+      mask_type mask([=](std::size_t i) { return i < nlanes; });
 
       auto value    = where(mask, arg);
       auto expected = reduce_op.on_host_serial(value);
@@ -118,7 +118,7 @@ KOKKOS_INLINE_FUNCTION void device_check_reduction_one_loader(
     bool const loaded_arg = loader.device_load(args + i, nlanes, arg);
     if (!loaded_arg) continue;
 
-    mask_type mask(KOKKOS_LAMBDA(std::size_t) { return true; });
+    mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return i < nlanes; });
 
     auto value    = where(mask, arg);
     auto expected = reduce_op.on_device_serial(value);

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -36,10 +36,8 @@ inline void host_check_reduction_one_loader(ReductionOp reduce_op,
     bool const loaded_arg = loader.host_load(args + i, nlanes, arg);
     if (!loaded_arg) continue;
 
-    mask_type mask(false);
-    for (std::size_t j = 0; j < nlanes; ++j) {
-      mask[j] = true;
-    }
+    mask_type mask(KOKKOS_LAMBDA(std::size_t) { return true; });
+
     auto value    = where(mask, arg);
     auto expected = reduce_op.on_host_serial(value);
     auto computed = reduce_op.on_host(value);
@@ -110,10 +108,8 @@ KOKKOS_INLINE_FUNCTION void device_check_reduction_one_loader(
     bool const loaded_arg = loader.device_load(args + i, nlanes, arg);
     if (!loaded_arg) continue;
 
-    mask_type mask(false);
-    for (std::size_t j = 0; j < nlanes; ++j) {
-      mask[j] = true;
-    }
+    mask_type mask(KOKKOS_LAMBDA(std::size_t) { return true; });
+
     auto value    = where(mask, arg);
     auto expected = reduce_op.on_device_serial(value);
     auto computed = reduce_op.on_device(value);

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -37,7 +37,7 @@ inline void host_check_reduction_one_loader(ReductionOp reduce_op,
     if (!loaded_arg) continue;
 
     if constexpr (std::is_same_v<Abi, Kokkos::Experimental::simd_abi::scalar>) {
-      mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return i < nlanes; });
+      mask_type mask(KOKKOS_LAMBDA(std::size_t j) { return j < nlanes; });
 
       auto value    = where(mask, arg);
       auto expected = reduce_op.on_host_serial(value);
@@ -45,7 +45,7 @@ inline void host_check_reduction_one_loader(ReductionOp reduce_op,
 
       gtest_checker().equality(expected, computed);
     } else {
-      mask_type mask([=](std::size_t i) { return i < nlanes; });
+      mask_type mask([=](std::size_t j) { return j < nlanes; });
 
       auto value    = where(mask, arg);
       auto expected = reduce_op.on_host_serial(value);
@@ -118,7 +118,7 @@ KOKKOS_INLINE_FUNCTION void device_check_reduction_one_loader(
     bool const loaded_arg = loader.device_load(args + i, nlanes, arg);
     if (!loaded_arg) continue;
 
-    mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return i < nlanes; });
+    mask_type mask(KOKKOS_LAMBDA(std::size_t j) { return j < nlanes; });
 
     auto value    = where(mask, arg);
     auto expected = reduce_op.on_device_serial(value);

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -35,9 +35,15 @@ inline void host_check_shift_on_one_loader(ShiftOp shift_op,
       continue;
     }
 
-    simd_type expected_result(KOKKOS_LAMBDA(std::size_t lane) {
-      return shift_op.on_host(simd_vals[lane], static_cast<int>(shift_by[i]));
-    });
+    DataType expected_val[width];
+    for (std::size_t lane = 0; lane < width; ++lane) {
+      expected_val[lane] =
+          shift_op.on_host(simd_vals[lane], static_cast<int>(shift_by[i]));
+    }
+
+    simd_type expected_result;
+    expected_result.copy_from(expected_val,
+                              Kokkos::Experimental::simd_flag_default);
 
     simd_type const computed_result =
         shift_op.on_host(simd_vals, static_cast<int>(shift_by[i]));
@@ -57,9 +63,15 @@ inline void host_check_shift_by_lanes_on_one_loader(
   bool const loaded_arg = loader.host_load(test_vals, width, simd_vals);
   ASSERT_TRUE(loaded_arg);
 
-  simd_type expected_result(KOKKOS_LAMBDA(std::size_t lane) {
-    return shift_op.on_host(simd_vals[lane], static_cast<int>(shift_by[lane]));
-  });
+  DataType expected_val[width];
+  for (std::size_t lane = 0; lane < width; ++lane) {
+    expected_val[lane] =
+        shift_op.on_host(simd_vals[lane], static_cast<int>(shift_by[lane]));
+  }
+
+  simd_type expected_result;
+  expected_result.copy_from(expected_val,
+                            Kokkos::Experimental::simd_flag_default);
 
   simd_type const computed_result = shift_op.on_host(simd_vals, shift_by);
   host_check_equality(expected_result, computed_result, width);

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -35,14 +35,9 @@ inline void host_check_shift_on_one_loader(ShiftOp shift_op,
       continue;
     }
 
-    simd_type expected_result;
-
-    for (std::size_t lane = 0; lane < width; ++lane) {
-      DataType value = simd_vals[lane];
-      expected_result[lane] =
-          shift_op.on_host(value, static_cast<int>(shift_by[i]));
-      EXPECT_EQ(value, value);
-    }
+    simd_type expected_result(KOKKOS_LAMBDA(std::size_t lane) {
+      return shift_op.on_host(simd_vals[lane], static_cast<int>(shift_by[i]));
+    });
 
     simd_type const computed_result =
         shift_op.on_host(simd_vals, static_cast<int>(shift_by[i]));
@@ -62,14 +57,10 @@ inline void host_check_shift_by_lanes_on_one_loader(
   bool const loaded_arg = loader.host_load(test_vals, width, simd_vals);
   ASSERT_TRUE(loaded_arg);
 
-  simd_type expected_result;
+  simd_type expected_result(KOKKOS_LAMBDA(std::size_t lane) {
+    return shift_op.on_host(simd_vals[lane], static_cast<int>(shift_by[lane]));
+  });
 
-  for (std::size_t lane = 0; lane < width; ++lane) {
-    DataType value = simd_vals[lane];
-    expected_result[lane] =
-        shift_op.on_host(value, static_cast<int>(shift_by[lane]));
-    EXPECT_EQ(value, value);
-  }
   simd_type const computed_result = shift_op.on_host(simd_vals, shift_by);
   host_check_equality(expected_result, computed_result, width);
 }
@@ -165,12 +156,9 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_on_one_loader(
       continue;
     }
 
-    simd_type expected_result;
-
-    for (std::size_t lane = 0; lane < width; ++lane) {
-      expected_result[lane] = shift_op.on_device(DataType(simd_vals[lane]),
-                                                 static_cast<int>(shift_by[i]));
-    }
+    simd_type expected_result(KOKKOS_LAMBDA(std::size_t lane) {
+      return shift_op.on_device(simd_vals[lane], static_cast<int>(shift_by[i]));
+    });
 
     simd_type const computed_result =
         shift_op.on_device(simd_vals, static_cast<int>(shift_by[i]));
@@ -188,12 +176,11 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_by_lanes_on_one_loader(
   simd_type simd_vals;
   loader.device_load(test_vals, width, simd_vals);
 
-  simd_type expected_result;
+  simd_type expected_result(KOKKOS_LAMBDA(std::size_t lane) {
+    return shift_op.on_device(simd_vals[lane],
+                              static_cast<int>(shift_by[lane]));
+  });
 
-  for (std::size_t lane = 0; lane < width; ++lane) {
-    expected_result[lane] = shift_op.on_device(
-        DataType(simd_vals[lane]), static_cast<int>(shift_by[lane]));
-  }
   simd_type const computed_result = shift_op.on_device(simd_vals, shift_by);
   device_check_equality(expected_result, computed_result, width);
 }

--- a/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
+++ b/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
@@ -34,17 +34,15 @@ inline void host_check_where_expr_scatter_to() {
     src.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
     for (std::size_t idx = 0; idx < nlanes; ++idx) {
-      mask_type mask(true);
-      mask[idx] = false;
+      mask_type mask([=](std::size_t i) { return i != idx; });
 
       DataType dst[simd_type::size()] = {0};
-      index_type index;
-      simd_type expected_result;
       for (std::size_t i = 0; i < nlanes; ++i) {
-        dst[i]             = (2 + (i * 2));
-        index[i]           = i;
-        expected_result[i] = (mask[i]) ? src[index[i]] : dst[i];
+        dst[i] = (2 + (i * 2));
       }
+      index_type index([=](std::size_t i) { return i; });
+      simd_type expected_result(
+          [=](std::size_t i) { return (mask[i]) ? src[index[i]] : dst[i]; });
       where(mask, src).scatter_to(dst, index);
 
       simd_type dst_simd;
@@ -67,17 +65,12 @@ inline void host_check_where_expr_gather_from() {
                           53, 71, 79, 83, 89, 93, 97, 103};
 
     for (std::size_t idx = 0; idx < nlanes; ++idx) {
-      mask_type mask(true);
-      mask[idx] = false;
+      mask_type mask([=](std::size_t i) { return i != idx; });
 
-      simd_type dst;
-      index_type index;
-      simd_type expected_result;
-      for (std::size_t i = 0; i < nlanes; ++i) {
-        dst[i]             = (2 + (i * 2));
-        index[i]           = i;
-        expected_result[i] = (mask[i]) ? src[index[i]] : dst[i];
-      }
+      simd_type dst([=](std::size_t i) { return (2 + (i * 2)); });
+      index_type index([=](std::size_t i) { return i; });
+      simd_type expected_result(
+          [=](std::size_t i) { return (mask[i]) ? src[index[i]] : dst[i]; });
       where(mask, dst).gather_from(src, index);
 
       host_check_equality(expected_result, dst, nlanes);
@@ -118,17 +111,16 @@ KOKKOS_INLINE_FUNCTION void device_check_where_expr_scatter_to() {
     src.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
     for (std::size_t idx = 0; idx < nlanes; ++idx) {
-      mask_type mask(true);
-      mask[idx] = false;
+      mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return i != idx; });
 
       DataType dst[simd_type::size()] = {0};
-      index_type index;
-      simd_type expected_result;
       for (std::size_t i = 0; i < nlanes; ++i) {
-        dst[i]             = (2 + (i * 2));
-        index[i]           = i;
-        expected_result[i] = (mask[i]) ? src[index[i]] : dst[i];
+        dst[i] = (2 + (i * 2));
       }
+      index_type index([=](std::size_t i) { return i; });
+      simd_type expected_result(KOKKOS_LAMBDA(std::size_t i) {
+        return (mask[i]) ? src[index[i]] : dst[i];
+      });
       where(mask, src).scatter_to(dst, index);
 
       simd_type dst_simd;
@@ -150,17 +142,13 @@ KOKKOS_INLINE_FUNCTION void device_check_where_expr_gather_from() {
                         53, 71, 79, 83, 89, 93, 97, 103};
 
   for (std::size_t idx = 0; idx < nlanes; ++idx) {
-    mask_type mask(true);
-    mask[idx] = false;
+    mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return i != idx; });
 
-    simd_type dst;
-    index_type index;
-    simd_type expected_result;
-    for (std::size_t i = 0; i < nlanes; ++i) {
-      dst[i]             = (2 + (i * 2));
-      index[i]           = i;
-      expected_result[i] = (mask[i]) ? src[index[i]] : dst[i];
-    }
+    simd_type dst([=](std::size_t i) { return (2 + (i * 2)); });
+    index_type index([=](std::size_t i) { return i; });
+    simd_type expected_result(KOKKOS_LAMBDA(std::size_t i) {
+      return (mask[i]) ? src[index[i]] : dst[i];
+    });
     where(mask, dst).gather_from(src, index);
 
     device_check_equality(expected_result, dst, nlanes);


### PR DESCRIPTION
This PR includes following changes:
- remove `reference operator[](std::size_t)` from all simd types since proxy reference is no longer part of P1928
- reimplement `value_type operator[](std::size_t) const` to avoid reinterpret casting simd vectors for accessing its elements

This should resolve #7560 and will likely also handle UB issues described in #7486.