### PR TITLE
benchmarks[cmake]: Bump Google Benchmark version to 1.9.1

### DIFF
--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -36,8 +36,8 @@ else()
   FetchContent_Declare(
     googlebenchmark
     DOWNLOAD_EXTRACT_TIMESTAMP FALSE
-    URL https://github.com/google/benchmark/archive/refs/tags/v1.7.1.tar.gz
-    URL_HASH MD5=0459a6c530df9851bee6504c3e37c2e7
+    URL https://github.com/google/benchmark/archive/refs/tags/v1.9.1.tar.gz
+    URL_HASH MD5=92000ef8b4a7b1e9229972f8943070a7
   )
   FetchContent_MakeAvailable(googlebenchmark)
   list(POP_BACK CMAKE_MESSAGE_INDENT)


### PR DESCRIPTION
Fetching v1.7.1 is erroring out with depre warnings.
v1.9.1 seems to be working fine.

```
_deps/googlebenchmark-src/src/benchmark_runner.cc", line 392: error: function "benchmark::MemoryManager::Stop(benchmark::MemoryManager::Result *)" was declared deprecated ("Use Stop(Result&) instead") [deprecated_entity_with_custom_message]
      memory_manager->Stop(memory_result);
                      ^
"/home/jciesko/kokkos/kokkos/build/_deps/googlebenchmark-src/include/benchmark/benchmark.h", line 386: note: because of a "deprecated" attribute
    BENCHMARK_DEPRECATED_MSG("Use Stop(Result&) instead")
    ^
```
```
nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2023 NVIDIA Corporation
Built on Fri_Nov__3_17:22:02_PDT_2023
Cuda compilation tools, release 12.3, V12.3.103
Build cuda_12.3.r12.3/compiler.33492891_0
```