### PR TITLE
Enable bugprone-unhandled-exception-at-new check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,7 +12,6 @@ Checks: >
   -bugprone-signed-char-misuse,
   -bugprone-suspicious-include,
   -bugprone-suspicious-memory-comparison,
-  -bugprone-unhandled-exception-at-new,
   cppcoreguidelines-pro-type-cstyle-cast,
   modernize-type-traits,
   modernize-use-nullptr,

--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -43,7 +43,7 @@ namespace Kokkos {
 namespace Impl {
 void hpx_thread_buffer::resize(const std::size_t num_threads,
                                const std::size_t size_per_thread,
-                               const std::size_t extra_space) noexcept {
+                               const std::size_t extra_space) {
   m_num_threads     = num_threads;
   m_size_per_thread = size_per_thread;
   m_extra_space     = extra_space;

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -82,7 +82,7 @@ class hpx_thread_buffer {
   hpx_thread_buffer &operator=(hpx_thread_buffer)         = delete;
 
   void resize(const std::size_t num_threads, const std::size_t size_per_thread,
-              const std::size_t extra_space = 0) noexcept;
+              const std::size_t extra_space = 0);
   void *get(std::size_t thread_num) const noexcept;
   void *get_extra_space() const noexcept;
 };


### PR DESCRIPTION
Clang-Tidy flagged a call to `new` without logic to handle the case a `std::bad_alloc` exception is thrown with HPX.
I propose dropping the `noexcept` specifier on the internal function that had the `new`.