### PR TITLE
A proposal for a new emoji layer in the project

### DIFF
--- a/core/src/Kokkos_Emoji.hpp
+++ b/core/src/Kokkos_Emoji.hpp
@@ -1,0 +1,165 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_EMOJI_HPP
+#define KOKKOS_EMOJI_HPP
+
+#include <Kokkos_Core.hpp>
+
+#define 🫘👷 KOKKOS_FUNCTION
+#define 🫘🐑 KOKKOS_LAMBDA
+
+namespace 🫘 {
+  /**
+   * Initialization.
+   */
+  void 🌅(int& argc, char* argv[]) { Kokkos::initialize(argc, argv); }
+
+  void 🌇() { Kokkos::finalize(); }
+
+  using 🔭💂 = Kokkos::ScopeGuard;
+
+  /**
+   * Spaces.
+   */
+  using 💘🔪🌌 = Kokkos::DefaultExecutionSpace;
+
+  using 💘🏠🔪🌌 = Kokkos::DefaultHostExecutionSpace;
+
+  /**
+   * Parallel constructs.
+   */
+  template <class... 🧹🧬>
+  void 🚅🚅(🧹🧬&& ... 🧹) {
+    Kokkos::parallel_for(std::forward<🧹🧬>(🧹)...);
+  }
+
+  template <class... 🧹🧬>
+  void 🚅🩻(🧹🧬&& ... 🧹) {
+    Kokkos::parallel_scan(std::forward<🧹🧬>(🧹)...);
+  }
+
+  template <class... 🧹🧬>
+  void 🚅🌱(🧹🧬&& ... 🧹) {
+    Kokkos::parallel_reduce(std::forward<🧹🧬>(🧹)...);
+  }
+
+  /**
+   * Policies.
+   */
+  template <class... 🧹🧬>
+  using 📏🚔 = Kokkos::RangePolicy<🧹🧬...>;
+
+  template <class... 🧹🧬>
+  using 🧊📏🚔 = Kokkos::MDRangePolicy<🧹🧬...>;
+
+  template <class... 🧹🧬>
+  using 🤼🚔 = Kokkos::TeamPolicy<🧹🧬...>;
+
+  template <class... 🧹🧬>
+  auto 🤼🧶📏(🧹🧬&& ... 🧹)
+      ->decltype(Kokkos::TeamThreadRange(std::forward<🧹🧬>(🧹)...)) {
+    return Kokkos::TeamThreadRange(std::forward<🧹🧬>(🧹)...);
+  }
+
+  template <class... 🧹🧬>
+  using 🤼🧶🧊📏 = Kokkos::TeamThreadMDRange<🧹🧬...>;
+
+  template <class... 🧹🧬>
+  auto 🧶🧭📏(🧹🧬&& ... 🧹)
+      ->decltype(Kokkos::ThreadVectorRange(std::forward<🧹🧬>(🧹)...)) {
+    return Kokkos::ThreadVectorRange(std::forward<🧹🧬>(🧹)...);
+  }
+
+  template <class... 🧹🧬>
+  using 🧶🧭🧊📏 = Kokkos::ThreadVectorMDRange<🧹🧬...>;
+
+  template <class... 🧹🧬>
+  auto 🤼🧭📏(🧹🧬&& ... 🧹)
+      ->decltype(Kokkos::TeamVectorRange(std::forward<🧹🧬>(🧹)...)) {
+    return Kokkos::TeamVectorRange(std::forward<🧹🧬>(🧹)...);
+  }
+
+  template <class... 🧹🧬>
+  using 🤼🧭🧊📏 = Kokkos::TeamVectorMDRange<🧹🧬...>;
+
+  /**
+   * Fences.
+   */
+  template <class... 🧹🧬>
+  void 🚧(🧹🧬&& ... 🧹) {
+    Kokkos::fence(std::forward<🧹🧬>(🧹)...);
+  }
+
+  /**
+   * Views.
+   */
+  template <class... 🧹🧬>
+  using 👁️ = Kokkos::View<🧹🧬...>;
+
+  // XXX missing include
+  // template <class... 🧹🧬>
+  // using 👁️👁️ = Kokkos::DualView<🧹🧬...>;
+
+  // TODO
+  // template <class... 🧹🧬>
+  // using 👁️👁️👁️ = Kokkos::TripleView<🧹🧬...>;
+
+  /**
+   * Mirrors.
+   */
+  template <class... 🧹🧬>
+  auto 🏗️🪞(🧹🧬&& ... 🧹)
+      ->decltype(Kokkos::create_mirror(std::forward<🧹🧬>(🧹)...)) {
+    return Kokkos::create_mirror(std::forward<🧹🧬>(🧹)...);
+  }
+
+  template <class... 🧹🧬>
+  auto 🏗️🪞👁️(🧹🧬&& ... 🧹)
+      ->decltype(Kokkos::create_mirror_view(std::forward<🧹🧬>(🧹)...)) {
+    return Kokkos::create_mirror_view(std::forward<🧹🧬>(🧹)...);
+  }
+
+  template <class... 🧹🧬>
+  auto 🏗️🪞👁️👯(🧹🧬&& ... 🧹)
+      ->decltype(Kokkos::create_mirror_view_and_copy(
+          std::forward<🧹🧬>(🧹)...)) {
+    return Kokkos::create_mirror_view_and_copy(std::forward<🧹🧬>(🧹)...);
+  }
+
+  /**
+   * Data movements.
+   */
+  template <class... 🧹🧬>
+  void 🕳️👯(🧹🧬&& ... 🧹) {
+    Kokkos::deep_copy(std::forward<🧹🧬>(🧹)...);
+  }
+
+  /**
+   * Print on screen.
+   */
+  template <class... 🧹🧬>
+  void 🖨️🛠️(🧹🧬&& ... 🧹) {
+    Kokkos::print_configuration(std::forward<🧹🧬>(🧹)...);
+  }
+
+  template <class... 🧹🧬>
+    🫘👷 void 🖨️📄(🧹🧬&& ... 🧹) {
+    Kokkos::printf(std::forward<🧹🧬>(🧹)...);
+  }
+}  // namespace 🫘
+
+#endif  // ifndef KOKKOS_EMOJI_HPP

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -6,4 +6,5 @@ if(_DEVICE_PARALLEL STREQUAL "NoTypeDefined"
 )
   kokkos_add_example_directories(relocatable_function)
 endif()
