### PR TITLE
Fix a bug in the simd non-masked reductions and min/max functions

### DIFF
--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -377,21 +377,20 @@ struct Identity {
 template <class T, class Abi, class BinaryOperation = std::plus<>>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 reduce(const basic_simd<T, Abi>& x, BinaryOperation binary_op = {}) {
-  return reduce(x, basic_simd<T, Abi>::mask_type(true),
-                Impl::Identity<T, BinaryOperation>(), binary_op);
+  return reduce(x, typename basic_simd<T, Abi>::mask_type(true),
+                T(Impl::Identity<T, BinaryOperation>()), binary_op);
 }
 
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 reduce_min(const basic_simd<T, Abi>& x) noexcept {
-  return reduce_min(x, basic_simd<T, Abi>::mask_type(true));
+  return reduce_min(x, typename basic_simd<T, Abi>::mask_type(true));
 }
 
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 reduce_max(const basic_simd<T, Abi>& x) noexcept {
-  auto v = where(true, x);
-  return reduce_max(x, basic_simd<T, Abi>::mask_type(true));
+  return reduce_max(x, typename basic_simd<T, Abi>::mask_type(true));
 }
 
 }  // namespace Experimental

--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -111,10 +111,13 @@ reduce(basic_simd<T, Abi> const& v,
 
 }  // namespace Experimental
 
