### PR TITLE
HIP: RangePolicy parallel_for with large work items

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -75,8 +75,9 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
     for (Member iwork =
              m_policy.begin() + threadIdx.y + blockDim.y * blockIdx.x;
          iwork < work_end;
-         iwork = iwork < work_end - work_stride ? iwork + work_stride
-                                                : work_end) {
+         iwork = iwork < static_cast<Member>(work_end - work_stride)
+                     ? iwork + work_stride
+                     : work_end) {
       this->template exec_range<WorkTag>(iwork);
     }
   }

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -69,8 +69,8 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
   Policy const& get_policy() const { return m_policy; }
 
   inline __device__ void operator()() const {
-    const Member work_stride = blockDim.y * gridDim.x;
-    const Member work_end    = m_policy.end();
+    const auto work_stride = Member(blockDim.y) * gridDim.x;
+    const Member work_end  = m_policy.end();
 
     for (Member iwork =
              m_policy.begin() + threadIdx.y + blockDim.y * blockIdx.x;

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
@@ -64,8 +64,9 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::HIP> {
     for (Member iwork =
              m_policy.begin() + threadIdx.y + blockDim.y * blockIdx.x;
          iwork < work_end;
-         iwork = iwork < work_end - work_stride ? iwork + work_stride
-                                                : work_end) {
+         iwork = iwork < static_cast<Member>(work_end - work_stride)
+                     ? iwork + work_stride
+                     : work_end) {
       this->template exec_range<WorkTag>(iwork);
     }
   }

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
@@ -84,11 +84,12 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::HIP> {
                       "valid execution configuration."));
     }
     const dim3 block(1, block_size, 1);
