### PR TITLE
Clean up CUDA API wrapper

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -41,7 +41,8 @@
 cudaStream_t Kokkos::Impl::cuda_get_deep_copy_stream() {
   static cudaStream_t s = nullptr;
   if (s == nullptr) {
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamCreate(&s));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (CudaInternal::singleton().cuda_stream_create_wrapper(&s)));
   }
   return s;
 }
@@ -58,7 +59,8 @@ namespace Kokkos {
 namespace Impl {
 
 void DeepCopyCuda(void *dst, const void *src, size_t n) {
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemcpy(dst, src, n, cudaMemcpyDefault));
+  KOKKOS_IMPL_CUDA_SAFE_CALL((CudaInternal::singleton().cuda_memcpy_wrapper(
+      dst, src, n, cudaMemcpyDefault)));
 }
 
 void DeepCopyAsyncCuda(const Cuda &instance, void *dst, const void *src,
@@ -70,6 +72,7 @@ void DeepCopyAsyncCuda(const Cuda &instance, void *dst, const void *src,
 
 void DeepCopyAsyncCuda(void *dst, const void *src, size_t n) {
   cudaStream_t s = cuda_get_deep_copy_stream();
+  CudaInternal::singleton().set_cuda_device();
   KOKKOS_IMPL_CUDA_SAFE_CALL(
       cudaMemcpyAsync(dst, src, n, cudaMemcpyDefault, s));
   Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Cuda>(

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -41,8 +41,7 @@
 cudaStream_t Kokkos::Impl::cuda_get_deep_copy_stream() {
   static cudaStream_t s = nullptr;
   if (s == nullptr) {
-    KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (CudaInternal::singleton().cuda_stream_create_wrapper(&s)));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamCreate(&s));
   }
   return s;
 }
@@ -59,8 +58,7 @@ namespace Kokkos {
 namespace Impl {
 
 void DeepCopyCuda(void *dst, const void *src, size_t n) {
-  KOKKOS_IMPL_CUDA_SAFE_CALL((CudaInternal::singleton().cuda_memcpy_wrapper(
-      dst, src, n, cudaMemcpyDefault)));
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemcpy(dst, src, n, cudaMemcpyDefault));
 }
 
 void DeepCopyAsyncCuda(const Cuda &instance, void *dst, const void *src,
@@ -73,8 +71,7 @@ void DeepCopyAsyncCuda(const Cuda &instance, void *dst, const void *src,
 void DeepCopyAsyncCuda(void *dst, const void *src, size_t n) {
   cudaStream_t s = cuda_get_deep_copy_stream();
   KOKKOS_IMPL_CUDA_SAFE_CALL(
-      (CudaInternal::singleton().cuda_memcpy_async_wrapper(
-          dst, src, n, cudaMemcpyDefault, s)));
+      cudaMemcpyAsync(dst, src, n, cudaMemcpyDefault, s));
   Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Cuda>(
       "Kokkos::Impl::DeepCopyAsyncCuda: Deep Copy Stream Sync",
       Kokkos::Tools::Experimental::SpecialSynchronizationCases::

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -72,7 +72,6 @@ void DeepCopyAsyncCuda(const Cuda &instance, void *dst, const void *src,
 
 void DeepCopyAsyncCuda(void *dst, const void *src, size_t n) {
   cudaStream_t s = cuda_get_deep_copy_stream();
-  CudaInternal::singleton().set_cuda_device();
   KOKKOS_IMPL_CUDA_SAFE_CALL(
       cudaMemcpyAsync(dst, src, n, cudaMemcpyDefault, s));
   Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Cuda>(

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -734,9 +734,7 @@ uint32_t Cuda::impl_instance_id() const noexcept {
   return m_space_instance->impl_get_instance_id();
 }
 
-cudaStream_t Cuda::cuda_stream() const {
-  return m_space_instance->get_stream();
-}
+cudaStream_t Cuda::cuda_stream() const { return m_space_instance->m_stream; }
 int Cuda::cuda_device() const { return m_space_instance->m_cudaDev; }
 const cudaDeviceProp &Cuda::cuda_device_prop() const {
   return m_space_instance->m_deviceProp;

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -168,271 +168,162 @@ class CudaInternal {
     }
   }
 
-  // Using cudaAPI function/objects will be w.r.t. device 0 unless
+  // Using CUDA API function/objects will be w.r.t. device 0 unless
   // cudaSetDevice(device_id) is called with the correct device_id.
   // The correct device_id is stored in the variable
-  // CudaInternal::m_cudaDev set in Cuda::impl_initialize(). It is not
-  // sufficient to call cudaSetDevice(m_cudaDev) during cuda initialization
-  // only, however, since if a user creates a new thread, that thread will be
-  // given the default cuda env with device_id=0, causing errors when
-  // device_id!=0 is requested by the user. To ensure against this, almost all
-  // cudaAPI calls, as well as using cudaStream_t variables, must be proceeded
-  // by cudaSetDevice(device_id).
+  // CudaInternal::m_cudaDev set in Cuda::impl_initialize(). In the case
+  // where multiple CUDA instances are used, or threads are launched
+  // using non-default CUDA execution space after initialization, all CUDA
+  // API calls must follow a call to cudaSetDevice(device_id) when an
+  // execution space or CudaInternal object is provided to ensure all
+  // computation is done on the correct device.
 
-  // This function sets device in cudaAPI to device requested at runtime (set in
-  // m_cudaDev).
+  // FIXME: Not all CUDA API calls require us to set device. Potential
+  // performance gain by selectively setting device.
+
+  // Set the device to the one stored by this instance for CUDA API calls.
   void set_cuda_device() const {
     verify_is_initialized("set_cuda_device");
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(m_cudaDev));
   }
 
-  // Return the class stream, optionally setting the device id.
-  template <bool setCudaDevice = true>
-  cudaStream_t get_stream() const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return m_stream;
-  }
-
-  // The following are wrappers for cudaAPI functions (C and C++ routines) which
-  // set the correct device id directly before the cudaAPI call (unless
-  // explicitly disabled by providing setCudaDevice=false template).
-  // setCudaDevice=true should be used for all API calls which take a stream
-  // unless it is guarenteed to be from a cuda instance with the correct device
-  // set already (e.g., back-to-back cudaAPI calls in a single function). For
-  // cudaAPI functions that take a stream, an optional input stream is
-  // available. If no stream is given, the stream for the CudaInternal instance
-  // is used. All cudaAPI calls should be wrapped in these interface functions
-  // to ensure safety when using threads.
-
-  // Helper function for selecting the correct input stream
-  cudaStream_t get_input_stream(cudaStream_t s) const {
-    return s == nullptr ? get_stream<false>() : s;
-  }
+  // CUDA API wrappers
 
   // C API routines
-  template <bool setCudaDevice = true>
   cudaError_t cuda_device_get_limit_wrapper(size_t* pValue,
                                             cudaLimit limit) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
     return cudaDeviceGetLimit(pValue, limit);
   }
 
-  template <bool setCudaDevice = true>
   cudaError_t cuda_device_set_limit_wrapper(cudaLimit limit,
                                             size_t value) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
     return cudaDeviceSetLimit(limit, value);
   }
 
-  template <bool setCudaDevice = true>
   cudaError_t cuda_event_create_wrapper(cudaEvent_t* event) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
     return cudaEventCreate(event);
   }
 
-  template <bool setCudaDevice = true>
-  cudaError_t cuda_event_destroy_wrapper(cudaEvent_t event) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaEventDestroy(event);
+  cudaError_t cuda_event_record_wrapper(cudaEvent_t event) const {
+    set_cuda_device();
+    return cudaEventRecord(event, m_stream);
   }
 
-  template <bool setCudaDevice = true>
-  cudaError_t cuda_event_record_wrapper(cudaEvent_t event,
-                                        cudaStream_t stream = nullptr) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaEventRecord(event, get_input_stream(stream));
-  }
-
-  template <bool setCudaDevice = true>
   cudaError_t cuda_event_synchronize_wrapper(cudaEvent_t event) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
     return cudaEventSynchronize(event);
   }
 
-  template <bool setCudaDevice = true>
   cudaError_t cuda_free_wrapper(void* devPtr) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
     return cudaFree(devPtr);
   }
 
-  template <bool setCudaDevice = true>
-  cudaError_t cuda_free_host_wrapper(void* ptr) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaFreeHost(ptr);
-  }
-
-  template <bool setCudaDevice = true>
   cudaError_t cuda_graph_add_dependencies_wrapper(
       cudaGraph_t graph, const cudaGraphNode_t* from, const cudaGraphNode_t* to,
       size_t numDependencies) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
     return cudaGraphAddDependencies(graph, from, to, numDependencies);
   }
 
