### PR TITLE
Add more tests for view usage violating preconditions

### DIFF
--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -344,7 +344,7 @@ class BasicView {
         !alloc_prop::execution_space::impl_is_initialized()) {
       // If initializing view data then
       // the execution space must be initialized.
-      Kokkos::Impl::throw_runtime_exception(
+      Kokkos::abort(
           "Constructing View and initializing data with uninitialized "
           "execution space");
     }

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -1007,7 +1007,7 @@ class View : public ViewTraits<DataType, Properties...> {
         !alloc_prop::execution_space::impl_is_initialized()) {
       // If initializing view data then
       // the execution space must be initialized.
-      Kokkos::Impl::throw_runtime_exception(
+      Kokkos::abort(
           "Constructing View and initializing data with uninitialized "
           "execution space");
     }

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -41,18 +41,32 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,
     Kokkos::View<int> v0;
     Kokkos::View<float*> v1;
     Kokkos::View<NonTrivial**> v2;
+    return std::make_tuple(v0, v1, v2);
   };
   EXPECT_EXIT(
       {
-        make_views();
+        { (void)make_views(); }
         std::exit(EXIT_SUCCESS);
       },
       ::testing::ExitedWithCode(EXIT_SUCCESS), "");
   EXPECT_EXIT(
       {
-        Kokkos::initialize();
-        Kokkos::finalize();
-        make_views();
+        {
+          Kokkos::initialize();
+          auto views =
+              make_views();  // views outlive the Kokkos execution environment
+          Kokkos::finalize();
+        }
+        std::exit(EXIT_SUCCESS);
+      },
+      ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+  EXPECT_EXIT(
+      {
+        {
+          Kokkos::initialize();
+          Kokkos::finalize();
+          (void)make_views();
+        }
         std::exit(EXIT_SUCCESS);
       },
       ::testing::ExitedWithCode(EXIT_SUCCESS), "");

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -114,6 +114,9 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
     defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENACC)
   std::string matcher1 = std::string("Kokkos::") +
+#ifdef KOKKOS_ENABLE_OPENACC
+                         "Experimental::"
+#endif
                          Kokkos::DefaultExecutionSpace::name() +
                          "::" + Kokkos::DefaultExecutionSpace::name() +
                          " instance constructor : ERROR device not initialized";

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -45,7 +45,7 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,
   };
   EXPECT_EXIT(
       {
-        { (void)make_views(); }
+        { auto views = make_views(); }
         std::exit(EXIT_SUCCESS);
       },
       ::testing::ExitedWithCode(EXIT_SUCCESS), "");
@@ -65,7 +65,7 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,
         {
           Kokkos::initialize();
           Kokkos::finalize();
-          (void)make_views();
+          auto views = make_views();
         }
         std::exit(EXIT_SUCCESS);
       },

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -106,18 +106,24 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
       },
       "Kokkos allocation \"v\" is being deallocated after Kokkos::finalize was "
       "called");
-  EXPECT_DEATH(
-      { Kokkos::View<int*> v("v", 0); },
+  std::string matcher =
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
+    defined(KOKKOS_ENABLE_SYCL)
+      std::string("Kokkos::") + Kokkos::DefaultExecutionSpace::name() +
+      "::" + Kokkos::DefaultExecutionSpace::name() +
+      " instance constructor : ERROR device not initialized";
+#else
       "Constructing View and initializing data with uninitialized execution "
-      "space");
+      "space";
+#endif
+  EXPECT_DEATH({ Kokkos::View<int*> v("v", 0); }, matcher);
   EXPECT_DEATH(
       {
         Kokkos::initialize();
         Kokkos::finalize();
         Kokkos::View<int*> v("v", 0);
       },
-      "Constructing View and initializing data with uninitialized execution "
-      "space");
+      matcher);
 }
 
 }  // namespace

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -106,25 +106,28 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
       },
       "Kokkos allocation \"v\" is being deallocated after Kokkos::finalize was "
       "called");
-#ifndef KOKKOS_ENABLE_SYCL
-  std::string matcher2 =
+  [[maybe_unused]] std::string error_constructing_view_with_unitialized_exec =
       "Constructing View and initializing data with uninitialized execution "
       "space";
+  [[maybe_unused]] std::string error_constructing_exec_space_instance =
+      std::string("Kokkos::") +
+#ifdef KOKKOS_ENABLE_OPENACC
+      "Experimental::"
 #endif
+      Kokkos::DefaultExecutionSpace::name() +
+      "::" + Kokkos::DefaultExecutionSpace::name() +
+      " instance constructor : ERROR device not initialized";
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
     defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENACC)
-  std::string matcher1 = std::string("Kokkos::") +
-#ifdef KOKKOS_ENABLE_OPENACC
-                         "Experimental::"
-#endif
-                         Kokkos::DefaultExecutionSpace::name() +
-                         "::" + Kokkos::DefaultExecutionSpace::name() +
-                         " instance constructor : ERROR device not initialized";
+  std::string matcher1 = error_constructing_exec_space_instance;
 #else
