### PR TITLE
Fix value comparison in ASSERT_EQ after bugprone-integer-division fix

### DIFF
--- a/containers/unit_tests/TestDynamicView.hpp
+++ b/containers/unit_tests/TestDynamicView.hpp
@@ -84,7 +84,8 @@ struct TestDynamicView {
           result_sum);
 
       ASSERT_EQ(result_sum,
-                static_cast<value_type>(da_size) * (da_size - 1) / 2);
+                static_cast<value_type>(static_cast<value_type>(da_size) *
+                                        (da_size - 1) / 2));
 
       // add 3x more entries i.e. 4x larger than previous size
       // the first 1/4 should remain the same
@@ -105,7 +106,9 @@ struct TestDynamicView {
           new_result_sum);
 
       ASSERT_EQ(new_result_sum + result_sum,
-                static_cast<value_type>(da_resize) * (da_resize - 1) / 2);
+                static_cast<value_type>(static_cast<value_type>(da_resize) *
+                                        (da_resize - 1)) /
+                    2);
     }  // end scope
 
     // Test: Create DynamicView, initialize size (via resize), run through
@@ -133,7 +136,8 @@ struct TestDynamicView {
           result_sum);
 
       ASSERT_EQ(result_sum,
-                static_cast<value_type>(da_size) * (da_size - 1) / 2);
+                static_cast<value_type>(static_cast<value_type>(da_size) *
+                                        (da_size - 1) / 2));
 
       // add 3x more entries i.e. 4x larger than previous size
       // the first 1/4 should remain the same
@@ -154,7 +158,9 @@ struct TestDynamicView {
           new_result_sum);
 
       ASSERT_EQ(new_result_sum + result_sum,
-                static_cast<value_type>(da_resize) * (da_resize - 1) / 2);
+                static_cast<value_type>(static_cast<value_type>(da_resize) *
+                                        (da_resize - 1)) /
+                    2);
     }  // end scope
 
     // Test: Create DynamicView, initialize size (via resize), run through
@@ -182,7 +188,9 @@ struct TestDynamicView {
           result_sum);
 
       ASSERT_EQ(result_sum,
-                static_cast<value_type>(da_size) * (da_size - 1) / 2);
+                static_cast<value_type>(static_cast<value_type>(da_size) *
+                                        (da_size - 1)) /
+                    2);
 
       // remove the final 3/4 entries i.e. first 1/4 remain
       unsigned da_resize = arg_total_size / 8;
@@ -202,7 +210,9 @@ struct TestDynamicView {
           new_result_sum);
 
       ASSERT_EQ(new_result_sum,
-                static_cast<value_type>(da_resize) * (da_resize - 1) / 2);
+                static_cast<value_type>(static_cast<value_type>(da_resize) *
+                                        (da_resize - 1)) /
+                    2);
     }  // end scope
 
     // Test: Reproducer to demonstrate compile-time error of deep_copy
@@ -234,7 +244,9 @@ struct TestDynamicView {
           result_sum);
 
       ASSERT_EQ(result_sum,
-                static_cast<value_type>(da_size) * (da_size - 1) / 2);
+                static_cast<value_type>(static_cast<value_type>(da_size) *
+                                        (da_size - 1)) /
+                    2);
 
       // Use an on-device View as intermediate to deep_copy the
       // device_dynamic_view to host, zero out the device_dynamic_view,
@@ -256,7 +268,9 @@ struct TestDynamicView {
           new_result_sum);
 
       ASSERT_EQ(new_result_sum,
-                static_cast<value_type>(da_size) * (da_size - 1) / 2);
+                static_cast<value_type>(static_cast<value_type>(da_size) *
+                                        (da_size - 1)) /
+                    2);
     }
   }
 };

