### PR TITLE
minor(graph): account for backend API change in graph instantiate

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -56,14 +56,9 @@ struct GraphImpl<Kokkos::Cuda> {
  public:
   void instantiate() {
     KOKKOS_EXPECTS(!m_graph_exec);
-    constexpr size_t error_log_size = 256;
-    cudaGraphNode_t error_node      = nullptr;
-    char error_log[error_log_size];
     KOKKOS_IMPL_CUDA_SAFE_CALL(
         (m_execution_space.impl_internal_space_instance()
-             ->cuda_graph_instantiate_wrapper(&m_graph_exec, m_graph,
-                                              &error_node, error_log,
-                                              error_log_size)));
+             ->cuda_graph_instantiate_wrapper(&m_graph_exec, m_graph)));
     KOKKOS_ENSURES(m_graph_exec);
     // TODO @graphs print out errors
   }

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -431,13 +431,17 @@ class CudaInternal {
 
   template <bool setCudaDevice = true>
   cudaError_t cuda_graph_instantiate_wrapper(cudaGraphExec_t* pGraphExec,
-                                             cudaGraph_t graph,
-                                             cudaGraphNode_t* pErrorNode,
-                                             char* pLogBuffer,
-                                             size_t bufferSize) const {
+                                             cudaGraph_t graph) const {
     if constexpr (setCudaDevice) set_cuda_device();
-    return cudaGraphInstantiate(pGraphExec, graph, pErrorNode, pLogBuffer,
-                                bufferSize);
+#if CUDA_VERSION < 12000
+    constexpr size_t error_log_size = 256;
+    cudaGraphNode_t error_node      = nullptr;
+    char error_log[error_log_size];
+    return cudaGraphInstantiate(pGraphExec, graph, &error_node, error_log,
+                                error_log_size);
+#else
+    return cudaGraphInstantiate(pGraphExec, graph);
+#endif
   }
 
   // Resizing of reduction related scratch spaces

--- a/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
@@ -73,11 +73,8 @@ class GraphImpl<Kokkos::HIP> {
 
   void instantiate() {
     KOKKOS_EXPECTS(!m_graph_exec);
-    constexpr size_t error_log_size = 256;
-    hipGraphNode_t error_node       = nullptr;
-    char error_log[error_log_size];
-    KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphInstantiate(
-        &m_graph_exec, m_graph, &error_node, error_log, error_log_size));
+    KOKKOS_IMPL_HIP_SAFE_CALL(
+        hipGraphInstantiate(&m_graph_exec, m_graph, nullptr, nullptr, 0));
     KOKKOS_ENSURES(m_graph_exec);
   }
 


### PR DESCRIPTION
This PR updates the wrappers for `cudaGraphInstantiate` and `hipGraphInstantiate`.

The API of `cudaGraphInstantiate` was changed in the update from cuda 11.8 to cuda 12.0. Since the update, the three last arguments have become unused:
- https://docs.nvidia.com/cuda/archive/11.8.0/cuda-runtime-api/group__CUDART__GRAPH.html#group__CUDART__GRAPH_1gb25beab33abe4b2d13edbb6e35cb72ff
- https://docs.nvidia.com/cuda/archive/12.0.0/cuda-runtime-api/group__CUDART__GRAPH.html#group__CUDART__GRAPH_1g0b72834c2e8a3c93c443c6c67626d0d9

The API of `hipGraphInstantiate` still involves the arguments corresponding to the three last arguments in the cuda function. However, as far back as ROCm 5.6, which is as far as the clr repository allows to go back, the three last arguments have always been unused on the hip side:
- https://github.com/ROCm/clr/blob/73ed8adfd08c38b6a40638c9d26ace5ec862ba68/hipamd/src/hip_graph.cpp#L1254-L1258
- https://github.com/ROCm/clr/blob/1b9c17779bbd913f30b06ee3051bd8b8dd60cd40/hipamd/src/hip_graph.cpp#L1335-L1347

The proposed change to pass `nullptr, nullptr, 0` follows a recent AMD example:
- https://github.com/ROCm/rocprofiler-sdk/blob/9de284a56886f09484b0b7e3d281bab834d3de73/tests/bin/hip-graph/hip-graph.cpp#L146