### PR TITLE
Drop `TeamPolicyInternal<{Cuda,HIP,SYCL},...>::verify_requested_vector_length()`

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -235,8 +235,8 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
         m_league_size(league_size_),
         m_team_size(team_size_request),
         m_vector_length((vector_length_request > 0)
-                            ? Kokkos::bit_floor(
-                                  static_cast<unsigned>(vector_length_request))
+                            ? Kokkos::bit_floor(std::min<unsigned>(
+                                  vector_length_request, vector_length_max()))
                             : 1),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -234,10 +234,8 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
       : m_space(space_),
         m_league_size(league_size_),
         m_team_size(team_size_request),
-        m_vector_length((vector_length_request > 0)
-                            ? Kokkos::bit_floor(std::min<unsigned>(
-                                  vector_length_request, vector_length_max()))
-                            : 1),
+        m_vector_length(Kokkos::bit_floor(std::clamp<unsigned>(
+            vector_length_request, 1, vector_length_max()))),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_chunk_size(Impl::CudaTraits::WarpSize),

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -32,6 +32,7 @@
 #include <Cuda/Kokkos_Cuda_ReduceScan.hpp>
 #include <Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp>
 #include <Cuda/Kokkos_Cuda_Team.hpp>
+#include <Kokkos_BitManipulation.hpp>
 #include <Kokkos_MinMax.hpp>
 #include <Kokkos_Vectorization.hpp>
 
@@ -172,26 +173,6 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
 
   inline static int vector_length_max() { return Impl::CudaTraits::WarpSize; }
 
