### PR TITLE
unified memory for support for the gfx942_apu architecture -- changes to the MemorySpaceAccess attributes between host and HIP spaces

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Space.hpp
+++ b/core/src/HIP/Kokkos_HIP_Space.hpp
@@ -275,11 +275,12 @@ static_assert(Kokkos::Impl::MemorySpaceAccess<HIPSpace, HIPSpace>::assignable);
 
 template <>
 struct MemorySpaceAccess<HostSpace, HIPSpace> {
-  enum : bool { assignable = false };
 #if !defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
-  enum : bool{accessible = false};
+  enum : bool { accessible = false };
+  enum : bool { assignable = false };
 #else
   enum : bool { accessible = true };
+  enum : bool { assignable = true };
 #endif
   enum : bool { deepcopy = true };
 };
@@ -304,8 +305,13 @@ struct MemorySpaceAccess<HostSpace, HIPManagedSpace> {
 
 template <>
 struct MemorySpaceAccess<HIPSpace, HostSpace> {
-  enum : bool { assignable = false };
+#if !defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
   enum : bool { accessible = false };
+  enum : bool { assignable = false };
+#else 
+  enum : bool { accessible = true };
+  enum : bool { assignable = true };
+#endif
   enum : bool { deepcopy = true };
 };
 


### PR DESCRIPTION
Adjustment to unified memory support for the GFX942_APU target. This fixs a compile time issue related to HostSpace/HIPSpace spaces being assignable to each other (when unified memory is active). We also addressed an issue for another template specialization in which the template parameters are interchanged such that the struct should behave similarly.

MemorySpaceAccess<HostSpace, HIPSpace> --> MemorySpaceAccess<HIPSpace, HostSpace>

 