### PR TITLE
Fix a memory leak in the initialization

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -454,7 +454,8 @@ void initialize_backends(const Kokkos::InitializationSettings& settings) {
 }
 
 void initialize_profiling(const Kokkos::Tools::InitArguments& args) {
-  auto initialization_status =
+  // Making this variable static prevents a leak if std::exit is called
+  static auto initialization_status =
       Kokkos::Tools::Impl::initialize_tools_subsystem(args);
   if (initialization_status.result ==
       Kokkos::Tools::Impl::InitializationStatus::InitializationResult::
@@ -729,7 +730,8 @@ void pre_initialize_internal(const Kokkos::InitializationSettings& settings) {
 }
 
 void post_initialize_internal(const Kokkos::InitializationSettings& settings) {
-  Kokkos::Tools::InitArguments tools_init_arguments;
+  // Making this variable static prevents a leak if std::exit is called
+  static Kokkos::Tools::InitArguments tools_init_arguments;
   combine(tools_init_arguments, settings);
   initialize_profiling(tools_init_arguments);
   g_is_initialized = true;
@@ -1009,7 +1011,8 @@ void Kokkos::initialize(int& argc, char* argv[]) {
         "Error: Kokkos::initialize() has already been called."
         " Kokkos can be initialized at most once.\n");
   }
-  InitializationSettings settings;
+  // Making this variable static prevents a leak if std::exit is called
+  static InitializationSettings settings;
   Impl::parse_environment_variables(settings);
   Impl::parse_command_line_arguments(argc, argv, settings);
   initialize_internal(settings);
@@ -1021,7 +1024,8 @@ void Kokkos::initialize(InitializationSettings const& settings) {
         "Error: Kokkos::initialize() has already been called."
         " Kokkos can be initialized at most once.\n");
   }
-  InitializationSettings tmp;
+  // Making this variable static prevents a leak if std::exit is called
+  static InitializationSettings tmp;
   Impl::parse_environment_variables(tmp);
   combine(tmp, settings);
   initialize_internal(tmp);


### PR DESCRIPTION
This PR fixes a memory leak in the initialization logic (caught here https://github.com/kokkos/kokkos/actions/runs/14967676811/job/42041325586?pr=8043#step:13:795).

If using the flag `--kokkos-tools-help`, `std::exit(EXIT_SUCCESS)` is called [here](https://github.com/kokkos/kokkos/blob/8ba28c263432f308b310a19abf0c84ce3511b5dd/core/src/impl/Kokkos_Core.cpp#L456-L465), which means that some local variables in some functions higher in the call stack are not correctly destroyed.
https://github.com/kokkos/kokkos/blob/8ba28c263432f308b310a19abf0c84ce3511b5dd/core/src/impl/Kokkos_Core.cpp#L732
https://github.com/kokkos/kokkos/blob/8ba28c263432f308b310a19abf0c84ce3511b5dd/core/src/impl/Kokkos_Core.cpp#L1012
https://github.com/kokkos/kokkos/blob/8ba28c263432f308b310a19abf0c84ce3511b5dd/core/src/impl/Kokkos_Core.cpp#L1024

Since Kokkos can only be initialized once, I simply made them static, which ensures that the destructors are called on exit. There may be a better way, but the others I've tried ended up being overly complicated.
