### PR TITLE
simd: fix simd class operator inconsistencies

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -56,11 +56,24 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
  public:
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 4;
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      value_type value)
+      value_type value) noexcept
       : m_value(_mm256_castsi256_pd(_mm256_set1_epi64x(-std::int64_t(value)))) {
   }
+  template <class U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+      basic_simd_mask<U, simd_abi::avx2_fixed_size<4>> const& other) noexcept
+      : m_value(static_cast<__m256d>(other)) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+      __m256d const& value_in) noexcept
+      : m_value(value_in) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -73,43 +86,57 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
             -std::int64_t(gen(std::integral_constant<std::size_t, 1>())),
             -std::int64_t(gen(std::integral_constant<std::size_t, 2>())),
             -std::int64_t(gen(std::integral_constant<std::size_t, 3>()))))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  basic_simd_mask(
       basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
-          i32_mask);
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 4;
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      __m256d const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256d()
-      const {
-    return m_value;
-  }
+          i32_mask) noexcept;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
     return (_mm256_movemask_pd(m_value) & (1 << i)) != 0;
   }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator||(basic_simd_mask const& other) const {
-    return basic_simd_mask(_mm256_or_pd(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator&&(basic_simd_mask const& other) const {
-    return basic_simd_mask(_mm256_and_pd(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+  operator!() const noexcept {
     auto const true_value = static_cast<__m256d>(basic_simd_mask(true));
     return basic_simd_mask(_mm256_andnot_pd(m_value, true_value));
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256d()
+      const noexcept {
+    return m_value;
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_and_pd(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_or_pd(lhs.m_value, rhs.m_value));
+  }
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const {
+      basic_simd_mask const& other) const noexcept {
     return _mm256_movemask_pd(m_value) == _mm256_movemask_pd(other.m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const {
+      basic_simd_mask const& other) const noexcept {
     return !operator==(other);
   }
+#else
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_movemask_pd(lhs.m_value) ==
+                           _mm256_movemask_pd(rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return !operator==(lhs, rhs);
+  }
+#endif
 };
 
 template <>
@@ -119,10 +146,19 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
  public:
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 4;
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      value_type value)
+      value_type value) noexcept
       : m_value(_mm_castsi128_ps(_mm_set1_epi32(-std::int32_t(value)))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+      __m128 const& value_in) noexcept
+      : m_value(value_in) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -135,40 +171,52 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
             -std::int32_t(gen(std::integral_constant<std::size_t, 1>())),
             -std::int32_t(gen(std::integral_constant<std::size_t, 2>())),
             -std::int32_t(gen(std::integral_constant<std::size_t, 3>()))))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 4;
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      __m128 const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128()
-      const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
     return (_mm_movemask_ps(m_value) & (1 << i)) != 0;
   }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator||(basic_simd_mask const& other) const {
-    return basic_simd_mask(_mm_or_ps(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator&&(basic_simd_mask const& other) const {
-    return basic_simd_mask(_mm_and_ps(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+  operator!() const noexcept {
     auto const true_value = static_cast<__m128>(basic_simd_mask(true));
     return basic_simd_mask(_mm_andnot_ps(m_value, true_value));
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128()
+      const noexcept {
+    return m_value;
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm_and_ps(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm_or_ps(lhs.m_value, rhs.m_value));
+  }
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const {
+      basic_simd_mask const& other) const noexcept {
     return _mm_movemask_ps(m_value) == _mm_movemask_ps(other.m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const {
+      basic_simd_mask const& other) const noexcept {
     return !operator==(other);
   }
+#else
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm_movemask_ps(lhs.m_value) ==
+                           _mm_movemask_ps(rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return !operator==(lhs, rhs);
+  }
+#endif
 };
 
 template <>
@@ -178,10 +226,18 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
  public:
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      value_type value)
+      value_type value) noexcept
       : m_value(_mm256_castsi256_ps(_mm256_set1_epi32(-std::int32_t(value)))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+      __m256 const& value_in) noexcept
+      : m_value(value_in) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -198,40 +254,52 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
             -std::int32_t(gen(std::integral_constant<std::size_t, 5>())),
             -std::int32_t(gen(std::integral_constant<std::size_t, 6>())),
             -std::int32_t(gen(std::integral_constant<std::size_t, 7>()))))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 8;
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      __m256 const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256()
-      const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
     return (_mm256_movemask_ps(m_value) & (1 << i)) != 0;
   }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator||(basic_simd_mask const& other) const {
-    return basic_simd_mask(_mm256_or_ps(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator&&(basic_simd_mask const& other) const {
-    return basic_simd_mask(_mm256_and_ps(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+  operator!() const noexcept {
     auto const true_value = static_cast<__m256>(basic_simd_mask(true));
     return basic_simd_mask(_mm256_andnot_ps(m_value, true_value));
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256()
+      const noexcept {
+    return m_value;
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_and_ps(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_or_ps(lhs.m_value, rhs.m_value));
+  }
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const {
-    return _mm256_movemask_ps(m_value) == _mm256_movemask_ps(other.m_value);
+      basic_simd_mask const& other) const noexcept {
+    return _mm256_movemask_ps(m_value) == _mm256_movemask_ps(other);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const {
+      basic_simd_mask const& other) const noexcept {
     return !operator==(other);
   }
+#else
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_movemask_ps(lhs.m_value) ==
+                           _mm256_movemask_ps(rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return !operator==(lhs, rhs);
+  }
+#endif
 };
 
 template <>
@@ -241,15 +309,23 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
  public:
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      value_type value)
-      : m_value(_mm_set1_epi32(-std::int32_t(value))) {}
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      value_type value) noexcept
+      : m_value(_mm_set1_epi32(-std::int32_t(value))) {}
+  template <class U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<U, abi_type> const& other) noexcept {
+    m_value = _mm_setr_epi32(-std::int32_t(other[0]), -std::int32_t(other[1]),
+                             -std::int32_t(other[2]), -std::int32_t(other[3]));
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      __m128i const& value_in)
+      __m128i const& value_in) noexcept
       : m_value(value_in) {}
   template <class G,
             std::enable_if_t<
@@ -263,41 +339,53 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
             -std::int32_t(gen(std::integral_constant<std::size_t, 1>())),
             -std::int32_t(gen(std::integral_constant<std::size_t, 2>())),
             -std::int32_t(gen(std::integral_constant<std::size_t, 3>())))) {}
-  template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
-      basic_simd_mask<U, abi_type> const& other) {
-    m_value = _mm_setr_epi32(-std::int32_t(other[0]), -std::int32_t(other[1]),
-                             -std::int32_t(other[2]), -std::int32_t(other[3]));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128i()
-      const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
     return (_mm_movemask_ps(_mm_castsi128_ps(m_value)) & (1 << i)) != 0;
   }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator||(basic_simd_mask const& other) const {
-    return basic_simd_mask(_mm_or_si128(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator&&(basic_simd_mask const& other) const {
-    return basic_simd_mask(_mm_and_si128(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+  operator!() const noexcept {
     auto const true_value = static_cast<__m128i>(basic_simd_mask(true));
     return basic_simd_mask(_mm_andnot_si128(m_value, true_value));
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128i()
+      const noexcept {
+    return m_value;
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm_and_si128(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm_or_si128(lhs.m_value, rhs.m_value));
+  }
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const {
+      basic_simd_mask const& other) const noexcept {
     return _mm_movemask_ps(_mm_castsi128_ps(m_value)) ==
            _mm_movemask_ps(_mm_castsi128_ps(other.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const {
+      basic_simd_mask const& other) const noexcept {
     return !operator==(other);
   }
+#else
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm_movemask_ps(_mm_castsi128_ps(lhs.m_value)) ==
+                           _mm_movemask_ps(_mm_castsi128_ps(rhs.m_value)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return !operator==(lhs, rhs);
+  }
+#endif
 };
 
 template <>
@@ -307,15 +395,22 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
  public:
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      value_type value)
-      : m_value(_mm256_set1_epi32(-std::int32_t(value))) {}
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      value_type value) noexcept
+      : m_value(_mm256_set1_epi32(-std::int32_t(value))) {}
+  template <class U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<U, abi_type> const& other) noexcept {
+    for (std::size_t i = 0; i < size(); ++i) (*this)[i] = other[i];
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      __m256i const& value_in)
+      __m256i const& value_in) noexcept
       : m_value(value_in) {}
   template <class G,
             std::enable_if_t<
@@ -333,40 +428,54 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
             -std::int32_t(gen(std::integral_constant<std::size_t, 5>())),
             -std::int32_t(gen(std::integral_constant<std::size_t, 6>())),
             -std::int32_t(gen(std::integral_constant<std::size_t, 7>())))) {}
-  template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
-      basic_simd_mask<U, abi_type> const& other) {
-    for (std::size_t i = 0; i < size(); ++i) (*this)[i] = other[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
-      const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
+  operator[](std::size_t i) const noexcept {
     return (_mm256_movemask_ps(_mm256_castsi256_ps(m_value)) & (1 << i)) != 0;
   }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator||(basic_simd_mask const& other) const {
-    return basic_simd_mask(_mm256_or_si256(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator&&(basic_simd_mask const& other) const {
-    return basic_simd_mask(_mm256_and_si256(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+  operator!() const noexcept {
     auto const true_value = static_cast<__m256i>(basic_simd_mask(true));
     return basic_simd_mask(_mm256_andnot_si256(m_value, true_value));
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
+      const noexcept {
+    return m_value;
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
+  }
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const {
+      basic_simd_mask const& other) const noexcept {
     return _mm256_movemask_ps(_mm256_castsi256_ps(m_value)) ==
            _mm256_movemask_ps(_mm256_castsi256_ps(other.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const {
+      basic_simd_mask const& other) const noexcept {
     return !operator==(other);
   }
+#else
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(
+        _mm256_movemask_ps(_mm256_castsi256_ps(lhs.m_value)) ==
+        _mm256_movemask_ps(_mm256_castsi256_ps(rhs.m_value)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return !operator==(lhs, rhs);
+  }
+#endif
 };
 
 template <>
@@ -376,15 +485,20 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
  public:
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      value_type value)
-      : m_value(_mm256_set1_epi64x(-std::int64_t(value))) {}
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      value_type value) noexcept
+      : m_value(_mm256_set1_epi64x(-std::int64_t(value))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      __m256i const& value_in)
+      __m256i const& value_in) noexcept
       : m_value(value_in) {}
   template <class G,
             std::enable_if_t<
@@ -398,38 +512,54 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
             -std::int64_t(gen(std::integral_constant<std::size_t, 1>())),
             -std::int64_t(gen(std::integral_constant<std::size_t, 2>())),
             -std::int64_t(gen(std::integral_constant<std::size_t, 3>())))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
-      basic_simd_mask<std::int32_t, abi_type> const& other)
-      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
-      const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
     return (_mm256_movemask_pd(_mm256_castsi256_pd(m_value)) & (1 << i)) != 0;
   }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator||(basic_simd_mask const& other) const {
-    return basic_simd_mask(_mm256_or_si256(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator&&(basic_simd_mask const& other) const {
-    return basic_simd_mask(_mm256_and_si256(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+  operator!() const noexcept {
     auto const true_value = static_cast<__m256i>(basic_simd_mask(true));
     return basic_simd_mask(_mm256_andnot_si256(m_value, true_value));
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
+      const noexcept {
+    return m_value;
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
+  }
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const {
+      basic_simd_mask const& other) const noexcept {
     return _mm256_movemask_pd(_mm256_castsi256_pd(m_value)) ==
            _mm256_movemask_pd(_mm256_castsi256_pd(other.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const {
+      basic_simd_mask const& other) const noexcept {
     return !operator==(other);
   }
+#else
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(
+        _mm256_movemask_pd(_mm256_castsi256_pd(lhs.m_value)) ==
+        _mm256_movemask_pd(_mm256_castsi256_pd(rhs.m_value)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return !operator==(lhs, rhs);
+  }
+#endif
 };
 
 template <>
@@ -439,18 +569,20 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
  public:
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      value_type value)
-      : m_value(_mm256_set1_epi64x(-std::int64_t(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
-      basic_simd_mask<std::int32_t, abi_type> const& other)
-      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      value_type value) noexcept
+      : m_value(_mm256_set1_epi64x(-std::int64_t(value))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      __m256i const& value_in)
+      __m256i const& value_in) noexcept
       : m_value(value_in) {}
   template <class G,
             std::enable_if_t<
@@ -464,40 +596,60 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
             -std::int64_t(gen(std::integral_constant<std::size_t, 1>())),
             -std::int64_t(gen(std::integral_constant<std::size_t, 2>())),
             -std::int64_t(gen(std::integral_constant<std::size_t, 3>())))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
-      const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
     return (_mm256_movemask_pd(_mm256_castsi256_pd(m_value)) & (1 << i)) != 0;
   }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator||(basic_simd_mask const& other) const {
-    return basic_simd_mask(_mm256_or_si256(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator&&(basic_simd_mask const& other) const {
-    return basic_simd_mask(_mm256_and_si256(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+  operator!() const noexcept {
     auto const true_value = static_cast<__m256i>(basic_simd_mask(true));
     return basic_simd_mask(_mm256_andnot_si256(m_value, true_value));
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
+      const noexcept {
+    return m_value;
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
+  }
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const {
+      basic_simd_mask const& other) const noexcept {
     return _mm256_movemask_pd(_mm256_castsi256_pd(m_value)) ==
            _mm256_movemask_pd(_mm256_castsi256_pd(other.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const {
+      basic_simd_mask const& other) const noexcept {
     return !operator==(other);
   }
+#else
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(
+        _mm256_movemask_pd(_mm256_castsi256_pd(lhs.m_value)) ==
+        _mm256_movemask_pd(_mm256_castsi256_pd(rhs.m_value)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return !operator==(lhs, rhs);
+  }
+#endif
 };
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& i32_mask)
+    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
+        i32_mask) noexcept
     : m_value(_mm256_castsi256_pd(
           _mm256_cvtepi32_epi64(static_cast<__m128i>(i32_mask)))) {}
 
@@ -509,22 +661,26 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
   using value_type = double;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
-      default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_pd(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m256d const& value_in)
+      __m256d const& value_in) noexcept
       : m_value(value_in) {}
   template <class G,
             std::enable_if_t<
@@ -543,12 +699,6 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
       value_type const* ptr, FlagType flag) {
     copy_from(ptr, flag);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    value_type tmp[size()];
-    _mm256_storeu_pd(tmp, m_value);
-    return tmp[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
     m_value = _mm256_loadu_pd(ptr);
@@ -565,10 +715,19 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
                                                      vector_aligned_tag) const {
     _mm256_store_pd(ptr, m_value);
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    value_type tmp[size()];
+    _mm256_storeu_pd(tmp, m_value);
+    return tmp[i];
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256d()
-      const {
+      const noexcept {
     return m_value;
   }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
     return basic_simd(
@@ -576,49 +735,26 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_add_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_sub_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm256_mul_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
-
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm256_div_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_add_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_sub_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
-                                   static_cast<__m256d>(rhs), _CMP_LT_OS));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
-                                   static_cast<__m256d>(rhs), _CMP_GT_OS));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
-                                   static_cast<__m256d>(rhs), _CMP_LE_OS));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
-                                   static_cast<__m256d>(rhs), _CMP_GE_OS));
-  }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
@@ -628,6 +764,26 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
   operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_NEQ_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
+                                   static_cast<__m256d>(rhs), _CMP_GE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
+                                   static_cast<__m256d>(rhs), _CMP_LE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
+                                   static_cast<__m256d>(rhs), _CMP_GT_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
+                                   static_cast<__m256d>(rhs), _CMP_LT_OS));
   }
 };
 
@@ -792,16 +948,23 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
   using value_type = float;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
-      default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      __m128 const& value_in) noexcept
+      : m_value(value_in) {}
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
@@ -811,7 +974,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept
       : m_value(_mm_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                             gen(std::integral_constant<std::size_t, 1>()),
                             gen(std::integral_constant<std::size_t, 2>()),
@@ -820,15 +983,6 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       value_type const* ptr, FlagType flag) {
     copy_from(ptr, flag);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m128 const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    auto index = _mm_cvtsi32_si128(i);
-    auto tmp   = _mm_permutevar_ps(m_value, index);
-    return _mm_cvtss_f32(tmp);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -846,13 +1000,31 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
                                                      vector_aligned_tag) const {
     _mm_store_ps(ptr, m_value);
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    auto index = _mm_cvtsi32_si128(i);
+    auto tmp   = _mm_permutevar_ps(m_value, index);
+    return _mm_cvtss_f32(tmp);
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128()
-      const {
+      const noexcept {
     return m_value;
   }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
     return basic_simd(_mm_sub_ps(_mm_set1_ps(0.0), m_value));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm_add_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm_sub_ps(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -862,30 +1034,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
   operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm_div_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm_add_ps(lhs.m_value, rhs.m_value));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm_sub_ps(lhs.m_value, rhs.m_value));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm_cmplt_ps(lhs.m_value, rhs.m_value));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm_cmpgt_ps(lhs.m_value, rhs.m_value));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm_cmple_ps(lhs.m_value, rhs.m_value));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm_cmpge_ps(lhs.m_value, rhs.m_value));
-  }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm_cmpeq_ps(lhs.m_value, rhs.m_value));
@@ -893,6 +1042,22 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm_cmpneq_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm_cmpge_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm_cmple_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm_cmpgt_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm_cmplt_ps(lhs.m_value, rhs.m_value));
   }
 };
 
@@ -1056,20 +1221,27 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
   using value_type = float;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
-      default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_ps(value_type(value))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      __m256 const& value_in) noexcept
+      : m_value(value_in) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -1090,15 +1262,6 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
       value_type const* ptr, FlagType flag) {
     copy_from(ptr, flag);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m256 const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    auto index = _mm256_set1_epi32(i);
-    auto tmp   = _mm256_permutevar8x32_ps(m_value, index);
-    return _mm256_cvtss_f32(tmp);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
     m_value = _mm256_loadu_ps(ptr);
@@ -1115,13 +1278,31 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
                                                      vector_aligned_tag) const {
     _mm256_store_ps(ptr, m_value);
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    auto index = _mm256_set1_epi32(i);
+    auto tmp   = _mm256_permutevar8x32_ps(m_value, index);
+    return _mm256_cvtss_f32(tmp);
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256()
       const {
     return m_value;
   }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
     return basic_simd(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_add_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_sub_ps(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -1131,34 +1312,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
   operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_div_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_add_ps(lhs.m_value, rhs.m_value));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_sub_ps(lhs.m_value, rhs.m_value));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
-                                   static_cast<__m256>(rhs), _CMP_LT_OS));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
-                                   static_cast<__m256>(rhs), _CMP_GT_OS));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
-                                   static_cast<__m256>(rhs), _CMP_LE_OS));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
-                                   static_cast<__m256>(rhs), _CMP_GE_OS));
-  }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
@@ -1168,6 +1322,26 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
   operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_NEQ_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
