### PR TITLE
DualView: Deprecate direct access to d_view and h_view

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -214,8 +214,13 @@ class DualView : public ViewTraits<DataType, Properties...> {
       SpaceAccessibility<Kokkos::HostSpace,
                          typename t_dev::memory_space>::accessible;
 
- public:
   //@}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+ public:
+#else
+ private:
+#endif
 
   // Moved this specifically after modified_flags to resolve an alignment issue
   // on MSVC/NVCC
@@ -225,6 +230,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
   t_host h_view;
   //@}
 
+ public:
   //! \name Constructors
   //@{
 
@@ -1190,10 +1196,10 @@ namespace Kokkos {
 template <class DT, class... DP, class ST, class... SP>
 void deep_copy(DualView<DT, DP...>& dst, const DualView<ST, SP...>& src) {
   if (src.need_sync_device()) {
-    deep_copy(dst.h_view, src.h_view);
+    deep_copy(dst.view_host(), src.view_host());
     dst.modify_host();
   } else {
-    deep_copy(dst.d_view, src.d_view);
+    deep_copy(dst.view_device(), src.view_device());
     dst.modify_device();
   }
 }
@@ -1202,10 +1208,10 @@ template <class ExecutionSpace, class DT, class... DP, class ST, class... SP>
 void deep_copy(const ExecutionSpace& exec, DualView<DT, DP...>& dst,
                const DualView<ST, SP...>& src) {
   if (src.need_sync_device()) {
-    deep_copy(exec, dst.h_view, src.h_view);
+    deep_copy(exec, dst.view_host(), src.view_host());
     dst.modify_host();
   } else {
-    deep_copy(exec, dst.d_view, src.d_view);
+    deep_copy(exec, dst.view_device(), src.view_device());
     dst.modify_device();
   }
 }

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -431,11 +431,19 @@ class DualView : public ViewTraits<DataType, Properties...> {
 #endif
   }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_INLINE_FUNCTION
   t_host view_host() const { return h_view; }
 
   KOKKOS_INLINE_FUNCTION
   t_dev view_device() const { return d_view; }
+#else
+  KOKKOS_INLINE_FUNCTION
+  const t_host& view_host() const { return h_view; }
+
+  KOKKOS_INLINE_FUNCTION
+  const t_dev& view_device() const { return d_view; }
+#endif
 
   KOKKOS_INLINE_FUNCTION constexpr bool is_allocated() const {
     return (d_view.is_allocated() && h_view.is_allocated());

--- a/containers/src/Kokkos_ErrorReporter.hpp
+++ b/containers/src/Kokkos_ErrorReporter.hpp
@@ -43,7 +43,7 @@ class ErrorReporter {
     clear();
   }
 
-  int getCapacity() const { return m_reports.h_view.extent(0); }
+  int getCapacity() const { return m_reports.view_host().extent(0); }
 
   int getNumReports();
 
@@ -69,9 +69,10 @@ class ErrorReporter {
   bool add_report(int reporter_id, report_type report) const {
     int idx = Kokkos::atomic_fetch_add(&m_numReportsAttempted(), 1);
 
-    if (idx >= 0 && (idx < static_cast<int>(m_reports.d_view.extent(0)))) {
-      m_reporters.d_view(idx) = reporter_id;
-      m_reports.d_view(idx)   = report;
+    if (idx >= 0 &&
+        (idx < static_cast<int>(m_reports.view_device().extent(0)))) {
+      m_reporters.view_device()(idx) = reporter_id;
+      m_reports.view_device()(idx)   = report;
       return true;
     } else {
       return false;
@@ -92,8 +93,8 @@ template <typename ReportType, typename DeviceType>
 inline int ErrorReporter<ReportType, DeviceType>::getNumReports() {
   int num_reports = 0;
   Kokkos::deep_copy(num_reports, m_numReportsAttempted);
-  if (num_reports > static_cast<int>(m_reports.h_view.extent(0))) {
-    num_reports = m_reports.h_view.extent(0);
+  if (num_reports > static_cast<int>(m_reports.view_host().extent(0))) {
+    num_reports = m_reports.view_host().extent(0);
   }
   return num_reports;
 }
@@ -119,8 +120,8 @@ void ErrorReporter<ReportType, DeviceType>::getReports(
     m_reporters.template sync<host_mirror_space>();
 
     for (int i = 0; i < num_reports; ++i) {
-      reporters_out.push_back(m_reporters.h_view(i));
-      reports_out.push_back(m_reports.h_view(i));
+      reporters_out.push_back(m_reporters.view_host()(i));
+      reports_out.push_back(m_reports.view_host()(i));
     }
   }
 }
@@ -143,8 +144,8 @@ void ErrorReporter<ReportType, DeviceType>::getReports(
     m_reporters.template sync<host_mirror_space>();
 
     for (int i = 0; i < num_reports; ++i) {
-      reporters_out(i) = m_reporters.h_view(i);
-      reports_out(i)   = m_reports.h_view(i);
+      reporters_out(i) = m_reporters.view_host()(i);
+      reports_out(i)   = m_reports.view_host()(i);
     }
   }
 }

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -123,16 +123,16 @@ struct test_dualview_combinations {
     } else {
       a = ViewType(Kokkos::view_alloc(Kokkos::WithoutInitializing, "A"), n, m);
     }
-    Kokkos::deep_copy(a.d_view, 1);
+    Kokkos::deep_copy(a.view_device(), 1);
 
     a.template modify<typename ViewType::execution_space>();
     a.template sync<typename ViewType::host_mirror_space>();
     a.template sync<typename ViewType::host_mirror_space>(
         Kokkos::DefaultExecutionSpace{});
 
-    a.h_view(5, 1) = 3;
-    a.h_view(6, 1) = 4;
-    a.h_view(7, 2) = 5;
+    a.view_host()(5, 1) = 3;
+    a.view_host()(6, 1) = 4;
+    a.view_host()(7, 2) = 5;
     a.template modify<typename ViewType::host_mirror_space>();
     ViewType b = Kokkos::subview(a, std::pair<unsigned int, unsigned int>(6, 9),
                                  std::pair<unsigned int, unsigned int>(0, 1));
@@ -141,16 +141,17 @@ struct test_dualview_combinations {
         Kokkos::DefaultExecutionSpace{});
     b.template modify<typename ViewType::execution_space>();
 
-    Kokkos::deep_copy(b.d_view, 2);
+    Kokkos::deep_copy(b.view_device(), 2);
 
     a.template sync<typename ViewType::host_mirror_space>();
     a.template sync<typename ViewType::host_mirror_space>(
         Kokkos::DefaultExecutionSpace{});
     Scalar count = 0;
-    for (unsigned int i = 0; i < a.d_view.extent(0); i++)
-      for (unsigned int j = 0; j < a.d_view.extent(1); j++)
-        count += a.h_view(i, j);
-    return count - a.d_view.extent(0) * a.d_view.extent(1) - 2 - 4 - 3 * 2;
+    for (unsigned int i = 0; i < a.view_device().extent(0); i++)
+      for (unsigned int j = 0; j < a.view_device().extent(1); j++)
+        count += a.view_host()(i, j);
+    return count - a.view_device().extent(0) * a.view_device().extent(1) - 2 -
+           4 - 3 * 2;
   }
 
   test_dualview_combinations(unsigned int size, bool with_init) {
@@ -191,7 +192,7 @@ struct test_dual_view_deep_copy {
     }
     const scalar_type sum_total = scalar_type(n * m);
 
-    Kokkos::deep_copy(a.d_view, 1);
+    Kokkos::deep_copy(a.view_device(), 1);
 
     if (use_templ_sync) {
       a.template modify<typename ViewType::execution_space>();
@@ -209,15 +210,16 @@ struct test_dual_view_deep_copy {
         typename ViewType::t_dev::memory_space::execution_space;
     Kokkos::parallel_reduce(
         Kokkos::RangePolicy<t_dev_exec_space>(0, n),
-        SumViewEntriesFunctor<scalar_type, typename ViewType::t_dev>(a.d_view),
+        SumViewEntriesFunctor<scalar_type, typename ViewType::t_dev>(
+            a.view_device()),
         a_d_sum);
     ASSERT_EQ(a_d_sum, sum_total);
 
     // Check host view is synced as expected
     scalar_type a_h_sum = 0;
-    for (size_t i = 0; i < a.h_view.extent(0); ++i)
-      for (size_t j = 0; j < a.h_view.extent(1); ++j) {
-        a_h_sum += a.h_view(i, j);
+    for (size_t i = 0; i < a.view_host().extent(0); ++i)
+      for (size_t j = 0; j < a.view_host().extent(1); ++j) {
+        a_h_sum += a.view_host()(i, j);
       }
 
     ASSERT_EQ(a_h_sum, sum_total);
@@ -237,15 +239,16 @@ struct test_dual_view_deep_copy {
     // Execute on the execution_space associated with t_dev's memory space
     Kokkos::parallel_reduce(
         Kokkos::RangePolicy<t_dev_exec_space>(0, n),
-        SumViewEntriesFunctor<scalar_type, typename ViewType::t_dev>(b.d_view),
+        SumViewEntriesFunctor<scalar_type, typename ViewType::t_dev>(
+            b.view_device()),
         b_d_sum);
     ASSERT_EQ(b_d_sum, sum_total);
 
     // Check host view is synced as expected
     scalar_type b_h_sum = 0;
-    for (size_t i = 0; i < b.h_view.extent(0); ++i)
-      for (size_t j = 0; j < b.h_view.extent(1); ++j) {
-        b_h_sum += b.h_view(i, j);
+    for (size_t i = 0; i < b.view_host().extent(0); ++i)
+      for (size_t j = 0; j < b.view_host().extent(1); ++j) {
+        b_h_sum += b.view_host()(i, j);
       }
 
     ASSERT_EQ(b_h_sum, sum_total);
@@ -256,8 +259,8 @@ struct test_dual_view_deep_copy {
     run_me<Kokkos::DualView<Scalar**, Kokkos::LayoutLeft, Device>>(10, 5, true);
     run_me<Kokkos::DualView<Scalar**, Kokkos::LayoutLeft, Device>>(10, 5,
                                                                    false);
-    // Test zero length but allocated (a.d_view.data!=nullptr but
-    // a.d_view.span()==0)
+    // Test zero length but allocated (a.view_device().data() != nullptr but
+    // a.view_device().span() == 0)
     run_me<Kokkos::DualView<Scalar**, Kokkos::LayoutLeft, Device>>(0, 5, true);
     run_me<Kokkos::DualView<Scalar**, Kokkos::LayoutLeft, Device>>(0, 5, false);
 
@@ -285,7 +288,7 @@ struct test_dualview_resize {
     else
       a = ViewType(Kokkos::view_alloc(Kokkos::WithoutInitializing, "A"), n, m);
 
-    Kokkos::deep_copy(a.d_view, 1);
+    Kokkos::deep_copy(a.view_device(), 1);
 
     /* Covers case "Resize on Device" */
     a.modify_device();
@@ -296,7 +299,7 @@ struct test_dualview_resize {
     ASSERT_EQ(a.extent(0), n * factor);
     ASSERT_EQ(a.extent(1), m * factor);
 
-    Kokkos::deep_copy(a.d_view, 1);
+    Kokkos::deep_copy(a.view_device(), 1);
     a.sync_host();
 
     // Check device view is initialized as expected
@@ -307,18 +310,18 @@ struct test_dualview_resize {
         "errors");
     Kokkos::parallel_for(
         Kokkos::MDRangePolicy<t_dev_exec_space, Kokkos::Rank<2>>(
-            {0, 0}, {a.d_view.extent(0), a.d_view.extent(1)}),
+            {0, 0}, {a.view_device().extent(0), a.view_device().extent(1)}),
         KOKKOS_LAMBDA(int i, int j) {
-          if (a.d_view(i, j) != 1) Kokkos::atomic_inc(errors_d.data());
+          if (a.view_device()(i, j) != 1) Kokkos::atomic_inc(errors_d.data());
         });
     int errors_d_scalar;
     Kokkos::deep_copy(errors_d_scalar, errors_d);
 
     // Check host view is synced as expected
     int errors_h_scalar = 0;
-    for (size_t i = 0; i < a.h_view.extent(0); ++i)
-      for (size_t j = 0; j < a.h_view.extent(1); ++j) {
-        if (a.h_view(i, j) != 1) ++errors_h_scalar;
+    for (size_t i = 0; i < a.view_host().extent(0); ++i)
+      for (size_t j = 0; j < a.view_host().extent(1); ++j) {
+        if (a.view_host()(i, j) != 1) ++errors_h_scalar;
       }
 
     // Check
@@ -345,17 +348,17 @@ struct test_dualview_resize {
         typename ViewType::t_dev::memory_space::execution_space;
     Kokkos::parallel_for(
         Kokkos::MDRangePolicy<t_dev_exec_space, Kokkos::Rank<2>>(
-            {0, 0}, {a.d_view.extent(0), a.d_view.extent(1)}),
+            {0, 0}, {a.view_device().extent(0), a.view_device().extent(1)}),
         KOKKOS_LAMBDA(int i, int j) {
-          if (a.d_view(i, j) != 1) Kokkos::atomic_inc(errors_d.data());
+          if (a.view_device()(i, j) != 1) Kokkos::atomic_inc(errors_d.data());
         });
     Kokkos::deep_copy(errors_d_scalar, errors_d);
 
     // Check host view is synced as expected
     errors_h_scalar = 0;
-    for (size_t i = 0; i < a.h_view.extent(0); ++i)
-      for (size_t j = 0; j < a.h_view.extent(1); ++j) {
-        if (a.h_view(i, j) != 1) ++errors_h_scalar;
+    for (size_t i = 0; i < a.view_host().extent(0); ++i)
+      for (size_t j = 0; j < a.view_host().extent(1); ++j) {
+        if (a.view_host()(i, j) != 1) ++errors_h_scalar;
       }
 
     // Check
@@ -390,7 +393,7 @@ struct test_dualview_realloc {
     ASSERT_EQ(a.extent(0), n);
     ASSERT_EQ(a.extent(1), m);
 
-    Kokkos::deep_copy(a.d_view, 1);
+    Kokkos::deep_copy(a.view_device(), 1);
 
     a.modify_device();
     a.sync_host();
@@ -403,18 +406,18 @@ struct test_dualview_realloc {
         "errors");
     Kokkos::parallel_for(
         Kokkos::MDRangePolicy<t_dev_exec_space, Kokkos::Rank<2>>(
-            {0, 0}, {a.d_view.extent(0), a.d_view.extent(1)}),
+            {0, 0}, {a.view_device().extent(0), a.view_device().extent(1)}),
         KOKKOS_LAMBDA(int i, int j) {
-          if (a.d_view(i, j) != 1) Kokkos::atomic_inc(errors_d.data());
+          if (a.view_device()(i, j) != 1) Kokkos::atomic_inc(errors_d.data());
         });
     int errors_d_scalar;
     Kokkos::deep_copy(errors_d_scalar, errors_d);
 
     // Check host view is synced as expected
     int errors_h_scalar = 0;
-    for (size_t i = 0; i < a.h_view.extent(0); ++i)
-      for (size_t j = 0; j < a.h_view.extent(1); ++j) {
-        if (a.h_view(i, j) != 1) ++errors_h_scalar;
+    for (size_t i = 0; i < a.view_host().extent(0); ++i)
+      for (size_t j = 0; j < a.view_host().extent(1); ++j) {
+        if (a.view_host()(i, j) != 1) ++errors_h_scalar;
       }
 
     // Check
@@ -661,8 +664,8 @@ auto initialize_view_of_views() {
 
   V v("v", 2);
   V w("w", 2);
-  dv_v.h_view(0) = v;
-  dv_v.h_view(1) = w;
+  dv_v.view_host()(0) = v;
+  dv_v.view_host()(1) = w;
 
   dv_v.modify_host();
   dv_v.sync_device();
@@ -673,19 +676,19 @@ auto initialize_view_of_views() {
 TEST(TEST_CATEGORY, dualview_sequential_host_init) {
   auto dv_v = initialize_view_of_views<Kokkos::View<double*, TEST_EXECSPACE>>();
   dv_v.resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), 2u);
-  ASSERT_EQ(dv_v.d_view.size(), 2u);
-  ASSERT_EQ(dv_v.h_view.size(), 2u);
+  ASSERT_EQ(dv_v.view_device().size(), 2u);
+  ASSERT_EQ(dv_v.view_host().size(), 2u);
 
   initialize_view_of_views<S<Kokkos::View<double*, TEST_EXECSPACE>>>();
 
   Kokkos::DualView<double*> dv(
       Kokkos::view_alloc("myView", Kokkos::SequentialHostInit), 1u);
   dv.resize(Kokkos::view_alloc(Kokkos::SequentialHostInit), 2u);
-  ASSERT_EQ(dv.d_view.size(), 2u);
-  ASSERT_EQ(dv.h_view.size(), 2u);
+  ASSERT_EQ(dv.view_device().size(), 2u);
+  ASSERT_EQ(dv.view_host().size(), 2u);
   dv.realloc(Kokkos::view_alloc(Kokkos::SequentialHostInit), 3u);
-  ASSERT_EQ(dv.d_view.size(), 3u);
-  ASSERT_EQ(dv.h_view.size(), 3u);
+  ASSERT_EQ(dv.view_device().size(), 3u);
+  ASSERT_EQ(dv.view_host().size(), 3u);
 }
 }  // anonymous namespace
 }  // namespace Test

--- a/example/tutorial/Advanced_Views/04_dualviews/dual_view.cpp
+++ b/example/tutorial/Advanced_Views/04_dualviews/dual_view.cpp
@@ -131,7 +131,7 @@ int main(int narg, char* arg[]) {
   {
     ParticleTypes test("Test");
     Kokkos::fence();
-    test.h_view(0) = ParticleType(-1e4, 1);
+    test.view_host()(0) = ParticleType(-1e4, 1);
     Kokkos::fence();
 
     int size = 1000000;
@@ -146,7 +146,7 @@ int main(int narg, char* arg[]) {
 
     // Get a reference to the host view of idx directly (equivalent to
     // idx.view<idx_type::host_mirror_space>() )
-    idx_type::t_host h_idx = idx.h_view;
+    idx_type::t_host h_idx = idx.view_host();
     using size_type        = view_type::size_type;
     for (int i = 0; i < size; ++i) {
       for (size_type j = 0; j < static_cast<size_type>(h_idx.extent(1)); ++j) {

--- a/example/tutorial/Algorithms/01_random_numbers/random_numbers.cpp
+++ b/example/tutorial/Algorithms/01_random_numbers/random_numbers.cpp
@@ -94,25 +94,25 @@ int main(int argc, char* args[]) {
     Kokkos::Timer timer;
     Kokkos::parallel_for(size,
                          generate_random<Kokkos::Random_XorShift64_Pool<> >(
-                             vals.d_view, rand_pool64, samples));
+                             vals.view_device(), rand_pool64, samples));
     Kokkos::fence();
 
     timer.reset();
     Kokkos::parallel_for(size,
                          generate_random<Kokkos::Random_XorShift64_Pool<> >(
-                             vals.d_view, rand_pool64, samples));
+                             vals.view_device(), rand_pool64, samples));
     Kokkos::fence();
     double time_64 = timer.seconds();
 
     Kokkos::parallel_for(size,
                          generate_random<Kokkos::Random_XorShift1024_Pool<> >(
-                             vals.d_view, rand_pool1024, samples));
+                             vals.view_device(), rand_pool1024, samples));
     Kokkos::fence();
 
     timer.reset();
     Kokkos::parallel_for(size,
                          generate_random<Kokkos::Random_XorShift1024_Pool<> >(
-                             vals.d_view, rand_pool1024, samples));
+                             vals.view_device(), rand_pool1024, samples));
     Kokkos::fence();
     double time_1024 = timer.seconds();
 
@@ -121,7 +121,7 @@ int main(int argc, char* args[]) {
     printf("#Time XorShift1024*: %e %e\n", time_1024,
            1.0e-9 * samples * size / time_1024);
 
-    Kokkos::deep_copy(vals.h_view, vals.d_view);
+    Kokkos::deep_copy(vals.view_host(), vals.view_device());
   }
   Kokkos::finalize();
   return 0;


### PR DESCRIPTION
While lookig at #7712, I noticed that we don't protect access to `d_view` and `h_view` although we already have `view_host()` and `view_device()`. Being able to assign Views directly is dangerous, particularly in case there is only one allocation and the two member variables must reference the same data.