### PR TITLE
Use realistic setup for CEA nightly tests

### DIFF
--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -18,8 +18,8 @@ jobs:
         build_type:
           - Release
         backend:
-          - name: OpenMP-x86_64-GCC/10.3-Static-PIC
-            configure: -DKokkos_ENABLE_OPENMP=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+          - name: OpenMP-x86_64-GCC/10.3-Shared
+            configure: -DKokkos_ENABLE_OPENMP=ON -DBUILD_SHARED_LIBS=ON
             test: -e cpu OMP_PROC_BIND=spread OMP_PLACES=threads
             modules: gcc/10.3.0/gcc-4.8.5 cmake/3.28.3/gcc-11.2.0
 

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -3,7 +3,6 @@ name: Nightly CEA builds
 on:
   schedule:
     - cron: "0 2 * * 1-5" # every weekday at 2am UTC
-  pull_request: # XXX for testing only, remove before merging!
 
 permissions: read-all
 
@@ -78,9 +77,9 @@ jobs:
             ctest \
               -V \
               --test-dir build \
-              -D ExperimentalStart \
-              -D ExperimentalUpdate \
-              -D ExperimentalConfigure
+              -D NightlyStart \
+              -D NightlyUpdate \
+              -D NightlyConfigure
 
       - name: Build
         continue-on-error: true
@@ -92,7 +91,7 @@ jobs:
             ctest \
               -V \
               --test-dir build \
-              -D ExperimentalBuild
+              -D NightlyBuild
 
       - name: Test
         continue-on-error: true
@@ -103,7 +102,7 @@ jobs:
             ctest \
               --output-on-failure \
               --test-dir build \
-              -D ExperimentalTest
+              -D NightlyTest
 
       - name: Submit
         run: |
@@ -112,4 +111,4 @@ jobs:
             -e local \
             ctest \
               --test-dir build \
-              -D ExperimentalSubmit
+              -D NightlySubmit

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -3,6 +3,7 @@ name: Nightly CEA builds
 on:
   schedule:
     - cron: "0 2 * * 1-5" # every weekday at 2am UTC
+  pull_request: # XXX for testing only, remove before merging!
 
 permissions: read-all
 
@@ -77,9 +78,9 @@ jobs:
             ctest \
               -V \
               --test-dir build \
-              -D NightlyStart \
-              -D NightlyUpdate \
-              -D NightlyConfigure
+              -D ExperimentalStart \
+              -D ExperimentalUpdate \
+              -D ExperimentalConfigure
 
       - name: Build
         continue-on-error: true
@@ -91,7 +92,7 @@ jobs:
             ctest \
               -V \
               --test-dir build \
-              -D NightlyBuild
+              -D ExperimentalBuild
 
       - name: Test
         continue-on-error: true
@@ -102,7 +103,7 @@ jobs:
             ctest \
               --output-on-failure \
               --test-dir build \
-              -D NightlyTest
+              -D ExperimentalTest
 
       - name: Submit
         run: |
@@ -111,4 +112,4 @@ jobs:
             -e local \
             ctest \
               --test-dir build \
-              -D NightlySubmit
+              -D ExperimentalSubmit

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -18,9 +18,29 @@ jobs:
         build_type:
           - Release
         backend:
-          - name: Cuda-A100-GCC/11.2-Cuda/12.2.1
-            configure: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON
+          - name: OpenMP-x86_64-GCC/10.3-Static-PIC
+            configure: -DKokkos_ENABLE_OPENMP=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+            test: -e cpu OMP_PROC_BIND=spread OMP_PLACES=threads
+            modules: gcc/10.3.0/gcc-4.8.5 cmake/3.28.3/gcc-11.2.0
+
+          - name: Cuda-A100-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE
+            configure: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON -DKokkos_ENABLE_CUDA_CONSTEXPR=ON -DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON
             test: -e gpu -g a100
+            modules: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
+
+          - name: Cuda-A100-UVM-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE
+            configure: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON -DKokkos_ENABLE_CUDA_UVM=ON -DKokkos_ENABLE_CUDA_CONSTEXPR=ON -DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON
+            test: -e gpu -g a100
+            modules: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
+
+          - name: Cuda-V100-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE
+            configure: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_CUDA_CONSTEXPR=ON -DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON
+            test: -e gpu -g v100
+            modules: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
+
+          - name: Cuda-V100-UVM-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE
+            configure: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_CUDA_UVM=ON -DKokkos_ENABLE_CUDA_CONSTEXPR=ON -DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON
+            test: -e gpu -g v100
             modules: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
 
     runs-on: [self-hosted, cuda]
@@ -38,7 +58,7 @@ jobs:
             -e local \
             cmake \
               -B build \
-              -DBUILDNAME=${{ matrix.backend.name }} \
+              -DBUILDNAME=${{ matrix.backend.name }}-${{ matrix.build_type }} \
               -DSITE=cea-ruche \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DCMAKE_CXX_STANDARD=17 \


### PR DESCRIPTION
This PR updates the CEA nightly tests to take into consideration the configuration requests listed by our projects. Especially:

- OpenMP with older versions of GCC (10.3);
- Cuda with A100 and V100 GPUs;
- Shared libraries;
- Cuda relocatable device code;

Ideas to incorporate in another PR:

- C++ 20.

Progress:

- [x] Add configuration;
- [x] Prevent to use for pull requests and reenable Nightly mode.

Outcomes:

- OpenMP-x86_64-GCC/10.3-Shared-Release
  - [Workflow](https://github.com/kokkos/kokkos/actions/runs/13335573280/job/37249883937?pr=7762);
  - [Dashboard](https://my.cdash.org/build/2821875);
- Cuda-A100-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE-Release
  - [Workflow](https://github.com/kokkos/kokkos/actions/runs/13335573280/job/37249884229?pr=7762);
  - [Dashboard](https://my.cdash.org/build/2821829);
- Cuda-A100-UVM-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE-Release
  - [Workflow](https://github.com/kokkos/kokkos/actions/runs/13335573280/job/37249884461?pr=7762);
  - [Dashboard](https://my.cdash.org/build/2821852);
- Cuda-V100-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE-Release
  - [Workflow](https://github.com/kokkos/kokkos/actions/runs/13335573280/job/37249884717?pr=7762);
  - [Dashboard](https://my.cdash.org/build/2821839);
- Cuda-V100-UVM-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE-Release
  - [Workflow](https://github.com/kokkos/kokkos/actions/runs/13335573280/job/37249884963?pr=7762);
  - [Dashboard](https://my.cdash.org/build/2821869).

As for #7704, there is an error during the Update step, which is due to the branch of this PR belonging to a fork. As for the cited PR, this should fade away when merged.

The tests revealed an NVCC warning:

```text
/.../kokkos/core/src/impl/Kokkos_TaskBase.hpp(281): warning #20011-D: calling a __host__ function("Kokkos::Impl::HostThreadTeamMember< ::Kokkos::Serial> ::HostThreadTeamMember( ::Kokkos::Impl::HostThreadTeamData &)") from a __host__ __device__ function("Kokkos::Impl::HostThreadTeamMember< ::Kokkos::Serial> ::HostThreadTeamMember [subobject]") is not allowed
```

https://github.com/kokkos/kokkos/blob/bd466f63f1980db18e3509542325365c9b00cfe0/core/src/impl/Kokkos_TaskBase.hpp#L281

Maybe this should be assessed in another PR?