### PR TITLE
DualView: Constructor with two Views make unique allocation check more strict and correct

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -359,7 +359,9 @@ class DualView : public ViewTraits<DataType, Properties...> {
       Kokkos::Impl::throw_runtime_exception(
           "DualView constructed with incompatible views");
     }
-    if (impl_dualview_is_single_device && (d_view.data() != h_view.data()))
+    if (Kokkos::SpaceAccessibility<Kokkos::HostSpace,
+                                   typename t_dev::memory_space>::accessible &&
+        (d_view.data() != h_view.data()))
       Kokkos::abort(
           "DualView storing one View constructed from two different Views");
   }

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -580,8 +580,9 @@ void check_dualview_external_view_construction() {
 // FIXME_MSVC+CUDA error C2094: label 'gtest_label_520' was undefined
 #if !(defined(KOKKOS_COMPILER_MSVC) && defined(KOKKOS_ENABLE_CUDA))
 TEST(TEST_CATEGORY_DEATH, dualview_external_view_construction) {
-  if constexpr (!Kokkos::DualView<
-                    int*, TEST_EXECSPACE>::impl_dualview_is_single_device) {
+  if constexpr (!Kokkos::SpaceAccessibility<
+                    Kokkos::HostSpace,
+                    TEST_EXECSPACE::memory_space>::accessible) {
     GTEST_SKIP() << "test only relevant if DualView uses one allocation";
   } else {
     // FIXME_CLANG We can't inline the function because recent clang versions


### PR DESCRIPTION
This should be the last useful thing we reverted in https://github.com/kokkos/kokkos/pull/7897.