+                                   static_cast<__m256>(rhs), _CMP_GE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
+                                   static_cast<__m256>(rhs), _CMP_LE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
+                                   static_cast<__m256>(rhs), _CMP_GT_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
+                                   static_cast<__m256>(rhs), _CMP_LT_OS));
   }
 };
 
@@ -1331,20 +1505,29 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
-      default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      __m128i const& value_in) noexcept
+      : m_value(value_in) {}
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm_set1_epi32(value_type(value))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -1362,21 +1545,6 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       value_type const* ptr, FlagType flag) {
     copy_from(ptr, flag);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m128i const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other);
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    switch (i) {
-      case 0: return _mm_extract_epi32(m_value, 0x0);
-      case 1: return _mm_extract_epi32(m_value, 0x1);
-      case 2: return _mm_extract_epi32(m_value, 0x2);
-      case 3: return _mm_extract_epi32(m_value, 0x3);
-      default: Kokkos::abort("Index out of bound"); break;
-    }
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
     // FIXME_HIP ROCm 5.6, 5.7, and 6.0 can't compile with the intrinsic used
@@ -1384,7 +1552,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
 #ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
     m_value = _mm_loadu_si128(reinterpret_cast<__m128i const*>(ptr));
 #else
-    m_value    = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask_type(true)));
+    m_value = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask_type(true)));
 #endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
@@ -1393,7 +1561,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
 #ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
     m_value = _mm_load_si128(reinterpret_cast<__m128i const*>(ptr));
 #else
-    m_value    = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask_type(true)));
+    m_value = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask_type(true)));
 #endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
