### PR TITLE
Test Mac OS X with native architecture flag

### DIFF
--- a/.github/workflows/continuous-integration-osx.yml
+++ b/.github/workflows/continuous-integration-osx.yml
@@ -34,6 +34,7 @@ jobs:
             -DKokkos_ENABLE_${{ matrix.backend }}=On
             -DCMAKE_CXX_FLAGS="-Werror"
             -DCMAKE_CXX_STANDARD=17
+            -DKokkos_ARCH_NATIVE=ON
             -DKokkos_ENABLE_COMPILER_WARNINGS=ON
             -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF
             -DKokkos_ENABLE_TESTS=On


### PR DESCRIPTION
In response to https://github.com/kokkos/kokkos/pull/7647#issuecomment-2575790525:
> [...] it seems like Arm Neon SIMD might not be currently tested in the CI since the OSX builds do not configure with arch flags.

I can confirm that ARCH_NEON is detected but I don't know anything more about the underlying hardware to know of we could set anything else other than `Kokkos_ARCH_NATIVE` for the same effect.