### PR TITLE
Use CDash for CEA nightly runs

### DIFF
--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -3,7 +3,6 @@ name: Nightly CEA builds
 on:
   schedule:
     - cron: "0 2 * * 1-5" # every weekday at 2am UTC
-  pull_request:  # XXX Remove me before merging!
 
 permissions: read-all
 

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -3,7 +3,6 @@ name: Nightly CEA builds
 on:
   schedule:
     - cron: "0 2 * * 1-5" # every weekday at 2am UTC
-  pull_request: # XXX used for testing, remove before merging!
 
 permissions: read-all
 

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'kokkos/kokkos'
 
     env:
-      build_jobs: 40
+      CMAKE_BUILD_PARALLEL_LEVEL: 17
 
     strategy:
       matrix:
@@ -21,7 +21,7 @@ jobs:
           - Debug
         backend:
           - name: cuda-a100
-            flags: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
+            flags: -DKokkos_ENABLE_CUDA=ON;-DKokkos_ARCH_AMPERE80=ON
             gpu: a100
             modules: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
 
@@ -30,28 +30,23 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Configure
-        run: |
-          run \
-            -m "${{ matrix.backend.modules }}" \
-            cmake -B build \
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-              -DCMAKE_CXX_STANDARD=17 \
-              -DCMAKE_CXX_FLAGS=-Werror \
-              -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
-              -DKokkos_ENABLE_TESTS=ON \
-              -DKokkos_ENABLE_EXAMPLES=ON \
-              ${{ matrix.backend.flags }}
-
-      - name: Build
-        run: |
-          run \
-            -m "${{ matrix.backend.modules }}" \
-            cmake --build build --parallel $build_jobs
-
-      - name: Test
+      - name: Configure, build, and test
         run: |
           run \
             -g ${{ matrix.backend.gpu }} \
             -m "${{ matrix.backend.modules }}" \
-            ctest --test-dir build --output-on-failure
+            ctest -VV \
+              -DCDASH_MODEL="Nightly" \
+              -DCMAKE_OPTIONS="$(echo "${ENV_CMAKE_OPTIONS}" | sed -e 's/^[ ]*//' | tr '\n' ';')" \
+              -DCTEST_BUILD_NAME=cea-${{ matrix.backend.name }} \
+              -DCTEST_SITE=cea-ruche \
+              -S CTestRun.cmake
+        env:
+          ENV_CMAKE_OPTIONS: |
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+            -DCMAKE_CXX_STANDARD=17
+            -DCMAKE_CXX_FLAGS=-Werror
+            -DKokkos_ENABLE_COMPILER_WARNINGS=ON
+            -DKokkos_ENABLE_TESTS=ON
+            -DKokkos_ENABLE_EXAMPLES=ON
+            ${{ matrix.backend.flags }}

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -38,7 +38,7 @@ jobs:
             -m "${{ matrix.backend.modules }}" \
             ctest -VV \
               -DCDASH_MODEL="Experimental" \
-              -DCMAKE_OPTIONS="$(echo "${ENV_CMAKE_OPTIONS}" | sed -e 's/^[ ]*//' | tr '\n' ';')" \
+              -DCMAKE_OPTIONS=\"$(echo "${ENV_CMAKE_OPTIONS}" | sed -e 's/^[ ]*//' | tr '\n' ';')\" \
               -DCTEST_BUILD_NAME=cea-${{ matrix.backend.name }} \
               -DCTEST_SITE=cea-ruche \
               -S CTestRun.cmake

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -56,7 +56,7 @@ jobs:
             -m "${{ matrix.backend.modules }}" \
             CMAKE_BUILD_PARALLEL_LEVEL=40 \
             ctest \
-              -VV \
+              -V \
               -D ExperimentalStart \
               -D ExperimentalConfigure \
               -D ExperimentalBuild
@@ -68,14 +68,14 @@ jobs:
             -g ${{ matrix.backend.gpu }} \
             -m "${{ matrix.backend.modules }}" \
             ctest \
-              -VV \
-              -D ExperimentalTest
+              -D ExperimentalTest \
+              --output-on-failure
 
       - name: Submit
         run: |
           cd build
           run \
             -m "${{ matrix.backend.modules }}" \
+            -l \
             ctest \
-              -VV \
               -D ExperimentalSubmit

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -50,7 +50,20 @@ jobs:
               -DKokkos_ENABLE_EXAMPLES=ON \
               ${{ matrix.backend.flags }}
 
