### PR TITLE
CI: use flang if available

### DIFF
--- a/.github/workflows/continuous-integration-linux.yml
+++ b/.github/workflows/continuous-integration-linux.yml
@@ -83,8 +83,15 @@ jobs:
           key: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.cmake_build_type }}-${{ matrix.openmp }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.cmake_build_type }}-${{ matrix.openmp }}-${{ github.ref }}
       - name: maybe_use_flang_new
-        if: ${{ matrix.cxx == 'clang++' && startsWith(matrix.distro,'fedora:') }}
-        run: echo "FC=flang-new" >> $GITHUB_ENV
+        if: ${{ matrix.cxx == 'clang++' }}
+        run: |
+          if type flang; then
+            echo "flang found"
+            echo "FC=flang" >> $GITHUB_ENV
+          elif type flang-new; then
+            echo "flang-new found"
+            echo "FC=flang-new" >> $GITHUB_ENV
+          fi
       - name: Configure Kokkos
         run: |
           cmake -B builddir \

--- a/example/build_cmake_installed/CMakeLists.txt
+++ b/example/build_cmake_installed/CMakeLists.txt
@@ -12,6 +12,9 @@ find_package(Kokkos REQUIRED)
 add_executable(example cmake_example.cpp foo.f)
 if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
   set_target_properties(example PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(example PRIVATE -fno-fortran-main)
+  endif()
 endif()
 
 # This is the only thing required to set up compiler/linker flags


### PR DESCRIPTION
We have flang on ubuntu now, too, plus `flang-new` go renamed to `flang` (https://github.com/llvm/llvm-project/pull/110023).