### PR TITLE
core(graph): add host node

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -35,6 +35,28 @@ namespace Kokkos {
 namespace Impl {
 
 template <typename Functor>
+struct GraphNodeThenHostImpl<Kokkos::Cuda, Functor> {
+  Functor m_functor;
+  cudaGraphNode_t m_node = nullptr;
+
+  explicit GraphNodeThenHostImpl(Functor functor)
+      : m_functor(std::move(functor)) {}
+
+  static void callback(void* data) {
+    reinterpret_cast<Functor*>(data)->operator()();
+  }
+
+  void add_to_graph(cudaGraph_t graph) {
+    cudaHostNodeParams params = {};
+    params.fn                 = callback;
+    params.userData           = &m_functor;
+
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        cudaGraphAddHostNode(&m_node, graph, nullptr, 0, &params));
+  }
+};
+
+template <typename Functor>
 struct GraphNodeCaptureImpl<Kokkos::Cuda, Functor> {
   Functor m_functor;
   cudaGraphNode_t m_node = nullptr;

--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -158,6 +158,21 @@ struct GraphImpl<Kokkos::Cuda> {
     m_nodes.push_back(std::move(arg_node_ptr));
   }
 
+  template <class NodeImpl>
+  std::enable_if_t<
+      Kokkos::Impl::is_graph_then_host_v<typename NodeImpl::kernel_type>>
+  add_node(std::shared_ptr<NodeImpl> arg_node_ptr) {
+    static_assert(
+        Kokkos::Impl::is_specialization_of_v<NodeImpl, GraphNodeImpl>);
+    KOKKOS_EXPECTS(bool(arg_node_ptr));
+
+    auto& kernel = arg_node_ptr->get_kernel();
+    kernel.add_to_graph(m_graph);
+    static_cast<node_details_t*>(arg_node_ptr.get())->node = kernel.m_node;
+
+    m_nodes.push_back(std::move(arg_node_ptr));
+  }
+
   template <class NodeImplPtr, class PredecessorRef>
   // requires PredecessorRef is a specialization of GraphNodeRef that has
   // already been added to this graph and NodeImpl is a specialization of

--- a/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
@@ -67,6 +67,11 @@ class GraphImpl<Kokkos::HIP> {
       Kokkos::Impl::is_graph_capture_v<typename NodeImpl::kernel_type>>
   add_node(const Kokkos::HIP& exec, std::shared_ptr<NodeImpl> arg_node_ptr);
 
+  template <class NodeImpl>
+  std::enable_if_t<
+      Kokkos::Impl::is_graph_then_host_v<typename NodeImpl::kernel_type>>
+  add_node(std::shared_ptr<NodeImpl> arg_node_ptr);
+
   template <class NodeImplPtr, class PredecessorRef>
   void add_predecessor(NodeImplPtr arg_node_ptr, PredecessorRef arg_pred_ref);
 
@@ -168,6 +173,20 @@ GraphImpl<Kokkos::HIP>::add_node(const Kokkos::HIP& exec,
 
   auto& kernel = arg_node_ptr->get_kernel();
   kernel.capture(exec, m_graph);
+  static_cast<node_details_t*>(arg_node_ptr.get())->node = kernel.m_node;
+
+  m_nodes.push_back(std::move(arg_node_ptr));
+}
+
+template <class NodeImpl>
+inline std::enable_if_t<
+    Kokkos::Impl::is_graph_then_host_v<typename NodeImpl::kernel_type>>
+GraphImpl<Kokkos::HIP>::add_node(std::shared_ptr<NodeImpl> arg_node_ptr) {
+  static_assert(Kokkos::Impl::is_specialization_of_v<NodeImpl, GraphNodeImpl>);
+  KOKKOS_EXPECTS(bool(arg_node_ptr));
+
+  auto& kernel = arg_node_ptr->get_kernel();
+  kernel.add_to_graph(m_graph);
   static_cast<node_details_t*>(arg_node_ptr.get())->node = kernel.m_node;
 
   m_nodes.push_back(std::move(arg_node_ptr));

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -58,7 +58,8 @@ class GraphNodeRef {
 
   static_assert(std::is_same_v<Predecessor, TypeErasedTag> ||
                     Kokkos::Impl::is_graph_kernel<Kernel>::value ||
-                    Kokkos::Impl::is_graph_capture<Kernel>::value,
+                    Kokkos::Impl::is_graph_capture_v<Kernel> ||
+                    Kokkos::Impl::is_graph_then_host_v<Kernel>,
                 "Invalid kernel template parameter given to GraphNodeRef");
 
   static_assert(!Kokkos::Impl::is_more_type_erased<Kernel, Predecessor>::value,
@@ -246,6 +247,34 @@ class GraphNodeRef {
   auto then(Label&& label, Functor&& functor) const {
     return this->then(std::forward<Label>(label), ExecutionSpace{},
                       std::forward<Functor>(functor));
+  }
+
+  template <typename Label, typename Functor>
+  auto then_host(Label&&, Functor&& functor) const {
+    using host_t = Kokkos::Impl::GraphNodeThenHostImpl<
+        ExecutionSpace, Kokkos::Impl::remove_cvref_t<Functor>>;
+    using return_t = GraphNodeRef<ExecutionSpace, host_t, GraphNodeRef>;
+
+    auto graph_ptr = m_graph_impl.lock();
+    KOKKOS_EXPECTS(bool(graph_ptr))
+
+    auto rv = Kokkos::Impl::GraphAccess::make_graph_node_ref(
+        m_graph_impl,
+        Kokkos::Impl::GraphAccess::make_node_shared_ptr<
+            typename return_t::node_impl_t>(
+            m_node_impl->execution_space_instance(),
+            Kokkos::Impl::_graph_node_host_ctor_tag{},
+            std::forward<Functor>(functor),
+            Kokkos::Impl::_graph_node_predecessor_ctor_tag{}, *this));
+
+    // Add the node itself to the backend's graph data structure, now that
+    // everything is set up.
+    graph_ptr->add_node(rv.m_node_impl);
+    // Add the predecessor we stored in the constructor above in the
+    // backend's data structure, now that everything is set up.
+    graph_ptr->add_predecessor(rv.m_node_impl, *this);
+    KOKKOS_ENSURES(bool(rv.m_node_impl))
+    return rv;
   }
 
 #if defined(KOKKOS_ENABLE_CUDA) ||                                           \

--- a/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
@@ -68,6 +68,11 @@ class GraphImpl<Kokkos::SYCL> {
 
   template <class NodeImpl>
   std::enable_if_t<
+      Kokkos::Impl::is_graph_then_host_v<typename NodeImpl::kernel_type>>
+  add_node(std::shared_ptr<NodeImpl> arg_node_ptr);
+
+  template <class NodeImpl>
+  std::enable_if_t<
       Kokkos::Impl::is_graph_capture_v<typename NodeImpl::kernel_type>>
   add_node(const Kokkos::SYCL& exec, std::shared_ptr<NodeImpl> arg_node_ptr);
 
@@ -136,6 +141,20 @@ GraphImpl<Kokkos::SYCL>::add_node(std::shared_ptr<NodeImpl> arg_node_ptr) {
   kernel.set_sycl_graph_node_ptr(&node);
   kernel.execute();
   KOKKOS_ENSURES(node);
+  m_nodes.push_back(std::move(arg_node_ptr));
+}
+
+template <class NodeImpl>
+std::enable_if_t<
+    Kokkos::Impl::is_graph_then_host_v<typename NodeImpl::kernel_type>>
+GraphImpl<Kokkos::SYCL>::add_node(std::shared_ptr<NodeImpl> arg_node_ptr) {
+  static_assert(Kokkos::Impl::is_specialization_of_v<NodeImpl, GraphNodeImpl>);
+  KOKKOS_EXPECTS(arg_node_ptr);
+
+  auto& kernel = arg_node_ptr->get_kernel();
+  kernel.add_to_graph(m_graph);
+  static_cast<node_details_t*>(arg_node_ptr.get())->node = kernel.m_node;
+
   m_nodes.push_back(std::move(arg_node_ptr));
 }
 

--- a/core/src/impl/Kokkos_Default_GraphNodeKernel.hpp
+++ b/core/src/impl/Kokkos_Default_GraphNodeKernel.hpp
@@ -45,6 +45,25 @@ struct GraphNodeKernelDefaultImpl {
   ExecutionSpace m_execution_space;
 };
 
+template <typename ExecutionSpace, typename Functor>
+struct GraphNodeThenHostImpl
+    : public GraphNodeKernelDefaultImpl<ExecutionSpace> {
+  using execute_kernel_vtable_base_t =
+      GraphNodeKernelDefaultImpl<ExecutionSpace>;
+
+  explicit GraphNodeThenHostImpl(Functor functor)
+      : execute_kernel_vtable_base_t{}, m_functor(std::move(functor)) {}
+
+  void execute_kernel() override final {
+    this->m_execution_space.fence(
+        "Kokkos::DefaultGraphNode::then_host: fence needed before host "
+        "callback");
+    m_functor();
+  }
+
+  Functor m_functor;
+};
+
 // TODO Indicate that this kernel specialization is only for the Host somehow?
 template <class ExecutionSpace, class PolicyType, class Functor,
           class PatternTag, class... Args>

--- a/core/src/impl/Kokkos_Default_Graph_Impl.hpp
+++ b/core/src/impl/Kokkos_Default_Graph_Impl.hpp
@@ -82,7 +82,7 @@ struct GraphImpl : private ExecutionSpaceInstanceStorage<ExecutionSpace> {
   // <editor-fold desc="required customizations"> {{{2
 
   template <class NodeImpl>
-  void add_node(std::shared_ptr<NodeImpl> const& arg_node_ptr) {
+  void add_node(std::shared_ptr<NodeImpl> arg_node_ptr) {
     static_assert(
         Kokkos::Impl::is_specialization_of_v<NodeImpl, GraphNodeImpl>);
     // Since this is always called before any calls to add_predecessor involving

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -37,6 +37,12 @@ struct is_graph_capture<
            Kokkos::Impl::is_specialization_of_v<T, GraphNodeCaptureImpl>>>
     : public std::true_type {};
 
+template <typename T>
+struct is_graph_then_host<
+    T, std::enable_if_t<
+           Kokkos::Impl::is_specialization_of_v<T, GraphNodeThenHostImpl>>>
+    : public std::true_type {};
+
 struct GraphAccess {
   template <class NodeType, class... Args>
   static auto make_node_shared_ptr(Args&&... args) {

--- a/core/src/impl/Kokkos_GraphImpl_fwd.hpp
+++ b/core/src/impl/Kokkos_GraphImpl_fwd.hpp
@@ -44,10 +44,20 @@ struct is_graph_capture : public std::false_type {};
 template <typename T>
 inline constexpr bool is_graph_capture_v = is_graph_capture<T>::value;
 
+template <typename ExecutionSpace, typename Functor>
+struct GraphNodeThenHostImpl;
+
+template <typename T, class Enable = void>
+struct is_graph_then_host : public std::false_type {};
+
+template <typename T>
+inline constexpr bool is_graph_then_host_v = is_graph_then_host<T>::value;
+
 struct _graph_node_kernel_ctor_tag {};
 struct _graph_node_capture_ctor_tag {};
 struct _graph_node_predecessor_ctor_tag {};
 struct _graph_node_is_root_ctor_tag {};
+struct _graph_node_host_ctor_tag {};
 
 struct GraphAccess;
 

--- a/core/src/impl/Kokkos_GraphNodeImpl.hpp
+++ b/core/src/impl/Kokkos_GraphNodeImpl.hpp
@@ -142,7 +142,8 @@ struct GraphNodeImpl<ExecutionSpace, Kernel,
   template <class KernelDeduced, class Tag,
             typename = std::enable_if_t<
                 std::is_same_v<Tag, _graph_node_kernel_ctor_tag> ||
-                std::is_same_v<Tag, _graph_node_capture_ctor_tag>>>
+                std::is_same_v<Tag, _graph_node_capture_ctor_tag> ||
+                std::is_same_v<Tag, _graph_node_host_ctor_tag>>>
   GraphNodeImpl(ExecutionSpace const& ex, Tag, KernelDeduced&& arg_kernel)
       : base_t(ex), m_kernel{(KernelDeduced&&)arg_kernel} {}
 
@@ -239,7 +240,8 @@ struct GraphNodeImpl
   template <class KernelDeduced, class PredecessorPtrDeduced, class Tag,
             typename = std::enable_if_t<
                 std::is_same_v<Tag, _graph_node_kernel_ctor_tag> ||
-                std::is_same_v<Tag, _graph_node_capture_ctor_tag>>>
+                std::is_same_v<Tag, _graph_node_capture_ctor_tag> ||
+                std::is_same_v<Tag, _graph_node_host_ctor_tag>>>
   GraphNodeImpl(ExecutionSpace const& ex, Tag, KernelDeduced&& arg_kernel,
                 _graph_node_predecessor_ctor_tag,
                 PredecessorPtrDeduced&& arg_predecessor)

--- a/core/src/impl/Kokkos_GraphNodeThenImpl.hpp
+++ b/core/src/impl/Kokkos_GraphNodeThenImpl.hpp
@@ -26,10 +26,10 @@ namespace Kokkos::Impl {
 // takes no argument.
 template <typename Functor>
 struct ThenWrapper {
-  Functor functor;
+  Functor m_functor;
   template <typename T>
   KOKKOS_FUNCTION void operator()(const T) const {
-    functor();
+    m_functor();
   }
 };
 


### PR DESCRIPTION
### Summary

This PR adds *host node* to `Kokkos::Graph`.

### Description

Adding a host node creates a new CPU execution node and adds it to graph. When the graph is launched, the node will invoke the specified CPU function when appropriate.

It can be used for when *host-side* computation is needed. This can be useful *e.g.* for additional synchronization, cleanup, routine business logic, and so on. Concrete examples could be:
- update host scalars
- read/write files (IO stuff)
- MPI exchange

Quoting [`SYCL` *host task* documentation](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:interfaces.hosttasks):
> This allows [host tasks](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#host-task) to be used for two purposes: either as a task which can perform arbitrary C++ code within the scheduling of the [SYCL runtime](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sycl-runtime) or as a task which can perform interoperability at a point within the scheduling of the [SYCL runtime](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sycl-runtime).

Quoting [`cudaGraphAddHostNode` documentation](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__GRAPH.html#group__CUDART__GRAPH_1g30e16d2715f09683f0aa8ac2b870cf71):
> Note that as specified by [cudaStreamAddCallback](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g74aa9f4b1c2f12d994bf13876a5a2498) no CUDA function may be called from callback. [cudaErrorNotPermitted](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1gg3f51e3575c2178246db0a94a430e003867b6095ab719b21659a400b553963eb3) may, but is not guaranteed to, be returned as a diagnostic in such case.

> :warning: Restrictions may apply on what is allowed to be done in the host node.