-      - name: Start, configure, and build
+      - name: Start, update and configure
+        run: |
+          cd build
+          run \
+            -m "${{ matrix.backend.modules }}" \
+            -e local \
+            CMAKE_BUILD_PARALLEL_LEVEL=40 \
+            ctest \
+              -V \
+              -D ExperimentalStart \
+              -D ExperimentalUpdate \
+              -D ExperimentalConfigure
+
+      - name: Build
         run: |
           cd build
           run \
@@ -59,8 +72,6 @@ jobs:
             CMAKE_BUILD_PARALLEL_LEVEL=40 \
             ctest \
               -V \
-              -D ExperimentalStart \
-              -D ExperimentalConfigure \
               -D ExperimentalBuild
 
       - name: Test

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -3,6 +3,7 @@ name: Nightly CEA builds
 on:
   schedule:
     - cron: "0 2 * * 1-5" # every weekday at 2am UTC
+  pull_request: # XXX used for testing, remove before merging!
 
 permissions: read-all
 

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -29,6 +29,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Initialize the build tree
+        # note: BUILDNAME sets the name of the build on the Dashboard
+        # note: SITE sets the name of the site on the Dashboard
+        # note: run is a Ruche command
         run: |
           run \
             -m "${{ matrix.backend.modules }}" \
@@ -48,12 +51,12 @@ jobs:
       - name: Start, update and configure
         continue-on-error: true
         run: |
-          cd build
           run \
             -m "${{ matrix.backend.modules }}" \
             -e local \
             ctest \
               -V \
+              --test-dir build \
               -D NightlyStart \
               -D NightlyUpdate \
               -D NightlyConfigure
@@ -61,31 +64,31 @@ jobs:
       - name: Build
         continue-on-error: true
         run: |
-          cd build
           run \
             -m "${{ matrix.backend.modules }}" \
             -e cpu \
             CMAKE_BUILD_PARALLEL_LEVEL=40 \
             ctest \
               -V \
+              --test-dir build \
               -D NightlyBuild
 
       - name: Test
         continue-on-error: true
         run: |
-          cd build
           run \
             -m "${{ matrix.backend.modules }}" \
             ${{ matrix.backend.test }} \
             ctest \
-              -D NightlyTest \
-              --output-on-failure
+              --output-on-failure \
+              --test-dir build \
+              -D NightlyTest
 
       - name: Submit
         run: |
-          cd build
           run \
             -m "${{ matrix.backend.modules }}" \
             -e local \
             ctest \
+              --test-dir build \
               -D NightlySubmit

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -19,7 +19,7 @@ jobs:
         build_type:
           - Release
         backend:
-          - name: cuda-a100
+          - name: Cuda-A100-GCC/11.2-Cuda/12.2.1
             configure: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
             test: -e gpu -g a100
             modules: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
@@ -55,9 +55,9 @@ jobs:
             -e local \
             ctest \
               -V \
-              -D ExperimentalStart \
-              -D ExperimentalUpdate \
-              -D ExperimentalConfigure
+              -D NightlyStart \
+              -D NightlyUpdate \
+              -D NightlyConfigure
 
       - name: Build
         continue-on-error: true
@@ -69,7 +69,7 @@ jobs:
             CMAKE_BUILD_PARALLEL_LEVEL=40 \
             ctest \
               -V \
-              -D ExperimentalBuild
+              -D NightlyBuild
 
       - name: Test
         continue-on-error: true
@@ -79,7 +79,7 @@ jobs:
             -m "${{ matrix.backend.modules }}" \
             ${{ matrix.backend.test }} \
             ctest \
-              -D ExperimentalTest \
+              -D NightlyTest \
               --output-on-failure
 
       - name: Submit
@@ -89,4 +89,4 @@ jobs:
             -m "${{ matrix.backend.modules }}" \
             -e local \
             ctest \
-              -D ExperimentalSubmit
+              -D NightlySubmit

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -12,17 +12,19 @@ jobs:
     # only run on original repo
     if: github.repository == 'kokkos/kokkos'
 
-    env:
-      CMAKE_BUILD_PARALLEL_LEVEL: 17
+    # allow all steps to perform even if errors occur
+    continue-on-error: true
 
     strategy:
+      # allow all matrix jobs to perform even if errors occur
+      fail-fast: false
       matrix:
         build_type:
           - Release
-          - Debug
+          # - Debug
         backend:
           - name: cuda-a100
-            flags: -DKokkos_ENABLE_CUDA=ON;-DKokkos_ARCH_AMPERE80=ON
+            flags: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
             gpu: a100
             modules: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
 
