### PR TITLE
Desul atomics: implement fallback generic atomic_op_fetch() in terms of atomic_fetch_op()

### DIFF
--- a/tpls/desul/include/desul/atomics/Fetch_Op_Generic.hpp
+++ b/tpls/desul/include/desul/atomics/Fetch_Op_Generic.hpp
@@ -28,8 +28,8 @@ namespace Impl {
   template <class T, class MemoryOrder, class MemoryScope>                         \
   ANNOTATION T HOST_OR_DEVICE##_atomic_##OP_FETCH(                                 \
       T* const dest, const T val, MemoryOrder order, MemoryScope scope) {          \
-    return HOST_OR_DEVICE##_atomic_oper_fetch(                                     \
-        OP_FETCH##_operator<T, const T>(), dest, val, order, scope);               \
+    return OP_FETCH##_operator<T, const T>::apply(                                 \
+        HOST_OR_DEVICE##_atomic_##FETCH_OP(dest, val, order, scope), val);         \
   }
 
 #define DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(FETCH_OP, OP_FETCH)           \
@@ -64,8 +64,8 @@ DESUL_IMPL_ATOMIC_FETCH_OP_HOST_AND_DEVICE(fetch_dec_mod, dec_mod_fetch)
   template <class T, class MemoryOrder, class MemoryScope>                           \
   ANNOTATION T HOST_OR_DEVICE##_atomic_##OP##_fetch(                                 \
       T* const dest, const unsigned int val, MemoryOrder order, MemoryScope scope) { \
-    return HOST_OR_DEVICE##_atomic_oper_fetch(                                       \
-        OP##_fetch_operator<T, const unsigned int>(), dest, val, order, scope);      \
+    return OP##_fetch_operator<T, const unsigned int>::apply(                        \
+        HOST_OR_DEVICE##_atomic_fetch_##OP(dest, val, order, scope), val);           \
   }
 
 #define DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(OP)           \
@@ -91,8 +91,10 @@ DESUL_IMPL_ATOMIC_FETCH_OP_SHIFT_HOST_AND_DEVICE(rshift)
   template <class T, class MemoryOrder, class MemoryScope>                           \
   ANNOTATION void HOST_OR_DEVICE##_atomic_store(                                     \
       T* const dest, const T val, MemoryOrder order, MemoryScope scope) {            \
-    (void)HOST_OR_DEVICE##_atomic_oper_fetch(                                        \
-        store_fetch_operator<T, const T>(), dest, val, order, scope);                \
+    store_fetch_operator<T, const T>::apply(                                         \
+        HOST_OR_DEVICE##_atomic_fetch_oper(                                          \
+            store_fetch_operator<T, const T>(), dest, val, order, scope),            \
+        val);                                                                        \
   }
 
 DESUL_IMPL_ATOMIC_LOAD_AND_STORE(DESUL_IMPL_HOST_FUNCTION, host)

--- a/tpls/desul/include/desul/atomics/Fetch_Op_ScopeCaller.hpp
+++ b/tpls/desul/include/desul/atomics/Fetch_Op_ScopeCaller.hpp
@@ -26,19 +26,6 @@ namespace Impl {
     T oldval = *dest;                                            \
     *dest = op.apply(oldval, val);                               \
     return oldval;                                               \
-  }                                                              \
-                                                                 \
-  template <class Oper, class T, class MemoryOrder>              \
-  ANNOTATION T HOST_OR_DEVICE##_atomic_oper_fetch(               \
-      const Oper& op,                                            \
-      T* const dest,                                             \
-      dont_deduce_this_parameter_t<const T> val,                 \
-      MemoryOrder /*order*/,                                     \
-      MemoryScopeCaller /*scope*/) {                             \
-    T oldval = *dest;                                            \
-    T newval = op.apply(oldval, val);                            \
-    *dest = newval;                                              \
-    return newval;                                               \
   }
 
 DESUL_IMPL_ATOMIC_FETCH_OPER(DESUL_IMPL_HOST_FUNCTION, host)

--- a/tpls/desul/include/desul/atomics/Lock_Based_Fetch_Op_CUDA.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Based_Fetch_Op_CUDA.hpp
@@ -51,40 +51,6 @@ __device__ T device_atomic_fetch_oper(const Oper& op,
   return return_val;
 }
 
