### PR TITLE
Perf serial for small kernel

### DIFF
--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -115,6 +115,8 @@ set(BENCHMARK_SOURCES
     PerfTest_ViewResize_8.cpp
     PerfTest_ViewResize_Raw.cpp
     PerfTest_KernelName.cpp
+    PerfTest_PtrAccess.cpp
+    PerfTest_FenceOverhead.cpp
 )
 
 if(Kokkos_ENABLE_OPENMPTARGET)

--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -114,6 +114,7 @@ set(BENCHMARK_SOURCES
     PerfTest_ViewResize_7.cpp
     PerfTest_ViewResize_8.cpp
     PerfTest_ViewResize_Raw.cpp
+    PerfTest_KernelName.cpp
 )
 
 if(Kokkos_ENABLE_OPENMPTARGET)

--- a/core/perf_test/PerfTest_FenceOverhead.cpp
+++ b/core/perf_test/PerfTest_FenceOverhead.cpp
@@ -1,0 +1,20 @@
+#include <Kokkos_Core.hpp>
+#include <benchmark/benchmark.h>
+
+static void FenceOverhead(benchmark::State& state) {
+  for (auto _ : state) {
+    Kokkos::parallel_for("", 0, KOKKOS_LAMBDA(int i){});
+    Kokkos::fence();
+  }
+}
+BENCHMARK(FenceOverhead)
+    ->Unit(benchmark::kMicrosecond);
+
+static void FenceOverhead_NoFence(benchmark::State& state) {
+  for (auto _ : state) {
+    Kokkos::parallel_for("", 0, KOKKOS_LAMBDA(int i){});
+  }
+}
+BENCHMARK(FenceOverhead_NoFence)
+    ->Unit(benchmark::kMicrosecond);
+

--- a/core/perf_test/PerfTest_KernelName.cpp
+++ b/core/perf_test/PerfTest_KernelName.cpp
@@ -1,0 +1,48 @@
+#include <Kokkos_Core.hpp>
+#include <benchmark/benchmark.h>
+
+static void BM_EmptyString(benchmark::State& state) {
+  for (auto _ : state) {
+    int r;
+    Kokkos::parallel_reduce("", 0, KOKKOS_LAMBDA(int, int&){}, r);
+  }
+}
+BENCHMARK(BM_EmptyString);
+
+static void BM_Defaulted(benchmark::State& state) {
+  for (auto _ : state) {
+    int r;
+    Kokkos::parallel_reduce(0, KOKKOS_LAMBDA(int, int&){}, r);
+  }
+}
+BENCHMARK(BM_Defaulted);
+
+static void BM_UserDefined(benchmark::State& state) {
+  std::string lbl = "Hello World";
+  for (auto _ : state) {
+    int r;
+    Kokkos::parallel_reduce(lbl, 0, KOKKOS_LAMBDA(int, int&){}, r);
+  }
+}
+BENCHMARK(BM_UserDefined);
+
+static void BM_LongString(benchmark::State& state) {
+  std::string lbl = "Hello World a long string that does not fit god dammit";
+  for (auto _ : state) {
+    Kokkos::parallel_for(lbl, 0, KOKKOS_LAMBDA(int){});
+  }
+}
+BENCHMARK(BM_LongString);
+
+struct StupidTagWithALongNameAAAAAAAAAAAAAAAAAAAA {};
+
+static void BM_UserDefinedWithTag(benchmark::State& state) {
+  std::string lbl = "Hello World";
+  for (auto _ : state) {
+    Kokkos::parallel_for(
+        lbl,
+        Kokkos::RangePolicy<StupidTagWithALongNameAAAAAAAAAAAAAAAAAAAA>(0, 0),
+        KOKKOS_LAMBDA(StupidTagWithALongNameAAAAAAAAAAAAAAAAAAAA, int){});
+  }
+}
+BENCHMARK(BM_UserDefinedWithTag);

--- a/core/perf_test/PerfTest_KernelName.cpp
+++ b/core/perf_test/PerfTest_KernelName.cpp
@@ -1,48 +1,58 @@
 #include <Kokkos_Core.hpp>
 #include <benchmark/benchmark.h>
 
