### PR TITLE
Add definition of `TEST_CATEGORY_FIXTURE()` for default device

### DIFF
--- a/core/unit_test/category_files/TestDefaultDeviceType_Category.hpp
+++ b/core/unit_test/category_files/TestDefaultDeviceType_Category.hpp
@@ -22,5 +22,6 @@
 #define TEST_CATEGORY defaultdevicetype
 #define TEST_CATEGORY_DEATH defaultdevicetype_DeathTest
 #define TEST_EXECSPACE Kokkos::DefaultExecutionSpace
+#define TEST_CATEGORY_FIXTURE(name) default_##name
 
 #endif


### PR DESCRIPTION
I had to add every time I wanted to build the Graph tests via
```diff
diff --git a/core/unit_test/default/TestDefaultDeviceDevelop.cpp b/core/unit_test/default/TestDefaultDeviceDevelop.cpp
index d85973ec1..5dacf6433 100644
--- a/core/unit_test/default/TestDefaultDeviceDevelop.cpp
+++ b/core/unit_test/default/TestDefaultDeviceDevelop.cpp
@@ -19,6 +19,7 @@
 #include <Kokkos_Core.hpp>

 #include <TestDefaultDeviceType_Category.hpp>
+#include <TestGraph.hpp>

 namespace Test {
```
(For those who don't know, that is a "trick" to selectively compile a specific test)

We might as well have it.