### PR TITLE
Address Clang-Tidy diagnostics

### DIFF
--- a/algorithms/src/sorting/Kokkos_BinOpsPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_BinOpsPublicAPI.hpp
@@ -82,7 +82,7 @@ struct BinOp3D {
   BinOp3D() = delete;
 #endif
 
-  BinOp3D(int max_bins[], typename KeyViewType::const_value_type min[],
+  BinOp3D(int const max_bins[], typename KeyViewType::const_value_type min[],
           typename KeyViewType::const_value_type max[]) {
     max_bins_[0] = max_bins[0];
     max_bins_[1] = max_bins[1];

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -168,7 +168,7 @@ void sort_via_binsort(const ExecutionSpace& exec,
     // using 10M as the cutoff for special behavior (roughly 40MB for the count
     // array)
     if ((max_val - min_val) < 10000000) {
-      max_bins     = max_val - min_val + 1;
+      max_bins     = static_cast<int64_t>(max_val - min_val + 1.);
       sort_in_bins = false;
     }
   }

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -1487,12 +1487,12 @@ class ScatterAccess<DataType, Op, DeviceType, Layout, ScatterDuplicated,
  private:
   view_type const& view;
 
+ public:
   // simplify RAII by disallowing copies
   ScatterAccess(ScatterAccess const& other)            = delete;
   ScatterAccess& operator=(ScatterAccess const& other) = delete;
   ScatterAccess& operator=(ScatterAccess&& other)      = delete;
 
- public:
   // do need to allow moves though, for the common
   // auto b = a.access();
   // that assignments turns into a move constructor call

--- a/containers/src/impl/Kokkos_UnorderedMap_impl.cpp
+++ b/containers/src/impl/Kokkos_UnorderedMap_impl.cpp
@@ -69,9 +69,9 @@ uint32_t find_hash_size(uint32_t size) {
   const uint32_t num_primes = sizeof(primes) / sizeof(uint32_t);
 
   uint32_t hsize = primes[num_primes - 1];
-  for (uint32_t i = 0; i < num_primes; ++i) {
-    if (size <= primes[i]) {
-      hsize = primes[i];
+  for (auto prime : primes) {
+    if (size <= prime) {
+      hsize = prime;
       break;
     }
   }

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -187,7 +187,8 @@ inline void configure_shmem_preference(const CudaInternal* cuda_instance,
   // don't undershoot by much but also don't allocate a whole new block just
   // because one is a few threads over otherwise.
   size_t num_blocks_desired =
-      (num_threads_desired + block_size * 0.8) / block_size;
+      (num_threads_desired + static_cast<size_t>(block_size * 0.8)) /
+      block_size;
   num_blocks_desired = ::std::min(max_blocks_regs, num_blocks_desired);
   if (num_blocks_desired == 0) num_blocks_desired = 1;
 

--- a/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
@@ -42,7 +42,7 @@ constexpr unsigned shfl_all_mask = 0xffffffffu;
 // Since the logic with respect to value sizes, etc., is the same everywhere,
 // put it all in one place.
 template <class Derived>
-struct in_place_shfl_op {
+struct in_place_shfl_op {  // NOLINT(bugprone-crtp-constructor-accessibility)
   // CRTP boilerplate
   __device__ KOKKOS_IMPL_FORCEINLINE const Derived& self() const noexcept {
     return *static_cast<Derived const*>(this);

--- a/core/src/Cuda/Kokkos_Cuda_View.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_View.hpp
@@ -105,6 +105,12 @@ class ViewDataHandle<
   }
 
   KOKKOS_INLINE_FUNCTION
+  static handle_type const&& assign(handle_type const&& arg_handle,
+                                    track_type const& /* arg_tracker */) {
+    return std::move(arg_handle);
+  }
+
+  KOKKOS_INLINE_FUNCTION
   static handle_type const assign(handle_type const& arg_handle,
                                   size_t offset) {
     return handle_type(arg_handle, offset);

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -330,11 +330,12 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
       }
     }
 
+    WorkRange()                            = delete;
+    WorkRange& operator=(const WorkRange&) = delete;
+
    private:
     member_type m_begin;
     member_type m_end;
-    WorkRange();
-    WorkRange& operator=(const WorkRange&);
   };
 };
 
@@ -1156,23 +1157,21 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
                     !Kokkos::is_reducer_v<ReducerValueType>,
                 "Only a scalar return types are allowed!");
 
-  val = ReducerValueType{};
+  using execution_space = typename TeamHandle::execution_space;
+  val                   = ReducerValueType{};
   Impl::md_parallel_impl<Rank>(policy, lambda, val);
+  // NOLINTNEXTLINE(readability-simplify-boolean-expr)
   if constexpr (false
 #ifdef KOKKOS_ENABLE_CUDA
-                || std::is_same_v<typename TeamHandle::execution_space,
-                                  Kokkos::Cuda>
+                || std::is_same_v<execution_space, Kokkos::Cuda>
 #elif defined(KOKKOS_ENABLE_HIP)
-                || std::is_same_v<typename TeamHandle::execution_space,
-                                  Kokkos::HIP>
+                || std::is_same_v<execution_space, Kokkos::HIP>
 #elif defined(KOKKOS_ENABLE_SYCL)
-                || std::is_same_v<typename TeamHandle::execution_space,
-                                  Kokkos::SYCL>
+                || std::is_same_v<execution_space, Kokkos::SYCL>
 #endif
   )
     policy.team.vector_reduce(
-        Kokkos::Sum<ReducerValueType, typename TeamHandle::execution_space>{
-            val});
+        Kokkos::Sum<ReducerValueType, execution_space>{val});
 }
 
 template <typename Rank, typename TeamHandle, typename Lambda>
@@ -1192,25 +1191,22 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
                     !Kokkos::is_reducer_v<ReducerValueType>,
                 "Only a scalar return types are allowed!");
 
-  val = ReducerValueType{};
+  using execution_space = typename TeamHandle::execution_space;
+  val                   = ReducerValueType{};
   Impl::md_parallel_impl<Rank>(policy, lambda, val);
+  // NOLINTNEXTLINE(readability-simplify-boolean-expr)
   if constexpr (false
 #ifdef KOKKOS_ENABLE_CUDA
-                || std::is_same_v<typename TeamHandle::execution_space,
-                                  Kokkos::Cuda>
+                || std::is_same_v<execution_space, Kokkos::Cuda>
 #elif defined(KOKKOS_ENABLE_HIP)
-                || std::is_same_v<typename TeamHandle::execution_space,
-                                  Kokkos::HIP>
+                || std::is_same_v<execution_space, Kokkos::HIP>
 #elif defined(KOKKOS_ENABLE_SYCL)
-                || std::is_same_v<typename TeamHandle::execution_space,
-                                  Kokkos::SYCL>
+                || std::is_same_v<execution_space, Kokkos::SYCL>
 #endif
   )
     policy.team.vector_reduce(
-        Kokkos::Sum<ReducerValueType, typename TeamHandle::execution_space>{
-            val});
-  policy.team.team_reduce(
-      Kokkos::Sum<ReducerValueType, typename TeamHandle::execution_space>{val});
+        Kokkos::Sum<ReducerValueType, execution_space>{val});
+  policy.team.team_reduce(Kokkos::Sum<ReducerValueType, execution_space>{val});
 }
 
 template <typename Rank, typename TeamHandle, typename Lambda>

