### PR TITLE
fix a broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ git clone -b develop  https://github.com/kokkos/kokkos.git
 To build Kokkos, you will need to have a C++ compiler that supports C++17 or later.
 All requirements including minimum and primary tested compiler versions can be found [here](https://kokkos.org/kokkos-core-wiki/get-started/requirements.html).
 
-Building and installation instructions are described [here](https://kokkos.org/kokkos-core-wiki/building.html).
+Building and installation instructions are described [here](https://kokkos.org/kokkos-core-wiki/get-started/building-from-source.html#configuring-and-building-kokkos).
 
 You can also install Kokkos using [Spack](https://spack.io/): `spack install kokkos`. [Available configuration options](https://packages.spack.io/package.html?name=kokkos) can be displayed using `spack info kokkos`.
 


### PR DESCRIPTION
* link in README.md was giving 404, now points to the correct URL