### PR TITLE
Jenkins CI: Install plug-in for SYCL+Cuda via shell script not package manager

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -280,7 +280,7 @@ pipeline {
                                 -DKokkos_ENABLE_EXAMPLES=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_BENCHMARKS=ON \
-                                -DoneDPL_ROOT=/opt/intel/oneapi/2025.0 \
+                                -DoneDPL_ROOT=/opt/intel/oneapi/dpl/2022.7 \
                                 -DKokkos_ENABLE_SYCL=ON \
                                 -DKokkos_ENABLE_SYCL_RELOCATABLE_DEVICE_CODE=ON \
                                 -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON \

--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -46,17 +46,16 @@ RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRO
     echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
     | tee /etc/apt/sources.list.d/oneAPI.list
 
-RUN wget -qO - https://developer.codeplay.com/apt/public.key \
-    | gpg --dearmor | tee /usr/share/keyrings/codeplay-keyring.gpg > /dev/null && \
-    echo "deb [signed-by=/usr/share/keyrings/codeplay-keyring.gpg] https://developer.codeplay.com/apt all main" \
-    | tee /etc/apt/sources.list.d/codeplay.list
-
 RUN apt-get update && apt-get install -y \
-        oneapi-nvidia-12.0 \
         intel-oneapi-compiler-dpcpp-cpp-2025.0 \
+        curl \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+RUN curl -LOJ "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2025.0.0&filters[]=12.0&filters[]=linux" && \
+    chmod +x oneapi-for-nvidia-gpus-2025.0.0-cuda-12.0-linux.sh && \
+    ./oneapi-for-nvidia-gpus-2025.0.0-cuda-12.0-linux.sh
 
 # sycl-ls, icpx
 ENV PATH=/opt/intel/oneapi/compiler/2025.0/bin/:$PATH


### PR DESCRIPTION
Also see the discussion at https://kokkosteam.slack.com/archives/G5CBLMFLP/p1743460964477879?thread_ts=1743429563.551069&cid=G5CBLMFLP.
It seems `oneapi-nvidia-12.0` depends on the unversioned `intel-basekit` that is the latest released version. Thus, to actually control the compiler version, we must not use that package.