### PR TITLE
Frontier nightly: remove build directories

### DIFF
--- a/.gitlab/olcf-gitlab-ci.yml
+++ b/.gitlab/olcf-gitlab-ci.yml
@@ -1,3 +1,7 @@
+stages:
+  - test
+  - clean_up
+
 hipcc:
   stage: test
   tags: [frontier, shell]
@@ -47,3 +51,20 @@ crayclang:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_HIP=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_TESTS=ON"
     - ctest -VV -E Kokkos_CoreUnitTest_DeviceAndThreads -D CDASH_MODEL="Nightly" -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}" -S CTestRun.cmake -D CTEST_SITE="frontier" -D CTEST_BUILD_NAME="crayclang/18.0.1-rocm/6.3.1"
+
+include:
+- project: ci/resources/templates
+  ref: main
+  file:
+    - /runners.yml
+
+clear-ci-builds:
+  stage: clean_up
+  extends:
+    - .frontier-shell-runner
+  variables:
+    GIT_STRATEGY: none
+    OLCF_SERVICE_ACCOUNT: ums018_auser
+  script:
+    - ls -la $HOME
+    - rm -rf $HOME/.jacamar-ci/{builds,cache}


### PR DESCRIPTION
Our nightly on Frontier is currently broken because we ran out-of-space.  This PR  removes the build and cache directories once we are done with the testing.