### PR TITLE
Add ROCm 5.6.1 build @ SNL

### DIFF
--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -53,3 +53,39 @@ jobs:
         working-directory: kokkos/build
         run: ctest --output-on-failure --timeout 3600
 
+  HIP_5_6_1:
+    name: SNL_HIP_ROCM_5_6_1
+    runs-on: [snl-kk-env-openblas-0.3.23-hip-5.6.1-latest]
+
+    steps:
+      - name: checkout_kokkos
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: kokkos/kokkos
+          path: kokkos
+
+      - name: configure_kokkos
+        run: |
+          rocm-smi
+          cd kokkos
+          cmake -S . -B build \
+            -DCMAKE_CXX_STANDARD=20 \
+            -DKokkos_ENABLE_HIP=ON \
+            -DKokkos_ARCH_AMD_GFX90A=ON \
+            -DKokkos_ARCH_NATIVE=ON \
+            -DCMAKE_CXX_EXTENSIONS=OFF \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF \
+            -DKokkos_ENABLE_TESTS=ON \
+            -DKokkos_ENABLE_EXAMPLES=ON \
+            -DKokkos_ENABLE_BENCHMARKS=ON
+
+      - name: build_and_install_kokkos
+        working-directory: kokkos
+        run: |
+          cmake --build build $(nproc)
+          cmake --install build --prefix install
+
+      - name: test_kokkos
+        working-directory: kokkos/build
+        run: ctest --output-on-failure --timeout 3600

--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -66,7 +66,6 @@ jobs:
 
       - name: configure_kokkos
         run: |
-          rocm-smi
           cd kokkos
           cmake -S . -B build \
             -DCMAKE_CXX_STANDARD=20 \

--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -68,7 +68,6 @@ jobs:
         run: |
           cd kokkos
           cmake -S . -B build \
-            -DCMAKE_CXX_STANDARD=20 \
             -DKokkos_ENABLE_HIP=ON \
             -DKokkos_ARCH_AMD_GFX90A=ON \
             -DKokkos_ARCH_NATIVE=ON \

--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: build_and_install_kokkos
         working-directory: kokkos
         run: |
-          cmake --build build $(nproc)
+          cmake --build build --parallel $(nproc)
           cmake --install build --prefix install
 
       - name: test_kokkos

--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -68,6 +68,7 @@ jobs:
         run: |
           cd kokkos
           cmake -S . -B build \
+            -DCMAKE_CXX_COMPILER=hipcc \
             -DKokkos_ENABLE_HIP=ON \
             -DKokkos_ARCH_AMD_GFX90A=ON \
             -DKokkos_ARCH_NATIVE=ON \


### PR DESCRIPTION
The corresponding runner is up internally at Sandia already

* ROCM 5.6.1
* C++20
* No deprecated code