### PR TITLE
Allow CEA nightly build to fail

### DIFF
--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -3,6 +3,7 @@ name: Nightly CEA builds
 on:
   schedule:
     - cron: "0 2 * * 1-5" # every weekday at 2am UTC
+  pull_request: # XXX for testing only, remove before merging!
 
 permissions: read-all
 
@@ -78,9 +79,9 @@ jobs:
             ctest \
               -V \
               --test-dir build \
-              -D NightlyStart \
-              -D NightlyUpdate \
-              -D NightlyConfigure
+              -D ExperimentalStart \
+              -D ExperimentalUpdate \
+              -D ExperimentalConfigure
 
       - name: Build
         id: build
@@ -93,7 +94,7 @@ jobs:
             ctest \
               -V \
               --test-dir build \
-              -D NightlyBuild
+              -D ExperimentalBuild
 
       - name: Test
         id: test
@@ -105,7 +106,7 @@ jobs:
             ctest \
               --output-on-failure \
               --test-dir build \
-              -D NightlyTest
+              -D ExperimentalTest
 
       - name: Submit
         run: |
@@ -114,7 +115,7 @@ jobs:
             -e local \
             ctest \
               --test-dir build \
-              -D NightlySubmit
+              -D ExperimentalSubmit
 
       # note: this marks the job as failed if any of the mentionned steps (that
       # have `continue-on-error`) has failed

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -69,6 +69,7 @@ jobs:
               ${{ matrix.backend.configure }}
 
       - name: Start, update and configure
+        id: start_update_configure
         continue-on-error: true
         run: |
           run \
@@ -82,6 +83,7 @@ jobs:
               -D NightlyConfigure
 
       - name: Build
+        id: build
         continue-on-error: true
         run: |
           run \
@@ -94,6 +96,7 @@ jobs:
               -D NightlyBuild
 
       - name: Test
+        id: test
         continue-on-error: true
         run: |
           run \
@@ -112,3 +115,14 @@ jobs:
             ctest \
               --test-dir build \
               -D NightlySubmit
+
+      # note: this marks the job as failed if any of the mentionned steps (that
+      # have `continue-on-error`) has failed
+      - name: Failure outcome
+        if: |-
+          ${{
+            steps.start_update_configure.outcome == 'failure' ||
+            steps.build.outcome == 'failure' ||
+            steps.test.outcome == 'failure'
+          }}
+        run: exit 1

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -3,7 +3,6 @@ name: Nightly CEA builds
 on:
   schedule:
     - cron: "0 2 * * 1-5" # every weekday at 2am UTC
-  pull_request: # XXX for testing only, remove before merging!
 
 permissions: read-all
 
@@ -79,9 +78,9 @@ jobs:
             ctest \
               -V \
               --test-dir build \
-              -D ExperimentalStart \
-              -D ExperimentalUpdate \
-              -D ExperimentalConfigure
+              -D NightlyStart \
+              -D NightlyUpdate \
+              -D NightlyConfigure
 
       - name: Build
         id: build
@@ -94,7 +93,7 @@ jobs:
             ctest \
               -V \
               --test-dir build \
-              -D ExperimentalBuild
+              -D NightlyBuild
 
       - name: Test
         id: test
@@ -106,7 +105,7 @@ jobs:
             ctest \
               --output-on-failure \
               --test-dir build \
-              -D ExperimentalTest
+              -D NightlyTest
 
       - name: Submit
         run: |
@@ -115,7 +114,7 @@ jobs:
             -e local \
             ctest \
               --test-dir build \
-              -D ExperimentalSubmit
+              -D NightlySubmit
 
       # note: this marks the job as failed if any of the mentionned steps (that
       # have `continue-on-error`) has failed


### PR DESCRIPTION
Currently, the CEA nightly build workflow never fails when trying to configure, build, and test the code. These steps are marked with `continue-on-error: true`, which allows the next step to perform if the current one failed. This allows to generate all the reports before sending them to the CDash instance. However, while any failure would be displayed on the dashboard, they are not reported on GitHub. By instance, the badge of the workflow, used in the weekly meeting document, is always green.

This PR adds an extra step that checks the outcome of the steps marked with `continue-on-error: true` and makes the job fail if any of them has failed.

- [x] Improve test script;
- [x] Prevent to run for pull request event and re-enable Nightly mode.

As in #7704, the CTest Update step fails because it currently runs on a feature branch outside of the repository (this does not happen when the nightly runs). Now, this error is reported at a higher level, as expected.

You can check that the workflow was executed without other errors.

Outcomes:

- Cuda-A100-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE-Release:
  - [Workflow](https://github.com/kokkos/kokkos/actions/runs/13433943764/job/37531862285);
  - [CDash](https://my.cdash.org/build/2828207);
- Cuda-A100-UVM-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE-Release:
  - [Workflow](https://github.com/kokkos/kokkos/actions/runs/13433943764/job/37531862626);
  - [CDash](https://my.cdash.org/build/2828201);
- Cuda-V100-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE-Release:
  - [Workflow](https://github.com/kokkos/kokkos/actions/runs/13433943764/job/37531862966);
  - [CDash](https://my.cdash.org/build/2828196);
- Cuda-V100-UVM-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE-Release:
  - [Workflow](https://github.com/kokkos/kokkos/actions/runs/13433943764/job/37531863348);
  - [CDash](https://my.cdash.org/build/2828218);
- OpenMP-x86_64-GCC/10.3-Shared-Release:
  - [Workflow](https://github.com/kokkos/kokkos/actions/runs/13433943764/job/37531861953); and
  - [CDash](https://my.cdash.org/build/2828212).