### PR TITLE
Drop obsolete ZeroMemset CTAD workaround for the Intel C++ Compiler Classic

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -842,13 +842,8 @@ contiguous_fill_or_memset(
       && !std::is_same_v<ExecutionSpace, Kokkos::OpenMP>
 #endif
   )
-    // FIXME intel/19 icpc fails to deduce template parameter here,
-    // resulting in compilation errors; explicitly passing the template
-    // parameter to ZeroMemset helps workaround the issue.
-    // See https://github.com/kokkos/kokkos/issues/7273.
-    ZeroMemset<ExecutionSpace>(
-        exec_space, dst.data(),
-        dst.size() * sizeof(typename ViewTraits<DT, DP...>::value_type));
+    ZeroMemset(exec_space, dst.data(),
+               dst.size() * sizeof(typename ViewTraits<DT, DP...>::value_type));
   else
     contiguous_fill(exec_space, dst, value);
 }

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -869,7 +869,8 @@ struct TestViewMirror {
 
     Kokkos::parallel_for(
         Kokkos::RangePolicy<typename DeviceType::execution_space>(0, int(10)),
-        CopyUnInit(a_d));
+        // decltype required for Intel classics, that doesn't recognize the CTAD
+        CopyUnInit<decltype(a_d)>(a_d));
 
     Kokkos::deep_copy(a_h, a_d);
 

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -869,8 +869,7 @@ struct TestViewMirror {
 
     Kokkos::parallel_for(
         Kokkos::RangePolicy<typename DeviceType::execution_space>(0, int(10)),
-        // decltype required for Intel classics, that doesn't recognize the CTAD
-        CopyUnInit<decltype(a_d)>(a_d));
+        CopyUnInit(a_d));
 
     Kokkos::deep_copy(a_h, a_d);
 


### PR DESCRIPTION
We dropped support for the Intel C++ Compiler Classic in https://github.com/kokkos/kokkos/pull/7737
I was looking into ZeroMemset for something unrelated.
~~I did a quick search and the View test occurrence is the only one I found.~~ **change was withdrawn**
They may be others but it is fine.