### PR TITLE
BasicView: Suppress uninitialized warnings

### DIFF
--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -96,9 +96,9 @@ transform_kokkos_slice_to_mdspan_slice(const T &s) {
   return KokkosSliceToMDSpanSliceImpl<T>::transform(s);
 }
 
-// FIXME_HPX spurious warnings like
+// FIXME spurious warnings like
 // error: 'SR.14123' may be used uninitialized [-Werror=maybe-uninitialized]
-#if defined(KOKKOS_ENABLE_HPX)
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #if !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
@@ -630,7 +630,7 @@ class BasicView {
   friend class BasicView;
 };
 
-#if defined(KOKKOS_ENABLE_HPX)
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
Follow-up to https://github.com/kokkos/kokkos/pull/8017. Addressing https://github.com/kokkos/kokkos/pull/8017#pullrequestreview-2799703870:
> Since this basically passed testing: I am ok merging it, but Daniel open a follow on PR to take away the #ifdef HPX. Since this reproduces with Serial only it seems a general issue. I am not convinced that it's worth it to spend 20 hours tracking down exactly which GCC version/header library or what not triggers it. If other people feel differently I will assign someone.