--- a/core/src/Kokkos_Tuners.hpp
+++ b/core/src/Kokkos_Tuners.hpp
@@ -201,7 +201,9 @@ template <class RootType, class Subtype>
 struct DimensionValueExtractor<ValueHierarchyNode<RootType, Subtype>> {
   static RootType get(const ValueHierarchyNode<RootType, Subtype>& dimension,
                       double fraction_to_traverse) {
-    size_t index = dimension.root_values.size() * fraction_to_traverse;
+    auto index =
+        static_cast<size_t>(static_cast<double>(dimension.root_values.size()) *
+                            fraction_to_traverse);
     return dimension.get_root_value(index);
   }
 };
@@ -237,7 +239,8 @@ struct GetMultidimensionalPoint<ValueHierarchyNode<ValueType, Subtype>, double,
       std::declval<std::tuple<ValueType>>(), std::declval<sub_tuple>()));
   static return_type build(const node_type& in, double fraction_to_traverse,
                            Indices... indices) {
-    size_t index         = in.sub_values.size() * fraction_to_traverse;
+    auto index = static_cast<size_t>(static_cast<double>(in.sub_values.size()) *
+                                     fraction_to_traverse);
     auto dimension_value = std::make_tuple(
         DimensionValueExtractor<node_type>::get(in, fraction_to_traverse));
     return std::tuple_cat(dimension_value,

--- a/core/src/Serial/Kokkos_Serial_Task.hpp
+++ b/core/src/Serial/Kokkos_Serial_Task.hpp
@@ -155,7 +155,7 @@ class TaskQueueSpecializationConstrained<
 
       queue->complete(task);
 
-    } while (1);
+    } while (true);
   }
 
   static void execute(scheduler_type const& scheduler) {

--- a/core/src/View/Kokkos_ViewAccessPreconditionsCheck.hpp
+++ b/core/src/View/Kokkos_ViewAccessPreconditionsCheck.hpp
@@ -52,16 +52,16 @@ struct RuntimeCheckBasicViewMemoryAccessViolation<MemorySpace, AccessSpace,
       if (tracker.has_record()) {
         strncat(err, tracker.template get_label<void>().c_str(), 128);
       } else {
-        strcat(err, "**UNMANAGED**");
+        strncat(err, "**UNMANAGED**", 24);
       }
     }))
 
     KOKKOS_IF_ON_DEVICE(({
-      strcat(err, "**UNAVAILABLE**");
+      strncat(err, "**UNAVAILABLE**", 24);
       (void)tracker;
     }))
 
