### PR TITLE
Add support for Zen 5 AMD microarchitecture

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -18,7 +18,7 @@ KOKKOS_DEVICES ?= "Threads"
 # ARM:      ARMv80,ARMv81,ARMv8-ThunderX,ARMv8-TX2,A64FX,ARMv9-Grace
 # IBM:      Power8,Power9
 # AMD-GPUS: AMD_GFX906,AMD_GFX908,AMD_GFX90A,AMD_GFX940,AMD_GFX942,AMD_GFX942_APU,AMD_GFX1030,AMD_GFX1100,AMD_GFX1103
-# AMD-CPUS: AMDAVX,Zen,Zen2,Zen3,Zen4
+# AMD-CPUS: AMDAVX,Zen,Zen2,Zen3,Zen4,Zen5
 # Intel-GPUs: Intel_Gen,Intel_Gen9,Intel_Gen11,Intel_Gen12LP,Intel_DG1,Intel_XeHP,Intel_PVC
 KOKKOS_ARCH ?= ""
 # Options: yes,no
@@ -436,13 +436,16 @@ KOKKOS_INTERNAL_USE_ARCH_IBM := $(strip $(shell echo $(KOKKOS_INTERNAL_USE_ARCH_
 
 # AMD based.
 KOKKOS_INTERNAL_USE_ARCH_AMDAVX := $(call kokkos_has_string,$(KOKKOS_ARCH),AMDAVX)
+KOKKOS_INTERNAL_USE_ARCH_ZEN5 := $(call kokkos_has_string,$(KOKKOS_ARCH),Zen5)
 KOKKOS_INTERNAL_USE_ARCH_ZEN4 := $(call kokkos_has_string,$(KOKKOS_ARCH),Zen4)
 KOKKOS_INTERNAL_USE_ARCH_ZEN3 := $(call kokkos_has_string,$(KOKKOS_ARCH),Zen3)
 KOKKOS_INTERNAL_USE_ARCH_ZEN2 := $(call kokkos_has_string,$(KOKKOS_ARCH),Zen2)
-ifeq ($(KOKKOS_INTERNAL_USE_ARCH_ZEN4), 0)
-  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_ZEN3), 0)
-    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_ZEN2), 0)
-      KOKKOS_INTERNAL_USE_ARCH_ZEN := $(call kokkos_has_string,$(KOKKOS_ARCH),Zen)
+ifeq ($(KOKKOS_INTERNAL_USE_ARCH_ZEN5), 0)
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_ZEN4), 0)
+    ifeq ($(KOKKOS_INTERNAL_USE_ARCH_ZEN3), 0)
+      ifeq ($(KOKKOS_INTERNAL_USE_ARCH_ZEN2), 0)
+        KOKKOS_INTERNAL_USE_ARCH_ZEN := $(call kokkos_has_string,$(KOKKOS_ARCH),Zen)
+      endif
     endif
   endif
 endif
@@ -866,6 +869,19 @@ ifeq ($(KOKKOS_INTERNAL_USE_ARCH_ZEN4), 1)
   else
     KOKKOS_CXXFLAGS += -march=znver4 -mtune=znver4
     KOKKOS_LDFLAGS += -march=znver4 -mtune=znver4
+  endif
+endif
+
+ifeq ($(KOKKOS_INTERNAL_USE_ARCH_ZEN5), 1)
+  tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AMD_ZEN5")
+  tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_AVX512XEON")
+
+  ifeq ($(KOKKOS_INTERNAL_COMPILER_INTEL), 1)
+    KOKKOS_CXXFLAGS += -xCORE-AVX512
+    KOKKOS_LDFLAGS += -xCORE-AVX512
+  else
+    KOKKOS_CXXFLAGS += -march=znver5 -mtune=znver5
+    KOKKOS_LDFLAGS += -march=znver5 -mtune=znver5
   endif
 endif
 

--- a/cmake/KokkosCore_config.h.in
+++ b/cmake/KokkosCore_config.h.in
@@ -120,6 +120,7 @@
 #cmakedefine KOKKOS_ARCH_AMD_ZEN2
 #cmakedefine KOKKOS_ARCH_AMD_ZEN3
 #cmakedefine KOKKOS_ARCH_AMD_ZEN4
+#cmakedefine KOKKOS_ARCH_AMD_ZEN5
 #cmakedefine KOKKOS_ARCH_AMD_GFX906
 #cmakedefine KOKKOS_ARCH_AMD_GFX908
 #cmakedefine KOKKOS_ARCH_AMD_GFX90A

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -68,6 +68,7 @@ declare_and_check_host_arch(ZEN "AMD Zen architecture")
 declare_and_check_host_arch(ZEN2 "AMD Zen2 architecture")
 declare_and_check_host_arch(ZEN3 "AMD Zen3 architecture")
 declare_and_check_host_arch(ZEN4 "AMD Zen4 architecture")
