### PR TITLE
Don't check flags for nvhpc due to spurious failures

### DIFF
--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -247,9 +247,9 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
     #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags if it is not nvcc_wrapper or clang+cuda.
     #FIXME_NVHPC nvc++ is failing the check spuriously with various version numbers.
     if(NOT (KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
-       OR NOT (KOKKOS_ENABLE_CUDA)
+       AND (NOT (KOKKOS_ENABLE_CUDA)
        OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper")
-       OR (${KOKKOS_CXX_COMPILER_ID} STREQUAL Clang)
+       OR (${KOKKOS_CXX_COMPILER_ID} STREQUAL Clang))
     )
       kokkos_check_flags(LINKER LANGUAGE ${KOKKOS_COMPILE_LANGUAGE} FLAGS ${KOKKOS_LINK_OPTIONS})
     endif()

--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -246,8 +246,10 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
     #exclude case of compiler_launcher. The launcher forwards to nvcc_wrapper and shadow the CXX compiler that CMake sees (compiler_launcher changes the compiler).
     #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags if it is not nvcc_wrapper or clang+cuda.
     #FIXME NVHPC with various version numbers does give false negatives in the check. Once this is stable the check can be renabled.
-    if(NOT(KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC) OR NOT (KOKKOS_ENABLE_CUDA) OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper") OR (${KOKKOS_CXX_COMPILER_ID}
-                                                                                        STREQUAL Clang)
+    if(NOT (KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
+       OR NOT (KOKKOS_ENABLE_CUDA)
+       OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper")
+       OR (${KOKKOS_CXX_COMPILER_ID} STREQUAL Clang)
     )
       kokkos_check_flags(LINKER LANGUAGE ${KOKKOS_COMPILE_LANGUAGE} FLAGS ${KOKKOS_LINK_OPTIONS})
     endif()
@@ -313,8 +315,10 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
     #exclude case of compiler_launcher. The launcher forwards to nvcc_wrapper and shadow the CXX compiler that CMake sees (compiler_launcher changes the compiler).
     #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags if it is not nvcc_wrapper or clang+cuda.
     #FIXME NVHPC with various version numbers does give false negatives in the check. Once this is stable the check can be renabled.
-    if(NOT(KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC) OR NOT (KOKKOS_ENABLE_CUDA) OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper") OR (${KOKKOS_CXX_COMPILER_ID}
-                                                                                        STREQUAL Clang)
+    if(NOT (KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
+       OR NOT (KOKKOS_ENABLE_CUDA)
+       OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper")
+       OR (${KOKKOS_CXX_COMPILER_ID} STREQUAL Clang)
     )
       kokkos_check_flags(COMPILER LANGUAGE ${KOKKOS_COMPILE_LANGUAGE} FLAGS ${ALL_KOKKOS_COMPILER_FLAGS})
     endif()

--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -314,7 +314,7 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.19)
     #exclude case of compiler_launcher. The launcher forwards to nvcc_wrapper and shadow the CXX compiler that CMake sees (compiler_launcher changes the compiler).
     #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags if it is not nvcc_wrapper or clang+cuda.
-    #FIXME NVHPC with various version numbers does give false negatives in the check. Once this is stable the check can be renabled.
+    #FIXME_NVHPC nvc++ is failing the check spuriously with various version numbers.
     if(NOT (KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
        OR NOT (KOKKOS_ENABLE_CUDA)
        OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper")

--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -245,7 +245,7 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
     #exclude case of compiler_launcher. The launcher forwards to nvcc_wrapper and shadow the CXX compiler that CMake sees (compiler_launcher changes the compiler).
     #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags if it is not nvcc_wrapper or clang+cuda.
-    #FIXME NVHPC with various version numbers does give false negatives in the check. Once this is stable the check can be renabled.
+    #FIXME_NVHPC nvc++ is failing the check spuriously with various version numbers.
     if(NOT (KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
        OR NOT (KOKKOS_ENABLE_CUDA)
        OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper")

--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -245,7 +245,8 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
     #exclude case of compiler_launcher. The launcher forwards to nvcc_wrapper and shadow the CXX compiler that CMake sees (compiler_launcher changes the compiler).
     #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags if it is not nvcc_wrapper or clang+cuda.
-    if(NOT (KOKKOS_ENABLE_CUDA) OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper") OR (${KOKKOS_CXX_COMPILER_ID}
+    #FIXME NVHPC with various version numbers does give false negatives in the check. Once this is stable the check can be renabled.
+    if(NOT(KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC) OR NOT (KOKKOS_ENABLE_CUDA) OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper") OR (${KOKKOS_CXX_COMPILER_ID}
                                                                                         STREQUAL Clang)
     )
       kokkos_check_flags(LINKER LANGUAGE ${KOKKOS_COMPILE_LANGUAGE} FLAGS ${KOKKOS_LINK_OPTIONS})
@@ -311,7 +312,8 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.19)
     #exclude case of compiler_launcher. The launcher forwards to nvcc_wrapper and shadow the CXX compiler that CMake sees (compiler_launcher changes the compiler).
     #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags if it is not nvcc_wrapper or clang+cuda.
-    if(NOT (KOKKOS_ENABLE_CUDA) OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper") OR (${KOKKOS_CXX_COMPILER_ID}
+    #FIXME NVHPC with various version numbers does give false negatives in the check. Once this is stable the check can be renabled.
+    if(NOT(KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC) OR NOT (KOKKOS_ENABLE_CUDA) OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper") OR (${KOKKOS_CXX_COMPILER_ID}
                                                                                         STREQUAL Clang)
     )
       kokkos_check_flags(COMPILER LANGUAGE ${KOKKOS_COMPILE_LANGUAGE} FLAGS ${ALL_KOKKOS_COMPILER_FLAGS})

--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -247,9 +247,8 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
     #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags if it is not nvcc_wrapper or clang+cuda.
     #FIXME_NVHPC nvc++ is failing the check spuriously with various version numbers.
     if(NOT (KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
-       AND (NOT (KOKKOS_ENABLE_CUDA)
-       OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper")
-       OR (${KOKKOS_CXX_COMPILER_ID} STREQUAL Clang))
+       AND (NOT (KOKKOS_ENABLE_CUDA) OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper") OR (${KOKKOS_CXX_COMPILER_ID}
+                                                                                             STREQUAL Clang))
     )
       kokkos_check_flags(LINKER LANGUAGE ${KOKKOS_COMPILE_LANGUAGE} FLAGS ${KOKKOS_LINK_OPTIONS})
     endif()
@@ -316,9 +315,8 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
     #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags if it is not nvcc_wrapper or clang+cuda.
     #FIXME_NVHPC nvc++ is failing the check spuriously with various version numbers.
     if(NOT (KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
-       AND (NOT (KOKKOS_ENABLE_CUDA)
-       OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper")
-       OR (${KOKKOS_CXX_COMPILER_ID} STREQUAL Clang))
+       AND (NOT (KOKKOS_ENABLE_CUDA) OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper") OR (${KOKKOS_CXX_COMPILER_ID}
+                                                                                             STREQUAL Clang))
     )
       kokkos_check_flags(COMPILER LANGUAGE ${KOKKOS_COMPILE_LANGUAGE} FLAGS ${ALL_KOKKOS_COMPILER_FLAGS})
     endif()

--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -316,9 +316,9 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
     #The CXX compiler CMake will invoke for the check is not able to consume the cuda flags if it is not nvcc_wrapper or clang+cuda.
     #FIXME_NVHPC nvc++ is failing the check spuriously with various version numbers.
     if(NOT (KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
-       OR NOT (KOKKOS_ENABLE_CUDA)
+       AND (NOT (KOKKOS_ENABLE_CUDA)
        OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper")
-       OR (${KOKKOS_CXX_COMPILER_ID} STREQUAL Clang)
+       OR (${KOKKOS_CXX_COMPILER_ID} STREQUAL Clang))
     )
       kokkos_check_flags(COMPILER LANGUAGE ${KOKKOS_COMPILE_LANGUAGE} FLAGS ${ALL_KOKKOS_COMPILER_FLAGS})
     endif()


### PR DESCRIPTION
@seyonglee discovered that the check gives false negatives depending on the version of NVHPC. Once this is stable the check can be reenabled.