### PR TITLE
SYCL: Improve device atomics

### DIFF
--- a/tpls/desul/include/desul/atomics/Fetch_Op_SYCL.hpp
+++ b/tpls/desul/include/desul/atomics/Fetch_Op_SYCL.hpp
@@ -11,48 +11,59 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <desul/atomics/Adapt_SYCL.hpp>
 #include <desul/atomics/Common.hpp>
+#include <desul/atomics/Operator_Function_Objects.hpp>
 
 namespace desul {
 namespace Impl {
 
 // clang-format off
-#define DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, TYPE)                                     \
-  template <class MemoryOrder>                                                            \
-  TYPE device_atomic_fetch_##OPER(TYPE* dest, TYPE val, MemoryOrder, MemoryScopeDevice) { \
-    sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeDevice> dest_ref(*dest);                \
-    return dest_ref.fetch_##OPER(val);                                                    \
-  }                                                                                       \
-  template <class MemoryOrder>                                                            \
-  TYPE device_atomic_fetch_##OPER(TYPE* dest, TYPE val, MemoryOrder, MemoryScopeCore  ) { \
-    sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeCore> dest_ref(*dest);                  \
-    return dest_ref.fetch_##OPER(val);                                                    \
+#define DESUL_IMPL_SYCL_ATOMIC_OPER(OPER, TYPE)                                             \
+  template <class MemoryOrder>                                                              \
+  TYPE device_atomic_fetch_##OPER(TYPE* dest, TYPE val, MemoryOrder, MemoryScopeDevice) {   \
+    sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeDevice> dest_ref(*dest);                  \
+    return dest_ref.fetch_##OPER(val);                                                      \
+  }                                                                                         \
+  template <class MemoryOrder>                                                              \
+  TYPE device_atomic_fetch_##OPER(TYPE* dest, TYPE val, MemoryOrder, MemoryScopeCore  ) {   \
+    sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeCore> dest_ref(*dest);                    \
+    return dest_ref.fetch_##OPER(val);                                                      \
+  }                                                                                         \
+  template <class MemoryOrder>                                                              \
+  TYPE device_atomic_##OPER##_fetch(TYPE* dest, TYPE val, MemoryOrder, MemoryScopeDevice) { \
+    sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeDevice> dest_ref(*dest);                  \
+    return OPER##_fetch_operator<TYPE, TYPE>::apply(dest_ref.fetch_##OPER(val), val);       \
+  }                                                                                         \
+  template <class MemoryOrder>                                                              \
+  TYPE device_atomic_##OPER##_fetch(TYPE* dest, TYPE val, MemoryOrder, MemoryScopeCore)   { \
+    sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeCore> dest_ref(*dest);                    \
+    return OPER##_fetch_operator<TYPE, TYPE>::apply(dest_ref.fetch_##OPER(val), val);       \
   }
 // clang-format on
 
-#define DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(OPER) \
-  DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, int)           \
-  DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, unsigned int)  \
-  DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, long)          \
-  DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, unsigned long) \
-  DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, long long)     \
-  DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, unsigned long long)
+#define DESUL_IMPL_SYCL_ATOMIC_OPER_INTEGRAL(OPER) \
+  DESUL_IMPL_SYCL_ATOMIC_OPER(OPER, int)           \
+  DESUL_IMPL_SYCL_ATOMIC_OPER(OPER, unsigned int)  \
+  DESUL_IMPL_SYCL_ATOMIC_OPER(OPER, long)          \
+  DESUL_IMPL_SYCL_ATOMIC_OPER(OPER, unsigned long) \
+  DESUL_IMPL_SYCL_ATOMIC_OPER(OPER, long long)     \
+  DESUL_IMPL_SYCL_ATOMIC_OPER(OPER, unsigned long long)
 
-#define DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_FLOATING_POINT(OPER) \
-  DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, float)               \
-  DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, double)
+#define DESUL_IMPL_SYCL_ATOMIC_OPER_FLOATING_POINT(OPER) \
+  DESUL_IMPL_SYCL_ATOMIC_OPER(OPER, float)               \
+  DESUL_IMPL_SYCL_ATOMIC_OPER(OPER, double)
 
-DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(add)
-DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(sub)
-DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(and)
-DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(or)
-DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(xor)
-DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(min)
-DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(max)
+DESUL_IMPL_SYCL_ATOMIC_OPER_INTEGRAL(add)
+DESUL_IMPL_SYCL_ATOMIC_OPER_INTEGRAL(sub)
+DESUL_IMPL_SYCL_ATOMIC_OPER_INTEGRAL(and)
+DESUL_IMPL_SYCL_ATOMIC_OPER_INTEGRAL(or)
+DESUL_IMPL_SYCL_ATOMIC_OPER_INTEGRAL(xor)
+DESUL_IMPL_SYCL_ATOMIC_OPER_INTEGRAL(min)
+DESUL_IMPL_SYCL_ATOMIC_OPER_INTEGRAL(max)
 
-DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_FLOATING_POINT(add)
-DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_FLOATING_POINT(sub)
-DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_FLOATING_POINT(min)
-DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_FLOATING_POINT(max)
+DESUL_IMPL_SYCL_ATOMIC_OPER_FLOATING_POINT(add)
+DESUL_IMPL_SYCL_ATOMIC_OPER_FLOATING_POINT(sub)
+DESUL_IMPL_SYCL_ATOMIC_OPER_FLOATING_POINT(min)
+DESUL_IMPL_SYCL_ATOMIC_OPER_FLOATING_POINT(max)
 
 // clang-format off
 #define DESUL_IMPL_SYCL_ATOMIC_INC(TYPE)                                     \
@@ -116,9 +127,9 @@ DESUL_IMPL_SYCL_ATOMIC_INC_DEC(double)
 #undef DESUL_IMPL_SYCL_ATOMIC_INC_DEC
 #undef DESUL_IMPL_SYCL_ATOMIC_INC
 #undef DESUL_IMPL_SYCL_ATOMIC_DEC
-#undef DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_FLOATING_POINT
-#undef DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL
-#undef DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER
+#undef DESUL_IMPL_SYCL_ATOMIC_OPER_FLOATING_POINT
+#undef DESUL_IMPL_SYCL_ATOMIC_OPER_INTEGRAL
+#undef DESUL_IMPL_SYCL_ATOMIC_OPER
 
 }  // namespace Impl
 }  // namespace desul

--- a/tpls/desul/include/desul/atomics/Fetch_Op_SYCL.hpp
+++ b/tpls/desul/include/desul/atomics/Fetch_Op_SYCL.hpp
@@ -54,6 +54,68 @@ DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_FLOATING_POINT(sub)
 DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_FLOATING_POINT(min)
 DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_FLOATING_POINT(max)
 
+// clang-format off
+#define DESUL_IMPL_SYCL_ATOMIC_INC(TYPE)                                     \
+  template <class MemoryOrder>                                               \
+  TYPE device_atomic_fetch_inc(TYPE* dest, MemoryOrder, MemoryScopeDevice) { \
+    sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeDevice> dest_ref(*dest);   \
+    return dest_ref++;                                                       \
+  }                                                                          \
+  template <class MemoryOrder>                                               \
+  TYPE device_atomic_fetch_inc(TYPE* dest, MemoryOrder, MemoryScopeCore  ) { \
+    sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeCore> dest_ref(*dest);     \
+    return dest_ref++;                                                       \
+  }                                                                          \
+  template <class MemoryOrder>                                               \
+  TYPE device_atomic_inc_fetch(TYPE* dest, MemoryOrder, MemoryScopeDevice) { \
+    sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeDevice> dest_ref(*dest);   \
+    return ++dest_ref;                                                       \
+  }                                                                          \
+  template <class MemoryOrder>                                               \
+  TYPE device_atomic_inc_fetch(TYPE* dest, MemoryOrder, MemoryScopeCore)   { \
+    sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeCore> dest_ref(*dest);     \
+    return ++dest_ref;                                                       \
+  }
+
+#define DESUL_IMPL_SYCL_ATOMIC_DEC(TYPE)                                     \
+  template <class MemoryOrder>                                               \
+  TYPE device_atomic_fetch_dec(TYPE* dest, MemoryOrder, MemoryScopeDevice) { \
+    sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeDevice> dest_ref(*dest);   \
+    return dest_ref--;                                                       \
+  }                                                                          \
+  template <class MemoryOrder>                                               \
+  TYPE device_atomic_fetch_dec(TYPE* dest, MemoryOrder, MemoryScopeCore  ) { \
+    sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeCore> dest_ref(*dest);     \
+    return dest_ref--;                                                       \
+  }                                                                          \
+  template <class MemoryOrder>                                               \
+  TYPE device_atomic_dec_fetch(TYPE* dest, MemoryOrder, MemoryScopeDevice) { \
+    sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeDevice> dest_ref(*dest);   \
+    return --dest_ref;                                                       \
+  }                                                                          \
+  template <class MemoryOrder>                                               \
+  TYPE device_atomic_dec_fetch(TYPE* dest, MemoryOrder, MemoryScopeCore)   { \
+    sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeCore> dest_ref(*dest);     \
+    return --dest_ref;                                                       \
+  }
+
+#define DESUL_IMPL_SYCL_ATOMIC_INC_DEC(TYPE) \
+  DESUL_IMPL_SYCL_ATOMIC_INC(TYPE)           \
+  DESUL_IMPL_SYCL_ATOMIC_DEC(TYPE)
+// clang-format on
+
+DESUL_IMPL_SYCL_ATOMIC_INC_DEC(int)
+DESUL_IMPL_SYCL_ATOMIC_INC_DEC(unsigned int)
+DESUL_IMPL_SYCL_ATOMIC_INC_DEC(long)
+DESUL_IMPL_SYCL_ATOMIC_INC_DEC(unsigned long)
+DESUL_IMPL_SYCL_ATOMIC_INC_DEC(long long)
+DESUL_IMPL_SYCL_ATOMIC_INC_DEC(unsigned long long)
+DESUL_IMPL_SYCL_ATOMIC_INC_DEC(float)
+DESUL_IMPL_SYCL_ATOMIC_INC_DEC(double)
+
+#undef DESUL_IMPL_SYCL_ATOMIC_INC_DEC
+#undef DESUL_IMPL_SYCL_ATOMIC_INC
+#undef DESUL_IMPL_SYCL_ATOMIC_DEC
 #undef DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_FLOATING_POINT
 #undef DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL
 #undef DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER


