### PR TITLE
Fix incorrect `MDRangePolicy` iterations when the rank is higher than 4 for Cuda

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -95,8 +95,20 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
 
   inline void execute() const {
     if (m_rp.m_num_tiles == 0) return;
-    const auto maxblocks  = m_rp.space().cuda_device_prop().maxGridSize;
+    // maximum number of blocks per grid as fetched by the API
+    const auto maxblocks_api = m_rp.space().cuda_device_prop().maxGridSize;
+
+    // maximum numebr of blocks per grid hard-coded for unpacking on device
+    const int maxblocks[3] = {mdrange_max_blocks_x, mdrange_max_blocks,
+                              mdrange_max_blocks};
+
+    // check hard-coded values are compatible with API values
+    KOKKOS_ASSERT(maxblocks[0] <= static_cast<int>(maxblocks_api[0]));
+    KOKKOS_ASSERT(maxblocks[1] <= static_cast<int>(maxblocks_api[1]));
+    KOKKOS_ASSERT(maxblocks[2] <= static_cast<int>(maxblocks_api[2]));
+
     const auto maxthreads = m_rp.space().cuda_device_prop().maxThreadsDim;
+
     [[maybe_unused]] const auto maxThreadsPerBlock =
         m_rp.space().cuda_device_prop().maxThreadsPerBlock;
     // make sure the Z dimension (it is less than x,y limits) isn't exceeded

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -96,7 +96,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
   inline void execute() const {
     if (m_rp.m_num_tiles == 0) return;
     // maximum number of blocks per grid as fetched by the API
-    const auto maxblocks_api = m_rp.space().cuda_device_prop().maxGridSize;
+    [[maybe_unused]] const auto maxblocks_api =
+        m_rp.space().cuda_device_prop().maxGridSize;
 
     // maximum numebr of blocks per grid hard-coded for unpacking on device
     const int maxblocks[3] = {mdrange_max_blocks_x, mdrange_max_blocks,

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -45,8 +45,8 @@ struct EmulateCUDADim3 {
 #define MAX_BLOCKS_X 4294967295;
 #define MAX_BLOCKS 4294967295;
 #elif defined(KOKKOS_ENABLE_SYCL)
-#define MAX_BLOCKS_X 65535;
-#define MAX_BLOCKS 65535;
+#define MAX_BLOCKS_X 4294967295;
+#define MAX_BLOCKS 4294967295;
 #else
 #error("Programming model not supported")
 #endif

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -38,6 +38,19 @@ struct EmulateCUDADim3 {
 };
 #endif
 
+#if defined(KOKKOS_ENABLE_CUDA)
+#define MAX_BLOCKS_X 2147483647;
+#define MAX_BLOCKS 65535;
+#elif defined(KOKKOS_ENABLE_HIP)
+#define MAX_BLOCKS_X 4294967295;
+#define MAX_BLOCKS 4294967295;
+#elif defined(KOKKOS_ENABLE_SYCL)
+#define MAX_BLOCKS_X 65535;
+#define MAX_BLOCKS 65535;
+#else
+#error("Programming model not supported")
+#endif
+
 template <class Tag, class Functor, class... Args>
 KOKKOS_IMPL_FORCEINLINE_FUNCTION std::enable_if_t<std::is_void_v<Tag>>
 _tag_invoke(Functor const& f, Args&&... args) {
@@ -276,18 +289,8 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
       : m_policy(policy_), m_func(f_) {}
 #endif
 
-#if defined(KOKKOS_ENABLE_CUDA)
-  static constexpr index_type max_blocks_x = 2147483647;
-  static constexpr index_type max_blocks   = 65535;
-#elif defined(KOKKOS_ENABLE_HIP)
-  static constexpr index_type max_blocks_x = 4294967295;
-  static constexpr index_type max_blocks   = 4294967295;
-#elif defined(KOKKOS_ENABLE_SYCL)
-  static constexpr index_type max_blocks_x = 65535;
-  static constexpr index_type max_blocks   = 65535;
-#else
-#error("Programming model not supported")
-#endif
+  static constexpr index_type max_blocks_x = MAX_BLOCKS_X;
+  static constexpr index_type max_blocks   = MAX_BLOCKS;
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
@@ -439,18 +442,8 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
       : m_policy(policy_), m_func(f_) {}
 #endif
 
-#if defined(KOKKOS_ENABLE_CUDA)
-  static constexpr index_type max_blocks_x = 2147483647;
-  static constexpr index_type max_blocks   = 65535;
-#elif defined(KOKKOS_ENABLE_HIP)
-  static constexpr index_type max_blocks_x = 4294967295;
-  static constexpr index_type max_blocks   = 4294967295;
-#elif defined(KOKKOS_ENABLE_SYCL)
-  static constexpr index_type max_blocks_x = 65535;
-  static constexpr index_type max_blocks   = 65535;
-#else
-#error("Programming model not supported")
-#endif
+  static constexpr index_type max_blocks_x = MAX_BLOCKS_X;
+  static constexpr index_type max_blocks   = MAX_BLOCKS;
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
@@ -651,18 +644,8 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
       : m_policy(policy_), m_func(f_) {}
 #endif
 
-#if defined(KOKKOS_ENABLE_CUDA)
-  static constexpr index_type max_blocks_x = 2147483647;
-  static constexpr index_type max_blocks   = 65535;
-#elif defined(KOKKOS_ENABLE_HIP)
-  static constexpr index_type max_blocks_x = 4294967295;
-  static constexpr index_type max_blocks   = 4294967295;
-#elif defined(KOKKOS_ENABLE_SYCL)
-  static constexpr index_type max_blocks_x = 65535;
-  static constexpr index_type max_blocks   = 65535;
-#else
-#error("Programming model not supported")
-#endif
+  static constexpr index_type max_blocks_x = MAX_BLOCKS_X;
+  static constexpr index_type max_blocks   = MAX_BLOCKS;
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -115,6 +115,7 @@ struct DeviceIterateTile<2, PolicyType, Functor, Tag> {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
+    // LL
     if (PolicyType::inner_direction == Iterate::Left) {
       // Loop over size maxnumblocks until full range covered
       for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
@@ -138,7 +139,9 @@ struct DeviceIterateTile<2, PolicyType, Functor, Tag> {
           }
         }
       }
-    } else {
+    }
+    // LR
+    else {
       for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
            tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
         const index_type offset_0 =
@@ -197,6 +200,7 @@ struct DeviceIterateTile<3, PolicyType, Functor, Tag> {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
+    // LL
     if (PolicyType::inner_direction == Iterate::Left) {
       for (index_type tile_id2 = static_cast<index_type>(blockIdx.z);
            tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.z) {
@@ -229,7 +233,9 @@ struct DeviceIterateTile<3, PolicyType, Functor, Tag> {
           }
         }
       }
-    } else {
+    }
+    // LR
+    else {
       for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
            tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
         const index_type offset_0 =
@@ -298,15 +304,17 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
+    // LL
     if (PolicyType::inner_direction == Iterate::Left) {
       const index_type temp0 = m_policy.m_tile_end[0];
       const index_type temp1 = m_policy.m_tile_end[1];
       const index_type numbl0 =
           (temp0 <= mdrange_max_blocks_x ? temp0 : mdrange_max_blocks_x);
       const index_type numbl1 =
-          (temp0 * temp1 > mdrange_max_blocks
+          (temp0 * temp1 > mdrange_max_blocks_x
                ? static_cast<index_type>(mdrange_max_blocks_x / numbl0)
-               : (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks));
+               : (temp1 <= mdrange_max_blocks_x ? temp1
+                                                : mdrange_max_blocks_x));
 
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
@@ -355,14 +363,16 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
           }
         }
       }
-    } else {
+    }
+    // LR
+    else {
       const index_type temp0 = m_policy.m_tile_end[0];
       const index_type temp1 = m_policy.m_tile_end[1];
       const index_type numbl1 =
-          (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks);
+          (temp1 <= mdrange_max_blocks_x ? temp1 : mdrange_max_blocks_x);
       const index_type numbl0 =
           (temp0 * temp1 > mdrange_max_blocks_x
-               ? index_type(mdrange_max_blocks / numbl1)
+               ? index_type(mdrange_max_blocks_x / numbl1)
                : (temp0 <= mdrange_max_blocks_x ? temp0
                                                 : mdrange_max_blocks_x));
 
@@ -458,9 +468,10 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
       const index_type numbl0 =
           (temp0 <= mdrange_max_blocks_x ? temp0 : mdrange_max_blocks_x);
       const index_type numbl1 =
-          (temp0 * temp1 > mdrange_max_blocks
+          (temp0 * temp1 > mdrange_max_blocks_x
                ? index_type(mdrange_max_blocks_x / numbl0)
-               : (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks));
+               : (temp1 <= mdrange_max_blocks_x ? temp1
+                                                : mdrange_max_blocks_x));
 
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
@@ -539,10 +550,10 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
       index_type temp0 = m_policy.m_tile_end[0];
       index_type temp1 = m_policy.m_tile_end[1];
       const index_type numbl1 =
-          (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks);
+          (temp1 <= mdrange_max_blocks_x ? temp1 : mdrange_max_blocks_x);
       const index_type numbl0 =
           (temp0 * temp1 > mdrange_max_blocks_x
-               ? static_cast<index_type>(mdrange_max_blocks / numbl1)
+               ? static_cast<index_type>(mdrange_max_blocks_x / numbl1)
                : (temp0 <= mdrange_max_blocks_x ? temp0
                                                 : mdrange_max_blocks_x));
 
@@ -662,9 +673,10 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
       const index_type numbl0 =
           (temp0 <= mdrange_max_blocks_x ? temp0 : mdrange_max_blocks_x);
       const index_type numbl1 =
-          (temp0 * temp1 > mdrange_max_blocks
+          (temp0 * temp1 > mdrange_max_blocks_x
                ? static_cast<index_type>(mdrange_max_blocks_x / numbl0)
-               : (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks));
+               : (temp1 <= mdrange_max_blocks_x ? temp1
+                                                : mdrange_max_blocks_x));
 
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
@@ -766,10 +778,10 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
       index_type temp0 = m_policy.m_tile_end[0];
       index_type temp1 = m_policy.m_tile_end[1];
       const index_type numbl1 =
-          (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks);
+          (temp1 <= mdrange_max_blocks_x ? temp1 : mdrange_max_blocks_x);
       const index_type numbl0 =
           (temp0 * temp1 > mdrange_max_blocks_x
-               ? static_cast<index_type>(mdrange_max_blocks / numbl1)
+               ? static_cast<index_type>(mdrange_max_blocks_x / numbl1)
                : (temp0 <= mdrange_max_blocks_x ? temp0
                                                 : mdrange_max_blocks_x));
 

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -276,8 +276,18 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
       : m_policy(policy_), m_func(f_) {}
 #endif
 
+#if defined(KOKKOS_ENABLE_CUDA)
   static constexpr index_type max_blocks_x = 2147483647;
   static constexpr index_type max_blocks   = 65535;
+#elif defined(KOKKOS_ENABLE_HIP)
+  static constexpr index_type max_blocks_x = 4294967295;
+  static constexpr index_type max_blocks   = 4294967295;
+#elif defined(KOKKOS_ENABLE_SYCL)
+  static constexpr index_type max_blocks_x = 65535;
+  static constexpr index_type max_blocks   = 65535;
+#else
+#error("Programming model not supported")
+#endif
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
@@ -429,8 +439,18 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
       : m_policy(policy_), m_func(f_) {}
 #endif
 
+#if defined(KOKKOS_ENABLE_CUDA)
   static constexpr index_type max_blocks_x = 2147483647;
   static constexpr index_type max_blocks   = 65535;
+#elif defined(KOKKOS_ENABLE_HIP)
+  static constexpr index_type max_blocks_x = 4294967295;
+  static constexpr index_type max_blocks   = 4294967295;
+#elif defined(KOKKOS_ENABLE_SYCL)
+  static constexpr index_type max_blocks_x = 65535;
+  static constexpr index_type max_blocks   = 65535;
+#else
+#error("Programming model not supported")
+#endif
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
@@ -631,8 +651,18 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
       : m_policy(policy_), m_func(f_) {}
 #endif
 
+#if defined(KOKKOS_ENABLE_CUDA)
   static constexpr index_type max_blocks_x = 2147483647;
   static constexpr index_type max_blocks   = 65535;
+#elif defined(KOKKOS_ENABLE_HIP)
+  static constexpr index_type max_blocks_x = 4294967295;
+  static constexpr index_type max_blocks   = 4294967295;
+#elif defined(KOKKOS_ENABLE_SYCL)
+  static constexpr index_type max_blocks_x = 65535;
+  static constexpr index_type max_blocks   = 65535;
+#else
+#error("Programming model not supported")
+#endif
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -631,7 +631,8 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
       : m_policy(policy_), m_func(f_) {}
 #endif
 
-  static constexpr index_type max_blocks = 65535;
+  static constexpr index_type max_blocks_x = 2147483647;
+  static constexpr index_type max_blocks   = 65535;
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
@@ -639,10 +640,10 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
     if (PolicyType::inner_direction == Iterate::Left) {
       index_type temp0        = m_policy.m_tile_end[0];
       index_type temp1        = m_policy.m_tile_end[1];
-      const index_type numbl0 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      const index_type numbl0 = (temp0 <= max_blocks_x ? temp0 : max_blocks_x);
       const index_type numbl1 =
           (temp0 * temp1 > max_blocks
-               ? static_cast<index_type>(max_blocks / numbl0)
+               ? static_cast<index_type>(max_blocks_x / numbl0)
                : (temp1 <= max_blocks ? temp1 : max_blocks));
 
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
@@ -744,9 +745,9 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
       index_type temp1        = m_policy.m_tile_end[1];
       const index_type numbl1 = (temp1 <= max_blocks ? temp1 : max_blocks);
       const index_type numbl0 =
-          (temp0 * temp1 > max_blocks
+          (temp0 * temp1 > max_blocks_x
                ? static_cast<index_type>(max_blocks / numbl1)
-               : (temp0 <= max_blocks ? temp0 : max_blocks));
+               : (temp0 <= max_blocks_x ? temp0 : max_blocks_x));
 
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -429,7 +429,8 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
       : m_policy(policy_), m_func(f_) {}
 #endif
 
-  static constexpr index_type max_blocks = 65535;
+  static constexpr index_type max_blocks_x = 2147483647;
+  static constexpr index_type max_blocks   = 65535;
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
@@ -437,10 +438,10 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
     if (PolicyType::inner_direction == Iterate::Left) {
       index_type temp0        = m_policy.m_tile_end[0];
       index_type temp1        = m_policy.m_tile_end[1];
-      const index_type numbl0 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      const index_type numbl0 = (temp0 <= max_blocks_x ? temp0 : max_blocks_x);
       const index_type numbl1 =
           (temp0 * temp1 > max_blocks
-               ? index_type(max_blocks / numbl0)
+               ? index_type(max_blocks_x / numbl0)
                : (temp1 <= max_blocks ? temp1 : max_blocks));
 
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
@@ -520,9 +521,9 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
       index_type temp1        = m_policy.m_tile_end[1];
       const index_type numbl1 = (temp1 <= max_blocks ? temp1 : max_blocks);
       const index_type numbl0 =
-          (temp0 * temp1 > max_blocks
+          (temp0 * temp1 > max_blocks_x
                ? static_cast<index_type>(max_blocks / numbl1)
-               : (temp0 <= max_blocks ? temp0 : max_blocks));
+               : (temp0 <= max_blocks_x ? temp0 : max_blocks_x));
 
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -20,7 +20,6 @@
 #include <Kokkos_Macros.hpp>
 
 #include <algorithm>
-#include <limits>
 
 #include <utility>
 
@@ -44,18 +43,9 @@ struct EmulateCUDADim3 {
 // https://docs.nvidia.com/cuda/cuda-c-programming-guide/#features-and-technical-specifications-technical-specifications-per-compute-capability
 constexpr int mdrange_max_blocks_x = 2147483647;  // 2^31 - 1
 constexpr int mdrange_max_blocks   = 65535;       // 2^16 - 1
-#elif defined(KOKKOS_ENABLE_HIP)
-// note:
-// https://rocm.docs.amd.com/projects/HIP/en/latest/reference/hardware_features.html
-// is _wrong_ about the grid size
-// here are valid values on MI250 and MI300A
-constexpr int mdrange_max_blocks_x = 2147483647;  // 2^31 - 1
-constexpr int mdrange_max_blocks   = 65536;       // 2^16
 #else
-constexpr std::size_t mdrange_max_blocks_x =
-    std::numeric_limits<std::size_t>::max();  // +inf
-constexpr std::size_t mdrange_max_blocks =
-    std::numeric_limits<std::size_t>::max();  // +inf
+constexpr int mdrange_max_blocks_x = 65535;  // 2^16 - 1
+constexpr int mdrange_max_blocks   = 65535;  // 2^16 - 1
 #endif
 
 template <class Tag, class Functor, class... Args>

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -20,6 +20,7 @@
 #include <Kokkos_Macros.hpp>
 
 #include <algorithm>
+#include <limits>
 
 #include <utility>
 
@@ -44,11 +45,11 @@ constexpr int mdrange_max_blocks   = 65535;       // 2^16 - 1
 #elif defined(KOKKOS_ENABLE_HIP)
 constexpr long mdrange_max_blocks_x = 4294967295;  // 2^32 - 1
 constexpr long mdrange_max_blocks   = 4294967295;  // 2^32 - 1
-#elif defined(KOKKOS_ENABLE_SYCL)
-constexpr int mdrange_max_blocks_x = 4294967295;  // 2^32 - 1
-constexpr int mdrange_max_blocks   = 4294967295;  // 2^32 - 1
 #else
-#error("Programming model not supported")
+constexpr std::size_t mdrange_max_blocks_x =
+    std::numeric_limits<std::size_t>::max();  // +inf
+constexpr std::size_t mdrange_max_blocks =
+    std::numeric_limits<std::size_t>::max();  // +inf
 #endif
 
 template <class Tag, class Functor, class... Args>

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -276,17 +276,18 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
       : m_policy(policy_), m_func(f_) {}
 #endif
 
-  static constexpr index_type max_blocks = 65535;
+  static constexpr index_type max_blocks_x = 2147483647;
+  static constexpr index_type max_blocks   = 65535;
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
     if (PolicyType::inner_direction == Iterate::Left) {
       const index_type temp0  = m_policy.m_tile_end[0];
       const index_type temp1  = m_policy.m_tile_end[1];
-      const index_type numbl0 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      const index_type numbl0 = (temp0 <= max_blocks_x ? temp0 : max_blocks_x);
       const index_type numbl1 =
           (temp0 * temp1 > max_blocks
-               ? static_cast<index_type>(max_blocks / numbl0)
+               ? static_cast<index_type>(max_blocks_x / numbl0)
                : (temp1 <= max_blocks ? temp1 : max_blocks));
 
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
@@ -341,9 +342,9 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
       const index_type temp1  = m_policy.m_tile_end[1];
       const index_type numbl1 = (temp1 <= max_blocks ? temp1 : max_blocks);
       const index_type numbl0 =
-          (temp0 * temp1 > max_blocks
+          (temp0 * temp1 > max_blocks_x
                ? index_type(max_blocks / numbl1)
-               : (temp0 <= max_blocks ? temp0 : max_blocks));
+               : (temp0 <= max_blocks_x ? temp0 : max_blocks_x));
 
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -39,14 +39,14 @@ struct EmulateCUDADim3 {
 #endif
 
 #if defined(KOKKOS_ENABLE_CUDA)
-#define MAX_BLOCKS_X 2147483647
-#define MAX_BLOCKS 65535
+constexpr int mdrange_max_blocks_x = 2147483647;  // 2^31 - 1
+constexpr int mdrange_max_blocks   = 65535;       // 2^16 - 1
 #elif defined(KOKKOS_ENABLE_HIP)
-#define MAX_BLOCKS_X 4294967295
-#define MAX_BLOCKS 4294967295
+constexpr int mdrange_max_blocks_x = 4294967295;  // 2^32 - 1
+constexpr int mdrange_max_blocks   = 4294967295;  // 2^32 - 1
 #elif defined(KOKKOS_ENABLE_SYCL)
-#define MAX_BLOCKS_X 4294967295
-#define MAX_BLOCKS 4294967295
+constexpr int mdrange_max_blocks_x = 4294967295;  // 2^32 - 1
+constexpr int mdrange_max_blocks   = 4294967295;  // 2^32 - 1
 #else
 #error("Programming model not supported")
 #endif
@@ -289,19 +289,17 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
       : m_policy(policy_), m_func(f_) {}
 #endif
 
-  static constexpr index_type max_blocks_x = MAX_BLOCKS_X;
-  static constexpr index_type max_blocks   = MAX_BLOCKS;
-
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
     if (PolicyType::inner_direction == Iterate::Left) {
-      const index_type temp0  = m_policy.m_tile_end[0];
-      const index_type temp1  = m_policy.m_tile_end[1];
-      const index_type numbl0 = (temp0 <= max_blocks_x ? temp0 : max_blocks_x);
+      const index_type temp0 = m_policy.m_tile_end[0];
+      const index_type temp1 = m_policy.m_tile_end[1];
+      const index_type numbl0 =
+          (temp0 <= mdrange_max_blocks_x ? temp0 : mdrange_max_blocks_x);
       const index_type numbl1 =
-          (temp0 * temp1 > max_blocks
-               ? static_cast<index_type>(max_blocks_x / numbl0)
-               : (temp1 <= max_blocks ? temp1 : max_blocks));
+          (temp0 * temp1 > mdrange_max_blocks
+               ? static_cast<index_type>(mdrange_max_blocks_x / numbl0)
+               : (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks));
 
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
@@ -351,13 +349,15 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
         }
       }
     } else {
-      const index_type temp0  = m_policy.m_tile_end[0];
-      const index_type temp1  = m_policy.m_tile_end[1];
-      const index_type numbl1 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      const index_type temp0 = m_policy.m_tile_end[0];
+      const index_type temp1 = m_policy.m_tile_end[1];
+      const index_type numbl1 =
+          (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks);
       const index_type numbl0 =
-          (temp0 * temp1 > max_blocks_x
-               ? index_type(max_blocks / numbl1)
-               : (temp0 <= max_blocks_x ? temp0 : max_blocks_x));
+          (temp0 * temp1 > mdrange_max_blocks_x
+               ? index_type(mdrange_max_blocks / numbl1)
+               : (temp0 <= mdrange_max_blocks_x ? temp0
+                                                : mdrange_max_blocks_x));
 
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;
@@ -442,20 +442,18 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
       : m_policy(policy_), m_func(f_) {}
 #endif
 
-  static constexpr index_type max_blocks_x = MAX_BLOCKS_X;
-  static constexpr index_type max_blocks   = MAX_BLOCKS;
-
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
     // LL
     if (PolicyType::inner_direction == Iterate::Left) {
-      index_type temp0        = m_policy.m_tile_end[0];
-      index_type temp1        = m_policy.m_tile_end[1];
-      const index_type numbl0 = (temp0 <= max_blocks_x ? temp0 : max_blocks_x);
+      index_type temp0 = m_policy.m_tile_end[0];
+      index_type temp1 = m_policy.m_tile_end[1];
+      const index_type numbl0 =
+          (temp0 <= mdrange_max_blocks_x ? temp0 : mdrange_max_blocks_x);
       const index_type numbl1 =
-          (temp0 * temp1 > max_blocks
-               ? index_type(max_blocks_x / numbl0)
-               : (temp1 <= max_blocks ? temp1 : max_blocks));
+          (temp0 * temp1 > mdrange_max_blocks
+               ? index_type(mdrange_max_blocks_x / numbl0)
+               : (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks));
 
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
@@ -464,13 +462,14 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
       const index_type thr_id1 =
           static_cast<index_type>(threadIdx.x) / m_policy.m_tile[0];
 
-      temp0                   = m_policy.m_tile_end[2];
-      temp1                   = m_policy.m_tile_end[3];
-      const index_type numbl2 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      temp0 = m_policy.m_tile_end[2];
+      temp1 = m_policy.m_tile_end[3];
+      const index_type numbl2 =
+          (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks);
       const index_type numbl3 =
-          (temp0 * temp1 > max_blocks
-               ? index_type(max_blocks / numbl2)
-               : (temp1 <= max_blocks ? temp1 : max_blocks));
+          (temp0 * temp1 > mdrange_max_blocks
+               ? index_type(mdrange_max_blocks / numbl2)
+               : (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks));
 
       const index_type tile_id2 = static_cast<index_type>(blockIdx.y) % numbl2;
       const index_type tile_id3 = static_cast<index_type>(blockIdx.y) / numbl2;
@@ -530,13 +529,15 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
     }
     // LR
     else {
-      index_type temp0        = m_policy.m_tile_end[0];
-      index_type temp1        = m_policy.m_tile_end[1];
-      const index_type numbl1 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      index_type temp0 = m_policy.m_tile_end[0];
+      index_type temp1 = m_policy.m_tile_end[1];
+      const index_type numbl1 =
+          (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks);
       const index_type numbl0 =
-          (temp0 * temp1 > max_blocks_x
-               ? static_cast<index_type>(max_blocks / numbl1)
-               : (temp0 <= max_blocks_x ? temp0 : max_blocks_x));
+          (temp0 * temp1 > mdrange_max_blocks_x
+               ? static_cast<index_type>(mdrange_max_blocks / numbl1)
+               : (temp0 <= mdrange_max_blocks_x ? temp0
+                                                : mdrange_max_blocks_x));
 
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;
@@ -545,13 +546,14 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
       const index_type thr_id1 =
           static_cast<index_type>(threadIdx.x) % m_policy.m_tile[1];
 
-      temp0                   = m_policy.m_tile_end[2];
-      temp1                   = m_policy.m_tile_end[3];
-      const index_type numbl3 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      temp0 = m_policy.m_tile_end[2];
+      temp1 = m_policy.m_tile_end[3];
+      const index_type numbl3 =
+          (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks);
       const index_type numbl2 =
-          (temp0 * temp1 > max_blocks
-               ? index_type(max_blocks / numbl3)
-               : (temp0 <= max_blocks ? temp0 : max_blocks));
+          (temp0 * temp1 > mdrange_max_blocks
+               ? index_type(mdrange_max_blocks / numbl3)
+               : (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks));
 
       const index_type tile_id2 = static_cast<index_type>(blockIdx.y) / numbl3;
       const index_type tile_id3 = static_cast<index_type>(blockIdx.y) % numbl3;
@@ -644,20 +646,18 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
       : m_policy(policy_), m_func(f_) {}
 #endif
 
-  static constexpr index_type max_blocks_x = MAX_BLOCKS_X;
-  static constexpr index_type max_blocks   = MAX_BLOCKS;
-
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
     // LL
     if (PolicyType::inner_direction == Iterate::Left) {
-      index_type temp0        = m_policy.m_tile_end[0];
-      index_type temp1        = m_policy.m_tile_end[1];
-      const index_type numbl0 = (temp0 <= max_blocks_x ? temp0 : max_blocks_x);
+      index_type temp0 = m_policy.m_tile_end[0];
+      index_type temp1 = m_policy.m_tile_end[1];
+      const index_type numbl0 =
+          (temp0 <= mdrange_max_blocks_x ? temp0 : mdrange_max_blocks_x);
       const index_type numbl1 =
-          (temp0 * temp1 > max_blocks
-               ? static_cast<index_type>(max_blocks_x / numbl0)
-               : (temp1 <= max_blocks ? temp1 : max_blocks));
+          (temp0 * temp1 > mdrange_max_blocks
+               ? static_cast<index_type>(mdrange_max_blocks_x / numbl0)
+               : (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks));
 
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
@@ -666,13 +666,14 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
       const index_type thr_id1 =
           static_cast<index_type>(threadIdx.x) / m_policy.m_tile[0];
 
-      temp0                   = m_policy.m_tile_end[2];
-      temp1                   = m_policy.m_tile_end[3];
-      const index_type numbl2 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      temp0 = m_policy.m_tile_end[2];
+      temp1 = m_policy.m_tile_end[3];
+      const index_type numbl2 =
+          (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks);
       const index_type numbl3 =
-          (temp0 * temp1 > max_blocks
-               ? static_cast<index_type>(max_blocks / numbl2)
-               : (temp1 <= max_blocks ? temp1 : max_blocks));
+          (temp0 * temp1 > mdrange_max_blocks
+               ? static_cast<index_type>(mdrange_max_blocks / numbl2)
+               : (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks));
 
       const index_type tile_id2 = static_cast<index_type>(blockIdx.y) % numbl2;
       const index_type tile_id3 = static_cast<index_type>(blockIdx.y) / numbl2;
@@ -681,13 +682,14 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
       const index_type thr_id3 =
           static_cast<index_type>(threadIdx.y) / m_policy.m_tile[2];
 
-      temp0                   = m_policy.m_tile_end[4];
-      temp1                   = m_policy.m_tile_end[5];
-      const index_type numbl4 = (temp0 <= max_blocks ? temp0 : max_blocks);
+      temp0 = m_policy.m_tile_end[4];
+      temp1 = m_policy.m_tile_end[5];
+      const index_type numbl4 =
+          (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks);
       const index_type numbl5 =
-          (temp0 * temp1 > max_blocks
-               ? static_cast<index_type>(max_blocks / numbl4)
-               : (temp1 <= max_blocks ? temp1 : max_blocks));
+          (temp0 * temp1 > mdrange_max_blocks
+               ? static_cast<index_type>(mdrange_max_blocks / numbl4)
+               : (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks));
 
       const index_type tile_id4 = static_cast<index_type>(blockIdx.z) % numbl4;
       const index_type tile_id5 = static_cast<index_type>(blockIdx.z) / numbl4;
@@ -754,13 +756,15 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
     }
     // LR
     else {
-      index_type temp0        = m_policy.m_tile_end[0];
-      index_type temp1        = m_policy.m_tile_end[1];
-      const index_type numbl1 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      index_type temp0 = m_policy.m_tile_end[0];
+      index_type temp1 = m_policy.m_tile_end[1];
+      const index_type numbl1 =
+          (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks);
       const index_type numbl0 =
-          (temp0 * temp1 > max_blocks_x
-               ? static_cast<index_type>(max_blocks / numbl1)
-               : (temp0 <= max_blocks_x ? temp0 : max_blocks_x));
+          (temp0 * temp1 > mdrange_max_blocks_x
+               ? static_cast<index_type>(mdrange_max_blocks / numbl1)
+               : (temp0 <= mdrange_max_blocks_x ? temp0
+                                                : mdrange_max_blocks_x));
 
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;
@@ -769,13 +773,14 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
       const index_type thr_id1 =
           static_cast<index_type>(threadIdx.x) % m_policy.m_tile[1];
 
-      temp0                   = m_policy.m_tile_end[2];
-      temp1                   = m_policy.m_tile_end[3];
-      const index_type numbl3 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      temp0 = m_policy.m_tile_end[2];
+      temp1 = m_policy.m_tile_end[3];
+      const index_type numbl3 =
+          (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks);
       const index_type numbl2 =
-          (temp0 * temp1 > max_blocks
-               ? static_cast<index_type>(max_blocks / numbl3)
-               : (temp0 <= max_blocks ? temp0 : max_blocks));
+          (temp0 * temp1 > mdrange_max_blocks
+               ? static_cast<index_type>(mdrange_max_blocks / numbl3)
+               : (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks));
 
       const index_type tile_id2 = static_cast<index_type>(blockIdx.y) / numbl3;
       const index_type tile_id3 = static_cast<index_type>(blockIdx.y) % numbl3;
@@ -784,13 +789,14 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
       const index_type thr_id3 =
           static_cast<index_type>(threadIdx.y) % m_policy.m_tile[3];
 
-      temp0                   = m_policy.m_tile_end[4];
-      temp1                   = m_policy.m_tile_end[5];
-      const index_type numbl5 = (temp1 <= max_blocks ? temp1 : max_blocks);
+      temp0 = m_policy.m_tile_end[4];
+      temp1 = m_policy.m_tile_end[5];
+      const index_type numbl5 =
+          (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks);
       const index_type numbl4 =
-          (temp0 * temp1 > max_blocks
-               ? static_cast<index_type>(max_blocks / numbl5)
-               : (temp0 <= max_blocks ? temp0 : max_blocks));
+          (temp0 * temp1 > mdrange_max_blocks
+               ? static_cast<index_type>(mdrange_max_blocks / numbl5)
+               : (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks));
 
       const index_type tile_id4 = static_cast<index_type>(blockIdx.z) / numbl5;
       const index_type tile_id5 = static_cast<index_type>(blockIdx.z) % numbl5;

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -45,10 +45,12 @@ struct EmulateCUDADim3 {
 constexpr int mdrange_max_blocks_x = 2147483647;  // 2^31 - 1
 constexpr int mdrange_max_blocks   = 65535;       // 2^16 - 1
 #elif defined(KOKKOS_ENABLE_HIP)
-// see:
+// note:
 // https://rocm.docs.amd.com/projects/HIP/en/latest/reference/hardware_features.html
-constexpr unsigned int mdrange_max_blocks_x = 4294967295;  // 2^32 - 1
-constexpr unsigned int mdrange_max_blocks   = 4294967295;  // 2^32 - 1
+// is _wrong_ about the grid size
+// here are valid values on MI250 and MI300A
+constexpr int mdrange_max_blocks_x = 2147483647;  // 2^31 - 1
+constexpr int mdrange_max_blocks   = 65536;       // 2^16
 #else
 constexpr std::size_t mdrange_max_blocks_x =
     std::numeric_limits<std::size_t>::max();  // +inf

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -40,9 +40,13 @@ struct EmulateCUDADim3 {
 #endif
 
 #if defined(KOKKOS_ENABLE_CUDA)
+// see:
+// https://docs.nvidia.com/cuda/cuda-c-programming-guide/#features-and-technical-specifications-technical-specifications-per-compute-capability
 constexpr int mdrange_max_blocks_x = 2147483647;  // 2^31 - 1
 constexpr int mdrange_max_blocks   = 65535;       // 2^16 - 1
 #elif defined(KOKKOS_ENABLE_HIP)
+// see:
+// https://rocm.docs.amd.com/projects/HIP/en/latest/reference/hardware_features.html
 constexpr long mdrange_max_blocks_x = 4294967295;  // 2^32 - 1
 constexpr long mdrange_max_blocks   = 4294967295;  // 2^32 - 1
 #else

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -47,8 +47,8 @@ constexpr int mdrange_max_blocks   = 65535;       // 2^16 - 1
 #elif defined(KOKKOS_ENABLE_HIP)
 // see:
 // https://rocm.docs.amd.com/projects/HIP/en/latest/reference/hardware_features.html
-constexpr long mdrange_max_blocks_x = 4294967295;  // 2^32 - 1
-constexpr long mdrange_max_blocks   = 4294967295;  // 2^32 - 1
+constexpr unsigned int mdrange_max_blocks_x = 4294967295;  // 2^32 - 1
+constexpr unsigned int mdrange_max_blocks   = 4294967295;  // 2^32 - 1
 #else
 constexpr std::size_t mdrange_max_blocks_x =
     std::numeric_limits<std::size_t>::max();  // +inf

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -102,7 +102,7 @@ struct DeviceIterateTile<2, PolicyType, Functor, Tag> {
         threadIdx(threadIdx_) {}
 #else
   KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(const PolicyType& policy_,
-                                                const Functor& f_)
+                                                  const Functor& f_)
       : m_policy(policy_), m_func(f_) {}
 #endif
 
@@ -184,7 +184,7 @@ struct DeviceIterateTile<3, PolicyType, Functor, Tag> {
         threadIdx(threadIdx_) {}
 #else
   KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(const PolicyType& policy_,
-                                                const Functor& f_)
+                                                  const Functor& f_)
       : m_policy(policy_), m_func(f_) {}
 #endif
 
@@ -285,7 +285,7 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
         threadIdx(threadIdx_) {}
 #else
   KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(const PolicyType& policy_,
-                                                const Functor& f_)
+                                                  const Functor& f_)
       : m_policy(policy_), m_func(f_) {}
 #endif
 
@@ -438,7 +438,7 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
         threadIdx(threadIdx_) {}
 #else
   KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(const PolicyType& policy_,
-                                                const Functor& f_)
+                                                  const Functor& f_)
       : m_policy(policy_), m_func(f_) {}
 #endif
 
@@ -642,7 +642,7 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
         threadIdx(threadIdx_) {}
 #else
   KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(const PolicyType& policy_,
-                                                const Functor& f_)
+                                                  const Functor& f_)
       : m_policy(policy_), m_func(f_) {}
 #endif
 
@@ -943,8 +943,8 @@ struct DeviceIterateTile {
         threadIdx(threadIdx_) {}
 #else
   KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(const PolicyType& policy_,
-                                                const Functor& f_,
-                                                value_type_storage v_)
+                                                  const Functor& f_,
+                                                  value_type_storage v_)
       : m_policy(policy_), m_func(f_), m_v(v_) {}
 #endif
 

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -42,8 +42,8 @@ struct EmulateCUDADim3 {
 constexpr int mdrange_max_blocks_x = 2147483647;  // 2^31 - 1
 constexpr int mdrange_max_blocks   = 65535;       // 2^16 - 1
 #elif defined(KOKKOS_ENABLE_HIP)
-constexpr int mdrange_max_blocks_x = 4294967295;  // 2^32 - 1
-constexpr int mdrange_max_blocks   = 4294967295;  // 2^32 - 1
+constexpr long mdrange_max_blocks_x = 4294967295;  // 2^32 - 1
+constexpr long mdrange_max_blocks   = 4294967295;  // 2^32 - 1
 #elif defined(KOKKOS_ENABLE_SYCL)
 constexpr int mdrange_max_blocks_x = 4294967295;  // 2^32 - 1
 constexpr int mdrange_max_blocks   = 4294967295;  // 2^32 - 1

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -39,14 +39,14 @@ struct EmulateCUDADim3 {
 #endif
 
 #if defined(KOKKOS_ENABLE_CUDA)
-#define MAX_BLOCKS_X 2147483647;
-#define MAX_BLOCKS 65535;
+#define MAX_BLOCKS_X 2147483647
+#define MAX_BLOCKS 65535
 #elif defined(KOKKOS_ENABLE_HIP)
-#define MAX_BLOCKS_X 4294967295;
-#define MAX_BLOCKS 4294967295;
+#define MAX_BLOCKS_X 4294967295
+#define MAX_BLOCKS 4294967295
 #elif defined(KOKKOS_ENABLE_SYCL)
-#define MAX_BLOCKS_X 4294967295;
-#define MAX_BLOCKS 4294967295;
+#define MAX_BLOCKS_X 4294967295
+#define MAX_BLOCKS 4294967295
 #else
 #error("Programming model not supported")
 #endif

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -3644,8 +3644,7 @@ struct TestMDRange_6D {
     if (min_max_value.min_val != 1 or min_max_value.max_val != 1) {
       printf(
           " Errors in test_for6_eval_once for shape (%d, %d, %d, %d, %d, %d) "
-          "and "
-          "iterate %s; min = %d, max = %d\n\n",
+          "and iterate %s; min = %d, max = %d\n\n",
           N0, N1, N2, N3, N4, N5, iterate_msg, min_max_value.min_val,
           min_max_value.max_val);
     }

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #include <cstdio>
+#include <sstream>
 
 #include <gtest/gtest.h>
 
@@ -2110,17 +2111,12 @@ struct TestMDRange_4D {
     DataType sum_value;
     parallel_reduce(range, functor, MinMax(min_max_value), sum_value);
 
-    if (min_max_value.min_val != 1 or min_max_value.max_val != 1) {
-      printf(
-          " Errors in test_for4_eval_once for shape (%d, %d, %d, %d) and "
-          "iterate %s; min = %d, max = %d\n\n",
-          N0, N1, N2, N3, iterate_msg, min_max_value.min_val,
-          min_max_value.max_val);
-    }
-
-    ASSERT_EQ(min_max_value.min_val, 1);
-    ASSERT_EQ(min_max_value.max_val, 1);
-    ASSERT_EQ(sum_value, N0 * N1 * N2 * N3);
+    std::ostringstream message;
+    message << "For shape (" << N0 << ", " << N1 << ", " << N2 << ", " << N3
+            << ") and iterate order " << iterate_msg;
+    ASSERT_EQ(min_max_value.min_val, 1) << message.str();
+    ASSERT_EQ(min_max_value.max_val, 1) << message.str();
+    ASSERT_EQ(sum_value, N0 * N1 * N2 * N3) << message.str();
   }  // end test_for4_eval_once_iterate
 };
 
@@ -2759,17 +2755,12 @@ struct TestMDRange_5D {
     DataType sum_value;
     parallel_reduce(range, functor, MinMax(min_max_value), sum_value);
 
-    if (min_max_value.min_val != 1 or min_max_value.max_val != 1) {
-      printf(
-          " Errors in test_for5_eval_once for shape (%d, %d, %d, %d, %d) and "
-          "iterate %s; min = %d, max = %d\n\n",
-          N0, N1, N2, N3, N4, iterate_msg, min_max_value.min_val,
-          min_max_value.max_val);
-    }
-
-    ASSERT_EQ(min_max_value.min_val, 1);
-    ASSERT_EQ(min_max_value.max_val, 1);
-    ASSERT_EQ(sum_value, N0 * N1 * N2 * N3 * N4);
+    std::ostringstream message;
+    message << "For shape (" << N0 << ", " << N1 << ", " << N2 << ", " << N3
+            << ", " << N4 << ") and iterate order " << iterate_msg;
+    ASSERT_EQ(min_max_value.min_val, 1) << message.str();
+    ASSERT_EQ(min_max_value.max_val, 1) << message.str();
+    ASSERT_EQ(sum_value, N0 * N1 * N2 * N3 * N4) << message.str();
   }  // end test_for5_eval_once_iterate
 };
 
@@ -3641,17 +3632,13 @@ struct TestMDRange_6D {
     DataType sum_value;
     parallel_reduce(range, functor, MinMax(min_max_value), sum_value);
 
-    if (min_max_value.min_val != 1 or min_max_value.max_val != 1) {
-      printf(
-          " Errors in test_for6_eval_once for shape (%d, %d, %d, %d, %d, %d) "
-          "and iterate %s; min = %d, max = %d\n\n",
-          N0, N1, N2, N3, N4, N5, iterate_msg, min_max_value.min_val,
-          min_max_value.max_val);
-    }
-
-    ASSERT_EQ(min_max_value.min_val, 1);
-    ASSERT_EQ(min_max_value.max_val, 1);
-    ASSERT_EQ(sum_value, N0 * N1 * N2 * N3 * N4 * N5);
+    std::ostringstream message;
+    message << "For shape (" << N0 << ", " << N1 << ", " << N2 << ", " << N3
+            << ", " << N4 << ", " << N5 << ") and iterate order "
+            << iterate_msg;
+    ASSERT_EQ(min_max_value.min_val, 1) << message.str();
+    ASSERT_EQ(min_max_value.max_val, 1) << message.str();
+    ASSERT_EQ(sum_value, N0 * N1 * N2 * N3 * N4 * N5) << message.str();
   }  // end test_for6_eval_once_iterate
 };
 

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -2106,10 +2106,10 @@ struct TestMDRange_4D {
 
     TestMDRange_4D functor(N0, N1, N2, N3);
 
-    parallel_for(range, functor);
+    Kokkos::parallel_for(range, functor);
     MinMaxValue min_max_value;
     DataType sum_value;
-    parallel_reduce(range, functor, MinMax(min_max_value), sum_value);
+    Kokkos::parallel_reduce(range, functor, MinMax(min_max_value), sum_value);
 
     std::ostringstream message;
     message << "For shape (" << N0 << ", " << N1 << ", " << N2 << ", " << N3
@@ -2750,10 +2750,10 @@ struct TestMDRange_5D {
 
     TestMDRange_5D functor(N0, N1, N2, N3, N4);
 
-    parallel_for(range, functor);
+    Kokkos::parallel_for(range, functor);
     MinMaxValue min_max_value;
     DataType sum_value;
-    parallel_reduce(range, functor, MinMax(min_max_value), sum_value);
+    Kokkos::parallel_reduce(range, functor, MinMax(min_max_value), sum_value);
 
     std::ostringstream message;
     message << "For shape (" << N0 << ", " << N1 << ", " << N2 << ", " << N3
@@ -3627,10 +3627,10 @@ struct TestMDRange_6D {
 
     TestMDRange_6D functor(N0, N1, N2, N3, N4, N5);
 
-    parallel_for(range, functor);
+    Kokkos::parallel_for(range, functor);
     MinMaxValue min_max_value;
     DataType sum_value;
-    parallel_reduce(range, functor, MinMax(min_max_value), sum_value);
+    Kokkos::parallel_reduce(range, functor, MinMax(min_max_value), sum_value);
 
     std::ostringstream message;
     message << "For shape (" << N0 << ", " << N1 << ", " << N2 << ", " << N3

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -1467,10 +1467,13 @@ struct TestMDRange_4D {
     lsum += input_view(i, j, k, l) * 3;
   }
 
+  using MinMax      = Kokkos::MinMax<DataType>;
+  using MinMaxValue = MinMax::value_type;
   KOKKOS_INLINE_FUNCTION
   void operator()(const AtomicTag &, const int i, const int j, const int k,
-                  const int l, int &lmax) const {
-    lmax = Kokkos::max(lmax, input_view(i, j, k, l));
+                  const int l, MinMaxValue &lminmax) const {
+    lminmax.min_val = Kokkos::min(lminmax.min_val, input_view(i, j, k, l));
+    lminmax.max_val = Kokkos::max(lminmax.max_val, input_view(i, j, k, l));
   }
 
   static void test_reduce4(const int N0, const int N1, const int N2,
@@ -2087,14 +2090,16 @@ struct TestMDRange_4D {
       TestMDRange_4D functor(N0, N1, N2, N3);
 
       parallel_for(range, functor);
-      DataType max_value = 0;
-      parallel_reduce(range, functor, Kokkos::Max<DataType>(max_value));
+      MinMaxValue min_max_value;
+      parallel_reduce(range, functor, MinMax(min_max_value));
 
-      if (max_value != 1) {
-        printf(" Errors in test_for4; mismatches = %d\n\n", max_value);
+      if (min_max_value.min_val != 1 or min_max_value.max_val != 1) {
+        printf(" Errors in test_for4; min = %d, max = %d\n\n",
+               min_max_value.min_val, min_max_value.max_val);
       }
 
-      ASSERT_EQ(max_value, 1);
+      ASSERT_EQ(min_max_value.min_val, 1);
+      ASSERT_EQ(min_max_value.max_val, 1);
     }
 
     {
@@ -2109,14 +2114,16 @@ struct TestMDRange_4D {
       TestMDRange_4D functor(N0, N1, N2, N3);
 
       parallel_for(range, functor);
-      DataType max_value = 0;
-      parallel_reduce(range, functor, Kokkos::Max<DataType>(max_value));
+      MinMaxValue min_max_value;
+      parallel_reduce(range, functor, MinMax(min_max_value));
 
-      if (max_value != 1) {
-        printf(" Errors in test_for4; mismatches = %d\n\n", max_value);
+      if (min_max_value.min_val != 1 or min_max_value.max_val != 1) {
+        printf(" Errors in test_for4; min = %d, max = %d\n\n",
+               min_max_value.min_val, min_max_value.max_val);
       }
 
-      ASSERT_EQ(max_value, 1);
+      ASSERT_EQ(min_max_value.min_val, 1);
+      ASSERT_EQ(min_max_value.max_val, 1);
     }
   }  // end test_for4_eval_once
 };
@@ -2168,10 +2175,13 @@ struct TestMDRange_5D {
     lsum += input_view(i, j, k, l, m) * 3;
   }
 
+  using MinMax      = Kokkos::MinMax<DataType>;
+  using MinMaxValue = MinMax::value_type;
   KOKKOS_INLINE_FUNCTION
   void operator()(const AtomicTag &, const int i, const int j, const int k,
-                  const int l, const int m, int &lmax) const {
-    lmax = Kokkos::max(lmax, input_view(i, j, k, l, m));
+                  const int l, const int m, MinMaxValue &lminmax) const {
+    lminmax.min_val = Kokkos::min(lminmax.min_val, input_view(i, j, k, l, m));
+    lminmax.max_val = Kokkos::max(lminmax.max_val, input_view(i, j, k, l, m));
   }
 
   static void test_reduce5(const int N0, const int N1, const int N2,
@@ -2731,14 +2741,16 @@ struct TestMDRange_5D {
       TestMDRange_5D functor(N0, N1, N2, N3, N4);
 
       parallel_for(range, functor);
-      DataType max_value = 0;
-      parallel_reduce(range, functor, Kokkos::Max<DataType>(max_value));
+      MinMaxValue min_max_value;
+      parallel_reduce(range, functor, MinMax(min_max_value));
 
-      if (max_value != 1) {
-        printf(" Errors in test_for5; mismatches = %d\n\n", max_value);
+      if (min_max_value.min_val != 1 or min_max_value.max_val != 1) {
+        printf(" Errors in test_for5; min = %d, max = %d\n\n",
+               min_max_value.min_val, min_max_value.max_val);
       }
 
-      ASSERT_EQ(max_value, 1);
+      ASSERT_EQ(min_max_value.min_val, 1);
+      ASSERT_EQ(min_max_value.max_val, 1);
     }
 
     {
@@ -2754,14 +2766,16 @@ struct TestMDRange_5D {
       TestMDRange_5D functor(N0, N1, N2, N3, N4);
 
       parallel_for(range, functor);
-      DataType max_value = 0;
-      parallel_reduce(range, functor, Kokkos::Max<DataType>(max_value));
+      MinMaxValue min_max_value;
+      parallel_reduce(range, functor, MinMax(min_max_value));
 
-      if (max_value != 1) {
-        printf(" Errors in test_for5; mismatches = %d\n\n", max_value);
+      if (min_max_value.min_val != 1 or min_max_value.max_val != 1) {
+        printf(" Errors in test_for5; min = %d, max = %d\n\n",
+               min_max_value.min_val, min_max_value.max_val);
       }
 
-      ASSERT_EQ(max_value, 1);
+      ASSERT_EQ(min_max_value.min_val, 1);
+      ASSERT_EQ(min_max_value.max_val, 1);
     }
   }  // end test_for5_eval_once
 };
@@ -2806,18 +2820,24 @@ struct TestMDRange_6D {
     Kokkos::atomic_add(&input_view(i, j, k, l, m, n), 1);
   }
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const AtomicTag &, const int i, const int j, const int k,
-                  const int l, const int m, const int n, int &lmax) const {
-    lmax = Kokkos::max(lmax, input_view(i, j, k, l, m, n));
-  }
-
   // reduction tagged operators
   KOKKOS_INLINE_FUNCTION
   void operator()(const InitTag &, const int i, const int j, const int k,
                   const int l, const int m, const int n,
                   value_type &lsum) const {
     lsum += input_view(i, j, k, l, m, n) * 3;
+  }
+
+  using MinMax      = Kokkos::MinMax<DataType>;
+  using MinMaxValue = MinMax::value_type;
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const AtomicTag &, const int i, const int j, const int k,
+                  const int l, const int m, const int n,
+                  MinMaxValue &lminmax) const {
+    lminmax.min_val =
+        Kokkos::min(lminmax.min_val, input_view(i, j, k, l, m, n));
+    lminmax.max_val =
+        Kokkos::max(lminmax.max_val, input_view(i, j, k, l, m, n));
   }
 
   static void test_reduce6(const int N0, const int N1, const int N2,
@@ -3607,14 +3627,16 @@ struct TestMDRange_6D {
       TestMDRange_6D functor(N0, N1, N2, N3, N4, N5);
 
       parallel_for(range, functor);
-      DataType max_value = 0;
-      parallel_reduce(range, functor, Kokkos::Max<DataType>(max_value));
+      MinMaxValue min_max_value;
+      parallel_reduce(range, functor, MinMax(min_max_value));
 
-      if (max_value != 1) {
-        printf(" Errors in test_for5; mismatches = %d\n\n", max_value);
+      if (min_max_value.min_val != 1 or min_max_value.max_val != 1) {
+        printf(" Errors in test_for6; min = %d, max = %d\n\n",
+               min_max_value.min_val, min_max_value.max_val);
       }
 
-      ASSERT_EQ(max_value, 1);
+      ASSERT_EQ(min_max_value.min_val, 1);
+      ASSERT_EQ(min_max_value.max_val, 1);
     }
 
     {
@@ -3630,14 +3652,16 @@ struct TestMDRange_6D {
       TestMDRange_6D functor(N0, N1, N2, N3, N4, N5);
 
       parallel_for(range, functor);
-      DataType max_value = 0;
-      parallel_reduce(range, functor, Kokkos::Max<DataType>(max_value));
+      MinMaxValue min_max_value;
+      parallel_reduce(range, functor, MinMax(min_max_value));
 
-      if (max_value != 1) {
-        printf(" Errors in test_for5; mismatches = %d\n\n", max_value);
+      if (min_max_value.min_val != 1 or min_max_value.max_val != 1) {
+        printf(" Errors in test_for6; min = %d, max = %d\n\n",
+               min_max_value.min_val, min_max_value.max_val);
       }
 
-      ASSERT_EQ(max_value, 1);
+      ASSERT_EQ(min_max_value.min_val, 1);
+      ASSERT_EQ(min_max_value.max_val, 1);
     }
   }  // end test_for6_eval_once
 };

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -2094,8 +2094,10 @@ struct TestMDRange_4D {
       parallel_reduce(range, functor, MinMax(min_max_value));
 
       if (min_max_value.min_val != 1 or min_max_value.max_val != 1) {
-        printf(" Errors in test_for4; min = %d, max = %d\n\n",
-               min_max_value.min_val, min_max_value.max_val);
+        printf(
+            " Errors in test_for4_eval_once for shape (%d, %d, %d, %d); min = "
+            "%d, max = %d\n\n",
+            N0, N1, N2, N3, min_max_value.min_val, min_max_value.max_val);
       }
 
       ASSERT_EQ(min_max_value.min_val, 1);
@@ -2118,8 +2120,10 @@ struct TestMDRange_4D {
       parallel_reduce(range, functor, MinMax(min_max_value));
 
       if (min_max_value.min_val != 1 or min_max_value.max_val != 1) {
-        printf(" Errors in test_for4; min = %d, max = %d\n\n",
-               min_max_value.min_val, min_max_value.max_val);
+        printf(
+            " Errors in test_for4_eval_once for shape (%d, %d, %d, %d); min = "
+            "%d, max = %d\n\n",
+            N0, N1, N2, N3, min_max_value.min_val, min_max_value.max_val);
       }
 
       ASSERT_EQ(min_max_value.min_val, 1);
@@ -2745,8 +2749,10 @@ struct TestMDRange_5D {
       parallel_reduce(range, functor, MinMax(min_max_value));
 
       if (min_max_value.min_val != 1 or min_max_value.max_val != 1) {
-        printf(" Errors in test_for5; min = %d, max = %d\n\n",
-               min_max_value.min_val, min_max_value.max_val);
+        printf(
+            " Errors in test_for5_eval_once for shape (%d, %d, %d, %d, %d); "
+            "min = %d, max = %d\n\n",
+            N0, N1, N2, N3, N4, min_max_value.min_val, min_max_value.max_val);
       }
 
       ASSERT_EQ(min_max_value.min_val, 1);
@@ -2770,8 +2776,10 @@ struct TestMDRange_5D {
       parallel_reduce(range, functor, MinMax(min_max_value));
 
       if (min_max_value.min_val != 1 or min_max_value.max_val != 1) {
-        printf(" Errors in test_for5; min = %d, max = %d\n\n",
-               min_max_value.min_val, min_max_value.max_val);
+        printf(
+            " Errors in test_for5_eval_once for shape (%d, %d, %d, %d, %d); "
+            "min = %d, max = %d\n\n",
+            N0, N1, N2, N3, N4, min_max_value.min_val, min_max_value.max_val);
       }
 
       ASSERT_EQ(min_max_value.min_val, 1);
@@ -3631,8 +3639,11 @@ struct TestMDRange_6D {
       parallel_reduce(range, functor, MinMax(min_max_value));
 
       if (min_max_value.min_val != 1 or min_max_value.max_val != 1) {
-        printf(" Errors in test_for6; min = %d, max = %d\n\n",
-               min_max_value.min_val, min_max_value.max_val);
+        printf(
+            " Errors in test_for6_eval_once for shape (%d, %d, %d, %d, %d, "
+            "%d); min = %d, max = %d\n\n",
+            N0, N1, N2, N3, N4, N5, min_max_value.min_val,
+            min_max_value.max_val);
       }
 
       ASSERT_EQ(min_max_value.min_val, 1);
@@ -3656,8 +3667,11 @@ struct TestMDRange_6D {
       parallel_reduce(range, functor, MinMax(min_max_value));
 
       if (min_max_value.min_val != 1 or min_max_value.max_val != 1) {
-        printf(" Errors in test_for6; min = %d, max = %d\n\n",
-               min_max_value.min_val, min_max_value.max_val);
+        printf(
+            " Errors in test_for6_eval_once for shape (%d, %d, %d, %d, %d, "
+            "%d); min = %d, max = %d\n\n",
+            N0, N1, N2, N3, N4, N5, min_max_value.min_val,
+            min_max_value.max_val);
       }
 
       ASSERT_EQ(min_max_value.min_val, 1);

--- a/core/unit_test/TestMDRange_a.hpp
+++ b/core/unit_test/TestMDRange_a.hpp
@@ -24,6 +24,11 @@ TEST(TEST_CATEGORY, mdrange_5d) {
   TestMDRange_5D<TEST_EXECSPACE>::test_reduce5(100, 10, 10, 10, 5);
 #endif
   TestMDRange_5D<TEST_EXECSPACE>::test_for5(100, 10, 10, 10, 5);
+  TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1024 * 1024, 1, 1, 1, 1);
+  TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1024 * 1024, 1, 1, 1);
+  TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, 1024 * 1024, 1, 1);
+  TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, 1, 1024 * 1024, 1);
+  TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, 1, 1, 1024 * 1024);
 }
 
 }  // namespace Test

--- a/core/unit_test/TestMDRange_a.hpp
+++ b/core/unit_test/TestMDRange_a.hpp
@@ -25,11 +25,12 @@ TEST(TEST_CATEGORY, mdrange_5d) {
 #endif
   TestMDRange_5D<TEST_EXECSPACE>::test_for5(100, 10, 10, 10, 5);
 #ifdef KOKKOS_ENABLE_CUDA
-  TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1024 * 1024, 1, 1, 1, 1);
-  TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1024 * 1024, 1, 1, 1);
-  TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, 1024 * 1024, 1, 1);
-  TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, 1, 1024 * 1024, 1);
-  TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, 1, 1, 1024 * 1024);
+  const int size_x = 2 << 19;  // 2^20
+  TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(size_x, 1, 1, 1, 1);
+  TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, size_x, 1, 1, 1);
+  TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, size_x, 1, 1);
+  TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, 1, size_x, 1);
+  TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, 1, 1, size_x);
 #endif
 }
 

--- a/core/unit_test/TestMDRange_a.hpp
+++ b/core/unit_test/TestMDRange_a.hpp
@@ -24,11 +24,13 @@ TEST(TEST_CATEGORY, mdrange_5d) {
   TestMDRange_5D<TEST_EXECSPACE>::test_reduce5(100, 10, 10, 10, 5);
 #endif
   TestMDRange_5D<TEST_EXECSPACE>::test_for5(100, 10, 10, 10, 5);
+#ifdef KOKKOS_ENABLE_CUDA
   TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1024 * 1024, 1, 1, 1, 1);
   TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1024 * 1024, 1, 1, 1);
   TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, 1024 * 1024, 1, 1);
   TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, 1, 1024 * 1024, 1);
   TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, 1, 1, 1024 * 1024);
+#endif
 }
 
 }  // namespace Test

--- a/core/unit_test/TestMDRange_b.hpp
+++ b/core/unit_test/TestMDRange_b.hpp
@@ -25,18 +25,13 @@ TEST(TEST_CATEGORY, mdrange_6d) {
 #endif
   TestMDRange_6D<TEST_EXECSPACE>::test_for6(10, 10, 10, 10, 5, 5);
 #ifdef KOKKOS_ENABLE_CUDA
-  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1024 * 1024, 1, 1, 1, 1,
-                                                      1);
-  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1024 * 1024, 1, 1, 1,
-                                                      1);
-  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1024 * 1024, 1, 1,
-                                                      1);
-  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1, 1024 * 1024, 1,
-                                                      1);
-  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1, 1, 1024 * 1024,
-                                                      1);
-  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1, 1, 1,
-                                                      1024 * 1024);
+  const int size_x = 2 << 19;  // 2^20
+  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(size_x, 1, 1, 1, 1, 1);
+  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, size_x, 1, 1, 1, 1);
+  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, size_x, 1, 1, 1);
+  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1, size_x, 1, 1);
+  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1, 1, size_x, 1);
+  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1, 1, 1, size_x);
 #endif
 }
 

