### PR TITLE
core(hip): set device not needed for event synchronization

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -163,11 +163,6 @@ class HIPInternal {
     return hipEventRecord(event, m_stream);
   }
 
-  hipError_t hip_event_synchronize_wrapper(hipEvent_t event) const {
-    set_hip_device();
-    return hipEventSynchronize(event);
-  }
-
   hipError_t hip_free_wrapper(void *ptr) const {
     set_hip_device();
     return hipFree(ptr);

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -521,8 +521,8 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
     const auto hip_device = hip_instance->m_hipDev;
     // Wait until the previous kernel that uses the constant buffer is done
     std::lock_guard<std::mutex> lock(HIPInternal::constantMemMutex[hip_device]);
-    KOKKOS_IMPL_HIP_SAFE_CALL(hip_instance->hip_event_synchronize_wrapper(
-        HIPInternal::constantMemReusable[hip_device]));
+    KOKKOS_IMPL_HIP_SAFE_CALL(
+        hipEventSynchronize(HIPInternal::constantMemReusable[hip_device]));
 
     // Copy functor (synchronously) to staging buffer in pinned host memory
     unsigned long *staging = hip_instance->constantMemHostStaging[hip_device];


### PR DESCRIPTION
This fixes #8027.