-    const int maxGridSizeX = m_policy.space().hip_device_prop().maxGridSize[0];
-    const dim3 grid(
-        std::min(typename Policy::index_type((nwork + block.y - 1) / block.y),
-                 typename Policy::index_type(maxGridSizeX)),
-        1, 1);
+    const int max_work_items =
+        m_policy.space().hip_device_prop().maxGridSize[0];
+    const auto n_blocks = std::min<typename Policy::index_type>(
+                              nwork + block.y - 1, max_work_items) /
+                          block.y;
+    const dim3 grid(n_blocks, 1, 1);
 
     Kokkos::Impl::hip_parallel_launch<DriverType, LaunchBounds>(
         *this, grid, block, 0, m_policy.space().impl_internal_space_instance(),

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
@@ -58,8 +58,8 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::HIP> {
   ParallelFor& operator=(ParallelFor const&) = delete;
 
   inline __device__ void operator()() const {
-    const Member work_stride = blockDim.y * gridDim.x;
-    const Member work_end    = m_policy.end();
+    const auto work_stride = Member(blockDim.y) * gridDim.x;
+    const Member work_end  = m_policy.end();
 
     for (Member iwork =
              m_policy.begin() + threadIdx.y + blockDim.y * blockIdx.x;
@@ -77,15 +77,19 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::HIP> {
     const int block_size =
         Kokkos::Impl::hip_get_preferred_blocksize<DriverType, LaunchBounds>(
             m_policy.space().hip_device());
-    const dim3 block(1, block_size, 1);
-    const dim3 grid(
-        typename Policy::index_type((nwork + block.y - 1) / block.y), 1, 1);
 
     if (block_size == 0) {
       Kokkos::Impl::throw_runtime_exception(
           std::string("Kokkos::Impl::ParallelFor< HIP > could not find a "
                       "valid execution configuration."));
     }
+    const dim3 block(1, block_size, 1);
+    const int maxGridSizeX = m_policy.space().hip_device_prop().maxGridSize[0];
+    const dim3 grid(
+        std::min(typename Policy::index_type((nwork + block.y - 1) / block.y),
+                 typename Policy::index_type(maxGridSizeX)),
+        1, 1);
+
     Kokkos::Impl::hip_parallel_launch<DriverType, LaunchBounds>(
         *this, grid, block, 0, m_policy.space().impl_internal_space_instance(),
         false);

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
@@ -85,12 +85,11 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::HIP> {
                       "valid execution configuration."));
     }
     const dim3 block(1, block_size, 1);
-    const int max_work_items =
-        m_policy.space().hip_device_prop().maxGridSize[0];
-    const auto n_blocks = std::min<typename Policy::index_type>(
-                              nwork + block.y - 1, max_work_items) /
-                          block.y;
-    const dim3 grid(n_blocks, 1, 1);
+    const int maxGridSizeX = m_policy.space().hip_device_prop().maxGridSize[0];
+    const dim3 grid(
+        std::min(typename Policy::index_type((nwork + block.y - 1) / block.y),
+                 typename Policy::index_type(maxGridSizeX)),
+        1, 1);
 
     Kokkos::Impl::hip_parallel_launch<DriverType, LaunchBounds>(
         *this, grid, block, 0, m_policy.space().impl_internal_space_instance(),

--- a/core/src/HIP/Kokkos_HIP_ZeroMemset.cpp
+++ b/core/src/HIP/Kokkos_HIP_ZeroMemset.cpp
@@ -28,7 +28,8 @@ namespace Impl {
 void zero_with_hip_kernel(const HIP& exec_space, void* dst, size_t cnt) {
   Kokkos::parallel_for(
       "Kokkos::ZeroMemset via parallel_for",
-      Kokkos::RangePolicy<Kokkos::HIP>(exec_space, 0, cnt),
+      Kokkos::RangePolicy<Kokkos::HIP, Kokkos::IndexType<size_t>>(exec_space, 0,
+                                                                  cnt),
       KOKKOS_LAMBDA(size_t i) { static_cast<char*>(dst)[i] = 0; });
 }
 

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -181,11 +181,11 @@ struct TestRange {
   void test_dynamic_policy() {
     auto const N_no_implicit_capture = N;
     using policy_t =
-        Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic> >;
+        Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic>>;
     int const concurrency = ExecSpace().concurrency();
 
     {
-      Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic> >
+      Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic>>
           count("Count", concurrency);
       Kokkos::View<int *, ExecSpace> a("A", N);
 
@@ -223,7 +223,7 @@ struct TestRange {
     }
 
     {
-      Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic> >
+      Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic>>
           count("Count", concurrency);
       Kokkos::View<int *, ExecSpace> a("A", N);
 
@@ -271,58 +271,58 @@ struct TestRange {
 
 TEST(TEST_CATEGORY, range_for) {
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(0);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(0);
     f.test_for();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(0);
-    f.test_for();
-  }
-
-  {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(2);
-    f.test_for();
-  }
-  {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(3);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(0);
     f.test_for();
   }
 
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(1000);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(2);
     f.test_for();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(1001);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(3);
+    f.test_for();
+  }
+
+  {
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(1000);
+    f.test_for();
+  }
+  {
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(1001);
     f.test_for();
   }
 }
 
 TEST(TEST_CATEGORY, range_reduce) {
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(0);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(0);
     f.test_reduce();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(0);
-    f.test_reduce();
-  }
-
-  {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(2);
-    f.test_reduce();
-  }
-  {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(3);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(0);
     f.test_reduce();
   }
 
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(1000);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(2);
     f.test_reduce();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(1001);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(3);
+    f.test_reduce();
+  }
+
+  {
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(1000);
+    f.test_reduce();
+  }
+  {
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(1001);
     f.test_reduce();
   }
 }
@@ -332,19 +332,51 @@ TEST(TEST_CATEGORY, range_dynamic_policy) {
 #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && \
     !defined(KOKKOS_ENABLE_SYCL)
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(0);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(0);
     f.test_dynamic_policy();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(3);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(3);
     f.test_dynamic_policy();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(1001);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(1001);
     f.test_dynamic_policy();
   }
 #endif
 }
 #endif
+
+void test_large_parallel_for_reduce() {
+  using ExecutionSpace              = typename TEST_EXECSPACE::execution_space;
+  constexpr long long unsigned size = 1llu << 32;
+  Kokkos::View<char *, TEST_EXECSPACE::memory_space> v(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "v"), size);
+
+  // We want to explicitly test that using a parallel_for for filling the View
+  // works to test if our internal block size calculations do not overflow.
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<ExecutionSpace,
+                          Kokkos::IndexType<long long unsigned>>(0, size),
+      KOKKOS_LAMBDA(long long unsigned) { v(i) = 1; });
+
+  long long unsigned sum;
+  Kokkos::parallel_reduce(
+      Kokkos::RangePolicy<ExecutionSpace,
+                          Kokkos::IndexType<long long unsigned>>(0, size),
+      KOKKOS_LAMBDA(long long unsigned, long long unsigned &partial_sum) {
+        partial_sum += 1;
+      },
+      sum);
+  ASSERT_EQ(sum, size);
+}
+
+TEST(TEST_CATEGORY, large_parallel_for_reduce) {
+  if constexpr (std::is_same_v<typename TEST_EXECSPACE::memory_space,
+                               Kokkos::HostSpace>) {
+    GTEST_SKIP() << "Disabling for host backends";
+  }
+  test_large_parallel_for_reduce();
+}
 
 }  // namespace Test

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -371,6 +371,8 @@ void test_large_parallel_for_reduce() {
   ASSERT_EQ(sum, size);
 }
 
+// For 32-bit builds a View can't store enough elements
+#ifndef KOKKOS_IMPL_32BIT
 TEST(TEST_CATEGORY, large_parallel_for_reduce) {
   if constexpr (std::is_same_v<typename TEST_EXECSPACE::memory_space,
                                Kokkos::HostSpace>) {
@@ -378,5 +380,6 @@ TEST(TEST_CATEGORY, large_parallel_for_reduce) {
   }
   test_large_parallel_for_reduce();
 }
+#endif
 
 }  // namespace Test

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -347,6 +347,8 @@ TEST(TEST_CATEGORY, range_dynamic_policy) {
 }
 #endif
 
+// For 32-bit builds a View can't store enough elements
+#ifndef KOKKOS_IMPL_32BIT
 void test_large_parallel_for_reduce() {
   using ExecutionSpace              = typename TEST_EXECSPACE::execution_space;
   constexpr long long unsigned size = 1llu << 32;
@@ -371,8 +373,6 @@ void test_large_parallel_for_reduce() {
   ASSERT_EQ(sum, size);
 }
 
-// For 32-bit builds a View can't store enough elements
-#ifndef KOKKOS_IMPL_32BIT
 TEST(TEST_CATEGORY, large_parallel_for_reduce) {
   if constexpr (std::is_same_v<typename TEST_EXECSPACE::memory_space,
                                Kokkos::HostSpace>) {

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -358,7 +358,7 @@ void test_large_parallel_for_reduce() {
   Kokkos::parallel_for(
       Kokkos::RangePolicy<ExecutionSpace,
                           Kokkos::IndexType<long long unsigned>>(0, size),
-      KOKKOS_LAMBDA(long long unsigned) { v(i) = 1; });
+      KOKKOS_LAMBDA(long long unsigned i) { v(i) = 1; });
 
   long long unsigned sum;
   Kokkos::parallel_reduce(

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -181,11 +181,11 @@ struct TestRange {
   void test_dynamic_policy() {
     auto const N_no_implicit_capture = N;
     using policy_t =
-        Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic>>;
+        Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic> >;
     int const concurrency = ExecSpace().concurrency();
 
     {
-      Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic>>
+      Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic> >
           count("Count", concurrency);
       Kokkos::View<int *, ExecSpace> a("A", N);
 
@@ -223,7 +223,7 @@ struct TestRange {
     }
 
     {
-      Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic>>
+      Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic> >
           count("Count", concurrency);
       Kokkos::View<int *, ExecSpace> a("A", N);
 
@@ -271,58 +271,58 @@ struct TestRange {
 
 TEST(TEST_CATEGORY, range_for) {
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(0);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(0);
     f.test_for();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(0);
-    f.test_for();
-  }
-
-  {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(2);
-    f.test_for();
-  }
-  {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(3);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(0);
     f.test_for();
   }
 
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(1000);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(2);
     f.test_for();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(1001);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(3);
+    f.test_for();
+  }
+
+  {
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(1000);
+    f.test_for();
+  }
+  {
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(1001);
     f.test_for();
   }
 }
 
 TEST(TEST_CATEGORY, range_reduce) {
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(0);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(0);
     f.test_reduce();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(0);
-    f.test_reduce();
-  }
-
-  {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(2);
-    f.test_reduce();
-  }
-  {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(3);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(0);
     f.test_reduce();
   }
 
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(1000);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(2);
     f.test_reduce();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(1001);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(3);
+    f.test_reduce();
+  }
+
+  {
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(1000);
+    f.test_reduce();
+  }
+  {
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(1001);
     f.test_reduce();
   }
 }
@@ -332,49 +332,19 @@ TEST(TEST_CATEGORY, range_dynamic_policy) {
 #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && \
     !defined(KOKKOS_ENABLE_SYCL)
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(0);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(0);
     f.test_dynamic_policy();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(3);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(3);
     f.test_dynamic_policy();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(1001);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(1001);
     f.test_dynamic_policy();
   }
 #endif
 }
 #endif
-
-void test_large_parallel_for_reduce() {
-  using ExecutionSpace              = typename TEST_EXECSPACE::execution_space;
-  constexpr long long unsigned size = 1llu << 32;
-  Kokkos::View<long long unsigned, TEST_EXECSPACE::memory_space> v("v");
-
-  // We want to explicitly test that using a parallel_for for filling the View
-  // works
-  Kokkos::parallel_for(
-      Kokkos::RangePolicy<ExecutionSpace,
-                          Kokkos::IndexType<long long unsigned>>(0, size),
-      KOKKOS_LAMBDA(long long unsigned) { Kokkos::atomic_add(v.data(), 1); });
-  long long unsigned sum;
-  Kokkos::deep_copy(sum, v);
-  ASSERT_EQ(sum, size);
-
-  sum = 0;
-  Kokkos::parallel_reduce(
-      Kokkos::RangePolicy<ExecutionSpace,
-                          Kokkos::IndexType<long long unsigned>>(0, size),
-      KOKKOS_LAMBDA(long long unsigned, long long unsigned &partial_sum) {
-        partial_sum += 1;
-      },
-      sum);
-  ASSERT_EQ(sum, size);
-}
-
-TEST(TEST_CATEGORY, large_parallel_for_reduce) {
-  test_large_parallel_for_reduce();
-}
 
 }  // namespace Test

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -181,11 +181,11 @@ struct TestRange {
   void test_dynamic_policy() {
     auto const N_no_implicit_capture = N;
     using policy_t =
-        Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic> >;
+        Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic>>;
     int const concurrency = ExecSpace().concurrency();
 
     {
-      Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic> >
+      Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic>>
           count("Count", concurrency);
       Kokkos::View<int *, ExecSpace> a("A", N);
 
@@ -223,7 +223,7 @@ struct TestRange {
     }
 
     {
-      Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic> >
+      Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic>>
           count("Count", concurrency);
       Kokkos::View<int *, ExecSpace> a("A", N);
 
@@ -271,58 +271,58 @@ struct TestRange {
 
 TEST(TEST_CATEGORY, range_for) {
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(0);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(0);
     f.test_for();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(0);
-    f.test_for();
-  }
-
-  {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(2);
-    f.test_for();
-  }
-  {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(3);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(0);
     f.test_for();
   }
 
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(1000);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(2);
     f.test_for();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(1001);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(3);
+    f.test_for();
+  }
+
+  {
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(1000);
+    f.test_for();
+  }
+  {
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(1001);
     f.test_for();
   }
 }
 
 TEST(TEST_CATEGORY, range_reduce) {
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(0);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(0);
     f.test_reduce();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(0);
-    f.test_reduce();
-  }
-
-  {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(2);
-    f.test_reduce();
-  }
-  {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(3);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(0);
     f.test_reduce();
   }
 
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(1000);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(2);
     f.test_reduce();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(1001);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(3);
+    f.test_reduce();
+  }
+
+  {
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>> f(1000);
+    f.test_reduce();
+  }
+  {
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(1001);
     f.test_reduce();
   }
 }
@@ -332,19 +332,49 @@ TEST(TEST_CATEGORY, range_dynamic_policy) {
 #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && \
     !defined(KOKKOS_ENABLE_SYCL)
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(0);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(0);
     f.test_dynamic_policy();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(3);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(3);
     f.test_dynamic_policy();
   }
   {
-    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> > f(1001);
+    TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(1001);
     f.test_dynamic_policy();
   }
 #endif
 }
 #endif
+
+void test_large_parallel_for_reduce() {
+  using ExecutionSpace              = typename TEST_EXECSPACE::execution_space;
+  constexpr long long unsigned size = 1llu << 32;
+  Kokkos::View<long long unsigned, TEST_EXECSPACE::memory_space> v("v");
+
+  // We want to explicitly test that using a parallel_for for filling the View
+  // works
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<ExecutionSpace,
+                          Kokkos::IndexType<long long unsigned>>(0, size),
+      KOKKOS_LAMBDA(long long unsigned) { Kokkos::atomic_add(v.data(), 1); });
+  long long unsigned sum;
+  Kokkos::deep_copy(sum, v);
+  ASSERT_EQ(sum, size);
+
+  sum = 0;
+  Kokkos::parallel_reduce(
+      Kokkos::RangePolicy<ExecutionSpace,
+                          Kokkos::IndexType<long long unsigned>>(0, size),
+      KOKKOS_LAMBDA(long long unsigned, long long unsigned &partial_sum) {
+        partial_sum += 1;
+      },
+      sum);
+  ASSERT_EQ(sum, size);
+}
+
+TEST(TEST_CATEGORY, large_parallel_for_reduce) {
+  test_large_parallel_for_reduce();
+}
 
 }  // namespace Test

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -679,6 +679,8 @@ void test_reduction_with_large_view() {
   Kokkos::View<int*, TEST_EXECSPACE::memory_space> v(
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "v"), size);
 
+  // We want to explicitly test that using a parallel_for for filling the View
+  // works
   Kokkos::parallel_for(
       Kokkos::RangePolicy<ExecutionSpace,
                           Kokkos::IndexType<long long unsigned>>(0, size),
@@ -687,8 +689,8 @@ void test_reduction_with_large_view() {
   Kokkos::parallel_reduce(
       Kokkos::RangePolicy<ExecutionSpace,
                           Kokkos::IndexType<long long unsigned>>(0, size),
-      KOKKOS_LAMBDA(long long unsigned i, long long unsigned& update) {
-        update += v(i);
+      KOKKOS_LAMBDA(long long unsigned i, long long unsigned& partial_sum) {
+        partial_sum += v(i);
       },
       sum);
   ASSERT_EQ(sum, size);

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -670,29 +670,37 @@ TEST(TEST_CATEGORY, reduction_with_large_iteration_count) {
                           FunctorReductionWithLargeIterationCount(), nu);
   ASSERT_DOUBLE_EQ(nu, double(N));
 }
-#endif
 
 void test_reduction_with_large_view() {
-  using ExecutionSpace       = typename TEST_EXECSPACE::execution_space;
-  constexpr std::size_t size = 1llu << 32;
+  using ExecutionSpace              = typename TEST_EXECSPACE::execution_space;
+  constexpr long long unsigned size = 1llu << 32;
   Kokkos::View<int*, TEST_EXECSPACE::memory_space> v(
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "v"), size);
 
   Kokkos::parallel_for(
-      Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<std::size_t>>(0,
-                                                                          size),
-      KOKKOS_LAMBDA(std::size_t i) { v(i) = 1; });
-  std::size_t sum;
+      Kokkos::RangePolicy<ExecutionSpace,
+                          Kokkos::IndexType<long long unsigned>>(0, size),
+      KOKKOS_LAMBDA(long long unsigned i) { v(i) = 1; });
+  long long unsigned sum;
   Kokkos::parallel_reduce(
-      Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<std::size_t>>(0,
-                                                                          size),
-      KOKKOS_LAMBDA(std::size_t i, std::size_t & update) { update += v(i); },
+      Kokkos::RangePolicy<ExecutionSpace,
+                          Kokkos::IndexType<long long unsigned>>(0, size),
+      KOKKOS_LAMBDA(long long unsigned i, long long unsigned& update) {
+        update += v(i);
+      },
       sum);
   ASSERT_EQ(sum, size);
 }
 
 TEST(TEST_CATEGORY, reduction_with_large_view) {
+  if constexpr (std::is_same_v<typename TEST_EXECSPACE::memory_space,
+                               Kokkos::HostSpace>) {
+    GTEST_SKIP() << "Disabling for host backends";
+  }
+
   test_reduction_with_large_view();
 }
+
+#endif
 
 }  // namespace Test

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -670,42 +670,6 @@ TEST(TEST_CATEGORY, reduction_with_large_iteration_count) {
                           FunctorReductionWithLargeIterationCount(), nu);
   ASSERT_DOUBLE_EQ(nu, double(N));
 }
-
-// For 32-bit builds a View can't store enough elements
-#ifndef KOKKOS_IMPL_32BIT
-void test_reduction_with_large_view() {
-  using ExecutionSpace              = typename TEST_EXECSPACE::execution_space;
-  constexpr long long unsigned size = 1llu << 32;
-  Kokkos::View<int*, TEST_EXECSPACE::memory_space> v(
-      Kokkos::view_alloc(Kokkos::WithoutInitializing, "v"), size);
-
-  // We want to explicitly test that using a parallel_for for filling the View
-  // works
-  Kokkos::parallel_for(
-      Kokkos::RangePolicy<ExecutionSpace,
-                          Kokkos::IndexType<long long unsigned>>(0, size),
-      KOKKOS_LAMBDA(long long unsigned i) { v(i) = 1; });
-  long long unsigned sum;
-  Kokkos::parallel_reduce(
-      Kokkos::RangePolicy<ExecutionSpace,
-                          Kokkos::IndexType<long long unsigned>>(0, size),
-      KOKKOS_LAMBDA(long long unsigned i, long long unsigned& partial_sum) {
-        partial_sum += v(i);
-      },
-      sum);
-  ASSERT_EQ(sum, size);
-}
-
-TEST(TEST_CATEGORY, reduction_with_large_view) {
-  if constexpr (std::is_same_v<typename TEST_EXECSPACE::memory_space,
-                               Kokkos::HostSpace>) {
-    GTEST_SKIP() << "Disabling for host backends";
-  }
-
-  test_reduction_with_large_view();
-}
-#endif
-
 #endif
 
 }  // namespace Test

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -670,7 +670,6 @@ TEST(TEST_CATEGORY, reduction_with_large_iteration_count) {
                           FunctorReductionWithLargeIterationCount(), nu);
   ASSERT_DOUBLE_EQ(nu, double(N));
 }
