### PR TITLE
OpenMPTarget: Remove support for non-llvm compilers.

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
@@ -67,8 +67,7 @@ void OpenMPTargetInternal::fence(const std::string& name,
   }
 }
 int OpenMPTargetInternal::concurrency() const {
-  int max_threads = 2048 * 80;
-#if defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
+  int max_threads    = 2048 * 80;
   int max_threads_sm = 2048;
 #if defined(KOKKOS_ARCH_AMPERE86)
   max_threads = max_threads_sm * 84;
@@ -80,13 +79,6 @@ int OpenMPTargetInternal::concurrency() const {
   max_threads = max_threads_sm * 80;
 #elif defined(KOKKOS_ARCH_PASCAL60) || defined(KOKKOS_ARCH_PASCAL61)
   max_threads = max_threads_sm * 60;
-#endif
-#elif defined(KOKKOS_ARCH_INTEL_GPU)
-#pragma omp target map(max_threads)
-  { max_threads = omp_get_num_procs(); }
-
-  // Multiply the number of processors with the SIMD length.
-  max_threads *= 32;
 #endif
 
   return max_threads;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Macros.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Macros.hpp
@@ -17,12 +17,6 @@
 #ifndef KOKKOS_OPENMPTARGET_MACROS_HPP
 #define KOKKOS_OPENMPTARGET_MACROS_HPP
 
-// Intel architectures prefer the classical hierarchical parallelism that relies
-// on OpenMP.
-#if defined(KOKKOS_ARCH_INTEL_GPU)
-#define KOKKOS_IMPL_OPENMPTARGET_HIERARCHICAL_INTEL_GPU
-#endif
-
 // Define a macro for llvm compiler greater than version 17 and on NVIDIA and
 // AMD GPUs. This would be useful in cases where non-OpenMP standard llvm
 // extensions can be used.

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_Team.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_Team.hpp
@@ -141,11 +141,6 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
 // the clang compiler. atomic_compare_exchange can be avoided since the standard
 // guarantees that the number of teams specified in the `num_teams` clause is
 // always less than or equal to the maximum concurrently running teams.
-#if !defined(KOKKOS_IMPL_OPENMPTARGET_HIERARCHICAL_INTEL_GPU)
-    KOKKOS_IMPL_OMPTARGET_PRAGMA(
-        teams thread_limit(team_size) firstprivate(a_functor)
-            num_teams(max_active_teams) is_device_ptr(scratch_ptr)
-                KOKKOS_IMPL_OMPX_DYN_CGROUP_MEM(shmem_size_L0))
 #pragma omp parallel
     {
       if (omp_get_num_teams() > max_active_teams)
@@ -165,23 +160,6 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
         a_functor(team);
       }
     }
-#else
-#pragma omp target teams distribute firstprivate(a_functor) \
-    is_device_ptr(scratch_ptr) num_teams(max_active_teams)  \
-    thread_limit(team_size)
-    for (int i = 0; i < league_size; i++) {
-#pragma omp parallel
-      {
-        if (omp_get_num_teams() > max_active_teams)
-          Kokkos::abort("`omp_set_num_teams` call was not respected.\n");
-
-        typename Policy::member_type team(i, league_size, team_size,
-                                          vector_length, scratch_ptr, i,
-                                          shmem_size_L0, shmem_size_L1);
-        a_functor(team);
-      }
-    }
-#endif
   }
 
  public:

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Team.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Team.hpp
@@ -23,14 +23,6 @@
 #include <OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp>
 #include <OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp>
 
