### PR TITLE
Add NVIDIA Blackwell support in generated makefiles

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -14,7 +14,7 @@ KOKKOS_VERSION = $(shell echo $(KOKKOS_VERSION_MAJOR)*10000+$(KOKKOS_VERSION_MIN
 KOKKOS_DEVICES ?= "Threads"
 # Options:
 # Intel:    KNC,KNL,SNB,HSW,BDW,SKL,SKX,ICL,ICX,SPR
-# NVIDIA:   Kepler,Kepler30,Kepler32,Kepler35,Kepler37,Maxwell,Maxwell50,Maxwell52,Maxwell53,Pascal60,Pascal61,Volta70,Volta72,Turing75,Ampere80,Ampere86,Ada89,Hopper90
+# NVIDIA:   Kepler,Kepler30,Kepler32,Kepler35,Kepler37,Maxwell,Maxwell50,Maxwell52,Maxwell53,Pascal60,Pascal61,Volta70,Volta72,Turing75,Ampere80,Ampere86,Ada89,Hopper90,Blackwell100,Blackwell120
 # ARM:      ARMv80,ARMv81,ARMv8-ThunderX,ARMv8-TX2,A64FX,ARMv9-Grace
 # IBM:      Power8,Power9
 # AMD-GPUS: AMD_GFX906,AMD_GFX908,AMD_GFX90A,AMD_GFX940,AMD_GFX942,AMD_GFX942_APU,AMD_GFX1030,AMD_GFX1100,AMD_GFX1103
@@ -390,22 +390,26 @@ KOKKOS_INTERNAL_USE_ARCH_AMPERE80 := $(call kokkos_has_string,$(KOKKOS_ARCH),Amp
 KOKKOS_INTERNAL_USE_ARCH_AMPERE86 := $(call kokkos_has_string,$(KOKKOS_ARCH),Ampere86)
 KOKKOS_INTERNAL_USE_ARCH_ADA89 := $(call kokkos_has_string,$(KOKKOS_ARCH),Ada89)
 KOKKOS_INTERNAL_USE_ARCH_HOPPER90 := $(call kokkos_has_string,$(KOKKOS_ARCH),Hopper90)
-KOKKOS_INTERNAL_USE_ARCH_NVIDIA := $(shell expr $(KOKKOS_INTERNAL_USE_ARCH_KEPLER30)  \
-                                              + $(KOKKOS_INTERNAL_USE_ARCH_KEPLER32)  \
-                                              + $(KOKKOS_INTERNAL_USE_ARCH_KEPLER35)  \
-                                              + $(KOKKOS_INTERNAL_USE_ARCH_KEPLER37)  \
-                                              + $(KOKKOS_INTERNAL_USE_ARCH_MAXWELL50) \
-                                              + $(KOKKOS_INTERNAL_USE_ARCH_MAXWELL52) \
-                                              + $(KOKKOS_INTERNAL_USE_ARCH_MAXWELL53) \
-                                              + $(KOKKOS_INTERNAL_USE_ARCH_PASCAL61)  \
-                                              + $(KOKKOS_INTERNAL_USE_ARCH_PASCAL60)  \
-                                              + $(KOKKOS_INTERNAL_USE_ARCH_VOLTA70)   \
-                                              + $(KOKKOS_INTERNAL_USE_ARCH_VOLTA72)   \
-                                              + $(KOKKOS_INTERNAL_USE_ARCH_TURING75)  \
-                                              + $(KOKKOS_INTERNAL_USE_ARCH_AMPERE80)  \
-                                              + $(KOKKOS_INTERNAL_USE_ARCH_AMPERE86)  \
-                                              + $(KOKKOS_INTERNAL_USE_ARCH_ADA89)     \
-                                              + $(KOKKOS_INTERNAL_USE_ARCH_HOPPER90))
+KOKKOS_INTERNAL_USE_ARCH_BLACKWELL100 := $(call kokkos_has_string,$(KOKKOS_ARCH),Blackwell100)
+KOKKOS_INTERNAL_USE_ARCH_BLACKWELL120 := $(call kokkos_has_string,$(KOKKOS_ARCH),Blackwell120)
+KOKKOS_INTERNAL_USE_ARCH_NVIDIA := $(shell expr $(KOKKOS_INTERNAL_USE_ARCH_KEPLER30)     \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_KEPLER32)     \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_KEPLER35)     \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_KEPLER37)     \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_MAXWELL50)    \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_MAXWELL52)    \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_MAXWELL53)    \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_PASCAL61)     \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_PASCAL60)     \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_VOLTA70)      \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_VOLTA72)      \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_TURING75)     \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_AMPERE80)     \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_AMPERE86)     \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_ADA89)        \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_HOPPER90)     \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_BLACKWELL100) \
+                                              + $(KOKKOS_INTERNAL_USE_ARCH_BLACKWELL120))
 
 #SEK: This seems like a bug to me
 ifeq ($(KOKKOS_INTERNAL_USE_ARCH_NVIDIA), 0)
@@ -1193,6 +1197,20 @@ ifeq ($(KOKKOS_INTERNAL_COMPILER_CRAY_CLANG), 0)
     tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_HOPPER90")
     ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
       KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_90
+    endif
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_BLACKWELL100), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_BLACKWELL")
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_BLACKWELL100")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
+      KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_100
+    endif
+  endif
+  ifeq ($(KOKKOS_INTERNAL_USE_ARCH_BLACKWELL120), 1)
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_BLACKWELL")
+    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_BLACKWELL120")
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_NVHPC), 0)
+      KOKKOS_INTERNAL_CUDA_ARCH_FLAG := $(KOKKOS_INTERNAL_CUDA_ARCH_FLAG)=sm_120
     endif
   endif
 endif


### PR DESCRIPTION
@stanmoore1 pointed out that we had not provided support for the NVIDIA Blackwell GPU architecture in the generated makefiles.
These are deprecated (see #7613) but we committed to maintain them until 5.0

At this time, there is no plan to cherry-pick into an hypothetical 4.6.2 patch release.