### PR TITLE
core(graph): allow construction from native graph (interop)

### DIFF
--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -169,6 +169,16 @@ create_graph(Closure&& arg_closure) {
   return create_graph(ExecutionSpace{}, (Closure&&)arg_closure);
 }
 
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
+    defined(KOKKOS_ENABLE_SYCL)
+template <class Exec, typename T>
+std::enable_if_t<Kokkos::is_execution_space_v<Exec>, Graph<Exec>>
+create_graph_from_native(Exec exec, T&& native_graph) {
+  return Kokkos::Impl::GraphAccess::construct_graph_from_native(
+      std::move(exec), std::forward<T>(native_graph));
+}
+#endif
+
 // </editor-fold> end create_graph }}}1
 //==============================================================================
 

--- a/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
@@ -42,6 +42,9 @@ class GraphImpl<Kokkos::SYCL> {
       GraphNodeImpl<Kokkos::SYCL, aggregate_impl_t,
                     Kokkos::Experimental::TypeErasedTag>;
 
+  using native_graph_t = sycl::ext::oneapi::experimental::command_graph<
+      sycl::ext::oneapi::experimental::graph_state::modifiable>;
+
   // Not movable or copyable; it spends its whole life as a shared_ptr in the
   // Graph object.
   GraphImpl()                            = delete;
@@ -53,6 +56,8 @@ class GraphImpl<Kokkos::SYCL> {
   ~GraphImpl();
 
   explicit GraphImpl(Kokkos::SYCL instance);
+
+  GraphImpl(Kokkos::SYCL instance, native_graph_t native_graph);
 
   void add_node(std::shared_ptr<aggregate_node_impl_t> const& arg_node_ptr);
 
@@ -83,9 +88,7 @@ class GraphImpl<Kokkos::SYCL> {
 
  private:
   Kokkos::SYCL m_execution_space;
-  sycl::ext::oneapi::experimental::command_graph<
-      sycl::ext::oneapi::experimental::graph_state::modifiable>
-      m_graph;
+  native_graph_t m_graph;
   std::optional<sycl::ext::oneapi::experimental::command_graph<
       sycl::ext::oneapi::experimental::graph_state::executable>>
       m_graph_exec;
@@ -101,6 +104,11 @@ inline GraphImpl<Kokkos::SYCL>::GraphImpl(Kokkos::SYCL instance)
     : m_execution_space(std::move(instance)),
       m_graph(m_execution_space.sycl_queue().get_context(),
               m_execution_space.sycl_queue().get_device()) {}
+
+inline GraphImpl<Kokkos::SYCL>::GraphImpl(Kokkos::SYCL instance,
+                                          native_graph_t native_graph)
+    : m_execution_space(std::move(instance)),
+      m_graph(std::move(native_graph)) {}
 
 inline void GraphImpl<Kokkos::SYCL>::add_node(
     std::shared_ptr<aggregate_node_impl_t> const& arg_node_ptr) {

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -40,6 +40,17 @@ struct GraphAccess {
         std::make_shared<GraphImpl<ExecutionSpace>>(std::move(ex))};
     //----------------------------------------//
   }
+
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
+    defined(KOKKOS_ENABLE_SYCL)
+  template <class Exec, typename T>
+  static auto construct_graph_from_native(Exec&& ex, T&& native_graph) {
+    return Kokkos::Experimental::Graph<Kokkos::Impl::remove_cvref_t<Exec>>{
+        std::make_shared<GraphImpl<Kokkos::Impl::remove_cvref_t<Exec>>>(
+            std::forward<Exec>(ex), std::forward<T>(native_graph))};
+  }
+#endif
+
   template <class ExecutionSpace>
   static auto create_root_ref(
       Kokkos::Experimental::Graph<ExecutionSpace>& arg_graph) {

--- a/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
@@ -37,9 +37,9 @@ struct Increment {
 class TEST_CATEGORY_FIXTURE(GraphInterOp) : public ::testing::Test {
  public:
   using execution_space = Kokkos::Cuda;
-  using view_t =
-      Kokkos::View<int, execution_space, Kokkos::MemoryTraits<Kokkos::Atomic>>;
-  using graph_t = Kokkos::Experimental::Graph<execution_space>;
+  using view_t          = Kokkos::View<int, Kokkos::CudaUVMSpace,
+                              Kokkos::MemoryTraits<Kokkos::Atomic>>;
+  using graph_t         = Kokkos::Experimental::Graph<execution_space>;
 
   void SetUp() override {
     data = view_t(Kokkos::view_alloc(exec, "witness"));
@@ -146,6 +146,27 @@ TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), instantiation_flags) {
 
   ASSERT_EQ(flags, 0u);
 #endif
+}
+
+// Build a Kokkos::Graph from an existing cudaGraph_t.
+TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), construct_from_native) {
+  cudaGraph_t native_graph = nullptr;
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGraphCreate(&native_graph, 0));
+
+  auto graph_from_native =
+      Kokkos::Experimental::create_graph_from_native(this->exec, native_graph);
+
+  ASSERT_EQ(native_graph, graph_from_native.native_graph());
+
+  auto root = Kokkos::Impl::GraphAccess::create_root_ref(graph_from_native);
+
+  root.then_parallel_for(1, Increment<view_t>{data});
+
+  graph_from_native.submit(this->exec);
+
+  this->exec.fence();
+
+  ASSERT_EQ(data(), 1);
 }
 
 }  // namespace

--- a/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
@@ -128,4 +128,31 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 #endif
 }
 
