### PR TITLE
[ci skip] Update nightly jenkins from ROCm 6.3 to ROCm 6.3.1

### DIFF
--- a/.jenkins_nightly
+++ b/.jenkins_nightly
@@ -109,7 +109,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.hipcc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-22.04:6.3-complete'
+                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-24.04:6.3.1-complete'
                             label 'rocm-docker && AMD_Radeon_Instinct_MI100'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
                         }


### PR DESCRIPTION
This PR's update the nightly to the latest version of ROCm. I've also updated the OS version. I've update the OS because I want to update the CMake version. The nightly is currently failing at configure time with 
```
-- Check for working CXX compiler: /opt/rocm/bin/hipcc
CMake Error at /var/jenkins/workspace/Kokkos_nightly/build/CMakeFiles/CMakeTmp/CMakeLists.txt:16 (add_executable):
  CXX_STANDARD is set to invalid value '23'


CMake Error at /opt/cmake/share/cmake-3.16/Modules/CMakeTestCXXCompiler.cmake:37 (try_compile):
  Failed to generate test project build system.
Call Stack (most recent call first):
  CMakeLists.txt:114 (project)
```
ROCm 6.3 supports c++23, so I think the issue is from CMake.