### PR TITLE
Fix dualview_external_view_construction compilation for recent clang

### DIFF
--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -503,6 +503,19 @@ TEST(TEST_CATEGORY, dualview_resize) {
                              /* Initialize */ false>();
 }
 
+template <typename ExecutionSpace>
+void check_dualview_external_view_construction() {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  Kokkos::View<int*, ExecutionSpace> view1("view1", 10);
+  Kokkos::View<int*, ExecutionSpace> view2("view2", 10);
+
+  Kokkos::DualView<int*, ExecutionSpace> v_dual(view1, view1);
+  ASSERT_DEATH(
+      (Kokkos::DualView<int*, ExecutionSpace>(view1, view2)),
+      "DualView storing one View constructed from two different Views");
+}
+
 // FIXME_MSVC+CUDA error C2094: label 'gtest_label_520' was undefined
 #if !(defined(KOKKOS_COMPILER_MSVC) && defined(KOKKOS_ENABLE_CUDA))
 TEST(TEST_CATEGORY_DEATH, dualview_external_view_construction) {
@@ -511,15 +524,7 @@ TEST(TEST_CATEGORY_DEATH, dualview_external_view_construction) {
                     TEST_EXECSPACE::memory_space>::accessible) {
     GTEST_SKIP() << "test only relevant if HostSpace can access memory space";
   } else {
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
-    Kokkos::View<int*, TEST_EXECSPACE> view1("view1", 10);
-    Kokkos::View<int*, TEST_EXECSPACE> view2("view2", 10);
-
-    Kokkos::DualView<int*, TEST_EXECSPACE> v_dual(view1, view1);
-    ASSERT_DEATH(
-        (Kokkos::DualView<int*, TEST_EXECSPACE>(view1, view2)),
-        "DualView storing one View constructed from two different Views");
+    check_dualview_external_view_construction<TEST_EXECSPACE>();
   }
 }
 #endif

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -524,6 +524,9 @@ TEST(TEST_CATEGORY_DEATH, dualview_external_view_construction) {
                     TEST_EXECSPACE::memory_space>::accessible) {
     GTEST_SKIP() << "test only relevant if HostSpace can access memory space";
   } else {
+    // FIXME_CLANG We can't inline the function because recent clang versions
+    // would deduce that a static_assert isn't satisfied for TEST_EXECSPACE.
+    // Thus, we need to template the function on the execution space.
     check_dualview_external_view_construction<TEST_EXECSPACE>();
   }
 }


### PR DESCRIPTION
Fixes https://my.cdash.org/viewBuildError.php?buildid=2808891. Since the test wasn't templated, the compiler decided that the `false` branch needed to be valid. Similar to the issue fixed in https://github.com/kokkos/kokkos/pull/7489.