### PR TITLE
Avoid pushing to the benchmark repository concurrently and archive results

### DIFF
--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -11,6 +11,8 @@ jobs:
   CI:
     continue-on-error: true
     strategy:
+      # We must avoid pushing to the benchmark repository concurrently.
+      max-parallel: 1
       matrix:
         distro: ['ubuntu:latest']
         cxx: ['g++', 'clang++']
@@ -50,6 +52,11 @@ jobs:
         run: |
           mkdir ${{ env.BUILD_ID }}
           find builddir/core/perf_test/ -name "*.json" -exec mv {} ${{ env.BUILD_ID }}/  \;
+      - name: Archive benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BUILD_ID }}
+          path: ${{ env.BUILD_ID }}
       - name: Push benchmark results
         if: ${{ github.ref == 'refs/heads/develop' }}
         uses: dmnemec/copy_file_to_another_repo_action@bbebd3da22e4a37d04dca5f782edd5201cb97083 # main

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Archive benchmark results
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.BUILD_ID }}
+          name: ${{ matrix.cxx }}-${{ matrix.backend }}
           path: ${{ env.BUILD_ID }}
       - name: Push benchmark results
         if: ${{ github.ref == 'refs/heads/develop' }}


### PR DESCRIPTION
Occasionally, the GitHub CI when pushing to `develop` shows as failing beacuse pushing to the benchmark repository fails, see, e.g., https://github.com/kokkos/kokkos/actions/runs/13770228644/job/38506741244.
This pull request make sure that the matrix builds don't run concurrently. Since they are only running for like 5 minutes it seems OK not to try a more difficult solution where we would run the benchmarks concurrently but then serialize pushing.

Also, we are running the benchmarks for pull request but never do anything with the results. Thios pull request proposes exporting them as artifacts.