### PR TITLE
Enable bugprone-integer-division check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,7 +5,6 @@ Checks: >
   -bugprone-branch-clone,
   -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape,
-  -bugprone-integer-division,
   -bugprone-macro-parentheses,
   -bugprone-misplaced-widening-cast,
   -bugprone-narrowing-conversions,

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamCount.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamCount.cpp
@@ -94,8 +94,8 @@ void test_A(const bool searched_value_exist, std::size_t numTeams,
 
   // Boundaries choosen so that every drawn number is at least once in the given
   // row
-  const ValueType lowerBound = numCols / 4;
-  const ValueType upperBound = 1 + numCols * 3 / 4;
+  const ValueType lowerBound = static_cast<ValueType>(numCols) / 4;
+  const ValueType upperBound = 1 + static_cast<ValueType>(numCols) * 3 / 4;
   const auto bounds          = make_bounds(lowerBound, upperBound);
 
   auto [dataView, dataViewBeforeOp_h] = create_random_view_and_host_clone(

--- a/containers/performance_tests/TestDynRankView.hpp
+++ b/containers/performance_tests/TestDynRankView.hpp
@@ -40,7 +40,7 @@ struct InitViewFunctor {
   void operator()(const int i) const {
     for (unsigned j = 0; j < _inview.extent(1); ++j) {
       for (unsigned k = 0; k < _inview.extent(2); ++k) {
-        _inview(i, j, k) = i / 2 - j * j + k / 3;
+        _inview(i, j, k) = double(i) / 2 - j * j + double(k) / 3;
       }
     }
   }
@@ -78,7 +78,7 @@ struct InitStrideViewFunctor {
   void operator()(const int i) const {
     for (unsigned j = 0; j < _inview.extent(1); ++j) {
       for (unsigned k = 0; k < _inview.extent(2); ++k) {
-        _inview(i, j, k) = i / 2 - j * j + k / 3;
+        _inview(i, j, k) = double(i) / 2 - j * j + double(k) / 3;
       }
     }
   }
@@ -95,7 +95,7 @@ struct InitViewRank7Functor {
   void operator()(const int i) const {
     for (unsigned j = 0; j < _inview.extent(1); ++j) {
       for (unsigned k = 0; k < _inview.extent(2); ++k) {
-        _inview(i, j, k, 0, 0, 0, 0) = i / 2 - j * j + k / 3;
+        _inview(i, j, k, 0, 0, 0, 0) = double(i) / 2 - j * j + double(k) / 3;
       }
     }
   }
@@ -113,7 +113,7 @@ struct InitDynRankViewFunctor {
   void operator()(const int i) const {
     for (unsigned j = 0; j < _inview.extent(1); ++j) {
       for (unsigned k = 0; k < _inview.extent(2); ++k) {
-        _inview(i, j, k) = i / 2 - j * j + k / 3;
+        _inview(i, j, k) = double(i) / 2 - j * j + double(k) / 3;
       }
     }
   }

--- a/containers/unit_tests/TestDynamicView.hpp
+++ b/containers/unit_tests/TestDynamicView.hpp
@@ -83,7 +83,8 @@ struct TestDynamicView {
           },
           result_sum);
 
-      ASSERT_EQ(result_sum, (value_type)(da_size * (da_size - 1) / 2));
+      ASSERT_EQ(result_sum,
+                static_cast<value_type>(da_size) * (da_size - 1) / 2);
 
       // add 3x more entries i.e. 4x larger than previous size
       // the first 1/4 should remain the same
@@ -104,7 +105,7 @@ struct TestDynamicView {
           new_result_sum);
 
       ASSERT_EQ(new_result_sum + result_sum,
-                (value_type)(da_resize * (da_resize - 1) / 2));
+                static_cast<value_type>(da_resize) * (da_resize - 1) / 2);
     }  // end scope
 
     // Test: Create DynamicView, initialize size (via resize), run through
@@ -131,7 +132,8 @@ struct TestDynamicView {
           },
           result_sum);
 
-      ASSERT_EQ(result_sum, (value_type)(da_size * (da_size - 1) / 2));
+      ASSERT_EQ(result_sum,
+                static_cast<value_type>(da_size) * (da_size - 1) / 2);
 
       // add 3x more entries i.e. 4x larger than previous size
       // the first 1/4 should remain the same
@@ -152,7 +154,7 @@ struct TestDynamicView {
           new_result_sum);
 
       ASSERT_EQ(new_result_sum + result_sum,
-                (value_type)(da_resize * (da_resize - 1) / 2));
+                static_cast<value_type>(da_resize) * (da_resize - 1) / 2);
     }  // end scope
 
     // Test: Create DynamicView, initialize size (via resize), run through
