### PR TITLE
Containers: Fix unit test list with deprecated code disabled

### DIFF
--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -11,6 +11,7 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
     set(UnitTestSources UnitTestMain.cpp)
     set(dir ${CMAKE_CURRENT_BINARY_DIR}/${dir})
     file(MAKE_DIRECTORY ${dir})
+    set(DeprecatedTests Vector StaticCrsGraph)
     foreach(
       Name
       Bitset
@@ -29,8 +30,8 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
       Vector
       ViewCtorPropEmbeddedDim
     )
-      if(NOT Kokkos_ENABLE_DEPRECATED_CODE_4 AND NOT Name IN_LIST "Vector,StaticCrsGraph")
-        continue() # skip Kokkos::{vector,StaticCrsGraph} tests if deprecated code 4 is not enabled
+      if(NOT Kokkos_ENABLE_DEPRECATED_CODE_4 AND Name IN_LIST DeprecatedTests)
+        continue() # skip tests for deprecated features if deprecated code 4 is not enabled
       endif()
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.


### PR DESCRIPTION
As noted in https://kokkosteam.slack.com/archives/G5CBLMFLP/p1744029395240139, we were not running any Container unit tests with deprecated code disabled. This pull request fixes that.

In particular `IN_LIST` can't be used with inline lists but needs to be given the name of a list.	