--- a/core/unit_test/TestParallelScanRangePolicy.hpp
+++ b/core/unit_test/TestParallelScanRangePolicy.hpp
@@ -72,10 +72,14 @@ struct TestParallelScanRangePolicy {
 
       for (size_t i = 0; i < work_size; ++i) {
         // Check prefix sum
-        ASSERT_EQ((static_cast<ValueType>(i) * (i - 1)) / 2, prefix_h(i));
+        ASSERT_EQ(
+            static_cast<ValueType>((static_cast<ValueType>(i) * (i - 1)) / 2),
+            prefix_h(i));
 
         // Check postfix sum
-        ASSERT_EQ((static_cast<ValueType>(i) * (i + 1)) / 2, postfix_h(i));
+        ASSERT_EQ(
+            static_cast<ValueType>((static_cast<ValueType>(i) * (i + 1)) / 2),
+            postfix_h(i));
       }
 
       // Reset results
@@ -103,7 +107,8 @@ struct TestParallelScanRangePolicy {
         ValueType return_val = 0;
         Kokkos::parallel_scan("TestWithStrArg2", work_size, *this, return_val);
         check_scan_results();
-        ASSERT_EQ(static_cast<ValueType>(work_size) * (work_size - 1) / 2,
+        ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
+                                         (work_size - 1) / 2),
                   return_val);  // sum( 0 .. N-1 )
       }
 
@@ -113,7 +118,8 @@ struct TestParallelScanRangePolicy {
         ValueType return_val = 0;
         Kokkos::parallel_scan(work_size, *this, return_val);
         check_scan_results();
-        ASSERT_EQ(static_cast<ValueType>(work_size) * (work_size - 1) / 2,
+        ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
+                                         (work_size - 1) / 2),
                   return_val);  // sum( 0 .. N-1 )
       }
 
@@ -123,7 +129,8 @@ struct TestParallelScanRangePolicy {
         Kokkos::View<ValueType, Kokkos::HostSpace> return_view("return_view");
         Kokkos::parallel_scan(work_size, *this, return_view);
         check_scan_results();
-        ASSERT_EQ(static_cast<ValueType>(work_size) * (work_size - 1) / 2,
+        ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
+                                         (work_size - 1) / 2),
                   return_view());  // sum( 0 .. N-1 )
       }
     } else {
@@ -145,7 +152,8 @@ struct TestParallelScanRangePolicy {
         ValueType return_val = 0;
         Kokkos::parallel_scan("TestWithStrArg4", policy, *this, return_val);
         check_scan_results();
-        ASSERT_EQ(static_cast<ValueType>(work_size) * (work_size - 1) / 2,
+        ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
+                                         (work_size - 1) / 2),
                   return_val);  // sum( 0 .. N-1 )
       }
 
@@ -155,7 +163,8 @@ struct TestParallelScanRangePolicy {
         ValueType return_val = 0;
         Kokkos::parallel_scan(policy, *this, return_val);
         check_scan_results();
-        ASSERT_EQ(static_cast<ValueType>(work_size) * (work_size - 1) / 2,
+        ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
+                                         (work_size - 1) / 2),
                   return_val);  // sum( 0 .. N-1 )
       }
 
@@ -168,7 +177,8 @@ struct TestParallelScanRangePolicy {
 
         ValueType total;
         Kokkos::deep_copy(total, return_view);
-        ASSERT_EQ(static_cast<ValueType>(work_size) * (work_size - 1) / 2,
+        ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
+                                         (work_size - 1) / 2),
                   total);  // sum( 0 .. N-1 )
       }
 
@@ -185,7 +195,8 @@ struct TestParallelScanRangePolicy {
         ValueType return_val = 0;
         Kokkos::parallel_scan(policy_with_require, *this, return_val);
         check_scan_results();
-        ASSERT_EQ(static_cast<ValueType>(work_size) * (work_size - 1) / 2,
+        ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
+                                         (work_size - 1) / 2),
                   return_val);  // sum( 0 .. N-1 )
       }
     }


### PR DESCRIPTION
Fixes the errors reported in https://github.com/kokkos/kokkos/pull/8002#issuecomment-2811022791.
Before https://github.com/kokkos/kokkos/pull/7985, we were explicitly casting one side of the comparison to the desired value type. #7985 is casting earlier so that the resulting value type might be different than the desired one. This pull request just adds additional casts to the desired comparison type in all tge places #7985 changed. 