### PR TITLE
simd: remove nodiscard attributes

### DIFF
--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -18,16 +18,7 @@
 #define KOKKOS_SIMD_HPP
 
 #include <Kokkos_SIMD_Common.hpp>
-
-// suppress NVCC warnings with the [[nodiscard]] attribute on overloaded
-// operators implemented as hidden friends
-#if defined(KOKKOS_COMPILER_NVCC) && KOKKOS_COMPILER_NVCC < 1130
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wattributes"
-#endif
-
 #include <Kokkos_SIMD_Scalar.hpp>
-
 #include <Kokkos_Macros.hpp>
 
 // FIXME_OPENMPTARGET The device pass disables all compiler macros checked
@@ -68,10 +59,6 @@
 #endif
 #include <Kokkos_SIMD_NEON.hpp>
 #endif
-#endif
-
-#if defined(KOKKOS_COMPILER_NVCC) && KOKKOS_COMPILER_NVCC < 1130
-#pragma GCC diagnostic pop
 #endif
 
 #include <Kokkos_SIMD_Common_Math.hpp>

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -647,60 +647,59 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
-  operator-() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(
         _mm256_sub_pd(_mm256_set1_pd(0.0), static_cast<__m256d>(m_value)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm256_add_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm256_sub_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm256_mul_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm256_div_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_EQ_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_NEQ_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_GE_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_LE_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_GT_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_LT_OS));
   }
