### PR TITLE
port STREAM benchmark to perf_test

### DIFF
--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -80,6 +80,7 @@ set(BENCHMARK_SOURCES
     PerfTest_ExecSpacePartitioning.cpp
     PerfTestHexGrad.cpp
     PerfTest_MallocFree.cpp
+    PerfTest_Stream.cpp
     PerfTest_ViewAllocate.cpp
     PerfTest_ViewCopy_a123.cpp
     PerfTest_ViewCopy_b123.cpp

--- a/core/perf_test/PerfTest_Stream.cpp
+++ b/core/perf_test/PerfTest_Stream.cpp
@@ -1,0 +1,249 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+#include <benchmark/benchmark.h>
+#include "Benchmark_Context.hpp"
+
+constexpr static double aInit  = 1.0;
+constexpr static double bInit  = 2.0;
+constexpr static double cInit  = 3.0;
+constexpr static double scalar = 4.0;
+
+using StreamDeviceArray =
+    Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Restrict>>;
+using StreamHostArray = typename StreamDeviceArray::HostMirror;
+
+using StreamIndex =
+    int64_t;  // different than benchmarks/stream, which uses int
+using Policy = Kokkos::RangePolicy<Kokkos::IndexType<StreamIndex>>;
+
+void perform_set(StreamDeviceArray& a, const double scalar) {
+  Kokkos::parallel_for(
+      "set", Policy(0, a.extent(0)),
+      KOKKOS_LAMBDA(const StreamIndex i) { a[i] = scalar; });
+
+  Kokkos::fence();
+}
+
+void perform_copy(StreamDeviceArray& a, StreamDeviceArray& b) {
+  Kokkos::parallel_for(
+      "copy", Policy(0, a.extent(0)),
+      KOKKOS_LAMBDA(const StreamIndex i) { b[i] = a[i]; });
+
+  Kokkos::fence();
+}
+
+void perform_scale(StreamDeviceArray& b, StreamDeviceArray& c,
+                   const double scalar) {
+  Kokkos::parallel_for(
+      "scale", Policy(0, b.extent(0)),
+      KOKKOS_LAMBDA(const StreamIndex i) { b[i] = scalar * c[i]; });
+
+  Kokkos::fence();
+}
+
+void perform_add(StreamDeviceArray& a, StreamDeviceArray& b,
+                 StreamDeviceArray& c) {
+  Kokkos::parallel_for(
+      "add", Policy(0, a.extent(0)),
+      KOKKOS_LAMBDA(const StreamIndex i) { c[i] = a[i] + b[i]; });
+
+  Kokkos::fence();
+}
+
+void perform_triad(StreamDeviceArray& a, StreamDeviceArray& b,
+                   StreamDeviceArray& c, const double scalar) {
+  Kokkos::parallel_for(
+      "triad", Policy(0, a.extent(0)),
+      KOKKOS_LAMBDA(const StreamIndex i) { a[i] = b[i] + scalar * c[i]; });
+
+  Kokkos::fence();
+}
+
+int validate_array(StreamDeviceArray& a_dev, const double expected) {
+  auto a = Kokkos::create_mirror_view(a_dev);
+  Kokkos::deep_copy(a, a_dev);
+
+  double error = 0.0;
+  for (StreamIndex i = 0; i < a.size(); ++i) {
+    error += std::abs(a[i] - expected);
+  }
+  double avgError = error / (double)a.size();
+
+  const double epsilon = 1.0e-13;
+  return std::abs(avgError / expected) > epsilon;
+}
+
+static void StreamSet(benchmark::State& state) {
+  const size_t N8                 = std::pow(state.range(0), 8);
+  static constexpr int DATA_RATIO = 1;
+  const double scalar             = 1.5;
+
+  StreamDeviceArray a("a", N8);
+
+  for (auto _ : state) {
+    Kokkos::Timer timer;
+    perform_set(a, scalar);
+    KokkosBenchmark::report_results(state, a, DATA_RATIO, timer.seconds());
+  }
+
+  if (validate_array(a, scalar)) {
+    state.SkipWithError("validation failure");
+  }
+}
+
+static void StreamCopy(benchmark::State& state) {
+  const size_t N8                 = std::pow(state.range(0), 8);
+  static constexpr int DATA_RATIO = 2;
+
+  StreamDeviceArray a("a", N8);
+  StreamDeviceArray b("b", N8);
+
+  perform_set(a, aInit);
+  perform_set(b, bInit);
+
+  for (auto _ : state) {
+    Kokkos::Timer timer;
+    perform_copy(a, b);
+    KokkosBenchmark::report_results(state, a, DATA_RATIO, timer.seconds());
+  }
+
+  if (validate_array(b, aInit)) {
+    state.SkipWithError("validation failure");
+  }
+}
+
+static void StreamScale(benchmark::State& state) {
+  const size_t N8                 = std::pow(state.range(0), 8);
+  static constexpr int DATA_RATIO = 2;
+
+  StreamDeviceArray a("a", N8);
+  StreamDeviceArray b("b", N8);
+
+  perform_set(a, aInit);
+  perform_set(b, bInit);
+
+  for (auto _ : state) {
+    Kokkos::Timer timer;
+    perform_scale(a, b, scalar);
+    KokkosBenchmark::report_results(state, b, DATA_RATIO, timer.seconds());
+  }
+
+  if (validate_array(a, bInit * scalar)) {
+    state.SkipWithError("validation failure");
+  }
+}
+
+static void StreamAdd(benchmark::State& state) {
+  const size_t N8                 = std::pow(state.range(0), 8);
+  static constexpr int DATA_RATIO = 3;
+
+  StreamDeviceArray a("a", N8);
+  StreamDeviceArray b("b", N8);
+  StreamDeviceArray c("c", N8);
+
+  perform_set(a, aInit);
+  perform_set(b, bInit);
+  perform_set(c, cInit);
+
+  for (auto _ : state) {
+    Kokkos::Timer timer;
+    perform_add(a, b, c);
+    KokkosBenchmark::report_results(state, c, DATA_RATIO, timer.seconds());
+  }
+
+  if (validate_array(c, aInit + bInit)) {
+    state.SkipWithError("validation failure");
+  }
+}
+
+static void StreamTriad(benchmark::State& state) {
+  const size_t N8                 = std::pow(state.range(0), 8);
+  static constexpr int DATA_RATIO = 3;
+
+  StreamDeviceArray a("a", N8);
+  StreamDeviceArray b("b", N8);
+  StreamDeviceArray c("c", N8);
+
+  perform_set(a, aInit);
+  perform_set(b, bInit);
+  perform_set(c, cInit);
+
+  for (auto _ : state) {
+    Kokkos::Timer timer;
+    perform_triad(a, b, c, scalar);
+    KokkosBenchmark::report_results(state, a, DATA_RATIO, timer.seconds());
+  }
+
+  if (validate_array(a, bInit + scalar * cInit)) {
+    state.SkipWithError("validation failure");
+  }
+}
+
+// skips a benchmark with an error from thrown exceptions
+template <void (*bm)(benchmark::State&)>
+static void or_skip(benchmark::State& state) {
+  try {
+    bm(state);
+  } catch (const std::runtime_error& e) {
+    state.SkipWithError(e.what());
+  }
+};
+
+namespace Test {
+
+BENCHMARK(or_skip<StreamSet>)
+    ->Name("StreamSet")
+    ->ArgName("N")
+    ->Arg(10)
+    ->Arg(15)
+    ->Unit(benchmark::kMillisecond)
+    ->UseManualTime();
+
+BENCHMARK(or_skip<StreamCopy>)
+    ->Name("StreamCopy")
+    ->ArgName("N")
+    ->Arg(10)
+    ->Arg(15)
+    ->Unit(benchmark::kMillisecond)
+    ->UseManualTime();
+
+BENCHMARK(or_skip<StreamScale>)
+    ->Name("StreamScale")
+    ->ArgName("N")
+    ->Arg(10)
+    ->Arg(15)
+    ->Unit(benchmark::kMillisecond)
+    ->UseManualTime();
+
+BENCHMARK(or_skip<StreamAdd>)
+    ->Name("StreamAdd")
+    ->ArgName("N")
+    ->Arg(10)
+    ->Arg(15)
+    ->Unit(benchmark::kMillisecond)
+    ->UseManualTime();
+
+BENCHMARK(or_skip<StreamTriad>)
+    ->Name("StreamTriad")
+    ->ArgName("N")
+    ->Arg(10)
+    ->Arg(15)
+    ->Unit(benchmark::kMillisecond)
+    ->UseManualTime();
+
+}  // namespace Test


### PR DESCRIPTION
`benchmarks/stream/Kokkos_stream` output:

```
Reports fastest timing per kernel
Creating Views...
Memory Sizes:
- Array Size:    100000000
- Per Array:           800.00 MB
- Total:              2400.00 MB
Benchmark kernels will be performed for 20 iterations.
-------------------------------------------------------------
Initializing Views...
Starting benchmarking...
Performing validation...
All solutions checked and verified.
-------------------------------------------------------------
Set               267745.41 MB/s
Copy              258916.39 MB/s
Scale             258756.15 MB/s
Add               260532.46 MB/s
Triad             260235.19 MB/s
-------------------------------------------------------------
```

`core/perf_test/Kokkos_PerformanceTest_Benchmark --benchmark_filter=Stream` output:
(my GPU has 12 GB of RAM, note benchmarks continue with a nice error message)

```
---------------------------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------
StreamSet/N:10/manual_time         3.00 ms         3.00 ms          232 FOM: GB/s=266.77/s MB=800
StreamSet/N:15/manual_time   ERROR OCCURRED: 'Kokkos ERROR: Cuda memory space failed to allocate 19.1 GiB (label="a").'
StreamCopy/N:10/manual_time        6.22 ms         6.22 ms          108 FOM: GB/s=257.249/s MB=1.6k
StreamCopy/N:15/manual_time  ERROR OCCURRED: 'Kokkos ERROR: Cuda memory space failed to allocate 19.1 GiB (label="a").'
StreamScale/N:10/manual_time       6.22 ms         6.22 ms          108 FOM: GB/s=257.207/s MB=1.6k
StreamScale/N:15/manual_time ERROR OCCURRED: 'Kokkos ERROR: Cuda memory space failed to allocate 19.1 GiB (label="a").'
StreamAdd/N:10/manual_time         9.29 ms         9.28 ms           72 FOM: GB/s=258.44/s MB=2.4k
StreamAdd/N:15/manual_time   ERROR OCCURRED: 'Kokkos ERROR: Cuda memory space failed to allocate 19.1 GiB (label="a").'
StreamTriad/N:10/manual_time       9.29 ms         9.29 ms           72 FOM: GB/s=258.24/s MB=2.4k
StreamTriad/N:15/manual_time ERROR OCCURRED: 'Kokkos ERROR: Cuda memory space failed to allocate 19.1 GiB (label="a").'
```

The small performance difference probably comes down to STREAM reporting fastest, while perf_test harness reports average.