-template <class Oper,
-          class T,
-          class MemoryOrder,
-          class MemoryScope,
-          // equivalent to:
-          //   requires !atomic_always_lock_free(sizeof(T))
-          std::enable_if_t<!atomic_always_lock_free(sizeof(T)), int> = 0>
-__device__ T device_atomic_oper_fetch(const Oper& op,
-                                      T* const dest,
-                                      dont_deduce_this_parameter_t<const T> val,
-                                      MemoryOrder /*order*/,
-                                      MemoryScope scope) {
-  // This is a way to avoid deadlock in a warp or wave front
-  T return_val;
-  int done = 0;
-  unsigned int mask = __activemask();
-  unsigned int active = __ballot_sync(mask, 1);
-  unsigned int done_active = 0;
-  while (active != done_active) {
-    if (!done) {
-      if (lock_address_cuda((void*)dest, scope)) {
-        device_atomic_thread_fence(MemoryOrderAcquire(), scope);
-        return_val = op.apply(*dest, val);
-        *dest = return_val;
-        device_atomic_thread_fence(MemoryOrderRelease(), scope);
-        unlock_address_cuda((void*)dest, scope);
-        done = 1;
-      }
-    }
-    done_active = __ballot_sync(mask, done);
-  }
-  return return_val;
-}
-
 }  // namespace Impl
 }  // namespace desul
 

--- a/tpls/desul/include/desul/atomics/Lock_Based_Fetch_Op_HIP.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Based_Fetch_Op_HIP.hpp
@@ -50,38 +50,6 @@ __device__ T device_atomic_fetch_oper(const Oper& op,
   return return_val;
 }
 
-template <class Oper,
-          class T,
-          class MemoryOrder,
-          class MemoryScope,
-          // equivalent to:
-          //   requires !atomic_always_lock_free(sizeof(T))
-          std::enable_if_t<!atomic_always_lock_free(sizeof(T)), int> = 0>
-__device__ T device_atomic_oper_fetch(const Oper& op,
-                                      T* const dest,
-                                      dont_deduce_this_parameter_t<const T> val,
-                                      MemoryOrder /*order*/,
-                                      MemoryScope scope) {
-  // This is a way to avoid deadlock in a warp or wave front
-  T return_val;
-  int done = 0;
-  unsigned long long int active = __ballot(1);
-  unsigned long long int done_active = 0;
-  while (active != done_active) {
-    if (!done) {
-      if (lock_address_hip((void*)dest, scope)) {
-        device_atomic_thread_fence(MemoryOrderAcquire(), scope);
-        return_val = op.apply(*dest, val);
-        *dest = return_val;
-        device_atomic_thread_fence(MemoryOrderRelease(), scope);
-        unlock_address_hip((void*)dest, scope);
-        done = 1;
-      }
-    }
-    done_active = __ballot(done);
-  }
-  return return_val;
-}
 }  // namespace Impl
 }  // namespace desul
 

--- a/tpls/desul/include/desul/atomics/Lock_Based_Fetch_Op_Host.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Based_Fetch_Op_Host.hpp
@@ -41,30 +41,6 @@ inline T host_atomic_fetch_oper(const Oper& op,
   return return_val;
 }
 
-template <class Oper,
-          class T,
-          class MemoryOrder,
-          class MemoryScope,
-          // equivalent to:
-          //   requires !atomic_always_lock_free(sizeof(T))
-          std::enable_if_t<!atomic_always_lock_free(sizeof(T)), int> = 0>
-inline T host_atomic_oper_fetch(const Oper& op,
-                                T* const dest,
-                                dont_deduce_this_parameter_t<const T> val,
-                                MemoryOrder /*order*/,
-                                MemoryScope scope) {
-  // Acquire a lock for the address
-  while (!lock_address((void*)dest, scope)) {
-  }
-
-  host_atomic_thread_fence(MemoryOrderAcquire(), scope);
-  T return_val = op.apply(*dest, val);
-  *dest = return_val;
-  host_atomic_thread_fence(MemoryOrderRelease(), scope);
-  unlock_address((void*)dest, scope);
-  return return_val;
-}
-
 }  // namespace Impl
 }  // namespace desul
 


### PR DESCRIPTION
Alternate resolution for the atomic view performance regression based on a conversation with Christian.
Instead of specializing atomic_op_fetch() in backends like in #8010 or #8013, we provide a default implementation that is based on atomic_fetch_op().

As always, this will be pending integration in upstream desul.