--- a/core/unit_test/TestMDRange_b.hpp
+++ b/core/unit_test/TestMDRange_b.hpp
@@ -19,11 +19,23 @@
 namespace Test {
 
 TEST(TEST_CATEGORY, mdrange_6d) {
-  TestMDRange_6D<TEST_EXECSPACE>::test_for6(10, 10, 10, 10, 5, 5);
 #ifndef KOKKOS_ENABLE_OPENMPTARGET
   // FIXME_OPENMPTARGET requires MDRange parallel_reduce
   TestMDRange_6D<TEST_EXECSPACE>::test_reduce6(100, 10, 10, 10, 5, 5);
 #endif
+  TestMDRange_6D<TEST_EXECSPACE>::test_for6(10, 10, 10, 10, 5, 5);
+  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1024 * 1024, 1, 1, 1, 1,
+                                                      1);
+  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1024 * 1024, 1, 1, 1,
+                                                      1);
+  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1024 * 1024, 1, 1,
+                                                      1);
+  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1, 1024 * 1024, 1,
+                                                      1);
+  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1, 1, 1024 * 1024,
+                                                      1);
+  TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1, 1, 1,
+                                                      1024 * 1024);
 }
 
 }  // namespace Test

--- a/core/unit_test/TestMDRange_b.hpp
+++ b/core/unit_test/TestMDRange_b.hpp
@@ -24,6 +24,7 @@ TEST(TEST_CATEGORY, mdrange_6d) {
   TestMDRange_6D<TEST_EXECSPACE>::test_reduce6(100, 10, 10, 10, 5, 5);
 #endif
   TestMDRange_6D<TEST_EXECSPACE>::test_for6(10, 10, 10, 10, 5, 5);
+#ifdef KOKKOS_ENABLE_CUDA
   TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1024 * 1024, 1, 1, 1, 1,
                                                       1);
   TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1024 * 1024, 1, 1, 1,
