### PR TITLE
Don't use -fno-fortran-main in the build_cmake_installed example for flang

### DIFF
--- a/example/build_cmake_installed/CMakeLists.txt
+++ b/example/build_cmake_installed/CMakeLists.txt
@@ -12,7 +12,6 @@ find_package(Kokkos REQUIRED)
 add_executable(example cmake_example.cpp foo.f)
 if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
   set_target_properties(example PROPERTIES LINKER_LANGUAGE Fortran)
-  target_link_options(example PRIVATE -fno-fortran-main)
 endif()
 
 # This is the only thing required to set up compiler/linker flags


### PR DESCRIPTION
This should address https://github.com/kokkos/kokkos/pull/7688#issuecomment-2603017523, i.e., the remaining `flang-new` issues in the CI
```
flang-new: error: unknown argument: '-fno-fortran-main'
```
by simply removing the flag. This is only an example anyway.