### PR TITLE
Enable bugprone-inc-dec-in-conditions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,7 +6,6 @@ Checks: >
   -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape,
   -bugprone-forwarding-reference-overload,
-  -bugprone-inc-dec-in-conditions,
   -bugprone-integer-division,
   -bugprone-macro-parentheses,
   -bugprone-misplaced-widening-cast,

--- a/algorithms/src/std_algorithms/impl/Kokkos_Unique.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Unique.hpp
@@ -185,6 +185,7 @@ KOKKOS_FUNCTION IteratorType unique_team_impl(const TeamHandleType& teamHandle,
           IteratorType result = first;
           IteratorType lfirst = first;
           while (++lfirst != last) {
+            // NOLINTNEXTLINE(bugprone-inc-dec-in-conditions)
             if (!pred(*result, *lfirst) && ++result != lfirst) {
               *result = std::move(*lfirst);
             }


### PR DESCRIPTION
Ignoring warning raised in the `unique()` team-level algo