### PR TITLE
Make fence in Serial non blocking when Kokkos_ENABLE_ATOMICS_BYPASS is set

### DIFF
--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -147,21 +147,20 @@ class Serial {
     auto fence = []() {};
 #else
     auto fence = []() {
-          std::lock_guard<std::mutex> lock_all_instances(
-              Impl::SerialInternal::all_instances_mutex);
-          for (auto* instance_ptr : Impl::SerialInternal::all_instances) {
-            std::lock_guard<std::mutex> lock_instance(
-                instance_ptr->m_instance_mutex);
-          }
-        };
+      std::lock_guard<std::mutex> lock_all_instances(
+          Impl::SerialInternal::all_instances_mutex);
+      for (auto* instance_ptr : Impl::SerialInternal::all_instances) {
+        std::lock_guard<std::mutex> lock_instance(
+            instance_ptr->m_instance_mutex);
+      }
+    };
 #endif
     if (Kokkos::Tools::profileLibraryLoaded()) {
       Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Serial>(
           name,
           Kokkos::Tools::Experimental::SpecialSynchronizationCases::
               GlobalDeviceSynchronization,
-              fence
-          );  // TODO: correct device ID
+          fence);  // TODO: correct device ID
     } else {
       fence();
     }
@@ -176,9 +175,9 @@ class Serial {
     auto fence = []() {};
 #else
     auto fence = [this]() {
-          auto* internal_instance = this->impl_internal_space_instance();
-          std::lock_guard<std::mutex> lock(internal_instance->m_instance_mutex);
-        };
+      auto* internal_instance = this->impl_internal_space_instance();
+      std::lock_guard<std::mutex> lock(internal_instance->m_instance_mutex);
+    };
 #endif
     if (Kokkos::Tools::profileLibraryLoaded()) {
       Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Serial>(

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -143,30 +143,53 @@ class Serial {
   /// method does not return until all dispatched functors on this
   /// device have completed.
   static void impl_static_fence(const std::string& name) {
-    Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Serial>(
-        name,
-        Kokkos::Tools::Experimental::SpecialSynchronizationCases::
-            GlobalDeviceSynchronization,
-        []() {
+#ifdef KOKKOS_ENABLE_ATOMICS_BYPASS
+    auto fence = []() {};
+#else
+    auto fence = []() {
           std::lock_guard<std::mutex> lock_all_instances(
               Impl::SerialInternal::all_instances_mutex);
           for (auto* instance_ptr : Impl::SerialInternal::all_instances) {
             std::lock_guard<std::mutex> lock_instance(
                 instance_ptr->m_instance_mutex);
           }
-        });  // TODO: correct device ID
+        };
+#endif
+    if (Kokkos::Tools::profileLibraryLoaded()) {
+      Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Serial>(
+          name,
+          Kokkos::Tools::Experimental::SpecialSynchronizationCases::
+              GlobalDeviceSynchronization,
+              fence
+          );  // TODO: correct device ID
+    } else {
+      fence();
+    }
+#ifndef KOKKOS_ENABLE_ATOMICS_BYPASS
     Kokkos::memory_fence();
+#endif
   }
 
   void fence(const std::string& name =
                  "Kokkos::Serial::fence: Unnamed Instance Fence") const {
-    Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Serial>(
-        name, Kokkos::Tools::Experimental::Impl::DirectFenceIDHandle{1},
-        [this]() {
+#ifdef KOKKOS_ENABLE_ATOMICS_BYPASS
+    auto fence = []() {};
+#else
+    auto fence = [this]() {
           auto* internal_instance = this->impl_internal_space_instance();
           std::lock_guard<std::mutex> lock(internal_instance->m_instance_mutex);
-        });  // TODO: correct device ID
+        };
+#endif
+    if (Kokkos::Tools::profileLibraryLoaded()) {
+      Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Serial>(
+          name, Kokkos::Tools::Experimental::Impl::DirectFenceIDHandle{1},
+          fence);  // TODO: correct device ID
+    } else {
+      fence();
+    }
+#ifndef KOKKOS_ENABLE_ATOMICS_BYPASS
     Kokkos::memory_fence();
+#endif
   }
 
   /** \brief  Return the maximum amount of concurrency.  */


### PR DESCRIPTION
#7080 made the Serial Backend thread safe.
#7369 introduced a compile flag (KOKKOS_ENABLE_ATOMICS_BYPASS), to ignore some of the mutex introduced in #7080.

This PR makes the flag also ignore mutex in fences in order to improve performances of the Serial Backend when used in a single thread.

Some benchmarks (generated with #7808) to highlight the problem:
```
// Before modifications
---------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations
---------------------------------------------------------------------------------------
ParallelFor_NoOverhead                             3.05 ns         3.05 ns    228454504
ParallelFor_Overhead_DefaultName                   3.53 ns         3.53 ns    198692974
ParallelFor_Overhead_EmptyName                     3.56 ns         3.53 ns    198272794
ParallelFor_Overhead_LongName                      3.09 ns         3.08 ns    228194378
ParallelFor_Overhead_LongTag                       3.08 ns         3.07 ns    229243737
ParallelFor_Overhead_Functor                       3.54 ns         3.53 ns    198504736
ParallelFor_Overhead_PolicyCreation                19.1 ns         18.9 ns     37335923
ParallelFor_Overhead_SpaceSpecificFence            29.4 ns         29.3 ns     24041731
ParallelFor_Overhead_NamedSpaceSpecificFence       10.3 ns         10.3 ns     65718519
ParallelFor_Overhead_FenceWithSpaceCreation        39.5 ns         39.5 ns     17668835
ParallelFor_Overhead_GlobalFence                   34.4 ns         34.4 ns     20324859
ParallelFor_Overhead_NamedGlobalFence              17.4 ns         17.4 ns     40578692
ParallelFor_Overhead_Full                          53.7 ns         53.2 ns     13069345

//After modifications
---------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations
---------------------------------------------------------------------------------------
ParallelFor_NoOverhead                             3.08 ns         3.05 ns    228946675
ParallelFor_Overhead_DefaultName                   3.55 ns         3.53 ns    198446903
ParallelFor_Overhead_EmptyName                     3.53 ns         3.53 ns    197516328
ParallelFor_Overhead_LongName                      3.05 ns         3.05 ns    228939852
ParallelFor_Overhead_LongTag                       3.05 ns         3.05 ns    229057928
ParallelFor_Overhead_Functor                       3.53 ns         3.53 ns    198392098
ParallelFor_Overhead_PolicyCreation                19.6 ns         19.4 ns     36036196
ParallelFor_Overhead_SpaceSpecificFence            11.7 ns         11.7 ns     60485673
ParallelFor_Overhead_NamedSpaceSpecificFence       2.84 ns         2.84 ns    244662262
ParallelFor_Overhead_FenceWithSpaceCreation        24.1 ns         24.1 ns     29228213
ParallelFor_Overhead_GlobalFence                   15.4 ns         15.4 ns     45923703
ParallelFor_Overhead_NamedGlobalFence              6.03 ns         5.98 ns    116174312
ParallelFor_Overhead_Full                          33.2 ns         33.1 ns     21067259
```