@@ -36,6 +37,7 @@ TEST(TEST_CATEGORY, mdrange_6d) {
                                                       1);
   TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1, 1, 1,
                                                       1024 * 1024);
+#endif
 }
 
 }  // namespace Test

--- a/core/unit_test/TestMDRange_e.hpp
+++ b/core/unit_test/TestMDRange_e.hpp
@@ -24,10 +24,12 @@ TEST(TEST_CATEGORY, mdrange_4d) {
   TestMDRange_4D<TEST_EXECSPACE>::test_reduce4(100, 10, 10, 10);
 #endif
   TestMDRange_4D<TEST_EXECSPACE>::test_for4(100, 10, 10, 10);
+#ifdef KOKKOS_ENABLE_CUDA
   TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1024 * 1024, 1, 1, 1);
   TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, 1024 * 1024, 1, 1);
   TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, 1, 1024 * 1024, 1);
   TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, 1, 1, 1024 * 1024);
+#endif
 }
 
 }  // namespace Test

--- a/core/unit_test/TestMDRange_e.hpp
+++ b/core/unit_test/TestMDRange_e.hpp
@@ -24,6 +24,10 @@ TEST(TEST_CATEGORY, mdrange_4d) {
   TestMDRange_4D<TEST_EXECSPACE>::test_reduce4(100, 10, 10, 10);
 #endif
   TestMDRange_4D<TEST_EXECSPACE>::test_for4(100, 10, 10, 10);
+  TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1024 * 1024, 1, 1, 1);
+  TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, 1024 * 1024, 1, 1);
+  TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, 1, 1024 * 1024, 1);
+  TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, 1, 1, 1024 * 1024);
 }
 
 }  // namespace Test

