### PR TITLE
Workaround hanging cuda install in windows CI

### DIFF
--- a/.github/workflows/continuous-integration-windows.yml
+++ b/.github/workflows/continuous-integration-windows.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         cuda: '12.4.1'
         method: 'network'
-        sub-packages: '["nvcc","cudart","thrust"]'
+        sub-packages: '["nvcc","cudart","thrust","visual_studio_integration"]'
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: configure
       shell: bash

--- a/.github/workflows/continuous-integration-windows.yml
+++ b/.github/workflows/continuous-integration-windows.yml
@@ -20,6 +20,8 @@ jobs:
       id: cuda-toolkit
       with:
         cuda: '12.4.1'
+        method: 'network'
+        sub-packages: '["nvcc","cudart","thrust"]'
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: configure
       shell: bash

--- a/.github/workflows/continuous-integration-windows.yml
+++ b/.github/workflows/continuous-integration-windows.yml
@@ -13,15 +13,13 @@ jobs:
   windows-cuda:
     # Cuda build on Windows
     name: Windows Cuda
-    runs-on: windows-2022
+    runs-on: windows-2019
 
     steps:
     - uses: Jimver/cuda-toolkit@8022558310ea543e35132143092835585f60e628 # v0.2.21
       id: cuda-toolkit
       with:
         cuda: '12.4.1'
-        method: 'network'
-        sub-packages: '["nvcc","cudart","thrust"]'
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: configure
       shell: bash
@@ -29,7 +27,7 @@ jobs:
         mkdir build
         mkdir c:/project
         cd build
-        cmake -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_TESTS=ON -DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON -DCMAKE_CXX_COMPILER="${CUDA_PATH}/bin/nvcc" ..
+        cmake -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_TESTS=ON -DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON ..
     - name: build library
       shell: bash
       run: |

--- a/.github/workflows/continuous-integration-windows.yml
+++ b/.github/workflows/continuous-integration-windows.yml
@@ -29,7 +29,7 @@ jobs:
         mkdir build
         mkdir c:/project
         cd build
-        cmake -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_TESTS=ON -DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON -DCMAKE_CXX_COMPILER="${CUDA_PATH}/bin/nvcc"
+        cmake -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_TESTS=ON -DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON -DCMAKE_CXX_COMPILER="${CUDA_PATH}/bin/nvcc" ..
     - name: build library
       shell: bash
       run: |

--- a/.github/workflows/continuous-integration-windows.yml
+++ b/.github/workflows/continuous-integration-windows.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         cuda: '12.4.1'
         method: 'network'
-        sub-packages: '["nvcc","cudart","thrust","visual_studio_integration"]'
+        sub-packages: '["nvcc","cudart","thrust"]'
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: configure
       shell: bash
@@ -29,7 +29,7 @@ jobs:
         mkdir build
         mkdir c:/project
         cd build
-        cmake -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_TESTS=ON -DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON ..
+        cmake -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_TESTS=ON -DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON -DCMAKE_CXX_COMPILER="${CUDA_PATH}/bin/nvcc"
     - name: build library
       shell: bash
       run: |


### PR DESCRIPTION
@romintomasetti posted on Slack that our CI for windows times out.

Some digging indicates that this is an issue upstream, see [this issue](https://github.com/Jimver/cuda-toolkit/issues/382)
This pr mimics a workaround another user posted [here](https://github.com/catboost/catboost/commit/147855b58f021b85e50e44a0bdafba96fd6e16eb).

The workaround manually selects the components that should be installed and uses the network installer. 