### PR TITLE
Prefer `bit_{ceil,floor}` to shifting left 1 by `Impl::int_log2`

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -414,7 +414,7 @@ __device__ void cuda_intra_block_reduce_scan(
 
   const unsigned value_count = functor.length();
   const unsigned not_less_power_of_two =
-      (1 << (Impl::int_log2(blockDim.y - 1) + 1));
+      Kokkos::Experimental::bit_ceil_builtin(blockDim.y);
   const unsigned BlockSizeMask = not_less_power_of_two - 1;
   // There is at most one warp that is neither completely full or empty.
   // For that warp, we shift all indices logically to the end and ignore join

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -254,7 +254,7 @@ __device__ void hip_intra_block_reduce_scan(
 
   const unsigned value_count = functor.length();
   const unsigned not_less_power_of_two =
-      (1 << (Impl::int_log2(blockDim.y - 1) + 1));
+      Kokkos::Experimental::bit_ceil_builtin(blockDim.y);
   const unsigned BlockSizeMask = not_less_power_of_two - 1;
   // There is at most one warp that is neither completely full or empty.
   // For that warp, we shift all indices logically to the end and ignore join

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -254,7 +254,7 @@ __device__ void hip_intra_block_reduce_scan(
 
   const unsigned value_count = functor.length();
   const unsigned not_less_power_of_two =
-      Kokkos::Experimental::bit_ceil_builtin(blockDim.y);
+      Kokkos::Experimental::bit_ceil_builtin<unsigned>(blockDim.y);
   const unsigned BlockSizeMask = not_less_power_of_two - 1;
   // There is at most one warp that is neither completely full or empty.
   // For that warp, we shift all indices logically to the end and ignore join

--- a/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
@@ -333,14 +333,15 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
   template <class FunctorType>
   int internal_team_size_recommended_for(const FunctorType& f) const {
     // FIXME_SYCL improve
-    return 1 << Kokkos::Impl::int_log2(internal_team_size_max_for(f));
+    return Kokkos::Experimental::bit_ceil_builtin(
+        internal_team_size_max_for(f));
   }
 
   template <class ValueType, class FunctorType>
   int internal_team_size_recommended_reduce(const FunctorType& f) const {
     // FIXME_SYCL improve
-    return 1 << Kokkos::Impl::int_log2(
-               internal_team_size_max_reduce<ValueType>(f));
+    return Kokkos::Experimental::bit_ceil_builtin(
+        internal_team_size_max_reduce<ValueType>(f));
   }
 };
 

--- a/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
@@ -333,14 +333,14 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
   template <class FunctorType>
   int internal_team_size_recommended_for(const FunctorType& f) const {
     // FIXME_SYCL improve
-    return Kokkos::Experimental::bit_ceil_builtin(
+    return Kokkos::Experimental::bit_ceil_builtin<unsigned>(
         internal_team_size_max_for(f));
   }
 
   template <class ValueType, class FunctorType>
   int internal_team_size_recommended_reduce(const FunctorType& f) const {
     // FIXME_SYCL improve
-    return Kokkos::Experimental::bit_ceil_builtin(
+    return Kokkos::Experimental::bit_ceil_builtin<unsigned>(
         internal_team_size_max_reduce<ValueType>(f));
   }
 };

--- a/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
@@ -333,14 +333,14 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
   template <class FunctorType>
   int internal_team_size_recommended_for(const FunctorType& f) const {
     // FIXME_SYCL improve
-    return Kokkos::Experimental::bit_ceil_builtin<unsigned>(
+    return Kokkos::Experimental::bit_floor_builtin<unsigned>(
         internal_team_size_max_for(f));
   }
 
   template <class ValueType, class FunctorType>
   int internal_team_size_recommended_reduce(const FunctorType& f) const {
     // FIXME_SYCL improve
-    return Kokkos::Experimental::bit_ceil_builtin<unsigned>(
+    return Kokkos::Experimental::bit_floor_builtin<unsigned>(
         internal_team_size_max_reduce<ValueType>(f));
   }
 };


### PR DESCRIPTION
Preliminary step towards removing `Impl::int_log2`

The motivation is to replace all hand rolled bit manipulation from `<impl/Kokkos_BitOps.hpp>` by the C++20 standard library facility.