### PR TITLE
Enable bugprone-unused-raii and suppress false positives

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,7 +23,6 @@ Checks: >
   -bugprone-suspicious-stringview-data-usage,
   -bugprone-unchecked-optional-access,
   -bugprone-unhandled-exception-at-new,
-  -bugprone-unused-raii,
   cppcoreguidelines-pro-type-cstyle-cast,
   modernize-type-traits,
   modernize-use-nullptr,

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1698,6 +1698,7 @@ inline void impl_resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
     Kokkos::Impl::DynRankViewRemap<drview_type, drview_type>(
         Impl::get_property<Impl::ExecutionSpaceTag>(prop_copy), v_resized, v);
   else {
+    // NOLINTNEXTLINE(bugprone-unused-raii)
     Kokkos::Impl::DynRankViewRemap<drview_type, drview_type>(v_resized, v);
     Kokkos::fence("Kokkos::resize(DynRankView)");
   }

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -211,6 +211,7 @@ struct TestNumericTraits<
 };
 #endif
 
+// NOLINTBEGIN(bugprone-unused-raii)
 TEST(TEST_CATEGORY, numeric_traits_infinity) {
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::half_t, Infinity>();
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Infinity>();
@@ -431,6 +432,7 @@ TEST(TEST_CATEGORY, numeric_traits_quiet_and_signaling_nan) {
   TestNumericTraits<TEST_EXECSPACE, long double, SignalingNaN>();
 #endif
 }
+// NOLINTEND(bugprone-unused-raii)
 KOKKOS_IMPL_DISABLE_UNREACHABLE_WARNINGS_POP()
 
 namespace NumericTraitsSFINAE {


### PR DESCRIPTION
The numerics traits clearly uses this pattern on purpose.
The occurrence in the else-clause in the resize of DynRankView is flagged because it is followed by a `fence()` and is not at the end of the compound statement.