### PR TITLE
[C++20 modules] Make sure some symbols have external linkage.

### DIFF
--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -19,7 +19,7 @@ NVIDIA-RTX5080:
     - export CMAKE_BUILD_PARALLEL_LEVEL=32
     - export ENV_CMAKE_OPTIONS=""
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_COMPILER=`pwd`/bin/nvcc_wrapper"
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Werror=all-warnings -Werror'"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Werror=all-warnings -Werror -Wno-attributes'"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_BLACKWELL120=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_AMD_ZEN5=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_CUDA=ON;"

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -49,11 +49,9 @@ struct AUTO_t {
   constexpr const AUTO_t &operator()() const { return *this; }
 };
 
-namespace {
 /**\brief Token to indicate that a parameter's value is to be automatically
  * selected */
-constexpr AUTO_t AUTO = Kokkos::AUTO_t();
-}  // namespace
+inline const AUTO_t AUTO = Kokkos::AUTO_t();
 
 struct InvalidType {};
 

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -51,7 +51,7 @@ struct AUTO_t {
 
 /**\brief Token to indicate that a parameter's value is to be automatically
  * selected */
-inline const AUTO_t AUTO = Kokkos::AUTO_t();
+inline constexpr AUTO_t AUTO{};
 
 struct InvalidType {};
 


### PR DESCRIPTION
I have been playing with using C++20 modules for deal.II (the full effort is documented here: https://github.com/dealii/dealii/issues/18071). One of the things that you find out when you do this is that header files are perhaps allowed when using modules, but that they really don't play nice. You can't use external libraries that are not modularized themselves. As a consequence, you have to wrap every external library you build on into a module (or module partition) itself. For Kokkos, this then looks as follows:
```
module;

#include <deal.II/base/config.h>

#include <Kokkos_Macros.hpp>
#if KOKKOS_VERSION >= 40200
#  include <Kokkos_Abort.hpp>
#else
#  include <Kokkos_Core.hpp>
#endif
#include <Kokkos_Array.hpp>
#include <Kokkos_Core.hpp>
#include <Kokkos_Core_fwd.hpp>
#include <Kokkos_DualView.hpp>
#include <Kokkos_Macros.hpp>

export module dealii:interface_partition_kokkos;
export
{
  namespace Kokkos
  {
    using Kokkos::abort;
    using Kokkos::abs;
    using Kokkos::ALL;
    using Kokkos::Array;
    using Kokkos::atomic_add;
    using Kokkos::AUTO;
    using Kokkos::finalize;

   [... many more symbols ...]
```
Among the symbols I need to be able to read in from a header file and then re-export is `Kokkos::AUTO`, which unfortunately is declared in a header file as
```
namespace {
  constexpr AUTO_t AUTO = Kokkos::AUTO_t();
}
```
Both the anonymous namespace and the `constexpr` implies that this is a symbol that has *internal* linkage -- in other words, it is replicated in every file that is compiled and that `#include`s this header file. The issue is that you can't use-and-reexport internal symbols. You can only do that with stuff that has external linkage.

This patch achieves this by naming the namespace and replacing the declaration of `AUTO` by
```
namespace Constants {
  inline const AUTO_t AUTO = Kokkos::AUTO_t();
}
using Constants::AUTO;
```
(Obviously the naming of the namespace is debatable.) From the user perspective, this has the same end result -- the variable is `const` -- but because it is declared as `inline` it has external linkage in the same way as `inline` functions have external linkage: The compiler replicates them in each translation unit, but marks them as "weak", and the linker then unifies it all into a single copy. 

`inline` variables are a C++17 thing, so this should be ok with current Kokkos dev. 

(I will note that in previous Kokkos versions, there were several more symbols that had that problem; specifically, these:
```
Kokkos::ALL;
Kokkos::WithoutInitializing;
Kokkos::AllowPadding;
```
These have all disappeared sometime between 3.7.0 and now, however.)