### PR TITLE
Update OSSF scorecard to use git mode

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,10 +27,11 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
         with:
           results_file: results.sarif
           results_format: sarif
+          file_mode: git
           # Scorecard team runs a weekly scan of public GitHub repos,
           # see https://github.com/ossf/scorecard#public-data.
           # Setting `publish_results: true` helps us scale by leveraging your workflow to


### PR DESCRIPTION
Scorecard got a `git` mode that allows us to not fetch the tarball but checkout the files with git. This allows us to `export-ignore` our workflows but have them analyzed in the scorecard.

fixes #7633