-  std::string matcher1 = matcher2;
+  std::string matcher1 = error_constructing_view_with_unitialized_exec;
 #endif
 #ifdef KOKKOS_ENABLE_SYCL
-  std::string matcher2 = matcher1;
+  std::string matcher2 = error_constructing_exec_space_instance;
+#else
+  std::string matcher2 = error_constructing_view_with_unitialized_exec;
+
 #endif
   EXPECT_DEATH({ Kokkos::View<int*> v("v", 0); }, matcher1);
   EXPECT_DEATH(

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -106,17 +106,22 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
       },
       "Kokkos allocation \"v\" is being deallocated after Kokkos::finalize was "
       "called");
+#ifndef KOKKOS_ENABLE_SYCL
   std::string matcher2 =
       "Constructing View and initializing data with uninitialized execution "
       "space";
+#endif
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
-    defined(KOKKOS_ENABLE_SYCL)
+    defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENACC)
   std::string matcher1 = std::string("Kokkos::") +
                          Kokkos::DefaultExecutionSpace::name() +
                          "::" + Kokkos::DefaultExecutionSpace::name() +
                          " instance constructor : ERROR device not initialized";
 #else
   std::string matcher1 = matcher2;
+#endif
+#ifdef KOKKOS_ENABLE_SYCL
+  std::string matcher2 = matcher1;
 #endif
   EXPECT_DEATH({ Kokkos::View<int*> v("v", 0); }, matcher1);
   EXPECT_DEATH(

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -112,7 +112,7 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
   [[maybe_unused]] std::string error_constructing_exec_space_instance =
       std::string("Kokkos::") +
 #ifdef KOKKOS_ENABLE_OPENACC
-      "Experimental::"
+      "Experimental::" +
 #endif
       Kokkos::DefaultExecutionSpace::name() +
       "::" + Kokkos::DefaultExecutionSpace::name() +

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -106,6 +106,7 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
       },
       "Kokkos allocation \"v\" is being deallocated after Kokkos::finalize was "
       "called");
+  // NOLINTBEGIN(bugprone-unused-local-non-trivial-variable)
   [[maybe_unused]] std::string error_constructing_view_with_unitialized_exec =
       "Constructing View and initializing data with uninitialized execution "
       "space";
@@ -117,17 +118,17 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
       Kokkos::DefaultExecutionSpace::name() +
       "::" + Kokkos::DefaultExecutionSpace::name() +
       " instance constructor : ERROR device not initialized";
+  // NOLINTEND(bugprone-unused-local-non-trivial-variable)
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
     defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENACC)
   std::string matcher1 = error_constructing_exec_space_instance;
 #else
   std::string matcher1 = error_constructing_view_with_unitialized_exec;
 #endif
-#ifdef KOKKOS_ENABLE_SYCL
+#if defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENACC)
   std::string matcher2 = error_constructing_exec_space_instance;
 #else
   std::string matcher2 = error_constructing_view_with_unitialized_exec;
-
 #endif
   EXPECT_DEATH({ Kokkos::View<int*> v("v", 0); }, matcher1);
   EXPECT_DEATH(

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -106,24 +106,26 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
       },
       "Kokkos allocation \"v\" is being deallocated after Kokkos::finalize was "
       "called");
-  std::string matcher =
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
-    defined(KOKKOS_ENABLE_SYCL)
-      std::string("Kokkos::") + Kokkos::DefaultExecutionSpace::name() +
-      "::" + Kokkos::DefaultExecutionSpace::name() +
-      " instance constructor : ERROR device not initialized";
-#else
+  std::string matcher2 =
       "Constructing View and initializing data with uninitialized execution "
       "space";
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
+    defined(KOKKOS_ENABLE_SYCL)
+  std::string matcher1 = std::string("Kokkos::") +
+                         Kokkos::DefaultExecutionSpace::name() +
+                         "::" + Kokkos::DefaultExecutionSpace::name() +
+                         " instance constructor : ERROR device not initialized";
+#else
+  std::string matcher1 = matcher2;
 #endif
-  EXPECT_DEATH({ Kokkos::View<int*> v("v", 0); }, matcher);
+  EXPECT_DEATH({ Kokkos::View<int*> v("v", 0); }, matcher1);
   EXPECT_DEATH(
       {
         Kokkos::initialize();
         Kokkos::finalize();
         Kokkos::View<int*> v("v", 0);
       },
-      matcher);
+      matcher2);
 }
 
 }  // namespace


### PR DESCRIPTION
Adding tests that checks that non-defaulted views can only be constructed after Kokkos::initialize() was called and must be destructed before Kokkos::finalize().
Change the behavior from throwing a runtime error to aborting in the case of View creations.