### PR TITLE
Get the concurrency from provided execution space instances

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -556,7 +556,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
           m_scratch_pool_id,
           static_cast<std::int64_t>(m_scratch_size[1]) *
               (std::min(
-                  static_cast<std::int64_t>(Cuda().concurrency() /
+                  static_cast<std::int64_t>(m_policy.space().concurrency() /
                                             (m_team_size * m_vector_size)),
                   static_cast<std::int64_t>(m_league_size))));
     }
@@ -922,7 +922,7 @@ class ParallelReduce<CombinedFunctorReducerType,
           m_scratch_pool_id,
           static_cast<std::int64_t>(m_scratch_size[1]) *
               (std::min(
-                  static_cast<std::int64_t>(Cuda().concurrency() /
+                  static_cast<std::int64_t>(m_policy.space().concurrency() /
                                             (m_team_size * m_vector_size)),
                   static_cast<std::int64_t>(m_league_size))));
     }

--- a/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
@@ -137,8 +137,7 @@ class UniqueToken<Cuda, UniqueTokenScope::Instance>
       : UniqueToken<Cuda, UniqueTokenScope::Global>(
             Kokkos::Cuda().concurrency()) {}
   explicit UniqueToken(execution_space const& arg)
-      : UniqueToken<Cuda, UniqueTokenScope::Global>(
-            Kokkos::Cuda().concurrency(), arg) {}
+      : UniqueToken<Cuda, UniqueTokenScope::Global>(arg.concurrency(), arg) {}
   explicit UniqueToken(size_type max_size)
       : UniqueToken<Cuda, UniqueTokenScope::Global>(max_size) {}
   UniqueToken(size_type max_size, execution_space const& arg)

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Team.hpp
@@ -151,7 +151,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>, HIP> {
           m_scratch_pool_id,
           static_cast<std::int64_t>(m_scratch_size[1]) *
               (std::min(
-                  static_cast<std::int64_t>(HIP().concurrency() /
+                  static_cast<std::int64_t>(m_policy.space().concurrency() /
                                             (m_team_size * m_vector_size)),
                   static_cast<std::int64_t>(m_league_size))));
     }

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
@@ -357,7 +357,7 @@ class ParallelReduce<CombinedFunctorReducerType,
           m_scratch_pool_id,
           static_cast<std::int64_t>(m_scratch_size[1]) *
               (std::min(
-                  static_cast<std::int64_t>(HIP().concurrency() /
+                  static_cast<std::int64_t>(m_policy.space().concurrency() /
                                             (m_team_size * m_vector_size)),
                   static_cast<std::int64_t>(m_league_size))));
     }

--- a/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
+++ b/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
@@ -129,7 +129,7 @@ class UniqueToken<HIP, UniqueTokenScope::Instance>
   UniqueToken()
       : UniqueToken<HIP, UniqueTokenScope::Global>(HIP().concurrency()) {}
   explicit UniqueToken(execution_space const& arg)
-      : UniqueToken<HIP, UniqueTokenScope::Global>(HIP().concurrency(), arg) {}
+      : UniqueToken<HIP, UniqueTokenScope::Global>(arg.concurrency(), arg) {}
   explicit UniqueToken(size_type max_size)
       : UniqueToken<HIP, UniqueTokenScope::Global>(max_size) {}
   UniqueToken(size_type max_size, execution_space const& arg)

--- a/core/src/HPX/Kokkos_HPX_WorkGraphPolicy.hpp
+++ b/core/src/HPX/Kokkos_HPX_WorkGraphPolicy.hpp
@@ -52,7 +52,7 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
   }
 
   void execute() const {
-    const int num_worker_threads = Kokkos::Experimental::HPX().concurrency();
+    const int num_worker_threads = m_policy().space().concurrency();
     Kokkos::Experimental::HPX().impl_bulk_plain(
         true, is_light_weight_policy<Policy>(), *this, num_worker_threads,
         hpx::threads::thread_stacksize::nostack);

--- a/core/src/HPX/Kokkos_HPX_WorkGraphPolicy.hpp
+++ b/core/src/HPX/Kokkos_HPX_WorkGraphPolicy.hpp
@@ -52,7 +52,7 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
   }
 
   void execute() const {
-    const int num_worker_threads = m_policy().space().concurrency();
+    const int num_worker_threads = m_policy.space().concurrency();
     Kokkos::Experimental::HPX().impl_bulk_plain(
         true, is_light_weight_policy<Policy>(), *this, num_worker_threads,
         hpx::threads::thread_stacksize::nostack);

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp
@@ -204,9 +204,7 @@ struct ParallelReduceSpecialize<FunctorType, Kokkos::RangePolicy<PolicyArgs...>,
     // based on NVIDIA-V100 and should be modifid to be based on the
     // architecture in the future.
     const int max_team_threads = 32;
-    const int max_teams =
-        p.space().impl_internal_space_instance()->concurrency() /
-        max_team_threads;
+    const int max_teams        = p.space().concurrency() / max_team_threads;
     // Number of elements in the reduction
     const auto value_count = FunctorAnalysis::value_count(f.get_functor());
 

--- a/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
@@ -130,8 +130,7 @@ class UniqueToken<SYCL, UniqueTokenScope::Instance>
             Kokkos::SYCL().concurrency()) {}
 
   explicit UniqueToken(execution_space const& arg)
-      : UniqueToken<SYCL, UniqueTokenScope::Global>(
-            Kokkos::SYCL().concurrency(), arg) {}
+      : UniqueToken<SYCL, UniqueTokenScope::Global>(arg.concurrency(), arg) {}
 
   explicit UniqueToken(size_type max_size)
       : UniqueToken<SYCL, UniqueTokenScope::Global>(max_size) {}


### PR DESCRIPTION
Most likely inconsequential as of today but nevertheless a bug.
We need to retrieve the concurrency from the exec space that is specified and not by summoning the default exec.