### PR TITLE
Set CRAYPE_LINK_TYPE to dynamic for Frontier nightlies

### DIFF
--- a/.gitlab/olcf-gitlab-ci.yml
+++ b/.gitlab/olcf-gitlab-ci.yml
@@ -7,6 +7,7 @@ hipcc:
   script:
     - module load rocm/6.0
     - export CMAKE_BUILD_PARALLEL_LEVEL=48
+    - export CRAYPE_LINK_TYPE=dynamic
     - export ENV_CMAKE_OPTIONS=""
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DCMAKE_CXX_COMPILER=hipcc"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_HIP=ON"
@@ -22,6 +23,7 @@ amdclang:
   script:
     - module load rocm/6.2.4
     - export CMAKE_BUILD_PARALLEL_LEVEL=48
+    - export CRAYPE_LINK_TYPE=dynamic
     - export ENV_CMAKE_OPTIONS=""
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DCMAKE_CXX_COMPILER=amdclang++"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DCMAKE_CXX_CLANG_TIDY=/opt/rocm-6.2.4/llvm/bin/clang-tidy\;-warnings-as-errors=*"
@@ -39,6 +41,7 @@ crayclang:
     - module load rocm/6.3.1
     - module load cce/18.0.1
     - export CMAKE_BUILD_PARALLEL_LEVEL=48
+    - export CRAYPE_LINK_TYPE=dynamic
     - export ENV_CMAKE_OPTIONS=""
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DCMAKE_CXX_COMPILER=CC"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_HIP=ON"


### PR DESCRIPTION
We finally report the results from Frontier on the CDASH but we have a warning at configuration time because I forgot to set `CRAYPE_LINK_TYPE` to `dynamic`.