### PR TITLE
Make [skip appveyor] skip appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,7 @@
 image:
   - Visual Studio 2019
+skip_commits:
+  message: /\[skip appveyor\]/
 clone_folder: c:\projects\source
 build_script:
 - cmd: >-


### PR DESCRIPTION
This should allow us to only skip the appveyor CI using `[skip appveyor]` in the commit message according to https://www.appveyor.com/docs/how-to/filtering-commits/#skip-commits.