### PR TITLE
MI300A: Filter out test causing timeout

### DIFF
--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -103,6 +103,7 @@ AMD-MI300A:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_COMPILER_WARNINGS=ON"
     - export CTEST_BUILD_NAME="AMD-MI300A"
     - export HSA_XNACK=1
+    - export GTEST_FILTER="-hip.atomic_views_integral" #FIXME: Test has kernel with much longer than expected execution time (Issue #7757)
     - ctest -VV
       -D CDASH_MODEL=${CDASH_MODEL}
       -D GITHUB_PR_ID="${GITHUB_PR_ID}"


### PR DESCRIPTION
This is meant as a temporary fix to allow CI to pass for MI300A. See https://github.com/kokkos/kokkos/issues/7757 for tracking of the issue.

Another solution would be to add a `GTEST_SKIP` for the specific ARCH, that way it would be visible in the output that this is broken. Maybe some prefer that.