### PR TITLE
Skip generation if grace support not detected

### DIFF
--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -362,9 +362,9 @@ if(KOKKOS_ARCH_ARMV9_GRACE)
       -msve-vector-bits=128
     )
   else()
-    message(
-      SEND_ERROR
-        "Unable to verify that the compiler has support for the ARMv9 Grace architecture failed. You may want to try -DKokkos_ARCH_NATIVE=ON instead"
+    message(SEND_ERROR "Your compiler does not appear to support the ARMv9 Grace architecture.
+Please ensure you are using a compatible compiler and toolchain.
+Alternatively, try configuring with -DKokkos_ARCH_NATIVE=ON to use the native architecture of your system."
     )
   endif()
 endif()

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -364,7 +364,7 @@ if(KOKKOS_ARCH_ARMV9_GRACE)
   else()
     message(
       SEND_ERROR
-        "Compiler does not support ARMv9 Grace architecture. You may want to try -DKokkos_ARCH_NATIVE=ON instead"
+        "Unable to verify that the compiler has support for the ARMv9 Grace architecture failed. You may want to try -DKokkos_ARCH_NATIVE=ON instead"
     )
   endif()
 endif()

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -362,7 +362,10 @@ if(KOKKOS_ARCH_ARMV9_GRACE)
       -msve-vector-bits=128
     )
   else()
-    message(SEND_ERROR "Compiler does not support ARMv9 Grace architecture")
+    message(
+      SEND_ERROR
+        "Compiler does not support ARMv9 Grace architecture. You may want to try -DKokkos_ARCH_NATIVE=ON instead"
+    )
   endif()
 endif()
 

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -362,7 +362,7 @@ if(KOKKOS_ARCH_ARMV9_GRACE)
       -msve-vector-bits=128
     )
   else()
-    message(WARNING "Compiler does not support ARMv9 Grace architecture")
+    message(SEND_ERROR "Compiler does not support ARMv9 Grace architecture")
   endif()
 endif()
 


### PR DESCRIPTION
Following up on https://github.com/kokkos/kokkos/pull/7858#discussion_r1987492945

Instead of just warning and pretending that Arm Neon support is enabled without us actually passing any flag to the compiler, skip generation.