+// Build a Kokkos::Graph from an existing hipGraph_t.
+TEST(TEST_CATEGORY, graph_construct_from_native) {
+  using view_t = Kokkos::View<int, Kokkos::HIPManagedSpace>;
+
+  hipGraph_t native_graph = nullptr;
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphCreate(&native_graph, 0));
+
+  const Kokkos::HIP exec{};
+
+  auto graph_from_native =
+      Kokkos::Experimental::create_graph_from_native(exec, native_graph);
+
+  ASSERT_EQ(native_graph, graph_from_native.native_graph());
+
+  auto root = Kokkos::Impl::GraphAccess::create_root_ref(graph_from_native);
+
+  const view_t data(Kokkos::view_alloc(exec, "witness"));
+
+  root.then_parallel_for(1, Increment<view_t>{data});
+
+  graph_from_native.submit(exec);
+
+  exec.fence();
+
+  ASSERT_EQ(data(), 1);
+}
+
 }  // namespace

--- a/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
@@ -115,4 +115,32 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 #endif
 }
 
+// Build a Kokkos::Graph from an existing SYCL command graph.
+TEST(TEST_CATEGORY, graph_construct_from_native) {
+  using graph_impl_t   = Kokkos::Impl::GraphImpl<Kokkos::SYCL>;
+  using native_graph_t = typename graph_impl_t::native_graph_t;
+
+  using view_t = Kokkos::View<int, Kokkos::SYCLSharedUSMSpace>;
+
+  const Kokkos::SYCL exec{};
+
+  native_graph_t native_graph(exec.sycl_queue().get_context(),
+                              exec.sycl_queue().get_device());
+
+  auto graph_from_native = Kokkos::Experimental::create_graph_from_native(
+      exec, std::move(native_graph));
+
+  auto root = Kokkos::Impl::GraphAccess::create_root_ref(graph_from_native);
+
+  const view_t data(Kokkos::view_alloc(exec, "witness"));
+
+  root.then_parallel_for(1, Increment<view_t>{data});
+
+  graph_from_native.submit(exec);
+
+  exec.fence();
+
+  ASSERT_EQ(data(), 1);
+}
+
 }  // namespace


### PR DESCRIPTION
## Summary

Allow building a `Kokkos::Graph` from a native graph (`cudaGraph_t`, `hipGraph_t`).

:bellhop_bell: This is an interoperability feature.

:warning: This PR only allows construction of a `Kokkos::Graph` from a native graph. It does not yet allow to link `Kokkos` nodes to *native* nodes.

## Description

Building a `Kokkos::Graph` from a native graph can be useful sometimes.

For instance, it's useful with [`Cuda` conditional nodes](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#conditional-while-nodes) to avoid creating Russian doll-like graphs. Indeed, when creating a `Cuda` *while* node, `Cuda` also creates a `cudaGraph_t` (child graph) attached to this *while* node, to which we can add the nodes that are in the *while* "body".

Without this interoperability PR, if we would want to add the nodes through `Kokkos::Graph` to this *while* "body", we'd be creating another `cudaGraph_t` (through `Kokkos::Graph`'s constructor) and would have to add it as a child graph to the *while* node's graph, which itself is already a child graph.

## Related

- extracted from #7552 