### PR TITLE
HIP: Fix performance regression with atomic views

### DIFF
--- a/tpls/desul/include/desul/atomics/Fetch_Op_HIP.hpp
+++ b/tpls/desul/include/desul/atomics/Fetch_Op_HIP.hpp
@@ -22,6 +22,12 @@ namespace Impl {
                                    val,                                 \
                                    HIPMemoryOrder<MemoryOrder>::value,  \
                                    HIPMemoryScope<MemoryScope>::value); \
+  }                                                                     \
+  template <class MemoryOrder, class MemoryScope>                       \
+  __device__ inline T device_atomic_##OP##_fetch(                       \
+      T* ptr, T val, MemoryOrder order, MemoryScope scope) {            \
+    return OP##_fetch_operator<T, T>::apply(                            \
+        device_atomic_fetch_##OP(ptr, val, order, scope), val);         \
   }
 
 #define DESUL_IMPL_HIP_ATOMIC_FETCH_OP_INTEGRAL(OP) \
@@ -59,6 +65,12 @@ DESUL_IMPL_HIP_ATOMIC_FETCH_OP_FLOATING_POINT(add)
                                   -val,                                \
                                   HIPMemoryOrder<MemoryOrder>::value,  \
                                   HIPMemoryScope<MemoryScope>::value); \
+  }                                                                    \
+  template <class MemoryOrder, class MemoryScope>                      \
+  __device__ inline T device_atomic_sub_fetch(                         \
+      T* ptr, T val, MemoryOrder order, MemoryScope scope) {           \
+    return sub_fetch_operator<T, T>::apply(                            \
+        device_atomic_fetch_sub(ptr, val, order, scope), val);         \
   }
 
 DESUL_IMPL_HIP_ATOMIC_FETCH_SUB(int)


### PR DESCRIPTION
Specialize atomic_op_fetch() and express it in terms of the op applied to atomic_fetch_op() and the argument.

(Need to be merged in upstream desul first)