### PR TITLE
found a copy-paste error in autotuning support: parallel_scan and parallel_reduce are mislabeled as parallel_for.

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -344,7 +344,7 @@ void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
         Experimental::make_variable_value(
             Experimental::kernel_name_context_variable_id, kernelPrefix),
         Experimental::make_variable_value(
-            Experimental::kernel_type_context_variable_id, "parallel_for")};
+            Experimental::kernel_type_context_variable_id, "parallel_scan")};
     Experimental::set_input_values(context_id, 2, contextValues);
   }
 #endif
@@ -375,7 +375,7 @@ void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
         Experimental::make_variable_value(
             Experimental::kernel_name_context_variable_id, kernelPrefix),
         Experimental::make_variable_value(
-            Experimental::kernel_type_context_variable_id, "parallel_for")};
+            Experimental::kernel_type_context_variable_id, "parallel_reduce")};
     Experimental::set_input_values(context_id, 2, contextValues);
   }
 #endif


### PR DESCRIPTION
While searching for (apparently non-existent) "size" support for uniquely identifying tuning contexts, I found a copy-paste error found in tuning setup for parallel_reduce, parallel_scan. They are mislabeled as parallel_for.