### PR TITLE
Deprecate Kokkos::MemoryManaged

### DIFF
--- a/containers/unit_tests/TestDynRankViewTypedefs.cpp
+++ b/containers/unit_tests/TestDynRankViewTypedefs.cpp
@@ -121,30 +121,30 @@ constexpr bool test_view_typedefs_impl() {
   // Uhm uniformtype removes all memorytraits?
   static_assert(std::is_same_v<typename ViewType::uniform_type,
                                Kokkos::DynRankView<typename ViewType::data_type, uniform_layout_type,
-                                            typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
+                                            typename ViewType::device_type, Kokkos::MemoryTraits<>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_const_type,
                                Kokkos::DynRankView<typename ViewType::const_data_type, uniform_layout_type,
-                                            typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
+                                            typename ViewType::device_type, Kokkos::MemoryTraits<>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_runtime_type,
                                Kokkos::DynRankView<typename data_analysis<DataType>::runtime_data_type, uniform_layout_type,
-                                            typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
+                                            typename ViewType::device_type, Kokkos::MemoryTraits<>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_runtime_const_type,
                                Kokkos::DynRankView<typename data_analysis<DataType>::runtime_const_data_type, uniform_layout_type,
-                                            typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
+                                            typename ViewType::device_type, Kokkos::MemoryTraits<>>>);
 
   using anonymous_device_type = Kokkos::Device<typename ViewType::execution_space, Kokkos::AnonymousSpace>;
   static_assert(std::is_same_v<typename ViewType::uniform_nomemspace_type,
                                Kokkos::DynRankView<typename ViewType::data_type, uniform_layout_type,
-                                            anonymous_device_type, Kokkos::MemoryTraits<0>>>);
+                                            anonymous_device_type, Kokkos::MemoryTraits<>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_const_nomemspace_type,
                                Kokkos::DynRankView<typename ViewType::const_data_type, uniform_layout_type,
-                                            anonymous_device_type, Kokkos::MemoryTraits<0>>>);
+                                            anonymous_device_type, Kokkos::MemoryTraits<>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_runtime_nomemspace_type,
                                Kokkos::DynRankView<typename data_analysis<DataType>::runtime_data_type, uniform_layout_type,
-                                            anonymous_device_type, Kokkos::MemoryTraits<0>>>);
+                                            anonymous_device_type, Kokkos::MemoryTraits<>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_runtime_const_nomemspace_type,
                                Kokkos::DynRankView<typename data_analysis<DataType>::runtime_const_data_type, uniform_layout_type,
-                                            anonymous_device_type, Kokkos::MemoryTraits<0>>>);
+                                            anonymous_device_type, Kokkos::MemoryTraits<>>>);
 */
 
   // ==================================