+kokkos_add_example_directories(emoji)
 kokkos_add_example_directories(tutorial)

--- a/example/emoji/CMakeLists.txt
+++ b/example/emoji/CMakeLists.txt
@@ -1,0 +1,4 @@
+kokkos_include_directories(${CMAKE_CURRENT_BINARY_DIR})
+kokkos_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
+kokkos_add_executable(emoji SOURCES emoji.cpp)

--- a/example/emoji/emoji.cpp
+++ b/example/emoji/emoji.cpp
@@ -1,0 +1,43 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <iostream>
+
+#include <Kokkos_Emoji.hpp>
+
+int main(int 🧹🧮, char* 🧹[]) {
+  🫘::🔭💂 🫘🔭(🧹🧮, 🧹);
+
+  🫘::🖨️🛠️(std::cout);
+
+  🫘::👁️<int*> 🧍👁️("my view", 10);
+  auto 🧍🪞👁️ = 🫘::🏗️🪞👁️(🧍👁️);
+
+  🫘::🚅🚅(
+      "initialization", 🫘::📏🚔<🫘::💘🏠🔪🌌>(0, 10), 🫘🐑 (int const 👆) {
+        🧍🪞👁️(👆) = 👆;
+      });
+  🫘::🚧("wait initialization");
+
+  🫘::🕳️👯(🧍👁️, 🧍🪞👁️);
+
+  int 💰;
+  🫘::🚅🌱(
+      "reduction",
+      10, 🫘🐑 (int const 👆, int& 🏡💰) { 🏡💰 += 🧍👁️(👆); }, 💰);
+
+  🫘::🖨️📄("sum is %i 💅\n", 💰);
+}


