### PR TITLE
`print_configuration`: print support for system allocated memory

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -219,7 +219,7 @@ void CudaInternal::print_configuration(std::ostream &s) const {
       << human_memory_size(prop.sharedMemPerBlock) << '\n'
       << "  Can access system allocated memory: " << prop.pageableMemoryAccess
       << '\n'
-      << "  Via Address Translation Service: "
+      << "    via Address Translation Service: "
       << prop.pageableMemoryAccessUsesHostPageTables << '\n';
   }
 }

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -216,7 +216,7 @@ void CudaInternal::print_configuration(std::ostream &s) const {
       << human_memory_size(prop.sharedMemPerBlock)
       << ", can access system allocated memory: "
       << prop.cudaDevAttrPageableMemoryAccess
-      << ", Address Translation Service: "
+      << ", via Address Translation Service: "
       << prop.cudaDevAttrPageableMemoryAccessUsesHostPageTables;
     if (m_cudaDev == i) s << " : Selected";
     s << '\n';

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -214,10 +214,9 @@ void CudaInternal::print_configuration(std::ostream &s) const {
       << ", Total Global Memory: " << human_memory_size(prop.totalGlobalMem)
       << ", Shared Memory per Block: "
       << human_memory_size(prop.sharedMemPerBlock)
-      << ", can access system allocated memory: "
-      << prop.cudaDevAttrPageableMemoryAccess
+      << ", can access system allocated memory: " << prop.pageableMemoryAccess
       << ", via Address Translation Service: "
-      << prop.cudaDevAttrPageableMemoryAccessUsesHostPageTables;
+      << prop.pageableMemoryAccessUsesHostPageTables;
     if (m_cudaDev == i) s << " : Selected";
     s << '\n';
   }

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -214,8 +214,8 @@ void CudaInternal::print_configuration(std::ostream &s) const {
       << ", Total Global Memory: " << human_memory_size(prop.totalGlobalMem)
       << ", Shared Memory per Block: "
       << human_memory_size(prop.sharedMemPerBlock)
-      << ", can access system allocated memory: " << prop.pageableMemoryAccess
-      << ", via Address Translation Service: "
+      << ", Can access system allocated memory: " << prop.pageableMemoryAccess
+      << ", Via Address Translation Service: "
       << prop.pageableMemoryAccessUsesHostPageTables;
     if (m_cudaDev == i) s << " : Selected";
     s << '\n';

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -209,16 +209,18 @@ void CudaInternal::print_configuration(std::ostream &s) const {
   for (int i : get_visible_devices()) {
     cudaDeviceProp prop;
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceProperties(&prop, i));
-    s << "Kokkos::Cuda[ " << i << " ] " << prop.name << " capability "
-      << prop.major << "." << prop.minor
-      << ", Total Global Memory: " << human_memory_size(prop.totalGlobalMem)
-      << ", Shared Memory per Block: "
-      << human_memory_size(prop.sharedMemPerBlock)
-      << ", Can access system allocated memory: " << prop.pageableMemoryAccess
-      << ", Via Address Translation Service: "
-      << prop.pageableMemoryAccessUsesHostPageTables;
+    s << "Kokkos::Cuda[ " << i << " ] " << prop.name;
     if (m_cudaDev == i) s << " : Selected";
-    s << '\n';
+    s << '\n'
+      << "  Capability: " << prop.major << "." << prop.minor << '\n'
+      << "  Total Global Memory: " << human_memory_size(prop.totalGlobalMem)
+      << '\n'
+      << "  Shared Memory per Block: "
+      << human_memory_size(prop.sharedMemPerBlock) << '\n'
+      << "  Can access system allocated memory: " << prop.pageableMemoryAccess
+      << '\n'
+      << "  Via Address Translation Service: "
+      << prop.pageableMemoryAccessUsesHostPageTables << '\n';
   }
 }
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -213,7 +213,11 @@ void CudaInternal::print_configuration(std::ostream &s) const {
       << prop.major << "." << prop.minor
       << ", Total Global Memory: " << human_memory_size(prop.totalGlobalMem)
       << ", Shared Memory per Block: "
-      << human_memory_size(prop.sharedMemPerBlock);
+      << human_memory_size(prop.sharedMemPerBlock)
+      << ", can access system allocated memory: "
+      << prop.cudaDevAttrPageableMemoryAccess
+      << ", Address Translation Service: "
+      << prop.cudaDevAttrPageableMemoryAccessUsesHostPageTables;
     if (m_cudaDev == i) s << " : Selected";
     s << '\n';
   }

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -174,7 +174,7 @@ void HIP::print_configuration(std::ostream& os, bool /*verbose*/) const {
 
   os << "\nRuntime Configuration:\n";
   os << "  XNACK enabled: ";
-  os << Kokkos::Impl::xnack_enabled() ? "yes\n": "no\n";
+  os << Kokkos::Impl::xnack_enabled() ? "yes\n" : "no\n";
 
   m_space_instance->print_configuration(os);
 }

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -177,7 +177,7 @@ void HIP::print_configuration(std::ostream& os, bool /*verbose*/) const {
   os << (Kokkos::Impl::xnack_environment_enabled() ? "yes\n" : "no\n");
   os << "  Kernel reports HMM module via `CONFIG_HMM_MIRROR=y` in "
         "`/boot/config`: ";
-  os << (Kokkos::Impl::xnack_hmm_found() ? "yes\n" : "no\n");
+  os << (Kokkos::Impl::xnack_boot_config_has_hmm_mirror() ? "yes\n" : "no\n");
 
   m_space_instance->print_configuration(os);
 }

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -173,8 +173,11 @@ void HIP::print_configuration(std::ostream& os, bool /*verbose*/) const {
 #endif
 
   os << "\nRuntime Configuration:\n";
-  os << "  XNACK enabled: ";
-  os << Kokkos::Impl::xnack_enabled() ? "yes\n" : "no\n";
+  os << "  XNACK environment variable set: ";
+  os << Kokkos::Impl::xnack_environment_enabled() ? "yes\n" : "no\n";
+  os << "  Kernel reports HMM module via `CONFIG_HMM_MIRROR=y` in "
+        "`/boot/config`: ";
+  os << Kokkos::Impl::xnack_hmm_found() ? "yes\n" : "no\n";
 
   m_space_instance->print_configuration(os);
 }

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -174,10 +174,10 @@ void HIP::print_configuration(std::ostream& os, bool /*verbose*/) const {
 
   os << "\nRuntime Configuration:\n";
   os << "  XNACK environment variable set: ";
-  os << Kokkos::Impl::xnack_environment_enabled() ? "yes\n" : "no\n";
+  os << (Kokkos::Impl::xnack_environment_enabled() ? "yes\n" : "no\n");
   os << "  Kernel reports HMM module via `CONFIG_HMM_MIRROR=y` in "
         "`/boot/config`: ";
-  os << Kokkos::Impl::xnack_hmm_found() ? "yes\n" : "no\n";
+  os << (Kokkos::Impl::xnack_hmm_found() ? "yes\n" : "no\n");
 
   m_space_instance->print_configuration(os);
 }

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -173,6 +173,8 @@ void HIP::print_configuration(std::ostream& os, bool /*verbose*/) const {
 #endif
 
   os << "\nRuntime Configuration:\n";
+  os << "  XNACK enabled: ";
+  os << Impl::xnack_enabled() ? "yes\n": "no\n";
 
   m_space_instance->print_configuration(os);
 }

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -174,7 +174,7 @@ void HIP::print_configuration(std::ostream& os, bool /*verbose*/) const {
 
   os << "\nRuntime Configuration:\n";
   os << "  XNACK enabled: ";
-  os << Impl::xnack_enabled() ? "yes\n": "no\n";
+  os << Kokkos::Impl::xnack_enabled() ? "yes\n": "no\n";
 
   m_space_instance->print_configuration(os);
 }

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -112,21 +112,23 @@ void HIPInternal::print_configuration(std::ostream &s) const {
     std::string gpu_type = hipProp.integrated == 1 ? "APU" : "dGPU";
 
     s << "Kokkos::HIP[ " << i << " ] "
-      << "gcnArch " << hipProp.gcnArchName << ", Total Global Memory: "
-      << ::Kokkos::Impl::human_memory_size(hipProp.totalGlobalMem)
-      << ", Shared Memory per Block: "
-      << ::Kokkos::Impl::human_memory_size(hipProp.sharedMemPerBlock)
-      << ", APU or dGPU: " << gpu_type
-      << ", Is Large Bar: " << hipProp.isLargeBar
-      << ", Supports Managed Memory: " << hipProp.managedMemory
-      << ", Architecture capable of accessing system allocated memory: "
-      << gpu_arch_can_access_system_allocations()
-      << ", System allows accessing system allocated memory on GPU: "
+      << "gcnArch " << hipProp.gcnArchName;
+    if (m_hipDev == i) s << " : Selected";
+    s << '\n'
+      << "  Total Global Memory: "
+      << ::Kokkos::Impl::human_memory_size(hipProp.totalGlobalMem) << '\n'
+      << "  Shared Memory per Block: "
+      << ::Kokkos::Impl::human_memory_size(hipProp.sharedMemPerBlock) << '\n'
+      << "  APU or dGPU: " << gpu_type << '\n'
+      << "  Is Large Bar: " << hipProp.isLargeBar << '\n'
+      << "  Supports Managed Memory: " << hipProp.managedMemory << '\n'
+      << "  Architecture capable of accessing system allocated memory: "
+      << gpu_arch_can_access_system_allocations() << '\n'
+      << "  System allows accessing system allocated memory on GPU: "
       << (xnack_boot_config_has_hmm_mirror() && xnack_environment_enabled() &&
           gpu_arch_can_access_system_allocations())
-      << ", Wavefront Size: " << hipProp.warpSize;
-    if (m_hipDev == i) s << " : Selected";
-    s << '\n';
+      << '\n'
+      << "  Wavefront Size: " << hipProp.warpSize << '\n';
   }
 }
 

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -26,6 +26,7 @@
 #include <HIP/Kokkos_HIP_Instance.hpp>
 #include <HIP/Kokkos_HIP.hpp>
 #include <HIP/Kokkos_HIP_Space.hpp>