-// FIXME_OPENMPTARGET - Using this macro to implement a workaround for
-// hierarchical reducers. It avoids hitting the code path which we wanted to
-// write but doesn't work. undef'ed at the end.
-// Intel compilers prefer the non-workaround version.
-#ifndef KOKKOS_ARCH_INTEL_GPU
-#define KOKKOS_IMPL_HIERARCHICAL_REDUCERS_WORKAROUND
-#endif
-
 namespace Kokkos {
 
 /** \brief  Inter-thread vector parallel_reduce. Executes lambda(iType i,
@@ -79,7 +71,6 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
   result = TeamThread_scratch[0];
 }
 
-#if !defined(KOKKOS_IMPL_HIERARCHICAL_REDUCERS_WORKAROUND)
 // For some reason the actual version we wanted to write doesn't work
 // and crashes. We should try this with every new compiler
 // This is the variant we actually wanted to write
@@ -114,58 +105,6 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
   }
   result.reference() = TeamThread_scratch[0];
 }
-#else
-template <typename iType, class Lambda, typename ReducerType>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
-parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
-                    iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
-                const Lambda& lambda, ReducerType result) {
-  using ValueType = typename ReducerType::value_type;
-
-  // FIXME_OPENMPTARGET - Make sure that if its an array reduction, number of
-  // elements in the array <= 32. For reduction we allocate, 16 bytes per
-  // element in the scratch space, hence, 16*32 = 512.
-  static_assert(sizeof(ValueType) <=
-                Impl::OpenMPTargetExecTeamMember::TEAM_REDUCE_SIZE);
-
-  ValueType* TeamThread_scratch =
-      static_cast<ValueType*>(loop_boundaries.team.impl_reduce_scratch());
-
-#pragma omp declare reduction(omp_red_teamthread_reducer                      \
-:ValueType : Impl::OpenMPTargetReducerWrapper<ReducerType>::join(omp_out,     \
-                                                                     omp_in)) \
-    initializer(Impl::OpenMPTargetReducerWrapper<ReducerType>::init(omp_priv))
-
-#pragma omp barrier
-  ValueType tmp;
-  result.init(tmp);
-  TeamThread_scratch[0] = tmp;
-#pragma omp barrier
-
-  iType team_size = iType(omp_get_num_threads());
-#pragma omp for reduction(                                     \
-        omp_red_teamthread_reducer : TeamThread_scratch[ : 1]) \
-    schedule(static, 1)
-  for (iType t = 0; t < team_size; t++) {
-    ValueType tmp2;
-    result.init(tmp2);
-
-    for (iType i = loop_boundaries.start + t; i < loop_boundaries.end;
-         i += team_size) {
-      lambda(i, tmp2);
-    }
-
-    // FIXME_OPENMPTARGET: Join should work but doesn't. Every threads gets a
-    // private TeamThread_scratch[0] and at the end of the for-loop the `join`
-    // operation is performed by OpenMP itself and hence the simple assignment
-    // works.
-    //    result.join(TeamThread_scratch[0], tmp2);
-    TeamThread_scratch[0] = tmp2;
-  }
-
-  result.reference() = TeamThread_scratch[0];
-}
-#endif  // KOKKOS_IMPL_HIERARCHICAL_REDUCERS_WORKAROUND
 
 /** \brief  Intra-thread vector parallel_reduce. Executes lambda(iType i,
  * ValueType & val) for each i=0..N-1.
@@ -347,7 +286,6 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
   result = TeamVector_scratch[0];
 }
 
-#if !defined(KOKKOS_IMPL_HIERARCHICAL_REDUCERS_WORKAROUND)
 template <typename iType, class Lambda, typename ReducerType>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
 parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
@@ -380,52 +318,6 @@ parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
 
   result.reference() = TeamVector_scratch[0];
 }
-#else
-template <typename iType, class Lambda, typename ReducerType>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
-parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
-                    iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
-                const Lambda& lambda, ReducerType const& result) {
-  using ValueType = typename ReducerType::value_type;
-
-  // FIXME_OPENMPTARGET - Make sure that if its an array reduction, number of
-  // elements in the array <= 32. For reduction we allocate, 16 bytes per
-  // element in the scratch space, hence, 16*32 = 512.
-  static_assert(sizeof(ValueType) <=
-                Impl::OpenMPTargetExecTeamMember::TEAM_REDUCE_SIZE);
-
-  ValueType* TeamVector_scratch =
-      static_cast<ValueType*>(loop_boundaries.team.impl_reduce_scratch());
-
-#pragma omp declare reduction(omp_red_teamthread_reducer                      \
-:ValueType : Impl::OpenMPTargetReducerWrapper<ReducerType>::join(omp_out,     \
-                                                                     omp_in)) \
-    initializer(Impl::OpenMPTargetReducerWrapper<ReducerType>::init(omp_priv))
-
-#pragma omp barrier
-  ValueType tmp;
-  result.init(tmp);
-  TeamVector_scratch[0] = tmp;
-#pragma omp barrier
-
-  iType team_size = iType(omp_get_num_threads());
-#pragma omp for simd reduction(                                \
-        omp_red_teamthread_reducer : TeamVector_scratch[ : 1]) \
-    schedule(static, 1)
-  for (iType t = 0; t < team_size; t++) {
-    ValueType tmp2;
-    result.init(tmp2);
-
-    for (iType i = loop_boundaries.start + t; i < loop_boundaries.end;
-         i += team_size) {
-      lambda(i, tmp2);
-    }
-    TeamVector_scratch[0] = tmp2;
-  }
-
-  result.reference() = TeamVector_scratch[0];
-}
-#endif  // KOKKOS_IMPL_HIERARCHICAL_REDUCERS_WORKAROUND
 
 namespace Impl {
 
@@ -523,9 +415,6 @@ class ParallelReduce<CombinedFunctorReducerType,
 
 }  // namespace Impl
 
-#ifdef KOKKOS_IMPL_HIERARCHICAL_REDUCERS_WORKAROUND
-#undef KOKKOS_IMPL_HIERARCHICAL_REDUCERS_WORKAROUND
-#endif
 }  // namespace Kokkos
 
 #endif

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Team.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Team.hpp
@@ -22,13 +22,6 @@
 #include <Kokkos_Parallel.hpp>
 #include <OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp>
 
-// FIXME_OPENMPTARGET - Using this macro to implement a workaround for
-// hierarchical scan. It avoids hitting the code path which we wanted to
-// write but doesn't work. undef'ed at the end.
-#ifndef KOKKOS_ARCH_INTEL_GPU
-#define KOKKOS_IMPL_TEAM_SCAN_WORKAROUND
-#endif
-
 namespace Kokkos {
 
 // This is largely the same code as in HIP and CUDA except for the member name
@@ -51,19 +44,6 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
   auto& member         = loop_bounds.team;
   const auto team_rank = member.team_rank();
 
-#if defined(KOKKOS_IMPL_TEAM_SCAN_WORKAROUND)
-  ValueType scan_val = {};
-
-  if (team_rank == 0) {
-    for (iType i = start; i < end; ++i) {
-      lambda(i, scan_val, true);
-    }
-  }
-  member.team_broadcast(scan_val, 0);
-  return_val = scan_val;
-
-#pragma omp barrier
-#else
   const auto team_size = member.team_size();
   const auto nchunk    = (end - start + team_size - 1) / team_size;
   ValueType accum      = {};
@@ -87,8 +67,6 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     member.team_broadcast(accum, team_size - 1);
   }
   return_val = accum;
-
-#endif
 }
 
 template <typename iType, class FunctorType>
@@ -158,9 +136,5 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
 }
 
 }  // namespace Kokkos
-
-#ifdef KOKKOS_IMPL_TEAM_SCAN_WORKAROUND
-#undef KOKKOS_IMPL_TEAM_SCAN_WORKAROUND
-#endif
 
 #endif

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -41,10 +41,9 @@ struct TestTeamPolicy {
     // FIXME_OPENMPTARGET temporary restriction for team size to be at least 32
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
         Kokkos::TeamPolicy<ScheduleType, ExecSpace>(
-            1,
-            std::is_same_v<ExecSpace, Kokkos::Experimental::OpenMPTarget>
-                ? 32
-                : 1)
+            1, std::is_same_v<ExecSpace, Kokkos::Experimental::OpenMPTarget>
+                   ? 32
+                   : 1)
             .team_size_max(*this, Kokkos::ParallelReduceTag()),
 #else
         Kokkos::TeamPolicy<ScheduleType, ExecSpace>(1, 1).team_size_max(


### PR DESCRIPTION
The PR is the first step in making the OpenMPTarget backend tailored to be supported by only LLVM compiler (i.e., clang++) .

In this PR, I only remove code paths specialized for non-llvm compilers or architectures not supported by llvm compilers. 