### PR TITLE
Check compiler and linker flags with CMake

### DIFF
--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -993,7 +993,7 @@ function(kokkos_check_flags)
 
   if(INP_LINKER)
     include(CheckLinkerFlag)
-    # temporarily set language flags to nothing ... the linker often can not handle these which leads to false errors
+    # temporarily set language flags to nothing ... the linker often cannot handle these which leads to false errors
     set(CMAKE_${INP_LANGUAGE}_FLAGS "")
     #delete cache so we always do the check
     unset(KOKKOS_LINK_OPTIONS_CHECK CACHE)

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -975,7 +975,7 @@ function(kokkos_check_flags)
 
   #check_compiler/linker_flag requires a whitespace separated list
   string(REPLACE ";" " " WHITESPACE_FLAGS "${INP_FLAGS}")
-  # sycl adds "-device ..." options that need quotes (which CMake removes). We need to add them here again.
+  # icpx adds "-device ..." options that need quotes (which CMake removes). We need to add them here again.
   string(REGEX REPLACE "(-device [A-Za-z0-9_\\\\.]*)" "\"\\1\"" QUOTED_FLAGS "${WHITESPACE_FLAGS}")
 
   if(INP_COMPILER)

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -995,7 +995,7 @@ function(kokkos_check_flags)
     include(CheckLinkerFlag)
     # temporarily set language flags to nothing ... the linker often can not handle these which leads to false errors
     set(CMAKE_${INP_LANGUAGE}_FLAGS "")
-    #disable caching
+    #delete cache so we always do the check
     unset(KOKKOS_LINK_OPTIONS_CHECK CACHE)
     check_linker_flag(${INP_LANGUAGE} "${QUOTED_FLAGS}" KOKKOS_LINK_OPTIONS_CHECK)
     if(NOT KOKKOS_LINK_OPTIONS_CHECK)

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -961,7 +961,7 @@ endfunction()
 #       FLAGS       --> flags to check
 #
 function(kokkos_check_flags)
-  cmake_parse_arguments(INP "COMPILER;LINKER" "" "FLAGS;LANGUAGE" ${ARGN})
+  cmake_parse_arguments(INP "COMPILER;LINKER" "LANGUAGE" "FLAGS" ${ARGN})
 
   # do nothing if no flags are given
   if(NOT INP_FLAGS)

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -994,7 +994,7 @@ function(kokkos_check_flags)
   if(INP_LINKER)
     include(CheckLinkerFlag)
     # temporarily set language flags to nothing ... the linker often can not handle these which leads to false errors
-    unset(CMAKE_${INP_LANGUAGE}_FLAGS)
+    set(CMAKE_${INP_LANGUAGE}_FLAGS "")
     #disable caching
     unset(KOKKOS_LINK_OPTIONS_CHECK CACHE)
     check_linker_flag(${INP_LANGUAGE} "${QUOTED_FLAGS}" KOKKOS_LINK_OPTIONS_CHECK)

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -958,6 +958,7 @@ endfunction()
 #
 #       COMPILER    --> do check for compiler
 #       LINKER      --> do check for linker
+#       LANGUAGE    --> the language for which to check (required)
 #       FLAGS       --> flags to check
 #
 function(kokkos_check_flags)

--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -243,12 +243,13 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
 
   #required for check_linker_flag
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
-      #exclude case of compiler_launcher. The launcher forwards to nvcc_wrapper and shadow the CXX compiler that CMake sees (compiler_launcher changes the compiler).
-      #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags if it is not nvcc_wrapper or clang+cuda.
-      if(NOT (KOKKOS_ENABLE_CUDA) OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper")
-                                            OR (${KOKKOS_CXX_COMPILER_ID} STREQUAL Clang))
-        kokkos_check_flags(LINKER LANGUAGE ${KOKKOS_COMPILE_LANGUAGE} FLAGS ${KOKKOS_LINK_OPTIONS})
-      endif()
+    #exclude case of compiler_launcher. The launcher forwards to nvcc_wrapper and shadow the CXX compiler that CMake sees (compiler_launcher changes the compiler).
+    #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags if it is not nvcc_wrapper or clang+cuda.
+    if(NOT (KOKKOS_ENABLE_CUDA) OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper") OR (${KOKKOS_CXX_COMPILER_ID}
+                                                                                        STREQUAL Clang)
+    )
+      kokkos_check_flags(LINKER LANGUAGE ${KOKKOS_COMPILE_LANGUAGE} FLAGS ${KOKKOS_LINK_OPTIONS})
+    endif()
   endif()
 
   list(APPEND ALL_KOKKOS_COMPILER_FLAGS ${KOKKOS_COMPILE_OPTIONS})

