### PR TITLE
Harmonize error message when building view before initialize or after finalize (CUDA and HIP)

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -500,6 +500,7 @@ void CudaInternal::finalize() {
   KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_free_wrapper(m_scratch_locks)));
   m_scratch_locks     = nullptr;
   m_num_scratch_locks = 0;
+  m_cudaDev           = -1;
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -129,8 +129,7 @@ void HIP::impl_finalize() {
   }
 
   Impl::HIPInternal::singleton().finalize();
-  KOKKOS_IMPL_HIP_SAFE_CALL(
-      hipSetDevice(Impl::HIPInternal::singleton().m_hipDev));
+
   KOKKOS_IMPL_HIP_SAFE_CALL(
       hipStreamDestroy(Impl::HIPInternal::singleton().m_stream));
 }

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -407,7 +407,7 @@ void HIPInternal::finalize() {
   KOKKOS_IMPL_HIP_SAFE_CALL(hip_free_wrapper(m_scratch_locks));
   m_scratch_locks     = nullptr;
   m_num_scratch_locks = 0;
-  m_hipDev = -1;
+  m_hipDev            = -1;
 }
 
 int HIPInternal::m_maxThreadsPerSM = 0;

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -374,8 +374,6 @@ void HIPInternal::finalize() {
   this->fence("Kokkos::HIPInternal::finalize: fence on finalization");
   was_finalized = true;
 
-  KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(m_hipDev));
-
   auto device_mem_space = Kokkos::HIPSpace::impl_create(m_hipDev, m_stream);
   if (nullptr != m_scratchSpace || nullptr != m_scratchFlags) {
     device_mem_space.deallocate(m_scratchFlags,

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -407,6 +407,7 @@ void HIPInternal::finalize() {
   KOKKOS_IMPL_HIP_SAFE_CALL(hip_free_wrapper(m_scratch_locks));
   m_scratch_locks     = nullptr;
   m_num_scratch_locks = 0;
+  m_hipDev = -1;
 }
 
 int HIPInternal::m_maxThreadsPerSM = 0;

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -374,6 +374,8 @@ void HIPInternal::finalize() {
   this->fence("Kokkos::HIPInternal::finalize: fence on finalization");
   was_finalized = true;
 
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(m_hipDev));
+
   auto device_mem_space = Kokkos::HIPSpace::impl_create(m_hipDev, m_stream);
   if (nullptr != m_scratchSpace || nullptr != m_scratchFlags) {
     device_mem_space.deallocate(m_scratchFlags,

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -119,9 +119,8 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
   (void)error_constructing_exec_space_instance;
 
   std::string matcher =
-#if defined(KOKKOS_ENABLE_CUDA) || \
-    defined(KOKKOS_ENABLE_HIP) || \
-    defined(KOKKOS_ENABLE_SYCL) //// These error out early
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
+    defined(KOKKOS_ENABLE_SYCL)  //// These error out early
       error_constructing_exec_space_instance;
 #else
       "Constructing View and initializing data with uninitialized execution "

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -107,9 +107,6 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
       "Kokkos allocation \"v\" is being deallocated after Kokkos::finalize was "
       "called");
   // NOLINTBEGIN(bugprone-unused-local-non-trivial-variable)
-  [[maybe_unused]] std::string error_constructing_view_with_unitialized_exec =
-      "Constructing View and initializing data with uninitialized execution "
-      "space";
   [[maybe_unused]] std::string error_constructing_exec_space_instance =
       std::string("Kokkos::") +
 #ifdef KOKKOS_ENABLE_OPENACC
@@ -118,26 +115,26 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
       Kokkos::DefaultExecutionSpace::name() +
       "::" + Kokkos::DefaultExecutionSpace::name() +
       " instance constructor : ERROR device not initialized";
-  // NOLINTEND(bugprone-unused-local-non-trivial-variable)
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
-    defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENACC)
-  std::string matcher1 = error_constructing_exec_space_instance;
+
+  (void)error_constructing_exec_space_instance;
+
+  std::string matcher =
+#if defined(KOKKOS_ENABLE_CUDA) || \
+    defined(KOKKOS_ENABLE_HIP) || \
+    defined(KOKKOS_ENABLE_SYCL) //// These error out early
+      error_constructing_exec_space_instance;
 #else
-  std::string matcher1 = error_constructing_view_with_unitialized_exec;
+      "Constructing View and initializing data with uninitialized execution "
+      "space";
 #endif
-#if defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENACC)
-  std::string matcher2 = error_constructing_exec_space_instance;
-#else
-  std::string matcher2 = error_constructing_view_with_unitialized_exec;
-#endif
-  EXPECT_DEATH({ Kokkos::View<int*> v("v", 0); }, matcher1);
+
+  EXPECT_DEATH({ Kokkos::View<int*> v("v", 0); }, matcher);
   EXPECT_DEATH(
       {
         Kokkos::initialize();
         Kokkos::finalize();
         Kokkos::View<int*> v("v", 0);
       },
-      matcher2);
+      matcher);
 }
-
 }  // namespace

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -106,27 +106,21 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
       },
       "Kokkos allocation \"v\" is being deallocated after Kokkos::finalize was "
       "called");
-  // NOLINTBEGIN(bugprone-unused-local-non-trivial-variable)
-  [[maybe_unused]] std::string error_constructing_exec_space_instance =
-      std::string("Kokkos::") +
-#ifdef KOKKOS_ENABLE_OPENACC
-      "Experimental::" +
-#endif
-      Kokkos::DefaultExecutionSpace::name() +
-      "::" + Kokkos::DefaultExecutionSpace::name() +
-      " instance constructor : ERROR device not initialized";
 
-  (void)error_constructing_exec_space_instance;
-
-  std::string matcher =
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
-    defined(KOKKOS_ENABLE_SYCL)  //// These error out early
-      error_constructing_exec_space_instance;
+    defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENACC)
+  std::string matcher = std::string("Kokkos::") +
+#ifdef KOKKOS_ENABLE_OPENACC
+                        "Experimental::" +
+#endif
+                        Kokkos::DefaultExecutionSpace::name() +
+                        "::" + Kokkos::DefaultExecutionSpace::name() +
+                        " instance constructor : ERROR device not initialized";
 #else
+  std::string matcher =
       "Constructing View and initializing data with uninitialized execution "
       "space";
 #endif
-
   EXPECT_DEATH({ Kokkos::View<int*> v("v", 0); }, matcher);
   EXPECT_DEATH(
       {
@@ -136,4 +130,5 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
       },
       matcher);
 }
+
 }  // namespace


### PR DESCRIPTION
Sets ` m_cudaDev` to initial value on `CudaInternal::finalize` of execution space instance. 
Notes:
- ~Does not manifest now but does manifest in planned tests~
- Does manifest in current tests
- ~Would become consistent to what we do for HIP~
- HIP and CUDA now correctly set the value to -1