### PR TITLE
HPSF CI: Fix scheduled runs to commit to Nightly

### DIFF
--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -1,7 +1,7 @@
 .common-setup:
   stage: test
   before_script:
-    - if [ ${CI_COMMIT_REF_NAME} == "schedule" ]; then
+    - if [ ${CI_PIPELINE_SOURCE} == "schedule" ]; then
         export CDASH_MODEL="Nightly";
       elif [ ${CI_COMMIT_REF_NAME} == "develop" ]; then
         export CDASH_MODEL="Continuous";


### PR DESCRIPTION
The latest nightlies commited to the wrong dashboard, see https://my.cdash.org/index.php?project=Kokkos due to the refactoring in https://github.com/kokkos/kokkos/pull/7707.