### PR TITLE
Fixup Clang-Tidy's bugprone-reserved-identifier check failing with CUDA

### DIFF
--- a/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
@@ -47,6 +47,7 @@
 #ifdef _CubLog
 #undef _CubLog
 #endif
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 #define _CubLog
 #include <thrust/device_ptr.h>
 #include <thrust/sort.h>

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -51,6 +51,7 @@
 #ifdef _CubLog
 #undef _CubLog
 #endif
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 #define _CubLog
 #include <thrust/device_ptr.h>
 #include <thrust/sort.h>

--- a/algorithms/src/std_algorithms/impl/Kokkos_InclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_InclusiveScan.hpp
@@ -53,6 +53,7 @@
 #ifdef _CubLog
 #undef _CubLog
 #endif
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 #define _CubLog
 #include <thrust/distance.h>
 #include <thrust/scan.h>

--- a/core/src/Cuda/Kokkos_Cuda_abort.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_abort.hpp
@@ -28,6 +28,7 @@ extern "C" {
 /*  Cuda runtime function, declared in <crt/device_runtime.h>
  *  Requires capability 2.x or better.
  */
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 [[noreturn]] __device__ void __assertfail(const void *message, const void *file,
                                           unsigned int line,
                                           const void *function,


### PR DESCRIPTION
Spotted in the CI on the CUDA-11.8-Clang-15 build on ORNL Jenkins
```
/var/jenkins/workspace/Kokkos_PR-7542/core/src/Cuda/Kokkos_Cuda_abort.hpp:31:30: error: declaration uses identifier '__assertfail', which is a reserved identifier [bugprone-reserved-identifier,-warnings-as-errors]
[[noreturn]] __device__ void __assertfail(const void *message, const void *file,
                             ^~~~~~~~~~~~
                             _assertfail
```
Fixup for #7820 