### PR TITLE
Fix unitialized use of test functor

### DIFF
--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -32,21 +32,25 @@ struct TestTeamPolicy {
 
   view_type m_flags;
 
-  TestTeamPolicy(const size_t league_size)
-      : m_flags(Kokkos::view_alloc(Kokkos::WithoutInitializing, "flags"),
-  // FIXME_OPENMPTARGET temporary restriction for team size to be at least 32
+  // initialie m_flags first with default view so that the class
+  // is fully initialized when *this is used to figure out the length
+  // for m_flags
+  TestTeamPolicy(const size_t league_size) : m_flags(view_type()) {
+    m_flags = view_type(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "flags"),
+    // FIXME_OPENMPTARGET temporary restriction for team size to be at least 32
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
-                Kokkos::TeamPolicy<ScheduleType, ExecSpace>(
-                    1, std::is_same<ExecSpace,
-                                    Kokkos::Experimental::OpenMPTarget>::value
-                           ? 32
-                           : 1)
-                    .team_size_max(*this, Kokkos::ParallelReduceTag()),
+        Kokkos::TeamPolicy<ScheduleType, ExecSpace>(
+            1,
+            std::is_same<ExecSpace, Kokkos::Experimental::OpenMPTarget>::value
+                ? 32
+                : 1)
+            .team_size_max(*this, Kokkos::ParallelReduceTag()),
 #else
-                Kokkos::TeamPolicy<ScheduleType, ExecSpace>(1, 1).team_size_max(
-                    *this, Kokkos::ParallelReduceTag()),
+        Kokkos::TeamPolicy<ScheduleType, ExecSpace>(1, 1).team_size_max(
+            *this, Kokkos::ParallelReduceTag()),
 #endif
-                league_size) {
+        league_size);
   }
 
   struct VerifyInitTag {};

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -32,17 +32,17 @@ struct TestTeamPolicy {
 
   view_type m_flags;
 
-  // initialie m_flags first with default view so that the class
+  // initialize m_flags first with default view so that the class
   // is fully initialized when *this is used to figure out the length
   // for m_flags
-  TestTeamPolicy(const size_t league_size) : m_flags(view_type()) {
+  TestTeamPolicy(const size_t league_size) : m_flags() {
     m_flags = view_type(
         Kokkos::view_alloc(Kokkos::WithoutInitializing, "flags"),
     // FIXME_OPENMPTARGET temporary restriction for team size to be at least 32
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
         Kokkos::TeamPolicy<ScheduleType, ExecSpace>(
             1,
-            std::is_same<ExecSpace, Kokkos::Experimental::OpenMPTarget>::value
+            std::is_same_v<ExecSpace, Kokkos::Experimental::OpenMPTarget>
                 ? 32
                 : 1)
             .team_size_max(*this, Kokkos::ParallelReduceTag()),


### PR DESCRIPTION
This showed up with GCC 13.2 + CUDA 12.6 when using the new view impl.

This only surfaced in the View refactor PR where the H200 build failed. 