### PR TITLE
Add constructors for Random_XorShift*_Pool with execution space argument

### DIFF
--- a/algorithms/unit_tests/TestRandom.hpp
+++ b/algorithms/unit_tests/TestRandom.hpp
@@ -479,13 +479,19 @@ struct generate_random_stream {
   ViewType vals;
   GeneratorPool rand_pool;
   int samples;
+  bool use_specific_gen;
 
-  generate_random_stream(ViewType vals_, GeneratorPool rand_pool_, int samples_)
-      : vals(vals_), rand_pool(rand_pool_), samples(samples_) {}
+  generate_random_stream(ViewType vals_, GeneratorPool rand_pool_, int samples_,
+                         bool use_specific_gen_)
+      : vals(vals_),
+        rand_pool(rand_pool_),
+        samples(samples_),
+        use_specific_gen(use_specific_gen_) {}
 
   KOKKOS_INLINE_FUNCTION
   void operator()(int i) const {
-    typename GeneratorPool::generator_type rand_gen = rand_pool.get_state();
+    typename GeneratorPool::generator_type rand_gen =
+        use_specific_gen ? rand_pool.get_state(i) : rand_pool.get_state();
 
     for (int k = 0; k < samples; k++) vals(i, k) = rand_gen.urand64();
 
@@ -506,9 +512,9 @@ void test_duplicate_stream() {
   Pool rand_pool(42);
   ViewType vals_d("Vals", n_streams, samples);
 
-  Kokkos::parallel_for(
-      Kokkos::RangePolicy<ExecutionSpace>(0, n_streams),
-      generate_random_stream<ExecutionSpace, Pool>(vals_d, rand_pool, samples));
+  Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, n_streams),
+                       generate_random_stream<ExecutionSpace, Pool>(
+                           vals_d, rand_pool, samples, false));
 
   auto vals_h =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, vals_d);
@@ -552,7 +558,11 @@ struct compare_random_streams {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(int i, std::size_t& mismatches) const {
-    typename GeneratorPool::generator_type rand_gen = rand_pool.get_state();
+    // this is problematic: on a GPU when launching with more than a single
+    // thread the generator returned is in principle random, using atomic
+    // locks to acquire a state.
+    // but we only launch it with a single thread so its ok.
+    typename GeneratorPool::generator_type rand_gen = rand_pool.get_state(i);
 
     for (int k = 0; k < samples; k++)
       if (vals(i, k) != rand_gen.urand64()) mismatches++;
@@ -561,32 +571,34 @@ struct compare_random_streams {
   }
 };
 
-template <class ExecutionSpace, class Pool>
-void test_async_initialization() {
+template <class ExecutionSpace, class Pool, class... Args>
+void test_async_initialization(Args... args) {
+  // using 2D View here to reuse functions from other test
   using ViewType = Kokkos::View<uint64_t**, ExecutionSpace>;
 
-  int n_streams = 1;
-  int samples   = 123456;
+  int samples = 123456;
 
   // use default execution space instance to generate reference values
-  Pool rand_pool_A(42);
-  ViewType vals_d("Vals", n_streams, samples);
+  Pool rand_pool_A(args...);
+
+  ViewType vals_d("Vals", 1, samples);
   // create two, distinct ExecutionSpace instances
   auto instances =
       Kokkos::Experimental::partition_space(ExecutionSpace{}, 1, 1);
   // use first instance to initialize values of vals_d
   Kokkos::parallel_for(
-      Kokkos::RangePolicy<ExecutionSpace>(instances.at(0), 0, n_streams),
-      generate_random_stream<ExecutionSpace, Pool>(vals_d, rand_pool_A,
-                                                   samples));
+      Kokkos::RangePolicy<ExecutionSpace>(instances.at(0), 0, 1),
+      generate_random_stream<ExecutionSpace, Pool>(vals_d, rand_pool_A, samples,
+                                                   true));
   instances.at(0).fence();
 
   // use second instance to initialize another Pool using the same seed
-  Pool rand_pool_B(instances.at(1), 42);
+  Pool rand_pool_B(instances.at(1), args...);
+
   std::size_t mismatches;
   // compare values in stream of rand_pool_B with vals_d
   Kokkos::parallel_reduce(
-      Kokkos::RangePolicy<ExecutionSpace>(instances.at(1), 0, n_streams),
+      Kokkos::RangePolicy<ExecutionSpace>(instances.at(1), 0, 1),
       compare_random_streams<ExecutionSpace, Pool>(vals_d, rand_pool_B,
                                                    samples),
       mismatches);
@@ -665,8 +677,12 @@ TEST(TEST_CATEGORY, Multi_streams) {
   AlgoRandomImpl::test_duplicate_stream<ExecutionSpace, Pool64>();
   AlgoRandomImpl::test_duplicate_stream<ExecutionSpace, Pool1024>();
 
-  AlgoRandomImpl::test_async_initialization<ExecutionSpace, Pool64>();
-  AlgoRandomImpl::test_async_initialization<ExecutionSpace, Pool1024>();
+  // Test with construction from seed
+  AlgoRandomImpl::test_async_initialization<ExecutionSpace, Pool64>(42);
+  AlgoRandomImpl::test_async_initialization<ExecutionSpace, Pool1024>(42);
+  // Test with construction from seed and num_states
+  AlgoRandomImpl::test_async_initialization<ExecutionSpace, Pool64>(42, 1);
+  AlgoRandomImpl::test_async_initialization<ExecutionSpace, Pool1024>(42, 1);
 }
 
 }  // namespace Test


### PR DESCRIPTION
Allows construction of instances with non-blocking initialization occurring on a given execution space instance. Also useful when multiple instances of a device are available, in which case the execution space argument is used to select a device.

For #8032 

I created a unit test that should test the new feature without duplicating any existing tests. However, since it's impossible to compare pools directly, the test is indirect. I'm open to suggestions for better tests.