### PR TITLE
Fix nightly Aurora testing

### DIFF
--- a/.gitlab/alcf-gitlab-ci.yml
+++ b/.gitlab/alcf-gitlab-ci.yml
@@ -46,7 +46,7 @@ Aurora:
   variables:
     ANL_AURORA_SCHEDULER_PARAMETERS: "-q debug -A kokkos_math -l select=1,walltime=60:00,filesystems=flare"
   script:
-    - module load cmake oneapi/eng-compiler
+    - module load cmake oneapi
     - module list
     - export CMAKE_BUILD_PARALLEL_LEVEL=48
     - export ENV_CMAKE_OPTIONS=""
@@ -57,7 +57,7 @@ Aurora:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_INTEL_PVC=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_NATIVE=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_TESTS=ON"
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-fsycl-device-code-split=per_kernel -fp-model=precise'"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Wno-pass-failed -fsycl-device-code-split=per_kernel -fp-model=precise'"
     - ctest -VV
         -D CDASH_MODEL=Nightly
         -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}"

--- a/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
@@ -77,6 +77,7 @@
 #define KOKKOS_IMPL_ONEDPL_HAS_SORT_BY_KEY
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wunused-local-typedef"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wunused-variable"

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -73,6 +73,7 @@
 #if defined(KOKKOS_ENABLE_ONEDPL)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wunused-local-typedef"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wunused-variable"


### PR DESCRIPTION
The latest compiler update on `Aurora` has the compiler in the `oneapi/release` module while `oneapi/eng-compiler` points to the previous compiler. At the moment, the nightly build doesn't run since it's complaining about inactive modules, see https://gitlab-ci.alcf.anl.gov/anl/kokkos_math/kokkos_core/nightly_testing/-/jobs/147469.

This pull request makes sure to just use the default `oneapi` module. On top of that, there are some more warnings coming from `oneDPL` (that the compiler doesn't treat as system includes) and `-Wpass-failed` from the pragma unit tests. We suppress the latter warning in other CI configurations as well.

https://gitlab-ci.alcf.anl.gov/anl/kokkos_math/kokkos_core/nightly_testing/-/jobs/147493 is a run with the updated module.