### PR TITLE
Fix AMD GPU auto-detect for ROCm 6.3

### DIFF
--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -1212,9 +1212,8 @@ if(KOKKOS_ENABLE_HIP AND NOT AMDGPU_ARCH_ALREADY_SPECIFIED AND NOT KOKKOS_IMPL_A
     )
   else()
     execute_process(COMMAND ${ROCM_ENUMERATOR} OUTPUT_VARIABLE GPU_ARCHS)
-    string(LENGTH "${GPU_ARCHS}" len_str)
-    # enumerator always output gfx000 as the first line
-    if(${len_str} LESS 8)
+    # Exits early if no GPU was detected
+    if("${GPU_ARCHS}" STREQUAL "")
       message(SEND_ERROR "HIP enabled but no AMD GPU architecture could be automatically detected. "
                          "Please manually specify one AMD GPU architecture via -DKokkos_ARCH_{..}=ON'."
       )


### PR DESCRIPTION
Before ROCm 6.3, `rocm_agent_enumerator` would always print `gfx000` first and then it would print the architecture of the GPUs that were found. So the autodetect exits early, if `rocm_agent_enumerator` only prints one architecture. ROCm 6.3 does not print `gfx000` anymore, so we cannot exit early anymore.