### PR TITLE
[4.6.1] Fixup bugprone-return-const-ref-from-parameter check

### DIFF
--- a/core/src/Kokkos_Clamp.hpp
+++ b/core/src/Kokkos_Clamp.hpp
@@ -25,6 +25,10 @@ template <class T>
 constexpr KOKKOS_INLINE_FUNCTION const T& clamp(const T& value, const T& lo,
                                                 const T& hi) {
   KOKKOS_EXPECTS(!(hi < lo));
+  // Capturing the result of std::clamp by reference produces a dangling
+  // reference if one of the parameters is a temporary and that parameter is
+  // returned.
+  // NOLINTNEXTLINE(bugprone-return-const-ref-from-parameter)
   return (value < lo) ? lo : (hi < value) ? hi : value;
 }
 
@@ -33,6 +37,10 @@ constexpr KOKKOS_INLINE_FUNCTION const T& clamp(const T& value, const T& lo,
                                                 const T& hi,
                                                 ComparatorType comp) {
   KOKKOS_EXPECTS(!comp(hi, lo));
+  // Capturing the result of std::clamp by reference produces a dangling
+  // reference if one of the parameters is a temporary and that parameter is
+  // returned.
+  // NOLINTNEXTLINE(bugprone-return-const-ref-from-parameter)
   return comp(value, lo) ? lo : comp(hi, value) ? hi : value;
 }
 

--- a/core/src/Kokkos_MinMax.hpp
+++ b/core/src/Kokkos_MinMax.hpp
@@ -27,12 +27,18 @@ namespace Kokkos {
 // max
 template <class T>
 constexpr KOKKOS_INLINE_FUNCTION const T& max(const T& a, const T& b) {
+  // Capturing the result of std::max by reference produces a dangling reference
+  // if one of the parameters is a temporary and that parameter is returned.
+  // NOLINTNEXTLINE(bugprone-return-const-ref-from-parameter)
   return (a < b) ? b : a;
 }
 
 template <class T, class ComparatorType>
 constexpr KOKKOS_INLINE_FUNCTION const T& max(const T& a, const T& b,
                                               ComparatorType comp) {
+  // Capturing the result of std::max by reference produces a dangling reference
+  // if one of the parameters is a temporary and that parameter is returned.
+  // NOLINTNEXTLINE(bugprone-return-const-ref-from-parameter)
   return comp(a, b) ? b : a;
 }
 
@@ -64,12 +70,18 @@ KOKKOS_INLINE_FUNCTION constexpr T max(std::initializer_list<T> ilist,
 // min
 template <class T>
 constexpr KOKKOS_INLINE_FUNCTION const T& min(const T& a, const T& b) {
+  // Capturing the result of std::min by reference produces a dangling reference
+  // if one of the parameters is a temporary and that parameter is returned.
+  // NOLINTNEXTLINE(bugprone-return-const-ref-from-parameter)
   return (b < a) ? b : a;
 }
 
 template <class T, class ComparatorType>
 constexpr KOKKOS_INLINE_FUNCTION const T& min(const T& a, const T& b,
                                               ComparatorType comp) {
+  // Capturing the result of std::min by reference produces a dangling reference
+  // if one of the parameters is a temporary and that parameter is returned.
+  // NOLINTNEXTLINE(bugprone-return-const-ref-from-parameter)
   return comp(b, a) ? b : a;
 }
 


### PR DESCRIPTION
Cherry-picking #8001 into the 4.6.1 release candidate branch to address failures showing in #8022 