### PR TITLE
DualView: Fix impl_dualview_stores_single_view

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -211,8 +211,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
  public:
   // does the DualView have only one device
   static constexpr bool impl_dualview_stores_single_view =
-      SpaceAccessibility<Kokkos::HostSpace,
-                         typename t_dev::memory_space>::accessible;
+      std::is_same_v<typename t_dev::device_type, typename t_host::device_type>;
 
  public:
   //@}

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -519,10 +519,9 @@ void check_dualview_external_view_construction() {
 // FIXME_MSVC+CUDA error C2094: label 'gtest_label_520' was undefined
 #if !(defined(KOKKOS_COMPILER_MSVC) && defined(KOKKOS_ENABLE_CUDA))
 TEST(TEST_CATEGORY_DEATH, dualview_external_view_construction) {
-  if constexpr (!Kokkos::SpaceAccessibility<
-                    Kokkos::DefaultHostExecutionSpace,
-                    TEST_EXECSPACE::memory_space>::accessible) {
-    GTEST_SKIP() << "test only relevant if HostSpace can access memory space";
+  if constexpr (!Kokkos::DualView<
+                    int*, TEST_EXECSPACE>::impl_dualview_stores_single_view) {
+    GTEST_SKIP() << "test only relevant if DualView uses one allocation";
   } else {
     // FIXME_CLANG We can't inline the function because recent clang versions
     // would deduce that a static_assert isn't satisfied for TEST_EXECSPACE.


### PR DESCRIPTION
Fixes #7746. #7712 wasn't meant to change when a single allocation was used but the definition of `impl_dualview_stores_single_view` was incompatible with what we are actually doing (in particular for `Kokkos::SharedSpace` with a GPU backend enabled).