-
 #endif
 
 }  // namespace Test

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -670,6 +670,42 @@ TEST(TEST_CATEGORY, reduction_with_large_iteration_count) {
                           FunctorReductionWithLargeIterationCount(), nu);
   ASSERT_DOUBLE_EQ(nu, double(N));
 }
+
+// For 32-bit builds a View can't store enough elements
+#ifndef KOKKOS_IMPL_32BIT
+void test_reduction_with_large_view() {
+  using ExecutionSpace              = typename TEST_EXECSPACE::execution_space;
+  constexpr long long unsigned size = 1llu << 32;
+  Kokkos::View<int*, TEST_EXECSPACE::memory_space> v(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "v"), size);
+
+  // We want to explicitly test that using a parallel_for for filling the View
+  // works
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<ExecutionSpace,
+                          Kokkos::IndexType<long long unsigned>>(0, size),
+      KOKKOS_LAMBDA(long long unsigned i) { v(i) = 1; });
+  long long unsigned sum;
+  Kokkos::parallel_reduce(
+      Kokkos::RangePolicy<ExecutionSpace,
+                          Kokkos::IndexType<long long unsigned>>(0, size),
+      KOKKOS_LAMBDA(long long unsigned i, long long unsigned& partial_sum) {
+        partial_sum += v(i);
+      },
+      sum);
+  ASSERT_EQ(sum, size);
+}
+
+TEST(TEST_CATEGORY, reduction_with_large_view) {
+  if constexpr (std::is_same_v<typename TEST_EXECSPACE::memory_space,
+                               Kokkos::HostSpace>) {
+    GTEST_SKIP() << "Disabling for host backends";
+  }
+
+  test_reduction_with_large_view();
+}
+#endif
+
 #endif
 
 }  // namespace Test

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -671,6 +671,8 @@ TEST(TEST_CATEGORY, reduction_with_large_iteration_count) {
   ASSERT_DOUBLE_EQ(nu, double(N));
 }
 