@@ -31,23 +33,49 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Configure, build, and test
+      - name: Initialize the build tree
         run: |
+          run \
+            -m "${{ matrix.backend.modules }}" \
+            cmake \
+              -B build \
+              -DBUILDNAME=${{ matrix.backend.name }} \
+              -DSITE=cea-ruche \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+              -DCMAKE_CXX_STANDARD=17 \
+              -DCMAKE_CXX_FLAGS=-Werror \
+              -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
+              -DKokkos_ENABLE_TESTS=ON \
+              -DKokkos_ENABLE_EXAMPLES=ON \
+              ${{ matrix.backend.flags }}
+
+      - name: Start, configure, and build
+        run: |
+          cd build
+          run \
+            -m "${{ matrix.backend.modules }}" \
+            CMAKE_BUILD_PARALLEL_LEVEL=40 \
+            ctest \
+              -VV \
+              -D ExperimentalStart \
+              -D ExperimentalConfigure \
+              -D ExperimentalBuild
+
+      - name: Test
+        run: |
+          cd build
           run \
             -g ${{ matrix.backend.gpu }} \
             -m "${{ matrix.backend.modules }}" \
-            ctest -VV \
-              -DCDASH_MODEL="Experimental" \
-              -DCMAKE_OPTIONS=\"$(echo "${ENV_CMAKE_OPTIONS}" | sed -e 's/^[ ]*//' | tr '\n' ';')\" \
-              -DCTEST_BUILD_NAME=cea-${{ matrix.backend.name }} \
-              -DCTEST_SITE=cea-ruche \
-              -S CTestRun.cmake
-        env:
-          ENV_CMAKE_OPTIONS: |
-            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-            -DCMAKE_CXX_STANDARD=17
-            -DCMAKE_CXX_FLAGS=-Werror
-            -DKokkos_ENABLE_COMPILER_WARNINGS=ON
-            -DKokkos_ENABLE_TESTS=ON
-            -DKokkos_ENABLE_EXAMPLES=ON
-            ${{ matrix.backend.flags }}
+            ctest \
+              -VV \
+              -D ExperimentalTest
+
+      - name: Submit
+        run: |
+          cd build
+          run \
+            -m "${{ matrix.backend.modules }}" \
+            ctest \
+              -VV \
+              -D ExperimentalSubmit

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -3,6 +3,7 @@ name: Nightly CEA builds
 on:
   schedule:
     - cron: "0 2 * * 1-5" # every weekday at 2am UTC
+  pull_request:
 
 permissions: read-all
 
@@ -36,7 +37,7 @@ jobs:
             -g ${{ matrix.backend.gpu }} \
             -m "${{ matrix.backend.modules }}" \
             ctest -VV \
-              -DCDASH_MODEL="Nightly" \
+              -DCDASH_MODEL="Experimental" \
               -DCMAKE_OPTIONS="$(echo "${ENV_CMAKE_OPTIONS}" | sed -e 's/^[ ]*//' | tr '\n' ';')" \
               -DCTEST_BUILD_NAME=cea-${{ matrix.backend.name }} \
               -DCTEST_SITE=cea-ruche \

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -12,16 +12,12 @@ jobs:
     # only run on original repo
     if: github.repository == 'kokkos/kokkos'
 
-    # allow all steps to perform even if errors occur
-    continue-on-error: true
-
     strategy:
       # allow all matrix jobs to perform even if errors occur
       fail-fast: false
       matrix:
         build_type:
           - Release
-          # - Debug
         backend:
           - name: cuda-a100
             flags: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
@@ -51,6 +47,7 @@ jobs:
               ${{ matrix.backend.flags }}
 
       - name: Start, update and configure
+        continue-on-error: true
         run: |
           cd build
           run \
@@ -64,6 +61,7 @@ jobs:
               -D ExperimentalConfigure
 
       - name: Build
+        continue-on-error: true
         run: |
           cd build
           run \
@@ -75,6 +73,7 @@ jobs:
               -D ExperimentalBuild
 
       - name: Test
+        continue-on-error: true
         run: |
           cd build
           run \

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -3,7 +3,7 @@ name: Nightly CEA builds
 on:
   schedule:
     - cron: "0 2 * * 1-5" # every weekday at 2am UTC
-  pull_request:
+  pull_request:  # XXX Remove me before merging!
 
 permissions: read-all
 

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -20,8 +20,8 @@ jobs:
           - Release
         backend:
           - name: cuda-a100
