### PR TITLE
cicd: rename smoketest to better reflect compiler

### DIFF
--- a/.github/workflows/continuous-integration-smoketest.yml
+++ b/.github/workflows/continuous-integration-smoketest.yml
@@ -10,8 +10,8 @@ concurrency:
 permissions: read-all
 
 jobs:
-  gcc-smoketest:
-    name: gcc-smoketest
+  clang-smoketest:
+    name: clang-smoketest
     runs-on: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
The compiler for the `gcc-smoketest` is hardcoded to `clang++`
https://github.com/kokkos/kokkos/blob/4692580a735100dbc597f9fdaeb927606a7c02f3/.github/workflows/continuous-integration-smoketest.yml#L30

Let's rename it accordingly.