### PR TITLE
Rework note at the end of the help message and ask users to cite Kokkos

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -824,8 +824,14 @@ instead of hyphens). For example, to disable warning messages, you can either
 specify --kokkos-disable-warnings or set the KOKKOS_DISABLE_WARNINGS
 environment variable to yes.
 
-Join us on Slack, visit https://kokkosteam.slack.com
-Report bugs to https://github.com/kokkos/kokkos/issues
+--------------------------------------------------------------------------------
+For support, documentation, and more information about Kokkos,
+visit the official website: https://kokkos.org
+
+If you use Kokkos in your work, please cite
+  https://doi.ieeecomputersociety.org/10.1109/TPDS.2021.3097283
+
+Kokkos is a Linux Foundation Project.
 --------------------------------------------------------------------------------
 )";
   std::cout << help_message << std::endl;

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -828,8 +828,8 @@ environment variable to yes.
 For support, documentation, and more information about Kokkos,
 visit the official website: https://kokkos.org
 
-If you use Kokkos in your work, please cite
-  https://doi.ieeecomputersociety.org/10.1109/TPDS.2021.3097283
+If you use Kokkos in your work, please cite the recommended papers
+found at https://kokkos.org/citing-kokkos in your science publications.
 
 Kokkos is a Linux Foundation Project.
 --------------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -828,8 +828,8 @@ environment variable to yes.
 For support, documentation, and more information about Kokkos,
 visit the official website: https://kokkos.org
 
-If you use Kokkos in your work, please cite the recommended papers
-found at https://kokkos.org/citing-kokkos in your science publications.
+Please cite the recommended publications listed at https://kokkos.org/citing-kokkos
+when using Kokkos in your scientific work.
 
 Kokkos is a Linux Foundation Project.
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Add a reference to our website and ask users to cite Kokkos in their work.

I opted for the DOI bookmark rather than referring to https://kokkos.org/about/publications/#citing-kokkos because the URL on our website may change.  We would have to update that DOI in the future if we intend users to cite some newer publication.  Since it is versioned with the code base, it felt appropriate.

I recently ran into more occurrences of mentioning Kokkos in the abstract but not actually citing it.
We could consider adding a message at configuration time as Trilinos does https://github.com/trilinos/Trilinos/blob/26c09fcb338d45ad0895da1f044baac688548c2f/CMakeLists.txt#L90 or/and when our package is found by CMake.  Feel free to comment on this.  (I was currently not planning to do it as part of this PR.)