### PR TITLE
perf(`Cuda`|`HIP`): create events with `[cuda|hip]EventDisableTiming` when timing is not needed

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -293,8 +293,8 @@ void CudaInternal::initialize(cudaStream_t stream) {
   }
 
   if (!constantMemReusablePerDevice[m_cudaDev])
-    KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (cuda_event_create_wrapper(&constantMemReusablePerDevice[m_cudaDev])));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cuda_event_create_with_flags_wrapper(
+        &constantMemReusablePerDevice[m_cudaDev], cudaEventDisableTiming));
 
   //----------------------------------
   // Multiblock reduction uses scratch flags for counters

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -202,9 +202,10 @@ class CudaInternal {
     return cudaDeviceSetLimit(limit, value);
   }
 
-  cudaError_t cuda_event_create_wrapper(cudaEvent_t* event) const {
+  cudaError_t cuda_event_create_with_flags_wrapper(
+      cudaEvent_t* event, const unsigned int flags) const {
     set_cuda_device();
-    return cudaEventCreate(event);
+    return cudaEventCreateWithFlags(event, flags);
   }
 
   cudaError_t cuda_event_record_wrapper(cudaEvent_t event) const {

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -212,8 +212,8 @@ void HIPInternal::initialize(hipStream_t stream) {
         static_cast<unsigned long *>(constant_mem_void_ptr);
   }
   if (!constantMemReusable[m_hipDev])
-    KOKKOS_IMPL_HIP_SAFE_CALL(
-        hip_event_create_wrapper(&constantMemReusable[m_hipDev]));
+    KOKKOS_IMPL_HIP_SAFE_CALL(hip_event_create_with_flags_wrapper(
+        &constantMemReusable[m_hipDev], hipEventDisableTiming));
 
   //----------------------------------
   // Multiblock reduction uses scratch flags for counters

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -152,9 +152,10 @@ class HIPInternal {
 
   // HIP API wrappers where we set the correct device id before calling the HIP
   // API functions.
-  hipError_t hip_event_create_wrapper(hipEvent_t *event) const {
+  hipError_t hip_event_create_with_flags_wrapper(
+      hipEvent_t *event, const unsigned int flags) const {
     set_hip_device();
-    return hipEventCreate(event);
+    return hipEventCreateWithFlags(event, flags);
   }
 
   hipError_t hip_event_record_wrapper(hipEvent_t event) const {


### PR DESCRIPTION
### Summary

This PR changes the way `Cuda` and `HIP` events are created when they are used in the constant memory launch mechanism for ensuring that only one kernel per device runs concurrently with this mechanism.

Since timing is never required for these events as they are used for synchronization purpose only, we gain... some `µs`.

Note that if one day someone tries to exploit these events to extract timing, they should get some runtime error.

### Description

From `Cuda` documentation:
> [cudaEventDisableTiming](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1ga5d3eff7c3623e2be533968d9cc1ee7e): Specifies that the created event does not need to record timing data. Events created with this flag specified and the [cudaEventBlockingSync](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g26509a522be9d449aa7c8c279612452d) flag not specified will provide the best performance when used with [cudaStreamWaitEvent()](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g7840e3984799941a61839de40413d1d9) and [cudaEventQuery()](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__EVENT.html#group__CUDART__EVENT_1g2bf738909b4a059023537eaa29d8a5b7).

`HIP` documentation is along the same lines.