### PR TITLE
Add Linux testing with arm64 container using clang-tidy

### DIFF
--- a/.github/workflows/continuous-integration-arm64.yml
+++ b/.github/workflows/continuous-integration-arm64.yml
@@ -1,0 +1,50 @@
+name: github-arm64
+
+on:
+  workflow_call:
+
+concurrency:
+  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}-arm64
+  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+
+permissions: read-all
+
+jobs:
+  arm64ci:
+    name: arm64-ci
+    runs-on: [ubuntu-24.04-arm]
+    container:
+      image: ghcr.io/kokkos/ci-containers/ubuntu:latest-arm64
+
+    strategy:
+      matrix:
+        include:
+          - backend: "SERIAL"
+            cmake_build_type: "RelWithDebInfo"
+          - backend: "THREADS"
+            cmake_build_type: "RelWithDebInfo"
+          - backend: "SERIAL"
+            cmake_build_type: "Debug"
+          - backend: "SERIAL"
+            cmake_build_type: "Release"
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: configure
+        run:
+          cmake -B build .
+            -DKokkos_ENABLE_${{ matrix.backend }}=On
+            -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*"
+            -DCMAKE_CXX_FLAGS="-Werror"
+            -DCMAKE_CXX_STANDARD=17
+            -DKokkos_ARCH_NATIVE=ON
+            -DKokkos_ENABLE_COMPILER_WARNINGS=ON
+            -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF
+            -DKokkos_ENABLE_TESTS=On
+            -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }}
+      - name: build
+        run:
+          cmake --build build --parallel 2
+      - name: test
+        working-directory: build
+        run: ctest --output-on-failure

--- a/.github/workflows/continuous-integration-arm64.yml
+++ b/.github/workflows/continuous-integration-arm64.yml
@@ -19,12 +19,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - backend: "SERIAL"
+          - backend: "OPENMP"
             cmake_build_type: "RelWithDebInfo"
           - backend: "THREADS"
             cmake_build_type: "RelWithDebInfo"
-          - backend: "SERIAL"
-            cmake_build_type: "Debug"
           - backend: "SERIAL"
             cmake_build_type: "Release"
 

--- a/.github/workflows/continuous-integration-stager.yml
+++ b/.github/workflows/continuous-integration-stager.yml
@@ -57,6 +57,10 @@ jobs:
     needs: [initial-check, clang-format-check, cmake-format-check]
     uses: ./.github/workflows/continuous-integration-osx.yml
 
+  arm64:
+    needs: [initial-check, clang-format-check, cmake-format-check]
+    uses: ./.github/workflows/continuous-integration-arm64.yml
+
   performance-test:
     needs: [initial-check, clang-format-check, cmake-format-check]
     uses: ./.github/workflows/performance-benchmark.yml


### PR DESCRIPTION
This pull request suggests to ~~replace the Mac OSX CI with one for~~ add arm64 Ubuntu CI for which we have a container now that inlcudes `clang-tidy`. ~~We can dicuss keeping the OSX one but it seems the scope tested is overlapping for the most part.~~
This detects the clang-tidy problem fixed in #7739, see https://github.com/masterleinad/kokkos/actions/runs/13180738480/job/36790639312.