### PR TITLE
simd: add simd type conversions

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -707,7 +707,7 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -1006,7 +1006,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
       : m_value(_mm_set1_ps(value_type(value))) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -1291,7 +1291,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -1585,7 +1585,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       : m_value(_mm_set1_epi32(value_type(value))) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -1812,7 +1812,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
       : m_value(_mm256_set1_epi32(value_type(value))) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -2047,7 +2047,7 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       : m_value(_mm256_set1_epi64x(value_type(value))) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -2287,7 +2287,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -69,8 +69,17 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
   }
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      basic_simd_mask<U, simd_abi::avx2_fixed_size<4>> const& other) noexcept
-      : m_value(static_cast<__m256d>(other)) {}
+      basic_simd_mask<U, abi_type> const& other) noexcept
+      : basic_simd_mask(
+            [&](std::size_t i) { return static_cast<double>(other[i]); }) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
+      basic_simd_mask<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m256d const& value_in) noexcept
       : m_value(value_in) {}
@@ -86,11 +95,6 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
             -std::int64_t(gen(std::integral_constant<std::size_t, 1>())),
             -std::int64_t(gen(std::integral_constant<std::size_t, 2>())),
             -std::int64_t(gen(std::integral_constant<std::size_t, 3>()))))) {}
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  basic_simd_mask(
-      basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
-          i32_mask) noexcept;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
@@ -145,6 +149,13 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       value_type value) noexcept
       : m_value(_mm_castsi128_ps(_mm_set1_epi32(-std::int32_t(value)))) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<U, abi_type> const& other) noexcept
+      : basic_simd_mask(
+            [&](std::size_t i) { return static_cast<float>(other[i]); }) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<std::int32_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m128 const& value_in) noexcept
       : m_value(value_in) {}
@@ -216,6 +227,13 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m256 const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<U, abi_type> const& other) noexcept
+      : basic_simd_mask(
+            [&](std::size_t i) { return static_cast<float>(other[i]); }) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<std::int32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -287,10 +305,12 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       : m_value(_mm_set1_epi32(-std::int32_t(value))) {}
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<U, abi_type> const& other) noexcept {
-    m_value = _mm_setr_epi32(-std::int32_t(other[0]), -std::int32_t(other[1]),
-                             -std::int32_t(other[2]), -std::int32_t(other[3]));
-  }
+      basic_simd_mask<U, abi_type> const& other) noexcept
+      : basic_simd_mask([&](std::size_t i) {
+          return static_cast<std::int32_t>(other[i]);
+        }) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<float, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m128i const& value_in) noexcept
       : m_value(value_in) {}