-  template <bool setCudaDevice = true>
   cudaError_t cuda_graph_add_empty_node_wrapper(
       cudaGraphNode_t* pGraphNode, cudaGraph_t graph,
       const cudaGraphNode_t* pDependencies, size_t numDependencies) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
     return cudaGraphAddEmptyNode(pGraphNode, graph, pDependencies,
                                  numDependencies);
   }
 
-  template <bool setCudaDevice = true>
   cudaError_t cuda_graph_add_kernel_node_wrapper(
       cudaGraphNode_t* pGraphNode, cudaGraph_t graph,
       const cudaGraphNode_t* pDependencies, size_t numDependencies,
       const cudaKernelNodeParams* pNodeParams) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
     return cudaGraphAddKernelNode(pGraphNode, graph, pDependencies,
                                   numDependencies, pNodeParams);
   }
 
-  template <bool setCudaDevice = true>
   cudaError_t cuda_graph_create_wrapper(cudaGraph_t* pGraph,
                                         unsigned int flags) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
     return cudaGraphCreate(pGraph, flags);
   }
 
-  template <bool setCudaDevice = true>
   cudaError_t cuda_graph_destroy_wrapper(cudaGraph_t graph) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
     return cudaGraphDestroy(graph);
   }
 
-  template <bool setCudaDevice = true>
   cudaError_t cuda_graph_exec_destroy_wrapper(cudaGraphExec_t graphExec) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
     return cudaGraphExecDestroy(graphExec);
   }
 
