### PR TITLE
[ci skip] Update nightly to use ROCm 6.3.1

### DIFF
--- a/.jenkins_nightly
+++ b/.jenkins_nightly
@@ -148,7 +148,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.hipcc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-22.04:6.3-complete'
+                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-24.04:6.3.1-complete'
                             label 'rocm-docker && AMD_Radeon_Instinct_MI210'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
                         }


### PR DESCRIPTION
In https://github.com/kokkos/kokkos/pull/7637, I forgot that we have two builds in the nightly that use ROCm 6.3. Of course I updated the one that was already working :disappointed: 