### PR TITLE
View Refactor: prepare BasicView for new View implementation

### DIFF
--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -25,6 +25,7 @@ static_assert(false,
 #include <impl/Kokkos_Utilities.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>
 #include <View/Kokkos_ViewAlloc.hpp>
+#include <View/Kokkos_ViewAccessPreconditionsCheck.hpp>
 #include <View/Kokkos_ViewCtor.hpp>
 #include <View/Kokkos_ViewTraits.hpp>
 #include <View/MDSpan/Kokkos_MDSpan_Header.hpp>
@@ -34,7 +35,34 @@ static_assert(false,
 #include <optional>
 #include <type_traits>
 
-// FIXME: we need to make this work for not using our mdspan impl
+#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+
+#define KOKKOS_IMPL_BASICVIEW_OPERATOR_VERIFY(...)                             \
+  if constexpr (Impl::IsReferenceCountedDataHandle<data_handle_type>::value) { \
+    Kokkos::Impl::runtime_check_memory_access_violation<memory_space>(         \
+        m_ptr.tracker());                                                      \
+    Kokkos::Impl::view_verify_operator_bounds(                                 \
+        m_ptr.tracker(), m_map.extents(), m_ptr.get(), __VA_ARGS__);           \
+  } else {                                                                     \
+    Kokkos::Impl::runtime_check_memory_access_violation<memory_space>(         \
+        Kokkos::Impl::SharedAllocationTracker());                              \
+    Kokkos::Impl::view_verify_operator_bounds(                                 \
+        Kokkos::Impl::SharedAllocationTracker(), m_map.extents(), m_ptr,       \
+        __VA_ARGS__);                                                          \
+  }
+
+#else
+
+#define KOKKOS_IMPL_BASICVIEW_OPERATOR_VERIFY(...)                             \
+  if constexpr (Impl::IsReferenceCountedDataHandle<data_handle_type>::value) { \
+    Kokkos::Impl::runtime_check_memory_access_violation<memory_space>(         \
+        m_ptr.tracker());                                                      \
+  } else {                                                                     \
+    Kokkos::Impl::runtime_check_memory_access_violation<memory_space>(         \
+        Kokkos::Impl::SharedAllocationTracker());                              \
+  }
+#endif
+
 #define KOKKOS_IMPL_NO_UNIQUE_ADDRESS _MDSPAN_NO_UNIQUE_ADDRESS
 namespace Kokkos::Impl {
 
@@ -68,35 +96,28 @@ transform_kokkos_slice_to_mdspan_slice(const T &s) {
   return KokkosSliceToMDSpanSliceImpl<T>::transform(s);
 }
 
-// We do have implementation detail versions of these in our mdspan impl
-// However they are not part of the public standard interface
-template <class T>
-struct is_layout_right_padded : public std::false_type {};
-
-template <size_t Pad>
-struct is_layout_right_padded<Kokkos::Experimental::layout_right_padded<Pad>>
-    : public std::true_type {};
-
-template <class T>
-struct is_layout_left_padded : public std::false_type {};
-
-template <size_t Pad>
-struct is_layout_left_padded<Kokkos::Experimental::layout_left_padded<Pad>>
-    : public std::true_type {};
-
+// BasicView has to be in a different namespace than Impl;
+// The reason for this is that if BasicView is in Impl, View (which derives from
+// BasicView) can cause function resolution to ADL-find The Kokkos::Impl
+// namespace i.e. an unqualified call can find an internal Kokkos function This
+// was already exhibited in some Kokkos functions that were named the same in
+// both Kokkos:: and Kokkos::Impl:: namespaces and caused an ambiguous call
+namespace BV {
 template <class ElementType, class Extents, class LayoutPolicy,
           class AccessorPolicy>
 class BasicView {
  public:
   using mdspan_type =
       mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>;
-  using extents_type     = typename mdspan_type::extents_type;
-  using layout_type      = typename mdspan_type::layout_type;
-  using accessor_type    = typename mdspan_type::accessor_type;
-  using mapping_type     = typename mdspan_type::mapping_type;
-  using element_type     = typename mdspan_type::element_type;
-  using value_type       = typename mdspan_type::value_type;
-  using index_type       = typename mdspan_type::index_type;
+  using extents_type  = typename mdspan_type::extents_type;
+  using layout_type   = typename mdspan_type::layout_type;
+  using accessor_type = typename mdspan_type::accessor_type;
+  using mapping_type  = typename mdspan_type::mapping_type;
+  using element_type  = typename mdspan_type::element_type;
+  using value_type    = typename mdspan_type::value_type;
+  // FIXME: backwards compatibility, should be changed to the same as mdspan
+  // index_type
+  using index_type       = typename mdspan_type::size_type;
   using size_type        = typename mdspan_type::size_type;
   using rank_type        = typename mdspan_type::rank_type;
   using data_handle_type = typename mdspan_type::data_handle_type;
@@ -128,11 +149,11 @@ class BasicView {
   template <class OtherMapping>
   KOKKOS_FUNCTION static constexpr void check_basic_view_constructibility(
       [[maybe_unused]] const OtherMapping &rhs) {
-    using src_t          = typename OtherMapping::layout_type;
-    using dst_t          = layout_type;
-    constexpr size_t rnk = mdspan_type::rank();
+    using src_t                           = typename OtherMapping::layout_type;
+    using dst_t                           = layout_type;
+    [[maybe_unused]] constexpr size_t rnk = mdspan_type::rank();
     if constexpr (!std::is_same_v<src_t, dst_t>) {
-      if constexpr (Impl::is_layout_left_padded<dst_t>::value) {
+      if constexpr (Impl::IsLayoutLeftPadded<dst_t>::value) {
         if constexpr (std::is_same_v<src_t, layout_stride>) {
           index_type stride = 1;
           for (size_t r = 0; r < rnk; r++) {
@@ -143,7 +164,7 @@ class BasicView {
           }
         }
       }
-      if constexpr (Impl::is_layout_right_padded<dst_t>::value) {
+      if constexpr (Impl::IsLayoutRightPadded<dst_t>::value) {
         if constexpr (std::is_same_v<src_t, layout_stride>) {
           index_type stride = 1;
           if constexpr (rnk > 0) {
@@ -165,7 +186,7 @@ class BasicView {
               Kokkos::abort("View assignment must have compatible layouts");
             stride *= rhs.extents().extent(r);
           }
-        } else if constexpr (Impl::is_layout_left_padded<src_t>::value &&
+        } else if constexpr (Impl::IsLayoutLeftPadded<src_t>::value &&
                              rnk > 1) {
           if (rhs.stride(1) != rhs.extents().extent(0))
             Kokkos::abort("View assignment must have compatible layouts");
@@ -181,7 +202,7 @@ class BasicView {
               stride *= rhs.extents().extent(r - 1);
             }
           }
-        } else if constexpr (Impl::is_layout_right_padded<src_t>::value &&
+        } else if constexpr (Impl::IsLayoutRightPadded<src_t>::value &&
                              rnk > 1) {
           if (rhs.stride(rnk - 2) != rhs.extents().extent(rnk - 1))
             Kokkos::abort("View assignment must have compatible layouts");
@@ -202,19 +223,7 @@ class BasicView {
         m_map(std::move(other.mapping())),
         m_acc(std::move(other.accessor())){};
 
-  template <class... OtherIndexTypes>
-  //    requires(std::is_constructible_v<mdspan_type, data_handle_type,
-  //                                     OtherIndexTypes...>)
-  KOKKOS_FUNCTION explicit constexpr BasicView(
-      std::enable_if_t<std::is_constructible_v<mdspan_type, data_handle_type,
-                                               OtherIndexTypes...>,
-                       data_handle_type>
-          p,
-      OtherIndexTypes... exts)
-      : m_ptr(std::move(p)),
-        m_map(extents_type(static_cast<index_type>(std::move(exts))...)),
-        m_acc{} {}
-
+ public:
   template <class OtherIndexType, size_t Size>
   // When doing C++20 we should switch to this, the conditional explicit we
   // can't do in 17
@@ -252,7 +261,10 @@ class BasicView {
                                       const accessor_type &a)
       : m_ptr(std::move(p)), m_map(m), m_acc(a) {}
 
-  template <class OtherT, class OtherE, class OtherL, class OtherA>
+  template <class OtherT, class OtherE, class OtherL, class OtherA,
+            typename = std::enable_if_t<std::is_constructible_v<
+                mdspan_type, typename BasicView<OtherT, OtherE, OtherL,
+                                                OtherA>::mdspan_type>>>
 //    requires(std::is_constructible_v<mdspan_type,
 //                                     typename BasicView<OtherT, OtherE,
 //                                     OtherL,
@@ -264,12 +276,7 @@ class BasicView {
       !std::is_convertible_v<const OtherA &, accessor_type>)
 #endif
       KOKKOS_INLINE_FUNCTION
-      BasicView(const BasicView<OtherT, OtherE, OtherL, OtherA> &other,
-                std::enable_if_t<
-                    std::is_constructible_v<
-                        mdspan_type, typename BasicView<OtherT, OtherE, OtherL,
-                                                        OtherA>::mdspan_type>,
-                    void *> = nullptr)
+      BasicView(const BasicView<OtherT, OtherE, OtherL, OtherA> &other)
       : m_ptr(other.m_ptr), m_map(other.m_map), m_acc(other.m_acc) {
     // Kokkos View precondition checks happen in release builds
     check_basic_view_constructibility(other.mapping());
@@ -348,15 +355,24 @@ class BasicView {
           "Constructing View and initializing data with uninitialized "
           "execution space");
     }
-    return data_handle_type(Impl::make_shared_allocation_record<ElementType>(
-        arg_mapping.required_span_size(),
-        Impl::get_property<Impl::LabelTag>(prop_copy),
-        Impl::get_property<Impl::MemorySpaceTag>(prop_copy),
-        has_exec ? std::optional<execution_space>{Impl::get_property<
-                       Impl::ExecutionSpaceTag>(prop_copy)}
-                 : std::optional<execution_space>{std::nullopt},
-        std::integral_constant<bool, alloc_prop::initialize>(),
-        std::integral_constant<bool, alloc_prop::sequential_host_init>()));
+    if constexpr (has_exec) {
+      return data_handle_type(Impl::make_shared_allocation_record<ElementType>(
+          arg_mapping.required_span_size(),
+          Impl::get_property<Impl::LabelTag>(prop_copy),
+          Impl::get_property<Impl::MemorySpaceTag>(prop_copy),
+          std::make_optional(
+              Impl::get_property<Impl::ExecutionSpaceTag>(prop_copy)),
+          std::bool_constant<alloc_prop::initialize>(),
+          std::bool_constant<alloc_prop::sequential_host_init>()));
+    } else {
+      return data_handle_type(Impl::make_shared_allocation_record<ElementType>(
+          arg_mapping.required_span_size(),
+          Impl::get_property<Impl::LabelTag>(prop_copy),
+          Impl::get_property<Impl::MemorySpaceTag>(prop_copy),
+          std::optional<execution_space>{},
+          std::bool_constant<alloc_prop::initialize>(),
+          std::bool_constant<alloc_prop::sequential_host_init>()));
+    }
   }
 
  public:
@@ -457,30 +473,6 @@ class BasicView {
     return m_acc.access(m_ptr,
                         m_map(static_cast<index_type>(std::move(indices))...));
   }
-
-  template <class OtherIndexType>
-    requires(
-        std::is_convertible_v<const OtherIndexType &, index_type> &&
-        std::is_nothrow_constructible_v<index_type, const OtherIndexType &>)
-  KOKKOS_FUNCTION constexpr reference operator[](
-      const Array<OtherIndexType, rank()> &indices) const {
-    return m_acc.access(m_ptr,
-                        [&]<size_t... Idxs>(std::index_sequence<Idxs...>) {
-                          return m_map(indices[Idxs]...);
-                        }(std::make_index_sequence<rank()>()));
-  }
-
-  template <class OtherIndexType>
-    requires(
-        std::is_convertible_v<const OtherIndexType &, index_type> &&
-        std::is_nothrow_constructible_v<index_type, const OtherIndexType &>)
-  KOKKOS_FUNCTION constexpr reference operator[](
-      std::span<OtherIndexType, rank()> indices) const {
-    return m_acc.access(m_ptr,
-                        [&]<size_t... Idxs>(std::index_sequence<Idxs...>) {
-                          return m_map(indices[Idxs]...);
-                        }(std::make_index_sequence<rank()>()));
-  }
 #endif
 
   // C++20 operator()
@@ -491,39 +483,16 @@ class BasicView {
              (sizeof...(OtherIndexTypes) == rank()))
   KOKKOS_FUNCTION constexpr reference operator()(
       OtherIndexTypes... indices) const {
+    KOKKOS_IMPL_BASICVIEW_OPERATOR_VERIFY(indices...);
     return m_acc.access(m_ptr,
                         m_map(static_cast<index_type>(std::move(indices))...));
-  }
-
-  template <class OtherIndexType>
-    requires(
-        std::is_convertible_v<const OtherIndexType &, index_type> &&
-        std::is_nothrow_constructible_v<index_type, const OtherIndexType &>)
-  KOKKOS_FUNCTION constexpr reference operator()(
-      const Array<OtherIndexType, rank()> &indices) const {
-    return m_acc.access(m_ptr,
-                        [&]<size_t... Idxs>(std::index_sequence<Idxs...>) {
-                          return m_map(indices[Idxs]...);
-                        }(std::make_index_sequence<rank()>()));
-  }
-
-  template <class OtherIndexType>
-    requires(
-        std::is_convertible_v<const OtherIndexType &, index_type> &&
-        std::is_nothrow_constructible_v<index_type, const OtherIndexType &>)
-  KOKKOS_FUNCTION constexpr reference operator()(
-      std::span<OtherIndexType, rank()> indices) const {
-    return m_acc.access(m_ptr,
-                        [&]<size_t... Idxs>(std::index_sequence<Idxs...>) {
-                          return m_map(indices[Idxs]...);
-                        }(std::make_index_sequence<rank()>()));
   }
 #else
   // C++17 variant of operator()
 
-  // Some weird unexplained issue in compiling the SFINAE version with CUDA/MSVC
+  // Some weird unexplained issue in compiling the SFINAE version with MSVC
   // So we just use post factor check here with static_assert
-#if defined(KOKKOS_ENABLE_CUDA) && defined(_WIN32)
+#if defined(_WIN32)
   template <class... OtherIndexTypes>
   KOKKOS_FUNCTION constexpr reference operator()(
       OtherIndexTypes... indices) const {
@@ -531,6 +500,7 @@ class BasicView {
     static_assert(
         (std::is_nothrow_constructible_v<index_type, OtherIndexTypes> && ...));
     static_assert((sizeof...(OtherIndexTypes)) == rank());
+    KOKKOS_IMPL_BASICVIEW_OPERATOR_VERIFY(indices...)
     return m_acc.access(m_ptr,
                         m_map(static_cast<index_type>(std::move(indices))...));
   }
@@ -543,11 +513,14 @@ class BasicView {
           ((sizeof...(OtherIndexTypes)) == rank()),
       reference>
   operator()(OtherIndexTypes... indices) const {
+    KOKKOS_IMPL_BASICVIEW_OPERATOR_VERIFY(indices...)
     return m_acc.access(m_ptr,
                         m_map(static_cast<index_type>(std::move(indices))...));
   }
 #endif
 #endif
+
+#undef KOKKOS_IMPL_BASICVIEW_OPERATOR_VERIFY
 
  private:
   // FIXME_CXX20: could use inline templated lambda in C++20 mode inside size()
@@ -647,6 +620,7 @@ class BasicView {
   template <class, class, class, class>
   friend class BasicView;
 };
+}  // namespace BV
 }  // namespace Kokkos::Impl
 
 #endif

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -99,9 +99,9 @@ transform_kokkos_slice_to_mdspan_slice(const T &s) {
 // BasicView has to be in a different namespace than Impl;
 // The reason for this is that if BasicView is in Impl, View (which derives from
 // BasicView) can cause function resolution to ADL-find the Kokkos::Impl
-// namespace, i.e., an unqualified call can find an internal Kokkos function. This
-// was already exhibited in some Kokkos functions that were named the same in
-// both Kokkos:: and Kokkos::Impl:: namespaces and caused an ambiguous call
+// namespace, i.e., an unqualified call can find an internal Kokkos function.
+// This was already exhibited in some Kokkos functions that were named the same
+// in both Kokkos:: and Kokkos::Impl:: namespaces and caused an ambiguous call
 namespace BV {
 template <class ElementType, class Extents, class LayoutPolicy,
           class AccessorPolicy>

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -223,7 +223,6 @@ class BasicView {
         m_map(std::move(other.mapping())),
         m_acc(std::move(other.accessor())){};
 
- public:
   template <class OtherIndexType, size_t Size>
   // When doing C++20 we should switch to this, the conditional explicit we
   // can't do in 17

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -98,8 +98,8 @@ transform_kokkos_slice_to_mdspan_slice(const T &s) {
 
 // BasicView has to be in a different namespace than Impl;
 // The reason for this is that if BasicView is in Impl, View (which derives from
-// BasicView) can cause function resolution to ADL-find The Kokkos::Impl
-// namespace i.e. an unqualified call can find an internal Kokkos function This
+// BasicView) can cause function resolution to ADL-find the Kokkos::Impl
+// namespace, i.e., an unqualified call can find an internal Kokkos function. This
 // was already exhibited in some Kokkos functions that were named the same in
 // both Kokkos:: and Kokkos::Impl:: namespaces and caused an ambiguous call
 namespace BV {

--- a/core/src/View/Kokkos_ViewAccessPreconditionsCheck.hpp
+++ b/core/src/View/Kokkos_ViewAccessPreconditionsCheck.hpp
@@ -15,7 +15,6 @@
 //@HEADER
 
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
-#include <Kokkos_Macros.hpp>
 static_assert(false,
               "Including non-public Kokkos header files is not allowed.");
 #endif

--- a/core/src/View/Kokkos_ViewAccessPreconditionsCheck.hpp
+++ b/core/src/View/Kokkos_ViewAccessPreconditionsCheck.hpp
@@ -1,0 +1,161 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+#include <Kokkos_Macros.hpp>
+static_assert(false,
+              "Including non-public Kokkos header files is not allowed.");
+#endif
+
+#ifndef KOKKOS_VIEW_CHECKING_HPP
+#define KOKKOS_VIEW_CHECKING_HPP
+
+#include <cstring>
+#include <Kokkos_Macros.hpp>
+#include <Kokkos_Concepts.hpp>
+#include <impl/Kokkos_SharedAlloc.hpp>
+#include <View/MDSpan/Kokkos_MDSpan_Header.hpp>
+
+namespace Kokkos::Impl {
+// primary template: memory space is accessible, do nothing.
+template <class MemorySpace, class AccessSpace,
+          bool = SpaceAccessibility<AccessSpace, MemorySpace>::accessible>
+struct RuntimeCheckBasicViewMemoryAccessViolation {
+  KOKKOS_FUNCTION RuntimeCheckBasicViewMemoryAccessViolation(
+      Kokkos::Impl::SharedAllocationTracker const &) {}
+};
+
+// explicit specialization: memory access violation will occur, call abort with
+// the specified error message.
+template <class MemorySpace, class AccessSpace>
+struct RuntimeCheckBasicViewMemoryAccessViolation<MemorySpace, AccessSpace,
+                                                  false> {
+  KOKKOS_FUNCTION RuntimeCheckBasicViewMemoryAccessViolation(
+      Kokkos::Impl::SharedAllocationTracker const &tracker) {
+    char err[256] =
+        "Kokkos::View ERROR: attempt to access inaccessible memory space "
+        "(label=\"";
+
+    KOKKOS_IF_ON_HOST(({
+      if (tracker.has_record()) {
+        strncat(err, tracker.template get_label<void>().c_str(), 128);
+      } else {
+        strcat(err, "**UNMANAGED**");
+      }
+    }))
+
+    KOKKOS_IF_ON_DEVICE(({
+      strcat(err, "**UNAVAILABLE**");
+      (void)tracker;
+    }))
+
+    strcat(err, "\")");
+
+    Kokkos::abort(err);
+  }
+};
+
+template <class MemorySpace>
+KOKKOS_FUNCTION void runtime_check_memory_access_violation(
+    SharedAllocationTracker const &track) {
+  KOKKOS_IF_ON_HOST(((void)RuntimeCheckBasicViewMemoryAccessViolation<
+                         MemorySpace, DefaultHostExecutionSpace>(track);))
+  KOKKOS_IF_ON_DEVICE(((void)RuntimeCheckBasicViewMemoryAccessViolation<
+                           MemorySpace, DefaultExecutionSpace>(track);))
+}
+
+template <class IndexType, std::size_t... Extents, class... Indices,
+          std::size_t... Enumerate>
+KOKKOS_FUNCTION bool within_range(
+    Kokkos::extents<IndexType, Extents...> const &exts,
+    std::index_sequence<Enumerate...>, Indices... indices) {
+  // FIXME[CUDA11]: This is written so weirdly to avoid warnings with CUDA 11
+  // Without the workaround this could just be written as:
+  // return ((indices < exts.extent(Enumerate)) && ...) &&
+  //     ((std::is_unsigned_v<decltype(indices)> ||
+  //       (indices >= static_cast<decltype(indices)>(0))) &&
+  //      ...);
+  [[maybe_unused]] auto check_index_min = [](auto idx) {
+    if constexpr (!std::is_unsigned_v<decltype(idx)>) {
+      return idx >= static_cast<decltype(idx)>(0);
+    }
+
+    return true;
+  };
+
+  return ((indices < exts.extent(Enumerate)) && ...) &&
+         (check_index_min(indices) && ...);
+}
+
+template <class... Indices>
+KOKKOS_FUNCTION constexpr char *append_formatted_multidimensional_index(
+    char *dest, Indices... indices) {
+  char *d = dest;
+  strcat(d, "[");
+  (
+      [&] {
+        d += strlen(d);
+        to_chars_i(d,
+                   d + 20,  // 20 digits ought to be enough
+                   indices);
+        strcat(d, ",");
+      }(),
+      ...);
+  d[strlen(d) - 1] = ']';  // overwrite trailing comma
+  return dest;
+}
+
+template <class IndexType, size_t... Extents, std::size_t... Enumerate>
+KOKKOS_FUNCTION void print_extents(
+    char *dest, Kokkos::extents<IndexType, Extents...> const &exts,
+    std::index_sequence<Enumerate...>) {
+  append_formatted_multidimensional_index(dest, exts.extent(Enumerate)...);
+}
+
+template <class ExtentsType, class... IndexTypes>
+KOKKOS_INLINE_FUNCTION void view_verify_operator_bounds(
+    SharedAllocationTracker const &tracker, const ExtentsType &exts,
+    [[maybe_unused]] const void *data, IndexTypes... idx) {
+  using idx_t = typename ExtentsType::index_type;
+  if (!within_range(exts, std::make_index_sequence<sizeof...(IndexTypes)>(),
+                    idx...)) {
+    char err[256] = "";
+    strcat(err, "Kokkos::View ERROR: out of bounds access");
+    strcat(err, " label=(\"");
+    KOKKOS_IF_ON_HOST(
+        if (tracker.has_record()) {
+          strncat(err, tracker.template get_label<void>().c_str(), 128);
+        } else { strcat(err, "**UNMANAGED**"); })
+    KOKKOS_IF_ON_DEVICE([&] {
+      if (!tracker.has_record()) {
+        strcat(err, "**UNMANAGED**");
+        return;
+      }
+      SharedAllocationHeader const *const header =
+          SharedAllocationHeader::get_header(data);
+      char const *const label = header->label();
+      strcat(err, label);
+    }();)
+    strcat(err, "\") with indices ");
+    append_formatted_multidimensional_index(err, static_cast<idx_t>(idx)...);
+    strcat(err, " but extents ");
+    print_extents(err, exts, std::make_index_sequence<sizeof...(IndexTypes)>());
+    Kokkos::abort(err);
+  }
+}
+}  // namespace Kokkos::Impl
+
+#endif  // KOKKOS_VIEW_CHECKING_HPP

--- a/core/src/View/Kokkos_ViewMapping.hpp
+++ b/core/src/View/Kokkos_ViewMapping.hpp
@@ -3353,6 +3353,9 @@ KOKKOS_FUNCTION bool within_range(Map const& map,
   return (((std::size_t)indices < map.extent(Enumerate)) && ...);
 }
 
+// Disabled when using MDSpan because the MDSpan implementation has its own
+// version
+#ifndef KOKKOS_ENABLE_IMPL_MDSPAN
 template <class... Indices>
 KOKKOS_FUNCTION constexpr char* append_formatted_multidimensional_index(
     char* dest, Indices... indices) {
@@ -3370,6 +3373,7 @@ KOKKOS_FUNCTION constexpr char* append_formatted_multidimensional_index(
   d[strlen(d) - 1] = ']';  // overwrite trailing comma
   return dest;
 }
+#endif
 
 template <class Map, class... Indices, std::size_t... Enumerate>
 KOKKOS_FUNCTION void print_extents(char* dest, Map const& map,

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -307,6 +307,13 @@ class ReferenceCountedDataHandle {
   pointer m_handle = nullptr;
 };
 
+template <class T>
+struct IsReferenceCountedDataHandle : std::false_type {};
+
+template <class ElementType, class MemorySpace>
+struct IsReferenceCountedDataHandle<
+    ReferenceCountedDataHandle<ElementType, MemorySpace>> : std::true_type {};
+
 template <class ElementType, class MemorySpace, class NestedAccessor>
 class ReferenceCountedAccessor;
 

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -314,6 +314,10 @@ template <class ElementType, class MemorySpace>
 struct IsReferenceCountedDataHandle<
     ReferenceCountedDataHandle<ElementType, MemorySpace>> : std::true_type {};
 
+template <class T>
+constexpr bool IsReferenceCountedDataHandleV =
+    IsReferenceCountedDataHandle<T>::value;
+
 template <class ElementType, class MemorySpace, class NestedAccessor>
 class ReferenceCountedAccessor;
 
@@ -324,6 +328,10 @@ template <class ElementType, class MemorySpace, class NestedAccessor>
 struct IsReferenceCountedAccessor<
     ReferenceCountedAccessor<ElementType, MemorySpace, NestedAccessor>>
     : std::true_type {};
+
+template <class T>
+constexpr bool IsReferenceCountedAccessorV =
+    IsReferenceCountedAccessor<T>::value;
 
 template <class ElementType, class MemorySpace, class NestedAccessor>
 class ReferenceCountedAccessor {

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
@@ -146,22 +146,15 @@ KOKKOS_INLINE_FUNCTION auto mapping_from_array_layout_impl(
           extents_type{dextents<index_type, MappingType::extents_type::rank()>{
               layout.dimension[Idx]...}}};
     } else {
-      if constexpr (std::is_same_v<ArrayLayout, LayoutRight> &&
-                    extents_type::rank() > 2) {
-        size_t product_of_dimensions = 1;
-        for (size_t r = 1; r < extents_type::rank(); r++)
-          product_of_dimensions *= layout.dimension[r];
-        if (product_of_dimensions != layout.stride)
-          Kokkos::abort(
-              "Invalid conversion from LayoutRight to layout_right_padded");
-        return MappingType();
-      } else {
-        return MappingType{
-            extents_type{
-                dextents<index_type, MappingType::extents_type::rank()>{
-                    layout.dimension[Idx]...}},
-            layout.stride};
-      }
+      // This doesn't work because LayoutRight is not the same as
+      // std::layout_right_padded
+      static_assert(!(std::is_same_v<ArrayLayout, LayoutRight> &&
+                      extents_type::rank() > 2));
+
+      return MappingType{
+          extents_type{dextents<index_type, MappingType::extents_type::rank()>{
+              layout.dimension[Idx]...}},
+          layout.stride};
     }
   }
 }

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
@@ -125,9 +125,6 @@ KOKKOS_INLINE_FUNCTION auto array_layout_from_mapping(
     }
     return layout;
   }
-#ifdef KOKKOS_COMPILER_INTEL
-  __builtin_unreachable();
-#endif
 }
 
 template <class MappingType, class ArrayLayout, size_t... Idx>
@@ -228,9 +225,6 @@ KOKKOS_INLINE_FUNCTION auto mapping_from_view_mapping(const VM &view_mapping) {
   } else {
     return mapping_type(extents_from_view_mapping<extents_type>(view_mapping));
   }
-#ifdef KOKKOS_COMPILER_INTEL
-  __builtin_unreachable();
-#endif
 }
 
 template <size_t ScalarSize>

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
@@ -30,6 +30,21 @@ static_assert(false,
 // nested mapping. This file provides interoperability helpers.
 
 namespace Kokkos::Impl {
+// We do have implementation detail versions of these in our mdspan impl
+// However they are not part of the public standard interface
+template <class T>
+struct IsLayoutRightPadded : public std::false_type {};
+
+template <size_t Pad>
+struct IsLayoutRightPadded<Kokkos::Experimental::layout_right_padded<Pad>>
+    : public std::true_type {};
+
+template <class T>
+struct IsLayoutLeftPadded : public std::false_type {};
+
+template <size_t Pad>
+struct IsLayoutLeftPadded<Kokkos::Experimental::layout_left_padded<Pad>>
+    : public std::true_type {};
 
 template <class ArrayLayout>
 struct LayoutFromArrayLayout;
@@ -110,6 +125,9 @@ KOKKOS_INLINE_FUNCTION auto array_layout_from_mapping(
     }
     return layout;
   }
+#ifdef KOKKOS_COMPILER_INTEL
+  __builtin_unreachable();
+#endif
 }
 
 template <class MappingType, class ArrayLayout, size_t... Idx>
@@ -139,6 +157,7 @@ KOKKOS_INLINE_FUNCTION auto mapping_from_array_layout_impl(
         if (product_of_dimensions != layout.stride)
           Kokkos::abort(
               "Invalid conversion from LayoutRight to layout_right_padded");
+        return MappingType();
       } else {
         return MappingType{
             extents_type{
@@ -149,6 +168,7 @@ KOKKOS_INLINE_FUNCTION auto mapping_from_array_layout_impl(
     }
   }
 }
+
 template <class MappingType, size_t... Idx>
 KOKKOS_INLINE_FUNCTION auto mapping_from_array_layout_impl(
     LayoutStride layout, std::index_sequence<Idx...>) {
@@ -208,8 +228,89 @@ KOKKOS_INLINE_FUNCTION auto mapping_from_view_mapping(const VM &view_mapping) {
   } else {
     return mapping_type(extents_from_view_mapping<extents_type>(view_mapping));
   }
+#ifdef KOKKOS_COMPILER_INTEL
+  __builtin_unreachable();
+#endif
 }
 
+template <size_t ScalarSize>
+struct Padding {
+  static constexpr size_t div =
+      ScalarSize == 0 ? 0 : static_cast<size_t>(MEMORY_ALIGNMENT) / ScalarSize;
+  static constexpr size_t mod =
+      ScalarSize == 0 ? 0 : static_cast<size_t>(MEMORY_ALIGNMENT) % ScalarSize;
+
+  // If memory alignment is a multiple of the trivial scalar size then attempt
+  // to align.
+  static constexpr size_t align  = ScalarSize != 0 && mod == 0 ? div : 0;
+  static constexpr size_t div_ok = (div != 0) ? div : 1;
+
+  KOKKOS_INLINE_FUNCTION
+  static constexpr size_t stride(size_t const N) {
+    return ((align != 0) &&
+            ((static_cast<size_t>(MEMORY_ALIGNMENT_THRESHOLD) * align) < N) &&
+            ((N % div_ok) != 0))
+               ? N + align - (N % div_ok)
+               : N;
+  }
+};
+
+template <class MappingType, size_t ScalarSize, class ViewCtorProperties,
+          class... Sizes>
+KOKKOS_INLINE_FUNCTION auto mapping_from_ctor_and_sizes(
+    const ViewCtorProperties &, const Sizes... args) {
+  using layout_t = typename MappingType::layout_type;
+  using ext_t    = typename MappingType::extents_type;
+  ext_t ext{args...};
+  constexpr bool padded = ViewCtorProperties::allow_padding;
+  if constexpr (IsLayoutLeftPadded<layout_t>::value && padded &&
+                ext_t::rank() > 1) {
+    return MappingType(ext, Padding<ScalarSize>::stride(ext.extent(0)));
+  } else if constexpr (IsLayoutRightPadded<layout_t>::value && padded &&
+                       ext_t::rank() > 1) {
+    return MappingType(
+        ext, Padding<ScalarSize>::stride(ext.extent(ext_t::rank() - 1)));
+  } else {
+    return MappingType(ext);
+  }
+}
+
+template <class MappingType, size_t ScalarSize, class ViewCtorProperties>
+KOKKOS_INLINE_FUNCTION auto mapping_from_ctor_and_8sizes(
+    const ViewCtorProperties &arg_prop, [[maybe_unused]] const size_t arg_N0,
+    [[maybe_unused]] const size_t arg_N1, [[maybe_unused]] const size_t arg_N2,
+    [[maybe_unused]] const size_t arg_N3, [[maybe_unused]] const size_t arg_N4,
+    [[maybe_unused]] const size_t arg_N5, [[maybe_unused]] const size_t arg_N6,
+    [[maybe_unused]] const size_t arg_N7) {
+  if constexpr (MappingType::extents_type::rank() == 0) {
+    return mapping_from_ctor_and_sizes<MappingType, ScalarSize>(arg_prop);
+  } else if constexpr (MappingType::extents_type::rank() == 1) {
+    return mapping_from_ctor_and_sizes<MappingType, ScalarSize>(arg_prop,
+                                                                arg_N0);
+  } else if constexpr (MappingType::extents_type::rank() == 2) {
+    return mapping_from_ctor_and_sizes<MappingType, ScalarSize>(arg_prop,
+                                                                arg_N0, arg_N1);
+  } else if constexpr (MappingType::extents_type::rank() == 3) {
+    return mapping_from_ctor_and_sizes<MappingType, ScalarSize>(
+        arg_prop, arg_N0, arg_N1, arg_N2);
+  } else if constexpr (MappingType::extents_type::rank() == 4) {
+    return mapping_from_ctor_and_sizes<MappingType, ScalarSize>(
+        arg_prop, arg_N0, arg_N1, arg_N2, arg_N3);
+  } else if constexpr (MappingType::extents_type::rank() == 5) {
+    return mapping_from_ctor_and_sizes<MappingType, ScalarSize>(
+        arg_prop, arg_N0, arg_N1, arg_N2, arg_N3, arg_N4);
+  } else if constexpr (MappingType::extents_type::rank() == 6) {
+    return mapping_from_ctor_and_sizes<MappingType, ScalarSize>(
+        arg_prop, arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5);
+  } else if constexpr (MappingType::extents_type::rank() == 7) {
+    return mapping_from_ctor_and_sizes<MappingType, ScalarSize>(
+        arg_prop, arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6);
+  } else if constexpr (MappingType::extents_type::rank() == 8) {
+    return mapping_from_ctor_and_sizes<MappingType, ScalarSize>(
+        arg_prop, arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6,
+        arg_N7);
+  }
+}
 }  // namespace Kokkos::Impl
 
 #endif  // KOKKOS_EXPERIMENTAL_MDSPAN_LAYOUT_HPP

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
@@ -32,35 +32,35 @@ static_assert(false,
 namespace Kokkos::Impl {
 // We do have implementation detail versions of these in our mdspan impl
 // However they are not part of the public standard interface
-template <class T>
-struct IsLayoutRightPadded : public std::false_type {};
+template <class>
+struct IsLayoutRightPadded : std::false_type {};
 
 template <size_t Pad>
-struct IsLayoutRightPadded<Kokkos::Experimental::layout_right_padded<Pad>>
-    : public std::true_type {};
+struct IsLayoutRightPadded<Experimental::layout_right_padded<Pad>>
+    : std::true_type {};
 
-template <class T>
-struct IsLayoutLeftPadded : public std::false_type {};
+template <class>
+struct IsLayoutLeftPadded : std::false_type {};
 
 template <size_t Pad>
-struct IsLayoutLeftPadded<Kokkos::Experimental::layout_left_padded<Pad>>
-    : public std::true_type {};
+struct IsLayoutLeftPadded<Experimental::layout_left_padded<Pad>>
+    : std::true_type {};
 
 template <class ArrayLayout>
 struct LayoutFromArrayLayout;
 
 template <>
-struct LayoutFromArrayLayout<Kokkos::LayoutLeft> {
-  using type = Kokkos::Experimental::layout_left_padded<dynamic_extent>;
+struct LayoutFromArrayLayout<LayoutLeft> {
+  using type = Experimental::layout_left_padded<dynamic_extent>;
 };
 
 template <>
-struct LayoutFromArrayLayout<Kokkos::LayoutRight> {
-  using type = Kokkos::Experimental::layout_right_padded<dynamic_extent>;
+struct LayoutFromArrayLayout<LayoutRight> {
+  using type = Experimental::layout_right_padded<dynamic_extent>;
 };
 
 template <>
-struct LayoutFromArrayLayout<Kokkos::LayoutStride> {
+struct LayoutFromArrayLayout<LayoutStride> {
   using type = layout_stride;
 };
 

--- a/core/unit_test/view/TestBasicView.hpp
+++ b/core/unit_test/view/TestBasicView.hpp
@@ -51,7 +51,7 @@ void test_default_constructor() {
   using accessor_type = Kokkos::Impl::CheckedReferenceCountedAccessor<
       T, typename ExecutionSpace::memory_space>;
   using view_type =
-      Kokkos::Impl::BasicView<T, extents_type, layout_type, accessor_type>;
+      Kokkos::Impl::BV::BasicView<T, extents_type, layout_type, accessor_type>;
   view_type view;
 
   EXPECT_FALSE(view.data_handle().has_record());
@@ -75,7 +75,7 @@ void test_extents_constructor(const ExtentsType &extents) {
   using accessor_type = Kokkos::Impl::CheckedReferenceCountedAccessor<
       T, typename ExecutionSpace::memory_space>;
   using view_type =
-      Kokkos::Impl::BasicView<T, extents_type, layout_type, accessor_type>;
+      Kokkos::Impl::BV::BasicView<T, extents_type, layout_type, accessor_type>;
 
   view_type view("test_view", extents);
 
@@ -110,7 +110,7 @@ void test_mapping_constructor(const ExtentsType &extents, std::size_t padding) {
   using accessor_type = Kokkos::Impl::CheckedReferenceCountedAccessor<
       T, typename ExecutionSpace::memory_space>;
   using view_type =
-      Kokkos::Impl::BasicView<T, extents_type, layout_type, accessor_type>;
+      Kokkos::Impl::BV::BasicView<T, extents_type, layout_type, accessor_type>;
   static_assert(std::is_same_v<typename view_type::mapping_type, mapping_type>);
 
   auto mapping = mapping_type(extents, padding);
@@ -163,7 +163,7 @@ void test_access_with_extents(const ExtentsType &extents) {
   using accessor_type = Kokkos::Impl::CheckedReferenceCountedAccessor<
       T, typename ExecutionSpace::memory_space>;
   using view_type =
-      Kokkos::Impl::BasicView<T, extents_type, layout_type, accessor_type>;
+      Kokkos::Impl::BV::BasicView<T, extents_type, layout_type, accessor_type>;
 
   auto view = view_type("test_view", extents);
 
@@ -203,7 +203,7 @@ TEST(TEST_CATEGORY, basic_view_access) {
     using accessor_type = Kokkos::Impl::CheckedReferenceCountedAccessor<
         T, typename ExecutionSpace::memory_space>;
     using basic_view_type =
-        Kokkos::Impl::BasicView<T, extents_type, layout_type, accessor_type>;
+        Kokkos::Impl::BV::BasicView<T, extents_type, layout_type, accessor_type>;
     using view_type = SrcViewType;
     static_assert(std::is_constructible_v<basic_view_type, SrcViewType>);
   }
@@ -231,11 +231,11 @@ void test_atomic_accessor() {
       Kokkos::Impl::CheckedReferenceCountedRelaxedAtomicAccessor<
           T, typename ExecutionSpace::memory_space>;
   using view_type =
-      Kokkos::Impl::BasicView<T, extents_type, layout_type, accessor_type>;
+      Kokkos::Impl::BV::BasicView<T, extents_type, layout_type, accessor_type>;
   using um_accessor_type = Kokkos::Impl::CheckedRelaxedAtomicAccessor<
       T, typename ExecutionSpace::memory_space>;
-  using um_view_type =
-      Kokkos::Impl::BasicView<T, extents_type, layout_type, um_accessor_type>;
+  using um_view_type = Kokkos::Impl::BV::BasicView<T, extents_type, layout_type,
+                                                   um_accessor_type>;
 
   extents_type extents{};
   auto view = view_type("test_view", extents);

--- a/core/unit_test/view/TestBasicViewMDSpanConversion.cpp
+++ b/core/unit_test/view/TestBasicViewMDSpanConversion.cpp
@@ -17,35 +17,34 @@
 #include <Kokkos_Core.hpp>
 #include <type_traits>
 
+using Kokkos::Impl::BV::BasicView;
 #if 0  // TODO: after View is using BasicView this should be true
 static_assert(
     std::is_convertible_v<
         Kokkos::View<long long ****, Kokkos::LayoutRight, Kokkos::Serial>,
-        Kokkos::Impl::BV::BasicView<long long, Kokkos::dextents<size_t, 4>,
-                          Kokkos::Experimental::layout_right_padded<>,
-                          Kokkos::Impl::CheckedReferenceCountedAccessor<
-                              long long, Kokkos::HostSpace>>>);
+        BasicView<long long, Kokkos::dextents<size_t, 4>,
+                  Kokkos::Experimental::layout_right_padded<>,
+                  Kokkos::Impl::CheckedReferenceCountedAccessor<
+                    long long, Kokkos::HostSpace>>>);
 #endif
 
-static_assert(
-    std::is_convertible_v<Kokkos::Impl::BV::BasicView<
-                              long long, Kokkos::dextents<size_t, 4>,
-                              Kokkos::Experimental::layout_right_padded<>,
-                              Kokkos::Impl::CheckedReferenceCountedAccessor<
-                                  long long, Kokkos::HostSpace>>,
-                          Kokkos::Impl::BV::BasicView<
-                              const long long, Kokkos::dextents<size_t, 4>,
-                              Kokkos::Experimental::layout_right_padded<>,
-                              Kokkos::Impl::CheckedReferenceCountedAccessor<
-                                  const long long, Kokkos::HostSpace>>>);
+static_assert(std::is_convertible_v<
+              BasicView<long long, Kokkos::dextents<size_t, 4>,
+                        Kokkos::Experimental::layout_right_padded<>,
+                        Kokkos::Impl::CheckedReferenceCountedAccessor<
+                            long long, Kokkos::HostSpace>>,
+              BasicView<const long long, Kokkos::dextents<size_t, 4>,
+                        Kokkos::Experimental::layout_right_padded<>,
+                        Kokkos::Impl::CheckedReferenceCountedAccessor<
+                            const long long, Kokkos::HostSpace>>>);
 #if 0  // TODO: after View is using BasicView this should be true
 static_assert(
     std::is_convertible_v<
         Kokkos::View<long long ****, Kokkos::LayoutRight, Kokkos::Serial>,
-        Kokkos::Impl::BV::BasicView<const long long, Kokkos::dextents<size_t, 4>,
-                          Kokkos::Experimental::layout_right_padded<>,
-                          Kokkos::Impl::CheckedReferenceCountedAccessor<
-                              const long long, Kokkos::HostSpace>>>);
+        BasicView<const long long, Kokkos::dextents<size_t, 4>,
+                  Kokkos::Experimental::layout_right_padded<>,
+                  Kokkos::Impl::CheckedReferenceCountedAccessor<
+                    const long long, Kokkos::HostSpace>>>);
 
 using test_atomic_view = Kokkos::View<double *, Kokkos::Serial,
                                       Kokkos::MemoryTraits<Kokkos::Atomic>>;

--- a/core/unit_test/view/TestBasicViewMDSpanConversion.cpp
+++ b/core/unit_test/view/TestBasicViewMDSpanConversion.cpp
@@ -21,27 +21,28 @@
 static_assert(
     std::is_convertible_v<
         Kokkos::View<long long ****, Kokkos::LayoutRight, Kokkos::Serial>,
-        Kokkos::Impl::BasicView<long long, Kokkos::dextents<size_t, 4>,
+        Kokkos::Impl::BV::BasicView<long long, Kokkos::dextents<size_t, 4>,
                           Kokkos::Experimental::layout_right_padded<>,
                           Kokkos::Impl::CheckedReferenceCountedAccessor<
                               long long, Kokkos::HostSpace>>>);
 #endif
 
 static_assert(
-    std::is_convertible_v<
-        Kokkos::Impl::BasicView<long long, Kokkos::dextents<size_t, 4>,
-                                Kokkos::Experimental::layout_right_padded<>,
-                                Kokkos::Impl::CheckedReferenceCountedAccessor<
-                                    long long, Kokkos::HostSpace>>,
-        Kokkos::Impl::BasicView<const long long, Kokkos::dextents<size_t, 4>,
-                                Kokkos::Experimental::layout_right_padded<>,
-                                Kokkos::Impl::CheckedReferenceCountedAccessor<
-                                    const long long, Kokkos::HostSpace>>>);
+    std::is_convertible_v<Kokkos::Impl::BV::BasicView<
+                              long long, Kokkos::dextents<size_t, 4>,
+                              Kokkos::Experimental::layout_right_padded<>,
+                              Kokkos::Impl::CheckedReferenceCountedAccessor<
+                                  long long, Kokkos::HostSpace>>,
+                          Kokkos::Impl::BV::BasicView<
+                              const long long, Kokkos::dextents<size_t, 4>,
+                              Kokkos::Experimental::layout_right_padded<>,
+                              Kokkos::Impl::CheckedReferenceCountedAccessor<
+                                  const long long, Kokkos::HostSpace>>>);
 #if 0  // TODO: after View is using BasicView this should be true
 static_assert(
     std::is_convertible_v<
         Kokkos::View<long long ****, Kokkos::LayoutRight, Kokkos::Serial>,
-        Kokkos::Impl::BasicView<const long long, Kokkos::dextents<size_t, 4>,
+        Kokkos::Impl::BV::BasicView<const long long, Kokkos::dextents<size_t, 4>,
                           Kokkos::Experimental::layout_right_padded<>,
                           Kokkos::Impl::CheckedReferenceCountedAccessor<
                               const long long, Kokkos::HostSpace>>>);


### PR DESCRIPTION
This pulls out some of the changes from https://github.com/kokkos/kokkos/pull/7427

Specifically, this PR:
* Adds verification macros using the view tracker inside of the BasicView accessor
* Moves BasicView inside its own namespace inside of Impl to prevent accidentally ADL-finding Kokkos::Impl functions when passing in anything derived from BasicView
* re-organize type aliases inside of BasicView and make them consistent (for now) with Kokkos type aliases
* Use helper type traits for padded layouts embedded in Kokkos rather than borrowed from the mdspan impl
* Removes a constructor unused in the new view implementation
* Move some method constraints to template parameters instead of regular arguments to workaround an NVCC compiler bug