### PR TITLE
SIMD: Avoid implicitly capturing this with copy capture

### DIFF
--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -2005,19 +2005,21 @@ class where_expression<basic_simd_mask<double, simd_abi::neon_fixed_size<2>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, element_aligned_tag) {
-    m_value = value_type(
-        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type([mem, this](std::size_t i) {
+      return (m_mask[i]) ? mem[i] : m_value[i];
+    });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, vector_aligned_tag) {
-    m_value = value_type(
-        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type([mem, this](std::size_t i) {
+      return (m_mask[i]) ? mem[i] : m_value[i];
+    });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       double const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
-    m_value = value_type([=](std::size_t i) {
+    m_value = value_type([index, mem, this](std::size_t i) {
       return (m_mask[i]) ? mem[index[i]] : m_value[i];
     });
   }
@@ -2096,18 +2098,20 @@ class where_expression<basic_simd_mask<float, simd_abi::neon_fixed_size<2>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
-    m_value = value_type(
-        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type([mem, this](std::size_t i) {
+      return (m_mask[i]) ? mem[i] : m_value[i];
+    });
   }
   void copy_from(float const* mem, vector_aligned_tag) {
-    m_value = value_type(
-        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type([mem, this](std::size_t i) {
+      return (m_mask[i]) ? mem[i] : m_value[i];
+    });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
-    m_value = value_type([=](std::size_t i) {
+    m_value = value_type([index, mem, this](std::size_t i) {
       return (m_mask[i]) ? mem[index[i]] : m_value[i];
     });
   }
@@ -2192,19 +2196,21 @@ class where_expression<basic_simd_mask<float, simd_abi::neon_fixed_size<4>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
-    m_value = value_type(
-        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type([mem, this](std::size_t i) {
+      return (m_mask[i]) ? mem[i] : m_value[i];
+    });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, vector_aligned_tag) {
-    m_value = value_type(
-        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type([mem, this](std::size_t i) {
+      return (m_mask[i]) ? mem[i] : m_value[i];
+    });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) {
-    m_value = value_type([=](std::size_t i) {
+    m_value = value_type([index, mem, this](std::size_t i) {
       return (m_mask[i]) ? mem[index[i]] : m_value[i];
     });
   }
@@ -2286,20 +2292,22 @@ class where_expression<
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
-    m_value = value_type(
-        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type([mem, this](std::size_t i) {
+      return (m_mask[i]) ? mem[i] : m_value[i];
+    });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, vector_aligned_tag) {
-    m_value = value_type(
-        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type([mem, this](std::size_t i) {
+      return (m_mask[i]) ? mem[i] : m_value[i];
+    });
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
-    m_value = value_type([=](std::size_t i) {
+    m_value = value_type([index, mem, this](std::size_t i) {
       return (m_mask[i]) ? mem[index[i]] : m_value[i];
     });
   }
@@ -2387,19 +2395,21 @@ class where_expression<
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
-    m_value = value_type(
-        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type([mem, this](std::size_t i) {
+      return (m_mask[i]) ? mem[i] : m_value[i];
+    });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, vector_aligned_tag) {
-    m_value = value_type(
-        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type([mem, this](std::size_t i) {
+      return (m_mask[i]) ? mem[i] : m_value[i];
+    });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) {
-    m_value = value_type([=](std::size_t i) {
+    m_value = value_type([mem, index, this](std::size_t i) {
       return (m_mask[i]) ? mem[index[i]] : m_value[i];
     });
   }
@@ -2481,20 +2491,22 @@ class where_expression<
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int64_t const* mem, element_aligned_tag) {
-    m_value = value_type(
-        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type([mem, this](std::size_t i) {
+      return (m_mask[i]) ? mem[i] : m_value[i];
+    });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int64_t const* mem, vector_aligned_tag) {
-    m_value = value_type(
-        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type([mem, this](std::size_t i) {
+      return (m_mask[i]) ? mem[i] : m_value[i];
+    });
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int64_t const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
-    m_value = value_type([=](std::size_t i) {
+    m_value = value_type([index, mem, this](std::size_t i) {
       return (m_mask[i]) ? mem[index[i]] : m_value[i];
     });
   }
@@ -2578,20 +2590,22 @@ class where_expression<
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::uint64_t const* mem, element_aligned_tag) {
-    m_value = value_type(
-        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type([mem, this](std::size_t i) {
+      return (m_mask[i]) ? mem[i] : m_value[i];
+    });
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::uint64_t const* mem, vector_aligned_tag) {
-    m_value = value_type(
-        [=](std::size_t i) { return (m_mask[i]) ? mem[i] : m_value[i]; });
+    m_value = value_type([mem, this](std::size_t i) {
+      return (m_mask[i]) ? mem[i] : m_value[i];
+    });
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint64_t const* mem,
       basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
-    m_value = value_type([=](std::size_t i) {
+    m_value = value_type([index, mem, this](std::size_t i) {
       return (m_mask[i]) ? mem[index[i]] : m_value[i];
     });
   }


### PR DESCRIPTION
`clang` with C++20 complains about implicit `this` captures with copy capture default bein deprecated while just adding `this` to the capture list makes clang with `C++17` complain that we are using a c++20 extension.
Making the capture variables explicit, makes both configurations happy.