### PR DESCRIPTION
It is well known that the new generation has a small attention span ([source 1](http://www.example.com), [source 2](http://www.example.com), [source 3](http://www.example.com)) and tends to be attracted to visually attractive symbols ([source 4](http://www.example.com), [source 5](http://www.example.com)). This trend has passed to older generations as well ([source 6](http://www.example.com), [source 7](http://www.example.com)). At the same time, it is a fact that large open source projects have difficulties to attract new developers, from either generations. Surveys show that potential developers want projects with attractive features.

To solve this dramatic problem, I propose in this PR to make Kokkos enter a new era of development style, and embrace this new trend of attractiveness, by the way of emojis 💅. This PR introduces the new `Kokkos_Emoji.hpp` header which proposes emoji aliases to the usual traditional Kokkos symbols. The future is now. Forget about supporting the most brand new devices, what the world wants is more emojis!

Using this header, the power of Kokkos is coupled with the power of emojis, fostering much clearer and much visually attractive code:

```cpp
int main(int 🧹🧮, char* 🧹[]) {
  🫘::🔭💂 🫘🔭(🧹🧮, 🧹);

  🫘::👁️<int*> 🧍👁️("my view", 10);
  auto 🧍🪞👁️ = 🫘::🏗️🪞👁️(🧍👁️);

  🫘::🚅🚅(
      "initialization", 🫘::📏🚔<🫘::💘🏠🔪🌌>(0, 10), 🫘🐑 (int const 👆) {
        🧍🪞👁️(👆) = 👆;
      });
  🫘::🚧("wait initialization");

  🫘::🕳️👯(🧍👁️, 🧍🪞👁️);

  int 💰;
  🫘::🚅🌱(
      "reduction", 10, 🫘🐑 (int const 👆, int& 🏡💰) { 🏡💰 += 🧍👁️(👆); }, 💰);

  🫘::🖨️📄("sum is %i 💅\n", 💰);
}
```

The benefits of using emojis is clear: variables are much shorter (the above example code is 36% more compact compared to using boring alphanumeric variables), which saves space on the disk (02% smaller file). The codes is also natively understandable by non-English speakers, which enables i18n out of the box.

Emojis were carefully selected to naturally convey the key ideas of their underlying symbols:

- `parallel_for`: 🚅🚅
- `parallel_scan`: 🚅🩻
- `View`: 👁️
- `create_mirror_view`: 🏗️🪞👁️

Check the files of the PR for more!

Not all symbols have an emoji equivalent yet, but this is a good start already. The Kokkos developers team should propose new emojis for the missing symbols. This will undoubtly foster consensus in the community.

The PR proposes an example code which uses the new emoji header. No new tests are provided, because who cares about tests when you're so visually attractive?

This works is done for Kokkos only (I mean, for 🫘 only), but it should be obviously expanded to the other parts of the Kokkos ecosystem. I have some ideas already:

- Kokkos Kernels: 🫘🫘
- Kokkos FFT: 🫘📊
- Kokkos Coms: 🫘📡

For consistency, the name of the organization and the name of the repos should be written with emojis too. (We may have to ask GitHub to allow that, this is a vital point after all.)

It is noteworthy to say that not all compilers support this mode (like, it works™ with GCC on my machine, so it should be enough already), consequently I propose to simply ditch them, as they are obviously not ready for the future.

Converting all tests and examples to emojis will be conduced in a next PR. Converting the entire codebase, and not only using an interface layer, will be achieved in the long run. A PR to update the API documentation will be proposed shortly. I think another interesting extension to this work would be to convert the entire documentation to only use emojis, and to not limit this visual attractiveness revolution to code only.

With this PR, the path to the future is open 🌈.