### PR TITLE
Fixing memory error in tuning API.

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -1167,13 +1167,19 @@ SetOrRange make_candidate_set(size_t size, std::string* data) {
 SetOrRange make_candidate_set(size_t size, int64_t* data) {
   SetOrRange value_set;
   value_set.set.size             = size;
-  value_set.set.values.int_value = data;
+  value_set.set.values.int_value = new int64_t[size];
+  for (size_t x = 0; x < size; ++x) {
+    value_set.set.values.int_value[x] = data[x];
+  }
   return value_set;
 }
 SetOrRange make_candidate_set(size_t size, double* data) {
   SetOrRange value_set;
   value_set.set.size                = size;
-  value_set.set.values.double_value = data;
+  value_set.set.values.double_value = new double[size];
+  for (size_t x = 0; x < size; ++x) {
+    value_set.set.values.double_value[x] = data[x];
+  }
   return value_set;
 }
 SetOrRange make_candidate_range(double lower, double upper, double step,

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -808,12 +808,22 @@ void finalize() {
 #ifdef KOKKOS_ENABLE_TUNING
   // clean up string candidate set
   for (auto& metadata_pair : Experimental::variable_metadata) {
-    auto metadata = metadata_pair.second;
-    if ((metadata.type == Experimental::ValueType::kokkos_value_string) &&
-        (metadata.valueQuantity ==
-         Experimental::CandidateValueType::kokkos_value_set)) {
-      auto candidate_set = metadata.candidates.set;
-      delete[] candidate_set.values.string_value;
+    const auto& metadata = metadata_pair.second;
+    if (metadata.valueQuantity !=
+        Experimental::CandidateValueType::kokkos_value_set) {
+      continue;
+    }
+    const auto candidate_set = metadata.candidates.set;
+    switch (metadata.type) {
+      case Experimental::ValueType::kokkos_value_string:
+        delete[] candidate_set.values.string_value;
+        break;
+      case Experimental::ValueType::kokkos_value_int64:
+        delete[] candidate_set.values.int_value;
+        break;
+      case Experimental::ValueType::kokkos_value_double:
+        delete[] candidate_set.values.double_value;
+        break;
     }
   }
 #endif


### PR DESCRIPTION
The make_candidate_set double and int64_t implementations don't correctly copy the set of candidates, but just copy the pointer. This change will copy the set of values.

While I thought that this code would also need to add an explcit destructor for the VariableInfo struct to clean up the memory allocated when constructing the struct, I can't seem to find that is the case with address sanitizer flags enabled. These variables are only meant to be declared once, so any currently leaked memory is small, but it is possibly a leak.

Regardless, this PR fixes issue #7874