### PR TITLE
[skip ci] Use latest version of CMake in nightly for ROCm 6.3-CXX23 configuration

### DIFF
--- a/.jenkins_nightly
+++ b/.jenkins_nightly
@@ -148,7 +148,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.hipcc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-24.04:6.3.1-complete'
+                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-24.04:6.3.1-complete --build-arg CMAKE_VERSION=3.31.3'
                             label 'rocm-docker && AMD_Radeon_Instinct_MI210'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
                         }


### PR DESCRIPTION
This should fix our nightly