### PR TITLE
New View implementation: Disallow constructing managed View with Kokkos::MemoryUnmanaged trait

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -560,7 +560,10 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
       : base_t(
             arg_prop,
             Impl::mapping_from_array_layout<typename mdspan_type::mapping_type>(
-                arg_layout)) {}
+                arg_layout)) {
+    static_assert(traits::is_managed,
+                  "Can't construct managed View with unmanaged memory trait!");
+  }
 
   template <class... P>
   KOKKOS_FUNCTION explicit View(
@@ -724,6 +727,8 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     static_assert(traits::array_layout::is_extent_constructible,
                   "Layout is not constructible from extent arguments. Use "
                   "overload taking a layout object instead.");
+    static_assert(traits::is_managed,
+                  "Can't construct managed View with unmanaged memory trait!");
   }
 
   template <class... P>


### PR DESCRIPTION
The new `View` implementation allows constructing a managed View with `Kokkos::MemoryUnmanaged` which then behaves like an unmanged `View` and leaks the memory ~~but still correctly deallocates memory~~.
The old implementation didn't allow that which seems sensible so this pull request reintroduces the respective `static_assert`s. Also, see https://github.com/kokkos/kokkos/blob/88485ca664e39a93725b44f99d3c4b03fcf701e7/core/src/View/Kokkos_ViewLegacy.hpp#L997-L998.

We don't have (direct) access to the View traits in `BasicView` so checking on the `Kokkos::View` level appears to be most appropriate.