### PR TITLE
Fix incorrect `MDRangePolicy` iterations when the rank is higher than 4 for HIP and SYCL and improve current Cuda fix

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -81,7 +81,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
 
   const FunctorType m_functor;
   const Policy m_rp;
-  MaxGridSize m_max_grid_size;
+  const MaxGridSize m_max_grid_size;
 
  public:
   template <typename Policy, typename Functor>
@@ -233,10 +233,16 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
 
   //  inline
   ParallelFor(const FunctorType& arg_functor, Policy arg_policy)
-      : m_functor(arg_functor), m_rp(arg_policy) {
-    const auto& maxblocks = m_rp.space().cuda_device_prop().maxGridSize;
-    std::copy_n(maxblocks, 3, Kokkos::begin(m_max_grid_size));
-  }
+      : m_functor(arg_functor),
+        m_rp(arg_policy),
+        m_max_grid_size({
+            static_cast<index_type>(
+                m_rp.space().cuda_device_prop().maxGridSize[0]),
+            static_cast<index_type>(
+                m_rp.space().cuda_device_prop().maxGridSize[1]),
+            static_cast<index_type>(
+                m_rp.space().cuda_device_prop().maxGridSize[2]),
+        }) {}
 };
 
 template <class CombinedFunctorReducerType, class... Traits>

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -77,9 +77,11 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
   using array_index_type = typename Policy::array_index_type;
   using index_type       = typename Policy::index_type;
   using LaunchBounds     = typename Policy::launch_bounds;
+  using MaxGridSize      = Kokkos::Array<index_type, 3>;
 
   const FunctorType m_functor;
   const Policy m_rp;
+  MaxGridSize m_max_grid_size;
 
  public:
   template <typename Policy, typename Functor>
@@ -89,27 +91,13 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
   Policy const& get_policy() const { return m_rp; }
   inline __device__ void operator()() const {
     Kokkos::Impl::DeviceIterateTile<Policy::rank, Policy, FunctorType,
-                                    typename Policy::work_tag>(m_rp, m_functor)
+                                    MaxGridSize, typename Policy::work_tag>(
+        m_rp, m_functor, m_max_grid_size)
         .exec_range();
   }
 
   inline void execute() const {
     if (m_rp.m_num_tiles == 0) return;
-
-    // maximum number of blocks in each dimension of the grid as fetched by the
-    // API
-    [[maybe_unused]] const auto maxblocks_api =
-        m_rp.space().cuda_device_prop().maxGridSize;
-
-    // maximum number of blocks in each dimension of the grid hard-coded for
-    // unpacking on device
-    const int maxblocks[3] = {mdrange_max_blocks_x, mdrange_max_blocks,
-                              mdrange_max_blocks};
-
-    // check hard-coded values are compatible with API values
-    KOKKOS_ASSERT(maxblocks[0] <= static_cast<int>(maxblocks_api[0]));
-    KOKKOS_ASSERT(maxblocks[1] <= static_cast<int>(maxblocks_api[1]));
-    KOKKOS_ASSERT(maxblocks[2] <= static_cast<int>(maxblocks_api[2]));
 
     // maximum number of threads in each dimension of the block as fetched by
     // the API
@@ -141,11 +129,11 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
     // allowed
     const auto check_grid_sizes = [&]([[maybe_unused]] const dim3& grid) {
       KOKKOS_ASSERT(grid.x > 0 &&
-                    grid.x <= static_cast<unsigned int>(maxblocks[0]));
+                    grid.x <= static_cast<unsigned int>(m_max_grid_size[0]));
       KOKKOS_ASSERT(grid.y > 0 &&
-                    grid.y <= static_cast<unsigned int>(maxblocks[1]));
+                    grid.y <= static_cast<unsigned int>(m_max_grid_size[1]));
       KOKKOS_ASSERT(grid.z > 0 &&
-                    grid.z <= static_cast<unsigned int>(maxblocks[2]));
+                    grid.z <= static_cast<unsigned int>(m_max_grid_size[2]));
     };
 
     if (RP::rank == 2) {
@@ -156,10 +144,10 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
       const dim3 grid(
           std::min<array_index_type>(
               (m_rp.m_upper[0] - m_rp.m_lower[0] + block.x - 1) / block.x,
-              maxblocks[0]),
+              m_max_grid_size[0]),
           std::min<array_index_type>(
               (m_rp.m_upper[1] - m_rp.m_lower[1] + block.y - 1) / block.y,
-              maxblocks[1]),
+              m_max_grid_size[1]),
           1);
       check_grid_sizes(grid);
 
