### PR TITLE
Cleanup `deep_copy(view, val)` internals (remove duplicated `contiguous_fill_or_memset` code)

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -863,34 +863,7 @@ contiguous_fill_or_memset(
 }
 
 template <class DT, class... DP>
-inline std::enable_if_t<
-    std::is_trivial_v<typename ViewTraits<DT, DP...>::value_type>>
-contiguous_fill_or_memset(
-    const View<DT, DP...>& dst,
-    typename ViewTraits<DT, DP...>::const_value_type& value) {
-  using ViewType        = View<DT, DP...>;
-  using exec_space_type = typename ViewType::execution_space;
-  exec_space_type exec;
-
-// On A64FX memset seems to do the wrong thing with regards to first touch
-// leading to the significant performance issues
-#ifndef KOKKOS_ARCH_A64FX
-  if (Impl::is_zero_byte(value))
-    // FIXME intel/19 icpc fails to deduce template parameter here,
-    // resulting in compilation errors; explicitly passing the template
-    // parameter to ZeroMemset helps workaround the issue.
-    // See https://github.com/kokkos/kokkos/issues/7273.
-    ZeroMemset<exec_space_type>(
-        exec, dst.data(), dst.size() * sizeof(typename ViewType::value_type));
-  else
-#endif
-    contiguous_fill(exec, dst, value);
-}
-
-template <class DT, class... DP>
-inline std::enable_if_t<
-    !std::is_trivial_v<typename ViewTraits<DT, DP...>::value_type>>
-contiguous_fill_or_memset(
+void contiguous_fill_or_memset(
     const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {
   using ViewType        = View<DT, DP...>;

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -869,7 +869,7 @@ void contiguous_fill_or_memset(
   using ViewType        = View<DT, DP...>;
   using exec_space_type = typename ViewType::execution_space;
 
-  contiguous_fill(exec_space_type(), dst, value);
+  contiguous_fill_or_memset(exec_space_type(), dst, value);
 }
 }  // namespace Impl
 

--- a/core/unit_test/TestWithoutInitializing.hpp
+++ b/core/unit_test/TestWithoutInitializing.hpp
@@ -216,6 +216,10 @@ TEST(TEST_CATEGORY, deep_copy_zero_memset) {
     GTEST_SKIP() << "skipping since the OpenACC backend doesn't implement "
                     "ZeroMemset";
 #endif
+#ifdef KOKKOS_ENABLE_OPENMP
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::OpenMP>)
+    GTEST_SKIP() << "skipping since the OpenMP backend doesn't use ZeroMemset";
+#endif
 
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels());


### PR DESCRIPTION
There is no point on duplicating the zeromemset logic for the overload that does not have an exec space instance argument.