### PR TITLE
Reduce number of iterations in team_scratch_1_queues

### DIFF
--- a/core/unit_test/cuda/TestCuda_TeamScratchStreams.cpp
+++ b/core/unit_test/cuda/TestCuda_TeamScratchStreams.cpp
@@ -104,7 +104,7 @@ void cuda_stream_scratch_test(
 }  // namespace Impl
 
 TEST(cuda, team_scratch_1_streams) {
-  int N      = 1000000;
+  int N      = 10000;
   int T      = 10;
   int M_base = 150;
 

--- a/core/unit_test/hip/TestHIP_TeamScratchStreams.cpp
+++ b/core/unit_test/hip/TestHIP_TeamScratchStreams.cpp
@@ -103,7 +103,7 @@ void hip_stream_scratch_test(int N, int T, int M_base,
 }  // namespace Impl
 
 TEST(hip, team_scratch_1_streams) {
-  int N      = 1000000;
+  int N      = 10000;
   int T      = 10;
   int M_base = 150;
 

--- a/core/unit_test/sycl/TestSYCL_TeamScratchStreams.cpp
+++ b/core/unit_test/sycl/TestSYCL_TeamScratchStreams.cpp
@@ -110,7 +110,7 @@ void sycl_queue_scratch_test(
 }  // namespace Impl
 
 TEST(sycl, team_scratch_1_queues) {
-  int N      = 1000000;
+  int N      = 10000;
   int T      = 10;
   int M_base = 150;
 


### PR DESCRIPTION
Our CI shows that `team_scratch_1_queues` is very expensive 
```
7: [       OK ] cuda.team_scratch_1_streams (24035 ms)
5: [       OK ] hip.team_scratch_1_streams (43609 ms)
11: [       OK ] sycl.team_scratch_1_queues (148337 ms)
```
and seems we really don't need 10^6 iterations. Reducing it to 10^4 brings it more inline with the runtimer for other tests.