+// For 32-bit builds a View can't store enough elements
+#ifndef KOKKOS_IMPL_32BIT
 void test_reduction_with_large_view() {
   using ExecutionSpace              = typename TEST_EXECSPACE::execution_space;
   constexpr long long unsigned size = 1llu << 32;
@@ -700,6 +702,7 @@ TEST(TEST_CATEGORY, reduction_with_large_view) {
 
   test_reduction_with_large_view();
 }
+#endif
 
 #endif
 


### PR DESCRIPTION
Alternative to https://github.com/kokkos/kokkos/pull/7793#issue-2867533165.
Our MI300A CI showed: 
```
Kokkos::RangePolicy bound type error: an unsafe implicit conversion is performed on a bound ([4294967296](tel:4294967296)), which may not preserve its original value.
```
for `hip.view_allocation_large_rank` and we should specify `size_t` as index type for the `ZeroMemset` kernel. Only fixing this, we deadlock, though.
This uncovered that we currently allow for a thread to address multiple work items in the call operator but we don't set the grid up accordingly. The new code is just copied from the Cuda backend. This doesn't fix the deadlock, though; in fact the grid launched was still the same.
Instead, it turned out that
```C++
const Member work_stride = blockDim.y * gridDim.x;
```
was overflowing and evaluated to 0. Making sure that the product is computed with `Member` fixes the issue.