### PR TITLE
Add missing `<cstddef>` header include in test

### DIFF
--- a/core/unit_test/TestDetectionIdiom.cpp
+++ b/core/unit_test/TestDetectionIdiom.cpp
@@ -16,6 +16,8 @@
 
 #include <Kokkos_DetectionIdiom.hpp>
 
+#include <cstddef>
+
 void test_nonesuch() {
   using Kokkos::nonesuch;
   static_assert(!std::is_constructible_v<nonesuch>);


### PR DESCRIPTION
Spotted when building with a development version of LLVM Clang
````
<kokkos>/core/unit_test/TestDetectionIdiom.cpp:49:47: error: no template named 'ptrdiff_t' in namespace 'std'; did you mean 'diff_t'?
   49 | using difference_type = Kokkos::detected_or_t<std::ptrdiff_t, diff_t, Ptr>;
      |                                               ^~~~~~~~~~~~~~
      |                                               diff_t
<kokkos>/core/unit_test/TestDetectionIdiom.cpp:46:1: note: 'diff_t' declared here
   46 | using diff_t = typename T::difference_type;
      | ^