@@ -173,13 +161,13 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
       const dim3 grid(
           std::min<array_index_type>(
               (m_rp.m_upper[0] - m_rp.m_lower[0] + block.x - 1) / block.x,
-              maxblocks[0]),
+              m_max_grid_size[0]),
           std::min<array_index_type>(
               (m_rp.m_upper[1] - m_rp.m_lower[1] + block.y - 1) / block.y,
-              maxblocks[1]),
+              m_max_grid_size[1]),
           std::min<array_index_type>(
               (m_rp.m_upper[2] - m_rp.m_lower[2] + block.z - 1) / block.z,
-              maxblocks[2]));
+              m_max_grid_size[2]));
       // ensure we don't exceed the capability of the device
       check_grid_sizes(grid);
 
@@ -193,13 +181,13 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
       check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(m_rp.m_tile_end[0] * m_rp.m_tile_end[1],
-                                     maxblocks[0]),
+                                     m_max_grid_size[0]),
           std::min<array_index_type>(
               (m_rp.m_upper[2] - m_rp.m_lower[2] + block.y - 1) / block.y,
-              maxblocks[1]),
+              m_max_grid_size[1]),
           std::min<array_index_type>(
               (m_rp.m_upper[3] - m_rp.m_lower[3] + block.z - 1) / block.z,
-              maxblocks[2]));
+              m_max_grid_size[2]));
       check_grid_sizes(grid);
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
@@ -211,12 +199,12 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
       check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(m_rp.m_tile_end[0] * m_rp.m_tile_end[1],
-                                     maxblocks[0]),
+                                     m_max_grid_size[0]),
           std::min<array_index_type>(m_rp.m_tile_end[2] * m_rp.m_tile_end[3],
-                                     maxblocks[1]),
+                                     m_max_grid_size[1]),
           std::min<array_index_type>(
               (m_rp.m_upper[4] - m_rp.m_lower[4] + block.z - 1) / block.z,
-              maxblocks[2]));
+              m_max_grid_size[2]));
       check_grid_sizes(grid);
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
@@ -229,11 +217,11 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
       check_block_sizes(block);
       const dim3 grid(
           std::min<array_index_type>(m_rp.m_tile_end[0] * m_rp.m_tile_end[1],
-                                     maxblocks[0]),
+                                     m_max_grid_size[0]),
           std::min<array_index_type>(m_rp.m_tile_end[2] * m_rp.m_tile_end[3],
-                                     maxblocks[1]),
+                                     m_max_grid_size[1]),
           std::min<array_index_type>(m_rp.m_tile_end[4] * m_rp.m_tile_end[5],
-                                     maxblocks[2]));
+                                     m_max_grid_size[2]));
       check_grid_sizes(grid);
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
@@ -245,7 +233,10 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
 
   //  inline
   ParallelFor(const FunctorType& arg_functor, Policy arg_policy)
-      : m_functor(arg_functor), m_rp(arg_policy) {}
+      : m_functor(arg_functor), m_rp(arg_policy) {
+    const auto& maxblocks = m_rp.space().cuda_device_prop().maxGridSize;
+    std::copy_n(maxblocks, 3, Kokkos::begin(m_max_grid_size));
+  }
 };
 
 template <class CombinedFunctorReducerType, class... Traits>

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -17,8 +17,6 @@
 #ifndef KOKKOS_HIP_PARALLEL_FOR_MDRANGE_HPP
 #define KOKKOS_HIP_PARALLEL_FOR_MDRANGE_HPP
 
-#include <algorithm>
-
 #include <Kokkos_Parallel.hpp>
 
 #include <HIP/Kokkos_HIP_BlockSize_Deduction.hpp>
@@ -44,7 +42,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
 
   const FunctorType m_functor;
   const Policy m_policy;