@@ -202,7 +202,7 @@ constexpr bool has_unified_mem_space = false;
 namespace TestInt {
   using layout_type = Kokkos::DefaultExecutionSpace::array_layout;
   using space = Kokkos::DefaultExecutionSpace;
-  using memory_traits = Kokkos::MemoryTraits<0>;
+  using memory_traits = Kokkos::MemoryTraits<>;
   // HostMirrorSpace is a mess so: if the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is not on its HostSpace
@@ -217,7 +217,7 @@ namespace TestInt {
 namespace TestIntDefaultExecutionSpace {
   using layout_type = Kokkos::DefaultExecutionSpace::array_layout;
   using space = Kokkos::DefaultExecutionSpace;
-  using memory_traits = Kokkos::MemoryTraits<0>;
+  using memory_traits = Kokkos::MemoryTraits<>;
   // HostMirrorSpace is a mess so: if the default exec is a host exec, it is HostSpace (note difference from View<int> ...)
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::HostSpace,
   // otherwise if unified memory is not on its also HostSpace!
@@ -232,7 +232,7 @@ namespace TestIntDefaultExecutionSpace {
 namespace TestFloatPPHostSpace {
   using layout_type = Kokkos::LayoutRight;
   using space = Kokkos::HostSpace;
-  using memory_traits = Kokkos::MemoryTraits<0>;
+  using memory_traits = Kokkos::MemoryTraits<>;
   using host_mirror_space = Kokkos::HostSpace;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, const float, const float&>(
                      ViewParams<const float, Kokkos::HostSpace>{}));
@@ -242,7 +242,7 @@ namespace TestFloatPPHostSpace {
 namespace TestFloatPPDeviceDefaultHostExecHostSpace {
   using layout_type = Kokkos::LayoutRight;
   using space = Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>;
-  using memory_traits = Kokkos::MemoryTraits<0>;
+  using memory_traits = Kokkos::MemoryTraits<>;
   using host_mirror_space = Kokkos::HostSpace;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, float, float&>(
                      ViewParams<float, Kokkos::LayoutRight, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>>{}));

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -805,7 +805,7 @@ inline void contiguous_fill(
                      std::conditional_t<ViewType::rank == 0,
                                         typename ViewType::memory_space,
                                         Kokkos::AnonymousSpace>>,
-      Kokkos::MemoryTraits<0>>;
+      Kokkos::MemoryTraits<>>;
 
   ViewTypeFlat dst_flat(dst.data(), dst.size());
   if (dst.span() < static_cast<size_t>(std::numeric_limits<int>::max())) {

--- a/core/src/Kokkos_MemoryTraits.hpp
+++ b/core/src/Kokkos_MemoryTraits.hpp
@@ -45,7 +45,7 @@ enum MemoryTraitsFlags {
   Aligned      = 0x10
 };
 
-template <unsigned T>
+template <unsigned T = 0>
 struct MemoryTraits {
   //! Tag this class as a kokkos memory traits:
   using memory_traits = MemoryTraits<T>;
@@ -71,7 +71,7 @@ struct MemoryTraits {
 namespace Kokkos {
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-using MemoryManaged KOKKOS_DEPRECATED = Kokkos::MemoryTraits<0>;
+using MemoryManaged KOKKOS_DEPRECATED = Kokkos::MemoryTraits<>;
 #endif
 using MemoryUnmanaged = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
 using MemoryRandomAccess =
@@ -108,7 +108,7 @@ template <typename Tp>
 struct is_default_memory_trait : std::false_type {};
 
 template <>
-struct is_default_memory_trait<Kokkos::MemoryTraits<0>> : std::true_type {};
+struct is_default_memory_trait<Kokkos::MemoryTraits<>> : std::true_type {};
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/Kokkos_MemoryTraits.hpp
+++ b/core/src/Kokkos_MemoryTraits.hpp
@@ -70,7 +70,9 @@ struct MemoryTraits {
 
 namespace Kokkos {
 
-using MemoryManaged   = Kokkos::MemoryTraits<0>;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+using MemoryManaged KOKKOS_DEPRECATED = Kokkos::MemoryTraits<0>;
+#endif
 using MemoryUnmanaged = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
 using MemoryRandomAccess =
     Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>;

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -403,7 +403,7 @@ struct ViewTraits {
   using MemoryTraits =
       std::conditional_t<!std::is_void_v<typename prop::memory_traits>,
                          typename prop::memory_traits,
-                         typename Kokkos::MemoryManaged>;
+                         typename Kokkos::MemoryTraits<0>>;
 
   using HooksPolicy =
       std::conditional_t<!std::is_void_v<typename prop::hooks_policy>,

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -403,7 +403,7 @@ struct ViewTraits {
   using MemoryTraits =
       std::conditional_t<!std::is_void_v<typename prop::memory_traits>,
                          typename prop::memory_traits,
-                         typename Kokkos::MemoryTraits<0>>;
+                         typename Kokkos::MemoryTraits<>>;
 
   using HooksPolicy =
       std::conditional_t<!std::is_void_v<typename prop::hooks_policy>,

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -880,15 +880,15 @@ struct TestViewMirror {
   }
 
   void static testit() {
-    test_mirror<Kokkos::MemoryTraits<0> >();
+    test_mirror<Kokkos::MemoryTraits<> >();
     test_mirror<Kokkos::MemoryTraits<Kokkos::Unmanaged> >();
-    test_mirror_view<Kokkos::MemoryTraits<0> >();
+    test_mirror_view<Kokkos::MemoryTraits<> >();
     test_mirror_view<Kokkos::MemoryTraits<Kokkos::Unmanaged> >();
-    test_mirror_copy<Kokkos::MemoryTraits<0> >();
+    test_mirror_copy<Kokkos::MemoryTraits<> >();
     test_mirror_copy<Kokkos::MemoryTraits<Kokkos::Unmanaged> >();
     test_mirror_copy_const_data_type();
     test_allocated();
-    test_mirror_no_initialize<Kokkos::MemoryTraits<0> >();
+    test_mirror_no_initialize<Kokkos::MemoryTraits<> >();
     test_mirror_no_initialize<Kokkos::MemoryTraits<Kokkos::Unmanaged> >();
   }
 };

--- a/core/unit_test/TestViewTypedefs.cpp
+++ b/core/unit_test/TestViewTypedefs.cpp
@@ -120,30 +120,30 @@ constexpr bool test_view_typedefs_impl() {
   // FIXME: uniformtype removes all memorytraits?
   static_assert(std::is_same_v<typename ViewType::uniform_type,
                                Kokkos::View<typename ViewType::data_type, uniform_layout_type,
-                                            typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
+                                            typename ViewType::device_type, Kokkos::MemoryTraits<>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_const_type,
                                Kokkos::View<typename ViewType::const_data_type, uniform_layout_type,
-                                            typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
+                                            typename ViewType::device_type, Kokkos::MemoryTraits<>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_runtime_type,
                                Kokkos::View<typename data_analysis<DataType>::runtime_data_type, uniform_layout_type,
-                                            typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
+                                            typename ViewType::device_type, Kokkos::MemoryTraits<>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_runtime_const_type,
                                Kokkos::View<typename data_analysis<DataType>::runtime_const_data_type, uniform_layout_type,
-                                            typename ViewType::device_type, Kokkos::MemoryTraits<0>>>);
+                                            typename ViewType::device_type, Kokkos::MemoryTraits<>>>);
 
   using anonymous_device_type = Kokkos::Device<typename ViewType::execution_space, Kokkos::AnonymousSpace>;
   static_assert(std::is_same_v<typename ViewType::uniform_nomemspace_type,
                                Kokkos::View<typename ViewType::data_type, uniform_layout_type,
-                                            anonymous_device_type, Kokkos::MemoryTraits<0>>>);
+                                            anonymous_device_type, Kokkos::MemoryTraits<>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_const_nomemspace_type,
                                Kokkos::View<typename ViewType::const_data_type, uniform_layout_type,
-                                            anonymous_device_type, Kokkos::MemoryTraits<0>>>);
+                                            anonymous_device_type, Kokkos::MemoryTraits<>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_runtime_nomemspace_type,
                                Kokkos::View<typename data_analysis<DataType>::runtime_data_type, uniform_layout_type,
-                                            anonymous_device_type, Kokkos::MemoryTraits<0>>>);
+                                            anonymous_device_type, Kokkos::MemoryTraits<>>>);
   static_assert(std::is_same_v<typename ViewType::uniform_runtime_const_nomemspace_type,
                                Kokkos::View<typename data_analysis<DataType>::runtime_const_data_type, uniform_layout_type,
-                                            anonymous_device_type, Kokkos::MemoryTraits<0>>>);
+                                            anonymous_device_type, Kokkos::MemoryTraits<>>>);
 
 
   // ==================================
@@ -205,7 +205,7 @@ constexpr bool has_unified_mem_space = false;
 namespace TestInt {
   using layout_type = Kokkos::DefaultExecutionSpace::array_layout;
   using space = Kokkos::DefaultExecutionSpace;
-  using memory_traits = Kokkos::MemoryTraits<0>;
+  using memory_traits = Kokkos::MemoryTraits<>;
   // HostMirrorSpace is a mess so: if the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is not on its HostSpace
@@ -220,7 +220,7 @@ namespace TestInt {
 namespace TestIntDefaultExecutionSpace {
   using layout_type = Kokkos::DefaultExecutionSpace::array_layout;
   using space = Kokkos::DefaultExecutionSpace;
-  using memory_traits = Kokkos::MemoryTraits<0>;
+  using memory_traits = Kokkos::MemoryTraits<>;
   // HostMirrorSpace is a mess so: if the default exec is a host exec, it is HostSpace (note difference from View<int> ...)
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::HostSpace,
   // otherwise if unified memory is not on its also HostSpace!
@@ -235,7 +235,7 @@ namespace TestIntDefaultExecutionSpace {
 namespace TestFloatPPHostSpace {
   using layout_type = Kokkos::LayoutRight;
   using space = Kokkos::HostSpace;
-  using memory_traits = Kokkos::MemoryTraits<0>;
+  using memory_traits = Kokkos::MemoryTraits<>;
   using host_mirror_space = Kokkos::HostSpace;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, const float, const float&>(
                      ViewParams<const float**, Kokkos::HostSpace>{}));
@@ -245,7 +245,7 @@ namespace TestFloatPPHostSpace {
 namespace TestFloatP3LayoutLeft {
   using layout_type = Kokkos::LayoutLeft;
   using space = Kokkos::DefaultExecutionSpace;
-  using memory_traits = Kokkos::MemoryTraits<0>;
+  using memory_traits = Kokkos::MemoryTraits<>;
   // HostMirrorSpace is a mess so: if the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is not on its HostSpace
@@ -260,7 +260,7 @@ namespace TestFloatP3LayoutLeft {
 namespace TestFloatPPDeviceDefaultHostExecHostSpace {
   using layout_type = Kokkos::LayoutRight;
   using space = Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>;
-  using memory_traits = Kokkos::MemoryTraits<0>;
+  using memory_traits = Kokkos::MemoryTraits<>;
   using host_mirror_space = Kokkos::HostSpace;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, float, float&>(
                      ViewParams<float[2][3], Kokkos::LayoutRight, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>>{}));

--- a/core/unit_test/default/TestDefaultDeviceTypeViewAPI.cpp
+++ b/core/unit_test/default/TestDefaultDeviceTypeViewAPI.cpp
@@ -32,7 +32,7 @@ struct TestViewAPI<
   using layout_type = Layout;
   using space_type  = Kokkos::DefaultExecutionSpace;
   using traits_type =
-      Kokkos::MemoryTraits<0>;  // maybe we want to add that later to the matrix
+      Kokkos::MemoryTraits<>;  // maybe we want to add that later to the matrix
   using view_type =
       Kokkos::View<data_type, layout_type, space_type, traits_type>;
   using alloc_layout_type =


### PR DESCRIPTION
Since `Kokkos::MemoryManaged` is the default,
```
Kokkos::View<int*, Kokkos::MemoryManaged> view("view", 10);
Kokkos::View>int*, Kokkos::MemoryManaged> unmanaged_view(view.data(), view.size());
```
is the same as
```
Kokkos::View<int*> view("view", 10);
Kokkos::View>int*> unmanaged_view(view.data(), view.size());
```
It's quite confusing that you can create an unmanaged `View` with the `Kokkos::MemoryManaged` memory trait. The reverse case, i.e., creating a managed `View` with the `Kokkos::MemoryUnmanaged` is handled in #8061.
This pull request is suggesting to just deprecate the `Kokkos::MemoryManaged` trait since we can't reasonably change the default behavior. Thus, the default template parameters imply that the resulting `View` is managed or unmanaged depending on runtime arguments and `Kokkos::MemoryUnmanaged` is a special case.

Also give `Kokkos::MemoryTraits` a default template parameter.