### PR TITLE
 DualView: Check construction from 2 Views with 1 stored

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -209,6 +209,12 @@ class DualView : public ViewTraits<DataType, Properties...> {
   t_modified_flags modified_flags;
 
  public:
+  // does the DualView have only one device
+  static constexpr bool impl_dualview_stores_single_view =
+      SpaceAccessibility<Kokkos::HostSpace,
+                         typename t_dev::memory_space>::accessible;
+
+ public:
   //@}
 
   // Moved this specifically after modified_flags to resolve an alignment issue
@@ -349,52 +355,10 @@ class DualView : public ViewTraits<DataType, Properties...> {
       Kokkos::Impl::throw_runtime_exception(
           "DualView constructed with incompatible views");
     }
+    if (impl_dualview_stores_single_view && (d_view.data() != h_view.data()))
+      Kokkos::abort(
+          "DualView storing one View constructed from two different Views");
   }
-  // does the DualView have only one device
-  struct impl_dualview_is_single_device {
-    enum : bool {
-      value = std::is_same_v<typename t_dev::device_type,
-                             typename t_host::device_type>
-    };
-  };
-
-  // does the given device match the device of t_dev?
-  template <typename Device>
-  struct impl_device_matches_tdev_device {
-    enum : bool { value = std::is_same_v<typename t_dev::device_type, Device> };
-  };
-  // does the given device match the device of t_host?
-  template <typename Device>
-  struct impl_device_matches_thost_device {
-    enum : bool {
-      value = std::is_same_v<typename t_host::device_type, Device>
-    };
-  };
-
-  // does the given device match the execution space of t_host?
-  template <typename Device>
-  struct impl_device_matches_thost_exec {
-    enum : bool {
-      value = std::is_same_v<typename t_host::execution_space, Device>
-    };
-  };
-
-  // does the given device match the execution space of t_dev?
-  template <typename Device>
-  struct impl_device_matches_tdev_exec {
-    enum : bool {
-      value = std::is_same_v<typename t_dev::execution_space, Device>
-    };
-  };
-
-  // does the given device's memory space match the memory space of t_dev?
-  template <typename Device>
-  struct impl_device_matches_tdev_memory_space {
-    enum : bool {
-      value = std::is_same_v<typename t_dev::memory_space,
-                             typename Device::memory_space>
-    };
-  };
 
   //@}
   //! \name Methods for synchronizing, marking as modified, and getting Views.
@@ -625,22 +589,25 @@ class DualView : public ViewTraits<DataType, Properties...> {
   }
 
   template <class Device>
-  void sync(const std::enable_if_t<
-                (std::is_same_v<typename traits::data_type,
-                                typename traits::non_const_data_type>) ||
-                    (std::is_same_v<Device, int>),
-                int>& = 0) {
-    sync_impl<Device>(std::true_type{});
+  void sync() {
+    if (impl_dualview_stores_single_view) return;
+
+    if constexpr (std::is_same_v<typename traits::data_type,
+                                 typename traits::non_const_data_type>)
+      sync_impl<Device>(std::true_type{});
+    else
+      sync_impl<Device>(std::false_type{});
   }
 
   template <class Device, class ExecutionSpace>
-  void sync(const ExecutionSpace& exec,
-            const std::enable_if_t<
-                (std::is_same_v<typename traits::data_type,
-                                typename traits::non_const_data_type>) ||
-                    (std::is_same_v<Device, int>),
-                int>& = 0) {
-    sync_impl<Device>(std::true_type{}, exec);
+  void sync(const ExecutionSpace& exec) {
+    if (impl_dualview_stores_single_view) return;
+
+    if constexpr (std::is_same_v<typename traits::data_type,
+                                 typename traits::non_const_data_type>)
+      sync_impl<Device>(std::true_type{}, exec);
+    else
+      sync_impl<Device>(std::false_type{}, exec);
   }
 
   // deliberately passing args by cref as they're used multiple times
@@ -664,24 +631,6 @@ class DualView : public ViewTraits<DataType, Properties...> {
       }
       impl_report_host_sync();
     }
-  }
-
-  template <class Device>
-  void sync(const std::enable_if_t<
-                (!std::is_same_v<typename traits::data_type,
-                                 typename traits::non_const_data_type>) ||
-                    (std::is_same_v<Device, int>),
-                int>& = 0) {
-    sync_impl<Device>(std::false_type{});
-  }
-  template <class Device, class ExecutionSpace>
-  void sync(const ExecutionSpace& exec,
-            const std::enable_if_t<
-                (!std::is_same_v<typename traits::data_type,
-                                 typename traits::non_const_data_type>) ||
-                    (std::is_same_v<Device, int>),
-                int>& = 0) {
-    sync_impl<Device>(std::false_type{}, exec);
   }
 
   // deliberately passing args by cref as they're used multiple times