@@ -1408,32 +1576,22 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       const {
     return m_value;
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(
-        _mm_cmpeq_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    switch (i) {
+      case 0: return _mm_extract_epi32(m_value, 0x0);
+      case 1: return _mm_extract_epi32(m_value, 0x1);
+      case 2: return _mm_extract_epi32(m_value, 0x2);
+      case 3: return _mm_extract_epi32(m_value, 0x3);
+      default: Kokkos::abort("Index out of bound"); break;
+    }
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(
-        _mm_cmpgt_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(
-        _mm_cmplt_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return (lhs < rhs) || (lhs == rhs);
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return (lhs > rhs) || (lhs == rhs);
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return !(lhs == rhs);
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm_add_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -1441,36 +1599,55 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
         _mm_sub_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm_add_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm_mullo_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm_srai_epi32(static_cast<__m128i>(lhs), rhs));
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm_sllv_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm_srav_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm_srai_epi32(static_cast<__m128i>(lhs), rhs));
+  }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator<<(basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(_mm_slli_epi32(static_cast<__m128i>(lhs), rhs));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm_sllv_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(
+        _mm_cmpeq_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return !(lhs == rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return (lhs > rhs) || (lhs == rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return (lhs < rhs) || (lhs == rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(
+        _mm_cmplt_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(
+        _mm_cmpgt_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
 };
 
@@ -1545,19 +1722,26 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
-      default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      __m256i const& value_in) noexcept
+      : m_value(value_in) {}
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi32(value_type(value))) {}
   template <class G,
             std::enable_if_t<
@@ -1579,22 +1763,6 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       value_type const* ptr, FlagType flag) {
     copy_from(ptr, flag);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m256i const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-// _mm256_cvtsi256_si32 was not added in GCC until 11
-#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
-    value_type tmp[size()];
-    _mm256_maskstore_epi32(tmp, static_cast<__m256i>(mask_type(true)), m_value);
-    return tmp[i];
-#else
-    auto index = _mm256_set1_epi32(i);
-    auto tmp   = _mm256_permutevar8x32_epi32(m_value, index);
-    return _mm256_cvtsi256_si32(tmp);
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1624,14 +1792,76 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
                                                      vector_aligned_tag) const {
     _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask_type(true)), m_value);
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+// _mm256_cvtsi256_si32 was not added in GCC until 11
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
+    value_type tmp[size()];
+    _mm256_maskstore_epi32(tmp, static_cast<__m256i>(mask_type(true)), m_value);
+    return tmp[i];
+#else
+    auto index = _mm256_set1_epi32(i);
+    auto tmp   = _mm256_permutevar8x32_epi32(m_value, index);
+    return _mm256_cvtsi256_si32(tmp);
+#endif
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
       const {
     return m_value;
   }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
+                                         static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_srav_epi32(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epi32(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return !(lhs == rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return (lhs > rhs) || (lhs == rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return (lhs < rhs) || (lhs == rhs);
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -1641,55 +1871,6 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs >= rhs);
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return (lhs < rhs) || (lhs == rhs);
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return (lhs > rhs) || (lhs == rhs);
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return !(lhs == rhs);
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
-                                         static_cast<__m256i>(rhs)));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_srav_epi32(static_cast<__m256i>(lhs),
-                                        static_cast<__m256i>(rhs)));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
-                                        static_cast<__m256i>(rhs)));
   }
 };
 
@@ -1766,20 +1947,32 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   using value_type = std::int64_t;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
-      default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      __m256i const& value_in) noexcept
+      : m_value(value_in) {}
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi64x(value_type(value))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other) noexcept
+      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -1796,24 +1989,6 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       value_type const* ptr, FlagType flag) {
     copy_from(ptr, flag);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m256i const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other);
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other)
-      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    switch (i) {
-      case 0: return _mm256_extract_epi64(m_value, 0x0);
-      case 1: return _mm256_extract_epi64(m_value, 0x1);
-      case 2: return _mm256_extract_epi64(m_value, 0x2);
-      case 3: return _mm256_extract_epi64(m_value, 0x3);
-      default: Kokkos::abort("Index out of bound"); break;
-    }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -1843,6 +2018,18 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
     _mm256_maskstore_epi64(reinterpret_cast<long long*>(ptr),
                            static_cast<__m256i>(mask_type(true)), m_value);
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    switch (i) {
+      case 0: return _mm256_extract_epi64(m_value, 0x0);
+      case 1: return _mm256_extract_epi64(m_value, 0x1);
+      case 2: return _mm256_extract_epi64(m_value, 0x2);
+      case 3: return _mm256_extract_epi64(m_value, 0x3);
+      default: Kokkos::abort("Index out of bound"); break;
+    }
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
       const {
     return m_value;
@@ -1855,21 +2042,41 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
   // fallback basic_simd multiplication using generator constructor
   // multiplying vectors of 64-bit signed integers is not available in AVX2
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_sllv_epi64(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
+  }
+  // fallback basic_simd shift right arithmetic using generator constructor
+  // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd([&](std::size_t i) { return lhs[i] >> rhs[i]; });
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
+  }
+  // fallback basic_simd shift right arithmetic using generator constructor
+  // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd([&](std::size_t i) { return lhs[i] >> rhs; });
   }
 
   // AVX2 only has eq and gt comparisons for int64
@@ -1879,6 +2086,18 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
                                         static_cast<__m256i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return !(lhs == rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return (lhs > rhs) || (lhs == rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return (lhs < rhs) || (lhs == rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpgt_epi64(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
@@ -1886,43 +2105,6 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return rhs > lhs;
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return (lhs < rhs) || (lhs == rhs);
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return (lhs > rhs) || (lhs == rhs);
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return !(lhs == rhs);
-  }
-
-  // fallback basic_simd shift right arithmetic using generator constructor
-  // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd([&](std::size_t i) { return lhs[i] >> rhs; });
-  }
-
-  // fallback basic_simd shift right arithmetic using generator constructor
-  // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd([&](std::size_t i) { return lhs[i] >> rhs[i]; });
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_sllv_epi64(static_cast<__m256i>(lhs),
-                                        static_cast<__m256i>(rhs)));
   }
 };
 
@@ -1998,21 +2180,34 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   using value_type = std::uint64_t;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
-      default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi64x(
             Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
+      __m256i const& value_in) noexcept
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other) noexcept
+      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int64_t, abi_type> const& other) noexcept
+      : m_value(static_cast<__m256i>(other)) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -2029,25 +2224,6 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       value_type const* ptr, FlagType flag) {
     copy_from(ptr, flag);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
-      __m256i const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other)
-      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int64_t, abi_type> const& other)
-      : m_value(static_cast<__m256i>(other)) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    switch (i) {
-      case 0: return _mm256_extract_epi64(m_value, 0x0);
-      case 1: return _mm256_extract_epi64(m_value, 0x1);
-      case 2: return _mm256_extract_epi64(m_value, 0x2);
-      case 3: return _mm256_extract_epi64(m_value, 0x3);
-      default: Kokkos::abort("Index out of bound"); break;
-    }
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -2077,10 +2253,23 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     _mm256_maskstore_epi64(reinterpret_cast<long long*>(ptr),
                            static_cast<__m256i>(mask_type(true)), m_value);
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    switch (i) {
+      case 0: return _mm256_extract_epi64(m_value, 0x0);
+      case 1: return _mm256_extract_epi64(m_value, 0x1);
+      case 2: return _mm256_extract_epi64(m_value, 0x2);
+      case 3: return _mm256_extract_epi64(m_value, 0x3);
+      default: Kokkos::abort("Index out of bound"); break;
+    }
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
       const {
     return m_value;
   }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
@@ -2091,31 +2280,11 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     return basic_simd(
         _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-
   // fallback basic_simd multiplication using generator constructor
   // multiplying vectors of 64-bit unsigned integers is not available in AVX2
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
-    return _mm256_srli_epi64(static_cast<__m256i>(lhs), rhs);
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return _mm256_srlv_epi64(static_cast<__m256i>(lhs),
-                             static_cast<__m256i>(rhs));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
-    return _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs);
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return _mm256_sllv_epi64(static_cast<__m256i>(lhs),
-                             static_cast<__m256i>(rhs));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator&(basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -2127,6 +2296,25 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     return _mm256_or_si256(static_cast<__m256i>(lhs),
                            static_cast<__m256i>(rhs));
   }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return _mm256_sllv_epi64(static_cast<__m256i>(lhs),
+                             static_cast<__m256i>(rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return _mm256_srlv_epi64(static_cast<__m256i>(lhs),
+                             static_cast<__m256i>(rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
+    return _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs);
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return _mm256_srli_epi64(static_cast<__m256i>(lhs), rhs);
+  }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epi64(static_cast<__m256i>(lhs),
@@ -2140,7 +2328,8 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other)
+    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const&
+        other) noexcept
     : m_value(static_cast<__m256i>(other)) {}
 
 }  // namespace Experimental
@@ -2205,7 +2394,8 @@ namespace Experimental {
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other) {
+    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const&
+        other) noexcept {
   std::int32_t arr[4];
   for (std::size_t i = 0; i < 4; ++i) {
     arr[i] = std::int32_t(other[i]);

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -45,21 +45,30 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<8>> {
   __mmask8 m_value;
 
  public:
-  using value_type                                        = bool;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
+  using value_type = bool;
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      value_type value)
+      value_type value) noexcept
       : m_value(-std::int16_t(value)) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+      __mmask8 const& value_in)
+      : m_value(value_in) {}
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
-      basic_simd_mask<U, simd_abi::avx512_fixed_size<8>> const& other)
+      basic_simd_mask<U, simd_abi::avx512_fixed_size<8>> const& other) noexcept
       : m_value(static_cast<__mmask8>(other)) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(G&& gen)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(G&& gen) noexcept
       : m_value(false) {
     m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 0>())))
                   ? m_value | 0x01
@@ -86,34 +95,35 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<8>> {
                   ? m_value | 0x80
                   : m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 8;
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      __mmask8 const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __mmask8()
-      const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
     auto const bit_mask = __mmask8(std::int16_t(1 << i));
     return (m_value & bit_mask) != 0;
   }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator||(basic_simd_mask const& other) const {
-    return basic_simd_mask(_kor_mask8(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator&&(basic_simd_mask const& other) const {
-    return basic_simd_mask(_kand_mask8(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+  operator!() const noexcept {
     static const __mmask8 true_value(
         static_cast<__mmask8>(basic_simd_mask(true)));
     return basic_simd_mask(_kxor_mask8(true_value, m_value));
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __mmask8()
+      const noexcept {
+    return m_value;
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_kand_mask8(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_kor_mask8(lhs.m_value, rhs.m_value));
+  }
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
       basic_simd_mask const& other) const {
     return m_value == other.m_value;
@@ -122,6 +132,16 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<8>> {
       basic_simd_mask const& other) const {
     return m_value != other.m_value;
   }
+#else
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(lhs.m_value == rhs.m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(lhs.m_value != rhs.m_value);
+  }
+#endif
 };
 
 template <class T>
@@ -129,21 +149,30 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<16>> {
   __mmask16 m_value;
 
  public:
-  using value_type                                        = bool;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() = default;
+  using value_type = bool;
+  using abi_type   = simd_abi::avx512_fixed_size<16>;
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 16;
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      value_type value)
+      value_type value) noexcept
       : m_value(-std::int32_t(value)) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+      __mmask16 const& value_in) noexcept
+      : m_value(value_in) {}
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
-      basic_simd_mask<U, simd_abi::avx512_fixed_size<16>> const& other)
+      basic_simd_mask<U, simd_abi::avx512_fixed_size<16>> const& other) noexcept
       : m_value(static_cast<__mmask16>(other)) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(G&& gen)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(G&& gen) noexcept
       : m_value(false) {
     m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 0>())))
                   ? m_value | 0x0001