-  MaxGridSize m_max_grid_size;
+  const MaxGridSize m_max_grid_size;
 
  public:
   ParallelFor()                              = delete;
@@ -173,10 +171,16 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
   }  // end execute
 
   ParallelFor(FunctorType const& arg_functor, Policy const& arg_policy)
-      : m_functor(arg_functor), m_policy(arg_policy) {
-    const auto& maxblocks = m_policy.space().hip_device_prop().maxGridSize;
-    std::copy_n(maxblocks, 3, Kokkos::begin(m_max_grid_size));
-  }
+      : m_functor(arg_functor),
+        m_policy(arg_policy),
+        m_max_grid_size({
+            static_cast<index_type>(
+                m_policy.space().hip_device_prop().maxGridSize[0]),
+            static_cast<index_type>(
+                m_policy.space().hip_device_prop().maxGridSize[1]),
+            static_cast<index_type>(
+                m_policy.space().hip_device_prop().maxGridSize[2]),
+        }) {}
 
   template <typename Policy, typename Functor>
   static int max_tile_size_product(const Policy&, const Functor&) {

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -70,8 +70,12 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
       // id0 to threadIdx.x; id1 to threadIdx.y
       sycl::range<3> local_sizes(m_tile[0], m_tile[1], 1);
 
-      sycl::range<3> global_sizes(m_tile_end[0] * m_tile[0],
-                                  m_tile_end[1] * m_tile[1], 1);
+      sycl::range<3> global_sizes(
+          std::min<array_index_type>(m_tile_end[0], m_max_grid_size[0]) *
+              m_tile[0],
+          std::min<array_index_type>(m_tile_end[1], m_max_grid_size[1]) *
+              m_tile[1],
+          1);
 
       return {global_sizes, local_sizes};
     }
@@ -79,9 +83,13 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
       // id0 to threadIdx.x; id1 to threadIdx.y; id2 to threadIdx.z
       sycl::range<3> local_sizes(m_tile[0], m_tile[1], m_tile[2]);
 
-      sycl::range<3> global_sizes(m_tile_end[0] * m_tile[0],
-                                  m_tile_end[1] * m_tile[1],
-                                  m_tile_end[2] * m_tile[2]);
+      sycl::range<3> global_sizes(
+          std::min<array_index_type>(m_tile_end[0], m_max_grid_size[0]) *
+              m_tile[0],
+          std::min<array_index_type>(m_tile_end[1], m_max_grid_size[1]) *
+              m_tile[1],
+          std::min<array_index_type>(m_tile_end[2], m_max_grid_size[2]) *
+              m_tile[2]);
 
       return {global_sizes, local_sizes};
     }
@@ -91,8 +99,13 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
       sycl::range<3> local_sizes(m_tile[0] * m_tile[1], m_tile[2], m_tile[3]);
 
       sycl::range<3> global_sizes(
-          m_tile_end[0] * m_tile[0] * m_tile_end[1] * m_tile[1],
-          m_tile_end[2] * m_tile[2], m_tile_end[3] * m_tile[3]);
+          std::min<array_index_type>(m_tile_end[0] * m_tile_end[1],
+                                     m_max_grid_size[0]) *
+              m_tile[0] * m_tile[1],
+          std::min<array_index_type>(m_tile_end[2], m_max_grid_size[1]) *
+              m_tile[2],
+          std::min<array_index_type>(m_tile_end[3], m_max_grid_size[2]) *
+              m_tile[3]);
 
       return {global_sizes, local_sizes};
     }
@@ -103,9 +116,14 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
                                  m_tile[4]);
 
       sycl::range<3> global_sizes(
-          m_tile_end[0] * m_tile[0] * m_tile_end[1] * m_tile[1],
-          m_tile_end[2] * m_tile[2] * m_tile_end[3] * m_tile[3],
-          m_tile_end[4] * m_tile[4]);
+          std::min<array_index_type>(m_tile_end[0] * m_tile_end[1],
+                                     m_max_grid_size[0]) *
+              m_tile[0] * m_tile[1],
+          std::min<array_index_type>(m_tile_end[2] * m_tile_end[3],
+                                     m_max_grid_size[1]) *
+              m_tile[2] * m_tile[3],
+          std::min<array_index_type>(m_tile_end[4], m_max_grid_size[2]) *
+              m_tile[4]);
 
       return {global_sizes, local_sizes};
     }