-  template <bool setCudaDevice = true>
-  cudaError_t cuda_graph_launch_wrapper(cudaGraphExec_t graphExec,
-                                        cudaStream_t stream = nullptr) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaGraphLaunch(graphExec, get_input_stream(stream));
+  cudaError_t cuda_graph_launch_wrapper(cudaGraphExec_t graphExec) const {
+    set_cuda_device();
+    return cudaGraphLaunch(graphExec, m_stream);
   }
 
-  template <bool setCudaDevice = true>
-  cudaError_t cuda_host_alloc_wrapper(void** pHost, size_t size,
-                                      unsigned int flags) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaHostAlloc(pHost, size, flags);
-  }
-
-  template <bool setCudaDevice = true>
   cudaError_t cuda_malloc_wrapper(void** devPtr, size_t size) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
     return cudaMalloc(devPtr, size);
   }
 
-  template <bool setCudaDevice = true>
   cudaError_t cuda_malloc_host_wrapper(void** ptr, size_t size) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
     return cudaMallocHost(ptr, size);
   }
 
-  template <bool setCudaDevice = true>
-  cudaError_t cuda_malloc_managed_wrapper(
-      void** devPtr, size_t size,
-      unsigned int flags = cudaMemAttachGlobal) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaMallocManaged(devPtr, size, flags);
+  cudaError_t cuda_mem_prefetch_async_wrapper(const void* devPtr, size_t count,
+                                              int dstDevice) const {
+    set_cuda_device();
+    return cudaMemPrefetchAsync(devPtr, count, dstDevice, m_stream);
   }
 
-  template <bool setCudaDevice = true>
-  cudaError_t cuda_mem_advise_wrapper(const void* devPtr, size_t count,
-                                      cudaMemoryAdvise advice,
-                                      int device) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaMemAdvise(devPtr, count, advice, device);
-  }
-
-  template <bool setCudaDevice = true>
-  cudaError_t cuda_mem_prefetch_async_wrapper(
-      const void* devPtr, size_t count, int dstDevice,
-      cudaStream_t stream = nullptr) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaMemPrefetchAsync(devPtr, count, dstDevice,
-                                get_input_stream(stream));
-  }
-
-  template <bool setCudaDevice = true>
-  cudaError_t cuda_memcpy_wrapper(void* dst, const void* src, size_t count,
-                                  cudaMemcpyKind kind) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaMemcpy(dst, src, count, kind);
-  }
-
-  template <bool setCudaDevice = true>
   cudaError_t cuda_memcpy_async_wrapper(void* dst, const void* src,
-                                        size_t count, cudaMemcpyKind kind,
-                                        cudaStream_t stream = nullptr) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaMemcpyAsync(dst, src, count, kind, get_input_stream(stream));
+                                        size_t count,
+                                        cudaMemcpyKind kind) const {
+    set_cuda_device();
+    return cudaMemcpyAsync(dst, src, count, kind, m_stream);
   }
 