@@ -200,34 +229,35 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<16>> {
             ? m_value | 0x8000
             : m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 16;
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      __mmask16 const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __mmask16()
-      const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
     auto const bit_mask = __mmask16(std::int32_t(1 << i));
     return (m_value & bit_mask) != 0;
   }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator||(basic_simd_mask const& other) const {
-    return basic_simd_mask(_kor_mask16(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator&&(basic_simd_mask const& other) const {
-    return basic_simd_mask(_kand_mask16(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+  operator!() const noexcept {
     static const __mmask16 true_value(
         static_cast<__mmask16>(basic_simd_mask(true)));
     return basic_simd_mask(_kxor_mask16(true_value, m_value));
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __mmask16()
+      const noexcept {
+    return m_value;
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_kor_mask16(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_kand_mask16(lhs.m_value, rhs.m_value));
+  }
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
       basic_simd_mask const& other) const {
     return m_value == other.m_value;
@@ -236,6 +266,16 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<16>> {
       basic_simd_mask const& other) const {
     return m_value != other.m_value;
   }
+#else
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(lhs.m_value == rhs.m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(lhs.m_value != rhs.m_value);
+  }
+#endif
 };
 
 template <>
@@ -246,22 +286,26 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
   using value_type = double;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
-      default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_pd(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m512d const& value_in)
+      __m512d const& value_in) noexcept
       : m_value(value_in) {}
   template <class G,
             std::enable_if_t<
@@ -286,12 +330,6 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
       value_type const* ptr, FlagType flag) {
     copy_from(ptr, flag);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    auto index = _mm512_set1_epi32(i);
-    auto tmp   = _mm512_permutexvar_pd(index, m_value);
-    return _mm512_cvtsd_f64(tmp);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
     m_value = _mm512_loadu_pd(ptr);
@@ -308,25 +346,24 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
                                                      vector_aligned_tag) const {
     _mm512_store_pd(ptr, m_value);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512d()
-      const {
-    return m_value;
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    auto index = _mm512_set1_epi32(i);
+    auto tmp   = _mm512_permutexvar_pd(index, m_value);
+    return _mm512_cvtsd_f64(tmp);
   }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
     return basic_simd(_mm512_sub_pd(_mm512_set1_pd(0.0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm512_mul_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512d()
+      const noexcept {
+    return m_value;
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm512_div_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
-  }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
@@ -337,26 +374,17 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
     return basic_simd(
         _mm512_sub_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
-                                        static_cast<__m512d>(rhs), _CMP_LT_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm512_mul_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(rhs),
-                                        static_cast<__m512d>(lhs), _CMP_GT_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm512_div_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
-                                        static_cast<__m512d>(rhs), _CMP_LE_OS));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(rhs),
-                                        static_cast<__m512d>(lhs), _CMP_GE_OS));
-  }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
@@ -366,6 +394,26 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
   operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(
         static_cast<__m512d>(lhs), static_cast<__m512d>(rhs), _CMP_NEQ_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(rhs),
+                                        static_cast<__m512d>(lhs), _CMP_GE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
+                                        static_cast<__m512d>(rhs), _CMP_LE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(rhs),
+                                        static_cast<__m512d>(lhs), _CMP_GT_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
+                                        static_cast<__m512d>(rhs), _CMP_LT_OS));
   }
 };
 
@@ -543,29 +591,33 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
   using value_type = float;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
-      default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_ps(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m256 const& value_in)
+      __m256 const& value_in) noexcept
       : m_value(value_in) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept
       : m_value(_mm256_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                                gen(std::integral_constant<std::size_t, 1>()),
                                gen(std::integral_constant<std::size_t, 2>()),
@@ -577,14 +629,8 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
   }
   template <typename FlagType>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType flag) {
+      value_type const* ptr, FlagType flag) noexcept {
     copy_from(ptr, flag);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    auto index = _mm256_set1_epi32(i);
-    auto tmp   = _mm256_permutexvar_ps(index, m_value);
-    return _mm256_cvtss_f32(tmp);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -602,23 +648,24 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
                                                      vector_aligned_tag) const {
     _mm256_store_ps(ptr, m_value);
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    auto index = _mm256_set1_epi32(i);
+    auto tmp   = _mm256_permutexvar_ps(index, m_value);
+    return _mm256_cvtss_f32(tmp);
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256()
-      const {
+      const noexcept {
     return m_value;
   }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
     return basic_simd(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_mul_ps(lhs.m_value, rhs.m_value));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_div_ps(lhs.m_value, rhs.m_value));
-  }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_add_ps(lhs.m_value, rhs.m_value));
@@ -627,22 +674,15 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
   operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_sub_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LT_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_mul_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GT_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_div_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LE_OS));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GE_OS));
-  }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_EQ_OS));
@@ -650,6 +690,22 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_NEQ_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GT_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LT_OS));
   }
 };
 
@@ -814,29 +870,33 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
   using value_type = float;
   using abi_type   = simd_abi::avx512_fixed_size<16>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
-      default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 16;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_ps(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m512 const& value_in)
+      __m512 const& value_in) noexcept
       : m_value(value_in) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept
       : m_value(
             _mm512_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                            gen(std::integral_constant<std::size_t, 1>()),
@@ -856,14 +916,8 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
                            gen(std::integral_constant<std::size_t, 15>()))) {}
   template <typename FlagType>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType flag) {
+      value_type const* ptr, FlagType flag) noexcept {
     copy_from(ptr, flag);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    auto index = _mm512_set1_epi32(i);
-    auto tmp   = _mm512_permutexvar_ps(index, m_value);
-    return _mm512_cvtss_f32(tmp);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
@@ -881,23 +935,24 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
                                                      vector_aligned_tag) const {
     _mm512_store_ps(ptr, m_value);
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    auto index = _mm512_set1_epi32(i);
+    auto tmp   = _mm512_permutexvar_ps(index, m_value);
+    return _mm512_cvtss_f32(tmp);
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512()
-      const {
+      const noexcept {
     return m_value;
   }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   operator-() const noexcept {
     return basic_simd(_mm512_sub_ps(_mm512_set1_ps(0.0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_mul_ps(lhs.m_value, rhs.m_value));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_div_ps(lhs.m_value, rhs.m_value));
-  }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_add_ps(lhs.m_value, rhs.m_value));
@@ -906,22 +961,15 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
   operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_sub_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LT_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_mul_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GT_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_div_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LE_OS));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GE_OS));
-  }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_EQ_OS));
@@ -929,6 +977,22 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_NEQ_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GT_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LT_OS));
   }
 };
 
