### PR TITLE
Do not check compiler and linker flags if `kokkos_launch_compiler` is used. 

### DIFF
--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -275,14 +275,8 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
       ${LIBRARY_NAME} PUBLIC $<$<COMPILE_LANGUAGE:${KOKKOS_COMPILE_LANGUAGE}>:${NODEDUP_CUDAFE_OPTIONS}>
     )
 
-    #exclude case of compiler_launcher. The launcher forwards to nvcc_wrapper and shadow the CXX compiler that CMake sees (compiler_launcher changes the compiler).
-    #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags if it is not nvcc_wrapper or clang+cuda.
-    if(KOKKOS_ENABLE_COMPILE_AS_CMAKE_LANGUAGE OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper")
-       OR (${KOKKOS_CXX_COMPILER_ID} STREQUAL Clang)
-    )
-      list(APPEND ALL_KOKKOS_COMPILER_FLAGS ${KOKKOS_CUDA_OPTIONS})
-      list(APPEND ALL_KOKKOS_COMPILER_FLAGS ${NODEDUP_CUDAFE_OPTIONS})
-    endif()
+    list(APPEND ALL_KOKKOS_COMPILER_FLAGS ${KOKKOS_CUDA_OPTIONS})
+    list(APPEND ALL_KOKKOS_COMPILER_FLAGS ${NODEDUP_CUDAFE_OPTIONS})
   endif()
 
   if(KOKKOS_ENABLE_HIP)
@@ -315,7 +309,13 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
 
   #required for check_compiler_flag
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.19)
-    kokkos_check_flags(COMPILER LANGUAGE ${KOKKOS_COMPILE_LANGUAGE} FLAGS ${ALL_KOKKOS_COMPILER_FLAGS})
+    #exclude case of compiler_launcher. The launcher forwards to nvcc_wrapper and shadow the CXX compiler that CMake sees (compiler_launcher changes the compiler).
+    #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags if it is not nvcc_wrapper or clang+cuda.
+    if(NOT (KOKKOS_ENABLE_CUDA) OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper") OR (${KOKKOS_CXX_COMPILER_ID}
+                                                                                        STREQUAL Clang)
+    )
+      kokkos_check_flags(COMPILER LANGUAGE ${KOKKOS_COMPILE_LANGUAGE} FLAGS ${ALL_KOKKOS_COMPILER_FLAGS})
+    endif()
   endif()
 
   if(KOKKOS_CXX_STANDARD_FEATURE)


### PR DESCRIPTION
fixes https://github.com/kokkos/kokkos/issues/7974

options like rdc are not processed as CUDA options but as general options.
This is a problem if the `kokkos_launch_compiler` script is used as CMake would dispatch the flag check without the launcher, thus invoking the host compiler directly -> fail as it does not know about rdc. 
To avoid this, we disable the compile flag check completely in the case of `kokkos_launch_compiler`.