### PR TITLE
OpenACC backend specialization of Random_UniqueIndex in Kokkos_Random.hpp

### DIFF
--- a/core/src/OpenACC/Kokkos_OpenACC.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC.hpp
@@ -33,6 +33,9 @@ static_assert(false,
 #include <impl/Kokkos_HostSharedPtr.hpp>
 
 #include <openacc.h>
+#ifdef KOKKOS_COMPILER_CLANG
+#include <omp.h>
+#endif
 
 #include <iosfwd>
 #include <string>


### PR DESCRIPTION
This PR contains the specialization of `Random_UniqueIndex` in `Kokkos_Random.hpp` for the OpenACC backend.
OpenACC does not provide a way to find the actual thread block size of a given GPU kernel, and thus this implementation uses a default team size value (`Kokkos::Impl::OpenACCTeamMember::DEFAULT_TEAM_SIZE_REC`) instead, which may be inefficient if the actual team size (thread block size) differs from this default value.