### PR TITLE
simd: refactor to suppress variable length array warning

### DIFF
--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -130,10 +130,12 @@ template <class T, class Abi>
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> \
   FUNC(Experimental::basic_simd<T, Abi> const& a) {                          \
     Experimental::basic_simd<T, Abi> result;                                 \
+    T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                  \
     for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
          ++i) {                                                              \
-      result[i] = Kokkos::FUNC(a[i]);                                        \
+      vals[i] = Kokkos::FUNC(a[i]);                                          \
     }                                                                        \
+    result.copy_from(vals, Kokkos::Experimental::simd_flag_default);         \
     return result;                                                           \
   }                                                                          \
   namespace Experimental {                                                   \
@@ -150,10 +152,12 @@ template <class T, class Abi>
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> \
   FUNC(Experimental::basic_simd<T, Abi> const& a) {                          \
     Experimental::basic_simd<T, Abi> result;                                 \
+    T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                  \
     for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
          ++i) {                                                              \
-      result[i] = Kokkos::FUNC(a[i]);                                        \
+      vals[i] = Kokkos::FUNC(a[i]);                                          \
     }                                                                        \
+    result.copy_from(vals, Kokkos::Experimental::simd_flag_default);         \
     return result;                                                           \
   }
 #endif

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -65,12 +65,13 @@ void host_check_math_op_one_loader(UnaryOp unary_op, std::size_t n,
     bool const loaded_arg = loader.host_load(args + i, nlanes, arg);
     if (!loaded_arg) continue;
 
+    if constexpr (std::is_same_v<UnaryOp, cbrt_op> ||
+                  std::is_same_v<UnaryOp, exp_op> ||
+                  std::is_same_v<UnaryOp, log_op>)
+      arg = Kokkos::abs(arg);
+
     typename decltype(unary_op.on_host(arg))::value_type expected_val[width];
     for (std::size_t lane = 0; lane < width; ++lane) {
-      if constexpr (std::is_same_v<UnaryOp, cbrt_op> ||
-                    std::is_same_v<UnaryOp, exp_op> ||
-                    std::is_same_v<UnaryOp, log_op>)
-        arg[lane] = Kokkos::abs(arg[lane]);
       expected_val[lane] = unary_op.on_host_serial(T(arg[lane]));
     }
 

--- a/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
+++ b/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
@@ -27,9 +27,9 @@ inline void host_check_where_expr_scatter_to() {
     using index_type = Kokkos::Experimental::basic_simd<std::int32_t, Abi>;
     using mask_type  = typename simd_type::mask_type;
 
-    std::size_t nlanes = simd_type::size();
-    DataType init[]    = {11, 13, 17, 19, 23, 29, 31, 37,
-                          53, 71, 79, 83, 89, 93, 97, 103};
+    constexpr std::size_t nlanes = simd_type::size();
+    DataType init[]              = {11, 13, 17, 19, 23, 29, 31, 37,
+                                    53, 71, 79, 83, 89, 93, 97, 103};
     simd_type src;
     src.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
@@ -38,7 +38,7 @@ inline void host_check_where_expr_scatter_to() {
                                    Kokkos::Experimental::simd_abi::scalar>) {
         mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return i != idx; });
 
-        DataType dst[simd_type::size()] = {0};
+        DataType dst[nlanes] = {0};
         for (std::size_t i = 0; i < nlanes; ++i) {
           dst[i] = (2 + (i * 2));
         }
@@ -55,7 +55,7 @@ inline void host_check_where_expr_scatter_to() {
       } else {
         mask_type mask([=](std::size_t i) { return i != idx; });
 
-        DataType dst[simd_type::size()] = {0};
+        DataType dst[nlanes] = {0};
         for (std::size_t i = 0; i < nlanes; ++i) {
           dst[i] = (2 + (i * 2));
         }
@@ -138,16 +138,16 @@ KOKKOS_INLINE_FUNCTION void device_check_where_expr_scatter_to() {
     using index_type = Kokkos::Experimental::basic_simd<std::int32_t, Abi>;
     using mask_type  = typename simd_type::mask_type;
 
-    std::size_t nlanes = simd_type::size();
-    DataType init[]    = {11, 13, 17, 19, 23, 29, 31, 37,
-                          53, 71, 79, 83, 89, 93, 97, 103};
+    constexpr std::size_t nlanes = simd_type::size();
+    DataType init[]              = {11, 13, 17, 19, 23, 29, 31, 37,
+                                    53, 71, 79, 83, 89, 93, 97, 103};
     simd_type src;
     src.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
     for (std::size_t idx = 0; idx < nlanes; ++idx) {
       mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return i != idx; });
 
-      DataType dst[simd_type::size()] = {0};
+      DataType dst[nlanes] = {0};
       for (std::size_t i = 0; i < nlanes; ++i) {
         dst[i] = (2 + (i * 2));
       }


### PR DESCRIPTION
Fixes #7674 

It seems `DataType dst[simd_type::size()]` was evaluated to be a variable length array for icpc. Refactored `simd_type::size()` to a constexpr variable.

Also removed few reference operator[] in fallback unary operations that were only used and tested in intel builds.