### PR TITLE
Enable bugprone-non-zero-enum-to-bool-conversion check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,6 @@ Checks: >
   -bugprone-macro-parentheses,
   -bugprone-misplaced-widening-cast,
   -bugprone-narrowing-conversions,
-  -bugprone-non-zero-enum-to-bool-conversion,
   -bugprone-signed-char-misuse,
   -bugprone-suspicious-include,
   -bugprone-suspicious-memory-comparison,

--- a/core/src/View/Kokkos_ViewMapping.hpp
+++ b/core/src/View/Kokkos_ViewMapping.hpp
@@ -44,6 +44,7 @@
 namespace Kokkos {
 namespace Impl {
 
+// NOLINTBEGIN(bugprone-non-zero-enum-to-bool-conversion)
 template <class T>
 struct is_integral_extent_type {
   enum : bool { value = std::is_same_v<T, Kokkos::ALL_t> ? 1 : 0 };
@@ -163,6 +164,7 @@ struct SubviewLegalArgsCompileTime<Kokkos::LayoutStride, Kokkos::LayoutStride,
                                    SubViewArgs...> {
   enum : bool { value = true };
 };
+// NOLINTEND(bugprone-non-zero-enum-to-bool-conversion)
 
 template <unsigned DomainRank, unsigned RangeRank>
 struct SubviewExtents {


### PR DESCRIPTION
Suppressing warnings from ViewMapping, since there is little point in updating code that will be dropped when the View mdspan refactor is completed.