### PR TITLE
DualView: Don't allocate modified_flags in modify

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -235,8 +235,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
   /// \brief Empty constructor.
   ///
   /// Both device and host View objects are constructed using their
-  /// default constructors.  The "modified" flags are both initialized
-  /// to "unmodified."
+  /// default constructors.  The "modified" flags are not allocated.
   DualView() = default;
 
   /// \brief Constructor that allocates View objects on both host and device.
@@ -790,9 +789,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
     if constexpr (impl_dualview_is_single_device) {
       return;
     } else {
-      if (modified_flags.data() == nullptr) {
-        modified_flags = t_modified_flags("DualView::modified_flags");
-      }
+      if (modified_flags.data() == nullptr) return;
 
       int dev = get_device_side<Device>();
 

--- a/containers/src/Kokkos_Vector.hpp
+++ b/containers/src/Kokkos_Vector.hpp
@@ -129,7 +129,6 @@ class KOKKOS_DEPRECATED vector
 
   void push_back(Scalar val) {
     DV::template sync<typename DV::t_host::device_type>();
-    DV::template modify<typename DV::t_host::device_type>();
     if (_size == span()) {
       size_t new_size = _size * _extra_storage;
       if (new_size == _size) new_size++;
@@ -138,6 +137,7 @@ class KOKKOS_DEPRECATED vector
 
     DV::view_host()(_size) = val;
     _size++;
+    DV::template modify<typename DV::t_host::device_type>();
   }
 
   void pop_back() { _size--; }

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -755,6 +755,25 @@ TEST(TEST_CATEGORY, dualview_sequential_host_init) {
   ASSERT_EQ(dv.view_device().size(), 3u);
   ASSERT_EQ(dv.view_host().size(), 3u);
 }
+
+TEST(TEST_CATEGORY, dualview_default_constructed) {
+  DualViewType dv;
+
+  dv.modify<TEST_EXECSPACE>();
+  ASSERT_FALSE(dv.need_sync_host());
+  ASSERT_FALSE(dv.need_sync_device());
+  dv.sync<TEST_EXECSPACE>();
+
+  dv.modify_host();
+  ASSERT_FALSE(dv.need_sync_host());
+  ASSERT_FALSE(dv.need_sync_device());
+  dv.sync_host();
+
+  dv.modify_device();
+  ASSERT_FALSE(dv.need_sync_host());
+  ASSERT_FALSE(dv.need_sync_device());
+  dv.sync_device();
+}
 }  // anonymous namespace
 }  // namespace Test
 


### PR DESCRIPTION
Related to #7946. Right now all constructors apart fromt the default constructor allocate the modified flags.
This allows constructing a defaulted DualView before Kokkos was initialized.
For such a default constructed DualView with unallocated modified flags, `sync*` and `modify*` are no-ops except that `modify` allocates the modified flags. This pull request clarifies the current behavior of the default constructor and provides consistent behavior for the `modufy*` members so that they are no-ops in that case and don't allocate.

The alternative would be to make the default constructor allocate the flags and remove all checks for `modified_flags.data()` being `nullptr`. That implies that `DualView` can't be default constructed before/after `Kokkos` was initialized/finalized.