### PR TITLE
Improve code documentation for `MDRangePolicy` packing and unpacking for GPUs

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -101,7 +101,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
     [[maybe_unused]] const auto maxblocks_api =
         m_rp.space().cuda_device_prop().maxGridSize;
 
-    // maximum numebr of blocks in each dimension of the grid hard-coded for
+    // maximum number of blocks in each dimension of the grid hard-coded for
     // unpacking on device
     const int maxblocks[3] = {mdrange_max_blocks_x, mdrange_max_blocks,
                               mdrange_max_blocks};

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -114,7 +114,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
         m_rp.space().cuda_device_prop().maxThreadsPerBlock;
     // make sure the Z dimension (it is less than x,y limits) isn't exceeded
     const auto clampZ = [&](const int input) {
-      return (input > maxthreads[2] ? maxthreads[2] : input);
+      return std::min(input, maxthreads[2]);
     };
     // make sure the block dimensions don't exceed the max number of threads
     // allowed

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -57,9 +57,14 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
   inline void execute() const {
     using ClosureType = ParallelFor<FunctorType, Policy, HIP>;
     if (m_policy.m_num_tiles == 0) return;
+
+    // maximum number of blocks per grid as fetched by the API
     auto const maxblocks = m_policy.space().hip_device_prop().maxGridSize;
+
     if (Policy::rank == 2) {
+      // id0 to threadIdx.x; id1 to threadIdx.y
       dim3 const block(m_policy.m_tile[0], m_policy.m_tile[1], 1);
+
       dim3 const grid(
           std::min<array_index_type>(
               (m_policy.m_upper[0] - m_policy.m_lower[0] + block.x - 1) /
@@ -70,12 +75,15 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
                   block.y,
               maxblocks[1]),
           1);
+
       hip_parallel_launch<ClosureType, LaunchBounds>(
           *this, grid, block, 0,
           m_policy.space().impl_internal_space_instance(), false);
     } else if (Policy::rank == 3) {
+      // id0 to threadIdx.x; id1 to threadIdx.y; id2 to threadIdx.z
       dim3 const block(m_policy.m_tile[0], m_policy.m_tile[1],
                        m_policy.m_tile[2]);
+
       dim3 const grid(
           std::min<array_index_type>(
               (m_policy.m_upper[0] - m_policy.m_lower[0] + block.x - 1) /
@@ -89,6 +97,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
               (m_policy.m_upper[2] - m_policy.m_lower[2] + block.z - 1) /
                   block.z,
               maxblocks[2]));
+
       hip_parallel_launch<ClosureType, LaunchBounds>(
           *this, grid, block, 0,
           m_policy.space().impl_internal_space_instance(), false);
@@ -97,6 +106,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
       // threadIdx.z
       dim3 const block(m_policy.m_tile[0] * m_policy.m_tile[1],
                        m_policy.m_tile[2], m_policy.m_tile[3]);
+
       dim3 const grid(
           std::min<array_index_type>(
               m_policy.m_tile_end[0] * m_policy.m_tile_end[1], maxblocks[0]),
@@ -108,6 +118,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
               (m_policy.m_upper[3] - m_policy.m_lower[3] + block.z - 1) /
                   block.z,
               maxblocks[2]));
+
       hip_parallel_launch<ClosureType, LaunchBounds>(
           *this, grid, block, 0,
           m_policy.space().impl_internal_space_instance(), false);
@@ -117,6 +128,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
       dim3 const block(m_policy.m_tile[0] * m_policy.m_tile[1],
                        m_policy.m_tile[2] * m_policy.m_tile[3],
                        m_policy.m_tile[4]);
+
       dim3 const grid(
           std::min<array_index_type>(
               m_policy.m_tile_end[0] * m_policy.m_tile_end[1], maxblocks[0]),
@@ -126,6 +138,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
               (m_policy.m_upper[4] - m_policy.m_lower[4] + block.z - 1) /
                   block.z,
               maxblocks[2]));
+
       hip_parallel_launch<ClosureType, LaunchBounds>(
           *this, grid, block, 0,
           m_policy.space().impl_internal_space_instance(), false);
@@ -135,6 +148,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
       dim3 const block(m_policy.m_tile[0] * m_policy.m_tile[1],
                        m_policy.m_tile[2] * m_policy.m_tile[3],
                        m_policy.m_tile[4] * m_policy.m_tile[5]);
+
       dim3 const grid(
           std::min<array_index_type>(
               m_policy.m_tile_end[0] * m_policy.m_tile_end[1], maxblocks[0]),
@@ -142,6 +156,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
               m_policy.m_tile_end[2] * m_policy.m_tile_end[3], maxblocks[1]),
           std::min<array_index_type>(
               m_policy.m_tile_end[4] * m_policy.m_tile_end[5], maxblocks[2]));
+
       hip_parallel_launch<ClosureType, LaunchBounds>(
           *this, grid, block, 0,
           m_policy.space().impl_internal_space_instance(), false);

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -58,7 +58,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
     using ClosureType = ParallelFor<FunctorType, Policy, HIP>;
     if (m_policy.m_num_tiles == 0) return;
 
