### PR TITLE
Fix and test stride for r>=rank

### DIFF
--- a/core/unit_test/TestViewAPI_e.hpp
+++ b/core/unit_test/TestViewAPI_e.hpp
@@ -104,6 +104,13 @@ void test_left_stride(Extents... extents) {
     ASSERT_EQ(all_strides[i], expected_stride);
     expected_stride *= view.extent(i);
   }
+  ASSERT_EQ(all_strides[view_type::rank()], expected_stride);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  for (size_t i = view_type::rank(); i < size_t(8); ++i) {
+    ASSERT_EQ(view.stride(i), view.stride(view_type::rank() - 1) *
+                                  view.extent(view_type::rank() - 1));
+  }
+#endif
 }
 
 template <typename DataType, typename... Extents>
@@ -120,12 +127,57 @@ void test_right_stride(Extents... extents) {
     ASSERT_EQ(all_strides[i], expected_stride);
     expected_stride *= view.extent(i);
   }
+  ASSERT_EQ(all_strides[view_type::rank()], expected_stride);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  for (size_t i = view_type::rank(); i < size_t(8); ++i) {
+    ASSERT_EQ(view.stride(i), size_t(1));
+  }
+#endif
+}
+
+template <typename DataType, typename... Extents>
+void test_stride_stride(Extents... extents) {
+  using view_type =
+      Kokkos::View<DataType, Kokkos::LayoutStride, Kokkos::HostSpace>;
+
+  auto test = [](auto view_org) {
+    view_type view(view_org);
+
+    size_t all_strides[view_type::rank() + 1];
+    view.stride(all_strides);
+
+    size_t max_stride     = 0;
+    size_t max_stride_idx = 0;
+    for (size_t i = 0; i < view_type::rank(); ++i) {
+      ASSERT_EQ(view.stride(i), view_org.stride(i));
+      ASSERT_EQ(all_strides[i], view_org.stride(i));
+      if (view.stride(i) > max_stride) {
+        max_stride     = view.stride(i);
+        max_stride_idx = i;
+      }
+    }
+    ASSERT_EQ(all_strides[view_type::rank()],
+              max_stride * view.extent(max_stride_idx));
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+    for (size_t i = view_type::rank(); i < size_t(8); ++i) {
+      ASSERT_EQ(view.stride(i), size_t(0));
+    }
+#endif
+  };
+
+  Kokkos::View<DataType, Kokkos::LayoutRight, Kokkos::HostSpace> view_right(
+      "view", extents...);
+  test(view_right);
+  Kokkos::View<DataType, Kokkos::LayoutRight, Kokkos::HostSpace> view_left(
+      "view", extents...);
+  test(view_left);
 }
 
 template <typename DataType, typename... Extents>
 void test_stride(Extents... extents) {
   test_right_stride<DataType>(extents...);
   test_left_stride<DataType>(extents...);
+  test_stride_stride<DataType>(extents...);
 }
 
 TEST(TEST_CATEGORY, view_stride_method) {


### PR DESCRIPTION
We didn't test v.stride(r) with r>= rank, we didn't test stride() for layout_stride at all, and we didn't test that the last value in the array overload of stride() is correct.

I added the tests and made the new view implementation match the behavior of the legacy implementation. 

Note: our documentation says you can't use r>=rank for stride(r): https://kokkos.org/kokkos-core-wiki/API/core/view/view.html#_CPPv4I0ENK6strideE6size_tRK5iType.

I reintroduced this behavior under deprecation. 