### PR TITLE
Fix bogus ClangTidy diagnostic in CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,6 +20,7 @@ Checks: >
   -bugprone-suspicious-include,
   -bugprone-suspicious-memory-comparison,
   -bugprone-suspicious-string-compare,
+  -bugprone-suspicious-stringview-data-usage,
   -bugprone-unchecked-optional-access,
   -bugprone-unhandled-exception-at-new,
   -bugprone-unhandled-self-assignment,

--- a/core/src/View/Kokkos_ViewCtor.hpp
+++ b/core/src/View/Kokkos_ViewCtor.hpp
@@ -219,9 +219,11 @@ struct ViewCtorProp : public ViewCtorProp<void, P>... {
   // Note that if P is empty, this constructor is the default constructor.
   // On the other hand, if P is not empty, the constraint implies that
   // there is no default constructor.
+  // NOLINTBEGIN(modernize-type-traits)
   template <typename... Args,
             typename = std::enable_if_t<std::conjunction_v<
                 std::is_constructible<view_ctor_prop_base<P>, Args &&>...>>>
+  // NOLINTEND(modernize-type-traits)
   ViewCtorProp(Args &&...args)
       : ViewCtorProp<void, P>(std::forward<Args>(args))... {}
 

--- a/core/src/impl/Kokkos_EBO.hpp
+++ b/core/src/impl/Kokkos_EBO.hpp
@@ -109,11 +109,13 @@ template <class T, template <class...> class CTorsNotOnDevice>
 struct EBOBaseImpl<T, false, CTorsNotOnDevice> {
   T m_ebo_object;
 
+  // NOLINTBEGIN(modernize-type-traits)
   template <class... Args, class _ignored = void,
             std::enable_if_t<std::is_void_v<_ignored> &&
                                  !CTorsNotOnDevice<Args...>::value &&
                                  std::is_constructible_v<T, Args...>,
                              int> = 0>
+  // NOLINTEND(modernize-type-traits)
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit EBOBaseImpl(
       Args&&... args) noexcept(noexcept(T(std::forward<Args>(args)...)))
       : m_ebo_object(std::forward<Args>(args)...) {}


### PR DESCRIPTION
Seen in #7687 
https://github.com/kokkos/kokkos/actions/runs/12858265330/job/35847451871?pr=7687#step:12:26
```
/__w/kokkos/kokkos/core/src/View/Kokkos_ViewCtor.hpp:224:63: error: use c++14 style type templates [modernize-type-traits,-warnings-as-errors]
  224 |                 std::is_constructible<view_ctor_prop_base<P>, Args &&>...>>>
      |                                                               ^~~~
      |
```
Our usage is fine AFAICT.  Here is a link to the [doc](https://en.cppreference.com/w/cpp/types/conjunction).
https://github.com/kokkos/kokkos/blob/b351407f4d616468d3c6ec2f851c70f65fc12945/core/src/View/Kokkos_ViewCtor.hpp#L222-L224