@@ -361,9 +381,12 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
       : m_value(_mm256_set1_epi32(-std::int32_t(value))) {}
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<U, abi_type> const& other) noexcept {
-    for (std::size_t i = 0; i < size(); ++i) (*this)[i] = other[i];
-  }
+      basic_simd_mask<U, abi_type> const& other) noexcept
+      : basic_simd_mask([&](std::size_t i) {
+          return static_cast<std::int32_t>(other[i]);
+        }) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<float, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
@@ -437,12 +460,21 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       value_type value) noexcept
       : m_value(_mm256_set1_epi64x(-std::int64_t(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
-      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
+  template <class U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<U, abi_type> const& other) noexcept
+      : basic_simd_mask([&](std::size_t i) {
+          return static_cast<std::int64_t>(other[i]);
+        }) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
+      basic_simd_mask<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -509,12 +541,21 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       value_type value) noexcept
       : m_value(_mm256_set1_epi64x(-std::int64_t(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
-      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
+  template <class U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<U, abi_type> const& other) noexcept
+      : basic_simd_mask([&](std::size_t i) {
+          return static_cast<std::uint64_t>(other[i]);
+        }) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
+      basic_simd_mask<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+      basic_simd_mask<std::int64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -567,10 +608,73 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
-        i32_mask) noexcept
-    : m_value(_mm256_castsi256_pd(
-          _mm256_cvtepi32_epi64(static_cast<__m128i>(i32_mask)))) {}
+    basic_simd_mask<float, abi_type> const& other) noexcept
+    : m_value(_mm256_cvtps_pd(static_cast<__m128>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
+    basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+    : m_value(_mm256_cvtepi32_pd(static_cast<__m128i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
+    basic_simd_mask<std::int64_t, abi_type> const& other) noexcept
+    : m_value(_mm256_castsi256_pd(static_cast<__m256i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
+    basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept
+    : m_value(_mm256_castsi256_pd(static_cast<__m256i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
+    basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+    : m_value(_mm_cvtepi32_ps(static_cast<__m128i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>::basic_simd_mask(
+    basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+    : m_value(_mm256_castsi256_ps(static_cast<__m256i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
+    basic_simd_mask<float, abi_type> const& other) noexcept
+    : m_value(_mm_castps_si128(static_cast<__m128>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>::basic_simd_mask(
+    basic_simd_mask<float, abi_type> const& other) noexcept
+    : m_value(_mm256_castps_si256(static_cast<__m256>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
+    basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+    : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
+    basic_simd_mask<double, abi_type> const& other) noexcept
+    : m_value(_mm256_castpd_si256(static_cast<__m256d>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
+    basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept
+    : m_value(static_cast<__m256i>(other)) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
+    basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+    : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
+    basic_simd_mask<double, abi_type> const& other) noexcept
+    : m_value(_mm256_castpd_si256(static_cast<__m256d>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
+    basic_simd_mask<std::int64_t, abi_type> const& other) noexcept
+    : m_value(static_cast<__m256i>(other)) {}
 
 template <>
 class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
@@ -601,6 +705,19 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256d const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -887,6 +1004,19 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm_set1_ps(value_type(value))) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<double, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -1159,6 +1289,17 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256 const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -1442,8 +1583,19 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm_set1_epi32(value_type(value))) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
+      basic_simd<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<double, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -1658,6 +1810,17 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi32(value_type(value))) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<float, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -1882,11 +2045,19 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi64x(value_type(value))) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept
-      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -2114,12 +2285,19 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept
-      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
+      basic_simd<std::int32_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int64_t, abi_type> const& other) noexcept
-      : m_value(static_cast<__m256i>(other)) {}
+      basic_simd<std::int64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -2238,12 +2416,6 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   }
 };
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const&
-        other) noexcept
-    : m_value(static_cast<__m256i>(other)) {}
-
 }  // namespace Experimental
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
@@ -2304,15 +2476,64 @@ basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> condition(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<double, simd_abi::avx2_fixed_size<4>>::basic_simd(
+    basic_simd<float, abi_type> const& other) noexcept
+    : m_value(_mm256_cvtps_pd(static_cast<__m128>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<double, simd_abi::avx2_fixed_size<4>>::basic_simd(
+    basic_simd<std::int32_t, abi_type> const& other) noexcept
+    : m_value(_mm256_cvtepi32_pd(static_cast<__m128i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::avx2_fixed_size<4>>::basic_simd(
+    basic_simd<double, abi_type> const& other) noexcept
+    : m_value(_mm256_cvtpd_ps(static_cast<__m256d>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::avx2_fixed_size<4>>::basic_simd(
+    basic_simd<std::int32_t, abi_type> const& other) noexcept
+    : m_value(_mm_cvtepi32_ps(static_cast<__m128i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::avx2_fixed_size<8>>::basic_simd(
+    basic_simd<std::int32_t, abi_type> const& other) noexcept
+    : m_value(_mm256_cvtepi32_ps(static_cast<__m256i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const&
-        other) noexcept {
-  std::int32_t arr[4];
-  for (std::size_t i = 0; i < 4; ++i) {
-    arr[i] = std::int32_t(other[i]);
-  }
-  this->copy_from(arr, element_aligned_tag{});
-}
+    basic_simd<float, abi_type> const& other) noexcept
+    : m_value(_mm_cvtps_epi32(static_cast<__m128>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
+    basic_simd<double, abi_type> const& other) noexcept
+    : m_value(_mm256_cvtpd_epi32(static_cast<__m256d>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>::basic_simd(
+    basic_simd<float, abi_type> const& other) noexcept
+    : m_value(_mm256_cvtps_epi32(static_cast<__m256>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
+    basic_simd<std::int32_t, abi_type> const& other) noexcept
+    : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
+    basic_simd<std::uint64_t, abi_type> const& other) noexcept
+    : m_value(static_cast<__m256i>(other)) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
+    basic_simd<std::int32_t, abi_type> const& other) noexcept
+    : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
+    basic_simd<std::int64_t, abi_type> const& other) noexcept
+    : m_value(static_cast<__m256i>(other)) {}
 
 template <>
 class const_where_expression<

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -287,7 +287,7 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -610,7 +610,7 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -907,7 +907,7 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -1205,7 +1205,7 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -1447,7 +1447,7 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -1693,7 +1693,7 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -1929,7 +1929,7 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -2165,7 +2165,7 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
       : m_value(_mm512_set1_epi64(value_type(value))) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -2402,7 +2402,7 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -285,6 +285,25 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m512d const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::uint32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -589,6 +608,25 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256 const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::uint32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -867,6 +905,19 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m512 const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::uint32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -1152,6 +1203,23 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::uint32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int64_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
@@ -1377,8 +1445,19 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m512i const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
+      basic_simd<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::uint32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -1612,10 +1691,25 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
-          other) noexcept
-      : m_value(static_cast<__m256i>(other)) {}
+      basic_simd<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -1833,10 +1927,19 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m512i const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
-          other) noexcept
-      : m_value(static_cast<__m512i>(other)) {}
+      basic_simd<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -2060,12 +2163,27 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_epi64(value_type(value))) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
-          other) noexcept
-      : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
+      basic_simd<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+          other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+          other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
           other) noexcept;
   template <class G,
             std::enable_if_t<
@@ -2282,12 +2400,28 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
       __m512i const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept
-      : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
+      basic_simd<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int64_t, abi_type> const& other) noexcept
-      : m_value(static_cast<__m512i>(other)) {}
+      basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+          other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+          other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+          other) noexcept;
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -2474,16 +2608,208 @@ basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> condition(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<double, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtps_pd(static_cast<__m256>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<double, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(_mm512_cvtepi64_pd(static_cast<__m512i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<double, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(_mm512_cvtepu64_pd(static_cast<__m512i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<double, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(_mm512_cvtepi32_pd(static_cast<__m256i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<double, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(_mm512_cvtepu32_pd(static_cast<__m256i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtpd_ps(static_cast<__m512d>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(_mm512_cvtepi64_ps(static_cast<__m512i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(_mm512_cvtepu64_ps(static_cast<__m512i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(_mm256_cvtepi32_ps(static_cast<__m256i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(_mm256_cvtepi32_ps(static_cast<__m256i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::avx512_fixed_size<16>>::basic_simd(
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
+        other) noexcept
+    : m_value(_mm512_cvtepi32_ps(static_cast<__m512i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::avx512_fixed_size<16>>::basic_simd(
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
+        other) noexcept
+    : m_value(_mm512_cvtepu32_ps(static_cast<__m512i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtpd_epi32(static_cast<__m512d>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm256_cvtps_epi32(static_cast<__m256>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(static_cast<__m256i>(other)) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
     basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>::basic_simd(
+    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& other) noexcept
+    : m_value(_mm512_cvtps_epi32(static_cast<__m512>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>::basic_simd(
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
+        other) noexcept
+    : m_value(static_cast<__m512i>(other)) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtpd_epu32(static_cast<__m512d>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm256_cvtps_epu32(static_cast<__m256>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(static_cast<__m256i>(other)) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>::basic_simd(
+    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& other) noexcept
+    : m_value(_mm512_cvtps_epu32(static_cast<__m512>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>::basic_simd(
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
+        other) noexcept
+    : m_value(static_cast<__m512i>(other)) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtpd_epi64(static_cast<__m512d>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
     basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(static_cast<__m512i>(other)) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtps_epi64(static_cast<__m256>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(_mm512_cvtepu32_epi64(static_cast<__m256i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtpd_epu64(static_cast<__m512d>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(static_cast<__m512i>(other)) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+    : m_value(_mm512_cvtps_epu64(static_cast<__m256>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
+    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+        other) noexcept
+    : m_value(_mm512_cvtepu32_epi64(static_cast<__m256i>(other))) {}
 
 template <>
 class const_where_expression<

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -386,6 +386,37 @@ struct Identity {
   }
 };
 
+template <typename From, typename To>
+struct is_value_preserving_conversion {
+  static constexpr bool value =
+      (std::is_integral_v<From> && std::is_integral_v<To>) ||
+      (std::is_floating_point_v<From> && std::is_floating_point_v<To>);
+};
+
+template <typename From, typename To>
+constexpr bool is_value_preserving_conversion_v =
+    is_value_preserving_conversion<From, To>::value;
+
+template <typename From, typename To>
+struct is_narrowing_conversion {
+  static constexpr bool value =
+      (is_value_preserving_conversion_v<From, To>)&&(sizeof(To) < sizeof(From));
+};
+
+template <typename From, typename To>
+constexpr bool is_narrowing_conversion_v =
+    is_narrowing_conversion<From, To>::value;
+
+template <typename From, typename To>
+struct needs_explicit_conversion
+    : std::integral_constant<bool,
+                             !is_value_preserving_conversion_v<From, To> ||
+                                 is_narrowing_conversion_v<From, To>> {};
+
+template <typename From, typename To>
+constexpr bool needs_explicit_conversion_v =
+    needs_explicit_conversion<From, To>::value;
+
 }  // namespace Impl
 
 // common implementations of host only simd reductions:

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -400,7 +400,7 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -666,7 +666,7 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -919,7 +919,7 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -1176,7 +1176,7 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -1388,7 +1388,7 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -1602,7 +1602,7 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -1813,7 +1813,7 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -1932,19 +1932,6 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
 };
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>::basic_simd(
-    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const&
-        other) noexcept
-    : m_value(
-          vmovn_s64(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other)))) {}
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>::basic_simd(
-    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const&
-        other) noexcept
-    : m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other))) {}
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> abs(
     basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a) {
   return a;

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -1183,9 +1183,9 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
       : m_value(basic_simd(
             [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -250,6 +250,10 @@ class neon_mask<Derived, 32, 4> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit neon_mask(
       uint32x4_t const& value_in) noexcept
       : m_value(value_in) {}
+  template <class U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit neon_mask(
+      neon_mask<U, 32, 4> const& other) noexcept
+      : m_value(static_cast<uint32x4_t>(other)) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -394,6 +398,17 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       float64x2_t const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<float, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -649,6 +664,17 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       float32x2_t const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+      basic_simd<double, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -891,6 +917,15 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       float32x4_t const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -1139,7 +1174,18 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       int32x2_t const& value_in) noexcept
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
@@ -1340,8 +1386,15 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       int32x4_t const& value_in) noexcept
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -1547,8 +1600,19 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       int64x2_t const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const&) noexcept;
+      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -1747,10 +1811,19 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       uint64x2_t const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept
-      : m_value(
-            vreinterpretq_u64_s64(vmovl_s32(static_cast<int32x2_t>(other)))) {}
+      basic_simd<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -1917,6 +1990,54 @@ basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> condition(
   return basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
       vbslq_u64(static_cast<uint64x2_t>(a), static_cast<uint64x2_t>(b),
                 static_cast<uint64x2_t>(c)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<double, simd_abi::neon_fixed_size<2>>::basic_simd(
+    basic_simd<float, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vcvt_f64_f32(static_cast<float32x2_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::neon_fixed_size<2>>::basic_simd(
+    basic_simd<double, simd_abi::neon_fixed_size<2>> const& other) noexcept
+    : m_value(vcvtx_f32_f64(static_cast<float64x2_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>::basic_simd(
+    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const&
+        other) noexcept
+    : m_value(vmovn_s64(static_cast<int64x2_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>::basic_simd(
+    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const&
+        other) noexcept
+    : m_value(vreinterpret_s32_u32(vmovn_u64(static_cast<uint64x2_t>(other)))) {
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>::basic_simd(
+    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const&
+        other) noexcept
+    : m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>::basic_simd(
+    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const&
+        other) noexcept
+    : m_value(vmovl_s32(static_cast<int32x2_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>::basic_simd(
+    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const&
+        other) noexcept
+    : m_value(vreinterpretq_u64_s64(static_cast<int64x2_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>::basic_simd(
+    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const&
+        other) noexcept
+    : m_value(vreinterpretq_u64_s64(vmovl_s32(static_cast<int32x2_t>(other)))) {
 }
 
 template <>

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -422,9 +422,9 @@ class basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
       : m_value(basic_simd(
             [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
@@ -727,9 +727,9 @@ class basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       : m_value(basic_simd(
             [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
@@ -1037,9 +1037,9 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       : m_value(basic_simd(
             [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
@@ -1384,9 +1384,9 @@ class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       : m_value(basic_simd(
             [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
@@ -1721,9 +1721,9 @@ class basic_simd<std::int64_t,
       : m_value(basic_simd(
             [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<double, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
@@ -2067,9 +2067,9 @@ class basic_simd<std::uint64_t,
       : m_value(basic_simd(
             [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<double, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -413,7 +413,19 @@ class basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       vls_float64_t const& value_in) noexcept
       : m_value(value_in) {}
-
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -706,6 +718,19 @@ class basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       vls_float32_t const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::uint32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -1003,7 +1028,19 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       vls_int32_t const& value_in) noexcept
       : m_value(value_in) {}
-
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::uint32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -1338,6 +1375,19 @@ class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       vls_uint32_t const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::int32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -1662,9 +1712,19 @@ class basic_simd<std::int64_t,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       vls_int64_t const& value_in) noexcept
       : m_value(value_in) {}
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<double, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other) noexcept;
-
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -1998,7 +2058,19 @@ class basic_simd<std::uint64_t,
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
-
+  template <typename U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(basic_simd(
+            [&](std::size_t i) { return static_cast<value_type>(other[i]); })) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+      basic_simd<std::int64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -2145,15 +2217,6 @@ class basic_simd<std::uint64_t,
             (to_sve_vla<value_type>)static_cast<implementation_type>(rhs)))));
   }
 };
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
-    basic_simd(
-        basic_simd<std::uint64_t,
-                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            other) noexcept
-    : m_value(svreinterpret_s64(
-          (to_sve_vla<std::uint64_t>)static_cast<vls_uint64_t>(other))) {}
 
 }  // namespace Experimental
 
@@ -2426,6 +2489,92 @@ condition(
                                       static_cast<vls_uint64_t>(b),
                                       static_cast<vls_uint64_t>(c))));
 }
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::basic_simd(
+    basic_simd<std::int64_t,
+               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+        other) noexcept
+    : m_value(svcvt_f64_z(svptrue_b64(), static_cast<vls_int64_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::basic_simd(
+    basic_simd<std::uint64_t,
+               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+        other) noexcept
+    : m_value(svcvt_f64_z(svptrue_b64(), static_cast<vls_uint64_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::basic_simd(
+    basic_simd<std::int32_t,
+               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+        other) noexcept
+    : m_value(svcvt_f32_z(svptrue_b32(), static_cast<vls_int32_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::basic_simd(
+    basic_simd<std::uint32_t,
+               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+        other) noexcept
+    : m_value(svcvt_f32_z(svptrue_b32(), static_cast<vls_uint32_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::
+    basic_simd(
+        basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+            other) noexcept
+    : m_value(svcvt_s32_z(svptrue_b32(), static_cast<vls_float32_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::
+    basic_simd(basic_simd<std::uint32_t,
+                          simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+                   other) noexcept
+    : m_value(svreinterpret_s32(static_cast<vls_uint32_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::
+    basic_simd(
+        basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+            other) noexcept
+    : m_value(svcvt_u32_z(svptrue_b32(), static_cast<vls_float32_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::
+    basic_simd(basic_simd<std::int32_t,
+                          simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+                   other) noexcept
+    : m_value(svreinterpret_u32(static_cast<vls_int32_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
+    basic_simd(basic_simd<
+               double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+                   other) noexcept
+    : m_value(svcvt_s64_z(svptrue_b64(), static_cast<vls_float64_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
+    basic_simd(
+        basic_simd<std::uint64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+            other) noexcept
+    : m_value(svreinterpret_s64(static_cast<vls_uint64_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
+    basic_simd(basic_simd<
+               double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+                   other) noexcept
+    : m_value(svcvt_u64_z(svptrue_b64(), static_cast<vls_float64_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
+    basic_simd(
+        basic_simd<std::int64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+            other) noexcept
+    : m_value(svreinterpret_u64(static_cast<vls_int64_t>(other))) {}
 
 template <>
 class const_where_expression<

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -2530,7 +2530,7 @@ basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::
     basic_simd(basic_simd<std::uint32_t,
                           simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
                    other) noexcept
-    : m_value(svreinterpret_s32(static_cast<vls_uint32_t>(other))) {}
+    : m_value(svreinterpret_s32_u32(static_cast<vls_uint32_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::
@@ -2544,7 +2544,7 @@ basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::
     basic_simd(basic_simd<std::int32_t,
                           simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
                    other) noexcept
-    : m_value(svreinterpret_u32(static_cast<vls_int32_t>(other))) {}
+    : m_value(svreinterpret_u32_s32(static_cast<vls_int32_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
@@ -2559,7 +2559,7 @@ basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
         basic_simd<std::uint64_t,
                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
             other) noexcept
-    : m_value(svreinterpret_s64(static_cast<vls_uint64_t>(other))) {}
+    : m_value(svreinterpret_s64_u64(static_cast<vls_uint64_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
@@ -2574,7 +2574,7 @@ basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
         basic_simd<std::int64_t,
                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
             other) noexcept
-    : m_value(svreinterpret_u64(static_cast<vls_int64_t>(other))) {}
+    : m_value(svreinterpret_u64_s64(static_cast<vls_int64_t>(other))) {}
 
 template <>
 class const_where_expression<

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -415,7 +415,7 @@ class basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -720,7 +720,7 @@ class basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -1030,7 +1030,7 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -1377,7 +1377,7 @@ class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -1714,7 +1714,7 @@ class basic_simd<std::int64_t,
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept
@@ -2060,7 +2060,7 @@ class basic_simd<std::uint64_t,
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -192,9 +192,13 @@ class basic_simd<T, simd_abi::scalar> {
       : m_value(value) {}
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      basic_simd<U, abi_type> const& other) noexcept
-      : m_value(static_cast<U>(other)) {}
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit
+#if __cplusplus >= 202002L
+      (Impl::needs_explicit_conversion_v<U, value_type>)
+#endif
+          basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      : m_value(static_cast<U>(other)) {
+  }
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -193,7 +193,7 @@ class basic_simd<T, simd_abi::scalar> {
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit
-#if __cplusplus >= 202002L
+#ifdef KOKKOS_ENABLE_CXX20
       (Impl::needs_explicit_conversion_v<U, value_type>)
 #endif
           basic_simd(basic_simd<U, abi_type> const& other) noexcept

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -46,48 +46,21 @@ class kokkos_checker {
   KOKKOS_INLINE_FUNCTION void truth(bool x) const {
     if (!x) Kokkos::abort("SIMD unit test truth condition failed on device");
   }
-
-#if defined(KOKKOS_IMPL_32BIT)
-  // This is needed to work around a bug where the comparison fails because it
-  // is done on the x87 fpu (which is the default for 32 bit gcc) in long
-  // double and a and b end up being different in long double but have the
-  // same value when casted to float or double. (see
-  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323#c109)
-  union EqualityCheck {
-    double d;
-    float f;
-    std::int64_t i64;
-    std::int32_t i32;
-  };
-
   template <class T>
-  KOKKOS_INLINE_FUNCTION void equality(T const& a, T const& b) const {
-    EqualityCheck v_a, v_b;
-    if constexpr (std::is_same_v<T, float>) {
-      v_a.f = a;
-      v_b.f = b;
-
-      std::int32_t a32 = v_a.i32;
-      std::int32_t b32 = v_b.i32;
-
-      if ((a32 ^ b32) != 0)
-        Kokkos::abort("SIMD unit test equality condition failed on device");
-    } else if constexpr (std::is_same_v<T, double>) {
-      v_a.d = a;
-      v_b.d = b;
-
-      std::int64_t a64 = v_a.i64;
-      std::int64_t b64 = v_b.i64;
-
-      if ((a64 ^ b64) != 0)
-        Kokkos::abort("SIMD unit test equality condition failed on device");
-    } else {
-      if (a != b)
-        Kokkos::abort("SIMD unit test equality condition failed on device");
-    }
+#if defined(KOKKOS_IMPL_32BIT)
+  KOKKOS_FUNCTION __attribute__((noinline)) void equality(T const& a,
+                                                          T const& b) const {
+    // This is needed to work around a bug where the comparison fails because it
+    // is done on the x87 fpu (which is the default for 32 bit gcc) in long
+    // double and a and b end up being different in long double but have the
+    // same value when casted to float or double. (see
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323#c109)
+    T const volatile* const pa = a;
+    T const volatile* const pb = b;
+    if (*pa != *pb)
+      Kokkos::abort("SIMD unit test equality condition failed on device");
   }
 #else
-  template <class T>
   KOKKOS_INLINE_FUNCTION void equality(T const& a, T const& b) const {
     if (a != b)
       Kokkos::abort("SIMD unit test equality condition failed on device");

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -47,8 +47,9 @@ class kokkos_checker {
     if (!x) Kokkos::abort("SIMD unit test truth condition failed on device");
   }
   template <class T>
-  KOKKOS_INLINE_FUNCTION void equality(T const& a, T const& b) const {
 #if defined(KOKKOS_IMPL_32BIT)
+  KOKKOS_FUNCTION __attribute__((noinline)) void equality(T const& a,
+                                                          T const& b) const {
     // This is needed to work around a bug where the comparison fails because it
     // is done on the x87 fpu (which is the default for 32 bit gcc) in long
     // double and a and b end up being different in long double but have the
@@ -58,11 +59,13 @@ class kokkos_checker {
     T const volatile vb = b;
     if (va != vb)
       Kokkos::abort("SIMD unit test equality condition failed on device");
+  }
 #else
+  KOKKOS_INLINE_FUNCTION void equality(T const& a, T const& b) const {
     if (a != b)
       Kokkos::abort("SIMD unit test equality condition failed on device");
-#endif
   }
+#endif
 };
 
 template <class T, class Abi>

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -47,25 +47,22 @@ class kokkos_checker {
     if (!x) Kokkos::abort("SIMD unit test truth condition failed on device");
   }
   template <class T>
+  KOKKOS_INLINE_FUNCTION void equality(T const& a, T const& b) const {
 #if defined(KOKKOS_IMPL_32BIT)
-  KOKKOS_FUNCTION __attribute__((noinline)) void equality(T const& a,
-                                                          T const& b) const {
     // This is needed to work around a bug where the comparison fails because it
     // is done on the x87 fpu (which is the default for 32 bit gcc) in long
     // double and a and b end up being different in long double but have the
     // same value when casted to float or double. (see
     // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323#c109)
-    T const volatile* const volatile pa = a;
-    T const volatile* const volatile pb = b;
+    T const volatile* const volatile pa = &a;
+    T const volatile* const volatile pb = &b;
     if (*pa != *pb)
       Kokkos::abort("SIMD unit test equality condition failed on device");
-  }
 #else
-  KOKKOS_INLINE_FUNCTION void equality(T const& a, T const& b) const {
     if (a != b)
       Kokkos::abort("SIMD unit test equality condition failed on device");
-  }
 #endif
+  }
 };
 
 template <class T, class Abi>

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -46,21 +46,48 @@ class kokkos_checker {
   KOKKOS_INLINE_FUNCTION void truth(bool x) const {
     if (!x) Kokkos::abort("SIMD unit test truth condition failed on device");
   }
-  template <class T>
+
 #if defined(KOKKOS_IMPL_32BIT)
-  KOKKOS_FUNCTION __attribute__((noinline)) void equality(T const& a,
-                                                          T const& b) const {
-    // This is needed to work around a bug where the comparison fails because it
-    // is done on the x87 fpu (which is the default for 32 bit gcc) in long
-    // double and a and b end up being different in long double but have the
-    // same value when casted to float or double. (see
-    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323#c109)
-    T const volatile va = a;
-    T const volatile vb = b;
-    if (va != vb)
-      Kokkos::abort("SIMD unit test equality condition failed on device");
+  // This is needed to work around a bug where the comparison fails because it
+  // is done on the x87 fpu (which is the default for 32 bit gcc) in long
+  // double and a and b end up being different in long double but have the
+  // same value when casted to float or double. (see
+  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323#c109)
+  union EqualityCheck {
+    double d;
+    float f;
+    std::int64_t i64;
+    std::int32_t i32;
+  };
+
+  template <class T>
+  KOKKOS_INLINE_FUNCTION void equality(T const& a, T const& b) const {
+    EqualityCheck v_a, v_b;
+    if constexpr (std::is_same_v<T, float>) {
+      v_a.f = a;
+      v_b.f = b;
+
+      std::int32_t a32 = v_a.i32;
+      std::int32_t b32 = v_b.i32;
+
+      if ((a32 ^ b32) != 0)
+        Kokkos::abort("SIMD unit test equality condition failed on device");
+    } else if constexpr (std::is_same_v<T, double>) {
+      v_a.d = a;
+      v_b.d = b;
+
+      std::int64_t a64 = v_a.i64;
+      std::int64_t b64 = v_b.i64;
+
+      if ((a64 ^ b64) != 0)
+        Kokkos::abort("SIMD unit test equality condition failed on device");
+    } else {
+      if (a != b)
+        Kokkos::abort("SIMD unit test equality condition failed on device");
+    }
   }
 #else
+  template <class T>
   KOKKOS_INLINE_FUNCTION void equality(T const& a, T const& b) const {
     if (a != b)
       Kokkos::abort("SIMD unit test equality condition failed on device");

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -55,8 +55,8 @@ class kokkos_checker {
     // double and a and b end up being different in long double but have the
     // same value when casted to float or double. (see
     // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323#c109)
-    T const volatile* const pa = a;
-    T const volatile* const pb = b;
+    T const volatile* const volatile pa = a;
+    T const volatile* const volatile pb = b;
     if (*pa != *pb)
       Kokkos::abort("SIMD unit test equality condition failed on device");
   }

--- a/simd/unit_tests/include/TestSIMD_Conversions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Conversions.hpp
@@ -27,196 +27,105 @@ import kokkos.simd;
 
 using Kokkos::Experimental::all_of;
 
-template <typename DataType>
-struct Gen_increment {
-  KOKKOS_FUNCTION DataType operator()(std::size_t i) { return (DataType)(i); }
-};
-
-struct Gen_bool {
-  KOKKOS_FUNCTION bool operator()(std::size_t i) { return 0 == (i & 1); }
-};
-
-template <typename Abi>
+template <typename Abi, typename DataTypeA, typename DataTypeB>
 inline void host_check_conversions() {
-  if constexpr (is_simd_avail_v<uint64_t, Abi>) {
+  if constexpr (is_simd_avail_v<DataTypeA, Abi> &&
+                is_simd_avail_v<DataTypeB, Abi>) {
+    DataTypeA test_val =
+        (std::is_signed_v<DataTypeA> && std::is_signed_v<DataTypeB>) ? -213
+                                                                     : 213;
+    bool test_mask_val = true;
     {
-      auto a = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(1);
-      auto b = Kokkos::Experimental::basic_simd<std::int64_t, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(1)));
+      auto from = Kokkos::Experimental::basic_simd<DataTypeA, Abi>(test_val);
+      auto to   = Kokkos::Experimental::basic_simd<DataTypeB, Abi>(from);
+      auto expected =
+          Kokkos::Experimental::basic_simd<DataTypeB, Abi>(test_val);
+      EXPECT_EQ(from.size(), to.size());
+      host_check_equality(to, decltype(to)(test_val), to.size());
+      host_check_equality(to, expected, to.size());
     }
     {
-      auto a = Kokkos::Experimental::basic_simd<std::int32_t, Abi>(1);
-      auto b = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(1)));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(1);
-      auto b = Kokkos::Experimental::basic_simd<std::int32_t, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(1)));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(
-          Gen_increment<std::uint64_t>());
-      auto b = Kokkos::Experimental::basic_simd<std::int64_t, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(Gen_increment<std::int64_t>())));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd<std::int32_t, Abi>(
-          Gen_increment<std::int32_t>());
-      auto b = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(Gen_increment<std::uint64_t>())));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(
-          Gen_increment<std::uint64_t>());
-      auto b = Kokkos::Experimental::basic_simd<std::int32_t, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(Gen_increment<std::int32_t>())));
+      auto from =
+          Kokkos::Experimental::basic_simd_mask<DataTypeA, Abi>(test_mask_val);
+      auto to = Kokkos::Experimental::basic_simd_mask<DataTypeB, Abi>(from);
+      auto expected =
+          Kokkos::Experimental::basic_simd_mask<DataTypeB, Abi>(test_mask_val);
+      EXPECT_EQ(from.size(), to.size());
+      EXPECT_TRUE(all_of(to == decltype(to)(test_mask_val)));
+      EXPECT_TRUE(all_of(to == expected));
     }
   }
+}
 
-  if constexpr (is_type_v<
-                    Kokkos::Experimental::basic_simd_mask<int32_t, Abi>> &&
-                is_type_v<
-                    Kokkos::Experimental::basic_simd_mask<int64_t, Abi>>) {
-    {
-      auto a = Kokkos::Experimental::basic_simd_mask<double, Abi>(true);
-      auto b = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(true)));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
-      auto b = Kokkos::Experimental::basic_simd_mask<std::uint64_t, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(true)));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
-      auto b = Kokkos::Experimental::basic_simd_mask<std::int64_t, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(true)));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
-      auto b = Kokkos::Experimental::basic_simd_mask<double, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(true)));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd_mask<double, Abi>(Gen_bool());
-      auto b = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(Gen_bool())));
-    }
-    {
-      auto a =
-          Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(Gen_bool());
-      auto b = Kokkos::Experimental::basic_simd_mask<std::uint64_t, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(Gen_bool())));
-    }
-    {
-      auto a =
-          Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(Gen_bool());
-      auto b = Kokkos::Experimental::basic_simd_mask<std::int64_t, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(Gen_bool())));
-    }
-    {
-      auto a =
-          Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(Gen_bool());
-      auto b = Kokkos::Experimental::basic_simd_mask<double, Abi>(a);
-      EXPECT_TRUE(all_of(b == decltype(b)(Gen_bool())));
-    }
-  }
+template <typename Abi, typename DataTypeA, typename... DataTypesB>
+inline void host_check_conversions_all_types_to(
+    Kokkos::Experimental::Impl::data_types<DataTypesB...>) {
+  (host_check_conversions<Abi, DataTypeA, DataTypesB>(), ...);
+}
+
+template <typename Abi, typename... DataTypesA>
+inline void host_check_conversions_all_types_from(
+    Kokkos::Experimental::Impl::data_types<DataTypesA...>) {
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (host_check_conversions_all_types_to<Abi, DataTypesA>(DataTypes()), ...);
 }
 
 template <typename... Abis>
 inline void host_check_conversions_all_abis(
     Kokkos::Experimental::Impl::abi_set<Abis...>) {
-  (host_check_conversions<Abis>(), ...);
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (host_check_conversions_all_types_from<Abis>(DataTypes()), ...);
 }
 
-template <typename Abi>
+template <typename Abi, typename DataTypeA, typename DataTypeB>
 KOKKOS_INLINE_FUNCTION void device_check_conversions() {
-  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<uint64_t, Abi>>) {
+  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataTypeA, Abi>> &&
+                is_type_v<Kokkos::Experimental::basic_simd<DataTypeB, Abi>>) {
+    DataTypeA test_val =
+        (std::is_signed_v<DataTypeA> && std::is_signed_v<DataTypeB>) ? -213
+                                                                     : 213;
+    bool test_mask_val = true;
     kokkos_checker checker;
     {
-      auto a = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(1);
-      auto b = Kokkos::Experimental::basic_simd<std::int64_t, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(1)));
+      auto from = Kokkos::Experimental::basic_simd<DataTypeA, Abi>(test_val);
+      auto to   = Kokkos::Experimental::basic_simd<DataTypeB, Abi>(from);
+      auto expected =
+          Kokkos::Experimental::basic_simd<DataTypeB, Abi>(test_val);
+      checker.truth(from.size() == to.size());
+      device_check_equality(to, decltype(to)(test_val), to.size());
+      device_check_equality(to, expected, to.size());
     }
     {
-      auto a = Kokkos::Experimental::basic_simd<std::int32_t, Abi>(1);
-      auto b = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(1)));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(1);
-      auto b = Kokkos::Experimental::basic_simd<std::int32_t, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(1)));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(
-          Gen_increment<std::uint64_t>());
-      auto b = Kokkos::Experimental::basic_simd<std::int64_t, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(Gen_increment<std::int64_t>())));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd<std::int32_t, Abi>(
-          Gen_increment<std::int32_t>());
-      auto b = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(Gen_increment<std::uint64_t>())));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd<std::uint64_t, Abi>(
-          Gen_increment<std::uint64_t>());
-      auto b = Kokkos::Experimental::basic_simd<std::int32_t, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(Gen_increment<std::int32_t>())));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd_mask<double, Abi>(true);
-      auto b = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(true)));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
-      auto b = Kokkos::Experimental::basic_simd_mask<std::uint64_t, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(true)));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
-      auto b = Kokkos::Experimental::basic_simd_mask<std::int64_t, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(true)));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(true);
-      auto b = Kokkos::Experimental::basic_simd_mask<double, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(true)));
-    }
-    {
-      auto a = Kokkos::Experimental::basic_simd_mask<double, Abi>(Gen_bool());
-      auto b = Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(Gen_bool())));
-    }
-    {
-      auto a =
-          Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(Gen_bool());
-      auto b = Kokkos::Experimental::basic_simd_mask<std::uint64_t, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(Gen_bool())));
-    }
-    {
-      auto a =
-          Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(Gen_bool());
-      auto b = Kokkos::Experimental::basic_simd_mask<std::int64_t, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(Gen_bool())));
-    }
-    {
-      auto a =
-          Kokkos::Experimental::basic_simd_mask<std::int32_t, Abi>(Gen_bool());
-      auto b = Kokkos::Experimental::basic_simd_mask<double, Abi>(a);
-      checker.truth(all_of(b == decltype(b)(Gen_bool())));
+      auto from =
+          Kokkos::Experimental::basic_simd_mask<DataTypeA, Abi>(test_mask_val);
+      auto to = Kokkos::Experimental::basic_simd_mask<DataTypeB, Abi>(from);
+      auto expected =
+          Kokkos::Experimental::basic_simd_mask<DataTypeB, Abi>(test_mask_val);
+      checker.truth(from.size() == to.size());
+      checker.truth(all_of(to == decltype(to)(test_mask_val)));
+      checker.truth(all_of(to == expected));
     }
   }
+}
+
+template <typename Abi, typename DataTypeA, typename... DataTypesB>
+KOKKOS_INLINE_FUNCTION void device_check_conversions_all_types_to(
+    Kokkos::Experimental::Impl::data_types<DataTypesB...>) {
+  (device_check_conversions<Abi, DataTypeA, DataTypesB>(), ...);
+}
+
+template <typename Abi, typename... DataTypesA>
+KOKKOS_INLINE_FUNCTION void device_check_conversions_all_types_from(
+    Kokkos::Experimental::Impl::data_types<DataTypesA...>) {
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (device_check_conversions_all_types_to<Abi, DataTypesA>(DataTypes()), ...);
 }
 
 template <typename... Abis>
 KOKKOS_INLINE_FUNCTION void device_check_conversions_all_abis(
     Kokkos::Experimental::Impl::abi_set<Abis...>) {
-  (device_check_conversions<Abis>(), ...);
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (device_check_conversions_all_types_from<Abis>(DataTypes()), ...);
 }
 
 class simd_device_conversions_functor {

--- a/simd/unit_tests/include/TestSIMD_Conversions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Conversions.hpp
@@ -79,8 +79,8 @@ inline void host_check_conversions_all_abis(
 
 template <typename Abi, typename DataTypeA, typename DataTypeB>
 KOKKOS_INLINE_FUNCTION void device_check_conversions() {
-  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataTypeA, Abi>> &&
-                is_type_v<Kokkos::Experimental::basic_simd<DataTypeB, Abi>>) {
+  if constexpr (is_simd_avail_v<DataTypeA, Abi> &&
+                is_simd_avail_v<DataTypeB, Abi>) {
     DataTypeA test_val =
         (std::is_signed_v<DataTypeA> && std::is_signed_v<DataTypeB>) ? -213
                                                                      : 213;


### PR DESCRIPTION
Initially from #6466.

This PR adds conversion constructors to `basic_simd` types:

```
template<class U, class UAbi>
  constexpr explicit(expression) basic_simd(const basic_simd<U, UAbi>& x) noexcept;
```


- Conversion constructors are defined `explicit` if the conversion from `U` to `basic_simd::value_type` is not value-preserving or narrowing.
- Since `explicit` specifier with an expression is available from c++20, all conversion constructors are `explicit` for c++17 builds.
- As fallback implementation, conversion constructors that use generator constructors to individually convert each vector lane are placed.