### PR TITLE
Avoid C-cast to void**

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -398,9 +398,10 @@ struct CudaParallelLaunchKernelInvoker<
       params.blockDim       = block;
       params.gridDim        = grid;
       params.sharedMemBytes = shmem;
-      params.func           = (void*)base_t::get_kernel_func();
-      params.kernelParams   = (void**)args;
-      params.extra          = nullptr;
+      // Casting a function pointer to a data pointer...
+      params.func         = reinterpret_cast<void*>(base_t::get_kernel_func());
+      params.kernelParams = const_cast<void**>(args);
+      params.extra        = nullptr;
 
       KOKKOS_IMPL_CUDA_SAFE_CALL(
           (cuda_instance->cuda_graph_add_kernel_node_wrapper(
@@ -511,9 +512,10 @@ struct CudaParallelLaunchKernelInvoker<
       params.blockDim       = block;
       params.gridDim        = grid;
       params.sharedMemBytes = shmem;
-      params.func           = (void*)base_t::get_kernel_func();
-      params.kernelParams   = (void**)args;
-      params.extra          = nullptr;
+      // Casting a function pointer to a data pointer...
+      params.func         = reinterpret_cast<void*>(base_t::get_kernel_func());
+      params.kernelParams = const_cast<void**>(args);
+      params.extra        = nullptr;
 
       KOKKOS_IMPL_CUDA_SAFE_CALL(
           (cuda_instance->cuda_graph_add_kernel_node_wrapper(

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -95,9 +95,12 @@ void HIP::impl_initialize(InitializationSettings const& settings) {
 
   // Allocate a staging buffer for constant mem in pinned host memory
   // and an event to avoid overwriting driver for previous kernel launches
+
+  void* constant_mem_void_ptr = nullptr;
   KOKKOS_IMPL_HIP_SAFE_CALL(hipHostMalloc(
-      reinterpret_cast<void**>(&Impl::HIPInternal::constantMemHostStaging),
-      Impl::HIPTraits::ConstantMemoryUsage));
+      &constant_mem_void_ptr, Impl::HIPTraits::ConstantMemoryUsage));
+  Impl::HIPInternal::constantMemHostStaging =
+      static_cast<unsigned long*>(constant_mem_void_ptr);
 
   KOKKOS_IMPL_HIP_SAFE_CALL(
       hipEventCreate(&Impl::HIPInternal::constantMemReusable));

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -396,9 +396,10 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
       params.blockDim       = block;
       params.gridDim        = grid;
       params.sharedMemBytes = shmem;
-      params.func           = (void *)base_t::get_kernel_func();
-      params.kernelParams   = (void **)args;
-      params.extra          = nullptr;
+      // Casting a function pointer to a data pointer...
+      params.func         = reinterpret_cast<void *>(base_t::get_kernel_func());
+      params.kernelParams = const_cast<void **>(args);
+      params.extra        = nullptr;
 
       KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphAddKernelNode(
           &graph_node, graph, /* dependencies = */ nullptr,
@@ -466,9 +467,10 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
       params.blockDim       = block;
       params.gridDim        = grid;
       params.sharedMemBytes = shmem;
-      params.func           = (void *)base_t::get_kernel_func();
-      params.kernelParams   = (void **)args;
-      params.extra          = nullptr;
+      // Casting a function pointer to a data pointer...
+      params.func         = reinterpret_cast<void *>(base_t::get_kernel_func());
+      params.kernelParams = const_cast<void **>(args);
+      params.extra        = nullptr;
 
       KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphAddKernelNode(
           &graph_node, graph, /* dependencies = */ nullptr,

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -90,14 +90,16 @@ TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), unmanaged_views) {
 
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(execs[0].cuda_device()));
     int *p0;
-    KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaMalloc(reinterpret_cast<void **>(&p0), sizeof(int) * 100));
+    void *p0_void_ptr = nullptr;
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&p0_void_ptr, sizeof(int) * 100));
+    p0 = static_cast<int *>(p0_void_ptr);
     Kokkos::View<int *, TEST_EXECSPACE> view0(p0, 100);
 
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(execs[1].cuda_device()));
     int *p;
-    KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaMalloc(reinterpret_cast<void **>(&p), sizeof(int) * 100));
+    void *p_void_ptr = nullptr;
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&p_void_ptr, sizeof(int) * 100));
+    p = static_cast<int *>(p_void_ptr);
     Kokkos::View<int *, TEST_EXECSPACE> view(p, 100);
 
     test_policies(execs[0], view0, execs[1], view);
@@ -129,10 +131,14 @@ TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), stream_sync_semantics_raw_cuda) {
     // Allocate data.
     int *value;
     int *check;
+    void *value_void_ptr = nullptr;
+    void *check_void_ptr = nullptr;
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaMallocHost(reinterpret_cast<void **>(&value), 1 * sizeof(int)));
+        cudaMallocHost(&value_void_ptr, 1 * sizeof(int)));
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaMallocHost(reinterpret_cast<void **>(&check), 1 * sizeof(int)));
+        cudaMallocHost(&check_void_ptr, 1 * sizeof(int)));
+    value = static_cast<int *>(value_void_ptr);
+    check = static_cast<int *>(check_void_ptr);
 
     // Launch "long" kernel on device 0.
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(devices[0]));

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -130,14 +130,15 @@ TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), stream_sync_semantics_raw_cuda) {
 
     // Allocate data.
     int *value;
-    int *check;
     void *value_void_ptr = nullptr;
-    void *check_void_ptr = nullptr;
     KOKKOS_IMPL_CUDA_SAFE_CALL(
         cudaMallocHost(&value_void_ptr, 1 * sizeof(int)));
+    value = static_cast<int *>(value_void_ptr);
+
+    int *check;
+    void *check_void_ptr = nullptr;
     KOKKOS_IMPL_CUDA_SAFE_CALL(
         cudaMallocHost(&check_void_ptr, 1 * sizeof(int)));
-    value = static_cast<int *>(value_void_ptr);
     check = static_cast<int *>(check_void_ptr);
 
     // Launch "long" kernel on device 0.


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/7576 We still have a UB because we need to cast a function pointer to a data pointer when using CUDA and HIP graph libraries.