### PR TITLE
SYCL: Update barriers in accordance with SYCL2020

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
@@ -226,7 +226,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                       {global_x, global_y, global_z},
                       {local_x, local_y, local_z})
                       .exec_range();
-                item.barrier(sycl::access::fence_space::local_space);
+                sycl::group_barrier(item.get_group());
 
                 SYCLReduction::workgroup_reduction<>(
                     item, local_mem, results_ptr, device_accessible_result_ptr,
@@ -239,7 +239,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                       scratch_flags_ref(*scratch_flags);
                   num_teams_done[0] = ++scratch_flags_ref;
                 }
-                item.barrier(sycl::access::fence_space::local_space);
+                sycl::group_barrier(item.get_group());
                 if (num_teams_done[0] == n_wgroups) {
                   if (local_id == 0) *scratch_flags = 0;
                   if (local_id >= static_cast<int>(n_wgroups))
@@ -285,7 +285,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                       scratch_flags_ref(*scratch_flags);
                   num_teams_done[0] = ++scratch_flags_ref;
                 }
-                item.barrier(sycl::access::fence_space::local_space);
+                sycl::group_barrier(item.get_group());
                 if (num_teams_done[0] == n_wgroups) {
                   if (local_id == 0) *scratch_flags = 0;
                   if (local_id >= static_cast<int>(n_wgroups))

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
@@ -167,7 +167,7 @@ class Kokkos::Impl::ParallelReduce<
                   else
                     functor(WorkTag(), id + begin, update);
                 }
-                item.barrier(sycl::access::fence_space::local_space);
+                sycl::group_barrier(item.get_group());
 
                 SYCLReduction::workgroup_reduction<>(
                     item, local_mem, results_ptr, device_accessible_result_ptr,
@@ -180,7 +180,7 @@ class Kokkos::Impl::ParallelReduce<
                       scratch_flags_ref(*scratch_flags);
                   num_teams_done[0] = ++scratch_flags_ref;
                 }
-                item.barrier(sycl::access::fence_space::local_space);
+                sycl::group_barrier(item.get_group());
                 if (num_teams_done[0] == n_wgroups) {
                   if (local_id == 0) *scratch_flags = 0;
                   if (local_id >= n_wgroups)
@@ -223,7 +223,7 @@ class Kokkos::Impl::ParallelReduce<
                       scratch_flags_ref(*scratch_flags);
                   num_teams_done[0] = ++scratch_flags_ref;
                 }
-                item.barrier(sycl::access::fence_space::local_space);
+                sycl::group_barrier(item.get_group());
                 if (num_teams_done[0] == n_wgroups) {
                   if (local_id == 0) *scratch_flags = 0;
                   if (local_id >= n_wgroups)

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -210,7 +210,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                     else
                       functor(WorkTag(), team_member, update);
                   }
-                  item.barrier(sycl::access::fence_space::local_space);
+                  sycl::group_barrier(item.get_group());
 
                   SYCLReduction::workgroup_reduction<>(
                       item, local_mem, results_ptr,
@@ -279,7 +279,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                         scratch_flags_ref(*scratch_flags);
                     num_teams_done[0] = ++scratch_flags_ref;
                   }
-                  item.barrier(sycl::access::fence_space::local_space);
+                  sycl::group_barrier(item.get_group());
                   if (num_teams_done[0] == n_wgroups) {
                     if (local_id == 0) *scratch_flags = 0;
                     if (local_id >= n_wgroups)

--- a/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
@@ -220,7 +220,7 @@ class ParallelScanSYCLBase {
               scratch_flags_ref(*scratch_flags);
           num_teams_done[0] = ++scratch_flags_ref;
         }
-        item.barrier(sycl::access::fence_space::global_space);
+        sycl::group_barrier(item.get_group());
         if (num_teams_done[0] == n_wgroups) {
           if (local_id == 0) *scratch_flags = 0;
           value_type total;
@@ -244,7 +244,7 @@ class ParallelScanSYCLBase {
                 &total,
                 &local_mem[item.get_sub_group().get_group_range()[0] - 1]);
             if (offset + wgroup_size < n_wgroups)
-              item.barrier(sycl::access::fence_space::global_space);
+              sycl::group_barrier(item.get_group());
           }
         }
       };

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -296,7 +296,7 @@ class SYCLTeamMember {
       intermediate += base_data[n_active_subgroups - 1];
     }
     // Make sure that the reduction array hasn't been modified in the meantime.
-    m_item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(m_item.get_group());
 
     return intermediate;
   }

--- a/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_WorkgroupReduction.hpp
@@ -191,7 +191,7 @@ std::enable_if_t<use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(
   if (id_in_sg == 0 && sg_group_id <= n_active_subgroups)
     local_mem[sg_group_id] = local_value;
 
-  item.barrier(sycl::access::fence_space::local_space);
+  sycl::group_barrier(item.get_group());
 
   // Do the final reduction only using the first subgroup.
   if (sg.get_group_id()[0] == 0) {
@@ -206,7 +206,7 @@ std::enable_if_t<use_shuffle_based_algorithm<ReducerType>> workgroup_reduction(
         if (id_in_sg + offset < n_active_subgroups) {
           final_reducer.join(&sg_value, &local_mem[(id_in_sg + offset)]);
         }
-      sg.barrier();
+      sycl::group_barrier(sg);
     }
 
     // Then, we proceed as before.


### PR DESCRIPTION
The only syntax for barriers SYCL2020 has is
```C++
template <typename Group>
void group_barrier(Group g,
                   memory_scope scope = Group::fence_scope);
```
see https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_group_barrier.
The feature was implemented in https://github.com/intel/llvm/pull/3858.