+#include <HIP/Kokkos_HIP_IsXnack.hpp>
 #include <impl/Kokkos_CheckedIntegerOps.hpp>
 #include <impl/Kokkos_DeviceManagement.hpp>
 #include <impl/Kokkos_Error.hpp>
@@ -118,6 +119,9 @@ void HIPInternal::print_configuration(std::ostream &s) const {
       << ", APU or dGPU: " << gpu_type
       << ", Is Large Bar: " << hipProp.isLargeBar
       << ", Supports Managed Memory: " << hipProp.managedMemory
+      << ", Supports accessing system allocated memory: "
+      << (xnack_hmm_found() and xnack_environment_enabled() and
+          gpu_arch_can_access_system_allocations())
       << ", Wavefront Size: " << hipProp.warpSize;
     if (m_hipDev == i) s << " : Selected";
     s << '\n';

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -120,7 +120,7 @@ void HIPInternal::print_configuration(std::ostream &s) const {
       << ", Is Large Bar: " << hipProp.isLargeBar
       << ", Supports Managed Memory: " << hipProp.managedMemory
       << ", Supports accessing system allocated memory: "
-      << (xnack_hmm_found() and xnack_environment_enabled() and
+      << (xnack_boot_config_has_hmm_mirror() and xnack_environment_enabled() and
           gpu_arch_can_access_system_allocations())
       << ", Wavefront Size: " << hipProp.warpSize;
     if (m_hipDev == i) s << " : Selected";

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -119,7 +119,9 @@ void HIPInternal::print_configuration(std::ostream &s) const {
       << ", APU or dGPU: " << gpu_type
       << ", Is Large Bar: " << hipProp.isLargeBar
       << ", Supports Managed Memory: " << hipProp.managedMemory
-      << ", Supports accessing system allocated memory: "
+      << ", Architecture capable of accessing system allocated memory: "
+      << gpu_arch_can_access_system_allocations()
+      << ", System allows accessing system allocated memory on GPU: "
       << (xnack_boot_config_has_hmm_mirror() and xnack_environment_enabled() and
           gpu_arch_can_access_system_allocations())
       << ", Wavefront Size: " << hipProp.warpSize;

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -122,7 +122,7 @@ void HIPInternal::print_configuration(std::ostream &s) const {
       << ", Architecture capable of accessing system allocated memory: "
       << gpu_arch_can_access_system_allocations()
       << ", System allows accessing system allocated memory on GPU: "
-      << (xnack_boot_config_has_hmm_mirror() and xnack_environment_enabled() and
+      << (xnack_boot_config_has_hmm_mirror() && xnack_environment_enabled() &&
           gpu_arch_can_access_system_allocations())
       << ", Wavefront Size: " << hipProp.warpSize;
     if (m_hipDev == i) s << " : Selected";

--- a/core/src/HIP/Kokkos_HIP_IsXnack.cpp
+++ b/core/src/HIP/Kokkos_HIP_IsXnack.cpp
@@ -89,4 +89,6 @@ bool xnack_boot_config_has_hmm_mirror() {
   return cache;
 }
 
+}
+
 }  // namespace Kokkos::Impl

--- a/core/src/HIP/Kokkos_HIP_IsXnack.cpp
+++ b/core/src/HIP/Kokkos_HIP_IsXnack.cpp
@@ -89,6 +89,4 @@ bool xnack_boot_config_has_hmm_mirror() {
   return cache;
 }
 
-}
-
 }  // namespace Kokkos::Impl

--- a/core/src/HIP/Kokkos_HIP_IsXnack.hpp
+++ b/core/src/HIP/Kokkos_HIP_IsXnack.hpp
@@ -48,8 +48,8 @@ bool xnack_boot_config_has_hmm_mirror();
 // Returns true iff the architecture of the gpu supports accessing system
 // allocated memory
 constexpr bool gpu_arch_can_access_system_allocations() {
-#if defined Kokkos_ARCH_AMD_GFX908 || Kokkos_ARCH_AMD_GFX90A || \
-    Kokkos_ARCH_AMD_GFX942 || Kokkos_ARCH_AMD_GFX942_APU
+#if defined(KOKKOS_ARCH_AMD_GFX908) || defined(Kokkos_ARCH_AMD_GFX90A) || \
+    defined(Kokkos_ARCH_AMD_GFX942) || defined(Kokkos_ARCH_AMD_GFX942_APU)
   return true;
 #else
   return false;

--- a/core/src/HIP/Kokkos_HIP_IsXnack.hpp
+++ b/core/src/HIP/Kokkos_HIP_IsXnack.hpp
@@ -45,6 +45,16 @@ so we infer its presence is not necessary.
 bool xnack_environment_enabled();
 // Returns true iff we detect CONFIG_HMM_MIROR=y in /boot/config-$(uname -r).
 bool xnack_boot_config_has_hmm_mirror();
+// Returns true iff the architecture of the gpu supports accessing system
+// allocated memory
+constexpr bool gpu_arch_can_access_system_allocations() {
+#if defined Kokkos_ARCH_AMD_GFX908 || Kokkos_ARCH_AMD_GFX90A || \
+    Kokkos_ARCH_AMD_GFX942 || Kokkos_ARCH_AMD_GFX942_APU
+  return true;
+#else
+  return false;
+#endif
+}
 }  // namespace Kokkos::Impl
 
 #endif  // KOKKOS_HIP_ISXNACK_HPP

--- a/core/src/HIP/Kokkos_HIP_IsXnack.hpp
+++ b/core/src/HIP/Kokkos_HIP_IsXnack.hpp
@@ -19,6 +19,8 @@
 #ifndef KOKKOS_HIP_ISXNACK_HPP
 #define KOKKOS_HIP_ISXNACK_HPP
 
+#include <Kokkos_Macros.hpp>
+
 namespace Kokkos::Impl {
 
 /*Based on AMD's ROCm 6.3.1 documentation:

--- a/core/src/HIP/Kokkos_HIP_IsXnack.hpp
+++ b/core/src/HIP/Kokkos_HIP_IsXnack.hpp
@@ -50,10 +50,11 @@ bool xnack_boot_config_has_hmm_mirror();
 // Returns true iff the architecture of the gpu supports accessing system
 // allocated memory
 constexpr bool gpu_arch_can_access_system_allocations() {
-#if defined(KOKKOS_ARCH_AMD_GFX908) || defined(Kokkos_ARCH_AMD_GFX90A) || \
-    defined(Kokkos_ARCH_AMD_GFX942) || defined(Kokkos_ARCH_AMD_GFX942_APU)
+#if defined(KOKKOS_ARCH_AMD_GFX908) || defined(KOKKOS_ARCH_AMD_GFX90A) || \
+    defined(KOKKOS_ARCH_AMD_GFX942) || defined(KOKKOS_ARCH_AMD_GFX942_APU)
   return true;
-#else
+#elif defined(KOKKOS_ARCH_AMD_GFX906) || defined(KOKKOS_ARCH_AMD_GFX1103) || \
+    defined(KOKKOS_ARCH_AMD_GFX1100) || defined(KOKKOS_ARCH_AMD_GFX1030)
   return false;
 #endif
 }


### PR DESCRIPTION
So far we do not have any information in `print_configuration` that tells us if system allocated memory is accessible on the device by default or not. This PR adds this for `CUDA`. For `HIP` it will follow ~#7567~ #7765, possibly adding a third check based on the architecture of the device -> added.

*depends on https://github.com/kokkos/kokkos/pull/7765*

### Cited documentation:
[`CUDA 11`](https://docs.nvidia.com/cuda/archive/11.0/pdf/CUDA_Runtime_API.pdf#page=55)
[`HIP` xnack detection](https://github.com/kokkos/kokkos/pull/7567) [`HIP` xnack detection refactor](https://github.com/kokkos/kokkos/pull/7765) [`HIP` archs that can read system allocated memory](https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/hip_runtime_api/memory_management/unified_memory.html#system-requirements)

Fixes https://github.com/kokkos/kokkos/issues/7452.