### PR TITLE
Check that parallel constructs invoked before initialize or after finalize will error out

### DIFF
--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -140,4 +140,63 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
       matcher2);
 }
 
+TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, parallel_for) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  EXPECT_DEATH({ Kokkos::parallel_for(0, KOKKOS_LAMBDA(int){}); }, "FIXME");
+  EXPECT_DEATH(
+      {
+        Kokkos::initialize();
+        Kokkos::finalize();
+        Kokkos::parallel_for(0, KOKKOS_LAMBDA(int){});
+      },
+      "FIXME");
+}
+
+TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,
+       parallel_reduce) {
+  EXPECT_DEATH(
+      {
+        float x;
+        Kokkos::parallel_reduce(0, KOKKOS_LAMBDA(int, float&){}, x);
+      },
+      "FIXME");
+  EXPECT_DEATH(
+      {
+        Kokkos::initialize();
+        Kokkos::finalize();
+        float x;
+        Kokkos::parallel_reduce(0, KOKKOS_LAMBDA(int, float&){}, x);
+      },
+      "FIXME");
+}
+
+TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, parallel_scan) {
+  EXPECT_DEATH(
+      { Kokkos::parallel_scan(0, KOKKOS_LAMBDA(int, float&, bool){}); },
+      "FIXME");
+  EXPECT_DEATH(
+      {
+        Kokkos::initialize();
+        Kokkos::finalize();
+        Kokkos::parallel_scan(0, KOKKOS_LAMBDA(int, float&, bool){});
+      },
+      "FIXME");
+
+  EXPECT_DEATH(
+      {
+        float x;
+        Kokkos::parallel_scan(0, KOKKOS_LAMBDA(int, float&, bool){}, x);
+      },
+      "FIXME");
+  EXPECT_DEATH(
+      {
+        Kokkos::initialize();
+        Kokkos::finalize();
+        float x;
+        Kokkos::parallel_scan(0, KOKKOS_LAMBDA(int, float&, bool){}, x);
+      },
+      "FIXME");
+}
+
 }  // namespace


### PR DESCRIPTION
The status quo is a mixed bag of not reporting the violation, throwing a runtime error, etc.
I propose that we abort in all cases, regardless of the range being empty.
This PR is limited to range policies.