### PR TITLE
Cherry pick 8045 - fix building benchmarks with Kokkos as a subdirectory/subproject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug Fixes
 * Fix symbol visibility: make sure that `AUTO` has external linkage [\#7898](https://github.com/kokkos/kokkos/pull/7898)
 * Building with generated makefiles: add missing HIP XNACK source file [\#8030](https://github.com/kokkos/kokkos/pull/8030)
+* Fix building benchmarks when Kokkos exists as a subproject/subdirectory [\#8045](https://github.com/kokkos/kokkos/pull/8045)
 
 ## 4.6.00
 

--- a/cmake/build_env_info.cmake
+++ b/cmake/build_env_info.cmake
@@ -106,7 +106,7 @@ function(check_git_setup)
   )
 
   add_library(impl_git_version ${CMAKE_CURRENT_BINARY_DIR}/generated/Kokkos_Version_Info.cpp)
-  target_include_directories(impl_git_version PUBLIC ${CMAKE_BINARY_DIR}/generated)
+  target_include_directories(impl_git_version PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/generated)
   target_compile_features(impl_git_version PRIVATE cxx_raw_string_literals)
   add_dependencies(impl_git_version AlwaysCheckGit)
 


### PR DESCRIPTION
Cheery pick of #8045