-template <class T, class Abi>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> min(
-    Experimental::basic_simd<T, Abi> const& a,
-    Experimental::basic_simd<T, Abi> const& b) {
+template <class T, class Abi,
+          std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,
+                           bool> = false>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<T, Abi>
+    min(Experimental::basic_simd<T, Abi> const& a,
+        Experimental::basic_simd<T, Abi> const& b) {
   Experimental::basic_simd<T, Abi> result;
   T vals[Experimental::basic_simd<T, Abi>::size()] = {0};
   for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size(); ++i) {
@@ -136,10 +139,13 @@ template <class T, class Abi>
 }  // namespace Experimental
 #endif
 
-template <class T, class Abi>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> max(
-    Experimental::basic_simd<T, Abi> const& a,
-    Experimental::basic_simd<T, Abi> const& b) {
+template <class T, class Abi,
+          std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,
+                           bool> = false>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_simd<T, Abi>
+    max(Experimental::basic_simd<T, Abi> const& a,
+        Experimental::basic_simd<T, Abi> const& b) {
   Experimental::basic_simd<T, Abi> result;
   T vals[Experimental::basic_simd<T, Abi>::size()] = {0};
   for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size(); ++i) {

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -490,6 +490,24 @@ reduce_max(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const&
 }
 
 template <class T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+    T, Experimental::simd_abi::scalar>
+min(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a,
+    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& b) {
+  return Experimental::basic_simd<T, Experimental::simd_abi::scalar>(
+      Kokkos::min(a[0], b[0]));
+}
+
+template <class T>
+[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+    T, Experimental::simd_abi::scalar>
+max(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a,
+    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& b) {
+  return Experimental::basic_simd<T, Experimental::simd_abi::scalar>(
+      Kokkos::max(a[0], b[0]));
+}
+
+template <class T>
 class const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
                              basic_simd<T, simd_abi::scalar>> {
  public:

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -451,11 +451,10 @@ template <class T, class BinaryOperation>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
     BinaryOperation binary_op) noexcept {
-  return reduce(
-      x,
-      Experimental::basic_simd<T, Experimental::simd_abi::scalar>::mask_type(
-          true),
-      Impl::Identity<T, BinaryOperation>(), binary_op);
+  return reduce(x,
+                typename Experimental::basic_simd<
+                    T, Experimental::simd_abi::scalar>::mask_type(true),
+                T(Impl::Identity<T, BinaryOperation>()), binary_op);
 }
 
 template <class T>

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -339,7 +339,21 @@ class minimum {
  public:
   template <typename T>
   auto on_host(T const& a, T const& b) const {
-    return Kokkos::min(a, b);
+    if constexpr (std::is_integral_v<T> || std::is_floating_point_v<T>) {
+      return Kokkos::min(a, b);
+    } else {
+#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
+#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
+      KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
+#endif
+      return Kokkos::Experimental::min(a, b);
+#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
+      KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+#endif
+#else
+      return Kokkos::min(a, b);
+#endif
+    }
   }
   template <typename T>
   KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
@@ -351,7 +365,21 @@ class maximum {
  public:
   template <typename T>
   auto on_host(T const& a, T const& b) const {
-    return Kokkos::max(a, b);
+    if constexpr (std::is_integral_v<T> || std::is_floating_point_v<T>) {
+      return Kokkos::max(a, b);
+    } else {
+#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
+#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
+      KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
+#endif
+      return Kokkos::Experimental::max(a, b);
+#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
+      KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+#endif
+#else
+      return Kokkos::max(a, b);
+#endif
+    }
   }
   template <typename T>
   KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -339,10 +339,10 @@ class minimum {
  public:
   template <typename T>
   auto on_host(T const& a, T const& b) const {
-    if constexpr (std::is_integral_v<T> || std::is_floating_point_v<T>) {
+#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
+    if constexpr (std::is_arithmetic_v<T>) {
       return Kokkos::min(a, b);
     } else {
-#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
 #ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
       KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
 #endif
@@ -350,10 +350,10 @@ class minimum {
 #ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
       KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 #endif
-#else
-      return Kokkos::min(a, b);
-#endif
     }
+#else
+    return Kokkos::min(a, b);
+#endif
   }
   template <typename T>
   KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
@@ -365,10 +365,10 @@ class maximum {
  public:
   template <typename T>
   auto on_host(T const& a, T const& b) const {
-    if constexpr (std::is_integral_v<T> || std::is_floating_point_v<T>) {
+#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
+    if constexpr (std::is_arithmetic_v<T>) {
       return Kokkos::max(a, b);
     } else {
-#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
 #ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
       KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
 #endif
@@ -376,10 +376,10 @@ class maximum {
 #ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
       KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 #endif
-#else
-      return Kokkos::max(a, b);
-#endif
     }
+#else
+    return Kokkos::max(a, b);
+#endif
   }
   template <typename T>
   KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -335,7 +335,131 @@ class log_op {
   }
 };
 
+class minimum {
+ public:
+  template <typename T>
+  auto on_host(T const& a, T const& b) const {
+    return Kokkos::min(a, b);
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
+    return Kokkos::min(a, b);
+  }
+};
+
+class maximum {
+ public:
+  template <typename T>
+  auto on_host(T const& a, T const& b) const {
+    return Kokkos::max(a, b);
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
+    return Kokkos::max(a, b);
+  }
+};
+
 class reduce_min {
+ public:
+  template <typename T, typename U, typename MaskType>
+  auto on_host(T const& a, U, MaskType) const {
+    return Kokkos::Experimental::reduce_min(a);
+  }
+  template <typename T, typename U, typename MaskType>
+  auto on_host_serial(T const& a, U, MaskType) const {
+    auto result = Kokkos::reduction_identity<U>::min();
+    for (std::size_t i = 0; i < a.size(); ++i) {
+      result = Kokkos::min(result, a[i]);
+    }
+    return result;
+  }
+
+  template <typename T, typename U, typename MaskType>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, U, MaskType) const {
+    return Kokkos::Experimental::reduce_min(a);
+  }
+  template <typename T, typename U, typename MaskType>
+  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a, U, MaskType) const {
+    auto result = Kokkos::reduction_identity<U>::min();
+    for (std::size_t i = 0; i < a.size(); ++i) {
+      result = Kokkos::min(result, a[i]);
+    }
+    return result;
+  }
+};
+
+class reduce_max {
+ public:
+  template <typename T, typename U, typename MaskType>
+  auto on_host(T const& a, U, MaskType) const {
+    return Kokkos::Experimental::reduce_max(a);
+  }
+  template <typename T, typename U, typename MaskType>
+  auto on_host_serial(T const& a, U, MaskType) const {
+    auto result = Kokkos::reduction_identity<U>::max();
+    for (std::size_t i = 0; i < a.size(); ++i) {
+      result = Kokkos::max(result, a[i]);
+    }
+    return result;
+  }
+
+  template <typename T, typename U, typename MaskType>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, U, MaskType) const {
+    return Kokkos::Experimental::reduce_max(a);
+  }
+  template <typename T, typename U, typename MaskType>
+  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a, U, MaskType) const {
+    auto result = Kokkos::reduction_identity<U>::max();
+    for (std::size_t i = 0; i < a.size(); ++i) {
+      result = Kokkos::max(result, a[i]);
+    }
+    return result;
+  }
+};
+
+template <typename BinaryOperation = std::plus<>>
+class reduce {
+ public:
+  template <typename T, typename U, typename MaskType>
+  auto on_host(T const& a, U, MaskType) const {
+    return Kokkos::Experimental::reduce(a, BinaryOperation());
+  }
+  template <typename T, typename U, typename MaskType>
+  auto on_host_serial(T const& a, U, MaskType) const {
+    U result = Kokkos::Experimental::Impl::Identity<U, BinaryOperation>();
+    for (std::size_t i = 0; i < a.size(); ++i) {
+      result = BinaryOperation()(result, a[i]);
+    }
+    return result;
+  }
+
+  template <typename T, typename U, typename MaskType>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, U, MaskType) const {
+    return Kokkos::Experimental::reduce(a, BinaryOperation());
+  }
+  template <typename T, typename U, typename MaskType>
+  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a, U, MaskType) const {
+    U result = Kokkos::Experimental::Impl::Identity<U, BinaryOperation>();
+    for (std::size_t i = 0; i < a.size(); ++i) {
+      if constexpr (std::is_same_v<BinaryOperation, std::plus<>>) {
+        result = result + a[i];
+      } else if constexpr (std::is_same_v<BinaryOperation, std::multiplies<>>) {
+        result = result * a[i];
+      } else if constexpr (std::is_same_v<BinaryOperation, std::bit_and<>>) {
+        result = result & a[i];
+      } else if constexpr (std::is_same_v<BinaryOperation, std::bit_or<>>) {
+        result = result | a[i];
+      } else if constexpr (std::is_same_v<BinaryOperation, std::bit_xor<>>) {
+        result = result ^ a[i];
+      } else {
+        Kokkos::abort("Unsupported reduce operation");
+      }
+    }
+    return result;
+  }
+};
+
+class masked_reduce_min {
  public:
   template <typename T, typename U, typename MaskType>
   auto on_host(T const& a, U, MaskType mask) const {
@@ -375,7 +499,7 @@ class reduce_min {
   }
 };
 
-class reduce_max {
+class masked_reduce_max {
  public:
   template <typename T, typename U, typename MaskType>
   auto on_host(T const& a, U, MaskType mask) const {
@@ -416,7 +540,7 @@ class reduce_max {
 };
 
 template <typename BinaryOperation = std::plus<>>
-class reduce {
+class masked_reduce {
  public:
   template <typename T, typename U, typename MaskType>
   auto on_host(T const& a, U const& identity, MaskType mask) const {

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -115,6 +115,9 @@ inline void host_check_all_math_ops(const DataType (&first_args)[n],
   host_check_math_op_all_loaders<Abi>(rounds(), n, first_args);
   host_check_math_op_all_loaders<Abi>(truncates(), n, first_args);
 
+  host_check_math_op_all_loaders<Abi>(minimum(), n, first_args, second_args);
+  host_check_math_op_all_loaders<Abi>(maximum(), n, first_args, second_args);
+
   // TODO: Place fallback implementations for all simd integer types
   if constexpr (std::is_floating_point_v<DataType>) {
 #if defined(__INTEL_COMPILER) && \
@@ -265,6 +268,9 @@ KOKKOS_INLINE_FUNCTION void device_check_all_math_ops(
   device_check_math_op_all_loaders<Abi>(ceils(), n, first_args);
   device_check_math_op_all_loaders<Abi>(rounds(), n, first_args);
   device_check_math_op_all_loaders<Abi>(truncates(), n, first_args);
+
+  device_check_math_op_all_loaders<Abi>(minimum(), n, first_args, second_args);
+  device_check_math_op_all_loaders<Abi>(maximum(), n, first_args, second_args);
 }
 
 template <typename Abi, typename DataType>

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -80,6 +80,12 @@ inline void host_check_all_reductions(const DataType (&args)[n]) {
   host_check_reduction_all_loaders<Abi>(reduce_max(), n, args);
   host_check_reduction_all_loaders<Abi>(reduce<std::plus<>>(), n, args);
   host_check_reduction_all_loaders<Abi>(reduce<std::multiplies<>>(), n, args);
+
+  host_check_reduction_all_loaders<Abi>(masked_reduce_min(), n, args);
+  host_check_reduction_all_loaders<Abi>(masked_reduce_max(), n, args);
+  host_check_reduction_all_loaders<Abi>(masked_reduce<std::plus<>>(), n, args);
+  host_check_reduction_all_loaders<Abi>(masked_reduce<std::multiplies<>>(), n,
+                                        args);
 }
 
 template <typename Abi, typename DataType>
@@ -159,6 +165,13 @@ KOKKOS_INLINE_FUNCTION void device_check_all_reductions(
   device_check_reduction_all_loaders<Abi>(reduce_max(), n, args);
   device_check_reduction_all_loaders<Abi>(reduce<std::plus<>>(), n, args);
   device_check_reduction_all_loaders<Abi>(reduce<std::multiplies<>>(), n, args);
+
+  device_check_reduction_all_loaders<Abi>(masked_reduce_min(), n, args);
+  device_check_reduction_all_loaders<Abi>(masked_reduce_max(), n, args);
+  device_check_reduction_all_loaders<Abi>(masked_reduce<std::plus<>>(), n,
+                                          args);
+  device_check_reduction_all_loaders<Abi>(masked_reduce<std::multiplies<>>(), n,
+                                          args);
 }
 
 template <typename Abi, typename DataType>


### PR DESCRIPTION
When instantiated, the non-masked versions of `reduce`, `reduce_min` and `reduce_max` would not compile due to a type deduction failure and a missing `typename` to get the mask type, this PR fixes this.

I added tests for these 3 functions, as well as tests for the min and max functions (see #7813)

There was also an error coming from the default implementations of the `min` and `max` functions in Kokkos_SIMD_Common_Math.hpp, they were marked `KOKKOS_FORCEINLINE_FUNCTION` which made them `__host__ __device__`, but with any simd abi other than scalar this would lead to using a vector type in device code, which is not supported by cuda.

I did the same thing as what was already done for the default implementations of the `reduce`, `reduce_min` and `reduce_max` functions, that is making the default implementation `KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION`, disabling it for the scalar abi and adding an implementation for the scalar abi in Kokkos_SIMD_Scalar.hpp

Additionally, I modified SIMDTesting_Ops.hpp to call `Kokkos::Experimental::min/max` instead of `Kokkos::min/max` for simd types when `KOKKOS_ENABLE_DEPRECATED_CODE_4` is `ON`