### PR TITLE
Reduce the overhead of tools binding during parallel_for call

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -299,6 +299,12 @@ bool profileLibraryLoaded() {
   return Kokkos::Tools::Experimental::isProfileLibraryLoaded;
 }
 
+void updateProfileLibraryState() {
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
+}
+
 void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
                       uint64_t* kernelID) {
   Experimental::invoke_kokkosp_callback(
@@ -787,9 +793,7 @@ void initialize(const std::string& profileLibrary) {
   Experimental::no_profiling.request_output_values = nullptr;
   Experimental::no_profiling.end_tuning_context    = nullptr;
 
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 
 void finalize() {
@@ -847,250 +851,148 @@ namespace Tools {
 namespace Experimental {
 void set_init_callback(initFunction callback) {
   current_callbacks.init = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_finalize_callback(finalizeFunction callback) {
   current_callbacks.finalize = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_parse_args_callback(parseArgsFunction callback) {
   current_callbacks.parse_args = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_print_help_callback(printHelpFunction callback) {
   current_callbacks.print_help = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_begin_parallel_for_callback(beginFunction callback) {
   current_callbacks.begin_parallel_for = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_end_parallel_for_callback(endFunction callback) {
   current_callbacks.end_parallel_for = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_begin_parallel_reduce_callback(beginFunction callback) {
   current_callbacks.begin_parallel_reduce = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_end_parallel_reduce_callback(endFunction callback) {
   current_callbacks.end_parallel_reduce = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_begin_parallel_scan_callback(beginFunction callback) {
   current_callbacks.begin_parallel_scan = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_end_parallel_scan_callback(endFunction callback) {
   current_callbacks.end_parallel_scan = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_push_region_callback(pushFunction callback) {
   current_callbacks.push_region = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_pop_region_callback(popFunction callback) {
   current_callbacks.pop_region = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_allocate_data_callback(allocateDataFunction callback) {
   current_callbacks.allocate_data = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_deallocate_data_callback(deallocateDataFunction callback) {
   current_callbacks.deallocate_data = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_create_profile_section_callback(
     createProfileSectionFunction callback) {
   current_callbacks.create_profile_section = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_start_profile_section_callback(startProfileSectionFunction callback) {
   current_callbacks.start_profile_section = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_stop_profile_section_callback(stopProfileSectionFunction callback) {
   current_callbacks.stop_profile_section = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_destroy_profile_section_callback(
     destroyProfileSectionFunction callback) {
   current_callbacks.destroy_profile_section = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_profile_event_callback(profileEventFunction callback) {
   current_callbacks.profile_event = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_begin_deep_copy_callback(beginDeepCopyFunction callback) {
   current_callbacks.begin_deep_copy = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_end_deep_copy_callback(endDeepCopyFunction callback) {
   current_callbacks.end_deep_copy = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_begin_fence_callback(beginFenceFunction callback) {
   current_callbacks.begin_fence = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_end_fence_callback(endFenceFunction callback) {
   current_callbacks.end_fence = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 
 void set_dual_view_sync_callback(dualViewSyncFunction callback) {
   current_callbacks.sync_dual_view = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_dual_view_modify_callback(dualViewModifyFunction callback) {
   current_callbacks.modify_dual_view = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_declare_metadata_callback(declareMetadataFunction callback) {
   current_callbacks.declare_metadata = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_request_tool_settings_callback(requestToolSettingsFunction callback) {
   current_callbacks.request_tool_settings = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_provide_tool_programming_interface_callback(
     provideToolProgrammingInterfaceFunction callback) {
   current_callbacks.provide_tool_programming_interface = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 
 void set_declare_output_type_callback(
     Experimental::outputTypeDeclarationFunction callback) {
   current_callbacks.declare_output_type = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_declare_input_type_callback(
     Experimental::inputTypeDeclarationFunction callback) {
   current_callbacks.declare_input_type = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_request_output_values_callback(
     Experimental::requestValueFunction callback) {
   current_callbacks.request_output_values = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_end_context_callback(Experimental::contextEndFunction callback) {
   current_callbacks.end_tuning_context = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_begin_context_callback(Experimental::contextBeginFunction callback) {
   current_callbacks.begin_tuning_context = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 void set_declare_optimization_goal_callback(
     Experimental::optimizationGoalDeclarationFunction callback) {
   current_callbacks.declare_optimization_goal = callback;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 
 void pause_tools() {
@@ -1101,9 +1003,7 @@ void pause_tools() {
 
 void resume_tools() {
   current_callbacks = backup_callbacks;
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 
 Kokkos::Tools::Experimental::EventSet get_callbacks() {
@@ -1111,10 +1011,7 @@ Kokkos::Tools::Experimental::EventSet get_callbacks() {
 }
 void set_callbacks(Kokkos::Tools::Experimental::EventSet new_events) {
   current_callbacks = new_events;
-
-  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
-      !Experimental::eventSetsEqual(Experimental::current_callbacks,
-                                    Experimental::no_profiling);
+  updateProfileLibraryState();
 }
 }  // namespace Experimental
 }  // namespace Tools

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -299,7 +299,7 @@ bool profileLibraryLoaded() {
   return Kokkos::Tools::Experimental::isProfileLibraryLoaded;
 }
 
-void updateProfileLibraryState() {
+static void updateProfileLibraryState() {
   Kokkos::Tools::Experimental::isProfileLibraryLoaded =
       !Experimental::eventSetsEqual(Experimental::current_callbacks,
                                     Experimental::no_profiling);

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -852,114 +852,250 @@ namespace Tools {
 namespace Experimental {
 void set_init_callback(initFunction callback) {
   current_callbacks.init = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_finalize_callback(finalizeFunction callback) {
   current_callbacks.finalize = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_parse_args_callback(parseArgsFunction callback) {
   current_callbacks.parse_args = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_print_help_callback(printHelpFunction callback) {
   current_callbacks.print_help = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_begin_parallel_for_callback(beginFunction callback) {
   current_callbacks.begin_parallel_for = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_end_parallel_for_callback(endFunction callback) {
   current_callbacks.end_parallel_for = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_begin_parallel_reduce_callback(beginFunction callback) {
   current_callbacks.begin_parallel_reduce = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_end_parallel_reduce_callback(endFunction callback) {
   current_callbacks.end_parallel_reduce = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_begin_parallel_scan_callback(beginFunction callback) {
   current_callbacks.begin_parallel_scan = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_end_parallel_scan_callback(endFunction callback) {
   current_callbacks.end_parallel_scan = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_push_region_callback(pushFunction callback) {
   current_callbacks.push_region = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_pop_region_callback(popFunction callback) {
   current_callbacks.pop_region = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_allocate_data_callback(allocateDataFunction callback) {
   current_callbacks.allocate_data = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_deallocate_data_callback(deallocateDataFunction callback) {
   current_callbacks.deallocate_data = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_create_profile_section_callback(
     createProfileSectionFunction callback) {
   current_callbacks.create_profile_section = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_start_profile_section_callback(startProfileSectionFunction callback) {
   current_callbacks.start_profile_section = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_stop_profile_section_callback(stopProfileSectionFunction callback) {
   current_callbacks.stop_profile_section = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_destroy_profile_section_callback(
     destroyProfileSectionFunction callback) {
   current_callbacks.destroy_profile_section = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_profile_event_callback(profileEventFunction callback) {
   current_callbacks.profile_event = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_begin_deep_copy_callback(beginDeepCopyFunction callback) {
   current_callbacks.begin_deep_copy = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_end_deep_copy_callback(endDeepCopyFunction callback) {
   current_callbacks.end_deep_copy = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_begin_fence_callback(beginFenceFunction callback) {
   current_callbacks.begin_fence = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_end_fence_callback(endFenceFunction callback) {
   current_callbacks.end_fence = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 
 void set_dual_view_sync_callback(dualViewSyncFunction callback) {
   current_callbacks.sync_dual_view = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_dual_view_modify_callback(dualViewModifyFunction callback) {
   current_callbacks.modify_dual_view = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_declare_metadata_callback(declareMetadataFunction callback) {
   current_callbacks.declare_metadata = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_request_tool_settings_callback(requestToolSettingsFunction callback) {
   current_callbacks.request_tool_settings = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_provide_tool_programming_interface_callback(
     provideToolProgrammingInterfaceFunction callback) {
   current_callbacks.provide_tool_programming_interface = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 
 void set_declare_output_type_callback(
     Experimental::outputTypeDeclarationFunction callback) {
   current_callbacks.declare_output_type = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_declare_input_type_callback(
     Experimental::inputTypeDeclarationFunction callback) {
   current_callbacks.declare_input_type = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_request_output_values_callback(
     Experimental::requestValueFunction callback) {
   current_callbacks.request_output_values = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_end_context_callback(Experimental::contextEndFunction callback) {
   current_callbacks.end_tuning_context = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_begin_context_callback(Experimental::contextBeginFunction callback) {
   current_callbacks.begin_tuning_context = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 void set_declare_optimization_goal_callback(
     Experimental::optimizationGoalDeclarationFunction callback) {
   current_callbacks.declare_optimization_goal = callback;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 
 void pause_tools() {
@@ -978,6 +1114,10 @@ Kokkos::Tools::Experimental::EventSet get_callbacks() {
 }
 void set_callbacks(Kokkos::Tools::Experimental::EventSet new_events) {
   current_callbacks = new_events;
+
+  Kokkos::Tools::Experimental::isProfileLibraryLoaded =
+      !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                    Experimental::no_profiling);
 }
 }  // namespace Experimental
 }  // namespace Tools


### PR DESCRIPTION
Profiling the `ParallelFor_NoOverhead` micro-bench from [PR7808](https://github.com/kokkos/kokkos/pull/7808), we noticed that the `Kokkos::Tools::Experimental::eventSetsEqual()` function takes almost 70% of total runtime.
This function is called in each parallel_for call and checks if any tool binding have been loaded. To do so, it performs around 30 comparisons to check if any binding has been set to a value different from nullptr.
We changed it to:
 - if `Kokkos_TOOLS_ENABLE_LIBDL=ON`, we add a boolean value that contains the state of the binding, returns it in `eventSetsEqual()`,
 - if `Kokkos_TOOLS_ENABLE_LIBDL=OFF`, return false.

Benchs results:
 - Prior changes:
```
gcc-13.3 -DKokkos_ENABLE_ATOMICS_BYPASS=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_LIBDL=Whatever`
-----------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations
-----------------------------------------------------------------------------
ParallelFor_NoOverhead                       13.3 ns         13.3 ns     53314075
ParallelFor_OverheadDefaultName              13.4 ns         13.4 ns     51106013
ParallelFor_OverheadEmptyName                13.2 ns         13.2 ns     52936970
ParallelFor_OverheadLongName                 13.2 ns         13.2 ns     53434358
ParallelFor_OverheadLongTag                  12.9 ns         12.9 ns     54592585
ParallelFor_OverheadFunctor                  13.4 ns         13.4 ns     52397768
ParallelFor_OverheadPolicyCreation           27.1 ns         27.1 ns     25622313
ParallelFor_OverheadSpaceSpecificFence       39.5 ns         39.4 ns     17806577
ParallelFor_OverheadSpaceCreation            52.5 ns         52.5 ns     13510436
ParallelFor_OverheadGlobalFence              48.6 ns         48.6 ns     14308786
ParallelFor_OverheadFull                     65.3 ns         65.3 ns     10817543
```
 - After changes
```
gcc-13.3 -DKokkos_ENABLE_ATOMICS_BYPASS=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_LIBDL=OFF
-----------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations
-----------------------------------------------------------------------------
ParallelFor_NoOverhead                       2.59 ns         2.59 ns    269613110
ParallelFor_OverheadDefaultName              3.06 ns         3.06 ns    228164441
ParallelFor_OverheadEmptyName                3.10 ns         3.10 ns    226018779
ParallelFor_OverheadLongName                 2.60 ns         2.60 ns    269869756
ParallelFor_OverheadLongTag                  2.59 ns         2.59 ns    268565954
ParallelFor_OverheadFunctor                  3.54 ns         3.54 ns    198943238
ParallelFor_OverheadPolicyCreation           18.5 ns         18.5 ns     37828441
ParallelFor_OverheadSpaceSpecificFence       29.2 ns         29.2 ns     24172174
ParallelFor_OverheadSpaceCreation            40.3 ns         40.3 ns     17159015
ParallelFor_OverheadGlobalFence              34.7 ns         34.7 ns     20111715
ParallelFor_OverheadFull                     51.2 ns         51.2 ns     13820636

gcc-13.3 -DKokkos_ENABLE_ATOMICS_BYPASS=ON -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_LIBDL=ON
-----------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations
-----------------------------------------------------------------------------
ParallelFor_NoOverhead                       2.58 ns         2.58 ns    269718978
ParallelFor_OverheadDefaultName              3.05 ns         3.05 ns    228820124
ParallelFor_OverheadEmptyName                3.05 ns         3.05 ns    228554635
ParallelFor_OverheadLongName                 2.59 ns         2.59 ns    268975096
ParallelFor_OverheadLongTag                  2.59 ns         2.59 ns    270844637
ParallelFor_OverheadFunctor                  3.55 ns         3.55 ns    196392974
ParallelFor_OverheadPolicyCreation           18.8 ns         18.8 ns     37626775
ParallelFor_OverheadSpaceSpecificFence       29.7 ns         29.7 ns     23311160
ParallelFor_OverheadSpaceCreation            41.4 ns         41.4 ns     16832733
ParallelFor_OverheadGlobalFence              35.7 ns         35.7 ns     19693230
ParallelFor_OverheadFull                     52.8 ns         52.8 ns     13383531
```




