### PR TITLE
Fix simd math functions not compiling when ARCH_NATIVE=ON

### DIFF
--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -173,9 +173,13 @@ template <class T, class Abi>
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 #define KOKKOS_IMPL_SIMD_UNARY_FUNCTION(FUNC)                                \
-  template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> \
-  FUNC(Experimental::basic_simd<T, Abi> const& a) {                          \
+  template <                                                                 \
+      class T, class Abi,                                                    \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>, \
+                       bool> = false>                                        \
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION                        \
+      Experimental::basic_simd<T, Abi>                                       \
+      FUNC(Experimental::basic_simd<T, Abi> const& a) {                      \
     Experimental::basic_simd<T, Abi> result;                                 \
     T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                  \
     for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
@@ -184,6 +188,15 @@ template <class T, class Abi>
     }                                                                        \
     result.copy_from(vals, Kokkos::Experimental::simd_flag_default);         \
     return result;                                                           \
+  }                                                                          \
+  template <                                                                 \
+      class T, class Abi,                                                    \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
+                       bool> = false>                                        \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::         \
+      basic_simd<T, Abi>                                                     \
+      FUNC(Experimental::basic_simd<T, Abi> const& a) {                      \
+    return Kokkos::FUNC(a[0]);                                               \
   }                                                                          \
   namespace Experimental {                                                   \
   template <class T, class Abi>                                              \
@@ -195,9 +208,13 @@ template <class T, class Abi>
   }
 #else
 #define KOKKOS_IMPL_SIMD_UNARY_FUNCTION(FUNC)                                \
-  template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> \
-  FUNC(Experimental::basic_simd<T, Abi> const& a) {                          \
+  template <                                                                 \
+      class T, class Abi,                                                    \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>, \
+                       bool> = false>                                        \
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION                        \
+      Experimental::basic_simd<T, Abi>                                       \
+      FUNC(Experimental::basic_simd<T, Abi> const& a) {                      \
     Experimental::basic_simd<T, Abi> result;                                 \
     T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                  \
     for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
@@ -206,6 +223,15 @@ template <class T, class Abi>
     }                                                                        \
     result.copy_from(vals, Kokkos::Experimental::simd_flag_default);         \
     return result;                                                           \
+  }                                                                          \
+  template <                                                                 \
+      class T, class Abi,                                                    \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
+                       bool> = false>                                        \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::         \
+      basic_simd<T, Abi>                                                     \
+      FUNC(Experimental::basic_simd<T, Abi> const& a) {                      \
+    return Kokkos::FUNC(a[0]);                                               \
   }
 #endif
 
@@ -236,10 +262,14 @@ KOKKOS_IMPL_SIMD_UNARY_FUNCTION(lgamma)
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 #define KOKKOS_IMPL_SIMD_BINARY_FUNCTION(FUNC)                               \
-  template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> \
-  FUNC(Experimental::basic_simd<T, Abi> const& a,                            \
-       Experimental::basic_simd<T, Abi> const& b) {                          \
+  template <                                                                 \
+      class T, class Abi,                                                    \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>, \
+                       bool> = false>                                        \
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION                        \
+      Experimental::basic_simd<T, Abi>                                       \
+      FUNC(Experimental::basic_simd<T, Abi> const& a,                        \
+           Experimental::basic_simd<T, Abi> const& b) {                      \
     Experimental::basic_simd<T, Abi> result;                                 \
     T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                  \
     for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
@@ -248,6 +278,16 @@ KOKKOS_IMPL_SIMD_UNARY_FUNCTION(lgamma)
     }                                                                        \
     result.copy_from(vals, Kokkos::Experimental::simd_flag_default);         \
     return result;                                                           \
+  }                                                                          \
+  template <                                                                 \
+      class T, class Abi,                                                    \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
+                       bool> = false>                                        \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::         \
+      basic_simd<T, Abi>                                                     \
+      FUNC(Experimental::basic_simd<T, Abi> const& a,                        \
+           Experimental::basic_simd<T, Abi> const& b) {                      \
+    return Kokkos::FUNC(a[0], b[0]);                                         \
   }                                                                          \
   namespace Experimental {                                                   \
   template <class T, class Abi>                                              \
@@ -259,10 +299,14 @@ KOKKOS_IMPL_SIMD_UNARY_FUNCTION(lgamma)
   }
 #else
 #define KOKKOS_IMPL_SIMD_BINARY_FUNCTION(FUNC)                               \
