### PR TITLE
Update SYCL+Cuda Dockerfile to oneAPI 2025.0 and Cuda 12

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -271,10 +271,10 @@ pipeline {
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-                                -DCMAKE_CXX_COMPILER=clang++ \
-                                -DCMAKE_CXX_FLAGS="-fsycl-device-code-split=per_kernel -Wno-deprecated-declarations -Werror -Wno-gnu-zero-variadic-macro-arguments -Wno-unknown-cuda-version -Wno-sycl-target" \
-                                -DCMAKE_PREFIX_PATH="$ONE_DPL_DIR" \
+                                -DCMAKE_CXX_COMPILER=icpx \
+                                -DCMAKE_CXX_FLAGS="-fsycl-device-code-split=per_kernel -fp-model=precise -Wno-deprecated-declarations -Werror -Wno-gnu-zero-variadic-macro-arguments -Wno-unknown-cuda-version -Wno-sycl-target" \
                                 -DKOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED=0 \
+                                -DKOKKOS_IMPL_HAVE_SYCL_EXT_ONEAPI_DEVICE_GLOBAL=OFF \
                                 -DKokkos_ARCH_NATIVE=ON \
                                 -DKokkos_ARCH_AMPERE80=ON \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
@@ -282,12 +282,15 @@ pipeline {
                                 -DKokkos_ENABLE_EXAMPLES=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_BENCHMARKS=ON \
+                                -DoneDPL_ROOT=/opt/intel/oneapi/2025.0 \
                                 -DKokkos_ENABLE_SYCL=ON \
                                 -DKokkos_ENABLE_SYCL_RELOCATABLE_DEVICE_CODE=ON \
                                 -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON \
                                 -DCMAKE_CXX_STANDARD=17 \
                               .. && \
-                              make -j8 && ctest --no-compress-output -T Test --verbose'''
+                              make -j8 && \
+                              export GTEST_FILTER="-sycl_graph.submit_six:sycl_multi_gpu.scratch_space" && \
+                              ctest --no-compress-output -T Test --verbose'''
                     }
                     post {
                         always {

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -273,8 +273,6 @@ pipeline {
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=icpx \
                                 -DCMAKE_CXX_FLAGS="-fsycl-device-code-split=per_kernel -fp-model=precise -Wno-deprecated-declarations -Werror -Wno-gnu-zero-variadic-macro-arguments -Wno-unknown-cuda-version -Wno-sycl-target" \
-                                -DKOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED=0 \
-                                -DKOKKOS_IMPL_HAVE_SYCL_EXT_ONEAPI_DEVICE_GLOBAL=OFF \
                                 -DKokkos_ARCH_NATIVE=ON \
                                 -DKokkos_ARCH_AMPERE80=ON \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -286,9 +286,7 @@ pipeline {
                                 -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON \
                                 -DCMAKE_CXX_STANDARD=17 \
                               .. && \
-                              make -j8 && \
-                              export GTEST_FILTER="-sycl_graph.submit_six:sycl_multi_gpu.scratch_space" && \
-                              ctest --no-compress-output -T Test --verbose'''
+                              make -j8 && ctest --no-compress-output -T Test --verbose'''
                     }
                     post {
                         always {

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -760,18 +760,23 @@ endif()
 #   implementation. Otherwise, the feature is not supported when building shared
 #   libraries. Thus, we don't even check for support if shared libraries are
 #   requested and SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined.
+#   As of oneAPI 2025.0.0, this feature only works well for Intel GPUs.
+#   For simplicity only test for JIT and PVC
 if(KOKKOS_ENABLE_SYCL)
   string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${KOKKOS_COMPILE_OPTIONS}")
   include(CheckCXXSymbolExists)
-  check_cxx_symbol_exists(SYCL_EXT_ONEAPI_DEVICE_GLOBAL "sycl/sycl.hpp" KOKKOS_IMPL_HAVE_SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
-  if(KOKKOS_IMPL_HAVE_SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
-    set(KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED ON)
-    # Use the non-separable compilation implementation to support shared libraries as well.
-    compiler_specific_flags(DEFAULT -DDESUL_SYCL_DEVICE_GLOBAL_SUPPORTED)
-  elseif(NOT BUILD_SHARED_LIBS AND KOKKOS_ENABLE_SYCL_RELOCATABLE_DEVICE_CODE)
-    include(CheckCXXSourceCompiles)
-    check_cxx_source_compiles(
-      "
+  if(Kokkos_ARCH_INTEL_PVC OR Kokkos_ARCH_INTEL_GEN)
+    check_cxx_symbol_exists(
+      SYCL_EXT_ONEAPI_DEVICE_GLOBAL "sycl/sycl.hpp" KOKKOS_IMPL_HAVE_SYCL_EXT_ONEAPI_DEVICE_GLOBAL
+    )
+    if(KOKKOS_IMPL_HAVE_SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
+      set(KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED ON)
+      # Use the non-separable compilation implementation to support shared libraries as well.
+      compiler_specific_flags(DEFAULT -DDESUL_SYCL_DEVICE_GLOBAL_SUPPORTED)
+    elseif(NOT BUILD_SHARED_LIBS AND KOKKOS_ENABLE_SYCL_RELOCATABLE_DEVICE_CODE)
+      include(CheckCXXSourceCompiles)
+      check_cxx_source_compiles(
+        "
       #include <sycl/sycl.hpp>
       using namespace sycl::ext::oneapi::experimental;
       using namespace sycl;
@@ -786,12 +791,13 @@ if(KOKKOS_ENABLE_SYCL)
 
       int main(){ return 0; }
       "
-      KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED
-    )
+        KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED
+      )
 
-    if(KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED)
-      # Only the separable compilation implementation is supported.
-      compiler_specific_flags(DEFAULT -fsycl-device-code-split=off -DDESUL_SYCL_DEVICE_GLOBAL_SUPPORTED)
+      if(KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED)
+        # Only the separable compilation implementation is supported.
+        compiler_specific_flags(DEFAULT -fsycl-device-code-split=off -DDESUL_SYCL_DEVICE_GLOBAL_SUPPORTED)
+      endif()
     endif()
   endif()
 

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -273,8 +273,9 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), submit_six) {
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP() << "skipping since OpenMPTarget can't use team_size 1";
 #endif
-#if defined(KOKKOS_ENABLE_SYCL) && \
-    !defined(SYCL_EXT_ONEAPI_GRAPH)  // FIXME_SYCL
+#if defined(KOKKOS_ENABLE_SYCL) &&      \
+    (!defined(SYCL_EXT_ONEAPI_GRAPH) || \
+     !defined(KOKKOS_ARCH_INTEL_GPU))  // FIXME_SYCL
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::SYCL>)
     GTEST_SKIP() << "skipping since test case is known to fail with SYCL";
 #endif

--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -1,4 +1,4 @@
-ARG BASE=nvcr.io/nvidia/cuda:11.7.1-devel-ubuntu22.04@sha256:a3184e4dc6f968da5bba86df3081ff3013f8e3674a9bfce544af8be905d2f17a
+ARG BASE=nvcr.io/nvidia/cuda:12.0.0-devel-ubuntu22.04@sha256:0578d90ce082ed37cdc8daf31d401b5a62594a847e9cf6b5cdf4c2356ac49869
 FROM $BASE
 
 ARG ADDITIONAL_PACKAGES
@@ -41,39 +41,24 @@ RUN CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSIO
     rm cmake*
 ENV PATH=${CMAKE_DIR}/bin:$PATH
 
-RUN wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB && \
-    apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB && \
-    echo "deb https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list && \
-    apt-get update -o Dir::Etc::sourcelist="sources.list.d/oneAPI.list" -o APT::Get::List-Cleanup="0" && \
-    apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.0.0 && \
+RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+    | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null && \
+    echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
+    | tee /etc/apt/sources.list.d/oneAPI.list
+
+RUN wget -qO - https://developer.codeplay.com/apt/public.key \
+    | gpg --dearmor | tee /usr/share/keyrings/codeplay-keyring.gpg > /dev/null && \
+    echo "deb [signed-by=/usr/share/keyrings/codeplay-keyring.gpg] https://developer.codeplay.com/apt all main" \
+    | tee /etc/apt/sources.list.d/codeplay.list
+
+RUN apt-get update && apt-get install -y \
+        oneapi-nvidia-12.0 \
+        intel-oneapi-compiler-dpcpp-cpp-2025.0 \
+        && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget https://cloud1.cees.ornl.gov/download/oneapi-for-nvidia-gpus-2023.0.0-linux.sh && \
-    echo "3416721faf83e5858e65795231bae47bb51ff91d4e8738613d498674f1636f72  oneapi-for-nvidia-gpus-2023.0.0-linux.sh" | sha256sum --check && \
-    chmod +x oneapi-for-nvidia-gpus-2023.0.0-linux.sh && \
-    ./oneapi-for-nvidia-gpus-2023.0.0-linux.sh -y && \
-    rm oneapi-for-nvidia-gpus-2023.0.0-linux.sh
-
-ENV ONE_DPL_DIR=/opt/onedpl
-RUN . /opt/intel/oneapi/setvars.sh --include-intel-llvm && \
-    ONE_DPL_VERSION=oneDPL-2022.2.0 && \
-    ONE_DPL_URL=https://github.com/oneapi-src/oneDPL/archive && \
-    ONE_DPL_ARCHIVE=${ONE_DPL_VERSION}-rc1.tar.gz && \
-    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
-    wget --quiet ${ONE_DPL_URL}/${ONE_DPL_ARCHIVE} && \
-    mkdir onedpl && \
-    tar -xf ${ONE_DPL_ARCHIVE} -C onedpl --strip-components=1 && cd onedpl && \
-    mkdir build && cd build && \
-    cmake -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX=${ONE_DPL_DIR} -DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=TRUE -DONEDPL_BACKEND="dpcpp_only" .. && \
-    make -j${NPROCS} install && \
-    rm -rf ${SCRATCH_DIR}
-
-# clang++
-ENV PATH=/opt/intel/oneapi/compiler/latest/linux/bin-llvm/:$PATH
 # sycl-ls, icpx
-ENV PATH=/opt/intel/oneapi/compiler/latest/linux/bin/:$PATH
-# libsycl
-ENV LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/latest/linux/lib:$LD_LIBRARY_PATH
-# libsvml
-ENV LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin:$LD_LIBRARY_PATH
+ENV PATH=/opt/intel/oneapi/compiler/2025.0/bin/:$PATH
+# libsycl, libsvml
+ENV LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/2025.0/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
We have been seeing issues with the sorting tests with oneAPI 2023.0.0 that don't appear with newer compiler versions and we decided that it makes sense not to use the minimum compiler version for uncommon architectures (NVIDIA GPUs).

We are starting from an NVIDIA docker image and the oneAPI and the Codeplay plugin with the package manegr as descrobed in https://www.intel.com/content/www/us/en/docs/oneapi/installation-guide-linux/2025-0/apt-005.html and https://developer.codeplay.com/apt/index.html. With that we aslo don't have to install `oneDPL` separately.

Since we are now using `icpx` instead of `clang++`, we need to use `-fp-model=precise` for the tests to pass.

Even though, support for device gloabl variables is detected we continue to disable it for this setup since it still onlt seems to work correctly for Intel GPUs.

Finally, we have seen problems with the `submit_six` graph test for other configurations as well and this pull request to just test it for `Intel` GPUs where we know that it works for recent compiler versions with immediate command lists.