@@ -179,7 +181,8 @@ struct TestDynamicView {
           },
           result_sum);
 
-      ASSERT_EQ(result_sum, (value_type)(da_size * (da_size - 1) / 2));
+      ASSERT_EQ(result_sum,
+                static_cast<value_type>(da_size) * (da_size - 1) / 2);
 
       // remove the final 3/4 entries i.e. first 1/4 remain
       unsigned da_resize = arg_total_size / 8;
@@ -198,7 +201,8 @@ struct TestDynamicView {
           },
           new_result_sum);
 
-      ASSERT_EQ(new_result_sum, (value_type)(da_resize * (da_resize - 1) / 2));
+      ASSERT_EQ(new_result_sum,
+                static_cast<value_type>(da_resize) * (da_resize - 1) / 2);
     }  // end scope
 
     // Test: Reproducer to demonstrate compile-time error of deep_copy
@@ -229,7 +233,8 @@ struct TestDynamicView {
           },
           result_sum);
 
-      ASSERT_EQ(result_sum, (value_type)(da_size * (da_size - 1) / 2));
+      ASSERT_EQ(result_sum,
+                static_cast<value_type>(da_size) * (da_size - 1) / 2);
 
       // Use an on-device View as intermediate to deep_copy the
       // device_dynamic_view to host, zero out the device_dynamic_view,
@@ -250,7 +255,8 @@ struct TestDynamicView {
           },
           new_result_sum);
 
-      ASSERT_EQ(new_result_sum, (value_type)(da_size * (da_size - 1) / 2));
+      ASSERT_EQ(new_result_sum,
+                static_cast<value_type>(da_size) * (da_size - 1) / 2);
     }
   }
 };

