### PR TITLE
Fix incompatible memory space uses

### DIFF
--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -270,18 +270,19 @@ void test_offsetview_construction() {
 
 template <typename Scalar, typename Device>
 void test_offsetview_unmanaged_construction() {
-  // Preallocated memory (Only need a valid address for this test)
-  Scalar s;
+  // Preallocated memory
+  Kokkos::View<Scalar, Device> s("s");
 
   {
     // Constructing an OffsetView directly around our preallocated memory
     Kokkos::Array<int64_t, 1> begins1{{2}};
     Kokkos::Array<int64_t, 1> ends1{{3}};
-    Kokkos::Experimental::OffsetView<Scalar*, Device> ov1(&s, begins1, ends1);
+    Kokkos::Experimental::OffsetView<Scalar*, Device> ov1(s.data(), begins1,
+                                                          ends1);
 
     // Constructing an OffsetView around an unmanaged View of our preallocated
     // memory
-    Kokkos::View<Scalar*, Device> v1(&s, ends1[0] - begins1[0]);
+    Kokkos::View<Scalar*, Device> v1(s.data(), ends1[0] - begins1[0]);
     Kokkos::Experimental::OffsetView<Scalar*, Device> ovv1(v1, begins1);
 
     // They should match
@@ -292,9 +293,10 @@ void test_offsetview_unmanaged_construction() {
   {
     Kokkos::Array<int64_t, 2> begins2{{-2, -7}};
     Kokkos::Array<int64_t, 2> ends2{{5, -3}};
-    Kokkos::Experimental::OffsetView<Scalar**, Device> ov2(&s, begins2, ends2);
+    Kokkos::Experimental::OffsetView<Scalar**, Device> ov2(s.data(), begins2,
+                                                           ends2);
 
-    Kokkos::View<Scalar**, Device> v2(&s, ends2[0] - begins2[0],
+    Kokkos::View<Scalar**, Device> v2(s.data(), ends2[0] - begins2[0],
                                       ends2[1] - begins2[1]);
     Kokkos::Experimental::OffsetView<Scalar**, Device> ovv2(v2, begins2);
 
@@ -305,10 +307,10 @@ void test_offsetview_unmanaged_construction() {
   {
     Kokkos::Array<int64_t, 3> begins3{{2, 3, 5}};
     Kokkos::Array<int64_t, 3> ends3{{7, 11, 13}};
-    Kokkos::Experimental::OffsetView<Scalar***, Device> ovv3(&s, begins3,
+    Kokkos::Experimental::OffsetView<Scalar***, Device> ovv3(s.data(), begins3,
                                                              ends3);
 
-    Kokkos::View<Scalar***, Device> v3(&s, ends3[0] - begins3[0],
+    Kokkos::View<Scalar***, Device> v3(s.data(), ends3[0] - begins3[0],
                                        ends3[1] - begins3[1],
                                        ends3[2] - begins3[2]);
     Kokkos::Experimental::OffsetView<Scalar***, Device> ov3(v3, begins3);
@@ -323,10 +325,11 @@ void test_offsetview_unmanaged_construction() {
     Kokkos::Array<int64_t, 1> begins{{-3}};
     Kokkos::Array<int64_t, 1> ends{{2}};
 
-    Kokkos::Experimental::OffsetView<Scalar*, Device> bb(&s, begins, ends);
-    Kokkos::Experimental::OffsetView<Scalar*, Device> bi(&s, begins, {2});
-    Kokkos::Experimental::OffsetView<Scalar*, Device> ib(&s, {-3}, ends);
-    Kokkos::Experimental::OffsetView<Scalar*, Device> ii(&s, {-3}, {2});
+    Kokkos::Experimental::OffsetView<Scalar*, Device> bb(s.data(), begins,
+                                                         ends);
+    Kokkos::Experimental::OffsetView<Scalar*, Device> bi(s.data(), begins, {2});
+    Kokkos::Experimental::OffsetView<Scalar*, Device> ib(s.data(), {-3}, ends);
+    Kokkos::Experimental::OffsetView<Scalar*, Device> ii(s.data(), {-3}, {2});
 
     ASSERT_EQ(bb, bi);
     ASSERT_EQ(bb, ib);
@@ -336,8 +339,8 @@ void test_offsetview_unmanaged_construction() {
 
 template <typename Scalar, typename Device>
 void test_offsetview_unmanaged_construction_death() {
-  // Preallocated memory (Only need a valid address for this test)
-  Scalar s;
+  // Preallocated memory
+  Kokkos::View<Scalar, Device> s("s");
 
   // Regular expression syntax on Windows is a pain. `.` does not match `\n`.
   // Feel free to make it work if you have time to spare.
@@ -351,10 +354,10 @@ void test_offsetview_unmanaged_construction_death() {
     using offset_view_type = Kokkos::Experimental::OffsetView<Scalar*, Device>;
 
     // Range calculations must be positive
-    (void)offset_view_type(&s, {0}, {1});
-    (void)offset_view_type(&s, {0}, {0});
+    (void)offset_view_type(s.data(), {0}, {1});
+    (void)offset_view_type(s.data(), {0}, {0});
     ASSERT_DEATH(
-        offset_view_type(&s, {0}, {-1}),
+        offset_view_type(s.data(), {0}, {-1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
@@ -366,9 +369,9 @@ void test_offsetview_unmanaged_construction_death() {
     using offset_view_type = Kokkos::Experimental::OffsetView<Scalar*, Device>;
 
     // Range calculations must not overflow
-    (void)offset_view_type(&s, {0}, {0x7fffffffffffffffl});
+    (void)offset_view_type(s.data(), {0}, {0x7fffffffffffffffl});
     ASSERT_DEATH(
-        offset_view_type(&s, {-1}, {0x7fffffffffffffffl}),
+        offset_view_type(s.data(), {-1}, {0x7fffffffffffffffl}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
@@ -376,7 +379,8 @@ void test_offsetview_unmanaged_construction_death() {
             "\\(-1\\)\\) "
             "overflows"));
     ASSERT_DEATH(
-        offset_view_type(&s, {-0x7fffffffffffffffl - 1}, {0x7fffffffffffffffl}),
+        offset_view_type(s.data(), {-0x7fffffffffffffffl - 1},
+                         {0x7fffffffffffffffl}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
@@ -384,7 +388,7 @@ void test_offsetview_unmanaged_construction_death() {
             "\\(-9223372036854775808\\)\\) "
             "overflows"));
     ASSERT_DEATH(
-        offset_view_type(&s, {-0x7fffffffffffffffl - 1}, {0}),
+        offset_view_type(s.data(), {-0x7fffffffffffffffl - 1}, {0}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
@@ -399,7 +403,7 @@ void test_offsetview_unmanaged_construction_death() {
     // Should throw when the rank of begins and/or ends doesn't match that
     // of OffsetView
     ASSERT_DEATH(
-        offset_view_type(&s, {0}, {1}),
+        offset_view_type(s.data(), {0}, {1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
@@ -407,13 +411,13 @@ void test_offsetview_unmanaged_construction_death() {
             ".*"
             "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
-        offset_view_type(&s, {0}, {1, 1}),
+        offset_view_type(s.data(), {0}, {1, 1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
             "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
-        offset_view_type(&s, {0}, {1, 1, 1}),
+        offset_view_type(s.data(), {0}, {1, 1, 1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
@@ -421,20 +425,20 @@ void test_offsetview_unmanaged_construction_death() {
             ".*"
             "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
-        offset_view_type(&s, {0, 0}, {1}),
+        offset_view_type(s.data(), {0, 0}, {1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
             "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)"));
-    (void)offset_view_type(&s, {0, 0}, {1, 1});
+    (void)offset_view_type(s.data(), {0, 0}, {1, 1});
     ASSERT_DEATH(
-        offset_view_type(&s, {0, 0}, {1, 1, 1}),
+        offset_view_type(s.data(), {0, 0}, {1, 1, 1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
             "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
-        offset_view_type(&s, {0, 0, 0}, {1}),
+        offset_view_type(s.data(), {0, 0, 0}, {1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
@@ -442,13 +446,13 @@ void test_offsetview_unmanaged_construction_death() {
             ".*"
             "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
-        offset_view_type(&s, {0, 0, 0}, {1, 1}),
+        offset_view_type(s.data(), {0, 0, 0}, {1, 1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
             "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
-        offset_view_type(&s, {0, 0, 0}, {1, 1, 1}),
+        offset_view_type(s.data(), {0, 0, 0}, {1, 1, 1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -272,17 +272,17 @@ template <typename Scalar, typename Device>
 void test_offsetview_unmanaged_construction() {
   // Preallocated memory
   Kokkos::View<Scalar, Device> s("s");
+  Scalar* ptr = s.data();  // obtain a pointer into the right address space
 
   {
     // Constructing an OffsetView directly around our preallocated memory
     Kokkos::Array<int64_t, 1> begins1{{2}};
     Kokkos::Array<int64_t, 1> ends1{{3}};
-    Kokkos::Experimental::OffsetView<Scalar*, Device> ov1(s.data(), begins1,
-                                                          ends1);
+    Kokkos::Experimental::OffsetView<Scalar*, Device> ov1(ptr, begins1, ends1);
 
     // Constructing an OffsetView around an unmanaged View of our preallocated
     // memory
-    Kokkos::View<Scalar*, Device> v1(s.data(), ends1[0] - begins1[0]);
+    Kokkos::View<Scalar*, Device> v1(ptr, ends1[0] - begins1[0]);
     Kokkos::Experimental::OffsetView<Scalar*, Device> ovv1(v1, begins1);
 
     // They should match
@@ -293,10 +293,9 @@ void test_offsetview_unmanaged_construction() {
   {
     Kokkos::Array<int64_t, 2> begins2{{-2, -7}};
     Kokkos::Array<int64_t, 2> ends2{{5, -3}};
-    Kokkos::Experimental::OffsetView<Scalar**, Device> ov2(s.data(), begins2,
-                                                           ends2);
+    Kokkos::Experimental::OffsetView<Scalar**, Device> ov2(ptr, begins2, ends2);
 
-    Kokkos::View<Scalar**, Device> v2(s.data(), ends2[0] - begins2[0],
+    Kokkos::View<Scalar**, Device> v2(ptr, ends2[0] - begins2[0],
                                       ends2[1] - begins2[1]);
     Kokkos::Experimental::OffsetView<Scalar**, Device> ovv2(v2, begins2);
 
@@ -307,10 +306,10 @@ void test_offsetview_unmanaged_construction() {
   {
     Kokkos::Array<int64_t, 3> begins3{{2, 3, 5}};
     Kokkos::Array<int64_t, 3> ends3{{7, 11, 13}};
-    Kokkos::Experimental::OffsetView<Scalar***, Device> ovv3(s.data(), begins3,
+    Kokkos::Experimental::OffsetView<Scalar***, Device> ovv3(ptr, begins3,
                                                              ends3);
 
-    Kokkos::View<Scalar***, Device> v3(s.data(), ends3[0] - begins3[0],
+    Kokkos::View<Scalar***, Device> v3(ptr, ends3[0] - begins3[0],
                                        ends3[1] - begins3[1],
                                        ends3[2] - begins3[2]);
     Kokkos::Experimental::OffsetView<Scalar***, Device> ov3(v3, begins3);
@@ -325,11 +324,10 @@ void test_offsetview_unmanaged_construction() {
     Kokkos::Array<int64_t, 1> begins{{-3}};
     Kokkos::Array<int64_t, 1> ends{{2}};
 
-    Kokkos::Experimental::OffsetView<Scalar*, Device> bb(s.data(), begins,
-                                                         ends);
-    Kokkos::Experimental::OffsetView<Scalar*, Device> bi(s.data(), begins, {2});
-    Kokkos::Experimental::OffsetView<Scalar*, Device> ib(s.data(), {-3}, ends);
-    Kokkos::Experimental::OffsetView<Scalar*, Device> ii(s.data(), {-3}, {2});
+    Kokkos::Experimental::OffsetView<Scalar*, Device> bb(ptr, begins, ends);
+    Kokkos::Experimental::OffsetView<Scalar*, Device> bi(ptr, begins, {2});
+    Kokkos::Experimental::OffsetView<Scalar*, Device> ib(ptr, {-3}, ends);
+    Kokkos::Experimental::OffsetView<Scalar*, Device> ii(ptr, {-3}, {2});
 
     ASSERT_EQ(bb, bi);
     ASSERT_EQ(bb, ib);
@@ -341,6 +339,7 @@ template <typename Scalar, typename Device>
 void test_offsetview_unmanaged_construction_death() {
   // Preallocated memory
   Kokkos::View<Scalar, Device> s("s");
+  Scalar* ptr = s.data();  // obtain a pointer into the right address space
 
   // Regular expression syntax on Windows is a pain. `.` does not match `\n`.
   // Feel free to make it work if you have time to spare.
@@ -354,10 +353,10 @@ void test_offsetview_unmanaged_construction_death() {
     using offset_view_type = Kokkos::Experimental::OffsetView<Scalar*, Device>;
 
     // Range calculations must be positive
-    (void)offset_view_type(s.data(), {0}, {1});
-    (void)offset_view_type(s.data(), {0}, {0});
+    (void)offset_view_type(ptr, {0}, {1});
+    (void)offset_view_type(ptr, {0}, {0});
     ASSERT_DEATH(
-        offset_view_type(s.data(), {0}, {-1}),
+        offset_view_type(ptr, {0}, {-1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
@@ -369,9 +368,9 @@ void test_offsetview_unmanaged_construction_death() {
     using offset_view_type = Kokkos::Experimental::OffsetView<Scalar*, Device>;
 
     // Range calculations must not overflow
-    (void)offset_view_type(s.data(), {0}, {0x7fffffffffffffffl});
+    (void)offset_view_type(ptr, {0}, {0x7fffffffffffffffl});
     ASSERT_DEATH(
-        offset_view_type(s.data(), {-1}, {0x7fffffffffffffffl}),
+        offset_view_type(ptr, {-1}, {0x7fffffffffffffffl}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
@@ -379,7 +378,7 @@ void test_offsetview_unmanaged_construction_death() {
             "\\(-1\\)\\) "
             "overflows"));
     ASSERT_DEATH(
-        offset_view_type(s.data(), {-0x7fffffffffffffffl - 1},
+        offset_view_type(ptr, {-0x7fffffffffffffffl - 1},
                          {0x7fffffffffffffffl}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
@@ -388,7 +387,7 @@ void test_offsetview_unmanaged_construction_death() {
             "\\(-9223372036854775808\\)\\) "
             "overflows"));
     ASSERT_DEATH(
-        offset_view_type(s.data(), {-0x7fffffffffffffffl - 1}, {0}),
+        offset_view_type(ptr, {-0x7fffffffffffffffl - 1}, {0}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
@@ -403,7 +402,7 @@ void test_offsetview_unmanaged_construction_death() {
     // Should throw when the rank of begins and/or ends doesn't match that
     // of OffsetView
     ASSERT_DEATH(
-        offset_view_type(s.data(), {0}, {1}),
+        offset_view_type(ptr, {0}, {1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
@@ -411,13 +410,13 @@ void test_offsetview_unmanaged_construction_death() {
             ".*"
             "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
-        offset_view_type(s.data(), {0}, {1, 1}),
+        offset_view_type(ptr, {0}, {1, 1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
             "begins\\.size\\(\\) \\(1\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
-        offset_view_type(s.data(), {0}, {1, 1, 1}),
+        offset_view_type(ptr, {0}, {1, 1, 1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
@@ -425,20 +424,20 @@ void test_offsetview_unmanaged_construction_death() {
             ".*"
             "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
-        offset_view_type(s.data(), {0, 0}, {1}),
+        offset_view_type(ptr, {0, 0}, {1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
             "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)"));
-    (void)offset_view_type(s.data(), {0, 0}, {1, 1});
+    (void)offset_view_type(ptr, {0, 0}, {1, 1});
     ASSERT_DEATH(
-        offset_view_type(s.data(), {0, 0}, {1, 1, 1}),
+        offset_view_type(ptr, {0, 0}, {1, 1, 1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
             "ends\\.size\\(\\) \\(3\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
-        offset_view_type(s.data(), {0, 0, 0}, {1}),
+        offset_view_type(ptr, {0, 0, 0}, {1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
@@ -446,13 +445,13 @@ void test_offsetview_unmanaged_construction_death() {
             ".*"
             "ends\\.size\\(\\) \\(1\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
-        offset_view_type(s.data(), {0, 0, 0}, {1, 1}),
+        offset_view_type(ptr, {0, 0, 0}, {1, 1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"
             "begins\\.size\\(\\) \\(3\\) != Rank \\(2\\)"));
     ASSERT_DEATH(
-        offset_view_type(s.data(), {0, 0, 0}, {1, 1, 1}),
+        offset_view_type(ptr, {0, 0, 0}, {1, 1, 1}),
         SKIP_REGEX_ON_WINDOWS(
             "Kokkos::Experimental::OffsetView ERROR: for unmanaged OffsetView"
             ".*"

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -975,9 +975,9 @@ struct checkScan {
 
     Kokkos::View<value_type[n], Kokkos::HostSpace> expected("expected");
     {
+      typename Reducer::result_view_type result("result");
+      Reducer reducer(result);
       value_type identity;
-      Kokkos::View<value_type, ExecutionSpace> dummy("dummy");
-      Reducer reducer = {dummy};
       reducer.init(identity);
 
       for (int i = 0; i < expected.extent_int(0); ++i) {

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -976,7 +976,8 @@ struct checkScan {
     Kokkos::View<value_type[n], Kokkos::HostSpace> expected("expected");
     {
       value_type identity;
-      Reducer reducer = {identity};
+      Kokkos::View<value_type, ExecutionSpace> dummy("dummy");
+      Reducer reducer = {dummy};
       reducer.init(identity);
 
       for (int i = 0; i < expected.extent_int(0); ++i) {

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1002,19 +1002,20 @@ class TestViewAPI {
     hView3 hv_3("dView3::HostMirror", N0);
     hView4 hv_4("dView4::HostMirror", N0);
 
-    dView0 dv_0_1(nullptr);
+    dView0 dummy("dummy");
+    dView0 dv_0_1(dummy.data());
     dView0 dv_0_2(hv_0.label(), hv_0.layout());
 
-    dView1 dv_1_1(nullptr, N0);
+    dView1 dv_1_1(dummy.data(), N0);
     dView1 dv_1_2(hv_1.label(), hv_1.layout());
 
-    dView2 dv_2_1(nullptr, N0);
+    dView2 dv_2_1(dummy.data(), N0);
     dView2 dv_2_2(hv_2.label(), hv_2.layout());
 
-    dView3 dv_3_1(nullptr, N0);
+    dView3 dv_3_1(dummy.data(), N0);
     dView3 dv_3_2(hv_3.label(), hv_3.layout());
 
-    dView4 dv_4_1(nullptr, N0);
+    dView4 dv_4_1(dummy.data(), N0);
     dView4 dv_4_2(hv_4.label(), hv_4.layout());
   }
 

--- a/core/unit_test/TestViewEmptyRuntimeUnmanaged.hpp
+++ b/core/unit_test/TestViewEmptyRuntimeUnmanaged.hpp
@@ -25,12 +25,6 @@ void test_empty_view_runtime_unmanaged() {
   T d{};
   auto* p = reinterpret_cast<T*>(0xABADBABE);
 
-  (void)Kokkos::View<T>(p);
-  (void)Kokkos::View<T>(&d);
-  (void)Kokkos::View<T>(nullptr);
-  (void)Kokkos::View<T>(NULL);  // NOLINT(modernize-use-nullptr)
-  (void)Kokkos::View<T>(0);     // NOLINT(modernize-use-nullptr)
-
   (void)Kokkos::View<T*>(p, 0);
   (void)Kokkos::View<T*>(&d, 0);
   (void)Kokkos::View<T*>(nullptr, 0);

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -647,25 +647,11 @@ void test_view_mapping() {
 
   //----------------------------------------
 
-  if (std::is_same_v<typename Space::memory_space, Kokkos::HostSpace>) {
+  {
     constexpr int N = 10;
 
     using T = Kokkos::View<int*, Space>;
     using C = Kokkos::View<const int*, Space>;
-
-    int data[N];
-
-    T vr1(data, N);  // View of non-const.
-    C cr1(vr1);      // View of const from view of non-const.
-    C cr2((const int*)data, N);
-
-    // Generate static_assert error:
-    // T tmp( cr1 );
-
-    ASSERT_EQ(vr1.span(), size_t(N));
-    ASSERT_EQ(cr1.span(), size_t(N));
-    ASSERT_EQ(vr1.data(), &data[0]);
-    ASSERT_EQ(cr1.data(), &data[0]);
 
     static_assert(std::is_same_v<typename T::data_type, int*>);
     static_assert(std::is_same_v<typename T::const_data_type, const int*>);
@@ -707,10 +693,26 @@ void test_view_mapping() {
 
     static_assert(C::rank == size_t(1));
 
-    ASSERT_EQ(vr1.extent(0), size_t(N));
-
     if (Kokkos::SpaceAccessibility<Kokkos::HostSpace,
-                                   typename Space::memory_space>::accessible) {
+                                   typename Space::memory_space>::accessible &&
+        Kokkos::SpaceAccessibility<typename Space::memory_space,
+                                   Kokkos::HostSpace>::assignable) {
+      int data[N];
+
+      T vr1(data, N);  // View of non-const.
+      C cr1(vr1);      // View of const from view of non-const.
+      C cr2((const int*)data, N);
+
+      // Generate static_assert error:
+      // T tmp( cr1 );
+
+      ASSERT_EQ(vr1.span(), size_t(N));
+      ASSERT_EQ(cr1.span(), size_t(N));
+      ASSERT_EQ(vr1.data(), &data[0]);
+      ASSERT_EQ(cr1.data(), &data[0]);
+
+      ASSERT_EQ(vr1.extent(0), size_t(N));
+
       for (int i = 0; i < N; ++i) data[i] = i + 1;
       for (int i = 0; i < N; ++i) ASSERT_EQ(vr1[i], i + 1);
       for (int i = 0; i < N; ++i) ASSERT_EQ(cr1[i], i + 1);

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -647,7 +647,7 @@ void test_view_mapping() {
 
   //----------------------------------------
 
-  {
+  if (std::is_same_v<typename Space::memory_space, Kokkos::HostSpace>) {
     constexpr int N = 10;
 
     using T = Kokkos::View<int*, Space>;

--- a/core/unit_test/TestViewMemoryAccessViolation.hpp
+++ b/core/unit_test/TestViewMemoryAccessViolation.hpp
@@ -91,16 +91,17 @@ void test_view_memory_access_violations_from_host() {
   test_view_memory_access_violation(make_view<V6>(lbl), host_exec_space, prefix + ".*" + lbl);
   test_view_memory_access_violation(make_view<V7>(lbl), host_exec_space, prefix + ".*" + lbl);
   test_view_memory_access_violation(make_view<V8>(lbl), host_exec_space, prefix + ".*" + lbl);
-  V0 v0("v0");
-  test_view_memory_access_violation(make_view<V0>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
-  test_view_memory_access_violation(make_view<V1>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
-  test_view_memory_access_violation(make_view<V2>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
-  test_view_memory_access_violation(make_view<V3>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
-  test_view_memory_access_violation(make_view<V4>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
-  test_view_memory_access_violation(make_view<V5>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
-  test_view_memory_access_violation(make_view<V6>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
-  test_view_memory_access_violation(make_view<V7>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
-  test_view_memory_access_violation(make_view<V8>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
+  V0 v0("v0");  // obtain a valid pointer for an allocation in the right space
+  int* const ptr = v0.data();
+  test_view_memory_access_violation(make_view<V0>(ptr), host_exec_space, prefix + ".*UNMANAGED");
+  test_view_memory_access_violation(make_view<V1>(ptr), host_exec_space, prefix + ".*UNMANAGED");
+  test_view_memory_access_violation(make_view<V2>(ptr), host_exec_space, prefix + ".*UNMANAGED");
+  test_view_memory_access_violation(make_view<V3>(ptr), host_exec_space, prefix + ".*UNMANAGED");
+  test_view_memory_access_violation(make_view<V4>(ptr), host_exec_space, prefix + ".*UNMANAGED");
+  test_view_memory_access_violation(make_view<V5>(ptr), host_exec_space, prefix + ".*UNMANAGED");
+  test_view_memory_access_violation(make_view<V6>(ptr), host_exec_space, prefix + ".*UNMANAGED");
+  test_view_memory_access_violation(make_view<V7>(ptr), host_exec_space, prefix + ".*UNMANAGED");
+  test_view_memory_access_violation(make_view<V8>(ptr), host_exec_space, prefix + ".*UNMANAGED");
   // clang-format on
 }
 
@@ -128,16 +129,17 @@ void test_view_memory_access_violations_from_device() {
   test_view_memory_access_violation(make_view<V6>(lbl), exec_space, prefix + ".*UNAVAILABLE");
   test_view_memory_access_violation(make_view<V7>(lbl), exec_space, prefix + ".*UNAVAILABLE");
   test_view_memory_access_violation(make_view<V8>(lbl), exec_space, prefix + ".*UNAVAILABLE");
-  V0 v0("v0");
-  test_view_memory_access_violation(make_view<V0>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
-  test_view_memory_access_violation(make_view<V1>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
-  test_view_memory_access_violation(make_view<V2>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
-  test_view_memory_access_violation(make_view<V3>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
-  test_view_memory_access_violation(make_view<V4>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
-  test_view_memory_access_violation(make_view<V5>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
-  test_view_memory_access_violation(make_view<V6>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
-  test_view_memory_access_violation(make_view<V7>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
-  test_view_memory_access_violation(make_view<V8>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
+  V0 v0("v0");  // obtain a valid pointer for an allocation in the right space
+  int* const ptr = v0.data();
+  test_view_memory_access_violation(make_view<V0>(ptr), exec_space, prefix + ".*UNAVAILABLE");
+  test_view_memory_access_violation(make_view<V1>(ptr), exec_space, prefix + ".*UNAVAILABLE");
+  test_view_memory_access_violation(make_view<V2>(ptr), exec_space, prefix + ".*UNAVAILABLE");
+  test_view_memory_access_violation(make_view<V3>(ptr), exec_space, prefix + ".*UNAVAILABLE");
+  test_view_memory_access_violation(make_view<V4>(ptr), exec_space, prefix + ".*UNAVAILABLE");
+  test_view_memory_access_violation(make_view<V5>(ptr), exec_space, prefix + ".*UNAVAILABLE");
+  test_view_memory_access_violation(make_view<V6>(ptr), exec_space, prefix + ".*UNAVAILABLE");
+  test_view_memory_access_violation(make_view<V7>(ptr), exec_space, prefix + ".*UNAVAILABLE");
+  test_view_memory_access_violation(make_view<V8>(ptr), exec_space, prefix + ".*UNAVAILABLE");
   // clang-format on
 }
 

--- a/core/unit_test/TestViewMemoryAccessViolation.hpp
+++ b/core/unit_test/TestViewMemoryAccessViolation.hpp
@@ -91,16 +91,16 @@ void test_view_memory_access_violations_from_host() {
   test_view_memory_access_violation(make_view<V6>(lbl), host_exec_space, prefix + ".*" + lbl);
   test_view_memory_access_violation(make_view<V7>(lbl), host_exec_space, prefix + ".*" + lbl);
   test_view_memory_access_violation(make_view<V8>(lbl), host_exec_space, prefix + ".*" + lbl);
-  int* const ptr = nullptr;
-  test_view_memory_access_violation(make_view<V0>(ptr), host_exec_space, prefix + ".*UNMANAGED");
-  test_view_memory_access_violation(make_view<V1>(ptr), host_exec_space, prefix + ".*UNMANAGED");
-  test_view_memory_access_violation(make_view<V2>(ptr), host_exec_space, prefix + ".*UNMANAGED");
-  test_view_memory_access_violation(make_view<V3>(ptr), host_exec_space, prefix + ".*UNMANAGED");
-  test_view_memory_access_violation(make_view<V4>(ptr), host_exec_space, prefix + ".*UNMANAGED");
-  test_view_memory_access_violation(make_view<V5>(ptr), host_exec_space, prefix + ".*UNMANAGED");
-  test_view_memory_access_violation(make_view<V6>(ptr), host_exec_space, prefix + ".*UNMANAGED");
-  test_view_memory_access_violation(make_view<V7>(ptr), host_exec_space, prefix + ".*UNMANAGED");
-  test_view_memory_access_violation(make_view<V8>(ptr), host_exec_space, prefix + ".*UNMANAGED");
+  V0 v0("v0");
+  test_view_memory_access_violation(make_view<V0>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
+  test_view_memory_access_violation(make_view<V1>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
+  test_view_memory_access_violation(make_view<V2>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
+  test_view_memory_access_violation(make_view<V3>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
+  test_view_memory_access_violation(make_view<V4>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
+  test_view_memory_access_violation(make_view<V5>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
+  test_view_memory_access_violation(make_view<V6>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
+  test_view_memory_access_violation(make_view<V7>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
+  test_view_memory_access_violation(make_view<V8>(v0.data()), host_exec_space, prefix + ".*UNMANAGED");
   // clang-format on
 }
 
@@ -128,16 +128,16 @@ void test_view_memory_access_violations_from_device() {
   test_view_memory_access_violation(make_view<V6>(lbl), exec_space, prefix + ".*UNAVAILABLE");
   test_view_memory_access_violation(make_view<V7>(lbl), exec_space, prefix + ".*UNAVAILABLE");
   test_view_memory_access_violation(make_view<V8>(lbl), exec_space, prefix + ".*UNAVAILABLE");
-  int* const ptr = nullptr;
-  test_view_memory_access_violation(make_view<V0>(ptr), exec_space, prefix + ".*UNAVAILABLE");
-  test_view_memory_access_violation(make_view<V1>(ptr), exec_space, prefix + ".*UNAVAILABLE");
-  test_view_memory_access_violation(make_view<V2>(ptr), exec_space, prefix + ".*UNAVAILABLE");
-  test_view_memory_access_violation(make_view<V3>(ptr), exec_space, prefix + ".*UNAVAILABLE");
-  test_view_memory_access_violation(make_view<V4>(ptr), exec_space, prefix + ".*UNAVAILABLE");
-  test_view_memory_access_violation(make_view<V5>(ptr), exec_space, prefix + ".*UNAVAILABLE");
-  test_view_memory_access_violation(make_view<V6>(ptr), exec_space, prefix + ".*UNAVAILABLE");
-  test_view_memory_access_violation(make_view<V7>(ptr), exec_space, prefix + ".*UNAVAILABLE");
-  test_view_memory_access_violation(make_view<V8>(ptr), exec_space, prefix + ".*UNAVAILABLE");
+  V0 v0("v0");
+  test_view_memory_access_violation(make_view<V0>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
+  test_view_memory_access_violation(make_view<V1>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
+  test_view_memory_access_violation(make_view<V2>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
+  test_view_memory_access_violation(make_view<V3>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
+  test_view_memory_access_violation(make_view<V4>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
+  test_view_memory_access_violation(make_view<V5>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
+  test_view_memory_access_violation(make_view<V6>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
+  test_view_memory_access_violation(make_view<V7>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
+  test_view_memory_access_violation(make_view<V8>(v0.data()), exec_space, prefix + ".*UNAVAILABLE");
   // clang-format on
 }
 

--- a/core/unit_test/TestViewOutOfBoundsAccess.hpp
+++ b/core/unit_test/TestViewOutOfBoundsAccess.hpp
@@ -107,6 +107,7 @@ template <class ExecutionSpace>
 void test_view_out_of_bounds_access() {
   ExecutionSpace const exec_space{};
   // clang-format off
+  using V0 = Kokkos::View<int,         ExecutionSpace>;
   using V1 = Kokkos::View<int*,        ExecutionSpace>;
   using V2 = Kokkos::View<int**,       ExecutionSpace>;
   using V3 = Kokkos::View<int***,      ExecutionSpace>;
@@ -125,15 +126,15 @@ void test_view_out_of_bounds_access() {
   TestViewOutOfBoundAccess(make_view<V6>(lbl), exec_space, prefix + ".*" + lbl);
   TestViewOutOfBoundAccess(make_view<V7>(lbl), exec_space, prefix + ".*" + lbl);
   TestViewOutOfBoundAccess(make_view<V8>(lbl), exec_space, prefix + ".*" + lbl);
-  int* const ptr = nullptr;
-  TestViewOutOfBoundAccess(make_view<V1>(ptr), exec_space, prefix + ".*UNMANAGED");
-  TestViewOutOfBoundAccess(make_view<V2>(ptr), exec_space, prefix + ".*UNMANAGED");
-  TestViewOutOfBoundAccess(make_view<V3>(ptr), exec_space, prefix + ".*UNMANAGED");
-  TestViewOutOfBoundAccess(make_view<V4>(ptr), exec_space, prefix + ".*UNMANAGED");
-  TestViewOutOfBoundAccess(make_view<V5>(ptr), exec_space, prefix + ".*UNMANAGED");
-  TestViewOutOfBoundAccess(make_view<V6>(ptr), exec_space, prefix + ".*UNMANAGED");
-  TestViewOutOfBoundAccess(make_view<V7>(ptr), exec_space, prefix + ".*UNMANAGED");
-  TestViewOutOfBoundAccess(make_view<V8>(ptr), exec_space, prefix + ".*UNMANAGED");
+  V0 v0("v0");
+  TestViewOutOfBoundAccess(make_view<V1>(v0.data()), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V2>(v0.data()), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V3>(v0.data()), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V4>(v0.data()), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V5>(v0.data()), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V6>(v0.data()), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V7>(v0.data()), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V8>(v0.data()), exec_space, prefix + ".*UNMANAGED");
   // clang-format on
 }
 

--- a/core/unit_test/TestViewOutOfBoundsAccess.hpp
+++ b/core/unit_test/TestViewOutOfBoundsAccess.hpp
@@ -126,15 +126,16 @@ void test_view_out_of_bounds_access() {
   TestViewOutOfBoundAccess(make_view<V6>(lbl), exec_space, prefix + ".*" + lbl);
   TestViewOutOfBoundAccess(make_view<V7>(lbl), exec_space, prefix + ".*" + lbl);
   TestViewOutOfBoundAccess(make_view<V8>(lbl), exec_space, prefix + ".*" + lbl);
-  V0 v0("v0");
-  TestViewOutOfBoundAccess(make_view<V1>(v0.data()), exec_space, prefix + ".*UNMANAGED");
-  TestViewOutOfBoundAccess(make_view<V2>(v0.data()), exec_space, prefix + ".*UNMANAGED");
-  TestViewOutOfBoundAccess(make_view<V3>(v0.data()), exec_space, prefix + ".*UNMANAGED");
-  TestViewOutOfBoundAccess(make_view<V4>(v0.data()), exec_space, prefix + ".*UNMANAGED");
-  TestViewOutOfBoundAccess(make_view<V5>(v0.data()), exec_space, prefix + ".*UNMANAGED");
-  TestViewOutOfBoundAccess(make_view<V6>(v0.data()), exec_space, prefix + ".*UNMANAGED");
-  TestViewOutOfBoundAccess(make_view<V7>(v0.data()), exec_space, prefix + ".*UNMANAGED");
-  TestViewOutOfBoundAccess(make_view<V8>(v0.data()), exec_space, prefix + ".*UNMANAGED");
+  V0 v0("v0");  // obtain a valid pointer for an allocation in the right space
+  int* const ptr = v0.data();  
+  TestViewOutOfBoundAccess(make_view<V1>(ptr), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V2>(ptr), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V3>(ptr), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V4>(ptr), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V5>(ptr), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V6>(ptr), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V7>(ptr), exec_space, prefix + ".*UNMANAGED");
+  TestViewOutOfBoundAccess(make_view<V8>(ptr), exec_space, prefix + ".*UNMANAGED");
   // clang-format on
 }
 


### PR DESCRIPTION
This pull requests constains the changes to the unit tests to make #7480 work.
We need to both fix
- using compatible memory spaces (precisely what #7480 is about)
- invalid pointers in non-empty Views (we only check the memory space for non-empty Views)