### PR DESCRIPTION
Corresponds to https://github.com/desul/desul/pull/138.
Similar to https://github.com/kokkos/kokkos/pull/8010, this pull request implements `device_atomic_oper_fetch` in terms of `device_atomic_fetch_oper`. Additionally, we add `device_atomic_fetch_[inc|dec]` and `device_atomic_[inc|dec]_fetch`.

On an A100:
Before:
```
5: [ RUN      ] sycl.atomic_operations_complexdouble
5: /app/kokkos/core/unit_test/TestAtomicOperations_complexdouble.hpp:26: Skipped
5: skipping since device_global variables are not available
5: [  SKIPPED ] sycl.atomic_operations_complexdouble (0 ms)
5: [ RUN      ] sycl.atomic_operations_complexfloat
5: [       OK ] sycl.atomic_operations_complexfloat (9 ms)
5: [ RUN      ] sycl.atomic_operations_double
5: [       OK ] sycl.atomic_operations_double (9 ms)
5: [ RUN      ] sycl.atomic_operations_float
5: [       OK ] sycl.atomic_operations_float (7 ms)
5: [ RUN      ] sycl.atomic_operations_int
5: [       OK ] sycl.atomic_operations_int (18 ms)
5: [ RUN      ] sycl.atomic_operations_long
5: [       OK ] sycl.atomic_operations_long (18 ms)
5: [ RUN      ] sycl.atomic_operations_longlong
5: [       OK ] sycl.atomic_operations_longlong (19 ms)
5: [ RUN      ] sycl.atomic_operations_unsigned
5: [       OK ] sycl.atomic_operations_unsigned (15 ms)
5: [ RUN      ] sycl.atomic_operations_unsignedlong
5: [       OK ] sycl.atomic_operations_unsignedlong (16 ms)
5: [ RUN      ] sycl.atomics
5: [       OK ] sycl.atomics (118 ms)
5: [ RUN      ] sycl.atomics_tpetra_max_abs
5: [       OK ] sycl.atomics_tpetra_max_abs (0 ms)
5: [ RUN      ] sycl.atomic_views_integral
5: [       OK ] sycl.atomic_views_integral (12970 ms)
5: [ RUN      ] sycl.atomic_views_nonintegral
5: [       OK ] sycl.atomic_views_nonintegral (96 ms)
5: [ RUN      ] sycl.atomic_view_api
5: [       OK ] sycl.atomic_view_api (0 ms)
```
After:
```
5: [ RUN      ] sycl.atomic_operations_complexdouble
5: /app/kokkos/core/unit_test/TestAtomicOperations_complexdouble.hpp:26: Skipped
5: skipping since device_global variables are not available
5: [  SKIPPED ] sycl.atomic_operations_complexdouble (0 ms)
5: [ RUN      ] sycl.atomic_operations_complexfloat
5: [       OK ] sycl.atomic_operations_complexfloat (8 ms)
5: [ RUN      ] sycl.atomic_operations_double
5: [       OK ] sycl.atomic_operations_double (8 ms)
5: [ RUN      ] sycl.atomic_operations_float
5: [       OK ] sycl.atomic_operations_float (7 ms)
5: [ RUN      ] sycl.atomic_operations_int
5: [       OK ] sycl.atomic_operations_int (18 ms)
5: [ RUN      ] sycl.atomic_operations_long
5: [       OK ] sycl.atomic_operations_long (17 ms)
5: [ RUN      ] sycl.atomic_operations_longlong
5: [       OK ] sycl.atomic_operations_longlong (18 ms)
5: [ RUN      ] sycl.atomic_operations_unsigned
5: [       OK ] sycl.atomic_operations_unsigned (15 ms)
5: [ RUN      ] sycl.atomic_operations_unsignedlong
5: [       OK ] sycl.atomic_operations_unsignedlong (15 ms)
5: [ RUN      ] sycl.atomics
5: [       OK ] sycl.atomics (123 ms)
5: [ RUN      ] sycl.atomics_tpetra_max_abs
5: [       OK ] sycl.atomics_tpetra_max_abs (0 ms)
5: [ RUN      ] sycl.atomic_views_integral
5: [       OK ] sycl.atomic_views_integral (20 ms)
5: [ RUN      ] sycl.atomic_views_nonintegral
5: [       OK ] sycl.atomic_views_nonintegral (116 ms)
5: [ RUN      ] sycl.atomic_view_api
5: [       OK ] sycl.atomic_view_api (0 ms)
```

The most significant change is `sycl.atomic_views_integral (12970 ms)` to `sycl.atomic_views_integral (20 ms)`.