### PR TITLE
[ci skip] add ci skip stage to Jenkins CI

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -17,6 +17,12 @@ pipeline {
     }
 
     stages {
+        stage('Check-ci-skip') {
+            agent any
+            steps {
+                scmSkip(deleteBuild: true, skipPattern:'.*\\[ci skip\\].*')
+            }
+        }
         stage('Clang-Format') {
             agent {
                 dockerfile {


### PR DESCRIPTION
Currently, we run the CI on every commit even the ones tagged with [ci skip]. I've looked at the jenkins server and the commits should not trigger the CI but they do. This PR adds a new stage that looks for [ci skip] and [skip ci] and if necessary, aborts the CI. The documentation of the plug-in is [here](https://plugins.jenkins.io/scmskip/).