@@ -708,12 +707,12 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    copysign(Experimental::basic_simd<
-                 double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-             Experimental::basic_simd<
-                 double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+copysign(Experimental::basic_simd<
+             double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+         Experimental::basic_simd<
+             double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
   __m256d const sign_mask = _mm256_set1_pd(-0.0);
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
@@ -721,60 +720,60 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
                     _mm256_and_pd(sign_mask, static_cast<__m256d>(b))));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    abs(Experimental::basic_simd<
-        double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+abs(Experimental::basic_simd<
+    double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   __m256d const sign_mask = _mm256_set1_pd(-0.0);
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    floor(Experimental::basic_simd<
-          double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+floor(Experimental::basic_simd<
+      double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_round_pd(static_cast<__m256d>(a),
                       (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    ceil(Experimental::basic_simd<
-         double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+ceil(Experimental::basic_simd<
+     double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_round_pd(static_cast<__m256d>(a),
                       (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    round(Experimental::basic_simd<
-          double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+round(Experimental::basic_simd<
+      double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_round_pd(static_cast<__m256d>(a),
                       (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    trunc(Experimental::basic_simd<
-          double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+trunc(Experimental::basic_simd<
+      double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_round_pd(static_cast<__m256d>(a),
                       (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    sqrt(Experimental::basic_simd<
-         double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+sqrt(Experimental::basic_simd<
+     double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_sqrt_pd(static_cast<__m256d>(a)));
@@ -782,28 +781,28 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
 
 #ifdef __INTEL_COMPILER
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    cbrt(Experimental::basic_simd<
-         double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+cbrt(Experimental::basic_simd<
+     double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cbrt_pd(static_cast<__m256d>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    exp(Experimental::basic_simd<
-        double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+exp(Experimental::basic_simd<
+    double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_exp_pd(static_cast<__m256d>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    log(Experimental::basic_simd<
-        double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+log(Experimental::basic_simd<
+    double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_log_pd(static_cast<__m256d>(a)));
@@ -811,37 +810,37 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
 
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    fma(Experimental::basic_simd<
-            double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-        Experimental::basic_simd<
-            double, Experimental::simd_abi::avx2_fixed_size<4>> const& b,
-        Experimental::basic_simd<
-            double, Experimental::simd_abi::avx2_fixed_size<4>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+fma(Experimental::basic_simd<
+        double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+    Experimental::basic_simd<
+        double, Experimental::simd_abi::avx2_fixed_size<4>> const& b,
+    Experimental::basic_simd<
+        double, Experimental::simd_abi::avx2_fixed_size<4>> const& c) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_fmadd_pd(static_cast<__m256d>(a), static_cast<__m256d>(b),
                       static_cast<__m256d>(c)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    max(Experimental::basic_simd<
-            double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-        Experimental::basic_simd<
-            double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+max(Experimental::basic_simd<
+        double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+    Experimental::basic_simd<
+        double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_max_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    min(Experimental::basic_simd<
-            double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-        Experimental::basic_simd<
-            double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+min(Experimental::basic_simd<
+        double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+    Experimental::basic_simd<
+        double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_min_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
@@ -849,11 +848,11 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx2_fixed_size<4>>
-    condition(basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& a,
-              basic_simd<double, simd_abi::avx2_fixed_size<4>> const& b,
-              basic_simd<double, simd_abi::avx2_fixed_size<4>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<double, simd_abi::avx2_fixed_size<4>> condition(
+    basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& a,
+    basic_simd<double, simd_abi::avx2_fixed_size<4>> const& b,
+    basic_simd<double, simd_abi::avx2_fixed_size<4>> const& c) {
   return basic_simd<double, simd_abi::avx2_fixed_size<4>>(
       _mm256_blendv_pd(static_cast<__m256d>(c), static_cast<__m256d>(b),
                        static_cast<__m256d>(a)));
@@ -932,62 +931,61 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
-  operator-() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(_mm_sub_ps(_mm_set1_ps(0.0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm_add_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm_sub_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm_mul_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm_div_ps(lhs.m_value, rhs.m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm_cmpeq_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm_cmpneq_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm_cmpge_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm_cmple_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm_cmpgt_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm_cmplt_ps(lhs.m_value, rhs.m_value));
   }
 };
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    copysign(Experimental::basic_simd<
-                 float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-             Experimental::basic_simd<
-                 float, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+copysign(Experimental::basic_simd<
+             float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+         Experimental::basic_simd<
+             float, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
   __m128 const sign_mask = _mm_set1_ps(-0.0);
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
@@ -995,9 +993,9 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
                  _mm_and_ps(sign_mask, static_cast<__m128>(b))));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    abs(Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> abs(
+    Experimental::basic_simd<
         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   __m128 const sign_mask = _mm_set1_ps(-0.0);
   return Experimental::basic_simd<float,
@@ -1005,50 +1003,50 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
       _mm_andnot_ps(sign_mask, static_cast<__m128>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    floor(Experimental::basic_simd<
-          float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+floor(Experimental::basic_simd<
+      float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_round_ps(static_cast<__m128>(a),
                    (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    ceil(Experimental::basic_simd<
-         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+ceil(Experimental::basic_simd<
+     float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_round_ps(static_cast<__m128>(a),
                    (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    round(Experimental::basic_simd<
-          float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+round(Experimental::basic_simd<
+      float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_round_ps(static_cast<__m128>(a),
                    (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    trunc(Experimental::basic_simd<
-          float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+trunc(Experimental::basic_simd<
+      float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_round_ps(static_cast<__m128>(a),
                    (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    sqrt(Experimental::basic_simd<
-         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+sqrt(Experimental::basic_simd<
+     float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_sqrt_ps(static_cast<__m128>(a)));
@@ -1056,27 +1054,27 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
 
 #ifdef __INTEL_COMPILER
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    cbrt(Experimental::basic_simd<
-         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
+cbrt(Experimental::basic_simd<
+     float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_cbrt_ps(static_cast<__m128>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    exp(Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> exp(
+    Experimental::basic_simd<
         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_exp_ps(static_cast<__m128>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    log(Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> log(
+    Experimental::basic_simd<
         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
@@ -1085,37 +1083,37 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
 
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    fma(Experimental::basic_simd<
-            float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-        Experimental::basic_simd<
-            float, Experimental::simd_abi::avx2_fixed_size<4>> const& b,
-        Experimental::basic_simd<
-            float, Experimental::simd_abi::avx2_fixed_size<4>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> fma(
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx2_fixed_size<4>> const& b,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx2_fixed_size<4>> const& c) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_fmadd_ps(static_cast<__m128>(a), static_cast<__m128>(b),
                    static_cast<__m128>(c)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    max(Experimental::basic_simd<
-            float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-        Experimental::basic_simd<
-            float, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> max(
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_max_ps(static_cast<__m128>(a), static_cast<__m128>(b)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-    min(Experimental::basic_simd<
-            float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-        Experimental::basic_simd<
-            float, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> min(
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_min_ps(static_cast<__m128>(a), static_cast<__m128>(b)));
@@ -1123,11 +1121,11 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<4>>
-    condition(basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& a,
-              basic_simd<float, simd_abi::avx2_fixed_size<4>> const& b,
-              basic_simd<float, simd_abi::avx2_fixed_size<4>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::avx2_fixed_size<4>> condition(
+    basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& a,
+    basic_simd<float, simd_abi::avx2_fixed_size<4>> const& b,
+    basic_simd<float, simd_abi::avx2_fixed_size<4>> const& c) {
   return basic_simd<float, simd_abi::avx2_fixed_size<4>>(_mm_blendv_ps(
       static_cast<__m128>(c), static_cast<__m128>(b), static_cast<__m128>(a)));
 }
@@ -1210,55 +1208,54 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
-  operator-() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_add_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_sub_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_mul_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_div_ps(lhs.m_value, rhs.m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_EQ_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_NEQ_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_GE_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_LE_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_GT_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_LT_OS));
   }
@@ -1266,12 +1263,12 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    copysign(Experimental::basic_simd<
-                 float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
-             Experimental::basic_simd<
-                 float, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+copysign(Experimental::basic_simd<
+             float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
+         Experimental::basic_simd<
+             float, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
   __m256 const sign_mask = _mm256_set1_ps(-0.0);
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<8>>(
@@ -1279,9 +1276,9 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
                     _mm256_and_ps(sign_mask, static_cast<__m256>(b))));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    abs(Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> abs(
+    Experimental::basic_simd<
         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   __m256 const sign_mask = _mm256_set1_ps(-0.0);
   return Experimental::basic_simd<float,
@@ -1289,50 +1286,50 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
       _mm256_andnot_ps(sign_mask, static_cast<__m256>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    floor(Experimental::basic_simd<
-          float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+floor(Experimental::basic_simd<
+      float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_round_ps(static_cast<__m256>(a),
                       (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    ceil(Experimental::basic_simd<
-         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+ceil(Experimental::basic_simd<
+     float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_round_ps(static_cast<__m256>(a),
                       (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    round(Experimental::basic_simd<
-          float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+round(Experimental::basic_simd<
+      float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_round_ps(static_cast<__m256>(a),
                       (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    trunc(Experimental::basic_simd<
-          float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+trunc(Experimental::basic_simd<
+      float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_round_ps(static_cast<__m256>(a),
                       (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    sqrt(Experimental::basic_simd<
-         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+sqrt(Experimental::basic_simd<
+     float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_sqrt_ps(static_cast<__m256>(a)));
@@ -1340,27 +1337,27 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
 
 #ifdef __INTEL_COMPILER
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    cbrt(Experimental::basic_simd<
-         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+cbrt(Experimental::basic_simd<
+     float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_cbrt_ps(static_cast<__m256>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    exp(Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> exp(
+    Experimental::basic_simd<
         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_exp_ps(static_cast<__m256>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    log(Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> log(
+    Experimental::basic_simd<
         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<8>>(
@@ -1369,37 +1366,37 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
 
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    fma(Experimental::basic_simd<
-            float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
-        Experimental::basic_simd<
-            float, Experimental::simd_abi::avx2_fixed_size<8>> const& b,
-        Experimental::basic_simd<
-            float, Experimental::simd_abi::avx2_fixed_size<8>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> fma(
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx2_fixed_size<8>> const& b,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx2_fixed_size<8>> const& c) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_fmadd_ps(static_cast<__m256>(a), static_cast<__m256>(b),
                       static_cast<__m256>(c)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    max(Experimental::basic_simd<
-            float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
-        Experimental::basic_simd<
-            float, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> max(
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_max_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    min(Experimental::basic_simd<
-            float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
-        Experimental::basic_simd<
-            float, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> min(
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_min_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
@@ -1407,11 +1404,11 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<8>>
-    condition(basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& a,
-              basic_simd<float, simd_abi::avx2_fixed_size<8>> const& b,
-              basic_simd<float, simd_abi::avx2_fixed_size<8>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::avx2_fixed_size<8>> condition(
+    basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& a,
+    basic_simd<float, simd_abi::avx2_fixed_size<8>> const& b,
+    basic_simd<float, simd_abi::avx2_fixed_size<8>> const& c) {
   return basic_simd<float, simd_abi::avx2_fixed_size<8>>(_mm256_blendv_ps(
       static_cast<__m256>(c), static_cast<__m256>(b), static_cast<__m256>(a)));
 }
@@ -1507,64 +1504,64 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
     }
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm_add_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm_sub_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm_mullo_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm_sllv_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm_srav_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(_mm_srai_epi32(static_cast<__m128i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(_mm_slli_epi32(static_cast<__m128i>(lhs), rhs));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         _mm_cmpeq_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return (lhs > rhs) || (lhs == rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return (lhs < rhs) || (lhs == rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         _mm_cmplt_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         _mm_cmpgt_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
@@ -1572,7 +1569,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>>
 abs(Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
@@ -1582,37 +1579,37 @@ abs(Experimental::basic_simd<
       _mm_abs_epi32(rhs));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    floor(Experimental::basic_simd<
-          std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+floor(Experimental::basic_simd<
+      std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    ceil(Experimental::basic_simd<
-         std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+ceil(Experimental::basic_simd<
+     std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    round(Experimental::basic_simd<
-          std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+round(Experimental::basic_simd<
+      std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    trunc(Experimental::basic_simd<
-          std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+trunc(Experimental::basic_simd<
+      std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
@@ -1620,12 +1617,11 @@ abs(Experimental::basic_simd<
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
-    condition(
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a,
-        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& b,
-        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> condition(
+    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a,
+    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& b,
+    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& c) {
   return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
       _mm_castps_si128(
           _mm_blendv_ps(_mm_castsi128_ps(static_cast<__m128i>(c)),
@@ -1731,71 +1727,71 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
                                          static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_srav_epi32(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epi32(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return (lhs > rhs) || (lhs == rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return (lhs < rhs) || (lhs == rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpgt_epi32(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs >= rhs);
   }
 };
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>>
 abs(Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
@@ -1805,37 +1801,37 @@ abs(Experimental::basic_simd<
       _mm256_abs_epi32(rhs));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    floor(Experimental::basic_simd<
-          std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+floor(Experimental::basic_simd<
+      std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    ceil(Experimental::basic_simd<
-         std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+ceil(Experimental::basic_simd<
+     std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    round(Experimental::basic_simd<
-          std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+round(Experimental::basic_simd<
+      std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-    trunc(Experimental::basic_simd<
-          std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
+trunc(Experimental::basic_simd<
+      std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
@@ -1843,12 +1839,11 @@ abs(Experimental::basic_simd<
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
-    condition(
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& a,
-        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& b,
-        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> condition(
+    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& a,
+    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& b,
+    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& c) {
   return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(
       _mm256_castps_si256(
           _mm256_blendv_ps(_mm256_castsi256_ps(static_cast<__m256i>(c)),
@@ -1954,75 +1949,74 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
-  operator-() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(
         _mm256_sub_epi64(_mm256_set1_epi64x(0), static_cast<__m256i>(m_value)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
   // fallback basic_simd multiplication using generator constructor
   // multiplying vectors of 64-bit signed integers is not available in AVX2
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_sllv_epi64(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
   // fallback basic_simd shift right arithmetic using generator constructor
   // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd([&](std::size_t i) { return lhs[i] >> rhs[i]; });
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(_mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
   }
   // fallback basic_simd shift right arithmetic using generator constructor
   // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd([&](std::size_t i) { return lhs[i] >> rhs; });
   }
 
   // AVX2 only has eq and gt comparisons for int64
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epi64(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return (lhs > rhs) || (lhs == rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return (lhs < rhs) || (lhs == rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpgt_epi64(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return rhs > lhs;
   }
 };
@@ -2031,7 +2025,7 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
 
 // Manually computing absolute values, because _mm256_abs_epi64
 // is not in AVX2; it's available in AVX512.
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>>
 abs(Experimental::basic_simd<
     std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
@@ -2040,37 +2034,37 @@ abs(Experimental::basic_simd<
       [&](std::size_t i) { return (a[i] < 0) ? -a[i] : a[i]; });
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    floor(Experimental::basic_simd<
-          std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+floor(Experimental::basic_simd<
+      std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    ceil(Experimental::basic_simd<
-         std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+ceil(Experimental::basic_simd<
+     std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    round(Experimental::basic_simd<
-          std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+round(Experimental::basic_simd<
+      std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    trunc(Experimental::basic_simd<
-          std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+trunc(Experimental::basic_simd<
+      std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
@@ -2078,12 +2072,11 @@ abs(Experimental::basic_simd<
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
-    condition(
-        basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a,
-        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& b,
-        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> condition(
+    basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a,
+    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& b,
+    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& c) {
   return basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
       _mm256_castpd_si256(
           _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
@@ -2189,58 +2182,58 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
   // fallback basic_simd multiplication using generator constructor
   // multiplying vectors of 64-bit unsigned integers is not available in AVX2
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator&(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return _mm256_and_si256(static_cast<__m256i>(lhs),
                             static_cast<__m256i>(rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator|(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return _mm256_or_si256(static_cast<__m256i>(lhs),
                            static_cast<__m256i>(rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return _mm256_sllv_epi64(static_cast<__m256i>(lhs),
                              static_cast<__m256i>(rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return _mm256_srlv_epi64(static_cast<__m256i>(lhs),
                              static_cast<__m256i>(rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, int rhs) noexcept {
     return _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, int rhs) noexcept {
     return _mm256_srli_epi64(static_cast<__m256i>(lhs), rhs);
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epi64(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
 };
@@ -2253,44 +2246,44 @@ basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>>
 abs(Experimental::basic_simd<
     std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    floor(Experimental::basic_simd<
-          std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+floor(Experimental::basic_simd<
+      std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    ceil(Experimental::basic_simd<
-         std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+ceil(Experimental::basic_simd<
+     std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    round(Experimental::basic_simd<
-          std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+round(Experimental::basic_simd<
+      std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-    trunc(Experimental::basic_simd<
-          std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
+trunc(Experimental::basic_simd<
+      std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
@@ -2298,12 +2291,11 @@ abs(Experimental::basic_simd<
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
-    condition(
-        basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a,
-        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& b,
-        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> condition(
+    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a,
+    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& b,
+    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& c) {
   return basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
       _mm256_castpd_si256(
           _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
@@ -2358,13 +2350,12 @@ class const_where_expression<
     }
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2459,13 +2450,12 @@ class const_where_expression<
     }
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2560,13 +2550,12 @@ class const_where_expression<
     }
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2661,13 +2650,12 @@ class const_where_expression<
     }
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2765,13 +2753,12 @@ class const_where_expression<
     }
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2873,13 +2860,12 @@ class const_where_expression<
     }
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2982,13 +2968,12 @@ class const_where_expression<
     }
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -332,8 +332,7 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
     return _mm512_cvtsd_f64(tmp);
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
-  operator-() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(_mm512_sub_pd(_mm512_set1_pd(0.0), m_value));
   }
 
@@ -342,54 +341,54 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm512_add_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm512_sub_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm512_mul_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm512_div_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
                                         static_cast<__m512d>(rhs), _CMP_EQ_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(
         static_cast<__m512d>(lhs), static_cast<__m512d>(rhs), _CMP_NEQ_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(rhs),
                                         static_cast<__m512d>(lhs), _CMP_GE_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
                                         static_cast<__m512d>(rhs), _CMP_LE_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(rhs),
                                         static_cast<__m512d>(lhs), _CMP_GT_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
                                         static_cast<__m512d>(rhs), _CMP_LT_OS));
   }
@@ -397,7 +396,7 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 copysign(Experimental::basic_simd<
              double, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
@@ -416,7 +415,7 @@ copysign(Experimental::basic_simd<
               sign_mask, reinterpret_cast<__m512i>(static_cast<__m512d>(b))))));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 abs(Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -433,7 +432,7 @@ abs(Experimental::basic_simd<
 #endif
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 floor(Experimental::basic_simd<
       double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -443,7 +442,7 @@ floor(Experimental::basic_simd<
       _mm512_roundscale_pd(val, _MM_FROUND_TO_NEG_INF));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 ceil(Experimental::basic_simd<
      double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -453,7 +452,7 @@ ceil(Experimental::basic_simd<
       _mm512_roundscale_pd(val, _MM_FROUND_TO_POS_INF));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 round(Experimental::basic_simd<
       double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -463,7 +462,7 @@ round(Experimental::basic_simd<
       _mm512_roundscale_pd(val, _MM_FROUND_TO_NEAREST_INT));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 trunc(Experimental::basic_simd<
       double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -473,7 +472,7 @@ trunc(Experimental::basic_simd<
       _mm512_roundscale_pd(val, _MM_FROUND_TO_ZERO));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 sqrt(Experimental::basic_simd<
      double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -484,7 +483,7 @@ sqrt(Experimental::basic_simd<
 
 #ifdef __INTEL_COMPILER
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 cbrt(Experimental::basic_simd<
      double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -493,7 +492,7 @@ cbrt(Experimental::basic_simd<
       _mm512_cbrt_pd(static_cast<__m512d>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 exp(Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -502,7 +501,7 @@ exp(Experimental::basic_simd<
       _mm512_exp_pd(static_cast<__m512d>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 log(Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -513,7 +512,7 @@ log(Experimental::basic_simd<
 
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 fma(Experimental::basic_simd<
         double, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
@@ -527,7 +526,7 @@ fma(Experimental::basic_simd<
                       static_cast<__m512d>(c)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 max(Experimental::basic_simd<
         double, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
@@ -538,7 +537,7 @@ max(Experimental::basic_simd<
       _mm512_max_pd(static_cast<__m512d>(a), static_cast<__m512d>(b)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 min(Experimental::basic_simd<
         double, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
@@ -551,11 +550,11 @@ min(Experimental::basic_simd<
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx512_fixed_size<8>>
-    condition(basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& a,
-              basic_simd<double, simd_abi::avx512_fixed_size<8>> const& b,
-              basic_simd<double, simd_abi::avx512_fixed_size<8>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<double, simd_abi::avx512_fixed_size<8>> condition(
+    basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& a,
+    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& b,
+    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& c) {
   return basic_simd<double, simd_abi::avx512_fixed_size<8>>(
       _mm512_mask_blend_pd(static_cast<__mmask8>(a), static_cast<__m512d>(c),
                            static_cast<__m512d>(b)));
@@ -639,50 +638,49 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
-  operator-() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_add_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_sub_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_mul_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_div_ps(lhs.m_value, rhs.m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_EQ_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_NEQ_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GE_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LE_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GT_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LT_OS));
   }
 };
@@ -712,7 +710,7 @@ abs(Experimental::basic_simd<
       _mm256_andnot_ps(sign_mask, static_cast<__m256>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<8>>
 floor(Experimental::basic_simd<
       float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -722,7 +720,7 @@ floor(Experimental::basic_simd<
       _mm256_roundscale_ps(val, _MM_FROUND_TO_NEG_INF));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<8>>
 ceil(Experimental::basic_simd<
      float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -732,7 +730,7 @@ ceil(Experimental::basic_simd<
       _mm256_roundscale_ps(val, _MM_FROUND_TO_POS_INF));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<8>>
 round(Experimental::basic_simd<
       float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -742,7 +740,7 @@ round(Experimental::basic_simd<
       _mm256_roundscale_ps(val, _MM_FROUND_TO_NEAREST_INT));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<8>>
 trunc(Experimental::basic_simd<
       float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -926,50 +924,49 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
-  operator-() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(_mm512_sub_ps(_mm512_set1_ps(0.0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_add_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_sub_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_mul_ps(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_div_ps(lhs.m_value, rhs.m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_EQ_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_NEQ_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GE_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LE_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GT_OS));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LT_OS));
   }
 };
@@ -999,7 +996,7 @@ abs(Experimental::basic_simd<
       _mm512_andnot_ps(sign_mask, static_cast<__m512>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
 floor(Experimental::basic_simd<
       float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
@@ -1009,7 +1006,7 @@ floor(Experimental::basic_simd<
       _mm512_roundscale_ps(val, _MM_FROUND_TO_NEG_INF));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
 ceil(Experimental::basic_simd<
      float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
@@ -1019,7 +1016,7 @@ ceil(Experimental::basic_simd<
       _mm512_roundscale_ps(val, _MM_FROUND_TO_POS_INF));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
 round(Experimental::basic_simd<
       float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
@@ -1029,7 +1026,7 @@ round(Experimental::basic_simd<
       _mm512_roundscale_ps(val, _MM_FROUND_TO_NEAREST_INT));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
 trunc(Experimental::basic_simd<
       float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
@@ -1221,72 +1218,71 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
-  operator-() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(_mm256_sub_epi32(_mm256_set1_epi32(0), m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
         _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
         _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
                                          static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_srav_epi32(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epi32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpneq_epi32_mask(static_cast<__m256i>(lhs),
                                               static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmple_epi32_mask(static_cast<__m256i>(rhs),
                                              static_cast<__m256i>(lhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmple_epi32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmplt_epi32_mask(static_cast<__m256i>(rhs),
                                              static_cast<__m256i>(lhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmplt_epi32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
@@ -1294,7 +1290,7 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>>
 abs(Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -1304,7 +1300,7 @@ abs(Experimental::basic_simd<
       _mm256_abs_epi32(rhs));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 floor(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -1313,7 +1309,7 @@ floor(Experimental::basic_simd<
       _mm512_cvtepi32_pd(static_cast<__m256i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 ceil(Experimental::basic_simd<
      std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -1322,7 +1318,7 @@ ceil(Experimental::basic_simd<
       _mm512_cvtepi32_pd(static_cast<__m256i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 round(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -1331,7 +1327,7 @@ round(Experimental::basic_simd<
       _mm512_cvtepi32_pd(static_cast<__m256i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 trunc(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -1342,12 +1338,11 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
-    condition(
-        basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a,
-        basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& b,
-        basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> condition(
+    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a,
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& b,
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& c) {
   return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
                               static_cast<__m256i>(b)));
@@ -1451,8 +1446,7 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
 #endif
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
-  operator-() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(_mm512_sub_epi32(_mm512_set1_epi32(0), m_value));
   }
 
@@ -1461,67 +1455,67 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
         _mm512_add_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
         _mm512_sub_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
                                          static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_sllv_epi32(static_cast<__m512i>(lhs),
                                         static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(_mm512_slli_epi32(static_cast<__m512i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(_mm512_srai_epi32(static_cast<__m512i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_srav_epi32(static_cast<__m512i>(lhs),
                                         static_cast<__m512i>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpeq_epi32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpneq_epi32_mask(static_cast<__m512i>(lhs),
                                               static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmple_epi32_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmple_epi32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epi32_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epi32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
@@ -1529,7 +1523,7 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>>
 abs(Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
@@ -1539,7 +1533,7 @@ abs(Experimental::basic_simd<
       _mm512_abs_epi32(rhs));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
 floor(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
@@ -1548,7 +1542,7 @@ floor(Experimental::basic_simd<
       _mm512_cvtepi32_ps(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
 ceil(Experimental::basic_simd<
      std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
@@ -1557,7 +1551,7 @@ ceil(Experimental::basic_simd<
       _mm512_cvtepi32_ps(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
 round(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
@@ -1566,7 +1560,7 @@ round(Experimental::basic_simd<
       _mm512_cvtepi32_ps(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
 trunc(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
@@ -1577,12 +1571,11 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>
-    condition(
-        basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& a,
-        basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& b,
-        basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> condition(
+    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& a,
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& b,
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& c) {
   return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
       _mm512_mask_blend_epi32(static_cast<__mmask16>(a),
                               static_cast<__m512i>(c),
@@ -1687,67 +1680,67 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
                                          static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_srlv_epi32(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(_mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epu32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmpneq_epu32_mask(static_cast<__m256i>(lhs),
                                               static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(rhs),
                                              static_cast<__m256i>(lhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(rhs),
                                              static_cast<__m256i>(lhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
@@ -1755,14 +1748,14 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>>
 abs(Experimental::basic_simd<
     std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 floor(Experimental::basic_simd<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -1771,7 +1764,7 @@ floor(Experimental::basic_simd<
       _mm512_cvtepu32_pd(static_cast<__m256i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 ceil(Experimental::basic_simd<
      std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -1780,7 +1773,7 @@ ceil(Experimental::basic_simd<
       _mm512_cvtepu32_pd(static_cast<__m256i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 round(Experimental::basic_simd<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -1789,7 +1782,7 @@ round(Experimental::basic_simd<
       _mm512_cvtepu32_pd(static_cast<__m256i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 trunc(Experimental::basic_simd<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -1800,12 +1793,11 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
-    condition(
-        basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a,
-        basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& b,
-        basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> condition(
+    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a,
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& b,
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& c) {
   return basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
                               static_cast<__m256i>(b)));
@@ -1917,67 +1909,67 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm512_add_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm512_sub_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
                                          static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_sllv_epi32(static_cast<__m512i>(lhs),
                                         static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_srlv_epi32(static_cast<__m512i>(lhs),
                                         static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(_mm512_slli_epi32(static_cast<__m512i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(_mm512_srli_epi32(static_cast<__m512i>(lhs), rhs));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpeq_epu32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpneq_epu32_mask(static_cast<__m512i>(lhs),
                                               static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmple_epu32_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmple_epu32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epu32_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epu32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
@@ -1985,14 +1977,14 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>>
 abs(Experimental::basic_simd<
     std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
 floor(Experimental::basic_simd<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
@@ -2001,7 +1993,7 @@ floor(Experimental::basic_simd<
       _mm512_cvtepu32_ps(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
 ceil(Experimental::basic_simd<
      std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
@@ -2010,7 +2002,7 @@ ceil(Experimental::basic_simd<
       _mm512_cvtepu32_ps(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
 round(Experimental::basic_simd<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
@@ -2019,7 +2011,7 @@ round(Experimental::basic_simd<
       _mm512_cvtepu32_ps(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
 trunc(Experimental::basic_simd<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
@@ -2030,7 +2022,7 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::uint32_t, simd_abi::avx512_fixed_size<16>>
 condition(
     basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& a,
@@ -2125,8 +2117,7 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
     return tmp[i];
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
-  operator-() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(_mm512_sub_epi64(_mm512_set1_epi64(0), m_value));
   }
 
@@ -2135,67 +2126,67 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
                                          static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, basic_simd const& rhs) {
     return basic_simd(_mm512_sllv_epi64(static_cast<__m512i>(lhs),
                                         static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, basic_simd const& rhs) {
     return basic_simd(_mm512_srav_epi64(static_cast<__m512i>(lhs),
                                         static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, int rhs) {
     return basic_simd(_mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, int rhs) {
     return basic_simd(_mm512_srai_epi64(static_cast<__m512i>(lhs), rhs));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpeq_epi64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpneq_epi64_mask(static_cast<__m512i>(lhs),
                                               static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmple_epi64_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epi64_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmple_epi64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epi64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
@@ -2203,7 +2194,7 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>>
 abs(Experimental::basic_simd<
     std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -2213,7 +2204,7 @@ abs(Experimental::basic_simd<
       _mm512_abs_epi64(rhs));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 floor(Experimental::basic_simd<
       std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -2222,7 +2213,7 @@ floor(Experimental::basic_simd<
       _mm512_cvtepi64_pd(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 ceil(Experimental::basic_simd<
      std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -2231,7 +2222,7 @@ ceil(Experimental::basic_simd<
       _mm512_cvtepi64_pd(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 round(Experimental::basic_simd<
       std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -2240,7 +2231,7 @@ round(Experimental::basic_simd<
       _mm512_cvtepi64_pd(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 trunc(Experimental::basic_simd<
       std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -2251,12 +2242,11 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
-    condition(
-        basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a,
-        basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& b,
-        basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> condition(
+    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a,
+    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& b,
+    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& c) {
   return basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_mask_blend_epi64(static_cast<__mmask8>(a), static_cast<__m512i>(c),
                               static_cast<__m512i>(b)));
@@ -2350,77 +2340,77 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
                                          static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator&(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return _mm512_and_epi64(static_cast<__m512i>(lhs),
                             static_cast<__m512i>(rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator|(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return _mm512_or_epi64(static_cast<__m512i>(lhs),
                            static_cast<__m512i>(rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, int rhs) noexcept {
     return _mm512_srli_epi64(static_cast<__m512i>(lhs), rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return _mm512_srlv_epi64(static_cast<__m512i>(lhs),
                              static_cast<__m512i>(rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, int rhs) noexcept {
     return _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return _mm512_sllv_epi64(static_cast<__m512i>(lhs),
                              static_cast<__m512i>(rhs));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpeq_epu64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmpneq_epu64_mask(static_cast<__m512i>(lhs),
                                               static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmple_epu64_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmple_epu64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epu64_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epu64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
@@ -2428,14 +2418,14 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>>
 abs(Experimental::basic_simd<
     std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 floor(Experimental::basic_simd<
       std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -2444,7 +2434,7 @@ floor(Experimental::basic_simd<
       _mm512_cvtepu64_pd(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 ceil(Experimental::basic_simd<
      std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -2453,7 +2443,7 @@ ceil(Experimental::basic_simd<
       _mm512_cvtepu64_pd(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 round(Experimental::basic_simd<
       std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -2462,7 +2452,7 @@ round(Experimental::basic_simd<
       _mm512_cvtepu64_pd(static_cast<__m512i>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
 trunc(Experimental::basic_simd<
       std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
@@ -2473,12 +2463,11 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
-    condition(
-        basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a,
-        basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& b,
-        basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> condition(
+    basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a,
+    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& b,
+    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& c) {
   return basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_mask_blend_epi64(static_cast<__mmask8>(a), static_cast<__m512i>(c),
                               static_cast<__m512i>(b)));
@@ -2533,13 +2522,12 @@ class const_where_expression<
                               static_cast<__m512d>(m_value), 8);
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2626,13 +2614,12 @@ class const_where_expression<
                               static_cast<__m256>(m_value), 4);
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2720,13 +2707,12 @@ class const_where_expression<
                               static_cast<__m512>(m_value), 4);
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2814,13 +2800,12 @@ class const_where_expression<
                                  static_cast<__m256i>(m_value), 4);
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2911,13 +2896,12 @@ class const_where_expression<
                                  static_cast<__m512i>(m_value), 4);
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -3008,13 +2992,12 @@ class const_where_expression<
                                  static_cast<__m256i>(m_value), 4);
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -3106,13 +3089,12 @@ class const_where_expression<
                                  static_cast<__m512i>(m_value), 4);
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -3203,13 +3185,12 @@ class const_where_expression<
                                  static_cast<__m512i>(m_value), 8);
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -3302,13 +3283,12 @@ class const_where_expression<
                                  static_cast<__m512i>(m_value), 8);
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -3363,11 +3343,11 @@ class where_expression<
 };
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
-    hmax(const_where_expression<
-         basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-         basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t hmax(
+    const_where_expression<
+        basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+        basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<std::int32_t>::max();
   }
@@ -3377,7 +3357,7 @@ class where_expression<
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
     basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
     basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
         m) noexcept {
@@ -3390,11 +3370,11 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
-    hmin(const_where_expression<
-         basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-         basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t hmin(
+    const_where_expression<
+        basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+        basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<std::int32_t>::min();
   }
@@ -3404,7 +3384,7 @@ class where_expression<
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
     basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
     basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
         m) noexcept {
@@ -3416,7 +3396,7 @@ class where_expression<
       _mm512_castsi256_si512(static_cast<__m256i>(v)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
     basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
     basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
         m) noexcept {
@@ -3427,7 +3407,7 @@ class where_expression<
                                       static_cast<__m512i>(v));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
     basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
     basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
         m) noexcept {
@@ -3439,11 +3419,11 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
-    hmax(const_where_expression<
-         basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
-         basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t hmax(
+    const_where_expression<
+        basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+        basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<std::uint32_t>::max();
   }
@@ -3453,7 +3433,7 @@ class where_expression<
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
     basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& v,
     basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
         m) noexcept {
@@ -3466,11 +3446,11 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
-    hmin(const_where_expression<
-         basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
-         basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t hmin(
+    const_where_expression<
+        basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+        basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<std::uint32_t>::min();
   }
@@ -3480,7 +3460,7 @@ class where_expression<
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
     basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& v,
     basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
         m) noexcept {
@@ -3492,7 +3472,7 @@ class where_expression<
       _mm512_castsi256_si512(static_cast<__m256i>(v)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
     basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& v,
     basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
         m) noexcept {
@@ -3503,7 +3483,7 @@ class where_expression<
                                       static_cast<__m512i>(v));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
     basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& v,
     basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
         m) noexcept {
@@ -3515,11 +3495,11 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t
-    hmax(const_where_expression<
-         basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-         basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t hmax(
+    const_where_expression<
+        basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+        basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<std::int64_t>::max();
   }
@@ -3528,7 +3508,7 @@ class where_expression<
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce_max(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce_max(
     basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
     basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
         m) noexcept {
@@ -3540,11 +3520,11 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t
-    hmin(const_where_expression<
-         basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-         basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t hmin(
+    const_where_expression<
+        basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+        basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<std::int64_t>::min();
   }
@@ -3553,7 +3533,7 @@ class where_expression<
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce_min(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce_min(
     basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
     basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
         m) noexcept {
@@ -3565,11 +3545,11 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t
-    hmax(const_where_expression<
-         basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
-         basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t hmax(
+    const_where_expression<
+        basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+        basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<std::uint64_t>::max();
   }
@@ -3578,7 +3558,7 @@ class where_expression<
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce_max(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce_max(
     basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& v,
     basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
         m) noexcept {
@@ -3590,11 +3570,11 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t
-    hmin(const_where_expression<
-         basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
-         basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t hmin(
+    const_where_expression<
+        basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+        basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<std::uint64_t>::min();
   }
@@ -3603,7 +3583,7 @@ class where_expression<
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce_min(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce_min(
     basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& v,
     basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
         m) noexcept {
@@ -3615,11 +3595,11 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    double hmax(const_where_expression<
-                basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-                basic_simd<double, simd_abi::avx512_fixed_size<8>>> const& x) {
+KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+double hmax(const_where_expression<
+            basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+            basic_simd<double, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<double>::max();
   }
@@ -3628,7 +3608,7 @@ class where_expression<
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_max(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_max(
     basic_simd<double, simd_abi::avx512_fixed_size<8>> const& v,
     basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
   if (none_of(m)) {
@@ -3639,11 +3619,11 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    double hmin(const_where_expression<
-                basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-                basic_simd<double, simd_abi::avx512_fixed_size<8>>> const& x) {
+KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+double hmin(const_where_expression<
+            basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+            basic_simd<double, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<double>::min();
   }
@@ -3652,7 +3632,7 @@ class where_expression<
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_min(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_min(
     basic_simd<double, simd_abi::avx512_fixed_size<8>> const& v,
     basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
   if (none_of(m)) {
@@ -3663,11 +3643,11 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    float hmax(const_where_expression<
-               basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-               basic_simd<float, simd_abi::avx512_fixed_size<8>>> const& x) {
+KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+float hmax(const_where_expression<
+           basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+           basic_simd<float, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<float>::max();
   }
@@ -3677,7 +3657,7 @@ class where_expression<
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
     basic_simd<float, simd_abi::avx512_fixed_size<8>> const& v,
     basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> m) noexcept {
   if (none_of(m)) {
@@ -3688,11 +3668,11 @@ class where_expression<
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    float hmin(const_where_expression<
-               basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-               basic_simd<float, simd_abi::avx512_fixed_size<8>>> const& x) {
+KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+float hmin(const_where_expression<
+           basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+           basic_simd<float, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<float>::min();
   }
@@ -3702,7 +3682,7 @@ class where_expression<
 }
 #endif
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
     basic_simd<float, simd_abi::avx512_fixed_size<8>> const& v,
     basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
   if (none_of(m)) {
@@ -3712,7 +3692,7 @@ class where_expression<
       static_cast<__mmask8>(m), _mm512_castps256_ps512(static_cast<__m256>(v)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
     basic_simd<float, simd_abi::avx512_fixed_size<16>> const& v,
     basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> m) noexcept {
   if (none_of(m)) {
@@ -3722,7 +3702,7 @@ class where_expression<
                                    static_cast<__m512>(v));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
     basic_simd<float, simd_abi::avx512_fixed_size<16>> const& v,
     basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& m) noexcept {
   if (none_of(m)) {
@@ -3732,7 +3712,7 @@ class where_expression<
                                    static_cast<__m512>(v));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
     basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
     basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& m,
     std::int32_t identity, std::plus<>) noexcept {
@@ -3744,7 +3724,7 @@ class where_expression<
       _mm512_castsi256_si512(static_cast<__m256i>(v)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
     basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
     basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& m,
     std::int32_t identity, std::plus<>) noexcept {
@@ -3755,7 +3735,7 @@ class where_expression<
                                       static_cast<__m512i>(v));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce(
     basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
     basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& m,
     std::int64_t identity, std::plus<>) noexcept {
@@ -3766,7 +3746,7 @@ class where_expression<
                                       static_cast<__m512i>(v));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
     basic_simd<double, simd_abi::avx512_fixed_size<8>> const& v,
     basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& m,
     double identity, std::plus<>) noexcept {
@@ -3777,7 +3757,7 @@ class where_expression<
                                    static_cast<__m512d>(v));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
     basic_simd<float, simd_abi::avx512_fixed_size<8>> const& v,
     basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& m,
     float identity, std::plus<>) noexcept {
@@ -3788,7 +3768,7 @@ class where_expression<
       static_cast<__mmask8>(m), _mm512_castps256_ps512(static_cast<__m256>(v)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
     basic_simd<float, simd_abi::avx512_fixed_size<16>> const& v,
     basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& m,
     float identity, std::plus<>) noexcept {

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -104,7 +104,7 @@ class where_expression<bool, T> : public const_where_expression<bool, T> {
 };
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     where_expression<basic_simd_mask<T, Abi>, basic_simd<T, Abi>>
     where(typename basic_simd<T, Abi>::mask_type const& mask,
           basic_simd<T, Abi>& value) {
@@ -112,7 +112,7 @@ template <class T, class Abi>
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     const_where_expression<basic_simd_mask<T, Abi>, basic_simd<T, Abi>>
     where(typename basic_simd<T, Abi>::mask_type const& mask,
           basic_simd<T, Abi> const& value) {
@@ -120,13 +120,13 @@ template <class T, class Abi>
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION where_expression<bool, T> where(
-    bool mask, T& value) {
+KOKKOS_FORCEINLINE_FUNCTION where_expression<bool, T> where(bool mask,
+                                                            T& value) {
   return where_expression(mask, value);
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION const_where_expression<bool, T> where(
+KOKKOS_FORCEINLINE_FUNCTION const_where_expression<bool, T> where(
     bool mask, T const& value) {
   return const_where_expression(mask, value);
 }
@@ -139,7 +139,7 @@ template <class T>
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
     Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] + rhs);
   return Experimental::basic_simd<result_member, Abi>(lhs) +
@@ -148,7 +148,7 @@ template <class T, class U, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
     U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs + rhs[0]);
   return Experimental::basic_simd<result_member, Abi>(lhs) +
@@ -173,7 +173,7 @@ KOKKOS_FORCEINLINE_FUNCTION where_expression<M, T>& operator+=(
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
     Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] - rhs);
   return Experimental::basic_simd<result_member, Abi>(lhs) -
@@ -182,7 +182,7 @@ template <class T, class U, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
     U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs - rhs[0]);
   return Experimental::basic_simd<result_member, Abi>(lhs) -
@@ -207,7 +207,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION where_expression<M, T>& operator-=(
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
     Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] * rhs);
   return Experimental::basic_simd<result_member, Abi>(lhs) *
@@ -216,7 +216,7 @@ template <class T, class U, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
     U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs * rhs[0]);
   return Experimental::basic_simd<result_member, Abi>(lhs) *
@@ -241,7 +241,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION where_expression<M, T>& operator*=(
 
 template <class T, class Abi,
           std::enable_if_t<std::is_integral_v<T>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
     Experimental::basic_simd<T, Abi> const& lhs,
     Experimental::basic_simd<T, Abi> const& rhs) {
   return Experimental::basic_simd<T, Abi>(
@@ -250,7 +250,7 @@ template <class T, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
     Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] / rhs);
   return Experimental::basic_simd<result_member, Abi>(lhs) /
@@ -259,7 +259,7 @@ template <class T, class U, class Abi,
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
     U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs / rhs[0]);
   return Experimental::basic_simd<result_member, Abi>(lhs) /
@@ -303,16 +303,16 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator<<=(
 // implement mask reductions for type bool to allow generic code to accept
 // both basic_simd<double, Abi> and just double
 
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION bool all_of(bool a) { return a; }
+KOKKOS_FORCEINLINE_FUNCTION bool all_of(bool a) { return a; }
 
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION bool any_of(bool a) { return a; }
+KOKKOS_FORCEINLINE_FUNCTION bool any_of(bool a) { return a; }
 
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION bool none_of(bool a) { return !a; }
+KOKKOS_FORCEINLINE_FUNCTION bool none_of(bool a) { return !a; }
 
 // fallback implementations of reductions across basic_simd_mask:
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool all_of(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool all_of(
     basic_simd_mask<T, Abi> const& a) {
   for (size_t i = 0; i < basic_simd_mask<T, Abi>::size(); ++i) {
     if (!a[i]) return false;
@@ -321,7 +321,7 @@ template <class T, class Abi>
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool any_of(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool any_of(
     basic_simd_mask<T, Abi> const& a) {
   for (size_t i = 0; i < basic_simd_mask<T, Abi>::size(); ++i) {
     if (a[i]) return true;
@@ -330,15 +330,14 @@ template <class T, class Abi>
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool none_of(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool none_of(
     basic_simd_mask<T, Abi> const& a) {
   return !any_of(a);
 }
 
 // A temporary device-callable implemenation of round half to nearest even
 template <typename T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION auto round_half_to_nearest_even(
-    T const& x) {
+KOKKOS_FORCEINLINE_FUNCTION auto round_half_to_nearest_even(T const& x) {
   auto ceil  = Kokkos::ceil(x);
   auto floor = Kokkos::floor(x);
 
@@ -375,20 +374,20 @@ struct Identity {
 
 // common implementations of host only simd reductions:
 template <class T, class Abi, class BinaryOperation = std::plus<>>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-reduce(const basic_simd<T, Abi>& x, BinaryOperation binary_op = {}) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T reduce(const basic_simd<T, Abi>& x,
+                                               BinaryOperation binary_op = {}) {
   return reduce(x, typename basic_simd<T, Abi>::mask_type(true),
                 T(Impl::Identity<T, BinaryOperation>()), binary_op);
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 reduce_min(const basic_simd<T, Abi>& x) noexcept {
   return reduce_min(x, typename basic_simd<T, Abi>::mask_type(true));
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 reduce_max(const basic_simd<T, Abi>& x) noexcept {
   return reduce_max(x, typename basic_simd<T, Abi>::mask_type(true));
 }

--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -38,8 +38,8 @@ class const_where_expression;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <typename T, typename Abi>
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead")
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead")
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
     hmin(const_where_expression<basic_simd_mask<T, Abi>,
                                 basic_simd<T, Abi>> const& x) {
   auto const& v = x.impl_get_value();
@@ -52,8 +52,8 @@ template <typename T, typename Abi>
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead")
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead")
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
     hmax(const_where_expression<basic_simd_mask<T, Abi>,
                                 basic_simd<T, Abi>> const& x) {
   auto const& v = x.impl_get_value();
@@ -69,7 +69,7 @@ template <class T, class Abi>
 template <
     typename T, typename Abi,
     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 reduce_min(basic_simd<T, Abi> const& v,
            typename basic_simd<T, Abi>::mask_type const& m) {
   auto result = Kokkos::reduction_identity<T>::min();
@@ -82,7 +82,7 @@ reduce_min(basic_simd<T, Abi> const& v,
 template <
     class T, class Abi,
     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 reduce_max(basic_simd<T, Abi> const& v,
            typename basic_simd<T, Abi>::mask_type const& m) {
   auto result = Kokkos::reduction_identity<T>::max();
@@ -95,7 +95,7 @@ reduce_max(basic_simd<T, Abi> const& v,
 template <
     class T, class Abi, class BinaryOperation = std::plus<>,
     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 reduce(basic_simd<T, Abi> const& v,
        typename basic_simd<T, Abi>::mask_type const& m, T identity,
        BinaryOperation op = {}) {
@@ -114,10 +114,9 @@ reduce(basic_simd<T, Abi> const& v,
 template <class T, class Abi,
           std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,
                            bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<T, Abi>
-    min(Experimental::basic_simd<T, Abi> const& a,
-        Experimental::basic_simd<T, Abi> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> min(
+    Experimental::basic_simd<T, Abi> const& a,
+    Experimental::basic_simd<T, Abi> const& b) {
   Experimental::basic_simd<T, Abi> result;
   T vals[Experimental::basic_simd<T, Abi>::size()] = {0};
   for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size(); ++i) {
@@ -130,7 +129,7 @@ template <class T, class Abi,
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 namespace Experimental {
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     Experimental::basic_simd<T, Abi>
     min(Experimental::basic_simd<T, Abi> const& a,
         Experimental::basic_simd<T, Abi> const& b) {
@@ -142,10 +141,9 @@ template <class T, class Abi>
 template <class T, class Abi,
           std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,
                            bool> = false>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<T, Abi>
-    max(Experimental::basic_simd<T, Abi> const& a,
-        Experimental::basic_simd<T, Abi> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> max(
+    Experimental::basic_simd<T, Abi> const& a,
+    Experimental::basic_simd<T, Abi> const& b) {
   Experimental::basic_simd<T, Abi> result;
   T vals[Experimental::basic_simd<T, Abi>::size()] = {0};
   for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size(); ++i) {
@@ -158,7 +156,7 @@ template <class T, class Abi,
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 namespace Experimental {
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     Experimental::basic_simd<T, Abi>
     max(Experimental::basic_simd<T, Abi> const& a,
         Experimental::basic_simd<T, Abi> const& b) {
@@ -172,66 +170,61 @@ template <class T, class Abi>
 // implementations.
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-#define KOKKOS_IMPL_SIMD_UNARY_FUNCTION(FUNC)                                \
-  template <                                                                 \
-      class T, class Abi,                                                    \
-      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>, \
-                       bool> = false>                                        \
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION                        \
-      Experimental::basic_simd<T, Abi>                                       \
-      FUNC(Experimental::basic_simd<T, Abi> const& a) {                      \
-    Experimental::basic_simd<T, Abi> result;                                 \
-    T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                  \
-    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
-         ++i) {                                                              \
-      vals[i] = Kokkos::FUNC(a[i]);                                          \
-    }                                                                        \
-    result.copy_from(vals, Kokkos::Experimental::simd_flag_default);         \
-    return result;                                                           \
-  }                                                                          \
-  template <                                                                 \
-      class T, class Abi,                                                    \
-      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
-                       bool> = false>                                        \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::         \
-      basic_simd<T, Abi>                                                     \
-      FUNC(Experimental::basic_simd<T, Abi> const& a) {                      \
-    return Kokkos::FUNC(a[0]);                                               \
-  }                                                                          \
-  namespace Experimental {                                                   \
-  template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION      \
-      basic_simd<T, Abi>                                                     \
-      FUNC(basic_simd<T, Abi> const& a) {                                    \
-    return Kokkos::FUNC(a);                                                  \
-  }                                                                          \
+#define KOKKOS_IMPL_SIMD_UNARY_FUNCTION(FUNC)                                  \
+  template <                                                                   \
+      class T, class Abi,                                                      \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
+                       bool> = false>                                          \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> FUNC( \
+      Experimental::basic_simd<T, Abi> const& a) {                             \
+    Experimental::basic_simd<T, Abi> result;                                   \
+    T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                    \
+    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();      \
+         ++i) {                                                                \
+      vals[i] = Kokkos::FUNC(a[i]);                                            \
+    }                                                                          \
+    result.copy_from(vals, Kokkos::Experimental::simd_flag_default);           \
+    return result;                                                             \
+  }                                                                            \
+  template <                                                                   \
+      class T, class Abi,                                                      \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,    \
+                       bool> = false>                                          \
+  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<T, Abi> FUNC( \
+      Experimental::basic_simd<T, Abi> const& a) {                             \
+    return Kokkos::FUNC(a[0]);                                                 \
+  }                                                                            \
+  namespace Experimental {                                                     \
+  template <class T, class Abi>                                                \
+  KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>   \
+  FUNC(basic_simd<T, Abi> const& a) {                                          \
+    return Kokkos::FUNC(a);                                                    \
+  }                                                                            \
   }
 #else
-#define KOKKOS_IMPL_SIMD_UNARY_FUNCTION(FUNC)                                \
-  template <                                                                 \
-      class T, class Abi,                                                    \
-      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>, \
-                       bool> = false>                                        \
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION                        \
-      Experimental::basic_simd<T, Abi>                                       \
-      FUNC(Experimental::basic_simd<T, Abi> const& a) {                      \
-    Experimental::basic_simd<T, Abi> result;                                 \
-    T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                  \
-    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
-         ++i) {                                                              \
-      vals[i] = Kokkos::FUNC(a[i]);                                          \
-    }                                                                        \
-    result.copy_from(vals, Kokkos::Experimental::simd_flag_default);         \
-    return result;                                                           \
-  }                                                                          \
-  template <                                                                 \
-      class T, class Abi,                                                    \
-      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
-                       bool> = false>                                        \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::         \
-      basic_simd<T, Abi>                                                     \
-      FUNC(Experimental::basic_simd<T, Abi> const& a) {                      \
-    return Kokkos::FUNC(a[0]);                                               \
+#define KOKKOS_IMPL_SIMD_UNARY_FUNCTION(FUNC)                                  \
+  template <                                                                   \
+      class T, class Abi,                                                      \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
+                       bool> = false>                                          \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> FUNC( \
+      Experimental::basic_simd<T, Abi> const& a) {                             \
+    Experimental::basic_simd<T, Abi> result;                                   \
+    T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                    \
+    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();      \
+         ++i) {                                                                \
+      vals[i] = Kokkos::FUNC(a[i]);                                            \
+    }                                                                          \
+    result.copy_from(vals, Kokkos::Experimental::simd_flag_default);           \
+    return result;                                                             \
+  }                                                                            \
+  template <                                                                   \
+      class T, class Abi,                                                      \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,    \
+                       bool> = false>                                          \
+  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<T, Abi> FUNC( \
+      Experimental::basic_simd<T, Abi> const& a) {                             \
+    return Kokkos::FUNC(a[0]);                                                 \
   }
 #endif
 
@@ -261,70 +254,65 @@ KOKKOS_IMPL_SIMD_UNARY_FUNCTION(tgamma)
 KOKKOS_IMPL_SIMD_UNARY_FUNCTION(lgamma)
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-#define KOKKOS_IMPL_SIMD_BINARY_FUNCTION(FUNC)                               \
-  template <                                                                 \
-      class T, class Abi,                                                    \
-      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>, \
-                       bool> = false>                                        \
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION                        \
-      Experimental::basic_simd<T, Abi>                                       \
-      FUNC(Experimental::basic_simd<T, Abi> const& a,                        \
-           Experimental::basic_simd<T, Abi> const& b) {                      \
-    Experimental::basic_simd<T, Abi> result;                                 \
-    T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                  \
-    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
-         ++i) {                                                              \
-      vals[i] = Kokkos::FUNC(a[i], b[i]);                                    \
-    }                                                                        \
-    result.copy_from(vals, Kokkos::Experimental::simd_flag_default);         \
-    return result;                                                           \
-  }                                                                          \
-  template <                                                                 \
-      class T, class Abi,                                                    \
-      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
-                       bool> = false>                                        \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::         \
-      basic_simd<T, Abi>                                                     \
-      FUNC(Experimental::basic_simd<T, Abi> const& a,                        \
-           Experimental::basic_simd<T, Abi> const& b) {                      \
-    return Kokkos::FUNC(a[0], b[0]);                                         \
-  }                                                                          \
-  namespace Experimental {                                                   \
-  template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION      \
-      basic_simd<T, Abi>                                                     \
-      FUNC(basic_simd<T, Abi> const& a, basic_simd<T, Abi> const& b) {       \
-    return Kokkos::FUNC(a, b);                                               \
-  }                                                                          \
+#define KOKKOS_IMPL_SIMD_BINARY_FUNCTION(FUNC)                                 \
+  template <                                                                   \
+      class T, class Abi,                                                      \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
+                       bool> = false>                                          \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> FUNC( \
+      Experimental::basic_simd<T, Abi> const& a,                               \
+      Experimental::basic_simd<T, Abi> const& b) {                             \
+    Experimental::basic_simd<T, Abi> result;                                   \
+    T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                    \
+    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();      \
+         ++i) {                                                                \
+      vals[i] = Kokkos::FUNC(a[i], b[i]);                                      \
+    }                                                                          \
+    result.copy_from(vals, Kokkos::Experimental::simd_flag_default);           \
+    return result;                                                             \
+  }                                                                            \
+  template <                                                                   \
+      class T, class Abi,                                                      \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,    \
+                       bool> = false>                                          \
+  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<T, Abi> FUNC( \
+      Experimental::basic_simd<T, Abi> const& a,                               \
+      Experimental::basic_simd<T, Abi> const& b) {                             \
+    return Kokkos::FUNC(a[0], b[0]);                                           \
+  }                                                                            \
+  namespace Experimental {                                                     \
+  template <class T, class Abi>                                                \
+  KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>   \
+  FUNC(basic_simd<T, Abi> const& a, basic_simd<T, Abi> const& b) {             \
+    return Kokkos::FUNC(a, b);                                                 \
+  }                                                                            \
   }
 #else
-#define KOKKOS_IMPL_SIMD_BINARY_FUNCTION(FUNC)                               \
-  template <                                                                 \
-      class T, class Abi,                                                    \
-      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>, \
-                       bool> = false>                                        \
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION                        \
-      Experimental::basic_simd<T, Abi>                                       \
-      FUNC(Experimental::basic_simd<T, Abi> const& a,                        \
-           Experimental::basic_simd<T, Abi> const& b) {                      \
-    Experimental::basic_simd<T, Abi> result;                                 \
-    T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                  \
-    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
-         ++i) {                                                              \
-      vals[i] = Kokkos::FUNC(a[i], b[i]);                                    \
-    }                                                                        \
-    result.copy_from(vals, Kokkos::Experimental::simd_flag_default);         \
-    return result;                                                           \
-  }                                                                          \
-  template <                                                                 \
-      class T, class Abi,                                                    \
-      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
-                       bool> = false>                                        \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::         \
-      basic_simd<T, Abi>                                                     \
-      FUNC(Experimental::basic_simd<T, Abi> const& a,                        \
-           Experimental::basic_simd<T, Abi> const& b) {                      \
-    return Kokkos::FUNC(a[0], b[0]);                                         \
+#define KOKKOS_IMPL_SIMD_BINARY_FUNCTION(FUNC)                                 \
+  template <                                                                   \
+      class T, class Abi,                                                      \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
+                       bool> = false>                                          \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> FUNC( \
+      Experimental::basic_simd<T, Abi> const& a,                               \
+      Experimental::basic_simd<T, Abi> const& b) {                             \
+    Experimental::basic_simd<T, Abi> result;                                   \
+    T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                    \
+    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();      \
+         ++i) {                                                                \
+      vals[i] = Kokkos::FUNC(a[i], b[i]);                                      \
+    }                                                                          \
+    result.copy_from(vals, Kokkos::Experimental::simd_flag_default);           \
+    return result;                                                             \
+  }                                                                            \
+  template <                                                                   \
+      class T, class Abi,                                                      \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,    \
+                       bool> = false>                                          \
+  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<T, Abi> FUNC( \
+      Experimental::basic_simd<T, Abi> const& a,                               \
+      Experimental::basic_simd<T, Abi> const& b) {                             \
+    return Kokkos::FUNC(a[0], b[0]);                                           \
   }
 #endif
 
@@ -334,75 +322,70 @@ KOKKOS_IMPL_SIMD_BINARY_FUNCTION(atan2)
 KOKKOS_IMPL_SIMD_BINARY_FUNCTION(copysign)
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-#define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                              \
-  template <                                                                 \
-      class T, class Abi,                                                    \
-      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>, \
-                       bool> = false>                                        \
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION                        \
-      Experimental::basic_simd<T, Abi>                                       \
-      FUNC(Experimental::basic_simd<T, Abi> const& a,                        \
-           Experimental::basic_simd<T, Abi> const& b,                        \
-           Experimental::basic_simd<T, Abi> const& c) {                      \
-    Experimental::basic_simd<T, Abi> result;                                 \
-    T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                  \
-    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
-         ++i) {                                                              \
-      vals[i] = Kokkos::FUNC(a[i], b[i], c[i]);                              \
-    }                                                                        \
-    result.copy_from(vals, Kokkos::Experimental::simd_flag_default);         \
-    return result;                                                           \
-  }                                                                          \
-  template <                                                                 \
-      class T, class Abi,                                                    \
-      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
-                       bool> = false>                                        \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::         \
-      basic_simd<T, Abi>                                                     \
-      FUNC(Experimental::basic_simd<T, Abi> const& a,                        \
-           Experimental::basic_simd<T, Abi> const& b,                        \
-           Experimental::basic_simd<T, Abi> const& c) {                      \
-    return Kokkos::FUNC(a[0], b[0], c[0]);                                   \
-  }                                                                          \
-  namespace Experimental {                                                   \
-  template <class T, class Abi>                                              \
-  [[nodiscard]] KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION      \
-      basic_simd<T, Abi>                                                     \
-      FUNC(basic_simd<T, Abi> const& a, basic_simd<T, Abi> const& b,         \
-           basic_simd<T, Abi> const& c) {                                    \
-    return Kokkos::FUNC(a, b, c);                                            \
-  }                                                                          \
+#define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                                \
+  template <                                                                   \
+      class T, class Abi,                                                      \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
+                       bool> = false>                                          \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> FUNC( \
+      Experimental::basic_simd<T, Abi> const& a,                               \
+      Experimental::basic_simd<T, Abi> const& b,                               \
+      Experimental::basic_simd<T, Abi> const& c) {                             \
+    Experimental::basic_simd<T, Abi> result;                                   \
+    T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                    \
+    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();      \
+         ++i) {                                                                \
+      vals[i] = Kokkos::FUNC(a[i], b[i], c[i]);                                \
+    }                                                                          \
+    result.copy_from(vals, Kokkos::Experimental::simd_flag_default);           \
+    return result;                                                             \
+  }                                                                            \
+  template <                                                                   \
+      class T, class Abi,                                                      \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,    \
+                       bool> = false>                                          \
+  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<T, Abi> FUNC( \
+      Experimental::basic_simd<T, Abi> const& a,                               \
+      Experimental::basic_simd<T, Abi> const& b,                               \
+      Experimental::basic_simd<T, Abi> const& c) {                             \
+    return Kokkos::FUNC(a[0], b[0], c[0]);                                     \
+  }                                                                            \
+  namespace Experimental {                                                     \
+  template <class T, class Abi>                                                \
+  KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>   \
+  FUNC(basic_simd<T, Abi> const& a, basic_simd<T, Abi> const& b,               \
+       basic_simd<T, Abi> const& c) {                                          \
+    return Kokkos::FUNC(a, b, c);                                              \
+  }                                                                            \
   }
 #else
-#define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                              \
-  template <                                                                 \
-      class T, class Abi,                                                    \
-      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>, \
-                       bool> = false>                                        \
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION                        \
-      Experimental::basic_simd<T, Abi>                                       \
-      FUNC(Experimental::basic_simd<T, Abi> const& a,                        \
-           Experimental::basic_simd<T, Abi> const& b,                        \
-           Experimental::basic_simd<T, Abi> const& c) {                      \
-    Experimental::basic_simd<T, Abi> result;                                 \
-    T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                  \
-    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();    \
-         ++i) {                                                              \
-      vals[i] = Kokkos::FUNC(a[i], b[i], c[i]);                              \
-    }                                                                        \
-    result.copy_from(vals, Kokkos::Experimental::simd_flag_default);         \
-    return result;                                                           \
-  }                                                                          \
-  template <                                                                 \
-      class T, class Abi,                                                    \
-      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
-                       bool> = false>                                        \
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::         \
-      basic_simd<T, Abi>                                                     \
-      FUNC(Experimental::basic_simd<T, Abi> const& a,                        \
-           Experimental::basic_simd<T, Abi> const& b,                        \
-           Experimental::basic_simd<T, Abi> const& c) {                      \
-    return Kokkos::FUNC(a[0], b[0], c[0]);                                   \
+#define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                                \
+  template <                                                                   \
+      class T, class Abi,                                                      \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
+                       bool> = false>                                          \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> FUNC( \
+      Experimental::basic_simd<T, Abi> const& a,                               \
+      Experimental::basic_simd<T, Abi> const& b,                               \
+      Experimental::basic_simd<T, Abi> const& c) {                             \
+    Experimental::basic_simd<T, Abi> result;                                   \
+    T vals[Experimental::basic_simd<T, Abi>::size()] = {0};                    \
+    for (std::size_t i = 0; i < Experimental::basic_simd<T, Abi>::size();      \
+         ++i) {                                                                \
+      vals[i] = Kokkos::FUNC(a[i], b[i], c[i]);                                \
+    }                                                                          \
+    result.copy_from(vals, Kokkos::Experimental::simd_flag_default);           \
+    return result;                                                             \
+  }                                                                            \
+  template <                                                                   \
+      class T, class Abi,                                                      \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,    \
+                       bool> = false>                                          \
+  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<T, Abi> FUNC( \
+      Experimental::basic_simd<T, Abi> const& a,                               \
+      Experimental::basic_simd<T, Abi> const& b,                               \
+      Experimental::basic_simd<T, Abi> const& c) {                             \
+    return Kokkos::FUNC(a[0], b[0], c[0]);                                     \
   }
 #endif
 

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -456,8 +456,7 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
     }
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
-  operator-() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(vnegq_f64(m_value));
   }
 
@@ -466,54 +465,54 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(vaddq_f64(static_cast<float64x2_t>(lhs),
                                 static_cast<float64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(vsubq_f64(static_cast<float64x2_t>(lhs),
                                 static_cast<float64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(vmulq_f64(static_cast<float64x2_t>(lhs),
                                 static_cast<float64x2_t>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(vdivq_f64(static_cast<float64x2_t>(lhs),
                                 static_cast<float64x2_t>(rhs)));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vceqq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(operator==(lhs, rhs));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcgeq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcleq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcgtq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcltq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
@@ -521,57 +520,57 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    abs(Experimental::basic_simd<
-        double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+abs(Experimental::basic_simd<
+    double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vabsq_f64(static_cast<float64x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    floor(Experimental::basic_simd<
-          double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+floor(Experimental::basic_simd<
+      double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vrndmq_f64(static_cast<float64x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    ceil(Experimental::basic_simd<
-         double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+ceil(Experimental::basic_simd<
+     double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vrndpq_f64(static_cast<float64x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    round(Experimental::basic_simd<
-          double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+round(Experimental::basic_simd<
+      double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vrndxq_f64(static_cast<float64x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    trunc(Experimental::basic_simd<
-          double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+trunc(Experimental::basic_simd<
+      double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vrndq_f64(static_cast<float64x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    copysign(Experimental::basic_simd<
-                 double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-             Experimental::basic_simd<
-                 double, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+copysign(Experimental::basic_simd<
+             double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
+         Experimental::basic_simd<
+             double, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
   uint64x2_t const sign_mask = vreinterpretq_u64_f64(vmovq_n_f64(-0.0));
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
@@ -581,46 +580,46 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
                     vreinterpretq_u64_f64(static_cast<float64x2_t>(b))))));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    sqrt(Experimental::basic_simd<
-         double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+sqrt(Experimental::basic_simd<
+     double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vsqrtq_f64(static_cast<float64x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    fma(Experimental::basic_simd<
-            double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-        Experimental::basic_simd<
-            double, Experimental::simd_abi::neon_fixed_size<2>> const& b,
-        Experimental::basic_simd<
-            double, Experimental::simd_abi::neon_fixed_size<2>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+fma(Experimental::basic_simd<
+        double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
+    Experimental::basic_simd<
+        double, Experimental::simd_abi::neon_fixed_size<2>> const& b,
+    Experimental::basic_simd<
+        double, Experimental::simd_abi::neon_fixed_size<2>> const& c) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vfmaq_f64(static_cast<float64x2_t>(c), static_cast<float64x2_t>(b),
                 static_cast<float64x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    max(Experimental::basic_simd<
-            double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-        Experimental::basic_simd<
-            double, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+max(Experimental::basic_simd<
+        double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
+    Experimental::basic_simd<
+        double, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vmaxq_f64(static_cast<float64x2_t>(a), static_cast<float64x2_t>(b)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-    min(Experimental::basic_simd<
-            double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-        Experimental::basic_simd<
-            double, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
+min(Experimental::basic_simd<
+        double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
+    Experimental::basic_simd<
+        double, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
   return Experimental::basic_simd<double,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vminq_f64(static_cast<float64x2_t>(a), static_cast<float64x2_t>(b)));
@@ -628,11 +627,11 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::neon_fixed_size<2>>
-    condition(basic_simd_mask<double, simd_abi::neon_fixed_size<2>> const& a,
-              basic_simd<double, simd_abi::neon_fixed_size<2>> const& b,
-              basic_simd<double, simd_abi::neon_fixed_size<2>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<double, simd_abi::neon_fixed_size<2>> condition(
+    basic_simd_mask<double, simd_abi::neon_fixed_size<2>> const& a,
+    basic_simd<double, simd_abi::neon_fixed_size<2>> const& b,
+    basic_simd<double, simd_abi::neon_fixed_size<2>> const& c) {
   return basic_simd<double, simd_abi::neon_fixed_size<2>>(
       vbslq_f64(static_cast<uint64x2_t>(a), static_cast<float64x2_t>(b),
                 static_cast<float64x2_t>(c)));
@@ -709,8 +708,7 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
     }
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
-  operator-() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(vneg_f32(m_value));
   }
 
@@ -719,102 +717,102 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(vadd_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(vsub_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(vmul_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(vdiv_f32(lhs.m_value, rhs.m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vceq_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcge_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcle_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcgt_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vclt_f32(lhs.m_value, rhs.m_value));
   }
 };
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-    abs(Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>> abs(
+    Experimental::basic_simd<
         float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vabs_f32(static_cast<float32x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-    floor(Experimental::basic_simd<
-          float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+floor(Experimental::basic_simd<
+      float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vrndm_f32(static_cast<float32x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-    ceil(Experimental::basic_simd<
-         float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+ceil(Experimental::basic_simd<
+     float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vrndp_f32(static_cast<float32x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-    round(Experimental::basic_simd<
-          float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+round(Experimental::basic_simd<
+      float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vrndx_f32(static_cast<float32x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-    trunc(Experimental::basic_simd<
-          float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+trunc(Experimental::basic_simd<
+      float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vrnd_f32(static_cast<float32x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-    copysign(Experimental::basic_simd<
-                 float, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-             Experimental::basic_simd<
-                 float, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+copysign(Experimental::basic_simd<
+             float, Experimental::simd_abi::neon_fixed_size<2>> const& a,
+         Experimental::basic_simd<
+             float, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
   uint32x2_t const sign_mask = vreinterpret_u32_f32(vmov_n_f32(-0.0));
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
@@ -824,46 +822,46 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
                    vreinterpret_u32_f32(static_cast<float32x2_t>(b))))));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-    sqrt(Experimental::basic_simd<
-         float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
+sqrt(Experimental::basic_simd<
+     float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vsqrt_f32(static_cast<float32x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-    fma(Experimental::basic_simd<
-            float, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-        Experimental::basic_simd<
-            float, Experimental::simd_abi::neon_fixed_size<2>> const& b,
-        Experimental::basic_simd<
-            float, Experimental::simd_abi::neon_fixed_size<2>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>> fma(
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::neon_fixed_size<2>> const& a,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::neon_fixed_size<2>> const& b,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::neon_fixed_size<2>> const& c) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vfma_f32(static_cast<float32x2_t>(c), static_cast<float32x2_t>(b),
                static_cast<float32x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-    max(Experimental::basic_simd<
-            float, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-        Experimental::basic_simd<
-            float, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>> max(
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::neon_fixed_size<2>> const& a,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vmax_f32(static_cast<float32x2_t>(a), static_cast<float32x2_t>(b)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-    min(Experimental::basic_simd<
-            float, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-        Experimental::basic_simd<
-            float, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>> min(
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::neon_fixed_size<2>> const& a,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<2>>(
       vmin_f32(static_cast<float32x2_t>(a), static_cast<float32x2_t>(b)));
@@ -871,11 +869,11 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::neon_fixed_size<2>>
-    condition(basic_simd_mask<float, simd_abi::neon_fixed_size<2>> const& a,
-              basic_simd<float, simd_abi::neon_fixed_size<2>> const& b,
-              basic_simd<float, simd_abi::neon_fixed_size<2>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::neon_fixed_size<2>> condition(
+    basic_simd_mask<float, simd_abi::neon_fixed_size<2>> const& a,
+    basic_simd<float, simd_abi::neon_fixed_size<2>> const& b,
+    basic_simd<float, simd_abi::neon_fixed_size<2>> const& c) {
   return basic_simd<float, simd_abi::neon_fixed_size<2>>(
       vbsl_f32(static_cast<uint32x2_t>(a), static_cast<float32x2_t>(b),
                static_cast<float32x2_t>(c)));
@@ -958,8 +956,7 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
     }
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
-  operator-() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(vnegq_f32(m_value));
   }
 
@@ -968,102 +965,102 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(vaddq_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(vsubq_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(vmulq_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(vdivq_f32(lhs.m_value, rhs.m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vceqq_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcgeq_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcleq_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcgtq_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(vcltq_f32(lhs.m_value, rhs.m_value));
   }
 };
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-    abs(Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>> abs(
+    Experimental::basic_simd<
         float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<4>>(
       vabsq_f32(static_cast<float32x4_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-    floor(Experimental::basic_simd<
-          float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+floor(Experimental::basic_simd<
+      float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<4>>(
       vrndmq_f32(static_cast<float32x4_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-    ceil(Experimental::basic_simd<
-         float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+ceil(Experimental::basic_simd<
+     float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<4>>(
       vrndpq_f32(static_cast<float32x4_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-    round(Experimental::basic_simd<
-          float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+round(Experimental::basic_simd<
+      float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<4>>(
       vrndxq_f32(static_cast<float32x4_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-    trunc(Experimental::basic_simd<
-          float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+trunc(Experimental::basic_simd<
+      float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<4>>(
       vrndq_f32(static_cast<float32x4_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-    copysign(Experimental::basic_simd<
-                 float, Experimental::simd_abi::neon_fixed_size<4>> const& a,
-             Experimental::basic_simd<
-                 float, Experimental::simd_abi::neon_fixed_size<4>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+copysign(Experimental::basic_simd<
+             float, Experimental::simd_abi::neon_fixed_size<4>> const& a,
+         Experimental::basic_simd<
+             float, Experimental::simd_abi::neon_fixed_size<4>> const& b) {
   uint32x4_t const sign_mask = vreinterpretq_u32_f32(vmovq_n_f32(-0.0));
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<4>>(
@@ -1073,46 +1070,46 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
                     vreinterpretq_u32_f32(static_cast<float32x4_t>(b))))));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-    sqrt(Experimental::basic_simd<
-         float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
+sqrt(Experimental::basic_simd<
+     float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<4>>(
       vsqrtq_f32(static_cast<float32x4_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-    fma(Experimental::basic_simd<
-            float, Experimental::simd_abi::neon_fixed_size<4>> const& a,
-        Experimental::basic_simd<
-            float, Experimental::simd_abi::neon_fixed_size<4>> const& b,
-        Experimental::basic_simd<
-            float, Experimental::simd_abi::neon_fixed_size<4>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>> fma(
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::neon_fixed_size<4>> const& a,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::neon_fixed_size<4>> const& b,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::neon_fixed_size<4>> const& c) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<4>>(
       vfmaq_f32(static_cast<float32x4_t>(c), static_cast<float32x4_t>(b),
                 static_cast<float32x4_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-    max(Experimental::basic_simd<
-            float, Experimental::simd_abi::neon_fixed_size<4>> const& a,
-        Experimental::basic_simd<
-            float, Experimental::simd_abi::neon_fixed_size<4>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>> max(
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::neon_fixed_size<4>> const& a,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::neon_fixed_size<4>> const& b) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<4>>(
       vmaxq_f32(static_cast<float32x4_t>(a), static_cast<float32x4_t>(b)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-    min(Experimental::basic_simd<
-            float, Experimental::simd_abi::neon_fixed_size<4>> const& a,
-        Experimental::basic_simd<
-            float, Experimental::simd_abi::neon_fixed_size<4>> const& b) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>> min(
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::neon_fixed_size<4>> const& a,
+    Experimental::basic_simd<
+        float, Experimental::simd_abi::neon_fixed_size<4>> const& b) {
   return Experimental::basic_simd<float,
                                   Experimental::simd_abi::neon_fixed_size<4>>(
       vminq_f32(static_cast<float32x4_t>(a), static_cast<float32x4_t>(b)));
@@ -1120,11 +1117,11 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::neon_fixed_size<4>>
-    condition(basic_simd_mask<float, simd_abi::neon_fixed_size<4>> const& a,
-              basic_simd<float, simd_abi::neon_fixed_size<4>> const& b,
-              basic_simd<float, simd_abi::neon_fixed_size<4>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::neon_fixed_size<4>> condition(
+    basic_simd_mask<float, simd_abi::neon_fixed_size<4>> const& a,
+    basic_simd<float, simd_abi::neon_fixed_size<4>> const& b,
+    basic_simd<float, simd_abi::neon_fixed_size<4>> const& c) {
   return basic_simd<float, simd_abi::neon_fixed_size<4>>(
       vbslq_f32(static_cast<uint32x4_t>(a), static_cast<float32x4_t>(b),
                 static_cast<float32x4_t>(c)));
@@ -1204,8 +1201,7 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
     }
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
-  operator-() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(vneg_s32(m_value));
   }
 
@@ -1214,68 +1210,68 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vadd_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vsub_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vmul_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vshl_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(vshl_s32(static_cast<int32x2_t>(lhs),
                                vneg_s32(static_cast<int32x2_t>(rhs))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(
         vshl_s32(static_cast<int32x2_t>(lhs), vmov_n_s32(std::int32_t(rhs))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(vshl_s32(static_cast<int32x2_t>(lhs),
                                vneg_s32(vmov_n_s32(std::int32_t(rhs)))));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vceq_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcge_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcle_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcgt_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vclt_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
@@ -1283,7 +1279,7 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
 abs(Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
@@ -1292,28 +1288,28 @@ abs(Experimental::basic_simd<
       vabs_s32(static_cast<int32x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
 floor(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
 ceil(Experimental::basic_simd<
      std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
 round(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
 trunc(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
@@ -1322,12 +1318,11 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>
-    condition(
-        basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& a,
-        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& b,
-        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> condition(
+    basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& a,
+    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& b,
+    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& c) {
   return basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
       vbsl_s32(static_cast<uint32x2_t>(a), static_cast<int32x2_t>(b),
                static_cast<int32x2_t>(c)));
@@ -1413,8 +1408,7 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
     }
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
-  operator-() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(vnegq_s32(m_value));
   }
 
@@ -1423,68 +1417,68 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vaddq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vsubq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vmulq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vshlq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(vshlq_s32(static_cast<int32x4_t>(lhs),
                                 vnegq_s32(static_cast<int32x4_t>(rhs))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(
         vshlq_s32(static_cast<int32x4_t>(lhs), vmovq_n_s32(std::int32_t(rhs))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(vshlq_s32(static_cast<int32x4_t>(lhs),
                                 vnegq_s32(vmovq_n_s32(std::int32_t(rhs)))));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vceqq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcgeq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcleq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcgtq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcltq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
@@ -1492,7 +1486,7 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
 abs(Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
@@ -1501,28 +1495,28 @@ abs(Experimental::basic_simd<
       vabsq_s32(static_cast<int32x4_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
 floor(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
 ceil(Experimental::basic_simd<
      std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
 round(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
 trunc(Experimental::basic_simd<
       std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
@@ -1531,12 +1525,11 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>
-    condition(
-        basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& a,
-        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& b,
-        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> condition(
+    basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& a,
+    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& b,
+    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& c) {
   return basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>(
       vbslq_s32(static_cast<uint32x4_t>(a), static_cast<int32x4_t>(b),
                 static_cast<int32x4_t>(c)));
@@ -1616,8 +1609,7 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
     }
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
-  operator-() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(vnegq_s64(m_value));
   }
 
@@ -1626,67 +1618,67 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vaddq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vsubq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vshlq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(vshlq_s64(static_cast<int64x2_t>(lhs),
                                 vnegq_s64(static_cast<int64x2_t>(rhs))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(
         vshlq_s64(static_cast<int64x2_t>(lhs), vmovq_n_s64(std::int64_t(rhs))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(vshlq_s64(static_cast<int64x2_t>(lhs),
                                 vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vceqq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcgeq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcleq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcgtq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vcltq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
@@ -1694,7 +1686,7 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
 abs(Experimental::basic_simd<
     std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
@@ -1703,28 +1695,28 @@ abs(Experimental::basic_simd<
       vabsq_s64(static_cast<int64x2_t>(a)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
 floor(Experimental::basic_simd<
       std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
 ceil(Experimental::basic_simd<
      std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
 round(Experimental::basic_simd<
       std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
 trunc(Experimental::basic_simd<
       std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
@@ -1733,12 +1725,11 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>
-    condition(
-        basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& a,
-        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& b,
-        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> condition(
+    basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& a,
+    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& b,
+    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& c) {
   return basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
       vbslq_s64(static_cast<uint64x2_t>(a), static_cast<int64x2_t>(b),
                 static_cast<int64x2_t>(c)));
@@ -1820,8 +1811,8 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
     }
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vsubq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
@@ -1831,55 +1822,55 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vaddq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator&(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vandq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator|(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vorrq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vshlq_u64(static_cast<uint64x2_t>(lhs),
                   vreinterpretq_s64_u64(static_cast<uint64x2_t>(rhs))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(vshlq_u64(
         static_cast<uint64x2_t>(lhs),
         vnegq_s64(vreinterpretq_s64_u64(static_cast<uint64x2_t>(rhs)))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(vshlq_u64(static_cast<uint64x2_t>(lhs),
                                 vmovq_n_s64(std::int64_t(rhs))));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(vshlq_u64(static_cast<uint64x2_t>(lhs),
                                 vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(
         vceqq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
 };
@@ -1897,36 +1888,36 @@ basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>::basic_simd(
         other) noexcept
     : m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other))) {}
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>
-    abs(basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> abs(
+    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
 }  // namespace Experimental
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>>
 floor(Experimental::basic_simd<
       std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>>
 ceil(Experimental::basic_simd<
      std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>>
 round(Experimental::basic_simd<
       std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
     std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>>
 trunc(Experimental::basic_simd<
       std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
@@ -1935,12 +1926,11 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>
-    condition(
-        basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a,
-        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& b,
-        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> condition(
+    basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a,
+    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& b,
+    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& c) {
   return basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
       vbslq_u64(static_cast<uint64x2_t>(a), static_cast<uint64x2_t>(b),
                 static_cast<uint64x2_t>(c)));
@@ -1981,13 +1971,12 @@ class const_where_expression<
     if (m_mask[1]) mem[index[1]] = m_value[1];
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2074,13 +2063,12 @@ class const_where_expression<
     if (m_mask[1]) mem[index[1]] = m_value[1];
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2172,13 +2160,12 @@ class const_where_expression<
     if (m_mask[3]) mem[index[3]] = m_value[3];
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2266,13 +2253,12 @@ class const_where_expression<
     if (m_mask[1]) mem[index[1]] = m_value[1];
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2369,13 +2355,12 @@ class const_where_expression<
     if (m_mask[3]) mem[index[3]] = m_value[3];
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2465,13 +2450,12 @@ class const_where_expression<
     if (m_mask[1]) mem[index[1]] = m_value[1];
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2564,13 +2548,12 @@ class const_where_expression<
     if (m_mask[1]) mem[index[1]] = m_value[1];
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
-  impl_get_value() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const& impl_get_value()
+      const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
-  impl_get_mask() const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -2627,7 +2610,7 @@ class where_expression<
   }
 };
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
 // reduce_min(
 //         simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& v,
 //         simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& m)
@@ -2635,7 +2618,7 @@ class where_expression<
 //   return vminv_s32(static_cast<int32x2_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
 // reduce_max(
 //         simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& v,
 //         simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& m)
@@ -2643,7 +2626,7 @@ class where_expression<
 //   return vmaxv_s32(static_cast<int32x2_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
 // reduce(
 //         simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& v,
 //         simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& m,
@@ -2652,7 +2635,7 @@ class where_expression<
 //   return vaddv_s32(static_cast<int32x2_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
 // reduce_min(
 //         simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& v,
 //         simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& m)
@@ -2660,14 +2643,14 @@ class where_expression<
 //   return vminvq_s32(static_cast<int32x4_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
 // reduce_max(
 //         simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& v,
 //         simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> m) noexcept {
 //   return vmaxvq_s32(static_cast<int32x4_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t
 // reduce(
 //         simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& v,
 //         simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& m,
@@ -2676,7 +2659,7 @@ class where_expression<
 //   return vaddvq_s32(static_cast<int32x4_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
 // reduce_min(
 //         simd<std::uint32_t, simd_abi::neon_fixed_size<2>> const& v,
 //         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>> const& m)
@@ -2684,7 +2667,7 @@ class where_expression<
 //   return vminv_u32(static_cast<uint32x2_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
 // reduce_max(
 //         simd<std::uint32_t, simd_abi::neon_fixed_size<2>> const& v,
 //         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>> const& m)
@@ -2692,7 +2675,7 @@ class where_expression<
 //   return vmaxv_u32(static_cast<uint32x2_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
 // reduce(
 //         simd<std::uint32_t, simd_abi::neon_fixed_size<2>> const& v,
 //         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>> const& m,
@@ -2701,7 +2684,7 @@ class where_expression<
 //   return vaddv_u32(static_cast<uint32x2_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
 // reduce_min(
 //         simd<std::uint32_t, simd_abi::neon_fixed_size<4>> const& v,
 //         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>> const& m)
@@ -2709,7 +2692,7 @@ class where_expression<
 //   return vminvq_u32(static_cast<uint32x4_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
 // reduce_max(
 //         simd<std::uint32_t, simd_abi::neon_fixed_size<4>> const& v,
 //         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>> const& m)
@@ -2717,7 +2700,7 @@ class where_expression<
 //   return vmaxvq_u32(static_cast<uint32x4_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t
 // reduce(
 //         simd<std::uint32_t, simd_abi::neon_fixed_size<4>> const& v,
 //         simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>> const& m,
@@ -2726,7 +2709,7 @@ class where_expression<
 //   return vaddvq_u32(static_cast<uint32x4_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t
 // reduce(
 //         simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& v,
 //         simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& m,
@@ -2735,7 +2718,7 @@ class where_expression<
 //   return vaddvq_s64(static_cast<int64x2_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t
 // reduce(
 //         simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& v,
 //         simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& m,
@@ -2743,14 +2726,14 @@ class where_expression<
 //   return vaddvq_u64(static_cast<uint64x2_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double
 // reduce_min(
 //     simd < double, simd_abi::neon_fixed_size < 2 >> const& v,
 //     simd_mask<double, simd_abi::neon_fixed_size<2>> const& m) noexcept {
 //   return vminvq_f64(static_cast<float64x2_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double
 // reduce_max(
 //                            simd<double, simd_abi::neon_fixed_size<2>> const&
 //                            v,
@@ -2758,7 +2741,7 @@ class where_expression<
 //   return vmaxvq_f64(static_cast<float64x2_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
 //                            simd<double, simd_abi::neon_fixed_size<2>> const&
 //                            v,
 //     simd_mask<double, simd_abi::neon_fixed_size<2>> const& m,
@@ -2767,7 +2750,7 @@ class where_expression<
 //   return vaddvq_f64(static_cast<float64x2_t>(x.impl_get_value()));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
 // reduce_min(
 //                            simd<float, simd_abi::neon_fixed_size<2>> const&
 //                            v,
@@ -2775,7 +2758,7 @@ class where_expression<
 //   return vminv_f32(static_cast<float32x2_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
 // reduce_max(
 //                            simd<float, simd_abi::neon_fixed_size<2>> const&
 //                            v,
@@ -2783,7 +2766,7 @@ class where_expression<
 //   return vmaxv_f32(static_cast<float32x2_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
 //                            simd<float, simd_abi::neon_fixed_size<2>> const&
 //                            v,
 //     simd_mask<float, simd_abi::neon_fixed_size<2>> const& m,
@@ -2792,7 +2775,7 @@ class where_expression<
 //   return vaddv_f32(static_cast<float32x2_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
 // reduce_min(
 //                            simd<float, simd_abi::neon_fixed_size<4>> const&
 //                            v,
@@ -2800,7 +2783,7 @@ class where_expression<
 //   return vminvq_f32(static_cast<float32x4_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float
 // reduce_max(
 //                            simd<float, simd_abi::neon_fixed_size<4>> const&
 //                            const& v
@@ -2808,7 +2791,7 @@ class where_expression<
 //   return vmaxvq_f32(static_cast<float32x4_t>(v));
 // }
 
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
 //                            simd<float, simd_abi::neon_fixed_size<4>> const&
 //                            v,
 //     simd_mask<float, simd_abi::neon_fixed_size<4>> const& m,

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -145,7 +145,7 @@ class basic_simd_mask<T, simd_abi::scalar> {
 };
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr bool all_of(
+KOKKOS_FORCEINLINE_FUNCTION constexpr bool all_of(
     basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const&
         a) noexcept {
   return static_cast<bool>(
@@ -153,7 +153,7 @@ template <class T>
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr bool any_of(
+KOKKOS_FORCEINLINE_FUNCTION constexpr bool any_of(
     basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const&
         a) noexcept {
   return static_cast<bool>(
@@ -161,7 +161,7 @@ template <class T>
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr bool none_of(
+KOKKOS_FORCEINLINE_FUNCTION constexpr bool none_of(
     basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const&
         a) noexcept {
   return static_cast<bool>(
@@ -237,64 +237,64 @@ class basic_simd<T, simd_abi::scalar> {
     return basic_simd(-m_value);
   }
 
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator+(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator+(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(lhs.m_value + rhs.m_value);
   }
   template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator+(basic_simd const& lhs, U rhs) {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator+(
+      basic_simd const& lhs, U rhs) {
     return lhs.m_value + basic_simd(rhs);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator-(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(lhs.m_value - rhs.m_value);
   }
   template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator-(basic_simd const& lhs, U rhs) {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator-(
+      basic_simd const& lhs, U rhs) {
     return lhs.m_value - basic_simd(rhs);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator*(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator*(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(lhs.m_value * rhs.m_value);
   }
   template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator*(basic_simd const& lhs, U rhs) {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator*(
+      basic_simd const& lhs, U rhs) {
     return lhs.m_value * basic_simd(rhs);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator/(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator/(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(lhs.m_value / rhs.m_value);
   }
   template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator/(basic_simd const& lhs, U rhs) {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator/(
+      basic_simd const& lhs, U rhs) {
     return lhs.m_value / basic_simd(rhs);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator&(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return lhs.m_value & rhs.m_value;
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator|(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return lhs.m_value | rhs.m_value;
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator<<(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator<<(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(lhs.m_value << rhs);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator<<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator<<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(lhs.m_value << rhs.m_value);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator>>(basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator>>(
+      basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(lhs.m_value >> rhs);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd
-  operator>>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator>>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(lhs.m_value >> rhs.m_value);
   }
 
@@ -329,28 +329,28 @@ class basic_simd<T, simd_abi::scalar> {
     return lhs;
   }
 
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
-  operator==(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type operator==(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(lhs.m_value == rhs.m_value);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
-  operator!=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type operator!=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(lhs.m_value != rhs.m_value);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
-  operator>=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(lhs.m_value >= rhs.m_value);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
-  operator<=(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(lhs.m_value <= rhs.m_value);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
-  operator>(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(lhs.m_value > rhs.m_value);
   }
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type
-  operator<(basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return mask_type(lhs.m_value < rhs.m_value);
   }
 };
@@ -358,7 +358,7 @@ class basic_simd<T, simd_abi::scalar> {
 }  // namespace Experimental
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
     T, Experimental::simd_abi::scalar>
 abs(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   if constexpr (std::is_signed_v<T>) {
@@ -368,7 +368,7 @@ abs(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
 }
 
 template <typename T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr auto floor(
+KOKKOS_FORCEINLINE_FUNCTION constexpr auto floor(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
   return Experimental::basic_simd<data_type, Experimental::simd_abi::scalar>(
@@ -376,7 +376,7 @@ template <typename T>
 }
 
 template <typename T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr auto ceil(
+KOKKOS_FORCEINLINE_FUNCTION constexpr auto ceil(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
   return Experimental::basic_simd<data_type, Experimental::simd_abi::scalar>(
@@ -384,7 +384,7 @@ template <typename T>
 }
 
 template <typename T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr auto round(
+KOKKOS_FORCEINLINE_FUNCTION constexpr auto round(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
   return Experimental::basic_simd<data_type, Experimental::simd_abi::scalar>(
@@ -392,7 +392,7 @@ template <typename T>
 }
 
 template <typename T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr auto trunc(
+KOKKOS_FORCEINLINE_FUNCTION constexpr auto trunc(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
   return Experimental::basic_simd<data_type, Experimental::simd_abi::scalar>(
@@ -400,7 +400,7 @@ template <typename T>
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
     T, Experimental::simd_abi::scalar>
 sqrt(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
   return Experimental::basic_simd<T, Experimental::simd_abi::scalar>(
@@ -418,7 +418,7 @@ fma(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
     T, Experimental::simd_abi::scalar>
 copysign(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a,
          Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& b) {
@@ -438,7 +438,7 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd<T, simd_abi::scalar> condition(
 }
 
 template <class T, class BinaryOperation>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
     Experimental::basic_simd_mask<T, Experimental::simd_abi::scalar> const&
         mask,
@@ -448,7 +448,7 @@ template <class T, class BinaryOperation>
 }
 
 template <class T, class BinaryOperation>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
     BinaryOperation binary_op) noexcept {
   return reduce(x,
@@ -458,7 +458,7 @@ template <class T, class BinaryOperation>
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
+KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
     Experimental::basic_simd_mask<T, Experimental::simd_abi::scalar> const&
         mask) noexcept {
@@ -467,14 +467,14 @@ template <class T>
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
+KOKKOS_FORCEINLINE_FUNCTION T
 reduce_min(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const&
                x) noexcept {
   return x[0];
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
+KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
     Experimental::basic_simd_mask<T, Experimental::simd_abi::scalar> const&
         mask) noexcept {
@@ -483,14 +483,14 @@ template <class T>
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
+KOKKOS_FORCEINLINE_FUNCTION T
 reduce_max(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const&
                x) noexcept {
   return x[0];
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
     T, Experimental::simd_abi::scalar>
 min(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a,
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& b) {
@@ -499,7 +499,7 @@ min(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a,
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
     T, Experimental::simd_abi::scalar>
 max(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a,
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& b) {
@@ -540,13 +540,11 @@ class const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
       mem[static_cast<Integral>(index)] = static_cast<T>(m_value);
   }
 
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION value_type const& impl_get_value()
-      const {
+  KOKKOS_FORCEINLINE_FUNCTION value_type const& impl_get_value() const {
     return m_value;
   }
 
-  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION mask_type const& impl_get_mask()
-      const {
+  KOKKOS_FORCEINLINE_FUNCTION mask_type const& impl_get_mask() const {
     return m_mask;
   }
 };
@@ -591,7 +589,7 @@ class where_expression<basic_simd_mask<T, simd_abi::scalar>,
 };
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
     where_expression<basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>,
                      basic_simd<T, Kokkos::Experimental::simd_abi::scalar>>
     where(typename basic_simd<
@@ -601,7 +599,7 @@ template <class T>
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION const_where_expression<
+KOKKOS_FORCEINLINE_FUNCTION const_where_expression<
     basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>,
     basic_simd<T, Kokkos::Experimental::simd_abi::scalar>>
 where(typename basic_simd<
@@ -612,8 +610,8 @@ where(typename basic_simd<
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class T>
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead")
-    KOKKOS_FORCEINLINE_FUNCTION T
+KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead")
+KOKKOS_FORCEINLINE_FUNCTION T
     hmax(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
                                 basic_simd<T, simd_abi::scalar>> const& x) {
   return static_cast<bool>(x.impl_get_mask())
@@ -623,7 +621,7 @@ template <class T>
 #endif
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
     const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
                            basic_simd<T, simd_abi::scalar>> const& x,
     T identity_element, std::plus<>) {
@@ -633,7 +631,7 @@ template <class T>
 }
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
+KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
     const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
                            basic_simd<T, simd_abi::scalar>> const& x) noexcept {
   return static_cast<bool>(x.impl_get_mask())
@@ -643,8 +641,8 @@ template <class T>
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class T>
-[[nodiscard]] KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead")
-    KOKKOS_FORCEINLINE_FUNCTION T
+KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead")
+KOKKOS_FORCEINLINE_FUNCTION T
     hmin(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
                                 basic_simd<T, simd_abi::scalar>> const& x) {
   return static_cast<bool>(x.impl_get_mask())
@@ -654,7 +652,7 @@ template <class T>
 #endif
 
 template <class T>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
+KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
     const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
                            basic_simd<T, simd_abi::scalar>> const& x) noexcept {
   return static_cast<bool>(x.impl_get_mask())


### PR DESCRIPTION
Removed `[[nodiscard]]` from all kokkos simd functions, since none of c++26 simd functions have `[[nodiscard]]` on them.