-  template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> \
-  FUNC(Experimental::basic_simd<T, Abi> const& a,                            \
-       Experimental::basic_simd<T, Abi> const& b) {                          \
+  template <                                                                 \
+      class T, class Abi,                                                    \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>, \
+                       bool> = false>                                        \
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION                        \
+      Experimental::basic_simd<T, Abi>                                       \
+      FUNC(Experimental::basic_simd<T, Abi> const& a,                        \
+           Experimental::basic_simd<T, Abi> const& b) {                      \
     Experimental::basic_simd<T, Abi> result;                                 \
     T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                  \
     for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
@@ -271,6 +315,16 @@ KOKKOS_IMPL_SIMD_UNARY_FUNCTION(lgamma)
     }                                                                        \
     result.copy_from(vals, Kokkos::Experimental::simd_flag_default);         \
     return result;                                                           \
+  }                                                                          \
+  template <                                                                 \
+      class T, class Abi,                                                    \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
+                       bool> = false>                                        \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::         \
+      basic_simd<T, Abi>                                                     \
+      FUNC(Experimental::basic_simd<T, Abi> const& a,                        \
+           Experimental::basic_simd<T, Abi> const& b) {                      \
+    return Kokkos::FUNC(a[0], b[0]);                                         \
   }
 #endif
 
@@ -281,11 +335,15 @@ KOKKOS_IMPL_SIMD_BINARY_FUNCTION(copysign)
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 #define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                              \
-  template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> \
-  FUNC(Experimental::basic_simd<T, Abi> const& a,                            \
-       Experimental::basic_simd<T, Abi> const& b,                            \
-       Experimental::basic_simd<T, Abi> const& c) {                          \
+  template <                                                                 \
+      class T, class Abi,                                                    \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>, \
+                       bool> = false>                                        \
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION                        \
+      Experimental::basic_simd<T, Abi>                                       \
+      FUNC(Experimental::basic_simd<T, Abi> const& a,                        \
+           Experimental::basic_simd<T, Abi> const& b,                        \
+           Experimental::basic_simd<T, Abi> const& c) {                      \
     Experimental::basic_simd<T, Abi> result;                                 \
     T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                  \
     for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
@@ -294,6 +352,17 @@ KOKKOS_IMPL_SIMD_BINARY_FUNCTION(copysign)
     }                                                                        \
     result.copy_from(vals, Kokkos::Experimental::simd_flag_default);         \
     return result;                                                           \
+  }                                                                          \
+  template <                                                                 \
+      class T, class Abi,                                                    \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
+                       bool> = false>                                        \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::         \
+      basic_simd<T, Abi>                                                     \
+      FUNC(Experimental::basic_simd<T, Abi> const& a,                        \
+           Experimental::basic_simd<T, Abi> const& b,                        \
+           Experimental::basic_simd<T, Abi> const& c) {                      \
+    return Kokkos::FUNC(a[0], b[0], c[0]);                                   \
   }                                                                          \
   namespace Experimental {                                                   \
   template <class T, class Abi>                                              \
@@ -306,11 +375,15 @@ KOKKOS_IMPL_SIMD_BINARY_FUNCTION(copysign)
   }
 #else
 #define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                              \
-  template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> \
-  FUNC(Experimental::basic_simd<T, Abi> const& a,                            \
-       Experimental::basic_simd<T, Abi> const& b,                            \
-       Experimental::basic_simd<T, Abi> const& c) {                          \
+  template <                                                                 \
+      class T, class Abi,                                                    \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>, \
+                       bool> = false>                                        \
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION                        \
+      Experimental::basic_simd<T, Abi>                                       \
+      FUNC(Experimental::basic_simd<T, Abi> const& a,                        \
+           Experimental::basic_simd<T, Abi> const& b,                        \
+           Experimental::basic_simd<T, Abi> const& c) {                      \
     Experimental::basic_simd<T, Abi> result;                                 \
     T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                  \
     for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
@@ -319,6 +392,17 @@ KOKKOS_IMPL_SIMD_BINARY_FUNCTION(copysign)
     }                                                                        \
     result.copy_from(vals, Kokkos::Experimental::simd_flag_default);         \
     return result;                                                           \
+  }                                                                          \
+  template <                                                                 \
+      class T, class Abi,                                                    \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
+                       bool> = false>                                        \
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::         \
+      basic_simd<T, Abi>                                                     \
+      FUNC(Experimental::basic_simd<T, Abi> const& a,                        \
+           Experimental::basic_simd<T, Abi> const& b,                        \
+           Experimental::basic_simd<T, Abi> const& c) {                      \
+    return Kokkos::FUNC(a[0], b[0], c[0]);                                   \
   }
 #endif
 

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -404,7 +404,7 @@ template <class T>
     T, Experimental::simd_abi::scalar>
 sqrt(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   return Experimental::basic_simd<T, Experimental::simd_abi::scalar>(
-      std::sqrt(static_cast<T>(a)));
+      Kokkos::sqrt(static_cast<T>(a)));
 }
 
 template <class T>