@@ -1092,25 +1156,29 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
-      default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m256i const& value_in)
+      __m256i const& value_in) noexcept
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other);
+      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -1134,20 +1202,6 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
       value_type const* ptr, FlagType flag) {
     copy_from(ptr, flag);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-// _mm256_cvtsi256_si32 was not added in GCC until 11
-#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
-    value_type tmp[size()];
-    _mm256_mask_storeu_epi32(tmp, static_cast<__mmask8>(mask_type(true)),
-                             m_value);
-    return tmp[i];
-#else
-    auto index = _mm256_set1_epi32(i);
-    auto tmp   = _mm256_permutevar8x32_epi32(m_value, index);
-    return _mm256_cvtsi256_si32(tmp);
-#endif
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
     m_value = _mm256_mask_loadu_epi32(
@@ -1168,8 +1222,24 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
     _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
                             m_value);
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+// _mm256_cvtsi256_si32 was not added in GCC until 11
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
+    value_type tmp[size()];
+    _mm256_mask_storeu_epi32(tmp, static_cast<__mmask8>(mask_type(true)),
+                             m_value);
+    return tmp[i];
+#else
+    auto index = _mm256_set1_epi32(i);
+    auto tmp   = _mm256_permutevar8x32_epi32(m_value, index);
+    return _mm256_cvtsi256_si32(tmp);
+#endif
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
-      const {
+      const noexcept {
     return m_value;
   }
 
@@ -1178,11 +1248,6 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
     return basic_simd(_mm256_sub_epi32(_mm256_set1_epi32(0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
-                                         static_cast<__m256i>(rhs)));
-  }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
@@ -1193,40 +1258,15 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
     return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
         _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmplt_epi32_mask(static_cast<__m256i>(lhs),
-                                             static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmplt_epi32_mask(static_cast<__m256i>(rhs),
-                                             static_cast<__m256i>(lhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmple_epi32_mask(static_cast<__m256i>(lhs),
-                                             static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmple_epi32_mask(static_cast<__m256i>(rhs),
-                                             static_cast<__m256i>(lhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmpeq_epi32_mask(static_cast<__m256i>(lhs),
-                                             static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmpneq_epi32_mask(static_cast<__m256i>(lhs),
-                                              static_cast<__m256i>(rhs)));
-  }
-
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
+                                         static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -1238,9 +1278,39 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
     return basic_simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
-                                        static_cast<__m256i>(rhs)));
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpeq_epi32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpneq_epi32_mask(static_cast<__m256i>(lhs),
+                                              static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmple_epi32_mask(static_cast<__m256i>(rhs),
+                                             static_cast<__m256i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmple_epi32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmplt_epi32_mask(static_cast<__m256i>(rhs),
+                                             static_cast<__m256i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmplt_epi32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
   }
 };
 
@@ -1313,25 +1383,29 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx512_fixed_size<16>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
-      default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 16;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_epi32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m512i const& value_in)
+      __m512i const& value_in) noexcept
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other);
+      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -1363,20 +1437,6 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
       value_type const* ptr, FlagType flag) {
     copy_from(ptr, flag);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-// _mm512_cvtsi512_si32 was not added in GCC until 11
-#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
-    value_type tmp[size()];
-    _mm512_mask_storeu_epi32(tmp, static_cast<__mmask16>(mask_type(true)),
-                             m_value);
-    return tmp[i];
-#else
-    auto index = _mm512_set1_epi32(i);
-    auto tmp   = _mm512_permutexvar_epi32(index, m_value);
-    return _mm512_cvtsi512_si32(tmp);
-#endif
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
     _mm512_mask_storeu_epi32(ptr, static_cast<__mmask16>(mask_type(true)),
@@ -1397,9 +1457,20 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
     m_value = _mm512_mask_load_epi32(
         _mm512_set1_epi32(0), static_cast<__mmask16>(mask_type(true)), ptr);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
-      const {
-    return m_value;
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+// _mm512_cvtsi512_si32 was not added in GCC until 11
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
+    value_type tmp[size()];
+    _mm512_mask_storeu_epi32(tmp, static_cast<__mmask16>(mask_type(true)),
+                             m_value);
+    return tmp[i];
+#else
+    auto index = _mm512_set1_epi32(i);
+    auto tmp   = _mm512_permutexvar_epi32(index, m_value);
+    return _mm512_cvtsi512_si32(tmp);
+#endif
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
@@ -1407,11 +1478,11 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
     return basic_simd(_mm512_sub_epi32(_mm512_set1_epi32(0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
-                                         static_cast<__m512i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
+      const noexcept {
+    return m_value;
   }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
@@ -1422,26 +1493,30 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
     return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
         _mm512_sub_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmplt_epi32_mask(static_cast<__m512i>(lhs),
-                                             static_cast<__m512i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
+                                         static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmplt_epi32_mask(static_cast<__m512i>(rhs),
-                                             static_cast<__m512i>(lhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_sllv_epi32(static_cast<__m512i>(lhs),
+                                        static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmple_epi32_mask(static_cast<__m512i>(lhs),
-                                             static_cast<__m512i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm512_slli_epi32(static_cast<__m512i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmple_epi32_mask(static_cast<__m512i>(rhs),
-                                             static_cast<__m512i>(lhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm512_srai_epi32(static_cast<__m512i>(lhs), rhs));
   }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_srav_epi32(static_cast<__m512i>(lhs),
+                                        static_cast<__m512i>(rhs)));
+  }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpeq_epi32_mask(static_cast<__m512i>(lhs),
@@ -1452,24 +1527,25 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
     return mask_type(_mm512_cmpneq_epi32_mask(static_cast<__m512i>(lhs),
                                               static_cast<__m512i>(rhs)));
   }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm512_srai_epi32(static_cast<__m512i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epi32_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_srav_epi32(static_cast<__m512i>(lhs),
-                                        static_cast<__m512i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epi32_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm512_slli_epi32(static_cast<__m512i>(lhs), rhs));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epi32_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_sllv_epi32(static_cast<__m512i>(lhs),
-                                        static_cast<__m512i>(rhs)));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epi32_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
   }
 };
 
@@ -1543,26 +1619,31 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
   using value_type = std::uint32_t;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
-      default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi32(
             Kokkos::bit_cast<std::int32_t>(value_type(value)))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m256i const& value_in)
+      __m256i const& value_in) noexcept
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other)
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+          other) noexcept
       : m_value(static_cast<__m256i>(other)) {}
   template <class G,
             std::enable_if_t<
@@ -1587,20 +1668,6 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
       value_type const* ptr, FlagType flag) {
     copy_from(ptr, flag);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-// _mm256_cvtsi256_si32 was not added in GCC until 11
-#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
-    value_type tmp[size()];
-    _mm256_mask_storeu_epi32(tmp, static_cast<__mmask8>(mask_type(true)),
-                             m_value);
-    return tmp[i];
-#else
-    auto index = _mm256_set1_epi32(i);
-    auto tmp   = _mm256_permutevar8x32_epi32(m_value, index);
-    return _mm256_cvtsi256_si32(tmp);
-#endif
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
     _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
@@ -1621,16 +1688,27 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
     m_value = _mm256_mask_load_epi32(
         _mm256_set1_epi32(0), static_cast<__mmask8>(mask_type(true)), ptr);
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+// _mm256_cvtsi256_si32 was not added in GCC until 11
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
+    value_type tmp[size()];
+    _mm256_mask_storeu_epi32(tmp, static_cast<__mmask8>(mask_type(true)),
+                             m_value);
+    return tmp[i];
+#else
+    auto index = _mm256_set1_epi32(i);
+    auto tmp   = _mm256_permutevar8x32_epi32(m_value, index);
+    return _mm256_cvtsi256_si32(tmp);
+#endif
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
-      const {
+      const noexcept {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
-                                         static_cast<__m256i>(rhs)));
-  }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
@@ -1641,41 +1719,15 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
     return basic_simd(
         _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(lhs),
-                                             static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(rhs),
-                                             static_cast<__m256i>(lhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(lhs),
-                                             static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(rhs),
-                                             static_cast<__m256i>(lhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmpeq_epu32_mask(static_cast<__m256i>(lhs),
-                                             static_cast<__m256i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmpneq_epu32_mask(static_cast<__m256i>(lhs),
-                                              static_cast<__m256i>(rhs)));
-  }
-
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
+                                         static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+                                        static_cast<__m256i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -1687,9 +1739,39 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
     return basic_simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
-                                        static_cast<__m256i>(rhs)));
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpeq_epu32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpneq_epu32_mask(static_cast<__m256i>(lhs),
+                                              static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(rhs),
+                                             static_cast<__m256i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(rhs),
+                                             static_cast<__m256i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
   }
 };
 
@@ -1759,26 +1841,31 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
   using value_type = std::uint32_t;
   using abi_type   = simd_abi::avx512_fixed_size<16>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
-      default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 16;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_epi32(
             Kokkos::bit_cast<std::int32_t>(value_type(value)))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m512i const& value_in)
+      __m512i const& value_in) noexcept
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& other)
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
+          other) noexcept
       : m_value(static_cast<__m512i>(other)) {}
   template <class G,
             std::enable_if_t<
