### PR TITLE
DualView: Clean-up code

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -606,11 +606,9 @@ class DualView : public ViewTraits<DataType, Properties...> {
       //    space");
       return;
     } else {
-      if constexpr (std::is_same_v<typename traits::data_type,
-                                   typename traits::non_const_data_type>)
-        sync_impl<Device>(std::true_type{});
-      else
-        sync_impl<Device>(std::false_type{});
+      sync_impl<Device>(
+          typename std::is_same<typename traits::data_type,
+                                typename traits::non_const_data_type>::type{});
     }
   }
 
@@ -619,11 +617,10 @@ class DualView : public ViewTraits<DataType, Properties...> {
     if constexpr (impl_dualview_is_single_device)
       return;
     else {
-      if constexpr (std::is_same_v<typename traits::data_type,
-                                   typename traits::non_const_data_type>)
-        sync_impl<Device>(std::true_type{}, exec);
-      else
-        sync_impl<Device>(std::false_type{}, exec);
+      sync_impl<Device>(
+          typename std::is_same<typename traits::data_type,
+                                typename traits::non_const_data_type>::type{},
+          exec);
     }
   }
 

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -90,7 +90,7 @@ struct test_dualview_copy_construction_and_assignment {
 
     // We can't test shallow equality of modified_flags because it's protected.
     // So we test it indirectly through sync state behavior.
-    if (!std::decay_t<SrcViewType>::impl_dualview_is_single_device) {
+    if (!SrcViewType::impl_dualview_is_single_device) {
       a.clear_sync_state();
       a.modify_host();
       ASSERT_TRUE(a.need_sync_device());

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -87,6 +87,17 @@ struct test_dualview_copy_construction_and_assignment {
 
     ASSERT_EQ(a.view_host(), c.view_host());
     ASSERT_EQ(a.view_device(), c.view_device());
+
+    // We can't test shallow equality of modified_flags because it's protected.
+    // So we test it indirectly through sync state behavior.
+    if (!std::decay_t<SrcViewType>::impl_dualview_stores_single_view) {
+      a.clear_sync_state();
+      a.modify_host();
+      ASSERT_TRUE(a.need_sync_device());
+      ASSERT_TRUE(b.need_sync_device());
+      ASSERT_TRUE(c.need_sync_device());
+      a.clear_sync_state();
+    }
   }
 };
 
@@ -528,9 +539,6 @@ void test_dualview_sync_should_fence() {
 }
 
 TEST(TEST_CATEGORY, dualview_sync_should_fence) {
-#ifdef KOKKOS_ENABLE_HPX  // FIXME
-  GTEST_SKIP() << "Known to fail with HPX";
-#endif
   test_dualview_sync_should_fence<TEST_EXECSPACE>();
 }
 
@@ -552,6 +560,34 @@ TEST(TEST_CATEGORY, dualview_resize) {
   Impl::test_dualview_resize<NoDefaultConstructor, TEST_EXECSPACE,
                              /* Initialize */ false>();
 }
+
+template <typename ExecutionSpace>
+void check_dualview_external_view_construction() {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  Kokkos::View<int*, ExecutionSpace> view1("view1", 10);
+  Kokkos::View<int*, ExecutionSpace> view2("view2", 10);
+
+  Kokkos::DualView<int*, ExecutionSpace> v_dual(view1, view1);
+  ASSERT_DEATH(
+      (Kokkos::DualView<int*, ExecutionSpace>(view1, view2)),
+      "DualView storing one View constructed from two different Views");
+}
+
+// FIXME_MSVC+CUDA error C2094: label 'gtest_label_520' was undefined
+#if !(defined(KOKKOS_COMPILER_MSVC) && defined(KOKKOS_ENABLE_CUDA))
+TEST(TEST_CATEGORY_DEATH, dualview_external_view_construction) {
+  if constexpr (!Kokkos::DualView<
+                    int*, TEST_EXECSPACE>::impl_dualview_stores_single_view) {
+    GTEST_SKIP() << "test only relevant if DualView uses one allocation";
+  } else {
+    // FIXME_CLANG We can't inline the function because recent clang versions
+    // would deduce that a static_assert isn't satisfied for TEST_EXECSPACE.
+    // Thus, we need to template the function on the execution space.
+    check_dualview_external_view_construction<TEST_EXECSPACE>();
+  }
+}
+#endif
 
 namespace {
 /**

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -90,7 +90,7 @@ struct test_dualview_copy_construction_and_assignment {
 
     // We can't test shallow equality of modified_flags because it's protected.
     // So we test it indirectly through sync state behavior.
-    if (!std::decay_t<SrcViewType>::impl_dualview_stores_single_view) {
+    if (!std::decay_t<SrcViewType>::impl_dualview_is_single_device) {
       a.clear_sync_state();
       a.modify_host();
       ASSERT_TRUE(a.need_sync_device());
@@ -539,6 +539,9 @@ void test_dualview_sync_should_fence() {
 }
 
 TEST(TEST_CATEGORY, dualview_sync_should_fence) {
+#ifdef KOKKOS_ENABLE_HPX  // FIXME_DUALVIEW_ASYNCHRONOUS_BACKENDS
+  GTEST_SKIP() << "Known to fail with HPX";
+#endif
   test_dualview_sync_should_fence<TEST_EXECSPACE>();
 }
 
@@ -578,7 +581,7 @@ void check_dualview_external_view_construction() {
 #if !(defined(KOKKOS_COMPILER_MSVC) && defined(KOKKOS_ENABLE_CUDA))
 TEST(TEST_CATEGORY_DEATH, dualview_external_view_construction) {
   if constexpr (!Kokkos::DualView<
-                    int*, TEST_EXECSPACE>::impl_dualview_stores_single_view) {
+                    int*, TEST_EXECSPACE>::impl_dualview_is_single_device) {
     GTEST_SKIP() << "test only relevant if DualView uses one allocation";
   } else {
     // FIXME_CLANG We can't inline the function because recent clang versions


### PR DESCRIPTION
~~Alternative to #7897. This pull request proposes to revert https://github.com/kokkos/kokkos/pull/7775 for the most part (by keeping the same skip conditions as in the previous release) to avoid introducing too many fences accepting to keep usage with asynchronous backends that skip `modify` and `sync` continue to be broken.~~
After reverting most `DualView` changes in the last release in #7897. This pull request restores the code cleanup without changing behavior.