### PR TITLE
Disable bad alloc test for ROCm 5.6 and earlier

### DIFF
--- a/core/unit_test/TestViewBadAlloc.hpp
+++ b/core/unit_test/TestViewBadAlloc.hpp
@@ -54,10 +54,10 @@ TEST(TEST_CATEGORY, view_bad_alloc) {
   }
 #endif
 #endif
-#if ((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 3))
+#if ((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR < 7))
   if (std::is_same_v<ExecutionSpace, Kokkos::HIP>) {
-    GTEST_SKIP()
-        << "ROCm 5.3 segfaults when trying to allocate too much memory";
+    GTEST_SKIP() << "ROCm 5.6 and earlier segfaults when trying to allocate "
+                    "too much memory";
   }
 #endif
 #if defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC


### PR DESCRIPTION
The bad alloc test segfaults instead of throwing an error. We didn't notice the issue because it works with ROCm 5.7 and we already disable this test for ROCm 5.3. I have disabled the test unconditionally for ROCm 5.6 and earlier. I can disable the test only when hipMallocAsync is used but I plan on removing the CMake option after the next release.