### PR TITLE
 core(cuda): set device not needed for event synchronization

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -213,11 +213,6 @@ class CudaInternal {
     return cudaEventRecord(event, m_stream);
   }
 
-  cudaError_t cuda_event_synchronize_wrapper(cudaEvent_t event) const {
-    set_cuda_device();
-    return cudaEventSynchronize(event);
-  }
-
   cudaError_t cuda_free_wrapper(void* devPtr) const {
     set_cuda_device();
     return cudaFree(devPtr);

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -594,8 +594,8 @@ struct CudaParallelLaunchKernelInvoker<
     // Wait until the previous kernel that uses the constant buffer is done
     std::lock_guard<std::mutex> lock(
         CudaInternal::constantMemMutexPerDevice[cuda_device]);
-    KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_event_synchronize_wrapper(
-        CudaInternal::constantMemReusablePerDevice[cuda_device])));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventSynchronize(
+        CudaInternal::constantMemReusablePerDevice[cuda_device]));
 
     // Copy functor (synchronously) to staging buffer in pinned host memory
     unsigned long* staging =


### PR DESCRIPTION
As per [`Cuda`'s documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#stream-and-event-behavior): 
> `cudaEventSynchronize()` and cudaEventQuery()` will succeed even if the input event is associated to a device that is different from the current device.

I'm not sure why we didn't removed this in:
- #7569

Related to:
- #7562