### PR TITLE
Fix ROCm 5.3

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -96,6 +96,11 @@ void* HIPSpace::impl_allocate(const int device_id,
                               const size_t arg_logical_size,
                               [[maybe_unused]] bool stream_sync_only) const {
   void* ptr = nullptr;
+  // ROCm 5.5 and earlier throw an error when using hipMallocAsync and
+  // arg_alloc_size is zero. Instead of trying to allocate memory, just return
+  // early.
+  if (arg_alloc_size == 0) return ptr;
+
   KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(device_id));
 
 #ifdef KOKKOS_ENABLE_IMPL_HIP_MALLOC_ASYNC

--- a/core/unit_test/TestNonTrivialScalarTypes.hpp
+++ b/core/unit_test/TestNonTrivialScalarTypes.hpp
@@ -141,7 +141,7 @@ struct array_reduce {
   KOKKOS_INLINE_FUNCTION
   array_reduce &operator=(const array_reduce &src) {
     // ROCm 5.5 and earlier returns the wrong result when early return is enable
-#if !defined(KOKKOKS_ENABLE_HIP) || (HIP_VERSION_MAJOR > 5) || \
+#if !defined(KOKKOS_ENABLE_HIP) || (HIP_VERSION_MAJOR > 5) || \
     ((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR >= 6))
     if (&src == this) return *this;
 #endif


### PR DESCRIPTION
This PR fixes the issue with ROCm 5.3:
 1. Fix the typo in the macro introduced in [here](https://github.com/kokkos/kokkos/pull/7761#discussion_r1956647202)
 2. ROCm 5.5 and earlier return an error code when using `hipMallocAsync` to allocate a memory block of size zero. Instead of trying to allocate memory, I just return early. I've decided to return early for all versions of ROCm but I am fine doing it only for ROCm 5.5 and earlier. I am just trying to minimize the code differences between ROCm versions.