### PR TITLE
kokkos(tools): use `std::string_view` instead of `std::string&` or `std::string`

### DIFF
--- a/core/src/Kokkos_Profiling_ProfileSection.hpp
+++ b/core/src/Kokkos_Profiling_ProfileSection.hpp
@@ -38,7 +38,7 @@ class [[nodiscard]] ProfilingSection {
 #if defined(__has_cpp_attribute) && __has_cpp_attribute(nodiscard) >= 201907
   [[nodiscard]]
 #endif
-  explicit ProfilingSection(const std::string& sectionName) {
+  explicit ProfilingSection(const std::string_view sectionName) {
     Kokkos::Profiling::createProfileSection(sectionName, &sectionID);
   }
 

--- a/core/src/Kokkos_Profiling_ScopedRegion.hpp
+++ b/core/src/Kokkos_Profiling_ScopedRegion.hpp
@@ -36,7 +36,7 @@ class [[nodiscard]] ScopedRegion {
 #if defined(__has_cpp_attribute) && __has_cpp_attribute(nodiscard) >= 201907
   [[nodiscard]]
 #endif
-  explicit ScopedRegion(std::string const &name) {
+  explicit ScopedRegion(const std::string_view name) {
     Kokkos::Profiling::pushRegion(name);
   }
   ~ScopedRegion() { Kokkos::Profiling::popRegion(); }

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -305,11 +305,11 @@ static void updateProfileLibraryState() {
                                     Experimental::no_profiling);
 }
 
-void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
+void beginParallelFor(const std::string_view kernelPrefix, const uint32_t devID,
                       uint64_t* kernelID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
-      Experimental::current_callbacks.begin_parallel_for, kernelPrefix.c_str(),
+      Experimental::current_callbacks.begin_parallel_for, kernelPrefix.data(),
       devID, kernelID);
 #ifdef KOKKOS_ENABLE_TUNING
   if (Kokkos::tune_internals()) {
@@ -336,11 +336,11 @@ void endParallelFor(const uint64_t kernelID) {
 #endif
 }
 
-void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
-                       uint64_t* kernelID) {
+void beginParallelScan(const std::string_view kernelPrefix,
+                       const uint32_t devID, uint64_t* kernelID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
-      Experimental::current_callbacks.begin_parallel_scan, kernelPrefix.c_str(),
+      Experimental::current_callbacks.begin_parallel_scan, kernelPrefix.data(),
       devID, kernelID);
 #ifdef KOKKOS_ENABLE_TUNING
   if (Kokkos::tune_internals()) {
@@ -367,12 +367,12 @@ void endParallelScan(const uint64_t kernelID) {
 #endif
 }
 
-void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
-                         uint64_t* kernelID) {
+void beginParallelReduce(const std::string_view kernelPrefix,
+                         const uint32_t devID, uint64_t* kernelID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
       Experimental::current_callbacks.begin_parallel_reduce,
-      kernelPrefix.c_str(), devID, kernelID);
+      kernelPrefix.data(), devID, kernelID);
 #ifdef KOKKOS_ENABLE_TUNING
   if (Kokkos::tune_internals()) {
     auto context_id = Experimental::get_new_context_id();
@@ -398,10 +398,10 @@ void endParallelReduce(const uint64_t kernelID) {
 #endif
 }
 
-void pushRegion(const std::string& kName) {
+void pushRegion(const std::string_view kName) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
-      Experimental::current_callbacks.push_region, kName.c_str());
+      Experimental::current_callbacks.push_region, kName.data());
 }
 
 void popRegion() {
@@ -410,30 +410,31 @@ void popRegion() {
       Experimental::current_callbacks.pop_region);
 }
 
-void allocateData(const SpaceHandle space, const std::string label,
+void allocateData(const SpaceHandle space, const std::string_view label,
                   const void* ptr, const uint64_t size) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
-      Experimental::current_callbacks.allocate_data, space, label.c_str(), ptr,
+      Experimental::current_callbacks.allocate_data, space, label.data(), ptr,
       size);
 }
 
-void deallocateData(const SpaceHandle space, const std::string label,
+void deallocateData(const SpaceHandle space, const std::string_view label,
                     const void* ptr, const uint64_t size) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
-      Experimental::current_callbacks.deallocate_data, space, label.c_str(),
-      ptr, size);
+      Experimental::current_callbacks.deallocate_data, space, label.data(), ptr,
+      size);
 }
 
