### PR TITLE
Enable bugprone-unhandled-self-assignment

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,7 +23,6 @@ Checks: >
   -bugprone-suspicious-stringview-data-usage,
   -bugprone-unchecked-optional-access,
   -bugprone-unhandled-exception-at-new,
-  -bugprone-unhandled-self-assignment,
   -bugprone-unused-raii,
   -bugprone-use-after-move,
   cppcoreguidelines-pro-type-cstyle-cast,

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -272,6 +272,7 @@ struct KOKKOS_DEPRECATED
 
   KOKKOS_INLINE_FUNCTION
   Array& operator=(const Array& rhs) {
+    if (&rhs == this) return *this;
     const size_t n = size() < rhs.size() ? size() : rhs.size();
     for (size_t i = 0; i < n; ++i) m_elem[i] = rhs[i];
     return *this;
@@ -340,6 +341,7 @@ struct KOKKOS_DEPRECATED
 
   KOKKOS_INLINE_FUNCTION
   Array& operator=(const Array& rhs) {
+    if (&rhs == this) return *this;
     const size_t n = size() < rhs.size() ? size() : rhs.size();
     for (size_t i = 0; i < n; ++i) m_elem[i * m_stride] = rhs[i];
     return *this;

--- a/core/src/Kokkos_Future.hpp
+++ b/core/src/Kokkos_Future.hpp
@@ -336,6 +336,7 @@ class KOKKOS_DEPRECATED BasicFuture {
 
   KOKKOS_INLINE_FUNCTION
   BasicFuture& operator=(BasicFuture const& rhs) {
+    if (&rhs == this) return *this;
     if (m_task || rhs.m_task) queue_type::assign(&m_task, rhs.m_task);
     return *this;
   }

--- a/core/src/Kokkos_TaskScheduler.hpp
+++ b/core/src/Kokkos_TaskScheduler.hpp
@@ -212,6 +212,7 @@ class KOKKOS_DEPRECATED BasicTaskScheduler : public Impl::TaskSchedulerBase {
 
   KOKKOS_INLINE_FUNCTION
   BasicTaskScheduler& operator=(BasicTaskScheduler const& rhs) {
+    if (&rhs == this) return *this;
     m_track = rhs.m_track;
     m_queue = rhs.m_queue;
     return *this;

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -619,6 +619,7 @@ union SharedAllocationTracker {
 
   KOKKOS_FORCEINLINE_FUNCTION
   SharedAllocationTracker& operator=(SharedAllocationTracker&& rhs) {
+    if (&rhs == this) return *this;
     auto swap_tmp     = m_record_bits;
     m_record_bits     = rhs.m_record_bits;
     rhs.m_record_bits = swap_tmp;
@@ -642,6 +643,7 @@ union SharedAllocationTracker {
         KOKKOS_FORCEINLINE_FUNCTION SharedAllocationTracker
         &
         operator=(const SharedAllocationTracker& rhs) {
+    if (&rhs == this) return *this;
     // If this is tracking then must decrement
     KOKKOS_IMPL_SHARED_ALLOCATION_TRACKER_DECREMENT
     m_record_bits = KOKKOS_IMPL_SHARED_ALLOCATION_CARRY_RECORD_BITS(rhs, true);

--- a/core/unit_test/TestAtomics.hpp
+++ b/core/unit_test/TestAtomics.hpp
@@ -47,6 +47,7 @@ struct SuperScalar {
 
   KOKKOS_INLINE_FUNCTION
   SuperScalar& operator=(const SuperScalar& src) {
+    if (&src == this) return *this;
     for (int i = 0; i < N; i++) {
       val[i] = src.val[i];
     }
@@ -55,6 +56,7 @@ struct SuperScalar {
 
   KOKKOS_INLINE_FUNCTION
   SuperScalar& operator=(const volatile SuperScalar& src) {
+    if (&src == this) return *this;
     for (int i = 0; i < N; i++) {
       val[i] = src.val[i];
     }
@@ -63,6 +65,7 @@ struct SuperScalar {
 
   KOKKOS_INLINE_FUNCTION
   void operator=(const SuperScalar& src) volatile {
+    if (&src == this) return;
     for (int i = 0; i < N; i++) {
       val[i] = src.val[i];
     }

--- a/core/unit_test/TestIrregularLayout.hpp
+++ b/core/unit_test/TestIrregularLayout.hpp
@@ -57,6 +57,7 @@ struct LayoutSelective {
   }
   KOKKOS_INLINE_FUNCTION
   LayoutSelective& operator=(LayoutSelective const& rhs) {
+    if (&rhs == this) return *this;
     assign(rhs.offset_list, rhs.list_size);
     return *this;
   }

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -3817,6 +3817,7 @@ struct TestMDRange_ReduceScalar {
     }
     KOKKOS_INLINE_FUNCTION
     void operator=(const Scalar &src) {
+      if (&src == this) return;
       for (int i = 0; i < 4; i++) v[i] = src.v[i];
     }
     KOKKOS_INLINE_FUNCTION

--- a/core/unit_test/TestNonTrivialScalarTypes.hpp
+++ b/core/unit_test/TestNonTrivialScalarTypes.hpp
@@ -140,6 +140,7 @@ struct array_reduce {
 
   KOKKOS_INLINE_FUNCTION
   array_reduce &operator=(const array_reduce &src) {
+    if (&src == this) return *this;
     for (int i = 0; i < N; i++) data[i] = src.data[i];
     return *this;
   }


### PR DESCRIPTION
Enable `bugprone-unhandled-self-assignment` with ClangTidy.
Explicitly check for self-assignment in user-defined copy assignment operators.