### PR TITLE
Add memory information functions for device

### DIFF
--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -107,9 +107,6 @@ void declare_configuration_metadata(const std::string& category,
 [[nodiscard]] int num_devices() noexcept;
 [[nodiscard]] int num_threads() noexcept;
 
-[[nodiscard]] size_t free_device_memory() noexcept;
-[[nodiscard]] size_t total_device_memory() noexcept;
-
 bool show_warnings() noexcept;
 bool tune_internals() noexcept;
 
@@ -142,6 +139,9 @@ void fence(const std::string& name /*= "Kokkos::fence: Unnamed Global Fence"*/);
 
 /** \brief Print "Bill of Materials" */
 void print_configuration(std::ostream& os, bool verbose = false);
+
+// Free and total memory on the device
+std::pair<std::size_t, std::size_t> device_memory_info(int n_streams = 1);
 
 }  // namespace Kokkos
 

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -107,6 +107,9 @@ void declare_configuration_metadata(const std::string& category,
 [[nodiscard]] int num_devices() noexcept;
 [[nodiscard]] int num_threads() noexcept;
 
+[[nodiscard]] size_t free_device_memory() noexcept;
+[[nodiscard]] size_t total_device_memory() noexcept;
+
 bool show_warnings() noexcept;
 bool tune_internals() noexcept;
 

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -141,7 +141,7 @@ void fence(const std::string& name /*= "Kokkos::fence: Unnamed Global Fence"*/);
 void print_configuration(std::ostream& os, bool verbose = false);
 
 // Free and total memory on the device
-std::pair<std::size_t, std::size_t> device_memory_info(int n_streams = 1);
+std::pair<std::size_t, std::size_t> device_memory_info();
 
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -208,18 +208,15 @@ std::vector<int> const& Kokkos::Impl::get_visible_devices() {
   }
 }
 
