### PR TITLE
An easier to maintain parallel_reduce implementation

### DIFF
--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1704,11 +1704,6 @@ inline std::enable_if_t<Kokkos::is_execution_policy<PolicyType>::value &&
                           std::is_pointer_v<ReturnType>)>
 parallel_reduce(const PolicyType& policy, const FunctorType& functor,
                 ReturnType& return_value) {
-  static_assert(
-      !std::is_const_v<ReturnType>,
-      "A const reduction result type is only allowed for a View, pointer or "
-      "reducer return type!");
-
   parallel_reduce("", policy, functor, return_value);
 }
 
@@ -1718,11 +1713,6 @@ inline std::enable_if_t<!(Kokkos::is_view<ReturnType>::value ||
                           std::is_pointer_v<ReturnType>)>
 parallel_reduce(const size_t& policy, const FunctorType& functor,
                 ReturnType& return_value) {
-  static_assert(
-      !std::is_const_v<ReturnType>,
-      "A const reduction result type is only allowed for a View, pointer or "
-      "reducer return type!");
-
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,
                                               FunctorType>::policy_type;
@@ -1735,11 +1725,6 @@ inline std::enable_if_t<!(Kokkos::is_view<ReturnType>::value ||
                           std::is_pointer_v<ReturnType>)>
 parallel_reduce(const std::string& label, const size_t& policy,
                 const FunctorType& functor, ReturnType& return_value) {
-  static_assert(
-      !std::is_const_v<ReturnType>,
-      "A const reduction result type is only allowed for a View, pointer or "
-      "reducer return type!");
-
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,
                                               FunctorType>::policy_type;
@@ -1835,14 +1820,6 @@ inline void parallel_reduce(
     const PolicyType& policy, const FunctorType& functor,
     std::enable_if_t<Kokkos::is_execution_policy<PolicyType>::value>* =
         nullptr) {
-  using FunctorAnalysis =
-      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
-                            FunctorType, void>;
-
-  static_assert(
-      FunctorAnalysis::has_final_member_function,
-      "Calling parallel_reduce without either return value or final function.");
-
   parallel_reduce("", policy, functor);
 }
 
@@ -1851,12 +1828,6 @@ inline void parallel_reduce(const size_t& policy, const FunctorType& functor) {
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,
                                               FunctorType>::policy_type;
-  using FunctorAnalysis =
-      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, policy_type,
-                            FunctorType, void>;
-  static_assert(
-      FunctorAnalysis::has_final_member_function,
-      "Calling parallel_reduce without either return value or final function.");
 
   parallel_reduce("", policy_type(0, policy), functor);
 }
@@ -1867,13 +1838,6 @@ inline void parallel_reduce(const std::string& label, const size_t& policy,
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,
                                               FunctorType>::policy_type;
-  using FunctorAnalysis =
-      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, policy_type,
-                            FunctorType, void>;
-
-  static_assert(
-      FunctorAnalysis::has_final_member_function,
-      "Calling parallel_reduce without either return value or final function.");
 
   parallel_reduce(label, policy_type(0, policy), functor);
 }


### PR DESCRIPTION
In `core/src/Kokkos_Parallel_Reduce.hpp`, each of the various `parallel_reduce` overloads have been implemented completely. It is not like `parallel_for` and `parallel_scan` where, for example, the case without label calls the case with label by passing "" as the label. Also, in the case of `parallel_reduce` there are many more overloads: with or without label, policy or work count, with or without result argument, different result types.

This is an attempt for a more DRY implementation of `parallel_reduce`. This will have its benefits. For example, in PR [7675](https://github.com/kokkos/kokkos/pull/7675), we could add less checks for `parallel_reduce`.

To-do:
* Currently all the static_asserts have been retained. The arguments involved in these asserts are passed as const reference. It should be enough to retain the static_asserts in the functions which are called at the end in the call stack.