### PR TITLE
Fix compiling with -Werror, deprecation warnings enabled, and deprecated code disabled

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -456,7 +456,9 @@ class DynRankView : private View<DataType*******, Properties...> {
   using const_scalar_array_type     = const_value_type;
   using non_const_scalar_array_type = non_const_value_type;
 #ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   using specialize KOKKOS_DEPRECATED = void;
+#endif
 #else
   using specialize = typename view_type::specialize;
 #endif

--- a/containers/unit_tests/TestDynRankViewTypedefs.cpp
+++ b/containers/unit_tests/TestDynRankViewTypedefs.cpp
@@ -63,7 +63,9 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::scalar_array_type, DataType>);
   static_assert(std::is_same_v<typename ViewType::const_scalar_array_type, typename data_analysis<DataType>::const_data_type>);
   static_assert(std::is_same_v<typename ViewType::non_const_scalar_array_type, typename data_analysis<DataType>::non_const_data_type>);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static_assert(std::is_same_v<typename ViewType::specialize, void>);
+#endif
 
   // FIXME: value_type definition conflicts with mdspan value_type
   static_assert(std::is_same_v<typename ViewType::value_type, ValueType>);


### PR DESCRIPTION
We should guard everything we deprecate with `#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4`.