@@ -116,9 +134,15 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
                                  m_tile[4] * m_tile[5]);
 
       sycl::range<3> global_sizes(
-          m_tile_end[0] * m_tile[0] * m_tile_end[1] * m_tile[1],
-          m_tile_end[2] * m_tile[2] * m_tile_end[3] * m_tile[3],
-          m_tile_end[4] * m_tile[4] * m_tile_end[5] * m_tile[5]);
+          std::min<array_index_type>(m_tile_end[0] * m_tile_end[1],
+                                     m_max_grid_size[0]) *
+              m_tile[0] * m_tile[1],
+          std::min<array_index_type>(m_tile_end[2] * m_tile_end[3],
+                                     m_max_grid_size[1]) *
+              m_tile[2] * m_tile[3],
+          std::min<array_index_type>(m_tile_end[4] * m_tile_end[5],
+                                     m_max_grid_size[2]) *
+              m_tile[4] * m_tile[5]);
 
       return {global_sizes, local_sizes};
     }

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -204,9 +204,13 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
             .template get_info<sycl::ext::oneapi::experimental::info::device::
                                    max_work_groups<3>>();
 
-    return {static_cast<index_type>(max_grid_size[0]),
+    // note that SYCL represents a (x, y, z) range with the the right-most term
+    // as the one varying the fastest, so the order must be reversed for Kokkos
+    // see:
+    // https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:multi-dim-linearization
+    return {static_cast<index_type>(max_grid_size[2]),
             static_cast<index_type>(max_grid_size[1]),
-            static_cast<index_type>(max_grid_size[2])};
+            static_cast<index_type>(max_grid_size[0])};
 #else
     // otherwise, we consider that the max is infinite
     return {std::numeric_limits<index_type>::max(),

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -213,24 +213,30 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)
       : m_functor(arg_functor),
         m_policy(arg_policy),
-  // the SYCL API does not allow to get the maximum grid size (maximum ND-range
+  // the SYCL specs do not allow to get the maximum grid size (maximum ND-range
   // size, maximum number of work groups)
-  // TODO update this when the API changes
+  // TODO update this when the specs change
 #ifdef SYCL_EXT_ONEAPI_MAX_WORK_GROUP_QUERY
         // we use an Intel extension if possible
         m_max_grid_size({
             static_cast<index_type>(
-                (sycl::device{sycl::gpu_selector_v})
-                    .get_info<sycl::ext::oneapi::experimental::info::device::
-                                  max_work_groups<3>>()[0]),
+                arg_policy.space()
+                    .sycl_queue()
+                    .get_device()
+                    .template get_info<sycl::ext::oneapi::experimental::info::
+                                           device::max_work_groups<3>>()[0]),
             static_cast<index_type>(
-                (sycl::device{sycl::gpu_selector_v})
-                    .get_info<sycl::ext::oneapi::experimental::info::device::
-                                  max_work_groups<3>>()[1]),
+                arg_policy.space()
+                    .sycl_queue()
+                    .get_device()
+                    .template get_info<sycl::ext::oneapi::experimental::info::
+                                           device::max_work_groups<3>>()[1]),
             static_cast<index_type>(
-                (sycl::device{sycl::gpu_selector_v})
-                    .get_info<sycl::ext::oneapi::experimental::info::device::
-                                  max_work_groups<3>>()[2]),
+                arg_policy.space()
+                    .sycl_queue()
+                    .get_device()
+                    .template get_info<sycl::ext::oneapi::experimental::info::
+                                           device::max_work_groups<3>>()[2]),
         }),
 #else
         // otherwise, we consider that the max is infinite

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -204,14 +204,14 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
             .template get_info<sycl::ext::oneapi::experimental::info::device::
                                    max_work_groups<3>>();
 
