### PR TITLE
SYCL: Fix maximum workgroup size in RangePolicy parallel_reduce

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Range.hpp
@@ -263,19 +263,10 @@ class Kokkos::Impl::ParallelReduce<
         auto multiple = kernel.get_info<sycl::info::kernel_device_specific::
                                             preferred_work_group_size_multiple>(
             q.get_device());
-        // FIXME_SYCL The code below queries the kernel for the maximum subgroup
-        // size but it turns out that this is not accurate and choosing a larger
-        // subgroup size gives better peformance (and is what the oneAPI
-        // reduction algorithm does).
-#ifndef KOKKOS_ARCH_INTEL_GPU
         auto max =
             kernel
                 .get_info<sycl::info::kernel_device_specific::work_group_size>(
                     q.get_device());
-#else
-        auto max =
-            q.get_device().get_info<sycl::info::device::max_work_group_size>();
-#endif
 
         auto max_local_memory =
             q.get_device().get_info<sycl::info::device::local_mem_size>();


### PR DESCRIPTION
Newer compiler releases (2025.0* at least) actually provide a sharper bound for the maximum work group size of a kernel and we had users that got too large of a workgroup size with the current code on Intel GPUs.