-void beginDeepCopy(const SpaceHandle dst_space, const std::string dst_label,
-                   const void* dst_ptr, const SpaceHandle src_space,
-                   const std::string src_label, const void* src_ptr,
+void beginDeepCopy(const SpaceHandle dst_space,
+                   const std::string_view dst_label, const void* dst_ptr,
+                   const SpaceHandle src_space,
+                   const std::string_view src_label, const void* src_ptr,
                    const uint64_t size) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.begin_deep_copy, dst_space,
-      dst_label.c_str(), dst_ptr, src_space, src_label.c_str(), src_ptr, size);
+      dst_label.data(), dst_ptr, src_space, src_label.data(), src_ptr, size);
 #ifdef KOKKOS_ENABLE_TUNING
   if (Experimental::current_callbacks.begin_deep_copy != nullptr) {
     if (Kokkos::tune_internals()) {
@@ -464,11 +465,11 @@ void endDeepCopy() {
 #endif
 }
 
-void beginFence(const std::string name, const uint32_t deviceId,
+void beginFence(const std::string_view name, const uint32_t deviceId,
                 uint64_t* handle) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
-      Experimental::current_callbacks.begin_fence, name.c_str(), deviceId,
+      Experimental::current_callbacks.begin_fence, name.data(), deviceId,
       handle);
 }
 
@@ -478,11 +479,11 @@ void endFence(const uint64_t handle) {
       Experimental::current_callbacks.end_fence, handle);
 }
 
-void createProfileSection(const std::string& sectionName, uint32_t* secID) {
+void createProfileSection(const std::string_view sectionName, uint32_t* secID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.create_profile_section,
-      sectionName.c_str(), secID);
+      sectionName.data(), secID);
 }
 
 void startSection(const uint32_t secID) {
@@ -503,10 +504,10 @@ void destroyProfileSection(const uint32_t secID) {
       Experimental::current_callbacks.destroy_profile_section, secID);
 }
 
