### PR TITLE
Reduce overhead of ExecPolicy

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -255,13 +255,6 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
     if constexpr (std::is_convertible_v<member_type, IndexType>) {
 #if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) || \
     defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
-
-      std::string msg =
-          "Kokkos::RangePolicy bound type error: an unsafe implicit conversion "
-          "is performed on a bound (" +
-          std::to_string(bound) +
-          "), which may "
-          "not preserve its original value.\n";
       bool warn = false;
 
       if constexpr (std::is_arithmetic_v<member_type> &&
@@ -283,6 +276,12 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
           (static_cast<IndexType>(static_cast<member_type>(bound)) != bound);
 
       if (warn) {
+        std::string msg =
+            "Kokkos::RangePolicy bound type error: an unsafe implicit "
+            "conversion is performed on a bound (" +
+            std::to_string(bound) +
+            "), which may not preserve its original value.\n";
+
 #ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
         Kokkos::abort(msg.c_str());
 #endif


### PR DESCRIPTION
String creation for a conversion warning was done during each kernel invocation, even if the warning wasn't raised, causing overhead ([see here](https://github.com/kokkos/kokkos/pull/7808)).

This PR remove this overhead by doing the string construction only when needed.

I am not sure the precompiler checks in the check_conversion_safety and check_bounds_validity functions use the correct variable: the warning messages need "KOKKOS_ENABLE_DEPRECATION_WARNINGS" to be displayed, but they seem to be in relation with bound checking and type conversion, not deprecation ?
