### PR TITLE
Drop `Impl::int_log2` in favor of `bit_width`

### DIFF
--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -273,7 +273,7 @@ class Bitset {
     block  = Impl::rotate_right(block, offset);
     return (((!(scan_direction & BIT_SCAN_REVERSE)
                   ? Impl::bit_scan_forward(block)
-                  : Impl::int_log2(block)) +
+                  : Experimental::bit_width_builtin(block) - 1) +
              offset) &
             block_mask) +
            block_start;

--- a/core/src/Threads/Kokkos_Threads_Spinwait.cpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.cpp
@@ -22,7 +22,7 @@
 
 #include <Kokkos_Atomic.hpp>
 #include <Threads/Kokkos_Threads_Spinwait.hpp>
-#include <impl/Kokkos_BitOps.hpp>
+#include <Kokkos_BitManipulation.hpp>  // bit_width
 
 #include <thread>
 #if defined(_WIN32)
@@ -40,7 +40,7 @@ void host_thread_yield(const uint32_t i, const WaitMode mode) {
   static constexpr uint32_t sleep_limit = 1 << 13;
   static constexpr uint32_t yield_limit = 1 << 12;
 
-  const int c = int_log2(i);
+  const int c = bit_width(i) - 1;
 
   if (WaitMode::ROOT != mode) {
     if (sleep_limit < i) {

--- a/core/src/impl/Kokkos_HostBarrier.cpp
+++ b/core/src/impl/Kokkos_HostBarrier.cpp
@@ -21,7 +21,7 @@
 #include <Kokkos_Macros.hpp>
 
 #include <impl/Kokkos_HostBarrier.hpp>
-#include <impl/Kokkos_BitOps.hpp>
+#include <Kokkos_BitManipulation.hpp>  // bit_width
 
 #include <impl/Kokkos_HostBarrier.hpp>
 
@@ -40,7 +40,7 @@ void HostBarrier::impl_backoff_wait_until_equal(
   unsigned count = 0u;
 
   while (!test_equal(ptr, v)) {
-    const int c = int_log2(++count);
+    const int c = bit_width(++count) - 1;
     if (!active_wait || c > log2_iterations_till_sleep) {
       std::this_thread::sleep_for(
           std::chrono::nanoseconds(c < 16 ? 256 * c : 4096));


### PR DESCRIPTION
Following up on #7934 

To convince yourself that `Impl::int_log2(x)` is the same as `bit_width(x)-1`  https://godbolt.org/z/9vvaKcGcP
Note that `int_log2(0)` has UB in some configurations, but `bit_width(0)` is well defined and returns `0`.