### PR TITLE
DualView: Skip sync and modify for host-accessible memory space

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -600,7 +600,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
   }
 
   template <class Device, class ExecutionSpace>
-  void sync(const ExecutionSpace& exec) {
+  void sync([[maybe_unused]] const ExecutionSpace& exec) {
     if constexpr (impl_dualview_stores_single_view)
       return;
     else {
@@ -661,7 +661,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
   }
 
   template <class ExecSpace>
-  void sync_host(const ExecSpace& exec) {
+  void sync_host([[maybe_unused]] const ExecSpace& exec) {
     if constexpr (impl_dualview_stores_single_view)
       return;
     else
@@ -701,7 +701,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
   }
 
   template <class ExecSpace>
-  void sync_device(const ExecSpace& exec) {
+  void sync_device([[maybe_unused]] const ExecSpace& exec) {
     if constexpr (impl_dualview_stores_single_view)
       return;
     else

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -209,9 +209,10 @@ class DualView : public ViewTraits<DataType, Properties...> {
   t_modified_flags modified_flags;
 
  public:
-  // does the DualView have only one device
+  // does the DualView only reference one View
   static constexpr bool impl_dualview_stores_single_view =
-      std::is_same_v<typename t_dev::device_type, typename t_host::device_type>;
+      SpaceAccessibility<Kokkos::HostSpace,
+                         typename t_dev::memory_space>::accessible;
 
  public:
   //@}
@@ -586,24 +587,29 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
   template <class Device>
   void sync() {
-    if (impl_dualview_stores_single_view) return;
-
-    if constexpr (std::is_same_v<typename traits::data_type,
-                                 typename traits::non_const_data_type>)
-      sync_impl<Device>(std::true_type{});
-    else
-      sync_impl<Device>(std::false_type{});
+    if constexpr (impl_dualview_stores_single_view) {
+      Kokkos::fence();
+      return;
+    } else {
+      if constexpr (std::is_same_v<typename traits::data_type,
+                                   typename traits::non_const_data_type>)
+        sync_impl<Device>(std::true_type{});
+      else
+        sync_impl<Device>(std::false_type{});
+    }
   }
 
   template <class Device, class ExecutionSpace>
   void sync(const ExecutionSpace& exec) {
-    if (impl_dualview_stores_single_view) return;
-
-    if constexpr (std::is_same_v<typename traits::data_type,
-                                 typename traits::non_const_data_type>)
-      sync_impl<Device>(std::true_type{}, exec);
-    else
-      sync_impl<Device>(std::false_type{}, exec);
+    if constexpr (impl_dualview_stores_single_view)
+      return;
+    else {
+      if constexpr (std::is_same_v<typename traits::data_type,
+                                   typename traits::non_const_data_type>)
+        sync_impl<Device>(std::true_type{}, exec);
+      else
+        sync_impl<Device>(std::false_type{}, exec);
+    }
   }
 
   // deliberately passing args by cref as they're used multiple times
@@ -656,9 +662,18 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
   template <class ExecSpace>
   void sync_host(const ExecSpace& exec) {
-    sync_host_impl(exec);
+    if constexpr (impl_dualview_stores_single_view)
+      return;
+    else
+      sync_host_impl(exec);
   }
-  void sync_host() { sync_host_impl(); }
+  void sync_host() {
+    if constexpr (impl_dualview_stores_single_view) {
+      Kokkos::fence();
+      return;
+    } else
+      sync_host_impl();
+  }
 
   // deliberately passing args by cref as they're used multiple times
   template <typename... Args>
@@ -687,9 +702,18 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
   template <class ExecSpace>
   void sync_device(const ExecSpace& exec) {
-    sync_device_impl(exec);
+    if constexpr (impl_dualview_stores_single_view)
+      return;
+    else
+      sync_device_impl(exec);
   }
-  void sync_device() { sync_device_impl(); }
+  void sync_device() {
+    if constexpr (impl_dualview_stores_single_view) {
+      Kokkos::fence();
+      return;
+    } else
+      sync_device_impl();
+  }
 
   template <class Device>
   bool need_sync() const {
@@ -745,55 +769,35 @@ class DualView : public ViewTraits<DataType, Properties...> {
   /// data as modified.
   template <class Device>
   void modify() {
-    if (impl_dualview_stores_single_view) return;
+    if constexpr (impl_dualview_stores_single_view) {
+      return;
+    } else {
+      if (modified_flags.data() == nullptr) {
+        modified_flags = t_modified_flags("DualView::modified_flags");
+      }
 
-    if (modified_flags.data() == nullptr) {
-      modified_flags = t_modified_flags("DualView::modified_flags");
-    }
+      int dev = get_device_side<Device>();
 
-    int dev = get_device_side<Device>();
+      if (dev == 1) {  // if Device is the same as DualView's device type
+        // Increment the device's modified count.
+        modified_flags(1) =
+            (modified_flags(1) > modified_flags(0) ? modified_flags(1)
+                                                   : modified_flags(0)) +
+            1;
+        impl_report_device_modification();
+      }
+      if (dev == 0) {  // hopefully Device is the same as DualView's host type
+        // Increment the host's modified count.
+        modified_flags(0) =
+            (modified_flags(1) > modified_flags(0) ? modified_flags(1)
+                                                   : modified_flags(0)) +
+            1;
+        impl_report_host_modification();
+      }
 
-    if (dev == 1) {  // if Device is the same as DualView's device type
-      // Increment the device's modified count.
-      modified_flags(1) =
-          (modified_flags(1) > modified_flags(0) ? modified_flags(1)
-                                                 : modified_flags(0)) +
-          1;
-      impl_report_device_modification();
-    }
-    if (dev == 0) {  // hopefully Device is the same as DualView's host type
-      // Increment the host's modified count.
-      modified_flags(0) =
-          (modified_flags(1) > modified_flags(0) ? modified_flags(1)
-                                                 : modified_flags(0)) +
-          1;
-      impl_report_host_modification();
-    }
-
-#ifdef KOKKOS_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK
-    if (modified_flags(0) && modified_flags(1)) {
-      std::string msg = "Kokkos::DualView::modify ERROR: ";
-      msg += "Concurrent modification of host and device views ";
-      msg += "in DualView \"";
-      msg += d_view.label();
-      msg += "\"\n";
-      Kokkos::abort(msg.c_str());
-    }
-#endif
-  }
-
-  inline void modify_host() {
-    if (impl_dualview_stores_single_view) return;
-
-    if (modified_flags.data() != nullptr) {
-      modified_flags(0) =
-          (modified_flags(1) > modified_flags(0) ? modified_flags(1)
-                                                 : modified_flags(0)) +
-          1;
-      impl_report_host_modification();
 #ifdef KOKKOS_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK
       if (modified_flags(0) && modified_flags(1)) {
-        std::string msg = "Kokkos::DualView::modify_host ERROR: ";
+        std::string msg = "Kokkos::DualView::modify ERROR: ";
         msg += "Concurrent modification of host and device views ";
         msg += "in DualView \"";
         msg += d_view.label();
@@ -801,28 +805,54 @@ class DualView : public ViewTraits<DataType, Properties...> {
         Kokkos::abort(msg.c_str());
       }
 #endif
+    }
+  }
+
+  inline void modify_host() {
+    if constexpr (impl_dualview_stores_single_view) {
+      return;
+    } else {
+      if (modified_flags.data() != nullptr) {
+        modified_flags(0) =
+            (modified_flags(1) > modified_flags(0) ? modified_flags(1)
+                                                   : modified_flags(0)) +
+            1;
+        impl_report_host_modification();
+#ifdef KOKKOS_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK
+        if (modified_flags(0) && modified_flags(1)) {
+          std::string msg = "Kokkos::DualView::modify_host ERROR: ";
+          msg += "Concurrent modification of host and device views ";
+          msg += "in DualView \"";
+          msg += d_view.label();
+          msg += "\"\n";
+          Kokkos::abort(msg.c_str());
+        }
+#endif
+      }
     }
   }
 
   inline void modify_device() {
-    if (impl_dualview_stores_single_view) return;
-
-    if (modified_flags.data() != nullptr) {
-      modified_flags(1) =
-          (modified_flags(1) > modified_flags(0) ? modified_flags(1)
-                                                 : modified_flags(0)) +
-          1;
-      impl_report_device_modification();
+    if constexpr (impl_dualview_stores_single_view) {
+      return;
+    } else {
+      if (modified_flags.data() != nullptr) {
+        modified_flags(1) =
+            (modified_flags(1) > modified_flags(0) ? modified_flags(1)
+                                                   : modified_flags(0)) +
+            1;
+        impl_report_device_modification();
 #ifdef KOKKOS_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK
-      if (modified_flags(0) && modified_flags(1)) {
-        std::string msg = "Kokkos::DualView::modify_device ERROR: ";
-        msg += "Concurrent modification of host and device views ";
-        msg += "in DualView \"";
-        msg += d_view.label();
-        msg += "\"\n";
-        Kokkos::abort(msg.c_str());
-      }
+        if (modified_flags(0) && modified_flags(1)) {
+          std::string msg = "Kokkos::DualView::modify_device ERROR: ";
+          msg += "Concurrent modification of host and device views ";
+          msg += "in DualView \"";
+          msg += d_view.label();
+          msg += "\"\n";
+          Kokkos::abort(msg.c_str());
+        }
 #endif
+      }
     }
   }
 

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -588,7 +588,8 @@ class DualView : public ViewTraits<DataType, Properties...> {
   template <class Device>
   void sync() {
     if constexpr (impl_dualview_stores_single_view) {
-      Kokkos::fence();
+      Kokkos::fence(
+          "Kokkos::DualView: fence for sync with host-accessible memory space");
       return;
     } else {
       if constexpr (std::is_same_v<typename traits::data_type,
@@ -669,7 +670,9 @@ class DualView : public ViewTraits<DataType, Properties...> {
   }
   void sync_host() {
     if constexpr (impl_dualview_stores_single_view) {
-      Kokkos::fence();
+      Kokkos::fence(
+          "Kokkos::DualView: fence for sync_host with host-accessible memory "
+          "space");
       return;
     } else
       sync_host_impl();
@@ -709,7 +712,9 @@ class DualView : public ViewTraits<DataType, Properties...> {
   }
   void sync_device() {
     if constexpr (impl_dualview_stores_single_view) {
-      Kokkos::fence();
+      Kokkos::fence(
+          "Kokkos::DualView: fence for sync_device with host-accessible memory "
+          "space");
       return;
     } else
       sync_device_impl();


### PR DESCRIPTION
Partly reverts #7748. `DualView` references only one `View` if the memory space is host-accessible. So far, we only skipped sync and modify if `t_dev`'s and `t_host`s `device_type` were the same. Given that that the `t_host` is a `HostMiror`, this effectively means that we would only skip `sync` and `modify` if the memory space is `HostSpace` to begin with.
This pull request proposes to skip `sync` and `modify` whenever the `DualView` only references one `View`. To keep code like
```C++
DualView<> a("a", 10);
A.modify<device>();
Kokkos::parallel_for<device>([=](int i){
a(i)=1;
});
A.sync<host>();
std::cout<<a.h_view(0)<<std::endl;
```
working (where the device's memory space is host-accessible, e.g., Kokkos::SharedSpace) the `sync*` overloads without an execution space instance argument still need to call `Kokkos::fence` since that's what downstream users are expecting (and it's an API without execution space instance). Note that the current behavior should cause problems with host asynchronous backends like `HPX` already when using this pattern.

User-visible changes are that `need_sync*` will always return `false` if the memory space is host-accessible.