### PR TITLE
Add initial View customization point

### DIFF
--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -289,7 +289,7 @@ struct MDSpanViewTraits {
                              mdspan_layout_type, accessor_type>;
 };
 
-// Usupported View Layout
+// Unsupported View Layout
 template <class Traits>
 struct MDSpanViewTraits<Traits, void, void> {
   using mdspan_type = UnsupportedKokkosArrayLayout;

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -168,7 +168,45 @@ struct ViewUniformType;
 }
 }  // namespace Kokkos
 
+// =========================================================
+// View template argument parsing
+// =========================================================
 namespace Kokkos {
+
+// =========================================================
+// Customization points for View for projects such as Sacado
+// =========================================================
+
+namespace Impl {
+// Type list for View Arguments
+template <class ValueType, class ArrayLayout, class DeviceType,
+          class MemoryTraits>
+struct ViewArguments {
+  using value_type    = ValueType;
+  using array_layout  = ArrayLayout;
+  using device_type   = DeviceType;
+  using memory_traits = MemoryTraits;
+  static_assert(!std::is_pointer_v<ValueType>);
+  static_assert(is_array_layout_v<ArrayLayout>);
+  static_assert(is_device_v<DeviceType>);
+  static_assert(is_memory_traits_v<MemoryTraits>);
+};
+
+// Customized mdspan/BasicView arguments
+template <class IndexType, class AccessorType>
+struct ViewCustomArguments {
+  using index_type    = IndexType;
+  using accessor_type = AccessorType;
+  static_assert(std::is_integral_v<IndexType>);
+};
+
+// Customization point to control mdspan arguments from view arguments
+// Default implementation returns void to indicate no customization
+template <class ValueType, class ArrayLayout, class DeviceType,
+          class MemoryTraits>
+constexpr void customize_view_arguments(
+    ViewArguments<ValueType, ArrayLayout, DeviceType, MemoryTraits>) {}
+}  // namespace Impl
 
 #ifdef KOKKOS_ENABLE_IMPL_MDSPAN
 namespace Impl {
@@ -228,25 +266,50 @@ template <class Traits>
 using accessor_from_view_traits_t =
     typename AccessorFromViewTraits<Traits>::type;
 
-template <class Traits, class Enabled = void>
-struct MDSpanViewTraits {
-  using mdspan_type = UnsupportedKokkosArrayLayout;
-};
-
 // "Natural" mdspan for a view if the View's ArrayLayout is supported.
-template <class Traits>
-struct MDSpanViewTraits<Traits, std::void_t<typename LayoutFromArrayLayout<
-                                    typename Traits::array_layout>::type>> {
+template <
+    class Traits,
+    class CustomizedArgs = decltype(customize_view_arguments(
+        ViewArguments<
+            typename Traits::value_type, typename Traits::array_layout,
+            typename Traits::device_type, typename Traits::memory_traits>())),
+    class Layout =
+        typename LayoutFromArrayLayout<typename Traits::array_layout>::type>
+struct MDSpanViewTraits {
   using index_type = std::size_t;
   using extents_type =
       typename ExtentsFromDataType<index_type,
                                    typename Traits::data_type>::type;
-  using mdspan_layout_type =
-      typename LayoutFromArrayLayout<typename Traits::array_layout>::type;
+  using mdspan_layout_type = Layout;
+  static_assert(
+      std::is_same_v<Layout, typename LayoutFromArrayLayout<
+                                 typename Traits::array_layout>::type>);
   using accessor_type = accessor_from_view_traits_t<Traits>;
   using mdspan_type   = mdspan<typename Traits::value_type, extents_type,
                              mdspan_layout_type, accessor_type>;
 };
+
+// Usupported View Layout
+template <class Traits>
+struct MDSpanViewTraits<Traits, void, void> {
+  using mdspan_type = UnsupportedKokkosArrayLayout;
+};
+
+// Customized View arguments
+template <class Traits, class IndexType, class AccessorType, class LayoutType>
+struct MDSpanViewTraits<Traits, ViewCustomArguments<IndexType, AccessorType>,
+                        LayoutType> {
+  using index_type = IndexType;
+  using extents_type =
+      typename ExtentsFromDataType<index_type,
+                                   typename Traits::data_type>::type;
+  using mdspan_layout_type = LayoutType;
+  using accessor_type      = AccessorType;
+  // This will static assert that accessor_type is legal
+  using mdspan_type = mdspan<typename Traits::value_type, extents_type,
+                             mdspan_layout_type, accessor_type>;
+};
+
 }  // namespace Impl
 #endif  // KOKKOS_ENABLE_IMPL_MDSPAN
 
@@ -463,6 +526,12 @@ struct ViewTraits {
   using hooks_policy      = HooksPolicy;
 
   using size_type = typename MemorySpace::size_type;
+
+  static constexpr bool impl_is_customized =
+      !std::is_same_v<void,
+                      decltype(customize_view_arguments(
+                          Impl::ViewArguments<value_type, array_layout,
+                                              device_type, memory_traits>()))>;
 
   enum { is_hostspace = std::is_same_v<MemorySpace, HostSpace> };
   enum { is_managed = MemoryTraits::is_unmanaged == 0 };

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
@@ -51,7 +51,9 @@ struct IsLayoutLeftPadded<Experimental::layout_left_padded<Pad>>
     : std::true_type {};
 
 template <class ArrayLayout>
-struct LayoutFromArrayLayout;
+struct LayoutFromArrayLayout {
+  using type = void;
+};
 
 template <>
 struct LayoutFromArrayLayout<LayoutLeft> {

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -93,11 +93,16 @@ set(COMPILE_ONLY_SOURCES
     TestTeamMDRangePolicyCTAD.cpp
     TestNestedReducerCTAD.cpp
     view/TestBasicViewMDSpanConversion.cpp
+    view/TestViewCustomization.cpp
     view/TestExtentsDatatypeConversion.cpp
 )
 
 if(NOT Kokkos_ENABLE_IMPL_MDSPAN OR KOKKOS_CXX_COMPILER_ID STREQUAL "Intel")
   list(REMOVE_ITEM COMPILE_ONLY_SOURCES view/TestBasicViewMDSpanConversion.cpp)
+endif()
+
+if(NOT Kokkos_ENABLE_IMPL_MDSPAN OR Kokkos_ENABLE_IMPL_VIEW_LEGACY)
+  list(REMOVE_ITEM COMPILE_ONLY_SOURCES view/TestViewCustomization.cpp)
 endif()
 
 #testing if windows.h and Kokkos_Core.hpp can be included

--- a/core/unit_test/view/TestViewCustomization.cpp
+++ b/core/unit_test/view/TestViewCustomization.cpp
@@ -1,0 +1,77 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+#include <type_traits>
+
+namespace Foo {
+
+struct FooVal {
+  int value;
+};
+
+struct BarVal {
+  int value;
+};
+// Customization point to control mdspan arguments from view arguments
+// Default implementation returns void to indicate no customization
+template <class LayoutType, class DeviceType, class MemoryTraits>
+constexpr auto customize_view_arguments(
+    Kokkos::Impl::ViewArguments<BarVal, LayoutType, DeviceType, MemoryTraits>) {
+  using mem_space_t = typename DeviceType::memory_space;
+  return Kokkos::Impl::ViewCustomArguments<
+      int, Kokkos::Impl::SpaceAwareAccessor<
+               mem_space_t, Kokkos::default_accessor<BarVal>>>{};
+}
+template <class LayoutType, class DeviceType, class MemoryTraits>
+constexpr auto customize_view_arguments(
+    Kokkos::Impl::ViewArguments<const BarVal, LayoutType, DeviceType,
+                                MemoryTraits>) {
+  using mem_space_t = typename DeviceType::memory_space;
+  return Kokkos::Impl::ViewCustomArguments<
+      unsigned, Kokkos::Impl::SpaceAwareAccessor<
+                    mem_space_t, Kokkos::default_accessor<const BarVal>>>{};
+}
+
+}  // namespace Foo
+
+using view_fooval_t  = Kokkos::View<Foo::FooVal*>;
+using view_barval_t  = Kokkos::View<Foo::BarVal*>;
+using view_cbarval_t = Kokkos::View<const Foo::BarVal*>;
+
+static_assert(!view_fooval_t::traits::impl_is_customized);
+static_assert(view_barval_t::traits::impl_is_customized);
+static_assert(view_cbarval_t::traits::impl_is_customized);
+
+static_assert(
+    std::is_same_v<typename view_fooval_t::extents_type::index_type, size_t>);
+static_assert(
+    std::is_same_v<typename view_barval_t::extents_type::index_type, int>);
+static_assert(std::is_same_v<typename view_cbarval_t::extents_type::index_type,
+                             unsigned>);
+
+using mem_space_t = typename Kokkos::DefaultExecutionSpace::memory_space;
+static_assert(std::is_same_v<typename view_fooval_t::accessor_type,
+                             Kokkos::Impl::CheckedReferenceCountedAccessor<
+                                 Foo::FooVal, mem_space_t>>);
+static_assert(
+    std::is_same_v<typename view_barval_t::accessor_type,
+                   Kokkos::Impl::SpaceAwareAccessor<
+                       mem_space_t, Kokkos::default_accessor<Foo::BarVal>>>);
+static_assert(std::is_same_v<
+              typename view_cbarval_t::accessor_type,
+              Kokkos::Impl::SpaceAwareAccessor<
+                  mem_space_t, Kokkos::default_accessor<const Foo::BarVal>>>);


### PR DESCRIPTION
This uses ADL based function lookup using functions that take a Kokkos::Impl::ViewArguments (effectively typelist) arg.

Thus its not yet fully public, but can easily be made public. It returns another special argument that speifies index_type and accessor_type.

This first PR only enables the customization of the accessor type effectively. It does not have the capability to pass arguments through to that accessor during construction. 