### PR TITLE
Fix spelling error in kokkos_arch.cmake

### DIFF
--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -1064,7 +1064,7 @@ if(KOKKOS_ENABLE_OPENACC)
     compiler_specific_flags(NVHPC -acc=gpu,multicore)
     message(
       STATUS
-        "No OpenACC target device is specificed; the OpenACC backend will be executed in an automatic fallback mode."
+        "No OpenACC target device is specified; the OpenACC backend will be executed in an automatic fallback mode."
     )
   endif()
 endif()


### PR DESCRIPTION
I found this when using Kokkos' OpenACC back-end.