### PR TITLE
add rank-1 view_fill `SharedSpace` view benchmark

### DIFF
--- a/core/perf_test/PerfTest_ViewFill.hpp
+++ b/core/perf_test/PerfTest_ViewFill.hpp
@@ -27,20 +27,23 @@ void fill_view(ViewType& a, typename ViewType::const_value_type& val,
                benchmark::State& state) {
   for (auto _ : state) {
     Kokkos::fence();
+
     Kokkos::Timer timer;
     Kokkos::deep_copy(a, val);
     KokkosBenchmark::report_results(state, a, 1, timer.seconds());
   }
 }
 
-template <class Layout>
+template <
+    class Layout,
+    class MemorySpace = typename Kokkos::DefaultExecutionSpace::memory_space>
 static void ViewFill_Rank1(benchmark::State& state) {
   const int N1 = state.range(0);
   const int N2 = N1 * N1;
   const int N4 = N2 * N2;
   const int N8 = N4 * N4;
 
-  Kokkos::View<double*, Layout> a("A1", N8);
+  Kokkos::View<double*, Layout, MemorySpace> a("A1", N8);
   fill_view(a, 1.1, state);
 }
 

--- a/core/perf_test/PerfTest_ViewFill_123.cpp
+++ b/core/perf_test/PerfTest_ViewFill_123.cpp
@@ -23,10 +23,24 @@ BENCHMARK(ViewFill_Rank1<Kokkos::LayoutLeft>)
     ->Arg(N)
     ->UseManualTime();
 
+#ifdef KOKKOS_HAS_SHARED_SPACE
+BENCHMARK(ViewFill_Rank1<Kokkos::LayoutLeft, Kokkos::SharedSpace>)
+    ->ArgName("N")
+    ->Arg(N)
+    ->UseManualTime();
+#endif
+
 BENCHMARK(ViewFill_Rank1<Kokkos::LayoutRight>)
     ->ArgName("N")
     ->Arg(N)
     ->UseManualTime();
+
+#ifdef KOKKOS_HAS_SHARED_SPACE
+BENCHMARK(ViewFill_Rank1<Kokkos::LayoutRight, Kokkos::SharedSpace>)
+    ->ArgName("N")
+    ->Arg(N)
+    ->UseManualTime();
+#endif
 
 BENCHMARK(ViewFill_Rank2<Kokkos::LayoutLeft>)
     ->ArgName("N")


### PR DESCRIPTION
Thought this might be worth adding after noticing `SharedSpace` was showing as ~60% of the speed vs `HipSpace` on MI300A:

```bash
cmake -S kokkos -B build-kokkos \
 -DKokkos_ENABLE_HIP=ON \
 -DCMAKE_CXX_COMPILER=hipcc \
 -DKokkos_ARCH_AMD_GFX942_APU=ON \
 -DKokkos_ENABLE_BENCHMARKS=ON
 
cmake --build build-kokkos --parallel $(nproc)

build-kokkos/core/perf_test/Kokkos_PerformanceTest_Benchmark \
  --benchmark_filter=ViewFill
```

| Memory Space | `deep_copy(view, 1.1)` |
|-|-|
| `HipSpace` | ~3 TB/s |
| `SharedSpace` | 1.9 TB/s |

<details>
<summary>full output</summary>

```
2025-02-27T09:59:41-08:00
Running build-kokkos/core/perf_test/Kokkos_PerformanceTest_Benchmark
Run on (192 X 3577.09 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x96)
  L1 Instruction 32 KiB (x96)
  L2 Unified 1024 KiB (x96)
  L3 Unified 32768 KiB (x12)
Load Average: 0.48, 1.07, 0.83
APU or dGPU: APU
Architecture capable of accessing system allocated memory: 1
CPU architecture: none
Default Device: HIP
GIT_BRANCH: develop
GIT_CLEAN_STATUS: DIRTY
GIT_COMMIT_DATE: 2025-02-27T10:10:23-05:00
GIT_COMMIT_DESCRIPTION: Add HPSF CI build running on NVIDIA P100 (#7815)
GIT_COMMIT_HASH: 31c69c16d
GPU architecture: none
Is Large Bar: 1
KOKKOS_COMPILER_CLANG: 1800
KOKKOS_ENABLE_ASM: no
KOKKOS_ENABLE_CXX17: yes
KOKKOS_ENABLE_CXX20: no
KOKKOS_ENABLE_CXX23: no
KOKKOS_ENABLE_CXX26: no
KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK: no
KOKKOS_ENABLE_HIP: yes
KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE: no
KOKKOS_ENABLE_HWLOC: no
KOKKOS_ENABLE_LIBDL: yes
KOKKOS_ENABLE_PRAGMA_IVDEP: no
KOKKOS_ENABLE_PRAGMA_LOOPCOUNT: no
KOKKOS_ENABLE_PRAGMA_UNROLL: no
KOKKOS_ENABLE_PRAGMA_VECTOR: no
KOKKOS_ENABLE_SERIAL: yes
Kernel reports HMM module via `CONFIG_HMM_MIRROR=y` in `/boot/config`: yes
Kokkos: HIP[ 0 ] gcnArch gfx942:sramecc+:xnack+ : Selected
Kokkos Version: 4.5.99
Shared Memory per Block: 64 KiB
Supports Managed Memory: 1
System allows accessing system allocated memory on GPU: 1
Total Global Memory: 128 GiB
Wavefront Size: 64
XNACK environment variable set: yes
macro  KOKKOS_ENABLE_HIP: defined
macro KOKKOS_ENABLE_IMPL_HIP_MALLOC_ASYNC: yes
macro KOKKOS_ENABLE_ROCTHRUST: defined
platform: 64bit
------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                          Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------------------------------------
ViewFill_Rank1<Kokkos::LayoutLeft>/N:10/manual_time                            0.000 s         0.000 s          2603 FOM: GB/s=3.00343k/s MB=800
ViewFill_Rank1<Kokkos::LayoutLeft, Kokkos::SharedSpace>/N:10/manual_time       0.000 s         0.000 s          1657 FOM: GB/s=1.89866k/s MB=800
ViewFill_Rank1<Kokkos::LayoutRight>/N:10/manual_time                           0.000 s         0.000 s          2626 FOM: GB/s=3.04125k/s MB=800
ViewFill_Rank1<Kokkos::LayoutRight, Kokkos::SharedSpace>/N:10/manual_time      0.000 s         0.000 s          1649 FOM: GB/s=1.89329k/s MB=800
ViewFill_Rank2<Kokkos::LayoutLeft>/N:10/manual_time                            0.000 s         0.000 s          2629 FOM: GB/s=3.03915k/s MB=800
```
</details>

