### PR TITLE
fix accidental c-style cast in create_data_handle

### DIFF
--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -365,22 +365,22 @@ class BasicView {
           "execution space");
     }
     if constexpr (has_exec) {
-      return data_handle_type(Impl::make_shared_allocation_record<ElementType>(
+      return data_handle_type{Impl::make_shared_allocation_record<ElementType>(
           arg_mapping.required_span_size(),
           Impl::get_property<Impl::LabelTag>(prop_copy),
           Impl::get_property<Impl::MemorySpaceTag>(prop_copy),
           std::make_optional(
               Impl::get_property<Impl::ExecutionSpaceTag>(prop_copy)),
           std::bool_constant<alloc_prop::initialize>(),
-          std::bool_constant<alloc_prop::sequential_host_init>()));
+          std::bool_constant<alloc_prop::sequential_host_init>())};
     } else {
-      return data_handle_type(Impl::make_shared_allocation_record<ElementType>(
+      return data_handle_type{Impl::make_shared_allocation_record<ElementType>(
           arg_mapping.required_span_size(),
           Impl::get_property<Impl::LabelTag>(prop_copy),
           Impl::get_property<Impl::MemorySpaceTag>(prop_copy),
           std::optional<execution_space>{},
           std::bool_constant<alloc_prop::initialize>(),
-          std::bool_constant<alloc_prop::sequential_host_init>()));
+          std::bool_constant<alloc_prop::sequential_host_init>())};
     }
   }
 

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -400,7 +400,7 @@ class BasicView {
       std::enable_if_t<Impl::ViewCtorProp<P...>::has_pointer,
                        typename mdspan_type::mapping_type> const &arg_mapping)
       : BasicView(
-            data_handle_type(Impl::get_property<Impl::PointerTag>(arg_prop)),
+            data_handle_type{Impl::get_property<Impl::PointerTag>(arg_prop)},
             arg_mapping) {}
 
  protected:

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -442,7 +442,7 @@ class ReferenceCountedAccessor {
       data_handle_type p,
 #endif
       size_t i) const {
-    return data_handle_type(p, m_nested_acc.offset(p.get(), i));
+    return data_handle_type{p, m_nested_acc.offset(p.get(), i)};
   }
 
   KOKKOS_FUNCTION


### PR DESCRIPTION
Basically this could accidentally introduce a `reinterpret_cast` and leak/corrupt memory