### PR TITLE
Drop `Impl::rotate_right` in favor of `rotr`

### DIFF
--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -270,7 +270,7 @@ class Bitset {
     offset = !(scan_direction & BIT_SCAN_REVERSE)
                  ? offset
                  : (offset + block_mask) & block_mask;
-    block  = Impl::rotate_right(block, offset);
+    block  = Experimental::rotr_builtin(block, offset);
     return (((!(scan_direction & BIT_SCAN_REVERSE)
                   ? Experimental::countr_zero_builtin(block)
                   : Experimental::bit_width_builtin(block) - 1) +

--- a/containers/src/impl/Kokkos_Bitset_impl.hpp
+++ b/containers/src/impl/Kokkos_Bitset_impl.hpp
@@ -28,12 +28,6 @@
 namespace Kokkos {
 namespace Impl {
 
-KOKKOS_FORCEINLINE_FUNCTION
-unsigned rotate_right(unsigned i, int r) {
-  constexpr int size = static_cast<int>(sizeof(unsigned) * CHAR_BIT);
-  return r ? ((i >> r) | (i << (size - r))) : i;
-}
-
 template <typename Bitset>
 struct BitsetCount {
   using bitset_type = Bitset;


### PR DESCRIPTION
Yet another getting rid of our own bit manipulation functions in favor of standard ones

https://godbolt.org/z/zeePPbWo5