+declare_and_check_host_arch(ZEN5 "AMD Zen5 architecture")
 declare_and_check_host_arch(RISCV_SG2042 "SG2042 (RISC-V) CPUs")
 declare_and_check_host_arch(RISCV_RVA22V "RVA22V (RISC-V) CPUs")
 
@@ -430,6 +431,22 @@ if(KOKKOS_ARCH_ZEN4)
     -mtune=znver4
   )
   set(KOKKOS_ARCH_AMD_ZEN4 ON)
+  set(KOKKOS_ARCH_AVX512XEON ON)
+endif()
+
+if(KOKKOS_ARCH_ZEN5)
+  compiler_specific_flags(
+    COMPILER_ID
+    KOKKOS_CXX_HOST_COMPILER_ID
+    MSVC
+    /arch:AVX512
+    NVHPC
+    -tp=zen5
+    DEFAULT
+    -march=znver5
+    -mtune=znver5
+  )
+  set(KOKKOS_ARCH_AMD_ZEN5 ON)
   set(KOKKOS_ARCH_AVX512XEON ON)
 endif()
 

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -664,6 +664,9 @@ void pre_initialize_internal(const Kokkos::InitializationSettings& settings) {
 #elif defined(KOKKOS_ARCH_AMD_ZEN4)
   declare_configuration_metadata("architecture", "CPU architecture",
                                  "AMD_ZEN4");
+#elif defined(KOKKOS_ARCH_AMD_ZEN5)
+  declare_configuration_metadata("architecture", "CPU architecture",
+                                 "AMD_ZEN5");
 #elif defined(KOKKOS_ARCH_RISCV_SG2042)
   declare_configuration_metadata("architecture", "CPU architecture",
                                  "SG2042 (RISC-V)")
@@ -745,14 +748,14 @@ void pre_initialize_internal(const Kokkos::InitializationSettings& settings) {
   declare_configuration_metadata("architecture", "GPU architecture",
                                  "AMD_GFX906");
 #elif defined(KOKKOS_ARCH_AMD_GFX908)
-      declare_configuration_metadata("architecture", "GPU architecture",
-                                     "AMD_GFX908");
+  declare_configuration_metadata("architecture", "GPU architecture",
+                                 "AMD_GFX908");
 #elif defined(KOKKOS_ARCH_AMD_GFX90A)
       declare_configuration_metadata("architecture", "GPU architecture",
                                      "AMD_GFX90A");
 #elif defined(KOKKOS_ARCH_AMD_GFX1030)
-  declare_configuration_metadata("architecture", "GPU architecture",
-                                 "AMD_GFX1030");
+      declare_configuration_metadata("architecture", "GPU architecture",
+                                     "AMD_GFX1030");
 #elif defined(KOKKOS_ARCH_AMD_GFX1100)
   declare_configuration_metadata("architecture", "GPU architecture",
                                  "AMD_GFX1100");

--- a/generate_makefile.bash
+++ b/generate_makefile.bash
@@ -157,6 +157,7 @@ display_help_text() {
       echo "                 ZEN2            = AMD Zen2-Core CPU"
       echo "                 ZEN3            = AMD Zen3-Core CPU"
       echo "                 ZEN4            = AMD Zen4-Core CPU"
+      echo "                 ZEN5            = AMD Zen5-Core CPU"
       echo "               [AMD: GPU]"
       echo "                 AMD_GFX906      = AMD GPU MI50/MI60 GFX906"
       echo "                 AMD_GFX908      = AMD GPU MI100 GFX908"

--- a/gnu_generate_makefile.bash
+++ b/gnu_generate_makefile.bash
@@ -140,6 +140,7 @@ do
       echo "                 ZEN2            = AMD Zen2-Core CPU"
       echo "                 ZEN3            = AMD Zen3-Core CPU"
       echo "                 ZEN4            = AMD Zen4-Core CPU"
+      echo "                 ZEN5            = AMD Zen5-Core CPU"
       echo "               [ARM]"
       echo "                 ARMv80          = ARMv8.0 Compatible CPU"
       echo "                 ARMv81          = ARMv8.1 Compatible CPU"


### PR DESCRIPTION
This PR adds support for Zen 5 AMD microarchitecture.

The changes mirror:
- https://github.com/kokkos/kokkos/pull/7550

For compiler support:
- it looks like `gcc` provides support as of version 14
- it looks like `nvhpc` does not provide support yet; as such the flag `-tp=zen5` is what we might expect the flag to be in a future version, but we can't test it yet