-void markEvent(const std::string& eventName) {
+void markEvent(const std::string_view eventName) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
-      Experimental::current_callbacks.profile_event, eventName.c_str());
+      Experimental::current_callbacks.profile_event, eventName.data());
 }
 
 bool printHelp(const std::string& args) {
@@ -1151,11 +1152,12 @@ VariableValue make_variable_value(size_t id, double val) {
   variable_value.value.double_value = val;
   return variable_value;
 }
-VariableValue make_variable_value(size_t id, const std::string& val) {
+VariableValue make_variable_value(size_t id, const std::string_view val) {
   VariableValue variable_value;
   variable_value.type_id = id;
-  strncpy(variable_value.value.string_value, val.c_str(),
-          KOKKOS_TOOLS_TUNING_STRING_LENGTH - 1);
+  strncpy(variable_value.value.string_value, val.data(),
+          std::max(val.size(),
+                   static_cast<size_t>(KOKKOS_TOOLS_TUNING_STRING_LENGTH - 1)));
   return variable_value;
 }
 SetOrRange make_candidate_set(size_t size, std::string* data) {

--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -82,37 +82,38 @@ struct ToolResponse {
 
 bool profileLibraryLoaded();
 
-void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
+void beginParallelFor(const std::string_view kernelPrefix, const uint32_t devID,
                       uint64_t* kernelID);
 void endParallelFor(const uint64_t kernelID);
-void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
-                       uint64_t* kernelID);
+void beginParallelScan(const std::string_view kernelPrefix,
+                       const uint32_t devID, uint64_t* kernelID);
 void endParallelScan(const uint64_t kernelID);
-void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
-                         uint64_t* kernelID);
+void beginParallelReduce(const std::string_view kernelPrefix,
+                         const uint32_t devID, uint64_t* kernelID);
 void endParallelReduce(const uint64_t kernelID);
 
-void pushRegion(const std::string& kName);
+void pushRegion(const std::string_view kName);
 void popRegion();
 
-void createProfileSection(const std::string& sectionName, uint32_t* secID);
+void createProfileSection(const std::string_view sectionName, uint32_t* secID);
 void startSection(const uint32_t secID);
 void stopSection(const uint32_t secID);
 void destroyProfileSection(const uint32_t secID);
 
-void markEvent(const std::string& evName);
+void markEvent(const std::string_view evName);
 
-void allocateData(const SpaceHandle space, const std::string label,
+void allocateData(const SpaceHandle space, const std::string_view label,
                   const void* ptr, const uint64_t size);
-void deallocateData(const SpaceHandle space, const std::string label,
+void deallocateData(const SpaceHandle space, const std::string_view label,
                     const void* ptr, const uint64_t size);
 
-void beginDeepCopy(const SpaceHandle dst_space, const std::string dst_label,
-                   const void* dst_ptr, const SpaceHandle src_space,
-                   const std::string src_label, const void* src_ptr,
+void beginDeepCopy(const SpaceHandle dst_space,
+                   const std::string_view dst_label, const void* dst_ptr,
+                   const SpaceHandle src_space,
+                   const std::string_view src_label, const void* src_ptr,
                    const uint64_t size);
 void endDeepCopy();
-void beginFence(const std::string name, const uint32_t deviceId,
+void beginFence(const std::string_view name, const uint32_t deviceId,
                 uint64_t* handle);
 void endFence(const uint64_t handle);
 


### PR DESCRIPTION
### Summary

The `Kokkos::Tools` API only needs `char` arrays, not `std::string`. It's a waste of resources to require the user to pass a `std::string` if *e.g.* the parallel-for label is a `char*`.

This PR modifies the API to work with `std::string_view` so we still get the length of the `char` array if needed.

The performance benefits of these changes are clear, especially if the tools are in the end not used, *i.e.* this PR pursues the following goal:
> When a `Kokkos::Tools` callback is **not set**, we must shrink the performance impact of the data passed to it.

### Discussion

We might wonder about null-termination of strings.

Since C++11, `std::string` is guaranteed to be null-terminated.

`std::string_view` does not guarantee that since it's just a view for a `char` array. So if the user passes in garbage / not null-terminated string, we might have issues (`GIGO`: *garbage in, garbage out*).

However, since the `Kokkos` C interface is designed for `char*`, I wonder if it's not already fragile to non-null-terminated strings.

Nevertheless, I feel like we need the `const std::string&` exactly for that purpose: ensure null-terminated strings. If you all agree with that, then I would say we just need to update those API functions that use `std::string` instead of `std::string&`.

### Details

The overhead of the `Kokkos::Tools` should be kept as small as possible.

Thus, forcing APIs to pass by `std::string&` (or even `std::string`...) possibly allocates memory, but only raw `char*` are needed ultimately.

Here is a quick code for benchmarking. It's always passing a `const char*` to the `Kokkos::Tools` functions. If they want a `std::string`, they'll need to allocate it and copy the incoming label, right ?

```c++
#include "benchmark/benchmark.h"

#include "Kokkos_Core.hpp"
#include "impl/Kokkos_Profiling.hpp"

static std::string label = "my very nice label for every one as a std::string, why not ?";

static void BenchmarkBeginParallelFor(benchmark::State& state) {
  for (auto _ : state) {
    uint64_t id = 0;
    Kokkos::Tools::beginParallelFor(label.c_str(), 0, &id);
  }
}

static void BenchmarkAllocateData(benchmark::State& state) {
  for(auto _ : state) {
    Kokkos::Tools::allocateData(
      Kokkos::Tools::make_space_handle(Kokkos::Cuda::name()),
      label.c_str(),
      nullptr,
      0
    );
  }
}

BENCHMARK(BenchmarkBeginParallelFor);
BENCHMARK(BenchmarkAllocateData);

BENCHMARK_MAIN();
```

I asked `Benchmark` to run for at least 5 seconds with `--benchmark_min_time=5s`. Host compiler is `gcc 14.2.0`, `Release` build. 

Here are the results for `std::string_view` (this PR):
```bash
BenchmarkBeginParallelFor       5.44 ns         5.44 ns   1267130672
BenchmarkAllocateData           11.6 ns         11.6 ns    597699513
```

and for `std::string` (the current state of the *develop*):
```bash
BenchmarkBeginParallelFor       19.3 ns         19.3 ns    362140794
BenchmarkAllocateData           25.3 ns         25.3 ns    278648365
```