### PR TITLE
Add path filter to mdspan GH action

### DIFF
--- a/.github/workflows/continuous-integration-stager.yml
+++ b/.github/workflows/continuous-integration-stager.yml
@@ -23,9 +23,6 @@ jobs:
   cmake-format-check:
     uses: ./.github/workflows/cmake-format-check.yml
 
-  mdspan-version-check:
-    uses: ./.github/workflows/mdspan-version-check.yml
-
   initial-check:
     uses: ./.github/workflows/continuous-integration-smoketest.yml
 

--- a/.github/workflows/mdspan-version-check.yml
+++ b/.github/workflows/mdspan-version-check.yml
@@ -3,11 +3,13 @@ name: mdspan version check
 on:
   push:
     paths:
+      - '.github/workflows/mdspan-version-check.yml'
       - 'tpls/mdspan/**'
     branches:
       - develop
   pull_request:
     paths:
+      - '.github/workflows/mdspan-version-check.yml'
       - 'tpls/mdspan/**'
 
 permissions: read-all

--- a/.github/workflows/mdspan-version-check.yml
+++ b/.github/workflows/mdspan-version-check.yml
@@ -1,7 +1,12 @@
 name: mdspan version check
 
 on:
-  workflow_call:
+  push:
+    paths:
+      - 'tpls/mdspan/**'
+    branches:
+      - develop
+  pull_request:
     paths:
       - 'tpls/mdspan/**'
 

--- a/.github/workflows/mdspan-version-check.yml
+++ b/.github/workflows/mdspan-version-check.yml
@@ -1,12 +1,6 @@
 name: mdspan version check
 
 on:
-  push:
-    paths:
-      - '.github/workflows/mdspan-version-check.yml'
-      - 'tpls/mdspan/**'
-    branches:
-      - develop
   pull_request:
     paths:
       - '.github/workflows/mdspan-version-check.yml'

--- a/.github/workflows/mdspan-version-check.yml
+++ b/.github/workflows/mdspan-version-check.yml
@@ -2,6 +2,8 @@ name: mdspan version check
 
 on:
   workflow_call:
+    paths:
+      - 'tpls/mdspan/**'
 
 permissions: read-all
 


### PR DESCRIPTION
Fixup for the GitHub action added in #7837

We only want to trigger if files in tpls/mdspan actually changed.

According to the doc
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
it only works on `push` or `pull_request`.

I am opening anyway and we can iterate to see if we can find a solution.