### PR TITLE
Ease runtime xnack check

### DIFF
--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -82,7 +82,9 @@ Kokkos::HIP::initialize WARNING: Could not determine that xnack is enabled.
                                  ARCH_AMD_GFX942_APU (MI300A) to access host
                                  allocations from the device. Set HSA_XNACK=1
                                  in your environment. For further information
-                                 on HMM support check `Kokkos::print_configuration`.)warning"
+                                 on HMM support call `Kokkos::print_configuration`,
+                                 or run with KOKKOS_PRINT_CONFIGURATION=1 in your
+                                 environemnt.)warning"
               << "\n";
   }
 

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -84,8 +84,8 @@ Kokkos::HIP::initialize WARNING: Could not determine that xnack is enabled.
                                  in your environment. For further information
                                  on HMM support call `Kokkos::print_configuration`,
                                  or run with KOKKOS_PRINT_CONFIGURATION=1 in your
-                                 environemnt.)warning"
-              << "\n";
+                                 environment.
+)warning"
   }
 
   if ((Kokkos::show_warnings()) &&

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -85,7 +85,7 @@ Kokkos::HIP::initialize WARNING: Could not determine that xnack is enabled.
                                  on HMM support call `Kokkos::print_configuration`,
                                  or run with KOKKOS_PRINT_CONFIGURATION=1 in your
                                  environment.
-)warning"
+)warning";
   }
 
   if ((Kokkos::show_warnings()) &&

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -75,15 +75,14 @@ void HIP::impl_initialize(InitializationSettings const& settings) {
   }
 #endif
 #ifdef KOKKOS_ARCH_AMD_GFX942_APU
-  if (!Kokkos::Impl::xnack_enabled()) {
+  if (!Kokkos::Impl::xnack_environment_enabled()) {
     std::cerr << R"warning(
 Kokkos::HIP::initialize WARNING: Could not determine that xnack is enabled.
                                  Kokkos requires xnack to be enabled for
                                  ARCH_AMD_GFX942_APU (MI300A) to access host
                                  allocations from the device. Set HSA_XNACK=1
-                                 in your environment and ensure
-                                 \"CONFIG_HMM_MIRROR=y\" is in the /boot/config
-                                 file and that file is readable)warning"
+                                 in your environment. For further information
+                                 on HMM support check `Kokkos::print_configuration`.)warning"
               << "\n";
   }
 

--- a/core/src/HIP/Kokkos_HIP_IsXnack.cpp
+++ b/core/src/HIP/Kokkos_HIP_IsXnack.cpp
@@ -84,7 +84,7 @@ bool xnack_environment_enabled() {
   return cache;
 }
 
