### PR TITLE
simd: replace simd mask comparison operators that return a bool

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -117,13 +117,14 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
     return basic_simd_mask(_mm256_or_pd(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const noexcept {
-    return _mm256_movemask_pd(m_value) == _mm256_movemask_pd(other.m_value);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_movemask_pd(lhs.m_value) ==
+                           _mm256_movemask_pd(rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const noexcept {
-    return !operator==(other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return !operator==(lhs, rhs);
   }
 };
 
@@ -185,13 +186,14 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
     return basic_simd_mask(_mm_or_ps(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const noexcept {
-    return _mm_movemask_ps(m_value) == _mm_movemask_ps(other.m_value);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm_movemask_ps(lhs.m_value) ==
+                           _mm_movemask_ps(rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const noexcept {
-    return !operator==(other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return !operator==(lhs, rhs);
   }
 };
 
@@ -256,13 +258,14 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
     return basic_simd_mask(_mm256_or_ps(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const noexcept {
-    return _mm256_movemask_ps(m_value) == _mm256_movemask_ps(other.m_value);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_movemask_ps(lhs.m_value) ==
+                           _mm256_movemask_ps(rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const noexcept {
-    return !operator==(other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return !operator==(lhs, rhs);
   }
 };
 
@@ -329,14 +332,14 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
     return basic_simd_mask(_mm_or_si128(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const noexcept {
-    return _mm_movemask_ps(_mm_castsi128_ps(m_value)) ==
-           _mm_movemask_ps(_mm_castsi128_ps(other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm_movemask_ps(_mm_castsi128_ps(lhs.m_value)) ==
+                           _mm_movemask_ps(_mm_castsi128_ps(rhs.m_value)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const noexcept {
-    return !operator==(other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return !operator==(lhs, rhs);
   }
 };
 
@@ -406,14 +409,15 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
     return basic_simd_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const noexcept {
-    return _mm256_movemask_ps(_mm256_castsi256_ps(m_value)) ==
-           _mm256_movemask_ps(_mm256_castsi256_ps(other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(
+        _mm256_movemask_ps(_mm256_castsi256_ps(lhs.m_value)) ==
+        _mm256_movemask_ps(_mm256_castsi256_ps(rhs.m_value)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const noexcept {
-    return !operator==(other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return !operator==(lhs, rhs);
   }
 };
 
@@ -477,14 +481,15 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
     return basic_simd_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const noexcept {
-    return _mm256_movemask_pd(_mm256_castsi256_pd(m_value)) ==
-           _mm256_movemask_pd(_mm256_castsi256_pd(other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(
+        _mm256_movemask_pd(_mm256_castsi256_pd(lhs.m_value)) ==
+        _mm256_movemask_pd(_mm256_castsi256_pd(rhs.m_value)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const noexcept {
-    return !operator==(other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return !operator==(lhs, rhs);
   }
 };
 
@@ -548,14 +553,15 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     return basic_simd_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const noexcept {
-    return _mm256_movemask_pd(_mm256_castsi256_pd(m_value)) ==
-           _mm256_movemask_pd(_mm256_castsi256_pd(other.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(
+        _mm256_movemask_pd(_mm256_castsi256_pd(lhs.m_value)) ==
+        _mm256_movemask_pd(_mm256_castsi256_pd(rhs.m_value)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const noexcept {
-    return !operator==(other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return !operator==(lhs, rhs);
   }
 };
 

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -123,13 +123,13 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<8>> {
     return basic_simd_mask(_kor_mask8(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const {
-    return m_value == other.m_value;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(lhs.m_value == rhs.m_value);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const {
-    return m_value != other.m_value;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(lhs.m_value != rhs.m_value);
   }
 };
 
@@ -246,13 +246,13 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<16>> {
     return basic_simd_mask(_kand_mask16(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const {
-    return m_value == other.m_value;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(lhs.m_value == rhs.m_value);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const {
-    return m_value != other.m_value;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(lhs.m_value != rhs.m_value);
   }
 };
 

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -314,19 +314,25 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator<<=(
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool all_of(
     basic_simd_mask<T, Abi> const& a) {
-  return a == basic_simd_mask<T, Abi>(true);
+  for (size_t i = 0; i < basic_simd_mask<T, Abi>::size(); ++i) {
+    if (!a[i]) return false;
+  }
+  return true;
 }
 
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool any_of(
     basic_simd_mask<T, Abi> const& a) {
-  return a != basic_simd_mask<T, Abi>(false);
+  for (size_t i = 0; i < basic_simd_mask<T, Abi>::size(); ++i) {
+    if (a[i]) return true;
+  }
+  return false;
 }
 
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool none_of(
     basic_simd_mask<T, Abi> const& a) {
-  return a == basic_simd_mask<T, Abi>(false);
+  return !any_of(a);
 }
 
 // A temporary device-callable implemenation of round half to nearest even

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -57,20 +57,6 @@ inline void host_check_equality(
   for (std::size_t i = 0; i < nlanes; ++i) {
     checker.equality(expected_result[i], computed_result[i]);
   }
-
-#ifdef __INTEL_COMPILER
-  if constexpr (!std::is_integral_v<T>) return;
-#endif
-
-  using mask_type =
-      typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
-  if constexpr (std::is_same_v<Abi, Kokkos::Experimental::simd_abi::scalar>) {
-    mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return (i < nlanes); });
-    checker.equality((expected_result == computed_result) && mask, mask);
-  } else {
-    mask_type mask([=](std::size_t i) { return (i < nlanes); });
-    checker.equality((expected_result == computed_result) && mask, mask);
-  }
 }
 
 template <class T, class Abi>
@@ -82,10 +68,6 @@ KOKKOS_INLINE_FUNCTION void device_check_equality(
   for (std::size_t i = 0; i < nlanes; ++i) {
     checker.equality(expected_result[i], computed_result[i]);
   }
-  using mask_type =
-      typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
-  mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return (i < nlanes); });
-  checker.equality((expected_result == computed_result) && mask, mask);
 }
 
 template <typename T, typename Abi>

--- a/simd/unit_tests/include/TestSIMD_Construction.hpp
+++ b/simd/unit_tests/include/TestSIMD_Construction.hpp
@@ -20,6 +20,8 @@
 #include <Kokkos_SIMD.hpp>
 #include <SIMDTesting_Utilities.hpp>
 
+using Kokkos::Experimental::all_of;
+
 template <typename Abi, typename DataType>
 inline void host_test_simd_traits() {
   using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
@@ -56,7 +58,7 @@ inline void host_test_mask_traits() {
   mask_type move_mask(std::move(copy_mask));
   default_mask = std::move(move_mask);
   result       = default_mask;
-  EXPECT_EQ(test_mask, result);
+  EXPECT_TRUE(all_of(test_mask == result));
 }
 
 template <typename Abi, typename DataType>
@@ -135,7 +137,7 @@ KOKKOS_INLINE_FUNCTION void device_test_mask_traits() {
   result       = default_mask;
 
   kokkos_checker checker;
-  checker.truth(test_mask == result);
+  checker.truth(all_of(test_mask == result));
 }
 
 template <typename Abi, typename DataType>

--- a/simd/unit_tests/include/TestSIMD_Conversions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Conversions.hpp
@@ -20,6 +20,8 @@
 #include <Kokkos_SIMD.hpp>
 #include <SIMDTesting_Utilities.hpp>
 
+using Kokkos::Experimental::all_of;
+
 template <typename Abi>
 inline void host_check_conversions() {
   if constexpr (is_type_v<Kokkos::Experimental::basic_simd<uint64_t, Abi>>) {
@@ -41,22 +43,22 @@ inline void host_check_conversions() {
     {
       auto a = Kokkos::Experimental::basic_simd_mask<double, Abi>(true);
       auto b = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(a);
-      EXPECT_TRUE(b == decltype(b)(true));
+      EXPECT_TRUE(all_of(b == decltype(b)(true)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
       auto b = Kokkos::Experimental::basic_simd_mask<std::uint64_t, Abi>(a);
-      EXPECT_TRUE(b == decltype(b)(true));
+      EXPECT_TRUE(all_of(b == decltype(b)(true)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
       auto b = Kokkos::Experimental::basic_simd_mask<std::int64_t, Abi>(a);
-      EXPECT_TRUE(b == decltype(b)(true));
+      EXPECT_TRUE(all_of(b == decltype(b)(true)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
       auto b = Kokkos::Experimental::basic_simd_mask<double, Abi>(a);
-      EXPECT_TRUE(b == decltype(b)(true));
+      EXPECT_TRUE(all_of(b == decltype(b)(true)));
     }
   }
 }
@@ -89,22 +91,22 @@ KOKKOS_INLINE_FUNCTION void device_check_conversions() {
     {
       auto a = Kokkos::Experimental::basic_simd_mask<double, Abi>(true);
       auto b = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(a);
-      checker.truth(b == decltype(b)(true));
+      checker.truth(all_of(b == decltype(b)(true)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
       auto b = Kokkos::Experimental::basic_simd_mask<std::uint64_t, Abi>(a);
-      checker.truth(b == decltype(b)(true));
+      checker.truth(all_of(b == decltype(b)(true)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
       auto b = Kokkos::Experimental::basic_simd_mask<std::int64_t, Abi>(a);
-      checker.truth(b == decltype(b)(true));
+      checker.truth(all_of(b == decltype(b)(true)));
     }
     {
       auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
       auto b = Kokkos::Experimental::basic_simd_mask<double, Abi>(a);
-      checker.truth(b == decltype(b)(true));
+      checker.truth(all_of(b == decltype(b)(true)));
     }
   }
 }


### PR DESCRIPTION
Part of #7776 (splitting it apart to reduce the size of the PR)

This PR replaces simd mask comparison operators that return bool with operators that return `basic_simd_mask`.
- `bool operator==(basic_simd_mask const&` -> `friend basic_simd_mask operator==(basic_simd_mask const&, basic_simd_mask const&`

Also adjusted `all_of`, `any_of` and `none_of` which were previously relying on mask comparisons to return a single bool value.