-    return MaxGridSize({static_cast<index_type>(max_grid_size[0]),
-                        static_cast<index_type>(max_grid_size[1]),
-                        static_cast<index_type>(max_grid_size[2])});
+    return {static_cast<index_type>(max_grid_size[0]),
+            static_cast<index_type>(max_grid_size[1]),
+            static_cast<index_type>(max_grid_size[2])};
 #else
     // otherwise, we consider that the max is infinite
-    return MaxGridSize({std::numeric_limits<index_type>::max(),
-                        std::numeric_limits<index_type>::max(),
-                        std::numeric_limits<index_type>::max()});
+    return {std::numeric_limits<index_type>::max(),
+            std::numeric_limits<index_type>::max(),
+            std::numeric_limits<index_type>::max()};
 #endif
   }
 

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -81,11 +81,13 @@ struct DeviceIterateTile<2, PolicyType, Functor, MaxGridSize, Tag> {
 #ifdef KOKKOS_ENABLE_SYCL
   KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(
       const PolicyType& policy_, const Functor& f_,
+      const MaxGridSize& max_grid_size_,
       const EmulateCUDADim3<index_type> gridDim_,
       const EmulateCUDADim3<index_type> blockIdx_,
       const EmulateCUDADim3<index_type> threadIdx_)
       : m_policy(policy_),
         m_func(f_),
+        m_max_grid_size(max_grid_size_),
         gridDim(gridDim_),
         blockIdx(blockIdx_),
         threadIdx(threadIdx_) {}
@@ -182,11 +184,13 @@ struct DeviceIterateTile<3, PolicyType, Functor, MaxGridSize, Tag> {
 #ifdef KOKKOS_ENABLE_SYCL
   KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(
       const PolicyType& policy_, const Functor& f_,
+      const MaxGridSize& max_grid_size_,
       const EmulateCUDADim3<index_type> gridDim_,
       const EmulateCUDADim3<index_type> blockIdx_,
       const EmulateCUDADim3<index_type> threadIdx_)
       : m_policy(policy_),
         m_func(f_),
+        m_max_grid_size(max_grid_size_),
         gridDim(gridDim_),
         blockIdx(blockIdx_),
         threadIdx(threadIdx_) {}
@@ -309,11 +313,13 @@ struct DeviceIterateTile<4, PolicyType, Functor, MaxGridSize, Tag> {
 #ifdef KOKKOS_ENABLE_SYCL
   KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(
       const PolicyType& policy_, const Functor& f_,
+      const MaxGridSize& max_grid_size_,
       const EmulateCUDADim3<index_type> gridDim_,
       const EmulateCUDADim3<index_type> blockIdx_,
       const EmulateCUDADim3<index_type> threadIdx_)
       : m_policy(policy_),
         m_func(f_),
+        m_max_grid_size(max_grid_size_),
         gridDim(gridDim_),
         blockIdx(blockIdx_),
         threadIdx(threadIdx_) {}
@@ -515,11 +521,13 @@ struct DeviceIterateTile<5, PolicyType, Functor, MaxGridSize, Tag> {
 #ifdef KOKKOS_ENABLE_SYCL
   KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(
       const PolicyType& policy_, const Functor& f_,
+      const MaxGridSize& max_grid_size_,
       const EmulateCUDADim3<index_type> gridDim_,
       const EmulateCUDADim3<index_type> blockIdx_,
       const EmulateCUDADim3<index_type> threadIdx_)
       : m_policy(policy_),
         m_func(f_),
+        m_max_grid_size(max_grid_size_),
         gridDim(gridDim_),
         blockIdx(blockIdx_),
         threadIdx(threadIdx_) {}
@@ -797,11 +805,13 @@ struct DeviceIterateTile<6, PolicyType, Functor, MaxGridSize, Tag> {
 #ifdef KOKKOS_ENABLE_SYCL
   KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(
       const PolicyType& policy_, const Functor& f_,
+      const MaxGridSize& max_grid_size_,
       const EmulateCUDADim3<index_type> gridDim_,
       const EmulateCUDADim3<index_type> blockIdx_,
       const EmulateCUDADim3<index_type> threadIdx_)
       : m_policy(policy_),
         m_func(f_),
+        m_max_grid_size(max_grid_size_),
         gridDim(gridDim_),
         blockIdx(blockIdx_),
         threadIdx(threadIdx_) {}

--- a/core/unit_test/TestMDRange_a.hpp
+++ b/core/unit_test/TestMDRange_a.hpp
@@ -24,14 +24,12 @@ TEST(TEST_CATEGORY, mdrange_5d) {
   TestMDRange_5D<TEST_EXECSPACE>::test_reduce5(100, 10, 10, 10, 5);
 #endif
   TestMDRange_5D<TEST_EXECSPACE>::test_for5(100, 10, 10, 10, 5);
-#ifdef KOKKOS_ENABLE_CUDA
   const int size_x = 2 << 19;  // 2^20
   TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(size_x, 1, 1, 1, 1);
   TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, size_x, 1, 1, 1);
   TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, size_x, 1, 1);
   TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, 1, size_x, 1);
   TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, 1, 1, size_x);
-#endif
 }
 
 }  // namespace Test