@@ -798,10 +747,10 @@ class DualView : public ViewTraits<DataType, Properties...> {
   /// If \c Device is the same as this DualView's device type, then
   /// mark the device's data as modified.  Otherwise, mark the host's
   /// data as modified.
-  template <class Device, class Dummy = DualView,
-            std::enable_if_t<!Dummy::impl_dualview_is_single_device::value>* =
-                nullptr>
+  template <class Device>
   void modify() {
+    if (impl_dualview_stores_single_view) return;
+
     if (modified_flags.data() == nullptr) {
       modified_flags = t_modified_flags("DualView::modified_flags");
     }
@@ -837,17 +786,9 @@ class DualView : public ViewTraits<DataType, Properties...> {
 #endif
   }
 
-  template <
-      class Device, class Dummy = DualView,
-      std::enable_if_t<Dummy::impl_dualview_is_single_device::value>* = nullptr>
-  void modify() {
-    return;
-  }
-
-  template <class Dummy = DualView,
-            std::enable_if_t<!Dummy::impl_dualview_is_single_device::value>* =
-                nullptr>
   inline void modify_host() {
+    if (impl_dualview_stores_single_view) return;
+
     if (modified_flags.data() != nullptr) {
       modified_flags(0) =
           (modified_flags(1) > modified_flags(0) ? modified_flags(1)
@@ -867,17 +808,9 @@ class DualView : public ViewTraits<DataType, Properties...> {
     }
   }
 
-  template <
-      class Dummy = DualView,
-      std::enable_if_t<Dummy::impl_dualview_is_single_device::value>* = nullptr>
-  inline void modify_host() {
-    return;
-  }
-
-  template <class Dummy = DualView,
-            std::enable_if_t<!Dummy::impl_dualview_is_single_device::value>* =
-                nullptr>
   inline void modify_device() {
+    if (impl_dualview_stores_single_view) return;
+
     if (modified_flags.data() != nullptr) {
       modified_flags(1) =
           (modified_flags(1) > modified_flags(0) ? modified_flags(1)
@@ -895,13 +828,6 @@ class DualView : public ViewTraits<DataType, Properties...> {
       }
 #endif
     }
-  }
-
-  template <
-      class Dummy = DualView,
-      std::enable_if_t<Dummy::impl_dualview_is_single_device::value>* = nullptr>
-  inline void modify_device() {
-    return;
   }
 
   inline void clear_sync_state() {

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -515,9 +515,12 @@ TEST(TEST_CATEGORY_DEATH, dualview_external_view_construction) {
     Kokkos::View<int*, TEST_EXECSPACE> view2("view2", 10);
 
     Kokkos::DualView<int*, TEST_EXECSPACE> v_dual(view1, view1);
+// FIXME_MSVC+CUDA error C2094: label 'gtest_label_520' was undefined
+#if !(defined(KOKKOS_COMPILER_MSVC) && defined(KOKKOS_ENABLE_CUDA))
     ASSERT_DEATH(
         (Kokkos::DualView<int*, TEST_EXECSPACE>(view1, view2)),
         "DualView storing one View constructed from two different Views");
+#endif
   }
 }
 

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -503,6 +503,8 @@ TEST(TEST_CATEGORY, dualview_resize) {
                              /* Initialize */ false>();
 }
 
+// FIXME_MSVC+CUDA error C2094: label 'gtest_label_520' was undefined
+#if !(defined(KOKKOS_COMPILER_MSVC) && defined(KOKKOS_ENABLE_CUDA))
 TEST(TEST_CATEGORY_DEATH, dualview_external_view_construction) {
   if constexpr (!Kokkos::SpaceAccessibility<
                     Kokkos::DefaultHostExecutionSpace,
@@ -515,14 +517,12 @@ TEST(TEST_CATEGORY_DEATH, dualview_external_view_construction) {
     Kokkos::View<int*, TEST_EXECSPACE> view2("view2", 10);
 
     Kokkos::DualView<int*, TEST_EXECSPACE> v_dual(view1, view1);
-// FIXME_MSVC+CUDA error C2094: label 'gtest_label_520' was undefined
-#if !(defined(KOKKOS_COMPILER_MSVC) && defined(KOKKOS_ENABLE_CUDA))
     ASSERT_DEATH(
         (Kokkos::DualView<int*, TEST_EXECSPACE>(view1, view2)),
         "DualView storing one View constructed from two different Views");
-#endif
   }
 }
+#endif
 
 namespace {
 /**


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/pull/7662#issuecomment-2616993197. Related to #7319.
If the `DualView`'s memeory space is host-accessible, `DualView` only stores one `View`. There is still is a constructor from2 Views that assumes that these two Views are synced. If only one `View` is stored we still need make sure that these in fact reference the same data. This pull request adds such a check.

Other changes:
- rename `impl_dualview_is_single_device` to `impl_dualview_stores_single_view`. We can discuss making it `private` or properly public.
- remove `impl_device_matches_tdev_device`, `impl_device_matches_thost_device`, `impl_device_matches_thost_exec`, `impl_device_matches_tdev_exec`, `impl_device_matches_tdev_memory_space`
- Clean-up the SFINAE for `sync` and `modify`