-bool xnack_hmm_found() {
+bool xnack_boot_config_has_hmm_mirror() {
   static bool cache = [] { return config_hmm_mirror_in_boot_config(); }();
   return cache;
 }

--- a/core/src/HIP/Kokkos_HIP_IsXnack.cpp
+++ b/core/src/HIP/Kokkos_HIP_IsXnack.cpp
@@ -80,12 +80,12 @@ bool config_hmm_mirror_in_boot_config() {
 namespace Kokkos::Impl {
 
 bool xnack_environment_enabled() {
-  static bool cache = [] { return config_hmm_mirror_in_boot_config(); }();
+  static bool cache = [] { return hsa_xnack_enabled_in_host_environment(); }();
   return cache;
 }
 
 bool xnack_hmm_found() {
-  static bool cache = [] { return hsa_xnack_enabled_in_host_environment(); }();
+  static bool cache = [] { return config_hmm_mirror_in_boot_config(); }();
   return cache;
 }
 

--- a/core/src/HIP/Kokkos_HIP_IsXnack.cpp
+++ b/core/src/HIP/Kokkos_HIP_IsXnack.cpp
@@ -79,11 +79,13 @@ bool config_hmm_mirror_in_boot_config() {
 
 namespace Kokkos::Impl {
 
-bool xnack_enabled() {
-  static bool cache = [] {
-    return config_hmm_mirror_in_boot_config() &&
-           hsa_xnack_enabled_in_host_environment();
-  }();
+bool xnack_environment_enabled() {
+  static bool cache = [] { return config_hmm_mirror_in_boot_config(); }();
+  return cache;
+}
+
+bool xnack_hmm_found() {
+  static bool cache = [] { return hsa_xnack_enabled_in_host_environment(); }();
   return cache;
 }
 

--- a/core/src/HIP/Kokkos_HIP_IsXnack.hpp
+++ b/core/src/HIP/Kokkos_HIP_IsXnack.hpp
@@ -21,10 +21,7 @@
 
 namespace Kokkos::Impl {
 
-/* Returns true iff we think the AMD MI300A can access allocations created with
-the system allocator.
-
-Based on AMD's ROCm 6.3.1 documentation:
+/*Based on AMD's ROCm 6.3.1 documentation:
 https://github.com/ROCm/HIP/blob/2c240cacff16c2bb18ce9e5b4c1b937ab17a0199/docs/how-to/hip_runtime_api/memory_management/unified_memory.rst?plain=1#L141-L146
 
     To ensure the proper functioning of system allocated unified memory on
@@ -43,7 +40,11 @@ be modified if a better way is determined to check for HMM support in Linux.
 Checking for CONFIG_HMM was considered, but it was not present on El Capitan,
 so we infer its presence is not necessary.
 */
-bool xnack_enabled();
+
+// Returns true iff we detect HSA_XNACK=1 in the environment.
+bool xnack_environment_enabled();
+// Returns true iff we detect CONFIG_HMM_MIROR=y in /boot/config-$(uname -r).
+bool xnack_hmm_found();
 }  // namespace Kokkos::Impl
 
 #endif  // KOKKOS_HIP_ISXNACK_HPP

--- a/core/src/HIP/Kokkos_HIP_IsXnack.hpp
+++ b/core/src/HIP/Kokkos_HIP_IsXnack.hpp
@@ -44,7 +44,7 @@ so we infer its presence is not necessary.
 // Returns true iff we detect HSA_XNACK=1 in the environment.
 bool xnack_environment_enabled();
 // Returns true iff we detect CONFIG_HMM_MIROR=y in /boot/config-$(uname -r).
-bool xnack_hmm_found();
+bool xnack_boot_config_has_hmm_mirror();
 }  // namespace Kokkos::Impl
 
 #endif  // KOKKOS_HIP_ISXNACK_HPP

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -187,12 +187,12 @@ Kokkos::HIP::allocation WARNING: The combination of device and system configurat
         }
 
         // check for correct runtime environment
-        if (!Kokkos::Impl::xnack_enabled())
+        if (!Kokkos::Impl::xnack_environment_enabled())
           std::cerr << R"warning(
 Kokkos::HIP::runtime WARNING: Kokkos was not able to verify that xnack is enabled.
                               Without xnack enabled, Kokkos::HIPManaged might not behave as expected.
-                              Set HSA_XNACK=1 in your environment and ensure "CONFIG_HMM_MIRROR=y"
-                              is in the /boot/config file and that file is readable.)warning"
+                              Set HSA_XNACK=1 in your environment. For further information on HMM support
+                              check `Kokkos::print_configuration`.)warning"
                     << std::endl;
       } while (false);
     }

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -194,7 +194,7 @@ Kokkos::HIP::runtime WARNING: Kokkos was not able to verify that xnack is enable
                               Set HSA_XNACK=1 in your environment. For further information on HMM support
                               call `Kokkos::print_configuration`, or run with KOKKOS_PRINT_CONFIGURATION=1
                               in your environment.
-)warning"
+)warning";
       } while (false);
     }
     auto const error_code = hipMallocManaged(&ptr, arg_alloc_size);

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -192,7 +192,8 @@ Kokkos::HIP::allocation WARNING: The combination of device and system configurat
 Kokkos::HIP::runtime WARNING: Kokkos was not able to verify that xnack is enabled.
                               Without xnack enabled, Kokkos::HIPManaged might not behave as expected.
                               Set HSA_XNACK=1 in your environment. For further information on HMM support
-                              check `Kokkos::print_configuration`.)warning"
+                              call `Kokkos::print_configuration`, or run with KOKKOS_PRINT_CONFIGURATION=1
+                              in your environment.)warning"
                     << std::endl;
       } while (false);
     }

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -193,8 +193,8 @@ Kokkos::HIP::runtime WARNING: Kokkos was not able to verify that xnack is enable
                               Without xnack enabled, Kokkos::HIPManaged might not behave as expected.
                               Set HSA_XNACK=1 in your environment. For further information on HMM support
                               call `Kokkos::print_configuration`, or run with KOKKOS_PRINT_CONFIGURATION=1
-                              in your environment.)warning"
-                    << std::endl;
+                              in your environment.
+)warning"
       } while (false);
     }
     auto const error_code = hipMallocManaged(&ptr, arg_alloc_size);


### PR DESCRIPTION
fixes #7727

This PR proposes to split the xnack check into two stages. Checking for the environment variable and the HMM kernel module. The environment check can be used in containers and will always be on, fixing #7727. The HMM kernel part of the check will be pushed into `print_configuration` in #7673. If we don't find the environment variable we print a warning including a hint to use `print_configuration`.

Rationale:
It is rather unlikely that users will know that they will have to set `HSA_XNACK=1` but do use a kernel without support for HMM.