### PR TITLE
HIP: assert instead of throwing an exception when block size is negative

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Error.cpp
+++ b/core/src/HIP/Kokkos_HIP_Error.cpp
@@ -1,0 +1,34 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <HIP/Kokkos_HIP_Error.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+void hip_internal_error_throw(hipError_t e, const char* name, const char* file,
+                              const int line) {
+  std::ostringstream out;
+  out << name << " error( " << hipGetErrorName(e)
+      << "): " << hipGetErrorString(e);
+  if (file) {
+    out << " " << file << ":" << line;
+  }
+  throw_runtime_exception(out.str());
+}
+
+}  // namespace Impl
+}  // namespace Kokkos

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -402,23 +402,6 @@ Kokkos::HIP::size_type *hip_internal_scratch_flags(const HIP &instance,
 
 //----------------------------------------------------------------------------
 
-namespace Kokkos {
-namespace Impl {
-void hip_internal_error_throw(hipError_t e, const char *name, const char *file,
-                              const int line) {
-  std::ostringstream out;
-  out << name << " error( " << hipGetErrorName(e)
-      << "): " << hipGetErrorString(e);
-  if (file) {
-    out << " " << file << ":" << line;
-  }
-  throw_runtime_exception(out.str());
-}
-}  // namespace Impl
-}  // namespace Kokkos
-
-//----------------------------------------------------------------------------
-
 void Kokkos::Impl::create_HIP_instances(std::vector<HIP> &instances) {
   for (int s = 0; s < int(instances.size()); s++) {
     hipStream_t stream;

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -159,10 +159,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
     using closure_type =
         ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP>;
     unsigned block_size = hip_get_max_blocksize<closure_type, LaunchBounds>();
-    if (block_size == 0)
-      Kokkos::Impl::throw_runtime_exception(
-          std::string("Kokkos::Impl::ParallelFor< HIP > could not find a valid "
-                      "tile size."));
+    KOKKOS_ASSERT(block_size > 0);
     return block_size;
   }
 };

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
@@ -80,11 +80,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::HIP> {
     const dim3 grid(
         typename Policy::index_type((nwork + block.y - 1) / block.y), 1, 1);
 
-    if (block_size == 0) {
-      Kokkos::Impl::throw_runtime_exception(
-          std::string("Kokkos::Impl::ParallelFor< HIP > could not find a "
-                      "valid execution configuration."));
-    }
+    KOKKOS_ASSERT(block_size > 0);
     Kokkos::Impl::hip_parallel_launch<DriverType, LaunchBounds>(
         *this, grid, block, 0, m_policy.space().impl_internal_space_instance(),
         false);

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
@@ -153,11 +153,7 @@ class ParallelReduce<CombinedFunctorReducerType,
     unsigned block_size =
         Kokkos::Impl::hip_get_preferred_blocksize<ParallelReduce, LaunchBounds>(
             instance, shmem_functor);
-    if (block_size == 0) {
-      Kokkos::Impl::throw_runtime_exception(
-          std::string("Kokkos::Impl::ParallelReduce< HIP > could not find a "
-                      "valid tile size."));
-    }
+    KOKKOS_ASSERT(block_size > 0);
     return block_size;
   }
 
@@ -233,11 +229,7 @@ class ParallelReduce<CombinedFunctorReducerType,
     using closure_type  = ParallelReduce<CombinedFunctorReducerType,
                                         Kokkos::MDRangePolicy<Traits...>, HIP>;
     unsigned block_size = hip_get_max_blocksize<closure_type, LaunchBounds>();
-    if (block_size == 0) {
-      Kokkos::Impl::throw_runtime_exception(
-          std::string("Kokkos::Impl::ParallelReduce< HIP > could not find a "
-                      "valid tile size."));
-    }
+    KOKKOS_ASSERT(block_size > 0);
     return block_size;
   }
 };

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_Range.hpp
@@ -231,6 +231,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
                                  !std::is_same<ReducerType, InvalidType>::value;
     if ((nwork > 0) || need_device_set) {
       const int block_size = local_block_size(m_functor_reducer.get_functor());
+#if !defined(NDEBUG) || defined(KOKKOS_ENFORCE_CONTRACTS) || \
+    defined(KOKKOS_ENABLE_DEBUG)
       if (block_size == 0) {
         const unsigned int shared_memory_required =
             hip_single_inter_block_reduce_scan_shmem<false, WorkTag,
@@ -240,14 +242,14 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
             m_policy.space()
                 .impl_internal_space_instance()
                 ->m_deviceProp.maxSharedMemoryPerMultiProcessor;
-        Kokkos::Impl::throw_runtime_exception(
-            std::string("Kokkos::Impl::ParallelReduce< HIP > could not find a "
-                        "valid execution configuration: your kernel requires " +
-                        std::to_string(shared_memory_required) +
-                        " bytes of shared memory per block but only " +
-                        std::to_string(shared_memory_available) +
-                        " bytes per block are available."));
+        printf(
+            "Kokkos::Impl::ParallelReduce< HIP > could not find a valid "
+            "execution configuration: your kernel requires %u bytes of shared "
+            "memory per block but only %u bytes per block are available.",
+            shared_memory_required, shared_memory_available);
+        KOKKOS_ASSERT(false);
       }
+#endif
 
       // REQUIRED ( 1 , N , 1 )
       dim3 block(1, block_size, 1);

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
@@ -329,10 +329,7 @@ class ParallelReduce<CombinedFunctorReducerType,
       m_team_size = arg_policy.team_size_recommended(
           arg_functor_reducer.get_functor(), arg_functor_reducer.get_reducer(),
           ParallelReduceTag());
-      if (m_team_size <= 0)
-        Kokkos::Impl::throw_runtime_exception(
-            "Kokkos::Impl::ParallelReduce<HIP, TeamPolicy> could not find a "
-            "valid execution configuration.");
+      KOKKOS_ASSERT(m_team_size > 0);
     }
 
     m_team_begin =

--- a/core/src/HIP/Kokkos_HIP_ParallelScan_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelScan_Range.hpp
@@ -299,11 +299,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, HIP>
   inline void execute() {
     const int block_size = static_cast<int>(
         local_block_size(Base::m_functor_reducer.get_functor()));
-    if (block_size == 0) {
-      Kokkos::Impl::throw_runtime_exception(
-          std::string("Kokkos::Impl::ParallelScan< HIP > could not find a "
-                      "valid execution configuration."));
-    }
+    KOKKOS_ASSERT(block_size > 0);
 
     Base::impl_execute(block_size);
   }
@@ -342,11 +338,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
   inline void execute() {
     const int block_size = static_cast<int>(
         local_block_size(Base::m_functor_reducer.get_functor()));
-    if (block_size == 0) {
-      Kokkos::Impl::throw_runtime_exception(
-          std::string("Kokkos::Impl::ParallelScan< HIP > could not find a "
-                      "valid execution configuration."));
-    }
+    KOKKOS_ASSERT(block_size > 0);
 
     Base::impl_execute(block_size);
 


### PR DESCRIPTION
This PR does two things:
 1. Move the implementation of `hip_internal_error_throw`  out of `Kokkos_HIP_Instance.cpp`. There is no reason for this function to be implemented in `Kokkos_HIP_Instance.cpp`. It just makes it harder to find the function.
 2. Instead of throwing an exception when we compute a block size negative. This aligns the HIP backend with the CUDA backend