--- a/core/perf_test/Benchmark_Context.hpp
+++ b/core/perf_test/Benchmark_Context.hpp
@@ -46,7 +46,7 @@ template <class ViewType>
 void report_results(benchmark::State& state, ViewType view, int data_ratio,
                     double time) {
   // data processed in megabytes
-  const double data_processed = data_ratio * view.size() *
+  const double data_processed = static_cast<double>(data_ratio) * view.size() *
                                 sizeof(typename ViewType::value_type) /
                                 1'000'000;
 

--- a/core/src/Kokkos_MathematicalSpecialFunctions.hpp
+++ b/core/src/Kokkos_MathematicalSpecialFunctions.hpp
@@ -502,8 +502,8 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_j0(const CmplxType& z,
       CmplxType cf, cs0;
       for (int k = bw_start; k >= 0; k--) {  // Backward recurrence (default:
                                              // 70)
-        cf                    = 2.0 * (k + 1.0) / z * cf1 - cf2;
-        RealType tmp_exponent = static_cast<RealType>(k) / 2;
+        cf               = 2.0 * (k + 1.0) / z * cf1 - cf2;
+        int tmp_exponent = k / 2;
         if (k == 0) cbj0 = cf;
         if ((k == 2 * (k / 2)) && (k != 0)) {
           if (y0 <= 1.0)
@@ -597,8 +597,8 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_y0(const CmplxType& z,
       CmplxType cf, cs0, ce;
       for (int k = bw_start; k >= 0; k--) {  // Backward recurrence (default:
                                              // 70)
-        cf                    = 2.0 * (k + 1.0) / z * cf1 - cf2;
-        RealType tmp_exponent = static_cast<RealType>(k) / 2;
+        cf               = 2.0 * (k + 1.0) / z * cf1 - cf2;
+        int tmp_exponent = k / 2;
         if (k == 0) cbj0 = cf;
         if ((k == 2 * (k / 2)) && (k != 0)) {
           if (y0 <= 1.0)
@@ -694,8 +694,8 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_j1(const CmplxType& z,
       CmplxType cf, cs0;
       for (int k = bw_start; k >= 0; k--) {  // Backward recurrence (default:
                                              // 70)
-        cf                    = 2.0 * (k + 1.0) / z * cf1 - cf2;
-        RealType tmp_exponent = static_cast<RealType>(k) / 2;
+        cf               = 2.0 * (k + 1.0) / z * cf1 - cf2;
+        int tmp_exponent = k / 2;
         if (k == 1) cbj1 = cf;
         if ((k == 2 * (k / 2)) && (k != 0)) {
           if (y0 <= 1.0)
@@ -793,8 +793,8 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_y1(const CmplxType& z,
       CmplxType cf, cs0, ce;
       for (int k = bw_start; k >= 0; k--) {  // Backward recurrence (default:
                                              // 70)
-        cf                    = 2.0 * (k + 1.0) / z * cf1 - cf2;
-        RealType tmp_exponent = static_cast<RealType>(k) / 2;
+        cf               = 2.0 * (k + 1.0) / z * cf1 - cf2;
+        int tmp_exponent = k / 2;
         if (k == 1) cbj1 = cf;
         if (k == 0) cbj0 = cf;
         if ((k == 2 * (k / 2)) && (k != 0)) {

--- a/core/src/Kokkos_MathematicalSpecialFunctions.hpp
+++ b/core/src/Kokkos_MathematicalSpecialFunctions.hpp
@@ -503,7 +503,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_j0(const CmplxType& z,
       for (int k = bw_start; k >= 0; k--) {  // Backward recurrence (default:
                                              // 70)
         cf                    = 2.0 * (k + 1.0) / z * cf1 - cf2;
-        RealType tmp_exponent = static_cast<RealType>(k / 2);
+        RealType tmp_exponent = static_cast<RealType>(k) / 2;
         if (k == 0) cbj0 = cf;
         if ((k == 2 * (k / 2)) && (k != 0)) {
           if (y0 <= 1.0)
@@ -598,7 +598,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_y0(const CmplxType& z,
       for (int k = bw_start; k >= 0; k--) {  // Backward recurrence (default:
                                              // 70)
         cf                    = 2.0 * (k + 1.0) / z * cf1 - cf2;
-        RealType tmp_exponent = static_cast<RealType>(k / 2);
+        RealType tmp_exponent = static_cast<RealType>(k) / 2;
         if (k == 0) cbj0 = cf;
         if ((k == 2 * (k / 2)) && (k != 0)) {
           if (y0 <= 1.0)
@@ -695,7 +695,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_j1(const CmplxType& z,
       for (int k = bw_start; k >= 0; k--) {  // Backward recurrence (default:
                                              // 70)
         cf                    = 2.0 * (k + 1.0) / z * cf1 - cf2;
-        RealType tmp_exponent = static_cast<RealType>(k / 2);
+        RealType tmp_exponent = static_cast<RealType>(k) / 2;
         if (k == 1) cbj1 = cf;
         if ((k == 2 * (k / 2)) && (k != 0)) {
           if (y0 <= 1.0)
@@ -794,7 +794,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_y1(const CmplxType& z,
       for (int k = bw_start; k >= 0; k--) {  // Backward recurrence (default:
                                              // 70)
         cf                    = 2.0 * (k + 1.0) / z * cf1 - cf2;
-        RealType tmp_exponent = static_cast<RealType>(k / 2);
+        RealType tmp_exponent = static_cast<RealType>(k) / 2;
         if (k == 1) cbj1 = cf;
         if (k == 0) cbj0 = cf;
         if ((k == 2 * (k / 2)) && (k != 0)) {

--- a/core/unit_test/TestAtomicViews.hpp
+++ b/core/unit_test/TestAtomicViews.hpp
@@ -405,15 +405,15 @@ T PlusEqualAtomicViewCheck(const int64_t input_length) {
   T result[2];
 
   if (N % 2 == 0) {
-    const int64_t half_sum_end = (N / 2) - 1;
-    const int64_t full_sum_end = N - 1;
-    result[0] = half_sum_end * (half_sum_end + 1) / 2;  // Even sum.
+    const T half_sum_end = static_cast<T>(N) / 2 - 1;
+    const T full_sum_end = static_cast<T>(N) - 1;
+    result[0]            = half_sum_end * (half_sum_end + 1) / 2;  // Even sum.
     result[1] =
         (full_sum_end * (full_sum_end + 1) / 2) - result[0];  // Odd sum.
   } else {
-    const int64_t half_sum_end = (T)(N / 2);
-    const int64_t full_sum_end = N - 2;
-    result[0] = half_sum_end * (half_sum_end - 1) / 2;  // Even sum.
+    const T half_sum_end = static_cast<T>(N) / 2;
+    const T full_sum_end = static_cast<T>(N) - 2;
+    result[0]            = half_sum_end * (half_sum_end - 1) / 2;  // Even sum.
     result[1] =
         (full_sum_end * (full_sum_end - 1) / 2) - result[0];  // Odd sum.
   }
@@ -494,14 +494,14 @@ T MinusEqualAtomicViewCheck(const int64_t input_length) {
   T result[2];
 
   if (N % 2 == 0) {
-    const int64_t half_sum_end = (N / 2) - 1;
-    const int64_t full_sum_end = N - 1;
+    const T half_sum_end = static_cast<T>(N) / 2 - 1;
+    const T full_sum_end = static_cast<T>(N) - 1;
     result[0] = -1 * (half_sum_end * (half_sum_end + 1) / 2);  // Even sum.
     result[1] =
         -1 * ((full_sum_end * (full_sum_end + 1) / 2) + result[0]);  // Odd sum.
   } else {
-    const int64_t half_sum_end = (int64_t)(N / 2);
-    const int64_t full_sum_end = N - 2;
+    const T half_sum_end = static_cast<T>(N) / 2;
+    const T full_sum_end = static_cast<T>(N) - 2;
     result[0] = -1 * (half_sum_end * (half_sum_end - 1) / 2);  // Even sum.
     result[1] =
         -1 * ((full_sum_end * (full_sum_end - 1) / 2) + result[0]);  // Odd sum.

--- a/core/unit_test/TestParallelScanRangePolicy.hpp
+++ b/core/unit_test/TestParallelScanRangePolicy.hpp
@@ -72,10 +72,10 @@ struct TestParallelScanRangePolicy {
 
       for (size_t i = 0; i < work_size; ++i) {
         // Check prefix sum
-        ASSERT_EQ(ValueType((i * (i - 1)) / 2), prefix_h(i));
+        ASSERT_EQ((static_cast<ValueType>(i) * (i - 1)) / 2, prefix_h(i));
 
         // Check postfix sum
-        ASSERT_EQ(ValueType(((i + 1) * i) / 2), postfix_h(i));
+        ASSERT_EQ((static_cast<ValueType>(i) * (i + 1)) / 2, prefix_h(i));
       }
 
       // Reset results
@@ -103,7 +103,7 @@ struct TestParallelScanRangePolicy {
         ValueType return_val = 0;
         Kokkos::parallel_scan("TestWithStrArg2", work_size, *this, return_val);
         check_scan_results();
-        ASSERT_EQ(ValueType(work_size * (work_size - 1) / 2),
+        ASSERT_EQ(static_cast<ValueType>(work_size) * (work_size - 1) / 2,
                   return_val);  // sum( 0 .. N-1 )
       }
 
@@ -113,7 +113,7 @@ struct TestParallelScanRangePolicy {
         ValueType return_val = 0;
         Kokkos::parallel_scan(work_size, *this, return_val);
         check_scan_results();
-        ASSERT_EQ(ValueType(work_size * (work_size - 1) / 2),
+        ASSERT_EQ(static_cast<ValueType>(work_size) * (work_size - 1) / 2,
                   return_val);  // sum( 0 .. N-1 )
       }
 
@@ -123,7 +123,7 @@ struct TestParallelScanRangePolicy {
         Kokkos::View<ValueType, Kokkos::HostSpace> return_view("return_view");
         Kokkos::parallel_scan(work_size, *this, return_view);
         check_scan_results();
-        ASSERT_EQ(ValueType(work_size * (work_size - 1) / 2),
+        ASSERT_EQ(static_cast<ValueType>(work_size) * (work_size - 1) / 2,
                   return_view());  // sum( 0 .. N-1 )
       }
     } else {
@@ -145,7 +145,7 @@ struct TestParallelScanRangePolicy {
         ValueType return_val = 0;
         Kokkos::parallel_scan("TestWithStrArg4", policy, *this, return_val);
         check_scan_results();
-        ASSERT_EQ(ValueType(work_size * (work_size - 1) / 2),
+        ASSERT_EQ(static_cast<ValueType>(work_size) * (work_size - 1) / 2,
                   return_val);  // sum( 0 .. N-1 )
       }
 
@@ -155,7 +155,7 @@ struct TestParallelScanRangePolicy {
         ValueType return_val = 0;
         Kokkos::parallel_scan(policy, *this, return_val);
         check_scan_results();
-        ASSERT_EQ(ValueType(work_size * (work_size - 1) / 2),
+        ASSERT_EQ(static_cast<ValueType>(work_size) * (work_size - 1) / 2,
                   return_val);  // sum( 0 .. N-1 )
       }
 
@@ -168,7 +168,7 @@ struct TestParallelScanRangePolicy {
 
         ValueType total;
         Kokkos::deep_copy(total, return_view);
-        ASSERT_EQ(ValueType(work_size * (work_size - 1) / 2),
+        ASSERT_EQ(static_cast<ValueType>(work_size) * (work_size - 1) / 2,
                   total);  // sum( 0 .. N-1 )
       }
 
@@ -185,7 +185,7 @@ struct TestParallelScanRangePolicy {
         ValueType return_val = 0;
         Kokkos::parallel_scan(policy_with_require, *this, return_val);
         check_scan_results();
-        ASSERT_EQ(ValueType(work_size * (work_size - 1) / 2),
+        ASSERT_EQ(static_cast<ValueType>(work_size) * (work_size - 1) / 2,
                   return_val);  // sum( 0 .. N-1 )
       }
     }

--- a/core/unit_test/TestParallelScanRangePolicy.hpp
+++ b/core/unit_test/TestParallelScanRangePolicy.hpp
@@ -75,7 +75,7 @@ struct TestParallelScanRangePolicy {
         ASSERT_EQ((static_cast<ValueType>(i) * (i - 1)) / 2, prefix_h(i));
 
         // Check postfix sum
-        ASSERT_EQ((static_cast<ValueType>(i) * (i + 1)) / 2, prefix_h(i));
+        ASSERT_EQ((static_cast<ValueType>(i) * (i + 1)) / 2, postfix_h(i));
       }
 
       // Reset results

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -645,6 +645,9 @@ struct functor_vec_scan_ret_val {
         },
         return_val);
 
+    // Suppressing diagnostic and not casting since that test is being
+    // instantantiated with user-defined types such as array_reduce
+    // NOLINTNEXTLINE(bugprone-integer-division)
     Scalar sum_ref = ((upper_bound - 1) * (upper_bound)) / 2;
 
     if (flag() == 0 && return_val != sum_ref) {


### PR DESCRIPTION
~~All fixes are in the tests.~~ **There is actually a change to the special math functions as pointed out by Daniel**
Mostly casting to express intent, one light refactor in `TestAtomicViews.hpp`, and one suppression (because I did not want to rework `array_reduce` nor introduce logic to handle the various types the test gets instantiated with).