--- a/core/unit_test/TestMDRange_e.hpp
+++ b/core/unit_test/TestMDRange_e.hpp
@@ -25,10 +25,11 @@ TEST(TEST_CATEGORY, mdrange_4d) {
 #endif
   TestMDRange_4D<TEST_EXECSPACE>::test_for4(100, 10, 10, 10);
 #ifdef KOKKOS_ENABLE_CUDA
-  TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1024 * 1024, 1, 1, 1);
-  TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, 1024 * 1024, 1, 1);
-  TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, 1, 1024 * 1024, 1);
-  TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, 1, 1, 1024 * 1024);
+  const int size_x = 2 << 19;  // 2^20
+  TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(size_x, 1, 1, 1);
+  TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, size_x, 1, 1);
+  TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, 1, size_x, 1);
+  TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, 1, 1, size_x);
 #endif
 }
 


### PR DESCRIPTION
This PR aims to solve an issue where a multidimensional range of 4 or more is incorrectly iterated, leading to some iterations being evaluated more than once.

Fixes #7697.

### Context

I'd like first to give a bit of context. Kokkos encodes `MDRangePolicy` dimensions within Cuda $x$, $y$, and $z$ dimensions:

| Rank | Dimensions encoded in $x$ | Dimensions encoded in $y$ | Dimensions encoded in $z$ |
|-|-|-|-|
| 2 | 1 | 2 | |
| 3 | 1 | 2 | 3 |
| 4 | 1, 2 | 3 | 4 |
| 5 | 1, 2 | 3, 4 | 5 |
| 6 | 1, 2 | 3, 4 | 5, 6 |

