### PR TITLE
OpenACC backend implementation of  partition_space() API

### DIFF
--- a/core/src/OpenACC/Kokkos_OpenACC.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACC.cpp
@@ -33,13 +33,11 @@ Kokkos::Experimental::OpenACC::OpenACC()
 }
 
 Kokkos::Experimental::OpenACC::OpenACC(int async_arg)
-    : m_space_instance(
-          new Kokkos::Experimental::Impl::OpenACCInternal,
-          [](Impl::OpenACCInternal* ptr) {
-            ptr->finalize();
-            atomic_dec(&Impl::OpenACCInternal::m_num_active_user_asyncs);
-            delete ptr;
-          }) {
+    : m_space_instance(new Kokkos::Experimental::Impl::OpenACCInternal,
+                       [](Impl::OpenACCInternal* ptr) {
+                         ptr->finalize();
+                         delete ptr;
+                       }) {
   Impl::OpenACCInternal::singleton().verify_is_initialized(
       "OpenACC instance constructor");
   m_space_instance->initialize(async_arg);

--- a/core/src/OpenACC/Kokkos_OpenACC.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACC.cpp
@@ -33,11 +33,13 @@ Kokkos::Experimental::OpenACC::OpenACC()
 }
 
 Kokkos::Experimental::OpenACC::OpenACC(int async_arg)
-    : m_space_instance(new Kokkos::Experimental::Impl::OpenACCInternal,
-                       [](Impl::OpenACCInternal* ptr) {
-                         ptr->finalize();
-                         delete ptr;
-                       }) {
+    : m_space_instance(
+          new Kokkos::Experimental::Impl::OpenACCInternal,
+          [](Impl::OpenACCInternal* ptr) {
+            ptr->finalize();
+            atomic_dec(&Impl::OpenACCInternal::m_num_active_user_asyncs);
+            delete ptr;
+          }) {
   Impl::OpenACCInternal::singleton().verify_is_initialized(
       "OpenACC instance constructor");
   m_space_instance->initialize(async_arg);

--- a/core/src/OpenACC/Kokkos_OpenACC_Instance.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Instance.cpp
@@ -13,8 +13,9 @@
 #include <iostream>
 
 // Arbitrary value to denote that we don't know yet what device to use.
-int Kokkos::Experimental::Impl::OpenACCInternal::m_acc_device_num = -1;
-int Kokkos::Experimental::Impl::OpenACCInternal::m_concurrency    = -1;
+int Kokkos::Experimental::Impl::OpenACCInternal::m_acc_device_num  = -1;
+int Kokkos::Experimental::Impl::OpenACCInternal::m_concurrency     = -1;
+int Kokkos::Experimental::Impl::OpenACCInternal::m_num_user_asyncs = 0;
 
 Kokkos::Experimental::Impl::OpenACCInternal&
 Kokkos::Experimental::Impl::OpenACCInternal::singleton() {
@@ -84,8 +85,10 @@ int Kokkos::Experimental::OpenACC::concurrency() const {
 
 void Kokkos::Experimental::Impl::create_OpenACC_instances(
     std::vector<OpenACC>& instances) {
-  // FIXME_OPENACC: this is not thread-safe, causing race conditions.
-  for (int s = 0; s < int(instances.size()); s++) {
-    instances[s] = OpenACC(s);
+  int instances_size = int(instances.size());
+  int num_user_asyncs =
+      atomic_fetch_add(&OpenACCInternal::m_num_user_asyncs, instances_size);
+  for (int s = 0; s < instances_size; s++) {
+    instances[s] = OpenACC(s + num_user_asyncs);
   }
 }

--- a/core/src/OpenACC/Kokkos_OpenACC_Instance.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Instance.cpp
@@ -13,10 +13,9 @@
 #include <iostream>
 
 // Arbitrary value to denote that we don't know yet what device to use.
-int Kokkos::Experimental::Impl::OpenACCInternal::m_acc_device_num         = -1;
-int Kokkos::Experimental::Impl::OpenACCInternal::m_concurrency            = -1;
-int Kokkos::Experimental::Impl::OpenACCInternal::m_num_user_asyncs        = 0;
-int Kokkos::Experimental::Impl::OpenACCInternal::m_num_active_user_asyncs = 0;
+int Kokkos::Experimental::Impl::OpenACCInternal::m_acc_device_num = -1;
+int Kokkos::Experimental::Impl::OpenACCInternal::m_concurrency    = -1;
+int Kokkos::Experimental::Impl::OpenACCInternal::m_next_async     = -1;
 
 Kokkos::Experimental::Impl::OpenACCInternal&
 Kokkos::Experimental::Impl::OpenACCInternal::singleton() {
@@ -83,17 +82,3 @@ int Kokkos::Experimental::OpenACC::concurrency() const {
   return Impl::OpenACCInternal::m_concurrency;
 }
 #endif
-
-void Kokkos::Experimental::Impl::create_OpenACC_instances(
-    std::vector<OpenACC>& instances) {
-  int instances_size = int(instances.size());
-  if (atomic_load(&OpenACCInternal::m_num_active_user_asyncs) == 0) {
-    atomic_store(&OpenACCInternal::m_num_user_asyncs, 0);
-  }
-  atomic_add(&OpenACCInternal::m_num_active_user_asyncs, instances_size);
-  int num_user_asyncs =
-      atomic_fetch_add(&OpenACCInternal::m_num_user_asyncs, instances_size);
-  for (int s = 0; s < instances_size; s++) {
-    instances[s] = OpenACC(s + num_user_asyncs);
-  }
-}

--- a/core/src/OpenACC/Kokkos_OpenACC_Instance.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Instance.cpp
@@ -81,3 +81,10 @@ int Kokkos::Experimental::OpenACC::concurrency() const {
   return Impl::OpenACCInternal::m_concurrency;
 }
 #endif
+
+void Kokkos::Experimental::Impl::create_OpenACC_instances(
+    std::vector<OpenACC>& instances) {
+  for (int s = 0; s < int(instances.size()); s++) {
+    instances[s] = OpenACC(s);
+  }
+}

--- a/core/src/OpenACC/Kokkos_OpenACC_Instance.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Instance.cpp
@@ -84,6 +84,7 @@ int Kokkos::Experimental::OpenACC::concurrency() const {
 
 void Kokkos::Experimental::Impl::create_OpenACC_instances(
     std::vector<OpenACC>& instances) {
+  // FIXME_OPENACC: this is not thread-safe, causing race conditions.
   for (int s = 0; s < int(instances.size()); s++) {
     instances[s] = OpenACC(s);
   }

--- a/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
@@ -48,36 +48,16 @@ void create_OpenACC_instances(std::vector<OpenACC>& instances);
 
 }  // namespace Kokkos::Experimental::Impl
 
-namespace Kokkos::Experimental {
-// Partitioning an Execution Space: expects space and integer arguments for
-// relative weight
-//   Customization point for backends
-//   Default behavior is to return the passed in instance
-
-template <class... Args>
-std::vector<OpenACC> partition_space(const OpenACC&, Args...) {
-  static_assert(
-      (... && std::is_arithmetic_v<Args>),
-      "Kokkos Error: partitioning arguments must be integers or floats");
-  std::vector<OpenACC> instances(sizeof...(Args));
-  Kokkos::Experimental::Impl::create_OpenACC_instances(instances);
-  return instances;
-}
-
+namespace Kokkos::Experimental::Impl {
+// For each space in partition, assign a new async ID, ignoring weights
 template <class T>
-std::vector<OpenACC> partition_space(const OpenACC&,
-                                     std::vector<T> const& weights) {
-  static_assert(
-      std::is_arithmetic_v<T>,
-      "Kokkos Error: partitioning arguments must be integers or floats");
-
-  // We only care about the number of instances to create and ignore weights
-  // otherwise.
+std::vector<OpenACC> impl_partition_space(const OpenACC& base_instance,
+                                          const std::vector<T>& weights) {
   std::vector<OpenACC> instances(weights.size());
   Kokkos::Experimental::Impl::create_OpenACC_instances(instances);
   return instances;
 }
 
-}  // namespace Kokkos::Experimental
+}  // namespace Kokkos::Experimental::Impl
 
 #endif

--- a/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
@@ -24,6 +24,7 @@ class OpenACCInternal {
   static int m_acc_device_num;
   static int m_concurrency;
   static int m_num_user_asyncs;
+  static int m_num_active_user_asyncs;
   int m_async_arg = acc_async_noval;
 
   OpenACCInternal() = default;

--- a/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
@@ -42,6 +42,40 @@ class OpenACCInternal {
   uint32_t instance_id() const noexcept;
 };
 
+void create_OpenACC_instances(std::vector<OpenACC>& instances);
+
 }  // namespace Kokkos::Experimental::Impl
+
+namespace Kokkos::Experimental {
+// Partitioning an Execution Space: expects space and integer arguments for
+// relative weight
+//   Customization point for backends
+//   Default behavior is to return the passed in instance
+
+template <class... Args>
+std::vector<OpenACC> partition_space(const OpenACC&, Args...) {
+  static_assert(
+      (... && std::is_arithmetic_v<Args>),
+      "Kokkos Error: partitioning arguments must be integers or floats");
+  std::vector<OpenACC> instances(sizeof...(Args));
+  Kokkos::Experimental::Impl::create_OpenACC_instances(instances);
+  return instances;
+}
+
+template <class T>
+std::vector<OpenACC> partition_space(const OpenACC&,
+                                     std::vector<T> const& weights) {
+  static_assert(
+      std::is_arithmetic_v<T>,
+      "Kokkos Error: partitioning arguments must be integers or floats");
+
+  // We only care about the number of instances to create and ignore weights
+  // otherwise.
+  std::vector<OpenACC> instances(weights.size());
+  Kokkos::Experimental::Impl::create_OpenACC_instances(instances);
+  return instances;
+}
+
+}  // namespace Kokkos::Experimental
 
 #endif

--- a/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
@@ -46,9 +46,6 @@ class OpenACCInternal {
 
 void create_OpenACC_instances(std::vector<OpenACC>& instances);
 
-}  // namespace Kokkos::Experimental::Impl
-
-namespace Kokkos::Experimental::Impl {
 // For each space in partition, assign a new async ID, ignoring weights
 template <class T>
 std::vector<OpenACC> impl_partition_space(const OpenACC& base_instance,

--- a/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
@@ -12,9 +12,6 @@
 #include <iosfwd>
 #include <string>
 
-#define KOKKOS_IMPL_ACC_ASYNC_RANGE_BEGIN 64
-#define KOKKOS_IMPL_ACC_ASYNC_RANGE_LENGTH 128
-
 namespace Kokkos::Experimental::Impl {
 
 class OpenACCInternal {
@@ -50,6 +47,8 @@ class OpenACCInternal {
 template <class T>
 std::vector<OpenACC> impl_partition_space(const OpenACC& base_instance,
                                           const std::vector<T>& weights) {
+  constexpr int KOKKOS_IMPL_ACC_ASYNC_RANGE_BEGIN  = 64;
+  constexpr int KOKKOS_IMPL_ACC_ASYNC_RANGE_LENGTH = 128;
   std::vector<OpenACC> instances;
   auto const n = weights.size();
   instances.reserve(n);
@@ -63,8 +62,5 @@ std::vector<OpenACC> impl_partition_space(const OpenACC& base_instance,
 }
 
 }  // namespace Kokkos::Experimental::Impl
-
-#undef KOKKOS_IMPL_ACC_ASYNC_RANGE_BEGIN
-#undef KOKKOS_IMPL_ACC_ASYNC_RANGE_LENGTH
 
 #endif

--- a/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
@@ -23,6 +23,7 @@ class OpenACCInternal {
  public:
   static int m_acc_device_num;
   static int m_concurrency;
+  static int m_num_user_asyncs;
   int m_async_arg = acc_async_noval;
 
   OpenACCInternal() = default;

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
@@ -324,7 +324,6 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
   value_type tmp;
   wrapped_reducer.init(&tmp);
 
-  ValueType tmp = ValueType();
 #pragma acc loop worker reduction(+ : tmp)
   for (iType i = loop_boundaries.start; i < loop_boundaries.end; i++)
     lambda(i, tmp);

--- a/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
@@ -301,7 +301,7 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
 
   TeamPolicyInternal(int league_size_request, int team_size_request,
                      int vector_length_request = 1)
-      : m_space(typename traits::execution_space()),
+      : m_space(),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_tune_team_size(false),

--- a/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
@@ -314,7 +314,7 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
                      const Kokkos::AUTO_t& /* team_size_request */
                      ,
                      int vector_length_request = 1)
-      : m_space(typename traits::execution_space()),
+      : m_space(),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_tune_team_size(true),
@@ -328,7 +328,7 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
                      const Kokkos::AUTO_t& /* team_size_request */
                      ,
                      const Kokkos::AUTO_t& /* vector_length_request */)
-      : m_space(typename traits::execution_space()),
+      : m_space(),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_tune_team_size(true),
@@ -338,7 +338,7 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
   }
   TeamPolicyInternal(int league_size_request, int team_size_request,
                      const Kokkos::AUTO_t& /* vector_length_request */)
-      : m_space(typename traits::execution_space()),
+      : m_space(),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_tune_team_size(false),

--- a/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
@@ -247,10 +247,10 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
         m_space(p.m_space) {}
 
   /** \brief  Specify league size, request team size */
-  TeamPolicyInternal(const typename traits::execution_space& space_,
+  TeamPolicyInternal(const typename traits::execution_space& space,
                      int league_size_request, int team_size_request,
                      int vector_length_request = 1)
-      : m_space(space_),
+      : m_space(space),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_tune_team_size(false),
@@ -259,12 +259,12 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
     init(league_size_request, team_size_request, vector_length_request);
   }
 
-  TeamPolicyInternal(const typename traits::execution_space& space_,
+  TeamPolicyInternal(const typename traits::execution_space& space,
                      int league_size_request,
                      const Kokkos::AUTO_t& /* team_size_request */
                      ,
                      int vector_length_request = 1)
-      : m_space(space_),
+      : m_space(space),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_tune_team_size(true),
@@ -274,12 +274,12 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
          vector_length_request);
   }
 
-  TeamPolicyInternal(const typename traits::execution_space& space_,
+  TeamPolicyInternal(const typename traits::execution_space& space,
                      int league_size_request,
                      const Kokkos::AUTO_t& /* team_size_request */
                      ,
                      const Kokkos::AUTO_t& /* vector_length_request */)
-      : m_space(space_),
+      : m_space(space),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_tune_team_size(true),
@@ -287,10 +287,10 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
         m_chunk_size(0) {
     init(league_size_request, default_team_size, 1);
   }
-  TeamPolicyInternal(const typename traits::execution_space& space_,
+  TeamPolicyInternal(const typename traits::execution_space& space,
                      int league_size_request, int team_size_request,
                      const Kokkos::AUTO_t& /* vector_length_request */)
-      : m_space(space_),
+      : m_space(space),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_tune_team_size(false),

--- a/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
@@ -187,6 +187,7 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
   //----------------------------------------
 
  private:
+  typename traits::execution_space m_space;
   int m_league_size;
   int m_team_size;
   int m_vector_length;
@@ -229,9 +230,7 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
            team_size_ * m_thread_scratch_size[level];
   }
 
-  Kokkos::Experimental::OpenACC space() const {
-    return Kokkos::Experimental::OpenACC();
-  }
+  Kokkos::Experimental::OpenACC space() const { return m_space; }
 
   template <class... OtherProperties>
   TeamPolicyInternal(const TeamPolicyInternal<OtherProperties...>& p)
@@ -244,13 +243,15 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
         m_thread_scratch_size(p.m_thread_scratch_size),
         m_tune_team_size(p.m_tune_team_size),
         m_tune_vector_length(p.m_tune_vector_length),
-        m_chunk_size(p.m_chunk_size) {}
+        m_chunk_size(p.m_chunk_size),
+        m_space(p.m_space) {}
 
   /** \brief  Specify league size, request team size */
-  TeamPolicyInternal(const typename traits::execution_space&,
+  TeamPolicyInternal(const typename traits::execution_space& space_,
                      int league_size_request, int team_size_request,
                      int vector_length_request = 1)
-      : m_team_scratch_size{0, 0},
+      : m_space(space_),
+        m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_tune_team_size(false),
         m_tune_vector_length(false),
@@ -258,12 +259,13 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
     init(league_size_request, team_size_request, vector_length_request);
   }
 
-  TeamPolicyInternal(const typename traits::execution_space&,
+  TeamPolicyInternal(const typename traits::execution_space& space_,
                      int league_size_request,
                      const Kokkos::AUTO_t& /* team_size_request */
                      ,
                      int vector_length_request = 1)
-      : m_team_scratch_size{0, 0},
+      : m_space(space_),
+        m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_tune_team_size(true),
         m_tune_vector_length(false),
@@ -272,22 +274,24 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
          vector_length_request);
   }
 
-  TeamPolicyInternal(const typename traits::execution_space&,
+  TeamPolicyInternal(const typename traits::execution_space& space_,
                      int league_size_request,
                      const Kokkos::AUTO_t& /* team_size_request */
                      ,
                      const Kokkos::AUTO_t& /* vector_length_request */)
-      : m_team_scratch_size{0, 0},
+      : m_space(space_),
+        m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_tune_team_size(true),
         m_tune_vector_length(true),
         m_chunk_size(0) {
     init(league_size_request, default_team_size, 1);
   }
-  TeamPolicyInternal(const typename traits::execution_space&,
+  TeamPolicyInternal(const typename traits::execution_space& space_,
                      int league_size_request, int team_size_request,
                      const Kokkos::AUTO_t& /* vector_length_request */)
-      : m_team_scratch_size{0, 0},
+      : m_space(space_),
+        m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_tune_team_size(false),
         m_tune_vector_length(true),
@@ -297,7 +301,8 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
 
   TeamPolicyInternal(int league_size_request, int team_size_request,
                      int vector_length_request = 1)
-      : m_team_scratch_size{0, 0},
+      : m_space(typename traits::execution_space()),
+        m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_tune_team_size(false),
         m_tune_vector_length(false),
@@ -309,7 +314,8 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
                      const Kokkos::AUTO_t& /* team_size_request */
                      ,
                      int vector_length_request = 1)
-      : m_team_scratch_size{0, 0},
+      : m_space(typename traits::execution_space()),
+        m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_tune_team_size(true),
         m_tune_vector_length(false),
@@ -322,7 +328,8 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
                      const Kokkos::AUTO_t& /* team_size_request */
                      ,
                      const Kokkos::AUTO_t& /* vector_length_request */)
-      : m_team_scratch_size{0, 0},
+      : m_space(typename traits::execution_space()),
+        m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_tune_team_size(true),
         m_tune_vector_length(true),
@@ -331,7 +338,8 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
   }
   TeamPolicyInternal(int league_size_request, int team_size_request,
                      const Kokkos::AUTO_t& /* vector_length_request */)
-      : m_team_scratch_size{0, 0},
+      : m_space(typename traits::execution_space()),
+        m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_tune_team_size(false),
         m_tune_vector_length(true),

--- a/core/src/decl/Kokkos_Declare_OPENACC.hpp
+++ b/core/src/decl/Kokkos_Declare_OPENACC.hpp
@@ -6,6 +6,7 @@
 
 #if defined(KOKKOS_ENABLE_OPENACC)
 #include <OpenACC/Kokkos_OpenACC.hpp>
+#include <OpenACC/Kokkos_OpenACC_Instance.hpp>
 #include <OpenACC/Kokkos_OpenACCSpace.hpp>
 #include <OpenACC/Kokkos_OpenACC_DeepCopy.hpp>
 #include <OpenACC/Kokkos_OpenACC_SharedAllocationRecord.hpp>

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -644,7 +644,6 @@ if(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_Abort.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_Complex.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ExecutionSpace.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ExecSpacePartitioning.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_MathematicalConstants.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_MathematicalSpecialFunctions.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_MinMaxClamp.cpp

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -68,6 +68,11 @@ void check_distinctive([[maybe_unused]] ExecSpace exec1,
     ASSERT_NE(exec1.impl_instance_id(), exec2.impl_instance_id());
   }
 #endif
+#ifdef KOKKOS_ENABLE_OPENACC
+  if constexpr (std::is_same_v<ExecSpace, Kokkos::Experimental::OpenACC>) {
+    ASSERT_NE(exec1.acc_async_queue(), exec2.acc_async_queue());
+  }
+#endif
 }
 }  // namespace
 


### PR DESCRIPTION
Added the OpenACC backend implementation of Kokkos::Experimental::partition_space() API.
Updated related unit test and CMake configurations.
(Additional minor bug fix) Deleted duplicate definition of a variable in the OpenACC ParallelReduce(Team) implementation.