### PR TITLE
Use `LSAN_OPTIONS=use_globals=0` in the ci

### DIFF
--- a/.github/workflows/continuous-integration-linux.yml
+++ b/.github/workflows/continuous-integration-linux.yml
@@ -162,6 +162,9 @@ jobs:
           ccache -z
           cmake --build builddir --parallel $(nproc)
           ccache -s
+      - name: Set asan runtime env
+        if: ${{ contains(matrix.cxx_extra_flags, '-fsanitize=address') }}
+        run: echo "LSAN_OPTIONS=use_globals=0" >> $GITHUB_ENV
       - name: Tests
         working-directory: builddir
         run: ctest --output-on-failure


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/pull/8042, just to see if other things are detected.

`LSAN_OPTIONS=use_globals=0` is exported as an env variable before the tests are launched for jobs using `-fsanitize=address`.