### PR TITLE
Enable bugprone-sizeof-expression and suppress false positives

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,6 @@ Checks: >
   -bugprone-non-zero-enum-to-bool-conversion,
   -bugprone-reserved-identifier,
   -bugprone-signed-char-misuse,
-  -bugprone-sizeof-expression,
   -bugprone-suspicious-include,
   -bugprone-suspicious-memory-comparison,
   -bugprone-unhandled-exception-at-new,

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -584,6 +584,7 @@ __device__ bool cuda_single_inter_block_reduce_scan2(
         "blockDim");
   }
 
+  // NOLINTNEXTLINE(bugprone-sizeof-expression)
   const integral_nonzero_constant<
       size_type, std::is_pointer_v<typename FunctorType::reference_type>
                      ? 0

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -584,12 +584,13 @@ __device__ bool cuda_single_inter_block_reduce_scan2(
         "blockDim");
   }
 
-  // NOLINTNEXTLINE(bugprone-sizeof-expression)
+  // NOLINTBEGIN(bugprone-sizeof-expression)
   const integral_nonzero_constant<
       size_type, std::is_pointer_v<typename FunctorType::reference_type>
                      ? 0
                      : sizeof(value_type) / sizeof(size_type)>
       word_count((sizeof(value_type) * functor.length()) / sizeof(size_type));
+  // NOLINTEND(bugprone-sizeof-expression)
 
   // Reduce the accumulation for the entire block.
   cuda_intra_block_reduce_scan<false>(functor, pointer_type(shared_data));

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -369,6 +369,7 @@ __device__ bool hip_single_inter_block_reduce_scan_impl(
         "blockDim");
   }
 
+  // NOLINTNEXTLINE(bugprone-sizeof-expression)
   const integral_nonzero_constant<
       size_type, std::is_pointer_v<typename FunctorType::reference_type>
                      ? 0

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -369,12 +369,13 @@ __device__ bool hip_single_inter_block_reduce_scan_impl(
         "blockDim");
   }
 
-  // NOLINTNEXTLINE(bugprone-sizeof-expression)
+  // NOLINTBEGIN(bugprone-sizeof-expression)
   const integral_nonzero_constant<
       size_type, std::is_pointer_v<typename FunctorType::reference_type>
                      ? 0
                      : sizeof(value_type) / sizeof(size_type)>
       word_count((sizeof(value_type) * functor.length()) / sizeof(size_type));
+  // NOLINTEND(bugprone-sizeof-expression)
 
   // Reduce the accumulation for the entire block.
   hip_intra_block_reduce_scan<false>(functor, pointer_type(shared_data));

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -861,6 +861,7 @@ struct FunctorAnalysis {
     static size_t team_shmem_size(F const&, int) { return 0; }
   };
 
+  // NOLINTBEGIN(bugprone-sizeof-expression)
   template <class F>
   struct DeduceTeamShmem<F, std::enable_if_t<0 < sizeof(&F::team_shmem_size)>> {
     enum : bool { value = true };
@@ -880,6 +881,7 @@ struct FunctorAnalysis {
       return f->shmem_size(team_size);
     }
   };
+  // NOLINTEND(bugprone-sizeof-expression)
 
   //----------------------------------------
 

--- a/core/src/impl/Kokkos_VLAEmulation.hpp
+++ b/core/src/impl/Kokkos_VLAEmulation.hpp
@@ -134,6 +134,7 @@ struct ObjectWithVLAEmulation {
   static /* constexpr */ size_t required_allocation_size(
       vla_entry_count_type num_vla_entries) {
     KOKKOS_EXPECTS(num_vla_entries >= 0);
+    // NOLINTNEXTLINE(bugprone-sizeof-expression)
     return sizeof(Derived) + num_vla_entries * sizeof(VLAValueType);
   }
 


### PR DESCRIPTION
~~These two instances are fine.
This is the old-fashioned C++-98 way of doing SFINAE.~~
Removed in #7822

The remaining suppression is in tasking utilities that are deprecated and will be removed in 5.0