-std::pair<std::size_t, std::size_t> Kokkos::device_memory_info(int n_streams) {
-  using ExecSpace          = Kokkos::DefaultExecutionSpace;
+std::pair<std::size_t, std::size_t> Kokkos::device_memory_info() {
   std::size_t free_memory  = 0;
   std::size_t total_memory = 0;
 
-  if (std::is_same_v<ExecSpace, Kokkos::DefaultHostExecutionSpace>) {
+  using memory_space = typename Kokkos::DefaultExecutionSpace::memory_space;
+  if (std::is_same_v<memory_space, Kokkos::DefaultHostExecutionSpace>) {
     return {free_memory, total_memory};
   }
-
-  using MemorySpace = typename ExecSpace::memory_space;
-  Kokkos::Impl::get_free_total_memory<MemorySpace>(free_memory, total_memory,
-                                                   n_streams);
+  Kokkos::Impl::get_free_total_memory<memory_space>(free_memory, total_memory);
 
   return {free_memory, total_memory};
 }

--- a/core/src/impl/Kokkos_DeviceUtils.hpp
+++ b/core/src/impl/Kokkos_DeviceUtils.hpp
@@ -18,159 +18,55 @@
 #define KOKKOS_DEVICE_UTILS_HPP
 
 #include <cstddef>
+#include <vector>
 #include <utility>
 
 namespace Kokkos {
 namespace Impl {
 
 // Host function to determine free and total device memory.
-// Will throw if execution space doesn't support this.
 template <typename MemorySpace>
 inline void get_free_total_memory(size_t& /* free_mem */,
                                   size_t& /* total_mem */) {}
 
-// Host function to determine free and total device memory.
-// Will throw if execution space doesn't support this.
-template <typename MemorySpace>
-inline void get_free_total_memory(size_t& /* free_mem */,
-                                  size_t& /* total_mem */,
-                                  int /* n_streams */) {}
-
 #ifdef KOKKOS_ENABLE_CUDA
 template <>
 inline void get_free_total_memory<Kokkos::CudaSpace>(size_t& free_mem,
-                                                     size_t& total_mem,
-                                                     int n_streams) {
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemGetInfo(&free_mem, &total_mem));
-  free_mem /= n_streams;
-  total_mem /= n_streams;
-}
-template <>
-inline void get_free_total_memory<Kokkos::CudaSpace>(size_t& free_mem,
                                                      size_t& total_mem) {
-  get_free_total_memory<Kokkos::CudaSpace>(free_mem, total_mem, 1);
-}
-template <>
-inline void get_free_total_memory<Kokkos::CudaUVMSpace>(size_t& free_mem,
-                                                        size_t& total_mem,
-                                                        int n_streams) {
-  get_free_total_memory<Kokkos::CudaSpace>(free_mem, total_mem, n_streams);
-}
-template <>
-inline void get_free_total_memory<Kokkos::CudaUVMSpace>(size_t& free_mem,
-                                                        size_t& total_mem) {
-  get_free_total_memory<Kokkos::CudaUVMSpace>(free_mem, total_mem, 1);
-}
-template <>
-inline void get_free_total_memory<Kokkos::CudaHostPinnedSpace>(
-    size_t& free_mem, size_t& total_mem, int n_streams) {
-  get_free_total_memory<Kokkos::CudaSpace>(free_mem, total_mem, n_streams);
-}
-template <>
-inline void get_free_total_memory<Kokkos::CudaHostPinnedSpace>(
-    size_t& free_mem, size_t& total_mem) {
-  get_free_total_memory<Kokkos::CudaHostPinnedSpace>(free_mem, total_mem, 1);
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemGetInfo(&free_mem, &total_mem));
 }
 #endif
 
 #ifdef KOKKOS_ENABLE_HIP
 template <>
 inline void get_free_total_memory<Kokkos::HIPSpace>(size_t& free_mem,
-                                                    size_t& total_mem,
-                                                    int n_streams) {
-  KOKKOS_IMPL_HIP_SAFE_CALL(hipMemGetInfo(&free_mem, &total_mem));
-  free_mem /= n_streams;
-  total_mem /= n_streams;
-}
-template <>
-inline void get_free_total_memory<Kokkos::HIPManagedSpace>(size_t& free_mem,
-                                                           size_t& total_mem,
-                                                           int n_streams) {
-  get_free_total_memory<Kokkos::HIPSpace>(free_mem, total_mem, n_streams);
-}
-template <>
-inline void get_free_total_memory<Kokkos::HIPSpace>(size_t& free_mem,
                                                     size_t& total_mem) {
-  get_free_total_memory<Kokkos::HIPSpace>(free_mem, total_mem, 1);
-}
-template <>
-inline void get_free_total_memory<Kokkos::HIPManagedSpace>(size_t& free_mem,
-                                                           size_t& total_mem) {
-  get_free_total_memory<Kokkos::HIPSpace>(free_mem, total_mem, 1);
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipMemGetInfo(&free_mem, &total_mem));
 }
 #endif
 
-// FIXME_SYCL Use compiler extension instead of low level interface when
-// available. Also, we assume to query memory associated with the default queue.
-#if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_ARCH_INTEL_GPU)
-template <>
-inline void get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(size_t& free_mem,
-                                                              size_t& total_mem,
-                                                              int n_streams) {
-  sycl::queue queue;
-  sycl::device device = queue.get_device();
-  auto level_zero_handle =
-      sycl::get_native<sycl::backend::ext_oneapi_level_zero>(device);
-
-  uint32_t n_memory_modules = 0;
-  zesDeviceEnumMemoryModules(level_zero_handle, &n_memory_modules, nullptr);
-
-  if (n_memory_modules == 0) {
-    throw std::runtime_error(
-        "Error: No memory modules for the SYCL backend found. Make sure that "
-        "ZES_ENABLE_SYSMAN=1 is set at run time!");
-  }
-
-  total_mem = 0;
-  free_mem  = 0;
-  std::vector<zes_mem_handle_t> mem_handles(n_memory_modules);
-  zesDeviceEnumMemoryModules(level_zero_handle, &n_memory_modules,
-                             mem_handles.data());
-
-  for (auto& mem_handle : mem_handles) {
-    zes_mem_properties_t memory_properties{ZES_STRUCTURE_TYPE_MEM_PROPERTIES};
-    zesMemoryGetProperties(mem_handle, &memory_properties);
-    // Only report HBM which zeMemAllocDevice allocates from.
-    if (memory_properties.type != ZES_MEM_TYPE_HBM) continue;
-
-    zes_mem_state_t memory_states{ZES_STRUCTURE_TYPE_MEM_STATE};
-    zesMemoryGetState(mem_handle, &memory_states);
-    total_mem += memory_states.size;
-    free_mem += memory_states.free;
-  }
-  free_mem /= n_streams;
-  total_mem /= n_streams;
-}
-
+#if defined(KOKKOS_ENABLE_SYCL)
 template <>
 inline void get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(
     size_t& free_mem, size_t& total_mem) {
-  get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(free_mem, total_mem, 1);
-}
+  std::vector<sycl::device> devices = Kokkos::Impl::get_sycl_devices();
+  if (devices.empty()) {
+    return;
+  }
+  int device_id = Kokkos::Impl::SYCLInternal::m_syclDev;
+  if (device_id < 0 || device_id >= static_cast<int>(devices.size())) {
+    return;
+  }
+  auto device = devices[Impl::SYCLInternal::m_syclDev];
 
-template <>
-inline void get_free_total_memory<Kokkos::SYCLHostUSMSpace>(size_t& free_mem,
-                                                            size_t& total_mem,
-                                                            int n_streams) {
-  get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(free_mem, total_mem,
-                                                    n_streams);
-}
-template <>
-inline void get_free_total_memory<Kokkos::SYCLHostUSMSpace>(size_t& free_mem,
-                                                            size_t& total_mem) {
-  get_free_total_memory<Kokkos::SYCLHostUSMSpace>(free_mem, total_mem, 1);
-}
-template <>
-inline void get_free_total_memory<Kokkos::SYCLSharedUSMSpace>(size_t& free_mem,
-                                                              size_t& total_mem,
-                                                              int n_streams) {
-  get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(free_mem, total_mem,
-                                                    n_streams);
-}
-template <>
-inline void get_free_total_memory<Kokkos::SYCLSharedUSMSpace>(
-    size_t& free_mem, size_t& total_mem) {
-  get_free_total_memory<Kokkos::SYCLSharedUSMSpace>(free_mem, total_mem, 1);
+  total_mem = 0;
+  free_mem  = 0;
+  if (device.is_gpu()) {
+    if (device.has(sycl::aspect::ext_intel_free_memory)) {
+      free_mem = device.get_info<sycl::ext::intel::info::device::free_memory>();
+      total_mem = device.get_info<sycl::info::device::global_mem_size>();
+    }
+  }
 }
 #endif
 

--- a/core/src/impl/Kokkos_DeviceUtils.hpp
+++ b/core/src/impl/Kokkos_DeviceUtils.hpp
@@ -1,0 +1,180 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_DEVICE_UTILS_HPP
+#define KOKKOS_DEVICE_UTILS_HPP
+
+#include <cstddef>
+#include <utility>
+
+namespace Kokkos {
+namespace Impl {
+
+// Host function to determine free and total device memory.
+// Will throw if execution space doesn't support this.
+template <typename MemorySpace>
+inline void get_free_total_memory(size_t& /* free_mem */,
+                                  size_t& /* total_mem */) {}
+
+// Host function to determine free and total device memory.
+// Will throw if execution space doesn't support this.
+template <typename MemorySpace>
+inline void get_free_total_memory(size_t& /* free_mem */,
+                                  size_t& /* total_mem */,
+                                  int /* n_streams */) {}
+
+#ifdef KOKKOS_ENABLE_CUDA
+template <>
+inline void get_free_total_memory<Kokkos::CudaSpace>(size_t& free_mem,
+                                                     size_t& total_mem,
+                                                     int n_streams) {
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemGetInfo(&free_mem, &total_mem));
+  free_mem /= n_streams;
+  total_mem /= n_streams;
+}
+template <>
+inline void get_free_total_memory<Kokkos::CudaSpace>(size_t& free_mem,
+                                                     size_t& total_mem) {
+  get_free_total_memory<Kokkos::CudaSpace>(free_mem, total_mem, 1);
+}
+template <>
+inline void get_free_total_memory<Kokkos::CudaUVMSpace>(size_t& free_mem,
+                                                        size_t& total_mem,
+                                                        int n_streams) {
+  get_free_total_memory<Kokkos::CudaSpace>(free_mem, total_mem, n_streams);
+}
+template <>
+inline void get_free_total_memory<Kokkos::CudaUVMSpace>(size_t& free_mem,
+                                                        size_t& total_mem) {
+  get_free_total_memory<Kokkos::CudaUVMSpace>(free_mem, total_mem, 1);
+}
+template <>
+inline void get_free_total_memory<Kokkos::CudaHostPinnedSpace>(
+    size_t& free_mem, size_t& total_mem, int n_streams) {
+  get_free_total_memory<Kokkos::CudaSpace>(free_mem, total_mem, n_streams);
+}
+template <>
+inline void get_free_total_memory<Kokkos::CudaHostPinnedSpace>(
+    size_t& free_mem, size_t& total_mem) {
+  get_free_total_memory<Kokkos::CudaHostPinnedSpace>(free_mem, total_mem, 1);
+}
+#endif
+
+#ifdef KOKKOS_ENABLE_HIP
+template <>
+inline void get_free_total_memory<Kokkos::HIPSpace>(size_t& free_mem,
+                                                    size_t& total_mem,
+                                                    int n_streams) {
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipMemGetInfo(&free_mem, &total_mem));
+  free_mem /= n_streams;
+  total_mem /= n_streams;
+}
+template <>
+inline void get_free_total_memory<Kokkos::HIPManagedSpace>(size_t& free_mem,
+                                                           size_t& total_mem,
+                                                           int n_streams) {
+  get_free_total_memory<Kokkos::HIPSpace>(free_mem, total_mem, n_streams);
+}
+template <>
+inline void get_free_total_memory<Kokkos::HIPSpace>(size_t& free_mem,
+                                                    size_t& total_mem) {
+  get_free_total_memory<Kokkos::HIPSpace>(free_mem, total_mem, 1);
+}
+template <>
+inline void get_free_total_memory<Kokkos::HIPManagedSpace>(size_t& free_mem,
+                                                           size_t& total_mem) {
+  get_free_total_memory<Kokkos::HIPSpace>(free_mem, total_mem, 1);
+}
+#endif
+
+// FIXME_SYCL Use compiler extension instead of low level interface when
+// available. Also, we assume to query memory associated with the default queue.
+#if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_ARCH_INTEL_GPU)
+template <>
+inline void get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(size_t& free_mem,
+                                                              size_t& total_mem,
+                                                              int n_streams) {
+  sycl::queue queue;
+  sycl::device device = queue.get_device();
+  auto level_zero_handle =
+      sycl::get_native<sycl::backend::ext_oneapi_level_zero>(device);
+
+  uint32_t n_memory_modules = 0;
+  zesDeviceEnumMemoryModules(level_zero_handle, &n_memory_modules, nullptr);
+
+  if (n_memory_modules == 0) {
+    throw std::runtime_error(
+        "Error: No memory modules for the SYCL backend found. Make sure that "
+        "ZES_ENABLE_SYSMAN=1 is set at run time!");
+  }
+
+  total_mem = 0;
+  free_mem  = 0;
+  std::vector<zes_mem_handle_t> mem_handles(n_memory_modules);
+  zesDeviceEnumMemoryModules(level_zero_handle, &n_memory_modules,
+                             mem_handles.data());
+
+  for (auto& mem_handle : mem_handles) {
+    zes_mem_properties_t memory_properties{ZES_STRUCTURE_TYPE_MEM_PROPERTIES};
+    zesMemoryGetProperties(mem_handle, &memory_properties);
+    // Only report HBM which zeMemAllocDevice allocates from.
+    if (memory_properties.type != ZES_MEM_TYPE_HBM) continue;
+
+    zes_mem_state_t memory_states{ZES_STRUCTURE_TYPE_MEM_STATE};
+    zesMemoryGetState(mem_handle, &memory_states);
+    total_mem += memory_states.size;
+    free_mem += memory_states.free;
+  }
+  free_mem /= n_streams;
+  total_mem /= n_streams;
+}
+
+template <>
+inline void get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(
+    size_t& free_mem, size_t& total_mem) {
+  get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(free_mem, total_mem, 1);
+}
+
+template <>
+inline void get_free_total_memory<Kokkos::SYCLHostUSMSpace>(size_t& free_mem,
+                                                            size_t& total_mem,
+                                                            int n_streams) {
+  get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(free_mem, total_mem,
+                                                    n_streams);
+}
+template <>
+inline void get_free_total_memory<Kokkos::SYCLHostUSMSpace>(size_t& free_mem,
+                                                            size_t& total_mem) {
+  get_free_total_memory<Kokkos::SYCLHostUSMSpace>(free_mem, total_mem, 1);
+}
+template <>
+inline void get_free_total_memory<Kokkos::SYCLSharedUSMSpace>(size_t& free_mem,
+                                                              size_t& total_mem,
+                                                              int n_streams) {
+  get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(free_mem, total_mem,
+                                                    n_streams);
+}
+template <>
+inline void get_free_total_memory<Kokkos::SYCLSharedUSMSpace>(
+    size_t& free_mem, size_t& total_mem) {
+  get_free_total_memory<Kokkos::SYCLSharedUSMSpace>(free_mem, total_mem, 1);
+}
+#endif
+
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif  // KOKKOS_DEVICE_UTILS_HPP


### PR DESCRIPTION
By providing memory information, users can better partition their problem and determine, for example, the number of cells that can be processed by a device. This helps maximize GPU memory usage and can improve overall efficiency.

Additionally, these functions are important when using memory-intensive solvers, such as algebraic multigrid methods, where memory requirements can be unpredictable.

The goal is to provide a portable function that works across different GPU backends, avoiding the need for backend-specific implementations. These functions will be called from the host.