### PR TITLE
Cuda, HIP: Fix parallel_for with more than 2^32 work items

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -73,8 +73,8 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
     const auto work_stride = Member(blockDim.y) * gridDim.x;
     const Member work_end  = m_policy.end();
 
-    for (Member iwork =
-             m_policy.begin() + threadIdx.y + blockDim.y * blockIdx.x;
+    for (Member iwork = m_policy.begin() + threadIdx.y +
+                        static_cast<Member>(blockDim.y) * blockIdx.x;
          iwork < work_end;
          iwork = iwork < static_cast<Member>(work_end - work_stride)
                      ? iwork + work_stride

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
@@ -61,8 +61,8 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::HIP> {
     const auto work_stride = Member(blockDim.y) * gridDim.x;
     const Member work_end  = m_policy.end();
 
-    for (Member iwork =
-             m_policy.begin() + threadIdx.y + blockDim.y * blockIdx.x;
+    for (Member iwork = m_policy.begin() + threadIdx.y +
+                        static_cast<Member>(blockDim.y) * blockIdx.x;
          iwork < work_end;
          iwork = iwork < static_cast<Member>(work_end - work_stride)
                      ? iwork + work_stride


### PR DESCRIPTION
Fixes #7890. This time `blockDim.y * blockIdx.x` did overflow.