-  template <bool setCudaDevice = true>
-  cudaError_t cuda_memcpy_to_symbol_async_wrapper(
-      const void* symbol, const void* src, size_t count, size_t offset,
-      cudaMemcpyKind kind, cudaStream_t stream = nullptr) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaMemcpyToSymbolAsync(symbol, src, count, offset, kind,
-                                   get_input_stream(stream));
+  cudaError_t cuda_memcpy_to_symbol_async_wrapper(const void* symbol,
+                                                  const void* src, size_t count,
+                                                  size_t offset,
+                                                  cudaMemcpyKind kind) const {
+    set_cuda_device();
+    return cudaMemcpyToSymbolAsync(symbol, src, count, offset, kind, m_stream);
   }
 
-  template <bool setCudaDevice = true>
   cudaError_t cuda_memset_wrapper(void* devPtr, int value, size_t count) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
     return cudaMemset(devPtr, value, count);
   }
 
-  template <bool setCudaDevice = true>
-  cudaError_t cuda_memset_async_wrapper(void* devPtr, int value, size_t count,
-                                        cudaStream_t stream = nullptr) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaMemsetAsync(devPtr, value, count, get_input_stream(stream));
+  cudaError_t cuda_memset_async_wrapper(void* devPtr, int value,
+                                        size_t count) const {
+    set_cuda_device();
+    return cudaMemsetAsync(devPtr, value, count, m_stream);
   }
 
-  template <bool setCudaDevice = true>
   cudaError_t cuda_pointer_get_attributes_wrapper(
       cudaPointerAttributes* attributes, const void* ptr) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
     return cudaPointerGetAttributes(attributes, ptr);
   }
 
-  template <bool setCudaDevice = true>
   cudaError_t cuda_stream_create_wrapper(cudaStream_t* pStream) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
     return cudaStreamCreate(pStream);
   }
 
-  template <bool setCudaDevice = true>
-  cudaError_t cuda_stream_destroy_wrapper(cudaStream_t stream) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaStreamDestroy(stream);
-  }
-
   // C++ API routines
