### PR TITLE
DualView: Store modified flags as bool

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -205,7 +205,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
  protected:
   // modified_flags[0] -> host
   // modified_flags[1] -> device
-  using t_modified_flags = View<unsigned int[2], LayoutLeft, Kokkos::HostSpace>;
+  using t_modified_flags = View<bool[2], LayoutLeft, Kokkos::HostSpace>;
   t_modified_flags modified_flags;
 
  public:
@@ -550,7 +550,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
     int dev = get_device_side<Device>();
 
     if (dev == 1) {  // if Device is the same as DualView's device type
-      if ((modified_flags(0) > 0) && (modified_flags(0) >= modified_flags(1))) {
+      if (modified_flags(0)) {
 #ifdef KOKKOS_ENABLE_CUDA
         if (std::is_same<typename t_dev::memory_space,
                          Kokkos::CudaUVMSpace>::value) {
@@ -562,12 +562,12 @@ class DualView : public ViewTraits<DataType, Properties...> {
 #endif
 
         deep_copy(args..., d_view, h_view);
-        modified_flags(0) = modified_flags(1) = 0;
+        modified_flags(0) = modified_flags(1) = false;
         impl_report_device_sync();
       }
     }
     if (dev == 0) {  // hopefully Device is the same as DualView's host type
-      if ((modified_flags(1) > 0) && (modified_flags(1) >= modified_flags(0))) {
+      if (modified_flags(1)) {
 #ifdef KOKKOS_ENABLE_CUDA
         if (std::is_same<typename t_dev::memory_space,
                          Kokkos::CudaUVMSpace>::value) {
@@ -579,7 +579,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
 #endif
 
         deep_copy(args..., h_view, d_view);
-        modified_flags(0) = modified_flags(1) = 0;
+        modified_flags(0) = modified_flags(1) = false;
         impl_report_host_sync();
       }
     }
@@ -627,14 +627,14 @@ class DualView : public ViewTraits<DataType, Properties...> {
     int dev = get_device_side<Device>();
 
     if (dev == 1) {  // if Device is the same as DualView's device type
-      if ((modified_flags(0) > 0) && (modified_flags(0) >= modified_flags(1))) {
+      if (modified_flags(0)) {
         Impl::throw_runtime_exception(
             "Calling sync on a DualView with a const datatype.");
       }
       impl_report_device_sync();
     }
     if (dev == 0) {  // hopefully Device is the same as DualView's host type
-      if ((modified_flags(1) > 0) && (modified_flags(1) >= modified_flags(0))) {
+      if (modified_flags(1)) {
         Impl::throw_runtime_exception(
             "Calling sync on a DualView with a const datatype.");
       }
@@ -662,7 +662,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
 #endif
 
       deep_copy(args..., h_view, d_view);
-      modified_flags(1) = modified_flags(0) = 0;
+      modified_flags(1) = modified_flags(0) = false;
       impl_report_host_sync();
     }
   }
@@ -705,7 +705,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
 #endif
 
       deep_copy(args..., d_view, h_view);
-      modified_flags(1) = modified_flags(0) = 0;
+      modified_flags(1) = modified_flags(0) = false;
       impl_report_device_sync();
     }
   }
@@ -734,12 +734,12 @@ class DualView : public ViewTraits<DataType, Properties...> {
     int dev = get_device_side<Device>();
 
     if (dev == 1) {  // if Device is the same as DualView's device type
-      if ((modified_flags(0) > 0) && (modified_flags(0) >= modified_flags(1))) {
+      if (modified_flags(0)) {
         return true;
       }
     }
     if (dev == 0) {  // hopefully Device is the same as DualView's host type
-      if ((modified_flags(1) > 0) && (modified_flags(1) >= modified_flags(0))) {
+      if (modified_flags(1)) {
         return true;
       }
     }
@@ -748,12 +748,12 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
   inline bool need_sync_host() const {
     if (modified_flags.data() == nullptr) return false;
-    return modified_flags(0) < modified_flags(1);
+    return modified_flags(1);
   }
 
   inline bool need_sync_device() const {
     if (modified_flags.data() == nullptr) return false;
-    return modified_flags(1) < modified_flags(0);
+    return modified_flags(0);
   }
   void impl_report_device_modification() {
     if (Kokkos::Tools::Experimental::get_callbacks().modify_dual_view !=
@@ -791,18 +791,12 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
       if (dev == 1) {  // if Device is the same as DualView's device type
         // Increment the device's modified count.
-        modified_flags(1) =
-            (modified_flags(1) > modified_flags(0) ? modified_flags(1)
-                                                   : modified_flags(0)) +
-            1;
+        modified_flags(1) = true;
         impl_report_device_modification();
       }
       if (dev == 0) {  // hopefully Device is the same as DualView's host type
         // Increment the host's modified count.
-        modified_flags(0) =
-            (modified_flags(1) > modified_flags(0) ? modified_flags(1)
-                                                   : modified_flags(0)) +
-            1;
+        modified_flags(0) = true;
         impl_report_host_modification();
       }
 
@@ -824,10 +818,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
       return;
     } else {
       if (modified_flags.data() != nullptr) {
-        modified_flags(0) =
-            (modified_flags(1) > modified_flags(0) ? modified_flags(1)
-                                                   : modified_flags(0)) +
-            1;
+        modified_flags(0) = true;
         impl_report_host_modification();
 #ifdef KOKKOS_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK
         if (modified_flags(0) && modified_flags(1)) {
@@ -848,10 +839,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
       return;
     } else {
       if (modified_flags.data() != nullptr) {
-        modified_flags(1) =
-            (modified_flags(1) > modified_flags(0) ? modified_flags(1)
-                                                   : modified_flags(0)) +
-            1;
+        modified_flags(1) = true;
         impl_report_device_modification();
 #ifdef KOKKOS_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK
         if (modified_flags(0) && modified_flags(1)) {
@@ -869,7 +857,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
   inline void clear_sync_state() {
     if (modified_flags.data() != nullptr)
-      modified_flags(1) = modified_flags(0) = 0;
+      modified_flags(1) = modified_flags(0) = false;
   }
 
   //@}
@@ -934,7 +922,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
     if (modified_flags.data() == nullptr) {
       modified_flags = t_modified_flags("DualView::modified_flags");
     } else
-      modified_flags(1) = modified_flags(0) = 0;
+      modified_flags(1) = modified_flags(0) = false;
   }
 
   template <class... ViewCtorArgs>
@@ -1015,7 +1003,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
         resync_host(properties);
 
         /* Mark Device copy as modified */
-        ++modified_flags(1);
+        modified_flags(1) = true;
       }
     };
 
@@ -1029,7 +1017,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
         resync_device(properties);
 
         /* Mark Host copy as modified */
-        ++modified_flags(0);
+        modified_flags(0) = true;
       }
     };
 
@@ -1070,10 +1058,10 @@ class DualView : public ViewTraits<DataType, Properties...> {
         return;
       }
     } else {
-      if (modified_flags(1) >= modified_flags(0)) {
-        resize_on_device(arg_prop);
-      } else {
+      if (modified_flags(0)) {
         resize_on_host(arg_prop);
+      } else {
+        resize_on_device(arg_prop);
       }
     }
   }

--- a/containers/src/Kokkos_Vector.hpp
+++ b/containers/src/Kokkos_Vector.hpp
@@ -128,16 +128,16 @@ class KOKKOS_DEPRECATED vector
   void reserve(size_t n) { DV::resize(size_t(n * _extra_storage)); }
 
   void push_back(Scalar val) {
-    DV::template sync<typename DV::t_host::device_type>();
     if (_size == span()) {
       size_t new_size = _size * _extra_storage;
       if (new_size == _size) new_size++;
       DV::resize(new_size);
     }
 
+    DV::sync_host();
     DV::view_host()(_size) = val;
     _size++;
-    DV::template modify<typename DV::t_host::device_type>();
+    DV::modify_host();
   }
 
   void pop_back() { _size--; }


### PR DESCRIPTION
Required for #7961. The current approach for `DualViews`'s `modified_flags` increments the host or device value to one higher than the other flags value in the respective `modify` call and it's currently not value for both flags to have the same value (other than 0). Calling modify both for the host-side and the device-side without sync isn't valid and we check for it in https://github.com/kokkos/kokkos/blob/ca8d31a245bc553b4de6d48e62ce8efe0c336154/containers/src/Kokkos_DualView.hpp#L832-L841, https://github.com/kokkos/kokkos/blob/ca8d31a245bc553b4de6d48e62ce8efe0c336154/containers/src/Kokkos_DualView.hpp#L856-L865, and https://github.com/kokkos/kokkos/blob/ca8d31a245bc553b4de6d48e62ce8efe0c336154/containers/src/Kokkos_DualView.hpp#L809-L818.

This ultimately means that we can just use `bool` flags instead.