--- a/core/unit_test/TestMDRange_a.hpp
+++ b/core/unit_test/TestMDRange_a.hpp
@@ -24,12 +24,15 @@ TEST(TEST_CATEGORY, mdrange_5d) {
   TestMDRange_5D<TEST_EXECSPACE>::test_reduce5(100, 10, 10, 10, 5);
 #endif
   TestMDRange_5D<TEST_EXECSPACE>::test_for5(100, 10, 10, 10, 5);
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
+    defined(KOKKOS_ENABLE_SYCL)
   const int size_x = 2 << 19;  // 2^20
   TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(size_x, 1, 1, 1, 1);
   TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, size_x, 1, 1, 1);
   TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, size_x, 1, 1);
   TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, 1, size_x, 1);
   TestMDRange_5D<TEST_EXECSPACE>::test_for5_eval_once(1, 1, 1, 1, size_x);
+#endif
 }
 
 }  // namespace Test

--- a/core/unit_test/TestMDRange_b.hpp
+++ b/core/unit_test/TestMDRange_b.hpp
@@ -24,6 +24,8 @@ TEST(TEST_CATEGORY, mdrange_6d) {
   TestMDRange_6D<TEST_EXECSPACE>::test_reduce6(100, 10, 10, 10, 5, 5);
 #endif
   TestMDRange_6D<TEST_EXECSPACE>::test_for6(10, 10, 10, 10, 5, 5);
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
+    defined(KOKKOS_ENABLE_SYCL)
   const int size_x = 2 << 19;  // 2^20
   TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(size_x, 1, 1, 1, 1, 1);
   TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, size_x, 1, 1, 1, 1);
@@ -31,6 +33,7 @@ TEST(TEST_CATEGORY, mdrange_6d) {
   TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1, size_x, 1, 1);
   TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1, 1, size_x, 1);
   TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1, 1, 1, size_x);
+#endif
 }
 
 }  // namespace Test

--- a/core/unit_test/TestMDRange_b.hpp
+++ b/core/unit_test/TestMDRange_b.hpp
@@ -24,7 +24,6 @@ TEST(TEST_CATEGORY, mdrange_6d) {
   TestMDRange_6D<TEST_EXECSPACE>::test_reduce6(100, 10, 10, 10, 5, 5);
 #endif
   TestMDRange_6D<TEST_EXECSPACE>::test_for6(10, 10, 10, 10, 5, 5);
-#ifdef KOKKOS_ENABLE_CUDA
   const int size_x = 2 << 19;  // 2^20
   TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(size_x, 1, 1, 1, 1, 1);
   TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, size_x, 1, 1, 1, 1);
@@ -32,7 +31,6 @@ TEST(TEST_CATEGORY, mdrange_6d) {
   TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1, size_x, 1, 1);
   TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1, 1, size_x, 1);
   TestMDRange_6D<TEST_EXECSPACE>::test_for6_eval_once(1, 1, 1, 1, 1, size_x);
-#endif
 }
 
 }  // namespace Test

