### PR TITLE
Use more static_asserts in TestViewMapping_a.hpp

### DIFF
--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -667,45 +667,45 @@ void test_view_mapping() {
     ASSERT_EQ(vr1.data(), &data[0]);
     ASSERT_EQ(cr1.data(), &data[0]);
 
-    ASSERT_TRUE((std::is_same_v<typename T::data_type, int*>));
-    ASSERT_TRUE((std::is_same_v<typename T::const_data_type, const int*>));
-    ASSERT_TRUE((std::is_same_v<typename T::non_const_data_type, int*>));
+    static_assert(std::is_same_v<typename T::data_type, int*>);
+    static_assert(std::is_same_v<typename T::const_data_type, const int*>);
+    static_assert(std::is_same_v<typename T::non_const_data_type, int*>);
 
-    ASSERT_TRUE((std::is_same_v<typename T::scalar_array_type, int*>));
-    ASSERT_TRUE(
-        (std::is_same_v<typename T::const_scalar_array_type, const int*>));
-    ASSERT_TRUE(
-        (std::is_same_v<typename T::non_const_scalar_array_type, int*>));
+    static_assert(std::is_same_v<typename T::scalar_array_type, int*>);
+    static_assert(
+        std::is_same_v<typename T::const_scalar_array_type, const int*>);
+    static_assert(
+        std::is_same_v<typename T::non_const_scalar_array_type, int*>);
 
-    ASSERT_TRUE((std::is_same_v<typename T::value_type, int>));
-    ASSERT_TRUE((std::is_same_v<typename T::const_value_type, const int>));
-    ASSERT_TRUE((std::is_same_v<typename T::non_const_value_type, int>));
+    static_assert(std::is_same_v<typename T::value_type, int>);
+    static_assert(std::is_same_v<typename T::const_value_type, const int>);
+    static_assert(std::is_same_v<typename T::non_const_value_type, int>);
 
-    ASSERT_TRUE((std::is_same_v<typename T::memory_space,
-                                typename Space::memory_space>));
-    ASSERT_TRUE((std::is_same_v<typename T::reference_type, int&>));
+    static_assert(
+        std::is_same_v<typename T::memory_space, typename Space::memory_space>);
+    static_assert(std::is_same_v<typename T::reference_type, int&>);
 
-    ASSERT_EQ(T::rank, size_t(1));
+    static_assert(T::rank == size_t(1));
 
-    ASSERT_TRUE((std::is_same_v<typename C::data_type, const int*>));
-    ASSERT_TRUE((std::is_same_v<typename C::const_data_type, const int*>));
-    ASSERT_TRUE((std::is_same_v<typename C::non_const_data_type, int*>));
+    static_assert(std::is_same_v<typename C::data_type, const int*>);
+    static_assert(std::is_same_v<typename C::const_data_type, const int*>);
+    static_assert(std::is_same_v<typename C::non_const_data_type, int*>);
 
-    ASSERT_TRUE((std::is_same_v<typename C::scalar_array_type, const int*>));
-    ASSERT_TRUE(
-        (std::is_same_v<typename C::const_scalar_array_type, const int*>));
-    ASSERT_TRUE(
-        (std::is_same_v<typename C::non_const_scalar_array_type, int*>));
+    static_assert(std::is_same_v<typename C::scalar_array_type, const int*>);
+    static_assert(
+        std::is_same_v<typename C::const_scalar_array_type, const int*>);
+    static_assert(
+        std::is_same_v<typename C::non_const_scalar_array_type, int*>);
 
-    ASSERT_TRUE((std::is_same_v<typename C::value_type, const int>));
-    ASSERT_TRUE((std::is_same_v<typename C::const_value_type, const int>));
-    ASSERT_TRUE((std::is_same_v<typename C::non_const_value_type, int>));
+    static_assert(std::is_same_v<typename C::value_type, const int>);
+    static_assert(std::is_same_v<typename C::const_value_type, const int>);
+    static_assert(std::is_same_v<typename C::non_const_value_type, int>);
 
-    ASSERT_TRUE((std::is_same_v<typename C::memory_space,
-                                typename Space::memory_space>));
-    ASSERT_TRUE((std::is_same_v<typename C::reference_type, const int&>));
+    static_assert(
+        std::is_same_v<typename C::memory_space, typename Space::memory_space>);
+    static_assert(std::is_same_v<typename C::reference_type, const int&>);
 
-    ASSERT_EQ(C::rank, size_t(1));
+    static_assert(C::rank == size_t(1));
 
     ASSERT_EQ(vr1.extent(0), size_t(N));
 
@@ -735,24 +735,24 @@ void test_view_mapping() {
     T vr1("vr1", N);
     C cr1(vr1);
 
-    ASSERT_TRUE((std::is_same_v<typename T::data_type, int*>));
-    ASSERT_TRUE((std::is_same_v<typename T::const_data_type, const int*>));
-    ASSERT_TRUE((std::is_same_v<typename T::non_const_data_type, int*>));
+    static_assert(std::is_same_v<typename T::data_type, int*>);
+    static_assert(std::is_same_v<typename T::const_data_type, const int*>);
+    static_assert(std::is_same_v<typename T::non_const_data_type, int*>);
 
-    ASSERT_TRUE((std::is_same_v<typename T::scalar_array_type, int*>));
-    ASSERT_TRUE(
-        (std::is_same_v<typename T::const_scalar_array_type, const int*>));
-    ASSERT_TRUE(
-        (std::is_same_v<typename T::non_const_scalar_array_type, int*>));
+    static_assert(std::is_same_v<typename T::scalar_array_type, int*>);
+    static_assert(
+        std::is_same_v<typename T::const_scalar_array_type, const int*>);
+    static_assert(
+        std::is_same_v<typename T::non_const_scalar_array_type, int*>);
 
-    ASSERT_TRUE((std::is_same_v<typename T::value_type, int>));
-    ASSERT_TRUE((std::is_same_v<typename T::const_value_type, const int>));
-    ASSERT_TRUE((std::is_same_v<typename T::non_const_value_type, int>));
+    static_assert(std::is_same_v<typename T::value_type, int>);
+    static_assert(std::is_same_v<typename T::const_value_type, const int>);
+    static_assert(std::is_same_v<typename T::non_const_value_type, int>);
 
-    ASSERT_TRUE((std::is_same_v<typename T::memory_space,
-                                typename Space::memory_space>));
-    ASSERT_TRUE((std::is_same_v<typename T::reference_type, int&>));
-    ASSERT_EQ(T::rank, size_t(1));
+    static_assert(
+        std::is_same_v<typename T::memory_space, typename Space::memory_space>);
+    static_assert(std::is_same_v<typename T::reference_type, int&>);
+    static_assert(T::rank == size_t(1));
 
     ASSERT_EQ(vr1.extent(0), size_t(N));
 


### PR DESCRIPTION
Split from https://github.com/kokkos/kokkos/pull/7657. Addressing https://github.com/kokkos/kokkos/pull/7657#pullrequestreview-2540291275. Some of the checks in `ViewMapping_a.hpp` can use `static_assert`s instead of runtime checks.