@@ -1811,20 +1898,6 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
       value_type const* ptr, FlagType flag) {
     copy_from(ptr, flag);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-// _mm512_cvtsi512_si32 was not added in GCC until 11
-#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
-    value_type tmp[size()];
-    _mm512_mask_storeu_epi32(tmp, static_cast<__mmask16>(mask_type(true)),
-                             m_value);
-    return tmp[i];
-#else
-    auto index = _mm512_set1_epi32(i);
-    auto tmp   = _mm512_permutexvar_epi32(index, m_value);
-    return _mm512_cvtsi512_si32(tmp);
-#endif
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
     m_value = _mm512_mask_loadu_epi32(
@@ -1845,15 +1918,27 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
     _mm512_mask_store_epi32(ptr, static_cast<__mmask16>(mask_type(true)),
                             m_value);
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+// _mm512_cvtsi512_si32 was not added in GCC until 11
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
+    value_type tmp[size()];
+    _mm512_mask_storeu_epi32(tmp, static_cast<__mmask16>(mask_type(true)),
+                             m_value);
+    return tmp[i];
+#else
+    auto index = _mm512_set1_epi32(i);
+    auto tmp   = _mm512_permutexvar_epi32(index, m_value);
+    return _mm512_cvtsi512_si32(tmp);
+#endif
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
       const {
     return m_value;
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
-                                         static_cast<__m512i>(rhs)));
-  }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
@@ -1864,41 +1949,15 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
     return basic_simd(
         _mm512_sub_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmplt_epu32_mask(static_cast<__m512i>(lhs),
-                                             static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmplt_epu32_mask(static_cast<__m512i>(rhs),
-                                             static_cast<__m512i>(lhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmple_epu32_mask(static_cast<__m512i>(lhs),
-                                             static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmple_epu32_mask(static_cast<__m512i>(rhs),
-                                             static_cast<__m512i>(lhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmpeq_epu32_mask(static_cast<__m512i>(lhs),
-                                             static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmpneq_epu32_mask(static_cast<__m512i>(lhs),
-                                              static_cast<__m512i>(rhs)));
-  }
-
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm512_srli_epi32(static_cast<__m512i>(lhs), rhs));
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
+                                         static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_sllv_epi32(static_cast<__m512i>(lhs),
+                                        static_cast<__m512i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -1910,9 +1969,39 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
     return basic_simd(_mm512_slli_epi32(static_cast<__m512i>(lhs), rhs));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_sllv_epi32(static_cast<__m512i>(lhs),
-                                        static_cast<__m512i>(rhs)));
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(_mm512_srli_epi32(static_cast<__m512i>(lhs), rhs));
+  }
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmpeq_epu32_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmpneq_epu32_mask(static_cast<__m512i>(lhs),
+                                              static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epu32_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epu32_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epu32_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epu32_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
   }
 };
 
@@ -1983,25 +2072,31 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
   using value_type = std::int64_t;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
-      default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_epi64(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other)
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+          other) noexcept
       : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other);
+      basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+          other) noexcept;
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -2025,15 +2120,6 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
       value_type const* ptr, FlagType flag) {
     copy_from(ptr, flag);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
-      __m512i const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    value_type tmp[size()];
-    _mm512_storeu_si512(tmp, m_value);
-    return tmp[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
     m_value = _mm512_loadu_si512(ptr);
@@ -2051,9 +2137,14 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
     _mm512_store_si512(ptr, m_value);
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
-      const {
-    return m_value;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
+      __m512i const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    value_type tmp[size()];
+    _mm512_storeu_si512(tmp, m_value);
+    return tmp[i];
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
@@ -2061,10 +2152,9 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
     return basic_simd(_mm512_sub_epi64(_mm512_set1_epi64(0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
-                                         static_cast<__m512i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
+      const {
+    return m_value;
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
@@ -2072,16 +2162,49 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
     return basic_simd(
         _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
+                                         static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, basic_simd const& rhs) {
+    return basic_simd(_mm512_sllv_epi64(static_cast<__m512i>(lhs),
+                                        static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) {
+    return basic_simd(_mm512_srav_epi64(static_cast<__m512i>(lhs),
+                                        static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator<<(basic_simd const& lhs, int rhs) {
+    return basic_simd(_mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator>>(basic_simd const& lhs, int rhs) {
+    return basic_simd(_mm512_srai_epi64(static_cast<__m512i>(lhs), rhs));
+  }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmplt_epi64_mask(static_cast<__m512i>(lhs),
+  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmpeq_epi64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmpneq_epi64_mask(static_cast<__m512i>(lhs),
+                                              static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epi64_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -2094,38 +2217,9 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
                                              static_cast<__m512i>(rhs)));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmple_epi64_mask(static_cast<__m512i>(rhs),
-                                             static_cast<__m512i>(lhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmpeq_epi64_mask(static_cast<__m512i>(lhs),
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epi64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmpneq_epi64_mask(static_cast<__m512i>(lhs),
-                                              static_cast<__m512i>(rhs)));
-  }
-
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) {
-    return basic_simd(_mm512_srai_epi64(static_cast<__m512i>(lhs), rhs));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) {
-    return basic_simd(_mm512_srav_epi64(static_cast<__m512i>(lhs),
-                                        static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) {
-    return basic_simd(_mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) {
-    return basic_simd(_mm512_sllv_epi64(static_cast<__m512i>(lhs),
-                                        static_cast<__m512i>(rhs)));
   }
 };
 
@@ -2198,27 +2292,34 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   using value_type = std::uint64_t;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd()                  = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(basic_simd&&) =
-      default;
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
+      basic_simd&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_epi64(
             Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
-      __m512i const& value_in)
+      __m512i const& value_in) noexcept
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other)
+      basic_simd<std::int32_t, abi_type> const& other) noexcept
       : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int64_t, abi_type> const& other) noexcept
+      : m_value(static_cast<__m512i>(other)) {}
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -2242,15 +2343,6 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
       value_type const* ptr, FlagType flag) {
     copy_from(ptr, flag);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int64_t, abi_type> const& other)
-      : m_value(static_cast<__m512i>(other)) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    value_type tmp[size()];
-    _mm512_storeu_si512(tmp, m_value);
-    return tmp[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
     m_value = _mm512_loadu_si512(ptr);
@@ -2268,16 +2360,18 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
     _mm512_store_si512(ptr, m_value);
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    value_type tmp[size()];
+    _mm512_storeu_si512(tmp, m_value);
+    return tmp[i];
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
-      const {
+      const noexcept {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
-                                         static_cast<__m512i>(rhs)));
-  }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
@@ -2287,6 +2381,21 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
+                                         static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator&(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return _mm512_and_epi64(static_cast<__m512i>(lhs),
+                            static_cast<__m512i>(rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
+  operator|(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return _mm512_or_epi64(static_cast<__m512i>(lhs),
+                           static_cast<__m512i>(rhs));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
   operator>>(basic_simd const& lhs, int rhs) noexcept {
@@ -2306,37 +2415,7 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
     return _mm512_sllv_epi64(static_cast<__m512i>(lhs),
                              static_cast<__m512i>(rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator&(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return _mm512_and_epi64(static_cast<__m512i>(lhs),
-                            static_cast<__m512i>(rhs));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator|(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return _mm512_or_epi64(static_cast<__m512i>(lhs),
-                           static_cast<__m512i>(rhs));
-  }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmplt_epu64_mask(static_cast<__m512i>(lhs),
-                                             static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmplt_epu64_mask(static_cast<__m512i>(rhs),
-                                             static_cast<__m512i>(lhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmple_epu64_mask(static_cast<__m512i>(lhs),
-                                             static_cast<__m512i>(rhs)));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmple_epu64_mask(static_cast<__m512i>(rhs),
-                                             static_cast<__m512i>(lhs)));
-  }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpeq_epu64_mask(static_cast<__m512i>(lhs),
@@ -2346,6 +2425,26 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpneq_epu64_mask(static_cast<__m512i>(lhs),
                                               static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epu64_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmple_epu64_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epu64_mask(static_cast<__m512i>(rhs),
+                                             static_cast<__m512i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(_mm512_cmplt_epu64_mask(static_cast<__m512i>(lhs),
+                                             static_cast<__m512i>(rhs)));
   }
 };
 
@@ -2409,12 +2508,14 @@ namespace Experimental {
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other)
+    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
     : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other)
+    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
     : m_value(static_cast<__m512i>(other)) {}
 
 template <>

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -303,30 +303,44 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator<<=(
 // implement mask reductions for type bool to allow generic code to accept
 // both basic_simd<double, Abi> and just double
 
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION bool all_of(bool a) { return a; }
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr bool all_of(
+    bool a) noexcept {
+  return a;
+}
 
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION bool any_of(bool a) { return a; }
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr bool any_of(
+    bool a) noexcept {
+  return a;
+}
 
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION bool none_of(bool a) { return !a; }
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr bool none_of(
+    bool a) noexcept {
+  return !a;
+}
 
 // fallback implementations of reductions across basic_simd_mask:
-
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool all_of(
-    basic_simd_mask<T, Abi> const& a) {
-  return a == basic_simd_mask<T, Abi>(true);
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr bool all_of(
+    basic_simd_mask<T, Abi> const& a) noexcept {
+  for (size_t i = 0; i < basic_simd_mask<T, Abi>::size(); ++i) {
+    if (!a[i]) return false;
+  }
+  return true;
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool any_of(
-    basic_simd_mask<T, Abi> const& a) {
-  return a != basic_simd_mask<T, Abi>(false);
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr bool any_of(
+    basic_simd_mask<T, Abi> const& a) noexcept {
+  for (size_t i = 0; i < basic_simd_mask<T, Abi>::size(); ++i) {
+    if (a[i]) return true;
+  }
+  return false;
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool none_of(
-    basic_simd_mask<T, Abi> const& a) {
-  return a == basic_simd_mask<T, Abi>(false);
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr bool none_of(
+    basic_simd_mask<T, Abi> const& a) noexcept {
+  return !any_of(a);
 }
 
 // A temporary device-callable implemenation of round half to nearest even

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -42,13 +42,21 @@ class basic_simd_mask<T, simd_abi::scalar> {
   bool m_value;
 
  public:
-  using value_type                            = bool;
-  using simd_type                             = basic_simd<T, simd_abi::scalar>;
-  using abi_type                              = simd_abi::scalar;
-  KOKKOS_DEFAULTED_FUNCTION basic_simd_mask() = default;
+  using value_type = bool;
+  using simd_type  = basic_simd<T, simd_abi::scalar>;
+  using abi_type   = simd_abi::scalar;
+
   KOKKOS_FORCEINLINE_FUNCTION static constexpr std::size_t size() { return 1; }
-  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(value_type value)
+
+  KOKKOS_DEFAULTED_FUNCTION constexpr basic_simd_mask() noexcept = default;
+
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+      value_type value) noexcept
       : m_value(value) {}
+  template <class U>
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+      basic_simd_mask<U, simd_abi::scalar> const& other) noexcept
+      : m_value(static_cast<bool>(other)) {}
   template <
       class G,
       std::enable_if_t<std::is_invocable_r_v<
@@ -57,27 +65,60 @@ class basic_simd_mask<T, simd_abi::scalar> {
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(gen(0)) {}
-  template <class U>
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask(
-      basic_simd_mask<U, simd_abi::scalar> const& other)
-      : m_value(static_cast<bool>(other)) {}
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator bool() const {
+
+  KOKKOS_FORCEINLINE_FUNCTION constexpr value_type operator[](
+      std::size_t) const {
     return m_value;
   }
-  KOKKOS_FORCEINLINE_FUNCTION value_type operator[](std::size_t) const {
-    return m_value;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask
-  operator||(basic_simd_mask const& other) const {
-    return basic_simd_mask(m_value || other.m_value);
-  }
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask
-  operator&&(basic_simd_mask const& other) const {
-    return basic_simd_mask(m_value && other.m_value);
-  }
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask operator!() const {
+
+  KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd_mask operator!()
+      const noexcept {
     return basic_simd_mask(!m_value);
   }
+
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator bool()
+      const noexcept {
+    return m_value;
+  }
+
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator&&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(static_cast<bool>(lhs) && static_cast<bool>(rhs));
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator||(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(static_cast<bool>(lhs) || static_cast<bool>(rhs));
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(static_cast<bool>(lhs) & static_cast<bool>(rhs));
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator|(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(static_cast<bool>(lhs) | static_cast<bool>(rhs));
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator^(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(static_cast<bool>(lhs) ^ static_cast<bool>(rhs));
+  }
+
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask& operator&=(
+      basic_simd_mask& lhs, basic_simd_mask const& rhs) noexcept {
+    lhs &= rhs;
+    return lhs;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask& operator|=(
+      basic_simd_mask& lhs, basic_simd_mask const& rhs) noexcept {
+    lhs |= rhs;
+    return lhs;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask& operator^=(
+      basic_simd_mask& lhs, basic_simd_mask const& rhs) noexcept {
+    lhs ^= rhs;
+    return lhs;
+  }
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_FORCEINLINE_FUNCTION bool operator==(
       basic_simd_mask const& other) const {
     return m_value == other.m_value;
@@ -86,29 +127,84 @@ class basic_simd_mask<T, simd_abi::scalar> {
       basic_simd_mask const& other) const {
     return m_value != other.m_value;
   }
+#else
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(static_cast<bool>(lhs) == static_cast<bool>(rhs));
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(static_cast<bool>(lhs) != static_cast<bool>(rhs));
+  }
+#endif
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator>=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(static_cast<bool>(lhs) >= static_cast<bool>(rhs));
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator<=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(static_cast<bool>(lhs) <= static_cast<bool>(rhs));
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator>(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(static_cast<bool>(lhs) > static_cast<bool>(rhs));
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator<(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(static_cast<bool>(lhs) < static_cast<bool>(rhs));
+  }
 };
+
+template <class T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr bool all_of(
+    basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const&
+        a) noexcept {
+  return static_cast<bool>(
+      a == basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(true));
+}
+
+template <class T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr bool any_of(
+    basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const&
+        a) noexcept {
+  return static_cast<bool>(
+      a != basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(false));
+}
+
+template <class T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr bool none_of(
+    basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const&
+        a) noexcept {
+  return static_cast<bool>(
+      a == basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(false));
+}
 
 template <class T>
 class basic_simd<T, simd_abi::scalar> {
   T m_value;
 
  public:
-  using value_type                       = T;
-  using abi_type                         = simd_abi::scalar;
-  using mask_type                        = basic_simd_mask<T, abi_type>;
-  KOKKOS_DEFAULTED_FUNCTION basic_simd() = default;
-  KOKKOS_DEFAULTED_FUNCTION basic_simd(basic_simd const&)            = default;
-  KOKKOS_DEFAULTED_FUNCTION basic_simd(basic_simd&&)                 = default;
-  KOKKOS_DEFAULTED_FUNCTION basic_simd& operator=(basic_simd const&) = default;
-  KOKKOS_DEFAULTED_FUNCTION basic_simd& operator=(basic_simd&&)      = default;
+  using value_type = T;
+  using abi_type   = simd_abi::scalar;
+  using mask_type  = basic_simd_mask<T, abi_type>;
+
   KOKKOS_FORCEINLINE_FUNCTION static constexpr std::size_t size() { return 1; }
+
+  KOKKOS_DEFAULTED_FUNCTION constexpr basic_simd() noexcept         = default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr basic_simd(basic_simd const&) = default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr basic_simd(basic_simd&&)      = default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr basic_simd& operator=(basic_simd const&) =
+      default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr basic_simd& operator=(basic_simd&&) =
+      default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd(U&& value) : m_value(value) {}
+  KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd(U&& value) noexcept
+      : m_value(value) {}
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<U, abi_type> const& other)
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      basic_simd<U, abi_type> const& other) noexcept
       : m_value(static_cast<U>(other)) {}
   template <class G,
             std::enable_if_t<
@@ -126,44 +222,32 @@ class basic_simd<T, simd_abi::scalar> {
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator T() const {
     return m_value;
   }
-  KOKKOS_FORCEINLINE_FUNCTION void copy_from(T const* ptr,
-                                             element_aligned_tag) {
+  KOKKOS_FORCEINLINE_FUNCTION constexpr void copy_from(T const* ptr,
+                                                       element_aligned_tag) {
     m_value = *ptr;
   }
-  KOKKOS_FORCEINLINE_FUNCTION void copy_from(T const* ptr, vector_aligned_tag) {
+  KOKKOS_FORCEINLINE_FUNCTION constexpr void copy_from(T const* ptr,
+                                                       vector_aligned_tag) {
     m_value = *ptr;
   }
-  KOKKOS_FORCEINLINE_FUNCTION void copy_to(T* ptr, element_aligned_tag) const {
+  KOKKOS_FORCEINLINE_FUNCTION constexpr void copy_to(
+      T* ptr, element_aligned_tag) const {
     *ptr = m_value;
   }
-  KOKKOS_FORCEINLINE_FUNCTION void copy_to(T* ptr, vector_aligned_tag) const {
+  KOKKOS_FORCEINLINE_FUNCTION constexpr void copy_to(T* ptr,
+                                                     vector_aligned_tag) const {
     *ptr = m_value;
   }
-  KOKKOS_FORCEINLINE_FUNCTION value_type operator[](std::size_t) const {
+
+  KOKKOS_FORCEINLINE_FUNCTION constexpr value_type operator[](
+      std::size_t) const {
     return m_value;
   }
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
+
+  KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd operator-() const noexcept {
     return basic_simd(-m_value);
   }
 
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(lhs.m_value * rhs.m_value);
-  }
-  template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator*(basic_simd const& lhs, U rhs) {
-    return lhs.m_value * basic_simd(rhs);
-  }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(lhs.m_value / rhs.m_value);
-  }
-  template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator/(basic_simd const& lhs, U rhs) {
-    return lhs.m_value / basic_simd(rhs);
-  }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
   operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(lhs.m_value + rhs.m_value);
@@ -183,12 +267,30 @@ class basic_simd<T, simd_abi::scalar> {
     return lhs.m_value - basic_simd(rhs);
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(lhs.m_value >> rhs);
+  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(lhs.m_value * rhs.m_value);
+  }
+  template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
+  operator*(basic_simd const& lhs, U rhs) {
+    return lhs.m_value * basic_simd(rhs);
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(lhs.m_value >> rhs.m_value);
+  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(lhs.m_value / rhs.m_value);
+  }
+  template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
+  operator/(basic_simd const& lhs, U rhs) {
+    return lhs.m_value / basic_simd(rhs);
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
+  operator&(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return lhs.m_value & rhs.m_value;
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
+  operator|(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return lhs.m_value | rhs.m_value;
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
   operator<<(basic_simd const& lhs, int rhs) noexcept {
@@ -199,13 +301,14 @@ class basic_simd<T, simd_abi::scalar> {
     return basic_simd(lhs.m_value << rhs.m_value);
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator&(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return lhs.m_value & rhs.m_value;
+  operator>>(basic_simd const& lhs, int rhs) noexcept {
+    return basic_simd(lhs.m_value >> rhs);
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator|(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return lhs.m_value | rhs.m_value;
+  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(lhs.m_value >> rhs.m_value);
   }
+
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
   operator+=(basic_simd& lhs, basic_simd const& rhs) noexcept {
     lhs = lhs + rhs;
@@ -227,31 +330,16 @@ class basic_simd<T, simd_abi::scalar> {
     return lhs;
   }
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator>>=(basic_simd& lhs, basic_simd const& rhs) noexcept {
-    lhs = lhs >> rhs;
-    return lhs;
-  }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
   operator<<=(basic_simd& lhs, basic_simd const& rhs) noexcept {
     lhs = lhs << rhs;
     return lhs;
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(lhs.m_value < rhs.m_value);
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
+  operator>>=(basic_simd& lhs, basic_simd const& rhs) noexcept {
+    lhs = lhs >> rhs;
+    return lhs;
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(lhs.m_value > rhs.m_value);
-  }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(lhs.m_value <= rhs.m_value);
-  }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(lhs.m_value >= rhs.m_value);
-  }
+
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
   operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(lhs.m_value == rhs.m_value);
@@ -260,14 +348,30 @@ class basic_simd<T, simd_abi::scalar> {
   operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(lhs.m_value != rhs.m_value);
   }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
+  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(lhs.m_value >= rhs.m_value);
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
+  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(lhs.m_value <= rhs.m_value);
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
+  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(lhs.m_value > rhs.m_value);
+  }
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
+  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(lhs.m_value < rhs.m_value);
+  }
 };
 
 }  // namespace Experimental
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar>
-    abs(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+    T, Experimental::simd_abi::scalar>
+abs(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   if constexpr (std::is_signed_v<T>) {
     return (a < 0 ? -a : a);
   }
@@ -275,7 +379,7 @@ template <class T>
 }
 
 template <typename T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto floor(
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr auto floor(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
   return Experimental::basic_simd<data_type, Experimental::simd_abi::scalar>(
@@ -283,7 +387,7 @@ template <typename T>
 }
 
 template <typename T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto ceil(
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr auto ceil(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
   return Experimental::basic_simd<data_type, Experimental::simd_abi::scalar>(
@@ -291,7 +395,7 @@ template <typename T>
 }
 
 template <typename T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto round(
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr auto round(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
   return Experimental::basic_simd<data_type, Experimental::simd_abi::scalar>(
@@ -299,7 +403,7 @@ template <typename T>
 }
 
 template <typename T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto trunc(
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr auto trunc(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
   return Experimental::basic_simd<data_type, Experimental::simd_abi::scalar>(
@@ -307,36 +411,35 @@ template <typename T>
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar>
-    sqrt(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+    T, Experimental::simd_abi::scalar>
+sqrt(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   return Experimental::basic_simd<T, Experimental::simd_abi::scalar>(
       std::sqrt(static_cast<T>(a)));
 }
 
 template <class T>
-KOKKOS_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar>
-    fma(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
-        Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& y,
-        Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& z) {
+KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+    T, Experimental::simd_abi::scalar>
+fma(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
+    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& y,
+    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& z) {
   return Experimental::basic_simd<T, Experimental::simd_abi::scalar>(
       (static_cast<T>(x) * static_cast<T>(y)) + static_cast<T>(z));
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar>
-    copysign(
-        Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a,
-        Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& b) {
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+    T, Experimental::simd_abi::scalar>
+copysign(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a,
+         Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& b) {
   return std::copysign(static_cast<T>(a), static_cast<T>(b));
 }
 
 namespace Experimental {
 
 template <class T>
-KOKKOS_FORCEINLINE_FUNCTION basic_simd<T, simd_abi::scalar> condition(
+KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd<T, simd_abi::scalar> condition(
     desul::Impl::dont_deduce_this_parameter_t<
         basic_simd_mask<T, simd_abi::scalar>> const& a,
     basic_simd<T, simd_abi::scalar> const& b,
@@ -346,19 +449,19 @@ KOKKOS_FORCEINLINE_FUNCTION basic_simd<T, simd_abi::scalar> condition(
 }
 
 template <class T, class BinaryOperation>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
-reduce(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
-       Experimental::basic_simd_mask<T, Experimental::simd_abi::scalar> const&
-           mask,
-       T identity, BinaryOperation) noexcept {
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
+    Experimental::basic_simd_mask<T, Experimental::simd_abi::scalar> const&
+        mask,
+    T identity, BinaryOperation) noexcept {
   if (!mask) return identity;
   return x[0];
 }
 
 template <class T, class BinaryOperation>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
-reduce(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
-       BinaryOperation binary_op) noexcept {
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
+    BinaryOperation binary_op) noexcept {
   return reduce(
       x,
       Experimental::basic_simd<T, Experimental::simd_abi::scalar>::mask_type(
@@ -367,7 +470,7 @@ reduce(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T reduce_min(
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
     Experimental::basic_simd_mask<T, Experimental::simd_abi::scalar> const&
         mask) noexcept {
@@ -383,7 +486,7 @@ reduce_min(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const&
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T reduce_max(
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
     Experimental::basic_simd_mask<T, Experimental::simd_abi::scalar> const&
         mask) noexcept {
@@ -501,24 +604,6 @@ where(typename basic_simd<
   return const_where_expression(mask, value);
 }
 
-template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION bool all_of(
-    basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const& a) {
-  return a == basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(true);
-}
-
-template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION bool any_of(
-    basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const& a) {
-  return a != basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(false);
-}
-
-template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION bool none_of(
-    basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const& a) {
-  return a == basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(false);
-}
-
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class T>
 [[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead")
@@ -532,19 +617,19 @@ template <class T>
 #endif
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
-reduce(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
-                              basic_simd<T, simd_abi::scalar>> const& x,
-       T identity_element, std::plus<>) {
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+    const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
+                           basic_simd<T, simd_abi::scalar>> const& x,
+    T identity_element, std::plus<>) {
   return static_cast<bool>(x.impl_get_mask())
              ? static_cast<T>(x.impl_get_value())
              : identity_element;
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
-reduce_max(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
-                                  basic_simd<T, simd_abi::scalar>> const& x) {
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
+    const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
+                           basic_simd<T, simd_abi::scalar>> const& x) noexcept {
   return static_cast<bool>(x.impl_get_mask())
              ? static_cast<T>(x.impl_get_value())
              : Kokkos::reduction_identity<T>::max();
@@ -563,9 +648,9 @@ template <class T>
 #endif
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
-reduce_min(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
-                                  basic_simd<T, simd_abi::scalar>> const& x) {
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
+    const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
+                           basic_simd<T, simd_abi::scalar>> const& x) noexcept {
   return static_cast<bool>(x.impl_get_mask())
              ? static_cast<T>(x.impl_get_value())
              : Kokkos::reduction_identity<T>::min();

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -570,6 +570,16 @@ reduce_min(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
              ? static_cast<T>(x.impl_get_value())
              : Kokkos::reduction_identity<T>::min();
 }
+#endif
+
+template <class T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
+reduce_min(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
+                                  basic_simd<T, simd_abi::scalar>> const& x) {
+  return static_cast<bool>(x.impl_get_mask())
+             ? static_cast<T>(x.impl_get_value())
+             : Kokkos::reduction_identity<T>::min();
+}
 
 }  // namespace Experimental
 }  // namespace Kokkos

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -82,10 +82,6 @@ KOKKOS_INLINE_FUNCTION void device_check_equality(
   for (std::size_t i = 0; i < nlanes; ++i) {
     checker.equality(expected_result[i], computed_result[i]);
   }
-  using mask_type =
-      typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
-  mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return (i < nlanes); });
-  checker.equality((expected_result == computed_result) && mask, mask);
 }
 
 template <typename T, typename Abi>

--- a/simd/unit_tests/include/TestSIMD_Construction.hpp
+++ b/simd/unit_tests/include/TestSIMD_Construction.hpp
@@ -56,7 +56,7 @@ inline void host_test_mask_traits() {
   mask_type move_mask(std::move(copy_mask));
   default_mask = std::move(move_mask);
   result       = default_mask;
-  EXPECT_EQ(test_mask, result);
+  EXPECT_TRUE(Kokkos::Experimental::all_of(test_mask == result));
 }
 
 template <typename Abi, typename DataType>
@@ -135,7 +135,7 @@ KOKKOS_INLINE_FUNCTION void device_test_mask_traits() {
   result       = default_mask;
 
   kokkos_checker checker;
-  checker.truth(test_mask == result);
+  checker.truth(Kokkos::Experimental::all_of(test_mask == result));
 }
 
 template <typename Abi, typename DataType>

--- a/simd/unit_tests/include/TestSIMD_Conversions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Conversions.hpp
@@ -26,37 +26,37 @@ inline void host_check_conversions() {
     {
       auto a = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(1);
       auto b = Kokkos::Experimental::basic_simd<std::int64_t, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(1)));
+      EXPECT_TRUE(Kokkos::Experimental::all_of(b == decltype(b)(1)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd<std::int32_t, Abi>(1);
       auto b = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(1)));
+      EXPECT_TRUE(Kokkos::Experimental::all_of(b == decltype(b)(1)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(1);
       auto b = Kokkos::Experimental::basic_simd<std::int32_t, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(1)));
+      EXPECT_TRUE(Kokkos::Experimental::all_of(b == decltype(b)(1)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd_mask<double, Abi>(true);
       auto b = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(a);
-      EXPECT_TRUE(b == decltype(b)(true));
+      EXPECT_TRUE(Kokkos::Experimental::all_of(b == decltype(b)(true)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
       auto b = Kokkos::Experimental::basic_simd_mask<std::uint64_t, Abi>(a);
-      EXPECT_TRUE(b == decltype(b)(true));
+      EXPECT_TRUE(Kokkos::Experimental::all_of(b == decltype(b)(true)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
       auto b = Kokkos::Experimental::basic_simd_mask<std::int64_t, Abi>(a);
-      EXPECT_TRUE(b == decltype(b)(true));
+      EXPECT_TRUE(Kokkos::Experimental::all_of(b == decltype(b)(true)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
       auto b = Kokkos::Experimental::basic_simd_mask<double, Abi>(a);
-      EXPECT_TRUE(b == decltype(b)(true));
+      EXPECT_TRUE(Kokkos::Experimental::all_of(b == decltype(b)(true)));
     }
   }
 }
@@ -74,37 +74,37 @@ KOKKOS_INLINE_FUNCTION void device_check_conversions() {
     {
       auto a = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(1);
       auto b = Kokkos::Experimental::basic_simd<std::int64_t, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(1)));
+      checker.truth(Kokkos::Experimental::all_of(b == decltype(b)(1)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd<std::int32_t, Abi>(1);
       auto b = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(1)));
+      checker.truth(Kokkos::Experimental::all_of(b == decltype(b)(1)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(1);
       auto b = Kokkos::Experimental::basic_simd<std::int32_t, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(1)));
+      checker.truth(Kokkos::Experimental::all_of(b == decltype(b)(1)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd_mask<double, Abi>(true);
       auto b = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(a);
-      checker.truth(b == decltype(b)(true));
+      checker.truth(Kokkos::Experimental::all_of(b == decltype(b)(true)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
       auto b = Kokkos::Experimental::basic_simd_mask<std::uint64_t, Abi>(a);
-      checker.truth(b == decltype(b)(true));
+      checker.truth(Kokkos::Experimental::all_of(b == decltype(b)(true)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
       auto b = Kokkos::Experimental::basic_simd_mask<std::int64_t, Abi>(a);
-      checker.truth(b == decltype(b)(true));
+      checker.truth(Kokkos::Experimental::all_of(b == decltype(b)(true)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
       auto b = Kokkos::Experimental::basic_simd_mask<double, Abi>(a);
-      checker.truth(b == decltype(b)(true));
+      checker.truth(Kokkos::Experimental::all_of(b == decltype(b)(true)));
     }
   }
 }

--- a/simd/unit_tests/include/TestSIMD_MaskOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MaskOps.hpp
@@ -25,23 +25,23 @@ inline void host_check_mask_ops() {
   if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
     using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
 
-    EXPECT_FALSE(none_of(mask_type(true)));
-    EXPECT_TRUE(none_of(mask_type(false)));
-    EXPECT_TRUE(all_of(mask_type(true)));
-    EXPECT_FALSE(all_of(mask_type(false)));
-    EXPECT_TRUE(any_of(mask_type(true)));
-    EXPECT_FALSE(any_of(mask_type(false)));
+    EXPECT_FALSE(Kokkos::Experimental::none_of(mask_type(true)));
+    EXPECT_TRUE(Kokkos::Experimental::none_of(mask_type(false)));
+    EXPECT_TRUE(Kokkos::Experimental::all_of(mask_type(true)));
+    EXPECT_FALSE(Kokkos::Experimental::all_of(mask_type(false)));
+    EXPECT_TRUE(Kokkos::Experimental::any_of(mask_type(true)));
+    EXPECT_FALSE(Kokkos::Experimental::any_of(mask_type(false)));
 
     for (std::size_t i = 0; i < mask_type::size(); ++i) {
       mask_type test_mask(KOKKOS_LAMBDA(std::size_t j) { return i == j; });
 
-      EXPECT_TRUE(any_of(test_mask));
-      EXPECT_FALSE(none_of(test_mask));
+      EXPECT_TRUE(Kokkos::Experimental::any_of(test_mask));
+      EXPECT_FALSE(Kokkos::Experimental::none_of(test_mask));
 
       if constexpr (mask_type::size() > 1) {
-        EXPECT_FALSE(all_of(test_mask));
+        EXPECT_FALSE(Kokkos::Experimental::all_of(test_mask));
       } else {
-        EXPECT_TRUE(all_of(test_mask));
+        EXPECT_TRUE(Kokkos::Experimental::all_of(test_mask));
       }
     }
   }
@@ -65,23 +65,23 @@ KOKKOS_INLINE_FUNCTION void device_check_mask_ops() {
   if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
     using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
     kokkos_checker checker;
-    checker.truth(!none_of(mask_type(true)));
-    checker.truth(none_of(mask_type(false)));
-    checker.truth(all_of(mask_type(true)));
-    checker.truth(!all_of(mask_type(false)));
-    checker.truth(any_of(mask_type(true)));
-    checker.truth(!any_of(mask_type(false)));
+    checker.truth(!Kokkos::Experimental::none_of(mask_type(true)));
+    checker.truth(Kokkos::Experimental::none_of(mask_type(false)));
+    checker.truth(Kokkos::Experimental::all_of(mask_type(true)));
+    checker.truth(!Kokkos::Experimental::all_of(mask_type(false)));
+    checker.truth(Kokkos::Experimental::any_of(mask_type(true)));
+    checker.truth(!Kokkos::Experimental::any_of(mask_type(false)));
 
     for (std::size_t i = 0; i < mask_type::size(); ++i) {
       mask_type test_mask(KOKKOS_LAMBDA(std::size_t j) { return i == j; });
 
-      checker.truth(any_of(test_mask));
-      checker.truth(!none_of(test_mask));
+      checker.truth(Kokkos::Experimental::any_of(test_mask));
+      checker.truth(!Kokkos::Experimental::none_of(test_mask));
 
       if constexpr (mask_type::size() > 1) {
-        checker.truth(!all_of(test_mask));
+        checker.truth(!Kokkos::Experimental::all_of(test_mask));
       } else {
-        checker.truth(all_of(test_mask));
+        checker.truth(Kokkos::Experimental::all_of(test_mask));
       }
     }
   }

--- a/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
+++ b/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
@@ -33,6 +33,14 @@ inline void host_check_where_expr_scatter_to() {
     simd_type src;
     src.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
+    // gcc build with cxxflag of -g and -O2 or above doesn't seem to properly
+    // load values into simd vectors until simd values are directly accessed.
+    // Placing a memory fence to ensure that simd values are fully loaded
+    // before executing simd instructions.
+#if defined(KOKKOS_COMPILER_GNU) && defined(NDEBUG)
+    __sync_synchronize();
+#endif
+
     for (std::size_t idx = 0; idx < nlanes; ++idx) {
       if constexpr (std::is_same_v<Abi,
                                    Kokkos::Experimental::simd_abi::scalar>) {

--- a/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
+++ b/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
@@ -33,14 +33,6 @@ inline void host_check_where_expr_scatter_to() {
     simd_type src;
     src.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
-    // gcc build with cxxflag of -g and -O2 or above doesn't seem to properly
-    // load values into simd vectors until simd values are directly accessed.
-    // Placing a memory fence to ensure that simd values are fully loaded
-    // before executing simd instructions.
-#if defined(KOKKOS_COMPILER_GNU) && defined(NDEBUG)
-    __sync_synchronize();
-#endif
-
     for (std::size_t idx = 0; idx < nlanes; ++idx) {
       if constexpr (std::is_same_v<Abi,
                                    Kokkos::Experimental::simd_abi::scalar>) {


### PR DESCRIPTION
This PR makes following changes:
- Reorganized and rearranged class definitions to match class overviews described in P1928
  - The main intent was to identify all missing operators from each simd type that were unintentionally relying on fallback implementations and those that are no longer in P1928 (i.e. `[const_]where_expression`, `copy_from|to`)
- Added missing `constexpr`, `friend`, `explicit` and `noexcept` specifiers
- Deprecated simd mask comparison operators that return by bool in favor of operators that return by `basic_simd_mask` (i.e. `bool operator==(basic_simd_mask const&)` -> `friend basic_simd_mask operator==(basic_simd_mask const&, basic_simd_mask const&)`