### PR TITLE
Disable bugprone-unused-raii in the Clang+CUDA build on ORNL Jenkins CI

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -476,7 +476,7 @@ pipeline {
                         sh '''rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
-                                -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*" \
+                                -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*;--checks=-bugprone-unused-raii" \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=clang++ \
                                 -DCMAKE_CXX_FLAGS="-Werror -Wno-unknown-cuda-version" \


### PR DESCRIPTION
The `CUDA-11.0.3-Clang-Tidy` has been failing since the merge of #7744

As it turns out, the `NOLINTBEGIN` and `NOLINTEND` commands were only introduced in [Clang-Tidy 14](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/index.html), whereas our CI job uses [version 12](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/index.html).

Considering that the numeric traits is riddled with places that would raise that warning, I propose to just wholesale diable it in builds that use Clang-Tidy <14.