--- a/core/unit_test/TestMDRange_e.hpp
+++ b/core/unit_test/TestMDRange_e.hpp
@@ -24,13 +24,11 @@ TEST(TEST_CATEGORY, mdrange_4d) {
   TestMDRange_4D<TEST_EXECSPACE>::test_reduce4(100, 10, 10, 10);
 #endif
   TestMDRange_4D<TEST_EXECSPACE>::test_for4(100, 10, 10, 10);
-#ifdef KOKKOS_ENABLE_CUDA
   const int size_x = 2 << 19;  // 2^20
   TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(size_x, 1, 1, 1);
   TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, size_x, 1, 1);
   TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, 1, size_x, 1);
   TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, 1, 1, size_x);
-#endif
 }
 
 }  // namespace Test

--- a/core/unit_test/TestMDRange_e.hpp
+++ b/core/unit_test/TestMDRange_e.hpp
@@ -24,11 +24,14 @@ TEST(TEST_CATEGORY, mdrange_4d) {
   TestMDRange_4D<TEST_EXECSPACE>::test_reduce4(100, 10, 10, 10);
 #endif
   TestMDRange_4D<TEST_EXECSPACE>::test_for4(100, 10, 10, 10);
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
+    defined(KOKKOS_ENABLE_SYCL)
   const int size_x = 2 << 19;  // 2^20
   TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(size_x, 1, 1, 1);
   TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, size_x, 1, 1);
   TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, 1, size_x, 1);
   TestMDRange_4D<TEST_EXECSPACE>::test_for4_eval_once(1, 1, 1, size_x);
+#endif
 }
 
 }  // namespace Test


### PR DESCRIPTION
This PR is a follow up of #7724 and #7868.

### Context

The initial problem, reported in #7697 and detailed in #7724, was that a multidimensional range of rank 4 or more with a high enough number of elements in the first or the second dimension ($(2^{16} - 1) \cdot 2$) was incorrectly iterated, leading to some iterations being evaluated more than once. There was a difference between the maximum number of blocks per grid (aka maximum grid size) used when packing blocks on the host, and the value used when unpacking blocks on the device. The difference stems from the fact that the value was fetched from the API on the host, and hardcoded with one single value for all dimensions and for all GPU backends on the device.

### Fix

#7724 proposed a fix for Cuda only by setting correct hardcoded values, and by providing tests. This PR improves the fix more durably by querying the maximum size of the grid from the API, and by passing it on the device. This way, the same value is used for packing on the host, and for unpacking on the device. This improves the fix for Cuda and now fixes the problem for HIP and SYCL.

### Implementation

To that aim, the signature of the constructor of `Kokkos::Impl::DeviceIterateTile` was changed to allow for an extra argument, only for the Cuda, HIP, and SYCL backends. Maybe it should be extended to all backends for consistency ?

Regarding SYCL, the API does not allow to fetch the maximum size of the grid yet (aka number of work groups). There is currently [a proposal to add it to the specifications](https://github.com/KhronosGroup/SYCL-Docs/pull/712) and two OneAPI extensions ([`sycl_ext_oneapi_max_work_group_query`](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_max_work_group_query.md) and [`sycl_ext_oneapi_launch_queries`](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_launch_queries.asciidoc)). In this PR, the first extension is used if possible, otherwise the fallback is to use the maximum value the current index type can store. This should be updated whenever possible.

For clarity, `maxblocks` on the host and `mdrange_max_blocks` on the device (designing the same thing) were renamed to `max_grid_size` (as both Cuda and HIP APIs name it).

Tests that were introduced by #7724 and restricted to the Cuda backend are now extended for HIP and SYCL. Other backends should not be tested, as the problem only occurs on these three programming models.

In order to make the tests pass on SYCL, the global sizes (i.e. the product of the number of threads per block by the number of blocks per grid) had to be limited to fit within the grid size (i.e. the product of the number of threads per block by the maximum number of blocks per grid), just like it is done with the Cuda and the HIP backends. The mechanism for each thread to then iterate to cover the entire iteration space is already implemented and [common to the three backends](https://github.com/kokkos/kokkos/blob/develop/core/src/impl/KokkosExp_IterateTileGPU.hpp). Especially when using SYCL on an NVIDIA GPU (which is the current SYCL test on Jenkins), this allows to iterate accordingly on dimensions $y$ and $z$ when the number of elements does not fit in $2^{16} - 1$ blocks.

### Progress

- [x] Cuda
- [x] HIP
- [x] SYCL