### PR TITLE
Fix numeric traits for MSVC+CUDA: use `__builtin_huge_val[f]()` for infinity 

### DIFF
--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -35,9 +35,15 @@ namespace Kokkos::Experimental {
 namespace Impl {
 // clang-format off
 template <class> struct infinity_helper {};
+#if defined(_MSC_VER)
+template <> struct infinity_helper<float> { static constexpr float value = __builtin_huge_valf(); };
+template <> struct infinity_helper<double> { static constexpr double value = __builtin_huge_val(); };
+template <> struct infinity_helper<long double> { static constexpr long double value = __builtin_huge_val(); };
+#else
 template <> struct infinity_helper<float> { static constexpr float value = HUGE_VALF; };
 template <> struct infinity_helper<double> { static constexpr double value = HUGE_VAL; };
 template <> struct infinity_helper<long double> { static constexpr long double value = HUGE_VALL; };
+#endif
 template <class> struct finite_min_helper {};
 template <> struct finite_min_helper<bool> { static constexpr bool value = false; };
 template <> struct finite_min_helper<char> { static constexpr char value = CHAR_MIN; };


### PR DESCRIPTION
An attempt to fix #7749

Per https://github.com/kokkos/kokkos/issues/7749#issuecomment-2841904339, this patch resolves the issue that was reported.

I was not able to reproduce on the compiler explorer, neither with the few MSVC nor NVCC versions available that I tried.
https://godbolt.org/z/5Ysnsbdaq
https://godbolt.org/z/Poq85MPY1

It would be good to add coverage in the CI but I am not sure how to go about it.