### PR TITLE
GitHub CI: Avoid redundant path to source directory

### DIFF
--- a/.github/workflows/continuous-integration-smoketest.yml
+++ b/.github/workflows/continuous-integration-smoketest.yml
@@ -45,8 +45,7 @@ jobs:
             -DKokkos_ENABLE_EXAMPLES=ON \
             -DKokkos_ENABLE_SERIAL=ON \
             -DKokkos_ENABLE_TESTS=ON \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            ..
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: build_and_install_kokkos
         run:  |


### PR DESCRIPTION
We are using `-S kokkos` to specify the source directory so the extra path at the end is ignored with a configuration warning.