### PR TITLE
Fixes function call chain in overloads of parallel_reduce

### DIFF
--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1711,25 +1711,22 @@ template <class FunctorType, class ReturnType>
 inline std::enable_if_t<!(Kokkos::is_view<ReturnType>::value ||
                           Kokkos::is_reducer<ReturnType>::value ||
                           std::is_pointer_v<ReturnType>)>
-parallel_reduce(const size_t& policy, const FunctorType& functor,
-                ReturnType& return_value) {
+parallel_reduce(const std::string& label, const size_t& work_count,
+                const FunctorType& functor, ReturnType& return_value) {
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,
                                               FunctorType>::policy_type;
-  parallel_reduce("", policy_type(0, policy), functor, return_value);
+
+  parallel_reduce(label, policy_type(0, work_count), functor, return_value);
 }
 
 template <class FunctorType, class ReturnType>
 inline std::enable_if_t<!(Kokkos::is_view<ReturnType>::value ||
                           Kokkos::is_reducer<ReturnType>::value ||
                           std::is_pointer_v<ReturnType>)>
-parallel_reduce(const std::string& label, const size_t& policy,
-                const FunctorType& functor, ReturnType& return_value) {
-  using policy_type =
-      typename Impl::ParallelReducePolicyType<void, size_t,
-                                              FunctorType>::policy_type;
-
-  parallel_reduce(label, policy_type(0, policy), functor, return_value);
+parallel_reduce(const size_t& work_count, const FunctorType& functor,
+                ReturnType& return_value) {
+  parallel_reduce("", work_count, functor, return_value);
 }
 
 // ReturnValue as View or Reducer: take by copy to allow for inline construction
@@ -1765,26 +1762,22 @@ template <class FunctorType, class ReturnType>
 inline std::enable_if_t<Kokkos::is_view<ReturnType>::value ||
                         Kokkos::is_reducer<ReturnType>::value ||
                         std::is_pointer_v<ReturnType>>
-parallel_reduce(const size_t& policy, const FunctorType& functor,
-                const ReturnType& return_value) {
+parallel_reduce(const std::string& label, const size_t& work_count,
+                const FunctorType& functor, const ReturnType& return_value) {
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,
                                               FunctorType>::policy_type;
 
-  parallel_reduce("", policy_type(0, policy), functor, return_value);
+  parallel_reduce(label, policy_type(0, work_count), functor, return_value);
 }
 
 template <class FunctorType, class ReturnType>
 inline std::enable_if_t<Kokkos::is_view<ReturnType>::value ||
                         Kokkos::is_reducer<ReturnType>::value ||
                         std::is_pointer_v<ReturnType>>
-parallel_reduce(const std::string& label, const size_t& policy,
-                const FunctorType& functor, const ReturnType& return_value) {
-  using policy_type =
-      typename Impl::ParallelReducePolicyType<void, size_t,
-                                              FunctorType>::policy_type;
-
-  parallel_reduce(label, policy_type(0, policy), functor, return_value);
+parallel_reduce(const size_t& work_count, const FunctorType& functor,
+                const ReturnType& return_value) {
+  parallel_reduce("", work_count, functor, return_value);
 }
 
 // No Return Argument
@@ -1824,22 +1817,19 @@ inline void parallel_reduce(
 }
 
 template <class FunctorType>
-inline void parallel_reduce(const size_t& policy, const FunctorType& functor) {
-  using policy_type =
-      typename Impl::ParallelReducePolicyType<void, size_t,
-                                              FunctorType>::policy_type;
-
-  parallel_reduce("", policy_type(0, policy), functor);
-}
-
-template <class FunctorType>
-inline void parallel_reduce(const std::string& label, const size_t& policy,
+inline void parallel_reduce(const std::string& label, const size_t& work_count,
                             const FunctorType& functor) {
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,
                                               FunctorType>::policy_type;
 
-  parallel_reduce(label, policy_type(0, policy), functor);
+  parallel_reduce(label, policy_type(0, work_count), functor);
+}
+
+template <class FunctorType>
+inline void parallel_reduce(const size_t& work_count,
+                            const FunctorType& functor) {
+  parallel_reduce("", work_count, functor);
 }
 
 }  // namespace Kokkos


### PR DESCRIPTION
In #8060, the overloads without a label and accepting a work count were locally instantiating the policy and then calling the overload which accepts policies. However, they should be calling the overloads that accept a work count but with a label. It is enough if those overloads instantiate a policy and call the overload accepting a policy.

This is how it is implemented in `parallel_for` and `parallel_scan`.

This is what will help to reduce the number of checks in #7675.

The name of the parameter has been changed from `policy` to `work_count`, wherever it is appropriate. `parallel_for` and `parallel_scan` use the name `work_count`.

Sorry for not taking care of this in #8060. 