### PR TITLE
Exit early at initialize when the user queries the kokkos help

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -46,10 +46,11 @@
 
 //----------------------------------------------------------------------------
 namespace {
-bool g_is_initialized = false;
-bool g_is_finalized   = false;
-bool g_show_warnings  = true;
-bool g_tune_internals = false;
+bool g_print_help_and_exit = false;  // whether to exit early at initialize
+bool g_is_initialized      = false;
+bool g_is_finalized        = false;
+bool g_show_warnings       = true;
+bool g_tune_internals      = false;
 // When compiling with clang/LLVM and using the GNU (GCC) C++ Standard Library
 // (any recent version between GCC 7.3 and GCC 9.2), std::deque SEGV's during
 // the unwinding of the atexit(3C) handlers at program termination.  However,
@@ -487,6 +488,9 @@ std::string version_string_from_int(int version_number) {
 }
 
 void pre_initialize_internal(const Kokkos::InitializationSettings& settings) {
+  if (g_print_help_and_exit) {
+    std::exit(EXIT_SUCCESS);
+  }
   if (settings.has_disable_warnings() && settings.get_disable_warnings())
     g_show_warnings = false;
   if (settings.has_tune_internals() && settings.get_tune_internals())
@@ -887,8 +891,11 @@ void Kokkos::Impl::parse_command_line_arguments(
       remove_flag = true;
     } else if (check_arg(argv[iarg], "--kokkos-help") ||
                check_arg(argv[iarg], "--help")) {
-      help_flag   = true;
-      remove_flag = std::string(argv[iarg]).find("--kokkos-") == 0;
+      help_flag = true;
+      bool const has_kokkos_prefix =
+          std::string(argv[iarg]).find("--kokkos-") == 0;
+      remove_flag           = has_kokkos_prefix;
+      g_print_help_and_exit = has_kokkos_prefix;
     } else if (check_arg_str(argv[iarg], "--kokkos-map-device-id-by",
                              map_device_id_by)) {
       if (!is_valid_map_device_id_by(map_device_id_by)) {

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -944,6 +944,7 @@ kokkos_add_executable_and_test(
   TestExecutionEnvironmentNonInitializedOrFinalized.cpp
   TestInitializationSettings.cpp
   TestInitializeFinalize.cpp
+  TestKokkosHelpCausesNormalProgramTermination.cpp
   TestLegionInitialization.cpp
   TestParseCmdLineArgsAndEnvVars.cpp
   TestPushFinalizeHook.cpp

--- a/core/unit_test/TestKokkosHelpCausesNormalProgramTermination.cpp
+++ b/core/unit_test/TestKokkosHelpCausesNormalProgramTermination.cpp
@@ -1,0 +1,50 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+
+#include "KokkosExecutionEnvironmentNeverInitializedFixture.hpp"
+
+namespace {
+
+using KokkosHelpCausesNormalProgramTermination_DeathTest =
+    KokkosExecutionEnvironmentNeverInitialized;
+
+TEST_F(KokkosHelpCausesNormalProgramTermination_DeathTest,
+       print_help_and_exit_early) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  int argc = 1;
+
+  char const *argv[] = {
+      "--kokkos-help",
+  };
+
+  ::testing::internal::CaptureStdout();
+
+  EXPECT_EXIT(
+      {
+        Kokkos::initialize(argc, const_cast<char **>(argv));
+        Kokkos::abort("better exit before getting there");
+      },
+      ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+
+  (void)::testing::internal::GetCapturedStdout();
+}
+
+}  // namespace

--- a/core/unit_test/TestKokkosHelpCausesNormalProgramTermination.cpp
+++ b/core/unit_test/TestKokkosHelpCausesNormalProgramTermination.cpp
@@ -33,6 +33,7 @@ TEST_F(KokkosHelpCausesNormalProgramTermination_DeathTest,
 
   char const *argv[] = {
       "--kokkos-help",
+      nullptr,
   };
 
   ::testing::internal::CaptureStdout();


### PR DESCRIPTION
This is following up on a discussion on the developer channel.

Causes normal program termination when the `--kokkos-help` flag is found.
Presumably when one explicitly queries the Kokkos Core runtime for the help message via the command line argument, one does not intend for the program to continue and execute to completion.
This does not change the behavior with `--help` (unprefixed).