### PR TITLE
Start CEA nightly tests earlier

### DIFF
--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -2,7 +2,7 @@ name: Nightly CEA builds
 
 on:
   schedule:
-    - cron: "0 2 * * 1-5" # every weekday at 2am UTC
+    - cron: "0 0 * * 1-5" # every weekday at midnight UTC
 
 permissions: read-all
 


### PR DESCRIPTION
This PR aims to start the nightly CEA tests earlier, as #7859 made it sometimes finish too late in the morning (passed 8am). The CI is now triggered at midnight.