-  inline static int verify_requested_vector_length(
-      int requested_vector_length) {
-    int test_vector_length =
-        std::min(requested_vector_length, vector_length_max());
-
-    // Allow only power-of-two vector_length
-    if (!(is_integral_power_of_two(test_vector_length))) {
-      int test_pow2 = 1;
-      for (int i = 0; i < 5; i++) {
-        test_pow2 = test_pow2 << 1;
-        if (test_pow2 > test_vector_length) {
-          break;
-        }
-      }
-      test_vector_length = test_pow2 >> 1;
-    }
-
-    return test_vector_length;
-  }
-
   inline static int scratch_size_max(int level) {
     // Cuda Teams use (team_size + 2)*sizeof(double) shared memory for team
     // reductions. They also use one int64_t in static shared memory for a
@@ -253,10 +234,10 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
       : m_space(space_),
         m_league_size(league_size_),
         m_team_size(team_size_request),
-        m_vector_length(
-            (vector_length_request > 0)
-                ? verify_requested_vector_length(vector_length_request)
-                : verify_requested_vector_length(1)),
+        m_vector_length((vector_length_request > 0)
+                            ? Kokkos::bit_floor(
+                                  static_cast<unsigned>(vector_length_request))
+                            : 1),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_chunk_size(Impl::CudaTraits::WarpSize),

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -173,6 +173,13 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
 
   inline static int vector_length_max() { return Impl::CudaTraits::WarpSize; }
 
+  inline static int impl_determine_vector_length(int requested) {
+    // restrict requested between 1 and max
+    unsigned vector_length = std::clamp(requested, 1, vector_length_max());
+    // return the largest integral power of 2 not greater than requested
+    return Kokkos::bit_floor(vector_length);
+  }
+
   inline static int scratch_size_max(int level) {
     // Cuda Teams use (team_size + 2)*sizeof(double) shared memory for team
     // reductions. They also use one int64_t in static shared memory for a
@@ -234,8 +241,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
       : m_space(space_),
         m_league_size(league_size_),
         m_team_size(team_size_request),
-        m_vector_length(Kokkos::bit_floor(std::clamp<unsigned>(
-            vector_length_request, 1, vector_length_max()))),
+        m_vector_length(impl_determine_vector_length(vector_length_request)),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_chunk_size(Impl::CudaTraits::WarpSize),

--- a/core/src/HIP/Kokkos_HIP_TeamPolicyInternal.hpp
+++ b/core/src/HIP/Kokkos_HIP_TeamPolicyInternal.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HIP_TEAM_POLICY_INTERNAL_HPP
 #define KOKKOS_HIP_TEAM_POLICY_INTERNAL_HPP
 
+#include <Kokkos_BitManipulation.hpp>
 #include <Kokkos_MinMax.hpp>
 
 namespace Kokkos {
@@ -133,26 +134,6 @@ class TeamPolicyInternal<HIP, Properties...>
   inline bool impl_auto_team_size() const { return m_tune_team_size; }
   static int vector_length_max() { return HIPTraits::WarpSize; }
 
-  static int verify_requested_vector_length(int requested_vector_length) {
-    int test_vector_length =
-        std::min(requested_vector_length, vector_length_max());
-
-    // Allow only power-of-two vector_length
-    if (!(is_integral_power_of_two(test_vector_length))) {
-      int test_pow2           = 1;
-      constexpr int warp_size = HIPTraits::WarpSize;
-      while (test_pow2 < warp_size) {
-        test_pow2 <<= 1;
-        if (test_pow2 > test_vector_length) {
-          break;
-        }
-      }
-      test_vector_length = test_pow2 >> 1;
-    }
-
-    return test_vector_length;
-  }
-
   inline static int scratch_size_max(int level) {
     // HIP Teams use (team_size + 2)*sizeof(double) shared memory for team
     // reductions. They also use one int64_t in static shared memory for a
@@ -213,10 +194,10 @@ class TeamPolicyInternal<HIP, Properties...>
       : m_space(space_),
         m_league_size(league_size_),
         m_team_size(team_size_request),
-        m_vector_length(
-            (vector_length_request > 0)
-                ? verify_requested_vector_length(vector_length_request)
-                : (verify_requested_vector_length(1))),
+        m_vector_length((vector_length_request > 0)
+                            ? Kokkos::bit_floor(
+                                  static_cast<unsigned>(vector_length_request))
+                            : 1),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_chunk_size(HIPTraits::WarpSize),

--- a/core/src/HIP/Kokkos_HIP_TeamPolicyInternal.hpp
+++ b/core/src/HIP/Kokkos_HIP_TeamPolicyInternal.hpp
@@ -194,10 +194,8 @@ class TeamPolicyInternal<HIP, Properties...>
       : m_space(space_),
         m_league_size(league_size_),
         m_team_size(team_size_request),
-        m_vector_length((vector_length_request > 0)
-                            ? Kokkos::bit_floor(std::min<unsigned>(
-                                  vector_length_request, vector_length_max()))
-                            : 1),
+        m_vector_length(Kokkos::bit_floor(std::clamp<unsigned>(
+            vector_length_request, 1, vector_length_max()))),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_chunk_size(HIPTraits::WarpSize),

--- a/core/src/HIP/Kokkos_HIP_TeamPolicyInternal.hpp
+++ b/core/src/HIP/Kokkos_HIP_TeamPolicyInternal.hpp
@@ -195,8 +195,8 @@ class TeamPolicyInternal<HIP, Properties...>
         m_league_size(league_size_),
         m_team_size(team_size_request),
         m_vector_length((vector_length_request > 0)
-                            ? Kokkos::bit_floor(
-                                  static_cast<unsigned>(vector_length_request))
+                            ? Kokkos::bit_floor(std::min<unsigned>(
+                                  vector_length_request, vector_length_max()))
                             : 1),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},

--- a/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
@@ -109,6 +109,15 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
     return *std::max_element(sub_group_sizes.begin(), sub_group_sizes.end());
   }
 
+ private:
+  static int determine_vector_length(int requested) {
+    // restrict requested between 1 and max
+    unsigned vector_length = std::clamp(requested, 1, vector_length_max());
+    // return the largest integral power of 2 not greater than requested
+    return Kokkos::bit_floor(vector_length);
+  }
+
+ public:
   static int scratch_size_max(int level) {
     return level == 0 ? 1024 * 32
                       :           // FIXME_SYCL arbitrarily setting this to 32kB
@@ -155,8 +164,7 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
       : m_space(space_),
         m_league_size(league_size_),
         m_team_size(team_size_request),
-        m_vector_length(Kokkos::bit_floor(std::clamp<unsigned>(
-            vector_length_request, 1, vector_length_max()))),
+        m_vector_length(determine_vector_length(vector_length_request)),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_chunk_size(vector_length_max()),

--- a/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
@@ -156,8 +156,8 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
         m_league_size(league_size_),
         m_team_size(team_size_request),
         m_vector_length((vector_length_request > 0)
-                            ? Kokkos::bit_floor(
-                                  static_cast<unsigned>(vector_length_request))
+                            ? Kokkos::bit_floor(std::min<unsigned>(
+                                  vector_length_request, vector_length_max()))
                             : 1),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},

--- a/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
@@ -155,10 +155,8 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
       : m_space(space_),
         m_league_size(league_size_),
         m_team_size(team_size_request),
-        m_vector_length((vector_length_request > 0)
-                            ? Kokkos::bit_floor(std::min<unsigned>(
-                                  vector_length_request, vector_length_max()))
-                            : 1),
+        m_vector_length(Kokkos::bit_floor(std::clamp<unsigned>(
+            vector_length_request, 1, vector_length_max()))),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_chunk_size(vector_length_max()),


### PR DESCRIPTION
Prefer `Kokkos::bit_floor` which is aligned with the standard and more readable.
See #7838 