-  template <typename T, bool setCudaDevice = true>
-  cudaError_t cuda_func_get_attributes_wrapper(cudaFuncAttributes* attr,
-                                               T* entry) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaFuncGetAttributes(attr, entry);
-  }
-
-  template <typename T, bool setCudaDevice = true>
-  cudaError_t cuda_func_set_attribute_wrapper(T* entry, cudaFuncAttribute attr,
-                                              int value) const {
-    if constexpr (setCudaDevice) set_cuda_device();
-    return cudaFuncSetAttribute(entry, attr, value);
-  }
-
-  template <bool setCudaDevice = true>
   cudaError_t cuda_graph_instantiate_wrapper(cudaGraphExec_t* pGraphExec,
                                              cudaGraph_t graph) const {
-    if constexpr (setCudaDevice) set_cuda_device();
+    set_cuda_device();
 #if CUDA_VERSION < 12000
     constexpr size_t error_log_size = 256;
     cudaGraphNode_t error_node      = nullptr;

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -321,6 +321,20 @@ class CudaInternal {
   }
 
   // C++ API routines
+  template <typename T>
+  cudaError_t cuda_func_get_attributes_wrapper(cudaFuncAttributes* attr,
+                                               T* entry) const {
+    set_cuda_device();
+    return cudaFuncGetAttributes(attr, entry);
+  }
+
+  template <typename T>
+  cudaError_t cuda_func_set_attribute_wrapper(T* entry, cudaFuncAttribute attr,
+                                              int value) const {
+    set_cuda_device();
+    return cudaFuncSetAttribute(entry, attr, value);
+  }
+
   cudaError_t cuda_graph_instantiate_wrapper(cudaGraphExec_t* pGraphExec,
                                              cudaGraph_t graph) const {
     set_cuda_device();

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -283,6 +283,12 @@ class CudaInternal {
     return cudaMemPrefetchAsync(devPtr, count, dstDevice, m_stream);
   }
 
+  cudaError_t cuda_memcpy_wrapper(void* dst, const void* src, size_t count,
+                                  cudaMemcpyKind kind) const {
+    set_cuda_device();
+    return cudaMemcpy(dst, src, count, kind);
+  }
+
   cudaError_t cuda_memcpy_async_wrapper(void* dst, const void* src,
                                         size_t count,
                                         cudaMemcpyKind kind) const {

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -130,30 +130,32 @@ inline void check_shmem_request(CudaInternal const* cuda_instance, int shmem) {
 // KernelFuncPtr does not necessarily contain that type information.
 template <class DriverType, class LaunchBounds, class KernelFuncPtr>
 const cudaFuncAttributes& get_cuda_kernel_func_attributes(
-    int cuda_device, const KernelFuncPtr& func) {
+    const CudaInternal* cuda_instance, const KernelFuncPtr& func) {
   // Only call cudaFuncGetAttributes once for each unique kernel
   // by leveraging static variable initialization rules
+  const auto cuda_device = cuda_instance->m_cudaDev;
   static std::map<int, cudaFuncAttributes> func_attr;
   if (func_attr.find(cuda_device) == func_attr.end()) {
     cudaFuncAttributes attr;
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(cuda_device));
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFuncGetAttributes(&attr, func));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (cuda_instance->cuda_func_get_attributes_wrapper(&attr, func)));
     func_attr.emplace(cuda_device, attr);
   }
   return func_attr[cuda_device];
 }
 
 template <class DriverType, class LaunchBounds, class KernelFuncPtr>
-inline void configure_shmem_preference(const int cuda_device,
+inline void configure_shmem_preference(const CudaInternal* cuda_instance,
                                        const KernelFuncPtr& func,
-                                       const cudaDeviceProp& device_props,
                                        const size_t block_size, int& shmem,
                                        const size_t occupancy) {
 #ifndef KOKKOS_ARCH_KEPLER
 
   const auto& func_attr =
-      get_cuda_kernel_func_attributes<DriverType, LaunchBounds>(cuda_device,
+      get_cuda_kernel_func_attributes<DriverType, LaunchBounds>(cuda_instance,
                                                                 func);
+
+  const auto device_props = cuda_instance->m_deviceProp;
 
   // Compute limits for number of blocks due to registers/SM
   const size_t regs_per_sm     = device_props.regsPerMultiprocessor;
@@ -219,10 +221,9 @@ inline void configure_shmem_preference(const int cuda_device,
   if (carveout > 100) carveout = 100;
 
   // Set the carveout, but only call it once per kernel or when it changes
-  // FIXME_CUDA_MULTIPLE_DEVICES
   auto set_cache_config = [&] {
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFuncSetAttribute(
-        func, cudaFuncAttributePreferredSharedMemoryCarveout, carveout));
+    KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_func_set_attribute_wrapper(
+        func, cudaFuncAttributePreferredSharedMemoryCarveout, carveout)));
     return carveout;
   };
   // Store the value in a static variable so we only reset if needed
@@ -496,8 +497,8 @@ struct CudaParallelLaunchKernelInvoker<
             driver.get_policy().impl_get_desired_occupancy().value();
         size_t block_size = static_cast<size_t>(block.x) * block.y * block.z;
         Impl::configure_shmem_preference<DriverType, LaunchBounds>(
-            cuda_instance->m_cudaDev, base_t::get_kernel_func(),
-            cuda_instance->m_deviceProp, block_size, shmem, desired_occupancy);
+            cuda_instance, base_t::get_kernel_func(), block_size, shmem,
+            desired_occupancy);
       }
 
       auto* driver_ptr = Impl::allocate_driver_storage_for_kernel(
@@ -685,8 +686,8 @@ struct CudaParallelLaunchImpl<
         Impl::configure_shmem_preference<
             DriverType,
             Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>>(
-            cuda_instance->m_cudaDev, base_t::get_kernel_func(),
-            cuda_instance->m_deviceProp, block_size, shmem, desired_occupancy);
+            cuda_instance, base_t::get_kernel_func(), block_size, shmem,
+            desired_occupancy);
       }
 
       desul::ensure_cuda_lock_arrays_on_device();