-            flags: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
-            gpu: a100
+            configure: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
+            test: -e gpu -g a100
             modules: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
 
     runs-on: [self-hosted, cuda]
@@ -44,7 +44,7 @@ jobs:
               -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
               -DKokkos_ENABLE_TESTS=ON \
               -DKokkos_ENABLE_EXAMPLES=ON \
-              ${{ matrix.backend.flags }}
+              ${{ matrix.backend.configure }}
 
       - name: Start, update and configure
         continue-on-error: true
@@ -53,7 +53,6 @@ jobs:
           run \
             -m "${{ matrix.backend.modules }}" \
             -e local \
-            CMAKE_BUILD_PARALLEL_LEVEL=40 \
             ctest \
               -V \
               -D ExperimentalStart \
@@ -78,8 +77,7 @@ jobs:
           cd build
           run \
             -m "${{ matrix.backend.modules }}" \
-            -e gpu \
-            -g ${{ matrix.backend.gpu }} \
+            ${{ matrix.backend.test }} \
             ctest \
               -D ExperimentalTest \
               --output-on-failure

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -37,13 +37,14 @@ jobs:
         run: |
           run \
             -m "${{ matrix.backend.modules }}" \
+            -e local \
             cmake \
               -B build \
               -DBUILDNAME=${{ matrix.backend.name }} \
               -DSITE=cea-ruche \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DCMAKE_CXX_STANDARD=17 \
-              -DCMAKE_CXX_FLAGS=-Werror \
+              -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
               -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
               -DKokkos_ENABLE_TESTS=ON \
               -DKokkos_ENABLE_EXAMPLES=ON \
@@ -54,6 +55,7 @@ jobs:
           cd build
           run \
             -m "${{ matrix.backend.modules }}" \
+            -e cpu \
             CMAKE_BUILD_PARALLEL_LEVEL=40 \
             ctest \
               -V \
@@ -65,8 +67,9 @@ jobs:
         run: |
           cd build
           run \
-            -g ${{ matrix.backend.gpu }} \
             -m "${{ matrix.backend.modules }}" \
+            -e gpu \
+            -g ${{ matrix.backend.gpu }} \
             ctest \
               -D ExperimentalTest \
               --output-on-failure
@@ -76,6 +79,6 @@ jobs:
           cd build
           run \
             -m "${{ matrix.backend.modules }}" \
-            -l \
+            -e local \
             ctest \
               -D ExperimentalSubmit


### PR DESCRIPTION
This PR aims to report CEA nightly runs on the CDash instance, following the work of #7667.

- [x] Convert current workflow to use CDash;
- [x] Split the tasks that need to be run on specific nodes;
- [x] Prevent to use for pull requests.

The setup I used is quite different from #7667, #7708, or #7556 that use a CTest Script, which executes all the steps in one command. This approach is not possible for the Ruche cluster, as we need to execute the Build step on a CPU node, and the Test step on a GPU node, meaning executing different commands. The CTest Command-Line is more adapted to the Ruche cluster context, but is tricky to setup. We need to initialize the build tree first, then to call the different CTest Command-Lines (on a node or not). I wrote a [gist](https://gist.github.com/pzehner/6377e9d554227b772d98a0ca7ff9ce7e) to explain the approach, as I found the documentation not helpful about it, and as I needed several iterations to have a workable setup. Please refer to it for more details.

The tricky part is that all variables must be set during the initialization (or pre-generation). Some Dashboard specific variables are set with a different name with a CTest Command-Line compared with a CTest Script. By instance, the build name is passed as `BUILDNAME` instead of `CTEST_BUILD_NAME`, and the site is passed as `SITE` instead of `CTEST_SITE`. Blame Kitware for that. Another thing, this setup requires to configure the build tree twice (one for the initialization with `cmake`, the other one with `ctest`).

- [Workflow execution outcome](https://github.com/kokkos/kokkos/actions/runs/13203128851/job/36859730943?pr=7704);
- [Generated dashboard](https://my.cdash.org/builds/2812712);
- Example for for a higher workload which will be the object of another PR:
  ![Dashboard on 2025-01-30](https://github.com/user-attachments/assets/d167f0b0-27b6-47e3-8838-c9b0a62b1096)

For reasons I do not understand, the Update step is always failing with `Update command failed: "/usr/bin/git" "fetch"`, but I can call this command successfully by hand. I think it may be related to the fact it currently runs on a feature branch outside of the repository.