### PR TITLE
[ci skip] CI: Add ALCF GitLab test scripts

### DIFF
--- a/.gitlab/alcf-gitlab-ci.yml
+++ b/.gitlab/alcf-gitlab-ci.yml
@@ -17,8 +17,6 @@ Polaris:
     - module load spack-pe-base/0.8.1
     - module load cmake/3.27.9 gcc/11.4.0
     - module list
-    - git clone https://github.com/kokkos/kokkos.git
-    - cd kokkos
     - export CMAKE_BUILD_PARALLEL_LEVEL=48
     - export ENV_CMAKE_OPTIONS=""
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_COMPILER=`pwd`/bin/nvcc_wrapper"

--- a/.gitlab/alcf-gitlab-ci.yml
+++ b/.gitlab/alcf-gitlab-ci.yml
@@ -1,0 +1,36 @@
+include:
+  - project: 'anl/ci-resources/defaults'
+    ref: main
+    file:
+      - '/runners.yml'
+
+Polaris:
+  stage: test
+  extends: .polaris-shell-runner
+  script:
+    - module use /opt/cray/pe/lmod/modulefiles/core
+    - module use /opt/cray/pe/lmod/modulefiles/craype-targets/default
+    - module load craype-x86-milan craype-accel-nvidia80
+    - module swap PrgEnv-nvhpc PrgEnv-gnu
+    - module use /soft/modulefiles
+    - module load cuda-PrgEnv-nvidia/12.2.91
+    - module load spack-pe-base/0.8.1
+    - module load cmake/3.27.9 gcc/11.4.0
+    - module list
+    - git clone https://github.com/kokkos/kokkos.git
+    - cd kokkos
+    - export CMAKE_BUILD_PARALLEL_LEVEL=48
+    - export ENV_CMAKE_OPTIONS=""
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_COMPILER=`pwd`/bin/nvcc_wrapper"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_VERBOSE_MAKEFILE=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Werror=all-warnings -Werror'"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_AMPERE80=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_CUDA=ON;"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_COMPILER_WARNINGS=ON;"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_TESTS=ON"
+    - ctest -VV
+        -D CDASH_MODEL=Nightly
+        -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}"
+        -S CTestRun.cmake
+        -D CTEST_SITE="gitlab-ci.alcf.anl.gov"
+        -D CTEST_BUILD_NAME="Polaris-A100"

--- a/.gitlab/sunspot-gitlab-ci.yml
+++ b/.gitlab/sunspot-gitlab-ci.yml
@@ -1,0 +1,40 @@
+include:
+  - project: 'anl/ci-resources/defaults'
+    ref: main
+    file:
+      - '/runners.yml'
+
+Aurora:
+  stage: test
+  extends: .aurora-batch-runner
+  variables:
+    ANL_AURORA_SCHEDULER_PARAMETERS: "-q debug -A kokkos_math -l select=1,walltime=60:00" 
+  script:
+    - module load cmake oneapi/eng-compiler
+    - module list
+    - git clone https://github.com/kokkos/kokkos.git
+    - cd kokkos
+    - export CMAKE_BUILD_PARALLEL_LEVEL=48
+    - export ENV_CMAKE_OPTIONS=""
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_BUILD_TYPE=Release"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_COMPILER=icpx"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_COMPILER_WARNINGS=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_SYCL=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_INTEL_PVC=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_NATIVE=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_TESTS=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-fsycl-device-code-split=per_kernel -fp-model=precise'"
+    - export CTEST_BUILD_NAME="INTEL-DATA-CENTER-MAX-1550"
+    - ctest -VV
+        -D CDASH_MODEL=Nightly
+        -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}"
+        -D OUTPUT_JUNIT_FILE=result_pvc1550.xml
+        -S CTestRun.cmake
+        -D CTEST_SITE="gitlab-sunspot.alcf.anl.gov"
+        -D CTEST_BUILD_NAME="${CTEST_BUILD_NAME}"
+  artifacts:
+    when: always
+    paths:
+      - kokkos/build/result_pvc1550.xml
+    reports:
+      junit: kokkos/build/result_pvc1550.xml

--- a/.gitlab/sunspot-gitlab-ci.yml
+++ b/.gitlab/sunspot-gitlab-ci.yml
@@ -22,14 +22,13 @@ Aurora:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_NATIVE=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_TESTS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-fsycl-device-code-split=per_kernel -fp-model=precise'"
-    - export CTEST_BUILD_NAME="INTEL-DATA-CENTER-MAX-1550"
     - ctest -VV
         -D CDASH_MODEL=Nightly
         -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}"
         -D OUTPUT_JUNIT_FILE=result_pvc1550.xml
         -S CTestRun.cmake
         -D CTEST_SITE="gitlab-sunspot.alcf.anl.gov"
-        -D CTEST_BUILD_NAME="${CTEST_BUILD_NAME}"
+        -D CTEST_BUILD_NAME="INTEL-DATA-CENTER-MAX-1550"
   artifacts:
     when: always
     paths:

--- a/.gitlab/sunspot-gitlab-ci.yml
+++ b/.gitlab/sunspot-gitlab-ci.yml
@@ -12,8 +12,6 @@ Aurora:
   script:
     - module load cmake oneapi/eng-compiler
     - module list
-    - git clone https://github.com/kokkos/kokkos.git
-    - cd kokkos
     - export CMAKE_BUILD_PARALLEL_LEVEL=48
     - export ENV_CMAKE_OPTIONS=""
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_BUILD_TYPE=Release"
@@ -35,6 +33,6 @@ Aurora:
   artifacts:
     when: always
     paths:
-      - kokkos/build/result_pvc1550.xml
+      - build/result_pvc1550.xml
     reports:
-      junit: kokkos/build/result_pvc1550.xml
+      junit: build/result_pvc1550.xml


### PR DESCRIPTION
These are the scripts used for https://gitlab-ci.alcf.anl.gov/anl/kokkos_math/kokkos_core and https://gitlab-sunspot.alcf.anl.gov/anl/CSC250STPM18_CNDA/kokkos right now.