### PR TITLE
HIP: Use default CMake version

### DIFF
--- a/scripts/docker/Dockerfile.hipcc
+++ b/scripts/docker/Dockerfile.hipcc
@@ -5,32 +5,10 @@ RUN apt-get update && apt-get install -y \
         kmod \
         wget \
         ccache \
+        cmake \
         file \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 ENV PATH=/opt/rocm/bin:$PATH
-
-RUN KEYDUMP_URL=https://cloud1.cees.ornl.gov/download && \
-    KEYDUMP_FILE=keydump && \
-    wget --quiet ${KEYDUMP_URL}/${KEYDUMP_FILE} && \
-    wget --quiet ${KEYDUMP_URL}/${KEYDUMP_FILE}.sig && \
-    gpg --import ${KEYDUMP_FILE} && \
-    gpg --verify ${KEYDUMP_FILE}.sig ${KEYDUMP_FILE} && \
-    rm ${KEYDUMP_FILE}*
-
-ARG CMAKE_VERSION=3.16.8
-ENV CMAKE_DIR=/opt/cmake
-RUN CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION} && \
-    CMAKE_SCRIPT=cmake-${CMAKE_VERSION}-Linux-x86_64.sh && \
-    CMAKE_SHA256=cmake-${CMAKE_VERSION}-SHA-256.txt && \
-    wget --quiet ${CMAKE_URL}/${CMAKE_SHA256} && \
-    wget --quiet ${CMAKE_URL}/${CMAKE_SHA256}.asc && \
-    wget --quiet ${CMAKE_URL}/${CMAKE_SCRIPT} && \
-    gpg --verify ${CMAKE_SHA256}.asc ${CMAKE_SHA256} && \
-    grep -i ${CMAKE_SCRIPT} ${CMAKE_SHA256} | sed -e s/linux/Linux/ | sha256sum --check && \
-    mkdir -p ${CMAKE_DIR} && \
-    sh ${CMAKE_SCRIPT} --skip-license --prefix=${CMAKE_DIR} && \
-    rm cmake*
-ENV PATH=${CMAKE_DIR}/bin:$PATH


### PR DESCRIPTION
Updating the base image didn't fix the nightly because we were using our own version of CMake. Let's just use the default of CMake to avoid this kind of issue in the future.