-    strcat(err, "\")");
+    strncat(err, "\")", 4);
 
     Kokkos::abort(err);
   }

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -186,6 +186,7 @@ struct ViewValueFunctor {
   void functor_instantiate_workaround() {
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
     defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENMPTARGET)
+    // NOLINTNEXTLINE(readability-simplify-boolean-expr)
     if (false) {
       parallel_for_implementation<DestroyTag>();
     }

--- a/core/src/impl/Kokkos_ConcurrentBitset.hpp
+++ b/core/src/impl/Kokkos_ConcurrentBitset.hpp
@@ -129,7 +129,7 @@ struct concurrent_bitset {
     // There is a zero bit available somewhere,
     // now find the (first) available bit and set it.
 
-    while (1) {
+    while (true) {
       const uint32_t word = bit >> bits_per_int_lg2;
       const uint32_t mask = 1u << (bit & bits_per_int_mask);
       const uint32_t prev = Kokkos::atomic_fetch_or(
@@ -215,7 +215,7 @@ struct concurrent_bitset {
     // There is a zero bit available somewhere,
     // now find the (first) available bit and set it.
 
-    while (1) {
+    while (true) {
       const uint32_t word = bit >> bits_per_int_lg2;
       const uint32_t mask = 1u << (bit & bits_per_int_mask);
       const uint32_t prev = Kokkos::atomic_fetch_or(

--- a/core/src/impl/Kokkos_MultipleTaskQueue.hpp
+++ b/core/src/impl/Kokkos_MultipleTaskQueue.hpp
@@ -126,6 +126,7 @@ struct MultipleTaskQueueTeamEntry {
  public:
   KOKKOS_INLINE_FUNCTION
   MultipleTaskQueueTeamEntry() {
+    // NOLINTNEXTLINE(modernize-loop-convert)
     for (int iPriority = 0; iPriority < NumPriorities; ++iPriority) {
       for (int iType = 0; iType < 2; ++iType) {
         m_failed_heads[iPriority][iType] = nullptr;

--- a/core/src/impl/Kokkos_OptionalRef.hpp
+++ b/core/src/impl/Kokkos_OptionalRef.hpp
@@ -53,6 +53,7 @@ struct OptionalRef {
   KOKKOS_INLINE_FUNCTION
   // MSVC requires that this copy constructor is not defaulted
   // if there exists a (non-defaulted) volatile one.
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   OptionalRef& operator=(OptionalRef const& other) noexcept {
     m_value = other.m_value;
     return *this;

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -101,11 +101,13 @@ class SharedAllocationRecord<void, void> {
   int m_count;
   std::string m_label;
 
+ public:
   SharedAllocationRecord(SharedAllocationRecord&&)                 = delete;
   SharedAllocationRecord(const SharedAllocationRecord&)            = delete;
   SharedAllocationRecord& operator=(SharedAllocationRecord&&)      = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;
 
+ protected:
   /**\brief  Construct and insert into 'arg_root' tracking set.
    *         use_count is zero.
    */
@@ -234,7 +236,7 @@ class SharedAllocationRecordCommon : public SharedAllocationRecord<void, void> {
   static void deallocate(record_base_t* arg_rec);
 
  public:
-  ~SharedAllocationRecordCommon();
+  ~SharedAllocationRecordCommon() override;
   template <class ExecutionSpace>
   SharedAllocationRecordCommon(
       ExecutionSpace const& exec, MemorySpace const& space,
@@ -318,7 +320,7 @@ class HostInaccessibleSharedAllocationRecordCommon
   static void deallocate(record_base_t* arg_rec);
 
  public:
-  ~HostInaccessibleSharedAllocationRecordCommon();
+  ~HostInaccessibleSharedAllocationRecordCommon() override;
   template <class ExecutionSpace>
   HostInaccessibleSharedAllocationRecordCommon(
       ExecutionSpace const& exec, MemorySpace const& space,
@@ -481,11 +483,11 @@ class SharedAllocationRecord
             &Kokkos::Impl::deallocate<MemorySpace, DestroyFunctor>),
         m_destroy() {}
 
+ public:
   SharedAllocationRecord()                                         = delete;
   SharedAllocationRecord(const SharedAllocationRecord&)            = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;
 
- public:
   DestroyFunctor m_destroy;
 
   // Allocate with a zero use count.  Incrementing the use count from zero to

--- a/core/src/impl/Kokkos_SingleTaskQueue.hpp
+++ b/core/src/impl/Kokkos_SingleTaskQueue.hpp
@@ -102,6 +102,7 @@ class SingleTaskQueue
       : base_t(arg_memory_pool) {}
 
   ~SingleTaskQueue() {
+    // NOLINTNEXTLINE(modernize-loop-convert)
     for (int i_priority = 0; i_priority < NumQueue; ++i_priority) {
       KOKKOS_EXPECTS(m_ready_queues[i_priority][TaskTeam].empty());
       KOKKOS_EXPECTS(m_ready_queues[i_priority][TaskSingle].empty());
@@ -128,6 +129,7 @@ class SingleTaskQueue
     OptionalRef<task_base_type> return_value;
     // always loop in order of priority first, then prefer team tasks over
     // single tasks
+    // NOLINTNEXTLINE(modernize-loop-convert)
     for (int i_priority = 0; i_priority < NumQueue; ++i_priority) {
       // Check for a team task with this priority
       return_value = m_ready_queues[i_priority][TaskTeam].pop();

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -79,6 +79,7 @@ KOKKOS_INLINE_FUNCTION constexpr char *strncpy(char *dest, const char *src,
   if (count != 0) {
     char *d = dest;
     do {
+      // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
       if (char const c = (*d++ = *src++); c == '\0') {
         while (--count != 0) {
           *d++ = '\0';

--- a/core/src/impl/Kokkos_TaskQueue.hpp
+++ b/core/src/impl/Kokkos_TaskQueue.hpp
@@ -96,6 +96,7 @@ class TaskQueue : public TaskQueueBase {
 
   //----------------------------------------
 
+ public:
   ~TaskQueue();
   TaskQueue()                            = delete;
   TaskQueue(TaskQueue&&)                 = delete;
@@ -103,6 +104,7 @@ class TaskQueue : public TaskQueueBase {
   TaskQueue& operator=(TaskQueue&&)      = delete;
   TaskQueue& operator=(TaskQueue const&) = delete;
 
+ protected:
   TaskQueue(const memory_pool& arg_memory_pool);
 
   // Schedule a task

--- a/tpls/desul/include/desul/atomics/Compare_Exchange_GCC.hpp
+++ b/tpls/desul/include/desul/atomics/Compare_Exchange_GCC.hpp
@@ -21,11 +21,11 @@ template <class T>
 struct host_atomic_exchange_available_gcc {
   constexpr static bool value =
 #ifndef DESUL_HAVE_LIBATOMIC
-      ((sizeof(T) == 4 && alignof(T) == 4) ||
+      ((sizeof(T) == 4 && alignof(T) == 4) ||  // NOLINT(bugprone-sizeof-expression)
 #ifdef DESUL_HAVE_16BYTE_COMPARE_AND_SWAP
-       (sizeof(T) == 16 && alignof(T) == 16) ||
+       (sizeof(T) == 16 && alignof(T) == 16) ||  // NOLINT(bugprone-sizeof-expression)
 #endif
-       (sizeof(T) == 8 && alignof(T) == 8)) &&
+       (sizeof(T) == 8 && alignof(T) == 8)) &&  // NOLINT(bugprone-sizeof-expression)
 #endif
       std::is_trivially_copyable<T>::value;
 };

--- a/tpls/desul/include/desul/atomics/Lock_Array_CUDA.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Array_CUDA.hpp
@@ -117,10 +117,10 @@ inline static
     copy_cuda_lock_arrays_to_device() {
   static bool once = []() {
     cudaMemcpyToSymbol(CUDA_SPACE_ATOMIC_LOCKS_DEVICE,
-                       &CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h,
+                       (void*)&CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h,
                        sizeof(int32_t*));
     cudaMemcpyToSymbol(CUDA_SPACE_ATOMIC_LOCKS_NODE,
-                       &CUDA_SPACE_ATOMIC_LOCKS_NODE_h,
+                       (void*)&CUDA_SPACE_ATOMIC_LOCKS_NODE_h,
                        sizeof(int32_t*));
     return true;
   }();

--- a/tpls/mdspan/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/tpls/mdspan/include/experimental/__p0009_bits/layout_stride.hpp
@@ -196,6 +196,11 @@ struct layout_stride {
         return s;
       }
 
+      MDSPAN_INLINE_FUNCTION
+      static constexpr const strides_storage_t&& fill_strides(const strides_storage_t&& s) {
+        return std::move(s);
+      }
+
       template<class IntegralType>
       static constexpr const strides_storage_t fill_strides(const std::array<IntegralType,extents_type::rank()>& s) {
         return strides_storage_t{static_cast<index_type>(s[Idxs])...};
@@ -270,6 +275,7 @@ struct layout_stride {
 
     //--------------------------------------------------------------------------------
 
+    // NOLINTNEXTLINE(modernize-use-equals-default)
     MDSPAN_INLINE_FUNCTION constexpr mapping() noexcept
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : m_members{


### PR DESCRIPTION
Address various diagnostics emitted by Clang-Tidy with Clang 19 and IntelLLVM 2024.2.1. Use `NOLINT` where justified.