-    // maximum number of blocks per grid as fetched by the API
+    // maximum number of blocks in each dimension of the grid as fetched by the
+    // API
     auto const maxblocks = m_policy.space().hip_device_prop().maxGridSize;
 
     if (Policy::rank == 2) {

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -61,25 +61,33 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     const auto& m_tile_end = m_policy.m_tile_end;
 
     if constexpr (Policy::rank == 2) {
+      // id0 to threadIdx.x; id1 to threadIdx.y
       sycl::range<3> local_sizes(m_tile[0], m_tile[1], 1);
+
       sycl::range<3> global_sizes(m_tile_end[0] * m_tile[0],
                                   m_tile_end[1] * m_tile[1], 1);
+
       return {global_sizes, local_sizes};
     }
     if constexpr (Policy::rank == 3) {
+      // id0 to threadIdx.x; id1 to threadIdx.y; id2 to threadIdx.z
       sycl::range<3> local_sizes(m_tile[0], m_tile[1], m_tile[2]);
+
       sycl::range<3> global_sizes(m_tile_end[0] * m_tile[0],
                                   m_tile_end[1] * m_tile[1],
                                   m_tile_end[2] * m_tile[2]);
+
       return {global_sizes, local_sizes};
     }
     if constexpr (Policy::rank == 4) {
       // id0,id1 encoded within first index; id2 to second index; id3 to third
       // index
       sycl::range<3> local_sizes(m_tile[0] * m_tile[1], m_tile[2], m_tile[3]);
+
       sycl::range<3> global_sizes(
           m_tile_end[0] * m_tile[0] * m_tile_end[1] * m_tile[1],
           m_tile_end[2] * m_tile[2], m_tile_end[3] * m_tile[3]);
+
       return {global_sizes, local_sizes};
     }
     if constexpr (Policy::rank == 5) {
@@ -87,10 +95,12 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
       // third index
       sycl::range<3> local_sizes(m_tile[0] * m_tile[1], m_tile[2] * m_tile[3],
                                  m_tile[4]);
+
       sycl::range<3> global_sizes(
           m_tile_end[0] * m_tile[0] * m_tile_end[1] * m_tile[1],
           m_tile_end[2] * m_tile[2] * m_tile_end[3] * m_tile[3],
           m_tile_end[4] * m_tile[4]);
+
       return {global_sizes, local_sizes};
     }
     if constexpr (Policy::rank == 6) {
@@ -98,10 +108,12 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
       // third index
       sycl::range<3> local_sizes(m_tile[0] * m_tile[1], m_tile[2] * m_tile[3],
                                  m_tile[4] * m_tile[5]);
+
       sycl::range<3> global_sizes(
           m_tile_end[0] * m_tile[0] * m_tile_end[1] * m_tile[1],
           m_tile_end[2] * m_tile[2] * m_tile_end[3] * m_tile[3],
           m_tile_end[4] * m_tile[4] * m_tile_end[5] * m_tile[5]);
+
       return {global_sizes, local_sizes};
     }
     static_assert(Policy::rank > 1 && Policy::rank < 7,

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -107,23 +107,29 @@ struct DeviceIterateTile<2, PolicyType, Functor, Tag> {
   void exec_range() const {
     // LL
     if (PolicyType::inner_direction == Iterate::Left) {
-      // Loop over size maxnumblocks until full range covered
+      // iterate over y blocks
       for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
            tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
+        // compute index for dimension 1
         const index_type offset_1 =
             tile_id1 * m_policy.m_tile[1] +
             static_cast<index_type>(threadIdx.y) +
             static_cast<index_type>(m_policy.m_lower[1]);
+        // check index for dimension 1 is within range
         if (offset_1 < m_policy.m_upper[1] &&
             static_cast<index_type>(threadIdx.y) < m_policy.m_tile[1]) {
+          // iterate over x blocks
           for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
                tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
+            // compute index for dimension 0
             const index_type offset_0 =
                 tile_id0 * m_policy.m_tile[0] +
                 static_cast<index_type>(threadIdx.x) +
                 static_cast<index_type>(m_policy.m_lower[0]);
+            // check index for dimension 0 is within range
             if (offset_0 < m_policy.m_upper[0] &&
                 static_cast<index_type>(threadIdx.x) < m_policy.m_tile[0]) {
+              // call kernel with computed indices
               Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1);
             }
           }
@@ -132,22 +138,29 @@ struct DeviceIterateTile<2, PolicyType, Functor, Tag> {
     }
     // LR
     else {
+      // iterate over x blocks
       for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
            tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
+        // compute index for dimension 0
         const index_type offset_0 =
             tile_id0 * m_policy.m_tile[0] +
             static_cast<index_type>(threadIdx.x) +
             static_cast<index_type>(m_policy.m_lower[0]);
+        // check index for dimension 0 is within range
         if (offset_0 < m_policy.m_upper[0] &&
             static_cast<index_type>(threadIdx.x) < m_policy.m_tile[0]) {
+          // iterate over y blocks
           for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
                tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
+            // compute index for dimension 1
             const index_type offset_1 =
                 tile_id1 * m_policy.m_tile[1] +
                 static_cast<index_type>(threadIdx.y) +
                 static_cast<index_type>(m_policy.m_lower[1]);
+            // check index for dimension 1 is within range
             if (offset_1 < m_policy.m_upper[1] &&
                 static_cast<index_type>(threadIdx.y) < m_policy.m_tile[1]) {
+              // call kernel with computed indices
               Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1);
             }
           }
@@ -192,30 +205,40 @@ struct DeviceIterateTile<3, PolicyType, Functor, Tag> {
   void exec_range() const {
     // LL
     if (PolicyType::inner_direction == Iterate::Left) {
+      // iterate over z blocks
       for (index_type tile_id2 = static_cast<index_type>(blockIdx.z);
            tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.z) {
+        // compute index for dimension 2
         const index_type offset_2 =
             tile_id2 * m_policy.m_tile[2] +
             static_cast<index_type>(threadIdx.z) +
             static_cast<index_type>(m_policy.m_lower[2]);
+        // check index for dimension 2 is within range
         if (offset_2 < m_policy.m_upper[2] &&
             static_cast<index_type>(threadIdx.z) < m_policy.m_tile[2]) {
+          // iterate over y blocks
           for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
                tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
+            // compute index for dimension 1
             const index_type offset_1 =
                 tile_id1 * m_policy.m_tile[1] +
                 static_cast<index_type>(threadIdx.y) +
                 static_cast<index_type>(m_policy.m_lower[1]);
+            // check index for dimension 1 is within range
             if (offset_1 < m_policy.m_upper[1] &&
                 static_cast<index_type>(threadIdx.y) < m_policy.m_tile[1]) {
+              // iterate over x blocks
               for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
                    tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
+                // compute index for dimension 0
                 const index_type offset_0 =
                     tile_id0 * m_policy.m_tile[0] +
                     static_cast<index_type>(threadIdx.x) +
                     static_cast<index_type>(m_policy.m_lower[0]);
+                // check index for dimension 0 is within range
                 if (offset_0 < m_policy.m_upper[0] &&
                     static_cast<index_type>(threadIdx.x) < m_policy.m_tile[0]) {
+                  // call kernel with computed indices
                   Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1, offset_2);
                 }
               }
@@ -226,30 +249,40 @@ struct DeviceIterateTile<3, PolicyType, Functor, Tag> {
     }
     // LR
     else {
+      // iterate over x blocks
       for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
            tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
+        // compute index for dimension 0
         const index_type offset_0 =
             tile_id0 * m_policy.m_tile[0] +
             static_cast<index_type>(threadIdx.x) +
             static_cast<index_type>(m_policy.m_lower[0]);
+        // check index for dimension 0 is within range
         if (offset_0 < m_policy.m_upper[0] &&
             static_cast<index_type>(threadIdx.x) < m_policy.m_tile[0]) {
+          // iterate over y blocks
           for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
                tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
+            // compute index for dimension 1
             const index_type offset_1 =
                 tile_id1 * m_policy.m_tile[1] +
                 static_cast<index_type>(threadIdx.y) +
                 static_cast<index_type>(m_policy.m_lower[1]);
+            // check index for dimension 1 is within range
             if (offset_1 < m_policy.m_upper[1] &&
                 static_cast<index_type>(threadIdx.y) < m_policy.m_tile[1]) {
+              // iterate over z blocks
               for (index_type tile_id2 = static_cast<index_type>(blockIdx.z);
                    tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.z) {
+                // compute index for dimension 2
                 const index_type offset_2 =
                     tile_id2 * m_policy.m_tile[2] +
                     static_cast<index_type>(threadIdx.z) +
                     static_cast<index_type>(m_policy.m_lower[2]);
+                // check index for dimension 2 is within range
                 if (offset_2 < m_policy.m_upper[2] &&
                     static_cast<index_type>(threadIdx.z) < m_policy.m_tile[2]) {
+                  // call kernel with computed indices
                   Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1, offset_2);
                 }
               }
@@ -296,53 +329,76 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
   void exec_range() const {
     // LL
     if (PolicyType::inner_direction == Iterate::Left) {
+      // number of tiles for dimension 0
       const index_type temp0 = m_policy.m_tile_end[0];
+      // number of tiles for dimension 1
       const index_type temp1 = m_policy.m_tile_end[1];
+
+      // number of virtual blocks for dimension 0
       const index_type numbl0 =
           (temp0 <= mdrange_max_blocks_x ? temp0 : mdrange_max_blocks_x);
+      // number of virtual blocks for dimension 1
       const index_type numbl1 =
           (temp0 * temp1 > mdrange_max_blocks_x
                ? static_cast<index_type>(mdrange_max_blocks_x / numbl0)
                : (temp1 <= mdrange_max_blocks_x ? temp1
                                                 : mdrange_max_blocks_x));
 
+      // first virtual block index for dimension 0
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
+      // first virtual block index for dimension 1
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
+
+      // virtual thread index for dimension 0
       const index_type thr_id0 =
           static_cast<index_type>(threadIdx.x) % m_policy.m_tile[0];
+      // virtual thread index for dimension 1
       const index_type thr_id1 =
           static_cast<index_type>(threadIdx.x) / m_policy.m_tile[0];
 
+      // iterate over z blocks
       for (index_type tile_id3 = static_cast<index_type>(blockIdx.z);
            tile_id3 < m_policy.m_tile_end[3]; tile_id3 += gridDim.z) {
+        // compute index for dimension 3
         const index_type offset_3 =
             tile_id3 * m_policy.m_tile[3] +
             static_cast<index_type>(threadIdx.z) +
             static_cast<index_type>(m_policy.m_lower[3]);
+        // check index for dimension 3 is within range
         if (offset_3 < m_policy.m_upper[3] &&
             static_cast<index_type>(threadIdx.z) < m_policy.m_tile[3]) {
+          // iterate over y blocks
           for (index_type tile_id2 = static_cast<index_type>(blockIdx.y);
                tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.y) {
+            // compute index for dimension 2
             const index_type offset_2 =
                 tile_id2 * m_policy.m_tile[2] +
                 static_cast<index_type>(threadIdx.y) +
                 static_cast<index_type>(m_policy.m_lower[2]);
+            // check index for dimension 2 is within range
             if (offset_2 < m_policy.m_upper[2] &&
                 static_cast<index_type>(threadIdx.y) < m_policy.m_tile[2]) {
+              // iterate over virtual blocks for dimension 1
               for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
                    j += numbl1) {
+                // compute index for dimension 1
                 const index_type offset_1 =
                     j * m_policy.m_tile[1] + thr_id1 +
                     static_cast<index_type>(m_policy.m_lower[1]);
+                // check index for dimension 1 is within range
                 if (offset_1 < m_policy.m_upper[1] &&
                     thr_id1 < m_policy.m_tile[1]) {
+                  // iterate over virtual blocks for dimension 0
                   for (index_type i = tile_id0; i < m_policy.m_tile_end[0];
                        i += numbl0) {
+                    // compute index for dimension 0
                     const index_type offset_0 =
                         i * m_policy.m_tile[0] + thr_id0 +
                         static_cast<index_type>(m_policy.m_lower[0]);
+                    // check index for dimension 0 is within range
                     if (offset_0 < m_policy.m_upper[0] &&
                         thr_id0 < m_policy.m_tile[0]) {
+                      // call kernel with computed indices
                       Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1,
                                              offset_2, offset_3);
                     }
@@ -356,54 +412,77 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
     }
     // LR
     else {
+      // number of tiles for dimension 0
       const index_type temp0 = m_policy.m_tile_end[0];
+      // number of tiles for dimension 1
       const index_type temp1 = m_policy.m_tile_end[1];
+
+      // number of virtual blocks for dimension 1
       const index_type numbl1 =
           (temp1 <= mdrange_max_blocks_x ? temp1 : mdrange_max_blocks_x);
+      // number of virtual blocks for dimension 0
       const index_type numbl0 =
           (temp0 * temp1 > mdrange_max_blocks_x
                ? index_type(mdrange_max_blocks_x / numbl1)
                : (temp0 <= mdrange_max_blocks_x ? temp0
                                                 : mdrange_max_blocks_x));
 
+      // first virtual block index for dimension 0
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
+      // first virtual block index for dimension 1
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;
+
+      // virtual thread index for dimension 0
       const index_type thr_id0 =
           static_cast<index_type>(threadIdx.x) / m_policy.m_tile[1];
+      // virtual thread index for dimension 1
       const index_type thr_id1 =
           static_cast<index_type>(threadIdx.x) % m_policy.m_tile[1];
 
+      // iterate over virtual blocks for dimension 0
       for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
+        // compute index for dimension 0
         const index_type offset_0 =
             i * m_policy.m_tile[0] + thr_id0 +
             static_cast<index_type>(m_policy.m_lower[0]);
+        // check index for dimension 0 is within range
         if (offset_0 < m_policy.m_upper[0] && thr_id0 < m_policy.m_tile[0]) {
+          // iterate over virtual blocks for dimension 1
           for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
                j += numbl1) {
+            // compute index for dimension 1
             const index_type offset_1 =
                 j * m_policy.m_tile[1] + thr_id1 +
                 static_cast<index_type>(m_policy.m_lower[1]);
+            // check index for dimension 1 is within range
             if (offset_1 < m_policy.m_upper[1] &&
                 thr_id1 < m_policy.m_tile[1]) {
+              // iterate over y blocks
               for (index_type tile_id2 = static_cast<index_type>(blockIdx.y);
                    tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.y) {
+                // compute index for dimension 2
                 const index_type offset_2 =
                     tile_id2 * m_policy.m_tile[2] +
                     static_cast<index_type>(threadIdx.y) +
                     static_cast<index_type>(m_policy.m_lower[2]);
+                // check index for dimension 2 is within range
                 if (offset_2 < m_policy.m_upper[2] &&
                     static_cast<index_type>(threadIdx.y) < m_policy.m_tile[2]) {
+                  // iterate over z blocks
                   for (index_type tile_id3 =
                            static_cast<index_type>(blockIdx.z);
                        tile_id3 < m_policy.m_tile_end[3];
                        tile_id3 += gridDim.z) {
+                    // compute index for dimension 3
                     const index_type offset_3 =
                         tile_id3 * m_policy.m_tile[3] +
                         static_cast<index_type>(threadIdx.z) +
                         static_cast<index_type>(m_policy.m_lower[3]);
+                    // check index for dimension 3 is within range
                     if (offset_3 < m_policy.m_upper[3] &&
                         static_cast<index_type>(threadIdx.z) <
                             m_policy.m_tile[3]) {
+                      // call kernel with computed indices
                       Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1,
                                              offset_2, offset_3);
                     }
@@ -453,75 +532,111 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
   void exec_range() const {
     // LL
     if (PolicyType::inner_direction == Iterate::Left) {
+      // number of tiles for dimension 0
       index_type temp0 = m_policy.m_tile_end[0];
+      // number of tiles for dimension 1
       index_type temp1 = m_policy.m_tile_end[1];
+
+      // number of virtual blocks for dimension 0
       const index_type numbl0 =
           (temp0 <= mdrange_max_blocks_x ? temp0 : mdrange_max_blocks_x);
+      // number of virtual blocks for dimension 1
       const index_type numbl1 =
           (temp0 * temp1 > mdrange_max_blocks_x
                ? index_type(mdrange_max_blocks_x / numbl0)
                : (temp1 <= mdrange_max_blocks_x ? temp1
                                                 : mdrange_max_blocks_x));
 
+      // first virtual block index for dimension 0
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
+      // first virtual block index for dimension 1
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
+
+      // virtual thread index for dimension 0
       const index_type thr_id0 =
           static_cast<index_type>(threadIdx.x) % m_policy.m_tile[0];
+      // virtual thread index for dimension 1
       const index_type thr_id1 =
           static_cast<index_type>(threadIdx.x) / m_policy.m_tile[0];
 
+      // number of tiles for dimension 2
       temp0 = m_policy.m_tile_end[2];
+      // number of tiles for dimension 3
       temp1 = m_policy.m_tile_end[3];
+
+      // number of virtual blocks for dimension 2
       const index_type numbl2 =
           (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks);
+      // number of virtual blocks for dimension 3
       const index_type numbl3 =
           (temp0 * temp1 > mdrange_max_blocks
                ? index_type(mdrange_max_blocks / numbl2)
                : (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks));
 
+      // first virtual block index for dimension 2
       const index_type tile_id2 = static_cast<index_type>(blockIdx.y) % numbl2;
+      // first virtual block index for dimension 3
       const index_type tile_id3 = static_cast<index_type>(blockIdx.y) / numbl2;
+
+      // virtual thread index for dimension 2
       const index_type thr_id2 =
           static_cast<index_type>(threadIdx.y) % m_policy.m_tile[2];
+      // virtual thread index for dimension 3
       const index_type thr_id3 =
           static_cast<index_type>(threadIdx.y) / m_policy.m_tile[2];
 
+      // iterate over z blocks
       for (index_type tile_id4 = static_cast<index_type>(blockIdx.z);
            tile_id4 < m_policy.m_tile_end[4]; tile_id4 += gridDim.z) {
+        // compute index for dimension 4
         const index_type offset_4 =
             tile_id4 * m_policy.m_tile[4] +
             static_cast<index_type>(threadIdx.z) +
             static_cast<index_type>(m_policy.m_lower[4]);
+        // check index for dimension 4 is within range
         if (offset_4 < m_policy.m_upper[4] &&
             static_cast<index_type>(threadIdx.z) < m_policy.m_tile[4]) {
+          // iterate over virtual blocks for dimension 3
           for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
                l += numbl3) {
+            // compute index for dimension 3
             const index_type offset_3 =
                 l * m_policy.m_tile[3] + thr_id3 +
                 static_cast<index_type>(m_policy.m_lower[3]);
+            // check index for dimension 3 is within range
             if (offset_3 < m_policy.m_upper[3] &&
                 thr_id3 < m_policy.m_tile[3]) {
+              // iterate over virtual blocks for dimension 2
               for (index_type k = tile_id2; k < m_policy.m_tile_end[2];
                    k += numbl2) {
+                // compute index for dimension 2
                 const index_type offset_2 =
                     k * m_policy.m_tile[2] + thr_id2 +
                     static_cast<index_type>(m_policy.m_lower[2]);
+                // check index for dimension 2 is within range
                 if (offset_2 < m_policy.m_upper[2] &&
                     thr_id2 < m_policy.m_tile[2]) {
+                  // iterate over virtual blocks for dimension 1
                   for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
                        j += numbl1) {
+                    // compute index for dimension 1
                     const index_type offset_1 =
                         j * m_policy.m_tile[1] + thr_id1 +
                         static_cast<index_type>(m_policy.m_lower[1]);
+                    // check index for dimension 1 is within range
                     if (offset_1 < m_policy.m_upper[1] &&
                         thr_id1 < m_policy.m_tile[1]) {
+                      // iterate over virtual blocks for dimension 0
                       for (index_type i = tile_id0; i < m_policy.m_tile_end[0];
                            i += numbl0) {
+                        // compute index for dimension 0
                         const index_type offset_0 =
                             i * m_policy.m_tile[0] + thr_id0 +
                             static_cast<index_type>(m_policy.m_lower[0]);
+                        // check index for dimension 0 is within range
                         if (offset_0 < m_policy.m_upper[0] &&
                             thr_id0 < m_policy.m_tile[0]) {
+                          // call kernel with computed indices
                           Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1,
                                                  offset_2, offset_3, offset_4);
                         }
@@ -537,76 +652,112 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
     }
     // LR
     else {
+      // number of tiles for dimension 0
       index_type temp0 = m_policy.m_tile_end[0];
+      // number of tiles for dimension 1
       index_type temp1 = m_policy.m_tile_end[1];
+
+      // number of virtual blocks for dimension 1
       const index_type numbl1 =
           (temp1 <= mdrange_max_blocks_x ? temp1 : mdrange_max_blocks_x);
+      // number of virtual blocks for dimension 0
       const index_type numbl0 =
           (temp0 * temp1 > mdrange_max_blocks_x
                ? static_cast<index_type>(mdrange_max_blocks_x / numbl1)
                : (temp0 <= mdrange_max_blocks_x ? temp0
                                                 : mdrange_max_blocks_x));
 
+      // first virtual block index for dimension 0
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
+      // first virtual block index for dimension 1
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;
+
+      // virtual thread index for dimension 0
       const index_type thr_id0 =
           static_cast<index_type>(threadIdx.x) / m_policy.m_tile[1];
+      // virtual thread index for dimension 1
       const index_type thr_id1 =
           static_cast<index_type>(threadIdx.x) % m_policy.m_tile[1];
 
+      // number of tiles for dimension 2
       temp0 = m_policy.m_tile_end[2];
+      // number of tiles for dimension 3
       temp1 = m_policy.m_tile_end[3];
+
+      // number of virtual blocks for dimension 3
       const index_type numbl3 =
           (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks);
+      // number of virtual blocks for dimension 2
       const index_type numbl2 =
           (temp0 * temp1 > mdrange_max_blocks
                ? index_type(mdrange_max_blocks / numbl3)
                : (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks));
 
+      // first virtual block index for dimension 2
       const index_type tile_id2 = static_cast<index_type>(blockIdx.y) / numbl3;
+      // first virtual block index for dimension 3
       const index_type tile_id3 = static_cast<index_type>(blockIdx.y) % numbl3;
+
+      // virtual thread index for dimension 2
       const index_type thr_id2 =
           static_cast<index_type>(threadIdx.y) / m_policy.m_tile[3];
+      // virtual thread index for dimension 3
       const index_type thr_id3 =
           static_cast<index_type>(threadIdx.y) % m_policy.m_tile[3];
 
+      // iterate over virtual blocks for dimension 0
       for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
+        // compute index for dimension 0
         const index_type offset_0 =
             i * m_policy.m_tile[0] + thr_id0 +
             static_cast<index_type>(m_policy.m_lower[0]);
+        // check index for dimension 0 is within range
         if (offset_0 < m_policy.m_upper[0] && thr_id0 < m_policy.m_tile[0]) {
+          // iterate over virtual blocks for dimension 1
           for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
                j += numbl1) {
+            // compute index for dimension 1
             const index_type offset_1 =
                 j * m_policy.m_tile[1] + thr_id1 +
                 static_cast<index_type>(m_policy.m_lower[1]);
+            // check index for dimension 1 is within range
             if (offset_1 < m_policy.m_upper[1] &&
                 thr_id1 < m_policy.m_tile[1]) {
+              // iterate over virtual blocks for dimension 2
               for (index_type k = tile_id2; k < m_policy.m_tile_end[2];
                    k += numbl2) {
+                // compute index for dimension 2
                 const index_type offset_2 =
                     k * m_policy.m_tile[2] + thr_id2 +
                     static_cast<index_type>(m_policy.m_lower[2]);
+                // check index for dimension 2 is within range
                 if (offset_2 < m_policy.m_upper[2] &&
                     thr_id2 < m_policy.m_tile[2]) {
+                  // iterate over virtual blocks for dimension 3
                   for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
                        l += numbl3) {
+                    // compute index for dimension 3
                     const index_type offset_3 =
                         l * m_policy.m_tile[3] + thr_id3 +
                         static_cast<index_type>(m_policy.m_lower[3]);
+                    // check index for dimension 3 is within range
                     if (offset_3 < m_policy.m_upper[3] &&
                         thr_id3 < m_policy.m_tile[3]) {
+                      // iterate over z blocks
                       for (index_type tile_id4 =
                                static_cast<index_type>(blockIdx.z);
                            tile_id4 < m_policy.m_tile_end[4];
                            tile_id4 += gridDim.z) {
+                        // compute index for dimension 3
                         const index_type offset_4 =
                             tile_id4 * m_policy.m_tile[4] +
                             static_cast<index_type>(threadIdx.z) +
                             static_cast<index_type>(m_policy.m_lower[4]);
+                        // check index for dimension 3 is within range
                         if (offset_4 < m_policy.m_upper[4] &&
                             static_cast<index_type>(threadIdx.z) <
                                 m_policy.m_tile[4]) {
+                          // call kernel with computed indices
                           Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1,
                                                  offset_2, offset_3, offset_4);
                         }
@@ -658,95 +809,144 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
   void exec_range() const {
     // LL
     if (PolicyType::inner_direction == Iterate::Left) {
+      // number of tiles for dimension 0
       index_type temp0 = m_policy.m_tile_end[0];
+      // number of tiles for dimension 1
       index_type temp1 = m_policy.m_tile_end[1];
+
+      // number of virtual blocks for dimension 0
       const index_type numbl0 =
           (temp0 <= mdrange_max_blocks_x ? temp0 : mdrange_max_blocks_x);
+      // number of virtual blocks for dimension 1
       const index_type numbl1 =
           (temp0 * temp1 > mdrange_max_blocks_x
                ? static_cast<index_type>(mdrange_max_blocks_x / numbl0)
                : (temp1 <= mdrange_max_blocks_x ? temp1
                                                 : mdrange_max_blocks_x));
 
+      // first virtual block index for dimension 0
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
+      // first virtual block index for dimension 1
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
+
+      // virtual thread index for dimension 0
       const index_type thr_id0 =
           static_cast<index_type>(threadIdx.x) % m_policy.m_tile[0];
+      // virtual thread index for dimension 1
       const index_type thr_id1 =
           static_cast<index_type>(threadIdx.x) / m_policy.m_tile[0];
 
+      // number of tiles for dimension 2
       temp0 = m_policy.m_tile_end[2];
+      // number of tiles for dimension 3
       temp1 = m_policy.m_tile_end[3];
+
+      // number of virtual blocks for dimension 2
       const index_type numbl2 =
           (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks);
+      // number of virtual blocks for dimension 3
       const index_type numbl3 =
           (temp0 * temp1 > mdrange_max_blocks
                ? static_cast<index_type>(mdrange_max_blocks / numbl2)
                : (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks));
 
+      // first virtual block index for dimension 2
       const index_type tile_id2 = static_cast<index_type>(blockIdx.y) % numbl2;
+      // first virtual block index for dimension 3
       const index_type tile_id3 = static_cast<index_type>(blockIdx.y) / numbl2;
+
+      // virtual thread index for dimension 2
       const index_type thr_id2 =
           static_cast<index_type>(threadIdx.y) % m_policy.m_tile[2];
+      // virtual thread index for dimension 3
       const index_type thr_id3 =
           static_cast<index_type>(threadIdx.y) / m_policy.m_tile[2];
 
+      // number of tiles for dimension 4
       temp0 = m_policy.m_tile_end[4];
+      // number of tiles for dimension 5
       temp1 = m_policy.m_tile_end[5];
+
+      // number of virtual blocks for dimension 4
       const index_type numbl4 =
           (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks);
+      // number of virtual blocks for dimension 5
       const index_type numbl5 =
           (temp0 * temp1 > mdrange_max_blocks
                ? static_cast<index_type>(mdrange_max_blocks / numbl4)
                : (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks));
 
+      // first virtual block index for dimension 4
       const index_type tile_id4 = static_cast<index_type>(blockIdx.z) % numbl4;
+      // first virtual block index for dimension 5
       const index_type tile_id5 = static_cast<index_type>(blockIdx.z) / numbl4;
+
+      // virtual thread index for dimension 4
       const index_type thr_id4 =
           static_cast<index_type>(threadIdx.z) % m_policy.m_tile[4];
+      // virtual thread index for dimension 5
       const index_type thr_id5 =
           static_cast<index_type>(threadIdx.z) / m_policy.m_tile[4];
 
+      // iterate over virtual blocks for dimension 5
       for (index_type n = tile_id5; n < m_policy.m_tile_end[5]; n += numbl5) {
+        // compute index for dimension 5
         const index_type offset_5 =
             n * m_policy.m_tile[5] + thr_id5 +
             static_cast<index_type>(m_policy.m_lower[5]);
+        // check index for dimension 5 is within range
         if (offset_5 < m_policy.m_upper[5] && thr_id5 < m_policy.m_tile[5]) {
+          // iterate over virtual blocks for dimension 4
           for (index_type m = tile_id4; m < m_policy.m_tile_end[4];
                m += numbl4) {
+            // compute index for dimension 4
             const index_type offset_4 =
                 m * m_policy.m_tile[4] + thr_id4 +
                 static_cast<index_type>(m_policy.m_lower[4]);
+            // check index for dimension 4 is within range
             if (offset_4 < m_policy.m_upper[4] &&
                 thr_id4 < m_policy.m_tile[4]) {
+              // iterate over virtual blocks for dimension 3
               for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
                    l += numbl3) {
+                // compute index for dimension 3
                 const index_type offset_3 =
                     l * m_policy.m_tile[3] + thr_id3 +
                     static_cast<index_type>(m_policy.m_lower[3]);
+                // check index for dimension 3 is within range
                 if (offset_3 < m_policy.m_upper[3] &&
                     thr_id3 < m_policy.m_tile[3]) {
+                  // iterate over virtual blocks for dimension 2
                   for (index_type k = tile_id2; k < m_policy.m_tile_end[2];
                        k += numbl2) {
+                    // compute index for dimension 2
                     const index_type offset_2 =
                         k * m_policy.m_tile[2] + thr_id2 +
                         static_cast<index_type>(m_policy.m_lower[2]);
+                    // check index for dimension 2 is within range
                     if (offset_2 < m_policy.m_upper[2] &&
                         thr_id2 < m_policy.m_tile[2]) {
+                      // iterate over virtual blocks for dimension 1
                       for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
                            j += numbl1) {
+                        // compute index for dimension 1
                         const index_type offset_1 =
                             j * m_policy.m_tile[1] + thr_id1 +
                             static_cast<index_type>(m_policy.m_lower[1]);
+                        // check index for dimension 1 is within range
                         if (offset_1 < m_policy.m_upper[1] &&
                             thr_id1 < m_policy.m_tile[1]) {
+                          // iterate over virtual blocks for dimension 0
                           for (index_type i = tile_id0;
                                i < m_policy.m_tile_end[0]; i += numbl0) {
+                            // compute index for dimension 0
                             const index_type offset_0 =
                                 i * m_policy.m_tile[0] + thr_id0 +
                                 static_cast<index_type>(m_policy.m_lower[0]);
+                            // check index for dimension 0 is within range
                             if (offset_0 < m_policy.m_upper[0] &&
                                 thr_id0 < m_policy.m_tile[0]) {
+                              // call kernel with computed indices
                               Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1,
                                                      offset_2, offset_3,
                                                      offset_4, offset_5);
@@ -765,95 +965,144 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
     }
     // LR
     else {
+      // number of tiles for dimension 0
       index_type temp0 = m_policy.m_tile_end[0];
+      // number of tiles for dimension 1
       index_type temp1 = m_policy.m_tile_end[1];
+
+      // number of virtual blocks for dimension 1
       const index_type numbl1 =
           (temp1 <= mdrange_max_blocks_x ? temp1 : mdrange_max_blocks_x);
+      // number of virtual blocks for dimension 0
       const index_type numbl0 =
           (temp0 * temp1 > mdrange_max_blocks_x
                ? static_cast<index_type>(mdrange_max_blocks_x / numbl1)
                : (temp0 <= mdrange_max_blocks_x ? temp0
                                                 : mdrange_max_blocks_x));
 
+      // first virtual block index for dimension 0
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
+      // first virtual block index for dimension 1
       const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;
+
+      // virtual thread index for dimension 0
       const index_type thr_id0 =
           static_cast<index_type>(threadIdx.x) / m_policy.m_tile[1];
+      // virtual thread index for dimension 1
       const index_type thr_id1 =
           static_cast<index_type>(threadIdx.x) % m_policy.m_tile[1];
 
+      // number of tiles for dimension 2
       temp0 = m_policy.m_tile_end[2];
+      // number of tiles for dimension 3
       temp1 = m_policy.m_tile_end[3];
+
+      // number of virtual blocks for dimension 3
       const index_type numbl3 =
           (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks);
+      // number of virtual blocks for dimension 2
       const index_type numbl2 =
           (temp0 * temp1 > mdrange_max_blocks
                ? static_cast<index_type>(mdrange_max_blocks / numbl3)
                : (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks));
 
+      // first virtual block index for dimension 2
       const index_type tile_id2 = static_cast<index_type>(blockIdx.y) / numbl3;
+      // first virtual block index for dimension 3
       const index_type tile_id3 = static_cast<index_type>(blockIdx.y) % numbl3;
+
+      // virtual thread index for dimension 2
       const index_type thr_id2 =
           static_cast<index_type>(threadIdx.y) / m_policy.m_tile[3];
+      // virtual thread index for dimension 3
       const index_type thr_id3 =
           static_cast<index_type>(threadIdx.y) % m_policy.m_tile[3];
 
+      // number of tiles for dimension 4
       temp0 = m_policy.m_tile_end[4];
+      // number of tiles for dimension 5
       temp1 = m_policy.m_tile_end[5];
+
+      // number of virtual blocks for dimension 5
       const index_type numbl5 =
           (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks);
+      // number of virtual blocks for dimension 3
       const index_type numbl4 =
           (temp0 * temp1 > mdrange_max_blocks
                ? static_cast<index_type>(mdrange_max_blocks / numbl5)
                : (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks));
 
+      // first virtual block index for dimension 4
       const index_type tile_id4 = static_cast<index_type>(blockIdx.z) / numbl5;
+      // first virtual block index for dimension 5
       const index_type tile_id5 = static_cast<index_type>(blockIdx.z) % numbl5;
+
+      // virtual thread index for dimension 4
       const index_type thr_id4 =
           static_cast<index_type>(threadIdx.z) / m_policy.m_tile[5];
+      // virtual thread index for dimension 5
       const index_type thr_id5 =
           static_cast<index_type>(threadIdx.z) % m_policy.m_tile[5];
 
+      // iterate over virtual blocks for dimension 0
       for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
+        // compute index for dimension 0
         const index_type offset_0 =
             i * m_policy.m_tile[0] + thr_id0 +
             static_cast<index_type>(m_policy.m_lower[0]);
+        // check index for dimension 0 is within range
         if (offset_0 < m_policy.m_upper[0] && thr_id0 < m_policy.m_tile[0]) {
+          // iterate over virtual blocks for dimension 1
           for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
                j += numbl1) {
+            // compute index for dimension 1
             const index_type offset_1 =
                 j * m_policy.m_tile[1] + thr_id1 +
                 static_cast<index_type>(m_policy.m_lower[1]);
+            // check index for dimension 1 is within range
             if (offset_1 < m_policy.m_upper[1] &&
                 thr_id1 < m_policy.m_tile[1]) {
+              // iterate over virtual blocks for dimension 2
               for (index_type k = tile_id2; k < m_policy.m_tile_end[2];
                    k += numbl2) {
+                // compute index for dimension 2
                 const index_type offset_2 =
                     k * m_policy.m_tile[2] + thr_id2 +
                     static_cast<index_type>(m_policy.m_lower[2]);
+                // check index for dimension 2 is within range
                 if (offset_2 < m_policy.m_upper[2] &&
                     thr_id2 < m_policy.m_tile[2]) {
+                  // iterate over virtual blocks for dimension 3
                   for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
                        l += numbl3) {
+                    // compute index for dimension 3
                     const index_type offset_3 =
                         l * m_policy.m_tile[3] + thr_id3 +
                         static_cast<index_type>(m_policy.m_lower[3]);
+                    // check index for dimension 3 is within range
                     if (offset_3 < m_policy.m_upper[3] &&
                         thr_id3 < m_policy.m_tile[3]) {
+                      // iterate over virtual blocks for dimension 4
                       for (index_type m = tile_id4; m < m_policy.m_tile_end[4];
                            m += numbl4) {
+                        // compute index for dimension 4
                         const index_type offset_4 =
                             m * m_policy.m_tile[4] + thr_id4 +
                             static_cast<index_type>(m_policy.m_lower[4]);
+                        // check index for dimension 4 is within range
                         if (offset_4 < m_policy.m_upper[4] &&
                             thr_id4 < m_policy.m_tile[4]) {
+                          // iterate over virtual blocks for dimension 5
                           for (index_type n = tile_id5;
                                n < m_policy.m_tile_end[5]; n += numbl5) {
+                            // compute index for dimension 5
                             const index_type offset_5 =
                                 n * m_policy.m_tile[5] + thr_id5 +
                                 static_cast<index_type>(m_policy.m_lower[5]);
+                              // check index for dimension 5 is within range
                             if (offset_5 < m_policy.m_upper[5] &&
                                 thr_id5 < m_policy.m_tile[5]) {
+                              // call kernel with computed indices
                               Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1,
                                                      offset_2, offset_3,
                                                      offset_4, offset_5);

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -336,13 +336,13 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
 
       // number of virtual blocks for dimension 0
       const index_type numbl0 =
-          (temp0 <= mdrange_max_blocks_x ? temp0 : mdrange_max_blocks_x);
+          Kokkos::min(temp0, static_cast<index_type>(mdrange_max_blocks_x));
       // number of virtual blocks for dimension 1
       const index_type numbl1 =
-          (temp0 * temp1 > mdrange_max_blocks_x
-               ? static_cast<index_type>(mdrange_max_blocks_x / numbl0)
-               : (temp1 <= mdrange_max_blocks_x ? temp1
-                                                : mdrange_max_blocks_x));
+          (temp0 * temp1 > static_cast<index_type>(mdrange_max_blocks_x)
+               ? static_cast<index_type>(mdrange_max_blocks_x) / numbl0
+               : Kokkos::min(temp1,
+                             static_cast<index_type>(mdrange_max_blocks_x)));
 
       // first virtual block index for dimension 0
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
@@ -419,13 +419,13 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
 
       // number of virtual blocks for dimension 1
       const index_type numbl1 =
-          (temp1 <= mdrange_max_blocks_x ? temp1 : mdrange_max_blocks_x);
+          Kokkos::min(temp1, static_cast<index_type>(mdrange_max_blocks_x));
       // number of virtual blocks for dimension 0
       const index_type numbl0 =
-          (temp0 * temp1 > mdrange_max_blocks_x
-               ? index_type(mdrange_max_blocks_x / numbl1)
-               : (temp0 <= mdrange_max_blocks_x ? temp0
-                                                : mdrange_max_blocks_x));
+          (temp0 * temp1 > static_cast<index_type>(mdrange_max_blocks_x)
+               ? static_cast<index_type>(mdrange_max_blocks_x) / numbl1
+               : Kokkos::min(temp0,
+                             static_cast<index_type>(mdrange_max_blocks_x)));
 
       // first virtual block index for dimension 0
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
@@ -539,13 +539,13 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
 
       // number of virtual blocks for dimension 0
       const index_type numbl0 =
-          (temp0 <= mdrange_max_blocks_x ? temp0 : mdrange_max_blocks_x);
+          Kokkos::min(temp0, static_cast<index_type>(mdrange_max_blocks_x));
       // number of virtual blocks for dimension 1
       const index_type numbl1 =
-          (temp0 * temp1 > mdrange_max_blocks_x
-               ? index_type(mdrange_max_blocks_x / numbl0)
-               : (temp1 <= mdrange_max_blocks_x ? temp1
-                                                : mdrange_max_blocks_x));
+          (temp0 * temp1 > static_cast<index_type>(mdrange_max_blocks_x)
+               ? static_cast<index_type>(mdrange_max_blocks_x) / numbl0
+               : Kokkos::min(temp1,
+                             static_cast<index_type>(mdrange_max_blocks_x)));
 
       // first virtual block index for dimension 0
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
@@ -566,12 +566,13 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
 
       // number of virtual blocks for dimension 2
       const index_type numbl2 =
-          (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks);
+          Kokkos::min(temp0, static_cast<index_type>(mdrange_max_blocks));
       // number of virtual blocks for dimension 3
       const index_type numbl3 =
-          (temp0 * temp1 > mdrange_max_blocks
-               ? index_type(mdrange_max_blocks / numbl2)
-               : (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks));
+          (temp0 * temp1 > static_cast<index_type>(mdrange_max_blocks)
+               ? static_cast<index_type>(mdrange_max_blocks) / numbl2
+               : Kokkos::min(temp1,
+                             static_cast<index_type>(mdrange_max_blocks)));
 
       // first virtual block index for dimension 2
       const index_type tile_id2 = static_cast<index_type>(blockIdx.y) % numbl2;
@@ -659,13 +660,13 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
 
       // number of virtual blocks for dimension 1
       const index_type numbl1 =
-          (temp1 <= mdrange_max_blocks_x ? temp1 : mdrange_max_blocks_x);
+          Kokkos::min(temp1, static_cast<index_type>(mdrange_max_blocks_x));
       // number of virtual blocks for dimension 0
       const index_type numbl0 =
-          (temp0 * temp1 > mdrange_max_blocks_x
-               ? static_cast<index_type>(mdrange_max_blocks_x / numbl1)
-               : (temp0 <= mdrange_max_blocks_x ? temp0
-                                                : mdrange_max_blocks_x));
+          (temp0 * temp1 > static_cast<index_type>(mdrange_max_blocks_x)
+               ? static_cast<index_type>(mdrange_max_blocks_x) / numbl1
+               : Kokkos::min(temp0,
+                             static_cast<index_type>(mdrange_max_blocks_x)));
 
       // first virtual block index for dimension 0
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
@@ -686,12 +687,13 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
 
       // number of virtual blocks for dimension 3
       const index_type numbl3 =
-          (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks);
+          Kokkos::min(temp1, static_cast<index_type>(mdrange_max_blocks));
       // number of virtual blocks for dimension 2
       const index_type numbl2 =
-          (temp0 * temp1 > mdrange_max_blocks
-               ? index_type(mdrange_max_blocks / numbl3)
-               : (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks));
+          (temp0 * temp1 > static_cast<index_type>(mdrange_max_blocks)
+               ? static_cast<index_type>(mdrange_max_blocks) / numbl3
+               : Kokkos::min(temp0,
+                             static_cast<index_type>(mdrange_max_blocks)));
 
       // first virtual block index for dimension 2
       const index_type tile_id2 = static_cast<index_type>(blockIdx.y) / numbl3;
@@ -816,13 +818,13 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
 
       // number of virtual blocks for dimension 0
       const index_type numbl0 =
-          (temp0 <= mdrange_max_blocks_x ? temp0 : mdrange_max_blocks_x);
+          Kokkos::min(temp0, static_cast<index_type>(mdrange_max_blocks_x));
       // number of virtual blocks for dimension 1
       const index_type numbl1 =
-          (temp0 * temp1 > mdrange_max_blocks_x
-               ? static_cast<index_type>(mdrange_max_blocks_x / numbl0)
-               : (temp1 <= mdrange_max_blocks_x ? temp1
-                                                : mdrange_max_blocks_x));
+          (temp0 * temp1 > static_cast<index_type>(mdrange_max_blocks_x)
+               ? static_cast<index_type>(mdrange_max_blocks_x) / numbl0
+               : Kokkos::min(temp1,
+                             static_cast<index_type>(mdrange_max_blocks_x)));
 
       // first virtual block index for dimension 0
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
@@ -843,12 +845,13 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
 
       // number of virtual blocks for dimension 2
       const index_type numbl2 =
-          (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks);
+          Kokkos::min(temp0, static_cast<index_type>(mdrange_max_blocks));
       // number of virtual blocks for dimension 3
       const index_type numbl3 =
-          (temp0 * temp1 > mdrange_max_blocks
-               ? static_cast<index_type>(mdrange_max_blocks / numbl2)
-               : (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks));
+          (temp0 * temp1 > static_cast<index_type>(mdrange_max_blocks)
+               ? static_cast<index_type>(mdrange_max_blocks) / numbl2
+               : Kokkos::min(temp1,
+                             static_cast<index_type>(mdrange_max_blocks)));
 
       // first virtual block index for dimension 2
       const index_type tile_id2 = static_cast<index_type>(blockIdx.y) % numbl2;
@@ -869,12 +872,13 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
 
       // number of virtual blocks for dimension 4
       const index_type numbl4 =
-          (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks);
+          Kokkos::min(temp0, static_cast<index_type>(mdrange_max_blocks));
       // number of virtual blocks for dimension 5
       const index_type numbl5 =
-          (temp0 * temp1 > mdrange_max_blocks
-               ? static_cast<index_type>(mdrange_max_blocks / numbl4)
-               : (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks));
+          (temp0 * temp1 > static_cast<index_type>(mdrange_max_blocks)
+               ? static_cast<index_type>(mdrange_max_blocks) / numbl4
+               : Kokkos::min(temp1,
+                             static_cast<index_type>(mdrange_max_blocks)));
 
       // first virtual block index for dimension 4
       const index_type tile_id4 = static_cast<index_type>(blockIdx.z) % numbl4;
@@ -972,13 +976,13 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
 
       // number of virtual blocks for dimension 1
       const index_type numbl1 =
-          (temp1 <= mdrange_max_blocks_x ? temp1 : mdrange_max_blocks_x);
+          Kokkos::min(temp1, static_cast<index_type>(mdrange_max_blocks_x));
       // number of virtual blocks for dimension 0
       const index_type numbl0 =
-          (temp0 * temp1 > mdrange_max_blocks_x
-               ? static_cast<index_type>(mdrange_max_blocks_x / numbl1)
-               : (temp0 <= mdrange_max_blocks_x ? temp0
-                                                : mdrange_max_blocks_x));
+          (temp0 * temp1 > static_cast<index_type>(mdrange_max_blocks_x)
+               ? static_cast<index_type>(mdrange_max_blocks_x) / numbl1
+               : Kokkos::min(temp0,
+                             static_cast<index_type>(mdrange_max_blocks_x)));
 
       // first virtual block index for dimension 0
       const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
@@ -999,12 +1003,13 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
 
       // number of virtual blocks for dimension 3
       const index_type numbl3 =
-          (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks);
+          Kokkos::min(temp1, static_cast<index_type>(mdrange_max_blocks));
       // number of virtual blocks for dimension 2
       const index_type numbl2 =
-          (temp0 * temp1 > mdrange_max_blocks
-               ? static_cast<index_type>(mdrange_max_blocks / numbl3)
-               : (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks));
+          (temp0 * temp1 > static_cast<index_type>(mdrange_max_blocks)
+               ? static_cast<index_type>(mdrange_max_blocks) / numbl3
+               : Kokkos::min(temp0,
+                             static_cast<index_type>(mdrange_max_blocks)));
 
       // first virtual block index for dimension 2
       const index_type tile_id2 = static_cast<index_type>(blockIdx.y) / numbl3;
@@ -1025,12 +1030,13 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
 
       // number of virtual blocks for dimension 5
       const index_type numbl5 =
-          (temp1 <= mdrange_max_blocks ? temp1 : mdrange_max_blocks);
+          Kokkos::min(temp1, static_cast<index_type>(mdrange_max_blocks));
       // number of virtual blocks for dimension 3
       const index_type numbl4 =
-          (temp0 * temp1 > mdrange_max_blocks
-               ? static_cast<index_type>(mdrange_max_blocks / numbl5)
-               : (temp0 <= mdrange_max_blocks ? temp0 : mdrange_max_blocks));
+          (temp0 * temp1 > static_cast<index_type>(mdrange_max_blocks)
+               ? static_cast<index_type>(mdrange_max_blocks) / numbl5
+               : Kokkos::min(temp0,
+                             static_cast<index_type>(mdrange_max_blocks)));
 
       // first virtual block index for dimension 4
       const index_type tile_id4 = static_cast<index_type>(blockIdx.z) / numbl5;
@@ -1099,7 +1105,7 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
                             const index_type offset_5 =
                                 n * m_policy.m_tile[5] + thr_id5 +
                                 static_cast<index_type>(m_policy.m_lower[5]);
-                              // check index for dimension 5 is within range
+                            // check index for dimension 5 is within range
                             if (offset_5 < m_policy.m_upper[5] &&
                                 thr_id5 < m_policy.m_tile[5]) {
                               // call kernel with computed indices


### PR DESCRIPTION
This PR is a follow-up of #7724, which dealt with `Kokkos::MDRangePolicy` on GPU. When working on it, it took me some time to understand what is going on for the unpacking step of the blocks (please find an explanation attempt in the description of the aforementioned PR). This PR aims to make the code easier to read and to understand, by:

- Adding comments and break lines in the code; and
- Simplifying the code by using `Kokkos::min` instead of ternaries whenever possible.