Let us take rank 4 by instance, and use the Cuda backend.

Here, this means that the number of threads per block in $x$ is the product of the tiles for dimensions 1 and 2, and that the number of blocks per grid in $x$ is the product of the number of tiles for dimensions 1 and 2. As Cuda limits the number of threads per block and the number of blocks per grid, Kokkos checks the number of threads per block, and limits the number of blocks per grid. This limitation comes in play if the iteration range exceeds the number of threads of the device. Note that the Cuda limits are not the same on the $x$, $y$, and $z$ dimensions. This step, which is named *packing* in the issue, [takes place on the host](https://github.com/kokkos/kokkos/blob/3a1d9e828c6601b96d8978fa8d1a7c68114bb24d/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp#L160-L174), and the limits are [fetched from the Cuda API](https://github.com/kokkos/kokkos/blob/3a1d9e828c6601b96d8978fa8d1a7c68114bb24d/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp#L98-L99).

Then, the threads on the device will execute for-loops to handle the packed dimensions 1 and 2, and to handle the possibly exceeding iteration range. Depending on the inner iteration order, the threads iterate over the $z$ blocks, then over the $y$ blocks, then over the "virtual blocks" for dimension 2, then over the "virtual blocks" for dimension 1 (here for the left iteration order). The "virtual blocks" are a partitioning of the $x$ dimension to contain dimensions 1 and 2 in it. The combined number of "virtual blocks" must fit within the maximum number of blocks per grid on the $x$ dimension. Their number is deduced from the number of tiles for dimensions 1 and 2 and from the maximum number of blocks per grid on the $x$ dimension. This step, named *unpacking* in the issue, [takes place on the device](https://github.com/kokkos/kokkos/blob/3a1d9e828c6601b96d8978fa8d1a7c68114bb24d/core/src/impl/KokkosExp_IterateTileGPU.hpp#L284-L330), where the Cuda API cannot be fetched.

Now, the problem reported in #7697 is that when performing the packing, the number of blocks per grid on the $x$ dimension is fetched from the [Cuda API](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#features-and-technical-specifications-technical-specifications-per-compute-capability), and the value is $2^{31} - 1$. But when performing the unpacking, the number of blocks per grid for any dimension is [hardcoded](https://github.com/kokkos/kokkos/blob/3a1d9e828c6601b96d8978fa8d1a7c68114bb24d/core/src/impl/KokkosExp_IterateTileGPU.hpp#L279) to $2^{16} - 1$. When the combined number of tiles for dimension 1 and 2 is larger than $2^{16} - 1$, this difference makes the "virtual blocks" smaller than what they should, and makes the threads iterate more than necessary, leading to some iterations being evaluated more than once. Note that the maximum number of blocks per grid for the $x$ dimension [used to be](https://en.wikipedia.org/wiki/CUDA#Technical_specification) $2^{16} - 1$ up to the last CC 2.x.

For higher ranks, the number of blocks per grid on the $y$ and $z$ dimensions is $2^{16} - 1$ both when fetched from the Cuda API, and for the hardcoded value. So the described problem will not happen if the number of tiles for dimension 3 and more is larger than $2^{16} - 1$.

The packing code is specific to each device backend (Cuda, HIP, and SYCL). The Cuda and HIP backends perform similarly. The SYCL backend, on the other hand, delegates the checks and the limitations to SYCL itself, according to a discussion with @masterleinad, for the reason we will see later.

The unpacking code is common to the three backends.

### Reproduction of the bug

This PR adds tests which check that views of rank 4 and higher with a large enough number of elements for each dimension are correctly iterated, for any iteration order (i.e., LL, LR, LR, RR). To this aim, each element of the view is atomically incremented, then the minimum and maximum value of the view is verified to be 1. The problem reported in the issue was reproduced for the Cuda backend for:

| Rank | Number of elements of the view | Inner iteration order |
|-|-|-|
| 4 | $2^{20} \times 1 \times 1 \times 1$ | Right |
| 4 | $1 \times 2^{20} \times 1 \times 1$ | Left |
| 5 | $2^{20} \times 1 \times 1 \times 1 \times 1$ | Right |
| 5 | $1 \times 2^{20} \times 1 \times 1 \times 1$ | Left |
| 6 | $2^{20} \times 1 \times 1 \times 1 \times 1 \times 1$ | Right |
| 6 | $1 \times 2^{20} \times 1 \times 1 \times 1 \times 1$ | Left |

Where $2^{20}$ is a large number of elements suggested in the issue.

Experimentally, the minimum number of elements to obtain the bug were found to be, on an NVIDIA A500 GPU:

| Rank | Number of elements of the view | Tiling | Inner iteration order |
|-|-|-|-|
| 4 | $(2^{16} - 1) \cdot 2 + 1 \times 1 \times 1 \times 1$ | $16 \times 2 \times 2 \times 2$ | Right |
| 4 | $1 \times (2^{16} - 1) \cdot 2 + 1 \times 1 \times 1$ | $2 \times 2 \times 2 \times 16$ | Left |
| 5 | $(2^{16} - 1) \cdot 2 + 1 \times 1 \times 1 \times 1 \times 1$ | $16 \times 2 \times 2 \times 2 \times 2$ | Right |
| 5 | $1 \times (2^{16} - 1) \cdot 2 + 1 \times 1 \times 1 \times 1$ | $2 \times 2 \times 2 \times 2 \times 16$ | Left |
| 6 | $2^{16} \times 1 \times 1 \times 1 \times 1 \times 1$ | $16 \times 2 \times 2 \times 2 \times 2 \times 2$ | Right |
| 6 | $1 \times (2^{16} - 1) \cdot 2 + 1 \times 1 \times 1 \times 1 \times 1$ | $2 \times 2 \times 2 \times 2 \times 2 \times 16$ | Left |

When the expected number of elements for the largest dimension was evaluated to $(2^{16} - 1) \times 16 + 1 \lessapprox 2^{20}$ (i.e. hardcoded maximum number of blocks per grid times the size of the tile plus one). *Note that I am not sure of this value.*

Note the different number of elements for rank 6 and iteration order right, for which the reason could not be identified.

### Reason of the bug

The problem is that the maximum number of blocks per grid (aka maximum grid size) for the code executed on the device is hardcoded with one single value for all dimensions, while the actual value varies by not only the dimension but also the programing model:

| Programming model | Max. num. of blocks per grid for $x$ | Max. num of blocks per grid for $y$ | Max. num. of blocks per grid for $z$ | Note |
|-|-|-|-|-|
| Cuda | $2^{31} - 1$ | $2^{16} - 1 $ | $2^{16} - 1 $ | Stable from CC 5.0 to 12.0 (latest) |
| HIP | $2^{32} - 1$, $2^{31} - 1$ | $2^{32} - 1$, $2^{16}$ | $2^{32} - 1$, $2^{16}$ | Discrepancy between the specs and the API |
| SYCL | | | | Not specified in the specs |

Sources for [Cuda](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#features-and-technical-specifications-technical-specifications-per-compute-capability); for HIP and SYCL, see the details below.

Consequently, the problem also occurs for HIP and for SYCL (this was tested). However, due to the uncertainties to fetch the accurate maximum number of blocks per grid for these programming models (see details below), we will first only fix the issue for the Cuda backend. We note that the value has been constant since at least CC 3.0.

<details>
<summary>
HIP case
</summary>

The [HIP documentation](https://rocm.docs.amd.com/projects/HIP/en/latest/reference/hardware_features.html) gives $2^{32} - 1$ for $x$, $y$, and $z$, but we got test failures, with iterations not being evaluated this time.

We directly checked `Kokkos::DefaultExecutionSpace().hip_device_prop().maxGridSize` with the following test code:

```cpp
#include <Kokkos_Core.hpp>

int main() {
    Kokkos::ScopeGuard kokkos;

#if defined(KOKKOS_ENABLE_CUDA)
    auto const maxblocks = Kokkos::DefaultExecutionSpace().cuda_device_prop().maxGridSize;
#elif defined(KOKKOS_ENABLE_HIP)
    auto const maxblocks = Kokkos::DefaultExecutionSpace().hip_device_prop().maxGridSize;
#else
#error "Programming model not supported"
#endif

    Kokkos::printf("Maxblocks: %d, %d, %d\n", maxblocks[0], maxblocks[1], maxblocks[2]);
}
```

On MI250 and MI300A, we obtained values which are much closer to what Cuda allows:

```text
Maxblocks: 2147483647, 65536, 65536
```

In other words, $2^{31} - 1$, $2^{16}$, and $2^{16}$ (note the difference of 1 with Cuda for $y$ and $z$, however).

@Rombur discussed about this difference with an AMD engineer, who reported he successfully launched a dummy kernel on one thread per block and $2^{32} - 1$ blocks per grid, for any dimension. According to him, the HIP API does not give accurate values. He is currently investigating the reasons why.

@Rombur opened an [issue](https://github.com/ROCm/clr/issues/140) on ROCm repository about this problem.

</details>

<details>
<summary>
SYCL case
</summary>

Note that SYCL does not specify the maximum number of blocks per grid in its specs, and it's not possible to query them officially. There is a [proposal to include them in the specs](https://github.com/KhronosGroup/SYCL-Docs/issues/386), and a [workaround to query them using OneAPI experimental functions](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_max_work_group_query.md). However, the experimental function gives results which are in contradiction with what `ze_info` gives.

Call to `ze_info`:

```text
 Device Name                                     Intel(R) Data Center GPU Max 1550
  Device Type                                     GPU
  Vendor ID                                       0x8086
  Device ID                                       0xbd6
  Subdevice ID                                    0x0
  Core Clock Rate                                 1600MHz
  Maximum Memory Allocation Size                  130535129088 (121.57GiB)
  Maximum Hardware Contexts                       65536
  Maximum Command Queue Priority                  0
  Number Threads Per EU                           8
  Physical EU SIMD Width                          16
  Number EU Per SubSlice                          8
  Number SubSlices Per Slice                      56
  Number Slices                                   2
  Timer Resolution                                12500000clks
  Compute properties:
    Maximum workgroup size                        1024
    Maximum workgroup sizes (X, Y, Z)             1024x1024x1024
    Maximum workgroup count (X, Y, Z)             4294967295x4294967295x4294967295
    Maximum Shared Local Memory Size Per Group    131072 (128KiB)
    Subgroup Sizes Supported                      16 32
  Module properties:
    SPIR-V supported version                      1.3
    Flags                                         fp16 fp64 int64_atomics dp4a
    fp16 properties:
      Denormals                                   yes
      Infinity and NaN                            yes
      Round to nearest even                       yes
      Round to zero                               yes
      Round to infinity                           yes
      IEEE754-2008 fused multiply-add             yes
      Correctly-rounded Div Sqrt                  no
      Support is emulated in software             no
    fp32 properties:
      Denormals                                   yes
      Infinity and NaN                            yes
      Round to nearest even                       yes
      Round to zero                               yes
      Round to infinity                           yes
      IEEE754-2008 fused multiply-add             yes
      Correctly-rounded Div Sqrt                  yes
      Support is emulated in software             no
    fp64 properties:
      Denormals                                   yes
      Infinity and NaN                            yes
      Round to nearest even                       yes
      Round to zero                               yes
      Round to infinity                           yes
      IEEE754-2008 fused multiply-add             yes
      Correctly-rounded Div Sqrt                  yes
      Support is emulated in software             no
    Maximum kernel arguments size                 2048 (2KiB)
    Print buffer size                             4194304 (4MiB)
  Device Name                                     Intel(R) Data Center GPU Max 1550
  Device Type                                     GPU
  Vendor ID                                       0x8086
  Device ID                                       0xbd6
  Subdevice ID                                    0x0
  Core Clock Rate                                 1600MHz
  Maximum Memory Allocation Size                  130535129088 (121.57GiB)
  Maximum Hardware Contexts                       65536
  Maximum Command Queue Priority                  0
  Number Threads Per EU                           8
  Physical EU SIMD Width                          16
  Number EU Per SubSlice                          8
  Number SubSlices Per Slice                      56
  Number Slices                                   2
  Timer Resolution                                12500000clks
  Compute properties:
    Maximum workgroup size                        1024
    Maximum workgroup sizes (X, Y, Z)             1024x1024x1024
    Maximum workgroup count (X, Y, Z)             4294967295x4294967295x4294967295
    Maximum Shared Local Memory Size Per Group    131072 (128KiB)
    Subgroup Sizes Supported                      16 32
  Module properties:
    SPIR-V supported version                      1.3
    Flags                                         fp16 fp64 int64_atomics dp4a
    fp16 properties:
      Denormals                                   yes
      Infinity and NaN                            yes
      Round to nearest even                       yes
      Round to zero                               yes
      Round to infinity                           yes
      IEEE754-2008 fused multiply-add             yes
      Correctly-rounded Div Sqrt                  no
      Support is emulated in software             no
    fp32 properties:
      Denormals                                   yes
      Infinity and NaN                            yes
      Round to nearest even                       yes
      Round to zero                               yes
      Round to infinity                           yes
      IEEE754-2008 fused multiply-add             yes
      Correctly-rounded Div Sqrt                  yes
      Support is emulated in software             no
    fp64 properties:
      Denormals                                   yes
      Infinity and NaN                            yes
      Round to nearest even                       yes
      Round to zero                               yes
      Round to infinity                           yes
      IEEE754-2008 fused multiply-add             yes
      Correctly-rounded Div Sqrt                  yes
      Support is emulated in software             no
    Maximum kernel arguments size                 2048 (2KiB)
    Print buffer size                             4194304 (4MiB
```

So, $2^{32} - 1$, on an Intel GPU Max 1550.

Use of experimental function:

```text
Intel(R) Data Center GPU Max 1550
Max number groups: x_max: 2147483647 y_max: 2147483647 z_max: 2147483647
Max global number groups: 2147483647
```

So, $2^{31} - 1$, on an Intel GPU Max 1550 as well.

We found out that the [implementation of the function](https://github.com/intel/llvm/blob/c0c91aa2235f7ba0f2aa3603667890ebe626b2c2/sycl/source/detail/device_info.hpp#L1120) just returns `std::numeric_limits<int>()` invariably.

We consequently tested to reach the limit manually with a SYCL code. Below is a code that runs a parallel loop with one thread per work group (or one thread per block in Cuda terminology), for a given loop size:

```cpp
#include <iostream>
#include <sycl/sycl.hpp>

//##define SIZE 2147483647  // 2^31 - 1
//#define SIZE 2147483648  // 2^31
#define SIZE 4294967295  // 2^32 - 1
//#define SIZE 4294967296  // 2^32

int main() {
    sycl::queue Q;
    std::cout << "Using device: " << Q.get_device().get_info<sycl::info::device::name>() << "\n";

    const sycl::range global_size{SIZE};
    const sycl::range local_size{1};

    Q.submit([&](sycl::handler &cgh) {
        cgh.parallel_for(
            sycl::nd_range{global_size, local_size},
            [=](auto itm) {
                auto a = 1+1;
        }   // end lambda in parallel_for
        );      // end parallel_for nd_range
    }).wait();         // end Q.submit

    return 0;
}
```

When the size is strictly higher than $2^{31} - 1$, the compiled code crashes, requesting to use `-fno-sycl-id-queries-fit-in-int` during compilation. On an Intel GPU Max 1550, we obtained the following behavior:

| Size | Without `-fno-sycl-id-queries-fit-in-int` | With `-fno-sycl-id-queries-fit-in-int` |
|-|-|-|
| $2^{31} - 1$ | Run | Run |
| $2^{31}$ | Crash | Run |
| $2^{32} - 1$ | Crash | Run |
| $2^{32} $ | Crash | Crash |

So we conclude that, at least for this GPU, the hardware limitation is $2^{32} - 1$, but there is a software limit of $2^{31} - 1$.

Eventually, as extracted above from a discussion with masterleinad, since packing/unpacking is not performed for SYCL, we do not need to worry about this backend anymore.

</details>

### Fix

This PR proposes a fix for the Cuda backend only, by differentiating the maximum number of blocks per grid for the $x$ dimension ($2^{31} - 1$) from the other two ($2^{16} - 1$), during the unpacking step on the device. It still relies on hardcoded values, which are extracted from the Cuda specs (listed above) and are checked against API values.

To avoid duplication of code, the hardcoded values are defined only once in the file.

With the provided fix, the tests introduced by the PR pass.

### Future fix

A better solution is to not rely on hardcoded values, and to get the values fetched from the API on the device instead. This would be proposed in a new PR.

### Progress

- [x] Add tests:
  - [x] Rank 4;
  - [x] Rank 5;
  - [x] Rank 6;
- [x] Fix:
  - [x] Rank 4;
  - [x] Rank 5;
  - [x] Rank 6;
- [x] Set hard-coded values:
  - [x] For Cuda;
  - ~For HIP~ (discrepancies between documentation and observed values); and
  - ~For SYCL~ (cannot be fetched).