### PR TITLE
Don't use recursive calls in stride computation

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -273,7 +273,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
       }
       if constexpr (std::is_same_v<LayoutType, layout_left> ||
                     Impl::IsLayoutLeftPadded<LayoutType>::value) {
-        return stride(rank() - 1) * extent(rank() - 1);
+        return base_t::stride(rank() - 1) * extent(rank() - 1);
       }
       if constexpr (std::is_same_v<LayoutType, layout_stride>) {
         return 0;

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -267,6 +267,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
     using LayoutType = typename mdspan_type::layout_type;
     if (r >= static_cast<iType>(rank())) {
+      if constexpr (rank() == 0) return 1;
       if constexpr (std::is_same_v<LayoutType, layout_right> ||
                     Impl::IsLayoutRightPadded<LayoutType>::value) {
         return 1;


### PR DESCRIPTION
https://github.com/kokkos/kokkos/pull/7984 broke our SYCL CI, see https://gitlab.spack.io/kokkos/kokkos/-/jobs/16268471/viewer.

Also fix the deprecated code path for `rank==0`.