### PR TITLE
CI: use more cores for linux build

### DIFF
--- a/.github/workflows/continuous-integration-linux.yml
+++ b/.github/workflows/continuous-integration-linux.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Build
         run: |
           ccache -z
-          cmake --build builddir --parallel 2
+          cmake --build builddir --parallel $(nproc)
           ccache -s
       - name: Tests
         working-directory: builddir


### PR DESCRIPTION
The hpx build is taking 2+hrs, so hopefully that helps with that.