### PR TITLE
add size_t in zero memset kernel

### DIFF
--- a/core/src/HIP/Kokkos_HIP_ZeroMemset.cpp
+++ b/core/src/HIP/Kokkos_HIP_ZeroMemset.cpp
@@ -28,7 +28,7 @@ namespace Impl {
 void zero_with_hip_kernel(const HIP& exec_space, void* dst, size_t cnt) {
   Kokkos::parallel_for(
       "Kokkos::ZeroMemset via parallel_for",
-      Kokkos::RangePolicy<Kokkos::HIP>(exec_space, 0, cnt),
+      Kokkos::RangePolicy<Kokkos::HIP, size_t>(exec_space, 0, cnt),
       KOKKOS_LAMBDA(size_t i) { static_cast<char*>(dst)[i] = 0; });
 }
 


### PR DESCRIPTION
Our MI300A CI showed: 
```
Kokkos::RangePolicy bound type error: an unsafe implicit conversion is performed on a bound ([4294967296](tel:4294967296)), which may not preserve its original value.
```
for `hip.view_allocation_large_rank`. It turns out it is in the memset via a kernel that we do if we are on MI300A. Specifying `size_t` as index type allows to makes it correct.

But we should look how this impacts performance and possibly decide which integer type to use before.