@@ -702,10 +703,11 @@ struct CudaParallelLaunchImpl<
     }
   }
 
-  static cudaFuncAttributes get_cuda_func_attributes(int cuda_device) {
+  static cudaFuncAttributes get_cuda_func_attributes(
+      const CudaInternal* cuda_instance) {
     return get_cuda_kernel_func_attributes<
         DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>>(
-        cuda_device, base_t::get_kernel_func());
+        cuda_instance, base_t::get_kernel_func());
   }
 };
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -42,7 +42,7 @@ template <typename ParallelType, typename Policy, typename LaunchBounds>
 int max_tile_size_product_helper(const Policy& pol, const LaunchBounds&) {
   cudaFuncAttributes attr =
       CudaParallelLaunch<ParallelType, LaunchBounds>::get_cuda_func_attributes(
-          pol.space().cuda_device());
+          pol.space().impl_internal_space_instance());
   auto const& prop = pol.space().cuda_device_prop();
 
   // Limits due to registers/SM, MDRange doesn't have
@@ -394,7 +394,8 @@ class ParallelReduce<CombinedFunctorReducerType,
         Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
                              Policy, Kokkos::Cuda>;
     cudaFuncAttributes attr = CudaParallelLaunch<closure_type, LaunchBounds>::
-        get_cuda_func_attributes(m_policy.space().cuda_device());
+        get_cuda_func_attributes(
+            m_policy.space().impl_internal_space_instance());
     while (
         (n && (maxShmemPerBlock < shmem_size)) ||
         (n >

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -88,7 +88,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
 
     cudaFuncAttributes attr =
         CudaParallelLaunch<ParallelFor, LaunchBounds>::get_cuda_func_attributes(
-            m_policy.space().cuda_device());
+            m_policy.space().impl_internal_space_instance());
     const int block_size =
         Kokkos::Impl::cuda_get_opt_block_size<FunctorType, LaunchBounds>(
             m_policy.space().impl_internal_space_instance(), attr, m_functor, 1,
@@ -270,7 +270,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
         Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
                              Policy, Kokkos::Cuda>;
     cudaFuncAttributes attr = CudaParallelLaunch<closure_type, LaunchBounds>::
-        get_cuda_func_attributes(m_policy.space().cuda_device());
+        get_cuda_func_attributes(
+            m_policy.space().impl_internal_space_instance());
     while (
         (n && (maxShmemPerBlock < shmem_size)) ||
         (n >

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -99,7 +99,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
         Impl::ParallelFor<FunctorType, TeamPolicy<Properties...>>;
     cudaFuncAttributes attr =
         CudaParallelLaunch<closure_type, typename traits::launch_bounds>::
-            get_cuda_func_attributes(space().cuda_device());
+            get_cuda_func_attributes(space().impl_internal_space_instance());
     int block_size =
         Kokkos::Impl::cuda_get_max_block_size<FunctorType,
                                               typename traits::launch_bounds>(
@@ -138,7 +138,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
         Impl::ParallelFor<FunctorType, TeamPolicy<Properties...>>;
     cudaFuncAttributes attr =
         CudaParallelLaunch<closure_type, typename traits::launch_bounds>::
-            get_cuda_func_attributes(space().cuda_device());
+            get_cuda_func_attributes(space().impl_internal_space_instance());
     const int block_size =
         Kokkos::Impl::cuda_get_opt_block_size<FunctorType,
                                               typename traits::launch_bounds>(
@@ -356,7 +356,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
 
     cudaFuncAttributes attr =
         CudaParallelLaunch<closure_type, typename traits::launch_bounds>::
-            get_cuda_func_attributes(space().cuda_device());
+            get_cuda_func_attributes(space().impl_internal_space_instance());
     const int block_size = std::forward<BlockSizeCallable>(block_size_callable)(
         space().impl_internal_space_instance(), attr, f,
         (size_t)impl_vector_length(),


### PR DESCRIPTION
Some cleanup for CUDA API wrapper to align with HIP multi GPU impl.

Changes:
- Do not call CUDA API wrappers from `CudaInternal::singleton` instance
- Update comments for CUDA API wrappers
- Remove stream args to CUDA API wrappers, set device before kernel launch
- Remove unused CUDA API wrappers
- Remove template option for setting device ID from CUDA API wrappers (always set)