--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -254,7 +254,7 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
         # sycl adds "-device ..." options that need quotes (which CMake removes). We need to add them here again.
         string(REGEX REPLACE "(-device [A-Za-z0-9_\\\\.]*)" "\"\\1\"" QUOTED_FLAGS "${WHITESPACE_FLAGS}")
         # temporarily set language flags to nothing ... the linker often can not handle these which leads to false errors
-        set(FLAGS_CACHE CMAKE_${KOKKOS_COMPILE_LANGUAGE}_FLAGS)
+        set(FLAGS_CACHE "${CMAKE_${KOKKOS_COMPILE_LANGUAGE}_FLAGS}")
         set(CMAKE_${KOKKOS_COMPILE_LANGUAGE}_FLAGS "")
         #disable caching
         unset(KOKKOS_LINK_OPTIONS_CHECK CACHE)

--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -244,10 +244,10 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
     if(KOKKOS_LINK_OPTIONS)
       include(CheckLinkerFlag)
-      #exclude case of compiler_launcher forwarding to nvcc_wrapper as the used CXX compiler is shadowed in this case (compiler_launcher changes the compiler).
-      #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags.
-      if(NOT (KOKKOS_ENABLE_CUDA) OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper") OR (${KOKKOS_CXX_COMPILER_ID}
-                                                                                          STREQUAL Clang)
+      #exclude case of compiler_launcher. The launcher forwards to nvcc_wrapper and shadow the CXX compiler that CMake sees (compiler_launcher changes the compiler).
+      #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags if it is not nvcc_wrapper or clang+cuda.
+      if(NOT ((KOKKOS_ENABLE_CUDA) AND NOT (("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper")
+                                            OR (${KOKKOS_CXX_COMPILER_ID} STREQUAL Clang)))
       )
         #check_linker_flag requires a whitespace separated list
         string(REPLACE ";" " " WHITESPACE_FLAGS "${KOKKOS_LINKER_OPTIONS}")
@@ -294,8 +294,8 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
       ${LIBRARY_NAME} PUBLIC $<$<COMPILE_LANGUAGE:${KOKKOS_COMPILE_LANGUAGE}>:${NODEDUP_CUDAFE_OPTIONS}>
     )
 
-    #exclude case of compiler_launcher forwarding to nvcc_wrapper as the used CXX compiler is shadowed in this case (compiler_launcher changes the compiler).
-    #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags.
+    #exclude case of compiler_launcher. The launcher forwards to nvcc_wrapper and shadow the CXX compiler that CMake sees (compiler_launcher changes the compiler).
+    #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags if it is not nvcc_wrapper or clang+cuda.
     if(KOKKOS_ENABLE_COMPILE_AS_CMAKE_LANGUAGE OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper")
        OR (${KOKKOS_CXX_COMPILER_ID} STREQUAL Clang)
     )

--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -254,7 +254,7 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
         # sycl adds "-device ..." options that need quotes (which CMake removes). We need to add them here again.
         string(REGEX REPLACE "(-device [A-Za-z0-9_\\\\.]*)" "\"\\1\"" QUOTED_FLAGS "${WHITESPACE_FLAGS}")
         # temporarily set language flags to nothing ... the linker often can not handle these which leads to false errors
-        set(FLAGS_CACHE CMAKE_${KOKKOS_COMPILE_LANGUAGE_FLAGS})
+        set(FLAGS_CACHE CMAKE_${KOKKOS_COMPILE_LANGUAGE}_FLAGS)
         set(CMAKE_${KOKKOS_COMPILE_LANGUAGE}_FLAGS "")
         #disable caching
         unset(KOKKOS_LINK_OPTIONS_CHECK CACHE)


### PR DESCRIPTION
This PR implements a check for the flags that we set for the libs `Kokkos::kokkos etc.` at configure time.
It allows large projects that build Kokkos in-tree to check if a set of `CMAKE_CXX_FLAGS` and the flags Kokkos adds are non compatible at configure time.

Caveats:

-  It only fully works with CMake >=3.19 for the compiler and >=3.18 for the linker check.
- When using `kokkos_launch_compiler` no checks are performed as CMake does not use launchers for the flag check.
- When building against an installed Kokkos, this check is not active.