### PR TITLE
HIP: Fix default launch bound for local memory launch

### DIFF
--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -245,9 +245,7 @@ struct HIPParallelLaunchKernelFunc<DriverType, Kokkos::LaunchBounds<0, 0>,
       HIPParallelLaunchKernelFuncData<DriverType, Kokkos::LaunchBounds<0, 0>,
                                       HIPLaunchMechanism::LocalMemory>;
   static auto get_kernel_func() {
-    return HIPParallelLaunchKernelFunc<
-        DriverType, Kokkos::LaunchBounds<HIPTraits::MaxThreadsPerBlock, 1>,
-        HIPLaunchMechanism::LocalMemory>::get_kernel_func();
+    return hip_parallel_launch_local_memory<DriverType>;
   }
 
   static constexpr auto default_launchbounds() { return true; }


### PR DESCRIPTION
@crtrott reported on slack that: "if you call (via virtual function or function ptr) a function inside the kernel that uses more registers than what a block size of `MaxThreadsPerBlock` allows, the code will crash at run time. This only happens for local memory launchevery other launch mechanism refers to the global function without launchbounds if they are defaulted."

I've done some digging and the reason we set `Kokkos::LaunchBounds<HIPTraits::MaxThreadsPerBlock, 1>` manually is because of bugs in old ROCm compiler (see https://github.com/kokkos/kokkos/pull/3102: "Defaults all kernels w/o a launch bounds attributes to \_\_launch_bounds\_\_(1024, 1) to ensure we always generate correct code.")

This PR fixes the issue.