@@ -414,7 +414,7 @@ fma(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& y,
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& z) {
   return Experimental::basic_simd<T, Experimental::simd_abi::scalar>(
-      (static_cast<T>(x) * static_cast<T>(y)) + static_cast<T>(z));
+      Kokkos::fma(static_cast<T>(x), static_cast<T>(y), static_cast<T>(z)));
 }
 
 template <class T>
@@ -422,7 +422,7 @@ template <class T>
     T, Experimental::simd_abi::scalar>
 copysign(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a,
          Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& b) {
-  return std::copysign(static_cast<T>(a), static_cast<T>(b));
+  return Kokkos::copysign(static_cast<T>(a), static_cast<T>(b));
 }
 
 namespace Experimental {

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -298,33 +298,33 @@ class basic_simd<T, simd_abi::scalar> {
     return basic_simd(lhs.m_value >> rhs.m_value);
   }
 
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator+=(basic_simd& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator+=(
+      basic_simd& lhs, basic_simd const& rhs) noexcept {
     lhs = lhs + rhs;
     return lhs;
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator-=(basic_simd& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator-=(
+      basic_simd& lhs, basic_simd const& rhs) noexcept {
     lhs = lhs - rhs;
     return lhs;
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator*=(basic_simd& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator*=(
+      basic_simd& lhs, basic_simd const& rhs) noexcept {
     lhs = lhs * rhs;
     return lhs;
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator/=(basic_simd& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator/=(
+      basic_simd& lhs, basic_simd const& rhs) noexcept {
     lhs = lhs / rhs;
     return lhs;
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator<<=(basic_simd& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator<<=(
+      basic_simd& lhs, basic_simd const& rhs) noexcept {
     lhs = lhs << rhs;
     return lhs;
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator>>=(basic_simd& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator>>=(
+      basic_simd& lhs, basic_simd const& rhs) noexcept {
     lhs = lhs >> rhs;
     return lhs;
   }

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -287,54 +287,6 @@ class shift_left_eq {
   }
 };
 
-class cbrt_op {
- public:
-  template <typename T>
-  auto on_host(T const& a) const {
-#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
-    return Kokkos::Experimental::cbrt(a);
-#else
-    return Kokkos::cbrt(a);
-#endif
-  }
-  template <typename T>
-  auto on_host_serial(T const& a) const {
-    return Kokkos::cbrt(a);
-  }
-};
-
-class exp_op {
- public:
-  template <typename T>
-  auto on_host(T const& a) const {
-#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
-    return Kokkos::Experimental::exp(a);
-#else
-    return Kokkos::exp(a);
-#endif
-  }
-  template <typename T>
-  auto on_host_serial(T const& a) const {
-    return Kokkos::exp(a);
-  }
-};
-
-class log_op {
- public:
-  template <typename T>
-  auto on_host(T const& a) const {
-#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
-    return Kokkos::Experimental::log(a);
-#else
-    return Kokkos::log(a);
-#endif
-  }
-  template <typename T>
-  auto on_host_serial(T const& a) const {
-    return Kokkos::log(a);
-  }
-};
-
 class minimum {
  public:
   template <typename T>
@@ -618,5 +570,172 @@ class masked_reduce {
     return result;
   }
 };
+
+#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
+#define KOKKOS_IMPL_SIMD_UNARY_TEST_OP(FUNC)                         \
+  class FUNC##_op {                                                  \
+   public:                                                           \
+    template <typename T>                                            \
+    auto on_host(T const& a) const {                                 \
+      return Kokkos::Experimental::FUNC(a);                          \
+    }                                                                \
+    template <typename T>                                            \
+    auto on_host_serial(T const& a) const {                          \
+      return Kokkos::FUNC(a);                                        \
+    }                                                                \
+    template <typename T>                                            \
+    KOKKOS_INLINE_FUNCTION auto on_device(T const& a) const {        \
+      return Kokkos::FUNC(a);                                        \
+    }                                                                \
+    template <typename T>                                            \
+    KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a) const { \
+      return Kokkos::FUNC(a);                                        \
+    }                                                                \
+  };
+
+#define KOKKOS_IMPL_SIMD_BINARY_TEST_OP(FUNC)                             \
+  class FUNC##_op {                                                       \
+   public:                                                                \
+    template <typename T>                                                 \
+    auto on_host(T const& a, T const& b) const {                          \
+      if constexpr (std::is_arithmetic_v<T>) {                            \
+        return Kokkos::FUNC(a, b);                                        \
+      } else {                                                            \
+        return Kokkos::Experimental::FUNC(a, b);                          \
+      }                                                                   \
+    }                                                                     \
+    template <typename T>                                                 \
+    KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const { \
+      return Kokkos::FUNC(a, b);                                          \
+    }                                                                     \
+  };
+
+#define KOKKOS_IMPL_SIMD_TERNARY_TEST_OP(FUNC)                    \
+  class FUNC##_op {                                               \
+   public:                                                        \
+    template <typename T>                                         \
+    auto on_host(T const& a, T const& b, T const& c) const {      \
+      if constexpr (std::is_arithmetic_v<T>) {                    \
+        return Kokkos::FUNC(a, b, c);                             \
+      } else {                                                    \
+        return Kokkos::Experimental::FUNC(a, b, c);               \
+      }                                                           \
+    }                                                             \
+    template <typename T>                                         \
+    KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b, \
+                                          T const& c) const {     \
+      return Kokkos::FUNC(a, b, c);                               \
+    }                                                             \
+  };
+#else
+#define KOKKOS_IMPL_SIMD_UNARY_TEST_OP(FUNC)                         \
+  class FUNC##_op {                                                  \
+   public:                                                           \
+    template <typename T>                                            \
+    auto on_host(T const& a) const {                                 \
+      return Kokkos::FUNC(a);                                        \
+    }                                                                \
+    template <typename T>                                            \
+    auto on_host_serial(T const& a) const {                          \
+      return Kokkos::FUNC(a);                                        \
+    }                                                                \
+    template <typename T>                                            \
+    KOKKOS_INLINE_FUNCTION auto on_device(T const& a) const {        \
+      return Kokkos::FUNC(a);                                        \
+    }                                                                \
+    template <typename T>                                            \
+    KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a) const { \
+      return Kokkos::FUNC(a);                                        \
+    }                                                                \
+  };
+
+#define KOKKOS_IMPL_SIMD_BINARY_TEST_OP(FUNC)                             \
+  class FUNC##_op {                                                       \
+   public:                                                                \
+    template <typename T>                                                 \
+    auto on_host(T const& a, T const& b) const {                          \
+      return Kokkos::FUNC(a, b);                                          \
+    }                                                                     \
+    template <typename T>                                                 \
+    KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const { \
+      return Kokkos::FUNC(a, b);                                          \
+    }                                                                     \
+  };
+
+#define KOKKOS_IMPL_SIMD_TERNARY_TEST_OP(FUNC)                    \
+  class FUNC##_op {                                               \
+   public:                                                        \
+    template <typename T>                                         \
+    auto on_host(T const& a, T const& b, T const& c) const {      \
+      return Kokkos::FUNC(a, b, c);                               \
+    }                                                             \
+    template <typename T>                                         \
+    KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b, \
+                                          T const& c) const {     \
+      return Kokkos::FUNC(a, b, c);                               \
+    }                                                             \
+  };
+#endif
+
+#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
+#endif
+
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(abs)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(exp)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(exp2)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(log)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(log10)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(log2)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(sqrt)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(cbrt)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(sin)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(cos)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(tan)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(asin)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(acos)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(atan)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(sinh)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(cosh)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(tanh)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(asinh)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(acosh)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(atanh)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(erf)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(erfc)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(tgamma)
+KOKKOS_IMPL_SIMD_UNARY_TEST_OP(lgamma)
+
+KOKKOS_IMPL_SIMD_BINARY_TEST_OP(pow)
+KOKKOS_IMPL_SIMD_BINARY_TEST_OP(hypot)
+KOKKOS_IMPL_SIMD_BINARY_TEST_OP(atan2)
+KOKKOS_IMPL_SIMD_BINARY_TEST_OP(copysign)
+
+KOKKOS_IMPL_SIMD_TERNARY_TEST_OP(fma)
+
+class ternary_hypot_op {
+ public:
+  template <typename T>
+  auto on_host(T const& a, T const& b, T const& c) const {
+#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
+    if constexpr (std::is_arithmetic_v<T>) {
+      return Kokkos::hypot(a, b, c);
+    } else {
+      return Kokkos::Experimental::hypot(a, b, c);
+    }
+#else
+    return Kokkos::hypot(a, b, c);
+#endif
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b,
+                                        T const& c) const {
+    return Kokkos::hypot(a, b, c);
+  }
+};
+
+#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+#endif
 
 #endif

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -385,7 +385,7 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_one_loader(UnaryOp unary_op,
       arg /= simd_type(10.1);
     }
 
-    // acosh defined for x >= 1
+    // acosh is defined for x >= 1
     if constexpr (std::is_same_v<UnaryOp, acosh_op>) {
       arg = Kokkos::abs(arg) + simd_type(1.0);
     }

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -20,6 +20,43 @@
 #include <Kokkos_SIMD.hpp>
 #include <SIMDTesting_Utilities.hpp>
 
+template <class Abi, class Loader, class TernaryOp, class T>
+void host_check_math_op_one_loader(TernaryOp ternary_op, std::size_t n,
+                                   T const* first_args, T const* second_args,
+                                   T const* third_args) {
+  Loader loader;
+  using simd_type             = Kokkos::Experimental::basic_simd<T, Abi>;
+  constexpr std::size_t width = simd_type::size();
+  for (std::size_t i = 0; i < n; i += width) {
+    std::size_t const nremaining = n - i;
+    std::size_t const nlanes     = Kokkos::min(nremaining, width);
+    simd_type first_arg;
+    bool const loaded_first_arg =
+        loader.host_load(first_args + i, nlanes, first_arg);
+    simd_type second_arg;
+    bool const loaded_second_arg =
+        loader.host_load(second_args + i, nlanes, second_arg);
+    simd_type third_arg;
+    bool const loaded_third_arg =
+        loader.host_load(third_args + i, nlanes, third_arg);
+    if (!(loaded_first_arg && loaded_second_arg && loaded_third_arg)) continue;
+
+    T expected_val[width];
+    for (std::size_t lane = 0; lane < width; ++lane) {
+      expected_val[lane] = ternary_op.on_host(
+          T(first_arg[lane]), T(second_arg[lane]), T(third_arg[lane]));
+    }
+
+    simd_type expected_result;
+    expected_result.copy_from(expected_val,
+                              Kokkos::Experimental::simd_flag_default);
+
+    simd_type const computed_result =
+        ternary_op.on_host(first_arg, second_arg, third_arg);
+    host_check_equality(expected_result, computed_result, nlanes);
+  }
+}
+
 template <class Abi, class Loader, class BinaryOp, class T>
 void host_check_math_op_one_loader(BinaryOp binary_op, std::size_t n,
                                    T const* first_args, T const* second_args) {
@@ -39,6 +76,12 @@ void host_check_math_op_one_loader(BinaryOp binary_op, std::size_t n,
     bool const loaded_second_arg =
         loader.host_load(second_args + i, nlanes, second_arg);
     if (!(loaded_first_arg && loaded_second_arg)) continue;
+
+    // The second argument of pow being negative and/or non-integer may provoke
+    // a domain error
+    if constexpr (std::is_same_v<BinaryOp, pow_op>) {
+      second_arg = Kokkos::round(Kokkos::abs(second_arg));
+    }
 
     T expected_val[width];
     for (std::size_t lane = 0; lane < width; ++lane) {
@@ -68,10 +111,29 @@ void host_check_math_op_one_loader(UnaryOp unary_op, std::size_t n,
     bool const loaded_arg = loader.host_load(args + i, nlanes, arg);
     if (!loaded_arg) continue;
 
-    if constexpr (std::is_same_v<UnaryOp, cbrt_op> ||
-                  std::is_same_v<UnaryOp, exp_op> ||
-                  std::is_same_v<UnaryOp, log_op>)
+    if constexpr (std::is_same_v<UnaryOp, sqrt_op>) {
       arg = Kokkos::abs(arg);
+    }
+
+    if constexpr (std::is_same_v<UnaryOp, log_op> ||
+                  std::is_same_v<UnaryOp, log10_op> ||
+                  std::is_same_v<UnaryOp, log2_op> ||
+                  std::is_same_v<UnaryOp, tgamma_op> ||
+                  std::is_same_v<UnaryOp, lgamma_op>) {
+      arg = Kokkos::abs(arg) + simd_type(0.1);
+    }
+
+    // These functions are defined for -1 < x < 1
+    if constexpr (std::is_same_v<UnaryOp, asin_op> ||
+                  std::is_same_v<UnaryOp, acos_op> ||
+                  std::is_same_v<UnaryOp, atanh_op>) {
+      arg /= simd_type(10.1);
+    }
+
+    // acosh is defined for x >= 1
+    if constexpr (std::is_same_v<UnaryOp, acosh_op>) {
+      arg = Kokkos::abs(arg) + simd_type(1.0);
+    }
 
     typename decltype(unary_op.on_host(arg))::value_type expected_val[width];
     for (std::size_t lane = 0; lane < width; ++lane) {
@@ -98,7 +160,8 @@ inline void host_check_math_op_all_loaders(Op op, std::size_t n,
 
 template <typename Abi, typename DataType, size_t n>
 inline void host_check_all_math_ops(const DataType (&first_args)[n],
-                                    const DataType (&second_args)[n]) {
+                                    const DataType (&second_args)[n],
+                                    const DataType (&third_args)[n]) {
   host_check_math_op_all_loaders<Abi>(plus(), n, first_args, second_args);
   host_check_math_op_all_loaders<Abi>(plus_eq(), n, first_args, second_args);
   host_check_math_op_all_loaders<Abi>(minus(), n, first_args, second_args);
@@ -120,12 +183,41 @@ inline void host_check_all_math_ops(const DataType (&first_args)[n],
 
   // TODO: Place fallback implementations for all simd integer types
   if constexpr (std::is_floating_point_v<DataType>) {
-#if defined(__INTEL_COMPILER) && \
-    (defined(KOKKOS_ARCH_AVX2) || defined(KOKKOS_ARCH_AVX512XEON))
-    host_check_math_op_all_loaders<Abi>(cbrt_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(abs_op(), n, first_args);
     host_check_math_op_all_loaders<Abi>(exp_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(exp2_op(), n, first_args);
     host_check_math_op_all_loaders<Abi>(log_op(), n, first_args);
-#endif
+    host_check_math_op_all_loaders<Abi>(log10_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(log2_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(sqrt_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(cbrt_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(sin_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(cos_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(tan_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(asin_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(acos_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(atan_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(sinh_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(cosh_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(tanh_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(asinh_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(acosh_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(atanh_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(erf_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(erfc_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(tgamma_op(), n, first_args);
+    host_check_math_op_all_loaders<Abi>(lgamma_op(), n, first_args);
+
+    host_check_math_op_all_loaders<Abi>(pow_op(), n, first_args, second_args);
+    host_check_math_op_all_loaders<Abi>(hypot_op(), n, first_args, second_args);
+    host_check_math_op_all_loaders<Abi>(atan2_op(), n, first_args, second_args);
+    host_check_math_op_all_loaders<Abi>(copysign_op(), n, first_args,
+                                        second_args);
+
+    host_check_math_op_all_loaders<Abi>(fma_op(), n, first_args, second_args,
+                                        third_args);
+    host_check_math_op_all_loaders<Abi>(ternary_hypot_op(), n, first_args,
+                                        second_args, third_args);
   }
 }
 
@@ -152,20 +244,27 @@ inline void host_check_math_ops() {
       alignas(alignment) DataType const second_args[] = {
           1.0,  0.2,  1.1,  1.8, -0.1,  -3.0, -2.4, 1.0,
           13.0, -3.2, -2.1, 3.0, -15.0, -0.5, -0.2, -0.2};
-      host_check_all_math_ops<Abi>(first_args, second_args);
+      alignas(alignment) DataType const third_args[] = {
+          3.7,  2.6,  9.8, 9.3,  9.9, -5.3, 8.5,  1.6,
+          -3.8, -0.4, 6.1, -5.3, 6.1, -8.9, -2.5, -5.2};
+      host_check_all_math_ops<Abi>(first_args, second_args, third_args);
     } else {
       if constexpr (std::is_signed_v<DataType>) {
         alignas(alignment) DataType const first_args[] = {
             1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2, -3, 7, 4, -9, -15};
         alignas(alignment) DataType const second_args[] = {
             1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2, 10, -15, 7, 2, -10};
-        host_check_all_math_ops<Abi>(first_args, second_args);
+        alignas(alignment) DataType const third_args[] = {
+            20, 3, -18, 3, 19, 11, 4, 20, 8, -8, 13, -18, -2, -5, -1, 11};
+        host_check_all_math_ops<Abi>(first_args, second_args, third_args);
       } else {
         alignas(alignment) DataType const first_args[] = {
             1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2, 11, 5, 8, 2, 14};
         alignas(alignment) DataType const second_args[] = {
             1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2, 3, 6, 20, 5, 14};
-        host_check_all_math_ops<Abi>(first_args, second_args);
+        alignas(alignment) DataType const third_args[] = {
+            10, 10, 6, 6, 16, 14, 18, 9, 19, 7, 0, 6, 2, 15, 10, 16};
+        host_check_all_math_ops<Abi>(first_args, second_args, third_args);
       }
     }
   }
@@ -182,6 +281,38 @@ inline void host_check_math_ops_all_abis(
     Kokkos::Experimental::Impl::abi_set<Abis...>) {
   using DataTypes = Kokkos::Experimental::Impl::data_type_set;
   (host_check_math_ops_all_types<Abis>(DataTypes()), ...);
+}
+
+template <typename Abi, typename Loader, typename TernaryOp, typename T>
+KOKKOS_INLINE_FUNCTION void device_check_math_op_one_loader(
+    TernaryOp ternary_op, std::size_t n, T const* first_args,
+    T const* second_args, T const* third_args) {
+  Loader loader;
+  using simd_type             = Kokkos::Experimental::basic_simd<T, Abi>;
+  constexpr std::size_t width = simd_type::size();
+  for (std::size_t i = 0; i < n; i += width) {
+    std::size_t const nremaining = n - i;
+    std::size_t const nlanes     = Kokkos::min(nremaining, width);
+    simd_type first_arg;
+    bool const loaded_first_arg =
+        loader.device_load(first_args + i, nlanes, first_arg);
+    simd_type second_arg;
+    bool const loaded_second_arg =
+        loader.device_load(second_args + i, nlanes, second_arg);
+    simd_type third_arg;
+    bool const loaded_third_arg =
+        loader.device_load(third_args + i, nlanes, third_arg);
+    if (!(loaded_first_arg && loaded_second_arg && loaded_third_arg)) continue;
+
+    simd_type expected_result(KOKKOS_LAMBDA(std::size_t lane) {
+      return ternary_op.on_device(first_arg[lane], second_arg[lane],
+                                  third_arg[lane]);
+    });
+
+    simd_type const computed_result =
+        ternary_op.on_device(first_arg, second_arg, third_arg);
+    device_check_equality(expected_result, computed_result, nlanes);
+  }
 }
 
 template <typename Abi, typename Loader, typename BinaryOp, typename T>
@@ -204,6 +335,12 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_one_loader(
     bool const loaded_second_arg =
         loader.device_load(second_args + i, nlanes, second_arg);
     if (!(loaded_first_arg && loaded_second_arg)) continue;
+
+    // The second argument of pow being negative and/or non-integer may provoke
+    // a domain error
+    if constexpr (std::is_same_v<BinaryOp, pow_op>) {
+      second_arg = Kokkos::round(Kokkos::abs(second_arg));
+    }
 
     simd_type expected_result(KOKKOS_LAMBDA(std::size_t lane) {
       return binary_op.on_device(first_arg[lane], second_arg[lane]);
@@ -228,6 +365,31 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_one_loader(UnaryOp unary_op,
     simd_type arg;
     bool const loaded_arg = loader.device_load(args + i, nlanes, arg);
     if (!loaded_arg) continue;
+
+    if constexpr (std::is_same_v<UnaryOp, sqrt_op>) {
+      arg = Kokkos::abs(arg);
+    }
+
+    if constexpr (std::is_same_v<UnaryOp, log_op> ||
+                  std::is_same_v<UnaryOp, log10_op> ||
+                  std::is_same_v<UnaryOp, log2_op> ||
+                  std::is_same_v<UnaryOp, tgamma_op> ||
+                  std::is_same_v<UnaryOp, lgamma_op>) {
+      arg = Kokkos::abs(arg) + simd_type(0.1);
+    }
+
+    // These functions are defined for -1 < x < 1
+    if constexpr (std::is_same_v<UnaryOp, asin_op> ||
+                  std::is_same_v<UnaryOp, acos_op> ||
+                  std::is_same_v<UnaryOp, atanh_op>) {
+      arg /= simd_type(10.1);
+    }
+
+    // acosh defined for x >= 1
+    if constexpr (std::is_same_v<UnaryOp, acosh_op>) {
+      arg = Kokkos::abs(arg) + simd_type(1.0);
+    }
+
     auto computed_result = unary_op.on_device(arg);
 
     decltype(computed_result) expected_result(KOKKOS_LAMBDA(std::size_t lane) {
@@ -250,7 +412,8 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_all_loaders(Op op,
 
 template <typename Abi, typename DataType, size_t n>
 KOKKOS_INLINE_FUNCTION void device_check_all_math_ops(
-    const DataType (&first_args)[n], const DataType (&second_args)[n]) {
+    const DataType (&first_args)[n], const DataType (&second_args)[n],
+    const DataType (&third_args)[n]) {
   device_check_math_op_all_loaders<Abi>(plus(), n, first_args, second_args);
   device_check_math_op_all_loaders<Abi>(plus_eq(), n, first_args, second_args);
   device_check_math_op_all_loaders<Abi>(minus(), n, first_args, second_args);
@@ -271,6 +434,46 @@ KOKKOS_INLINE_FUNCTION void device_check_all_math_ops(
 
   device_check_math_op_all_loaders<Abi>(minimum(), n, first_args, second_args);
   device_check_math_op_all_loaders<Abi>(maximum(), n, first_args, second_args);
+
+  if constexpr (std::is_floating_point_v<DataType>) {
+    device_check_math_op_all_loaders<Abi>(abs_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(exp_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(exp2_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(log_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(log10_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(log2_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(sqrt_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(cbrt_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(sin_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(cos_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(tan_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(asin_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(acos_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(atan_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(sinh_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(cosh_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(tanh_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(asinh_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(acosh_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(atanh_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(erf_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(erfc_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(tgamma_op(), n, first_args);
+    device_check_math_op_all_loaders<Abi>(lgamma_op(), n, first_args);
+
+    device_check_math_op_all_loaders<Abi>(pow_op(), n, first_args, second_args);
+    device_check_math_op_all_loaders<Abi>(hypot_op(), n, first_args,
+                                          second_args);
+    device_check_math_op_all_loaders<Abi>(atan2_op(), n, first_args,
+                                          second_args);
+    device_check_math_op_all_loaders<Abi>(copysign_op(), n, first_args,
+                                          second_args);
+
+    device_check_math_op_all_loaders<Abi>(fma_op(), n, first_args, second_args,
+                                          third_args);
+    device_check_math_op_all_loaders<Abi>(ternary_hypot_op(), n, first_args,
+                                          second_args, third_args);
+  }
 }
 
 template <typename Abi, typename DataType>
@@ -292,20 +495,27 @@ KOKKOS_INLINE_FUNCTION void device_check_math_ops() {
       DataType const second_args[] = {1.0,   0.2,  1.1,  1.8,  -0.1, -3.0,
                                       -2.4,  1.0,  13.0, -3.2, -2.1, 3.0,
                                       -15.0, -0.5, -0.2, -0.2};
-      device_check_all_math_ops<Abi>(first_args, second_args);
+      DataType const third_args[]  = {3.7, 2.6,  9.8,  9.3,  9.9, -5.3,
+                                      8.5, 1.6,  -3.8, -0.4, 6.1, -5.3,
+                                      6.1, -8.9, -2.5, -5.2};
+      device_check_all_math_ops<Abi>(first_args, second_args, third_args);
     } else {
       if constexpr (std::is_signed_v<DataType>) {
         DataType const first_args[]  = {1, 2, -1, 10, 0, 1, -2, 10,
                                         0, 1, -2, -3, 7, 4, -9, -15};
         DataType const second_args[] = {1,  2,  1,  1,  1,   -3, -2, 1,
                                         13, -3, -2, 10, -15, 7,  2,  -10};
-        device_check_all_math_ops<Abi>(first_args, second_args);
+        DataType const third_args[]  = {20, 3,  -18, 3,   19, 11, 4,  20,
+                                        8,  -8, 13,  -18, -2, -5, -1, 11};
+        device_check_all_math_ops<Abi>(first_args, second_args, third_args);
       } else {
         DataType const first_args[]  = {1, 2, 1, 10, 0, 1, 2, 10,
                                         0, 1, 2, 11, 5, 8, 2, 14};
         DataType const second_args[] = {1,  2, 1, 1, 1, 3,  2, 1,
                                         13, 3, 2, 3, 6, 20, 5, 14};
-        device_check_all_math_ops<Abi>(first_args, second_args);
+        DataType const third_args[]  = {10, 10, 6, 6, 16, 14, 18, 9,
+                                        19, 7,  0, 6, 2,  15, 10, 16};
+        device_check_all_math_ops<Abi>(first_args, second_args, third_args);
       }
     }
   }


### PR DESCRIPTION
This is a follow-up PR to #7845

The fallback implementations of the simd math functions in Kokkos_SIMD_Common_Math.hpp were marked `KOKKOS_FORCEINLINE_FUNCTION` which made them `__host__ __device__` and led to compile errors on cuda when trying to instantiate them with any abi other than `scalar` (because vector types inside `__device__` functions are not allowed).

My fix is to mark the old default implementation `KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION`, restrict it to non-scalar simd abis, and add a specific implementation for the scalar abi (note that I did not specialize over the abi, but used a `std::enable_if` to allow specializations in Kokkos_SIMD_Scalar.hpp to be prioritized by the compiler).

Additionally, this PR adds tests for all math functions, they are currently only tested for floating point types and special values (e.g. `exp(1.) == 0.`) are not necessarily tested, although I make sure that the test arguments are valid for each function.
Smaller changes related to this include:
- removing the `[[nodiscard]]` specifier from the compound assignment operators in the scalar abi (otherwise `a += b;` emits a warning)
- Calling the math functions in namespace `Kokkos` instead of `std` for the scalar abi specializations of `sqrt` and `copysign`, both for consistency and the fact that they wouldn't compile with integer types on nvcc because the integer `std` overloads are not available (these specializations could be removed in favor of the fallback implementation since they only call the scalar version of the fonction?)
- Using `Kokkos::fma` instead of doing `x * y + z` by hand for the scalar abi, I noticed a 1 ulp difference between the two on host, which made the test fail when the default execution space was a host space because the `kokkos_checker` in SIMDTesting_Utilities.hpp uses exact inequality, in contrast with the `gtest_checker` which has a margin of error for floating point types (of 4 ulp I believe).
  Another fix for this would have been to also use a comparison with a margin of error for the device checker, I don't know what would be the preferred solution
  
  Note: there should be a slight conflict with #6581 for the changes in TestSimd_MathOps.hpp