### PR TITLE
Build benchmarks in nightly CEA builds

### DIFF
--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -1,8 +1,9 @@
-name: Nightly CEA builds
+name: Experimental CEA builds
 
 on:
   schedule:
     - cron: "0 2 * * 1-5" # every weekday at 2am UTC
+  pull_request: # XXX remove before merging!
 
 permissions: read-all
 
@@ -87,9 +88,9 @@ jobs:
             ctest \
               -V \
               --test-dir build \
-              -D NightlyStart \
-              -D NightlyUpdate \
-              -D NightlyConfigure
+              -D ExperimentalStart \
+              -D ExperimentalUpdate \
+              -D ExperimentalConfigure
 
       - name: Build
         id: build
@@ -102,7 +103,7 @@ jobs:
             ctest \
               -V \
               --test-dir build \
-              -D NightlyBuild
+              -D ExperimentalBuild
 
       - name: Test
         id: test
@@ -114,7 +115,7 @@ jobs:
             ctest \
               --output-on-failure \
               --test-dir build \
-              -D NightlyTest
+              -D ExperimentalTest
 
       - name: Submit
         run: |
@@ -123,7 +124,7 @@ jobs:
             -e local \
             ctest \
               --test-dir build \
-              -D NightlySubmit
+              -D ExperimentalSubmit
 
       # note: this marks the job as failed if any of the mentionned steps (that
       # have `continue-on-error`) has failed

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -1,9 +1,8 @@
-name: Experimental CEA builds
+name: Nightly CEA builds
 
 on:
   schedule:
     - cron: "0 2 * * 1-5" # every weekday at 2am UTC
-  pull_request: # XXX remove before merging!
 
 permissions: read-all
 
@@ -88,9 +87,9 @@ jobs:
             ctest \
               -V \
               --test-dir build \
-              -D ExperimentalStart \
-              -D ExperimentalUpdate \
-              -D ExperimentalConfigure
+              -D NightlyStart \
+              -D NightlyUpdate \
+              -D NightlyConfigure
 
       - name: Build
         id: build
@@ -103,7 +102,7 @@ jobs:
             ctest \
               -V \
               --test-dir build \
-              -D ExperimentalBuild
+              -D NightlyBuild
 
       - name: Test
         id: test
@@ -115,7 +114,7 @@ jobs:
             ctest \
               --output-on-failure \
               --test-dir build \
-              -D ExperimentalTest
+              -D NightlyTest
 
       - name: Submit
         run: |
@@ -124,7 +123,7 @@ jobs:
             -e local \
             ctest \
               --test-dir build \
-              -D ExperimentalSubmit
+              -D NightlySubmit
 
       # note: this marks the job as failed if any of the mentionned steps (that
       # have `continue-on-error`) has failed

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -74,6 +74,7 @@ jobs:
               -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
               -DKokkos_ENABLE_TESTS=ON \
               -DKokkos_ENABLE_EXAMPLES=ON \
+              -DKokkos_ENABLE_BENCHMARKS=ON \
               ${{ matrix.backend.configure }}
 
       - name: Start, update and configure


### PR DESCRIPTION
This PR enables the benchmarks for the nightly CEA builds.

Outcomes:

- OpenMP-x86_64-GCC/10.3-Shared-C++17-Release
  - [Action](https://github.com/kokkos/kokkos/actions/runs/13769415061/job/38503997462?pr=7859)
  - [Dashboard](https://my.cdash.org/builds/2849593)
- Cuda-A100-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE-C++17-Release
  - [Action](https://github.com/kokkos/kokkos/actions/runs/13769415061/job/38503997962?pr=7859)
  - [Dashboard](https://my.cdash.org/builds/2849527)
- Cuda-A100-UVM-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE-C++17-Release 
  - [Action](https://github.com/kokkos/kokkos/actions/runs/13769415061/job/38503998444?pr=7859)
  - [Dashboard](https://my.cdash.org/builds/2849513)
- Cuda-V100-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE-C++17-Release
  - [Action](https://github.com/kokkos/kokkos/actions/runs/13769415061/job/38503998893?pr=7859)
  - [Dashboard](https://my.cdash.org/builds/2849544)
- Cuda-V100-UVM-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE-C++17-Release
  - [Action](https://github.com/kokkos/kokkos/actions/runs/13769415061/job/38503999385?pr=7859)
  - [Dashboard](https://my.cdash.org/builds/2849570)
- Cuda-A100-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE-C++20-Release
  - [Action](https://github.com/kokkos/kokkos/actions/runs/13769415061/job/38503999898?pr=7859)
  - [Dashboard](https://my.cdash.org/builds/2849585)
- Cuda-A100-UVM-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE-C++20-Release
  - [Action](https://github.com/kokkos/kokkos/actions/runs/13769415061/job/38504000317?pr=7859)
  - [Dashboard](https://my.cdash.org/builds/2849617)
- Cuda-V100-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE-C++20-Release
  - [Action](https://github.com/kokkos/kokkos/actions/runs/13769415061/job/38504000969?pr=7859)
  - [Dashboard](https://my.cdash.org/builds/2849657)
- Cuda-V100-UVM-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE-C++20-Release
  - [Actions](https://github.com/kokkos/kokkos/actions/runs/13769415061/job/38504001429?pr=7859)
  - [Dashboard](https://my.cdash.org/builds/2849722)

Progress:

- [x] Change configuration;
- [x] Revert commit that allows the CI to run on pull requests.