-static void BM_EmptyString(benchmark::State& state) {
+static void KernalName_EmptyString(benchmark::State& state) {
   for (auto _ : state) {
-    int r;
-    Kokkos::parallel_reduce("", 0, KOKKOS_LAMBDA(int, int&){}, r);
+    Kokkos::parallel_for("", 0, KOKKOS_LAMBDA(int){});
+    Kokkos::fence();
   }
 }
-BENCHMARK(BM_EmptyString);
+BENCHMARK(KernalName_EmptyString)
+  ->Unit(benchmark::kMicrosecond);
 
-static void BM_Defaulted(benchmark::State& state) {
+static void KernalName_Defaulted(benchmark::State& state) {
   for (auto _ : state) {
-    int r;
-    Kokkos::parallel_reduce(0, KOKKOS_LAMBDA(int, int&){}, r);
+    Kokkos::parallel_for(0, KOKKOS_LAMBDA(int){});
+    Kokkos::fence();
   }
 }
-BENCHMARK(BM_Defaulted);
+BENCHMARK(KernalName_Defaulted)
+  ->Unit(benchmark::kMicrosecond);
 
-static void BM_UserDefined(benchmark::State& state) {
+static void KernalName_UserDefined(benchmark::State& state) {
   std::string lbl = "Hello World";
   for (auto _ : state) {
-    int r;
-    Kokkos::parallel_reduce(lbl, 0, KOKKOS_LAMBDA(int, int&){}, r);
+    Kokkos::parallel_for(lbl, 0, KOKKOS_LAMBDA(int){});
+    Kokkos::fence();
   }
 }
-BENCHMARK(BM_UserDefined);
+BENCHMARK(KernalName_UserDefined)
+  ->Unit(benchmark::kMicrosecond);
 
-static void BM_LongString(benchmark::State& state) {
+static void KernalName_LongString(benchmark::State& state) {
   std::string lbl = "Hello World a long string that does not fit god dammit";
+  for (int i = 0; i < 15; ++i) {
+    lbl+=lbl;
+  }
   for (auto _ : state) {
     Kokkos::parallel_for(lbl, 0, KOKKOS_LAMBDA(int){});
+    Kokkos::fence();
   }
 }
-BENCHMARK(BM_LongString);
+BENCHMARK(KernalName_LongString)
+  ->Unit(benchmark::kMicrosecond);
 
 struct StupidTagWithALongNameAAAAAAAAAAAAAAAAAAAA {};
 
-static void BM_UserDefinedWithTag(benchmark::State& state) {
+static void KernalName_UserDefinedWithTag(benchmark::State& state) {
   std::string lbl = "Hello World";
   for (auto _ : state) {
     Kokkos::parallel_for(
         lbl,
         Kokkos::RangePolicy<StupidTagWithALongNameAAAAAAAAAAAAAAAAAAAA>(0, 0),
         KOKKOS_LAMBDA(StupidTagWithALongNameAAAAAAAAAAAAAAAAAAAA, int){});
+    Kokkos::fence();
   }
 }
-BENCHMARK(BM_UserDefinedWithTag);
+BENCHMARK(KernalName_UserDefinedWithTag)
+  ->Unit(benchmark::kMicrosecond);

--- a/core/perf_test/PerfTest_PtrAccess.cpp
+++ b/core/perf_test/PerfTest_PtrAccess.cpp
@@ -1,0 +1,62 @@
+#include <Kokkos_Core.hpp>
+#include <benchmark/benchmark.h>
+
+static void OperatorParentesisImpact_View(benchmark::State& state) {
+  for (auto _ : state) {
+    int N = state.range(0);
+
+    Kokkos::View<double*> a("a", N);
+    Kokkos::View<double*> b("b", N);
+
+    Kokkos::parallel_for("", N, KOKKOS_LAMBDA(int i){
+          a(i)+=b(i);
+        });
+    Kokkos::fence();
+  }
+}
+BENCHMARK(OperatorParentesisImpact_View)
+    ->ArgName("N")
+    ->RangeMultiplier(16)
+    ->Range(1, int64_t(1) << 20)
+    ->Unit(benchmark::kMicrosecond);
+
+static void OperatorParentesisImpact_Ptr1(benchmark::State& state) {
+  for (auto _ : state) {
+    int N = state.range(0);
+
+    Kokkos::View<double*> a("a", N);
+    Kokkos::View<double*> b("b", N);
+
+    Kokkos::parallel_for("", N, KOKKOS_LAMBDA(int i){
+          a.data()[i]+=b.data()[i];
+        });
+    Kokkos::fence();
+  }
+}
+BENCHMARK(OperatorParentesisImpact_Ptr1)
+    ->ArgName("N")
+    ->RangeMultiplier(16)
+    ->Range(1, int64_t(1) << 20)
+    ->Unit(benchmark::kMicrosecond);
+
+static void OperatorParentesisImpact_Ptr2(benchmark::State& state) {
+  for (auto _ : state) {
+    int N = state.range(0);
+
+    Kokkos::View<double*> a("a", N);
+    Kokkos::View<double*> b("b", N);
+
+    double* aptr = a.data();
+    double* bptr = b.data();
+
+    Kokkos::parallel_for("", N, KOKKOS_LAMBDA(int i){
+          aptr[i]+=bptr[i];
+        });
+    Kokkos::fence();
+  }
+}
+BENCHMARK(OperatorParentesisImpact_Ptr2)
+    ->ArgName("N")
+    ->RangeMultiplier(16)
+    ->Range(1, int64_t(1) << 20)
+    ->Unit(benchmark::kMicrosecond);


### PR DESCRIPTION
3 new micro-benchmarks to test performances degradation that were reported by users for small kernels on the Serial backend:
 - PerfTest_KernelName: test if the name used for a kernel has an impact on performance.
=> We couldn't reproduce the finding of our user, even very long name doesn't seem to have any impact.
 - PerfTest_PtrAccess: test if accessing a View's data through the operator operator() or directly through the C-array return by data() have an impact on performance.
=> Again, we couldn't find an impact on performance, be it on very small kernel (1 iteration), or larger ones (1 million iteration).
 - PerfTest_FenceOverhead: test the impact of Kokkos::fence()
=> we notice a 25% increase in the overhead of an empty Kokkos::parallel_for when followed by a Kokkos::fence().
Taking advantage of the empty kernel, on this same bench, we also to compiled with the following flag which were reported as having an impact on performance:
"-DKokkos_ENABLE_LIBDL=OFF": we couldn't see a difference
"-DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF": we get a 2x speedup by passing this option.