### PR TITLE
core(graph): allow building `Kokkos::Graph` object directly

### DIFF
--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -39,14 +39,17 @@ namespace Experimental {
 //==============================================================================
 // <editor-fold desc="Graph"> {{{1
 
-template <class ExecutionSpace>
+template <class ExecutionSpace = DefaultExecutionSpace>
 struct [[nodiscard]] Graph {
+  static_assert(Kokkos::is_execution_space_v<ExecutionSpace>);
+
  public:
   //----------------------------------------------------------------------------
   // <editor-fold desc="public member types"> {{{2
 
   using execution_space = ExecutionSpace;
   using graph           = Graph;
+  using root_t          = GraphNodeRef<ExecutionSpace>;
 
   // </editor-fold> end public member types }}}2
   //----------------------------------------------------------------------------
@@ -63,33 +66,48 @@ struct [[nodiscard]] Graph {
   //----------------------------------------------------------------------------
   // <editor-fold desc="private data members"> {{{2
 
-  using impl_t                       = Kokkos::Impl::GraphImpl<ExecutionSpace>;
-  std::shared_ptr<impl_t> m_impl_ptr = nullptr;
+  using impl_t      = Kokkos::Impl::GraphImpl<ExecutionSpace>;
+  using root_impl_t = typename impl_t::root_node_impl_t;
+
+  std::shared_ptr<impl_t> m_impl_ptr  = nullptr;
+  std::shared_ptr<root_impl_t> m_root = nullptr;
 
   // </editor-fold> end private data members }}}2
   //----------------------------------------------------------------------------
 
-  //----------------------------------------------------------------------------
-  // <editor-fold desc="private ctors"> {{{2
-
-  // Note: only create_graph() uses this constructor, but we can't just make
-  // that a friend instead of GraphAccess because of the way that friend
-  // function template injection works.
-  explicit Graph(std::shared_ptr<impl_t> arg_impl_ptr)
-      : m_impl_ptr(std::move(arg_impl_ptr)) {}
-
-  // </editor-fold> end private ctors }}}2
-  //----------------------------------------------------------------------------
-
  public:
+  // Construct an empty graph with a root node.
+  Graph(ExecutionSpace exec = ExecutionSpace{})
+      : m_impl_ptr{std::make_shared<impl_t>(std::move(exec))},
+        m_root{m_impl_ptr->create_root_node_ptr()} {}
+
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
+    defined(KOKKOS_ENABLE_SYCL)
+  // Construct a graph from a native graph, add a root node.
+  template <typename T>
+#if defined(KOKKOS_ENABLE_CXX20)
+    requires std::same_as<ExecutionSpace, Kokkos::DefaultExecutionSpace>
+#endif
+  Graph(ExecutionSpace exec, T&& native_graph)
+      : m_impl_ptr{std::make_shared<impl_t>(std::move(exec),
+                                            std::forward<T>(native_graph))},
+        m_root{m_impl_ptr->create_root_node_ptr()} {
+  }
+#endif
+
   ExecutionSpace const& get_execution_space() const {
     return m_impl_ptr->get_execution_space();
   }
 
+  // Once the graph is instantiated, it is undefined behavior to add nodes.
+  // TODO Add a locking mechanism to avoid users shooting themselves
+  //      in the foot.
   void instantiate() {
     KOKKOS_EXPECTS(bool(m_impl_ptr))
     (*m_impl_ptr).instantiate();
   }
+
+  auto root_node() const { return root_t{m_impl_ptr, m_root}; }
 
   void submit(const execution_space& exec) const {
     KOKKOS_EXPECTS(bool(m_impl_ptr))
@@ -144,19 +162,12 @@ Graph<ExecutionSpace> create_graph(ExecutionSpace ex, Closure&& arg_closure) {
   // create a Graph class without graph having public constructors. We can't
   // just make `create_graph` itself a friend because of the way that friend
   // function template injection works.
-  auto rv = Kokkos::Impl::GraphAccess::construct_graph(std::move(ex));
+  Graph<ExecutionSpace> rv{std::move(ex)};
   // Invoke the user's graph construction closure
-  ((Closure&&)arg_closure)(Kokkos::Impl::GraphAccess::create_root_ref(rv));
+  ((Closure&&)arg_closure)(rv.root_node());
   // and given them back the graph
   // KOKKOS_ENSURES(rv.m_impl_ptr.use_count() == 1)
   return rv;
-}
-
-template <class ExecutionSpace = DefaultExecutionSpace>
-std::enable_if_t<Kokkos::is_execution_space_v<ExecutionSpace>,
-                 Graph<ExecutionSpace>>
-create_graph(ExecutionSpace exec = ExecutionSpace{}) {
-  return Kokkos::Impl::GraphAccess::construct_graph(std::move(exec));
 }
 
 template <
@@ -168,16 +179,6 @@ std::enable_if_t<
 create_graph(Closure&& arg_closure) {
   return create_graph(ExecutionSpace{}, (Closure&&)arg_closure);
 }
-
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
-    defined(KOKKOS_ENABLE_SYCL)
-template <class Exec, typename T>
-std::enable_if_t<Kokkos::is_execution_space_v<Exec>, Graph<Exec>>
-create_graph_from_native(Exec exec, T&& native_graph) {
-  return Kokkos::Impl::GraphAccess::construct_graph_from_native(
-      std::move(exec), std::forward<T>(native_graph));
-}
-#endif
 
 // </editor-fold> end create_graph }}}1
 //==============================================================================

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -86,6 +86,7 @@ class GraphNodeRef {
   template <class, class, class>
   friend class GraphNodeRef;
   friend struct Kokkos::Impl::GraphAccess;
+  friend struct Graph<execution_space>;
 
   // </editor-fold> end Friends }}}2
   //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -38,36 +38,6 @@ struct is_graph_capture<
     : public std::true_type {};
 
 struct GraphAccess {
-  template <class ExecutionSpace>
-  static Kokkos::Experimental::Graph<ExecutionSpace> construct_graph(
-      ExecutionSpace ex) {
-    //----------------------------------------//
-    return Kokkos::Experimental::Graph<ExecutionSpace>{
-        std::make_shared<GraphImpl<ExecutionSpace>>(std::move(ex))};
-    //----------------------------------------//
-  }
-
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
-    defined(KOKKOS_ENABLE_SYCL)
-  template <class Exec, typename T>
-  static auto construct_graph_from_native(Exec&& ex, T&& native_graph) {
-    return Kokkos::Experimental::Graph<Kokkos::Impl::remove_cvref_t<Exec>>{
-        std::make_shared<GraphImpl<Kokkos::Impl::remove_cvref_t<Exec>>>(
-            std::forward<Exec>(ex), std::forward<T>(native_graph))};
-  }
-#endif
-
-  template <class ExecutionSpace>
-  static auto create_root_ref(
-      Kokkos::Experimental::Graph<ExecutionSpace>& arg_graph) {
-    auto const& graph_impl_ptr = arg_graph.m_impl_ptr;
-
-    auto root_ptr = graph_impl_ptr->create_root_node_ptr();
-
-    return Kokkos::Experimental::GraphNodeRef<ExecutionSpace>{
-        graph_impl_ptr, std::move(root_ptr)};
-  }
-
   template <class NodeType, class... Args>
   static auto make_node_shared_ptr(Args&&... args) {
     static_assert(

--- a/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
@@ -155,14 +155,11 @@ TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), construct_from_native) {
   cudaGraph_t native_graph = nullptr;
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGraphCreate(&native_graph, 0));
 
-  auto graph_from_native =
-      Kokkos::Experimental::create_graph_from_native(this->exec, native_graph);
+  Kokkos::Experimental::Graph graph_from_native(this->exec, native_graph);
 
   ASSERT_EQ(native_graph, graph_from_native.native_graph());
 
-  auto root = Kokkos::Impl::GraphAccess::create_root_ref(graph_from_native);
-
-  root.then_parallel_for(1, Increment<view_t>{data});
+  graph_from_native.root_node().then_parallel_for(1, Increment<view_t>{data});
 
   graph_from_native.submit(this->exec);
 

--- a/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
@@ -40,10 +40,7 @@ TEST(TEST_CATEGORY, graph_promises_on_native_objects) {
 #if !defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
   GTEST_SKIP() << "This test will not work without native graph support";
 #else
-  auto graph = Kokkos::Experimental::create_graph<Kokkos::HIP>();
-
-  auto root = Kokkos::Impl::GraphAccess::create_root_ref(graph);
-
+  Kokkos::Experimental::Graph<Kokkos::HIP> graph{};
   // Before instantiation, the HIP graph is valid, but the HIP executable
   // graph is still null.
   hipGraph_t hip_graph = graph.native_graph();
@@ -86,11 +83,9 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 
   view_t data(Kokkos::view_alloc(exec, "witness"));
 
-  auto graph = Kokkos::Experimental::create_graph(exec);
+  Kokkos::Experimental::Graph graph{exec};
 
-  auto root = Kokkos::Impl::GraphAccess::create_root_ref(graph);
-
-  root.then_parallel_for(1, Increment<view_t>{data});
+  graph.root_node().then_parallel_for(1, Increment<view_t>{data});
 
   graph.instantiate();
 
@@ -140,16 +135,13 @@ TEST(TEST_CATEGORY, graph_construct_from_native) {
 
   const Kokkos::HIP exec{};
 
-  auto graph_from_native =
-      Kokkos::Experimental::create_graph_from_native(exec, native_graph);
+  Kokkos::Experimental::Graph graph_from_native(exec, native_graph);
 
   ASSERT_EQ(native_graph, graph_from_native.native_graph());
 
-  auto root = Kokkos::Impl::GraphAccess::create_root_ref(graph_from_native);
-
   const view_t data(Kokkos::view_alloc(exec, "witness"));
 
-  root.then_parallel_for(1, Increment<view_t>{data});
+  graph_from_native.root_node().then_parallel_for(1, Increment<view_t>{data});
 
   graph_from_native.submit(exec);
 

--- a/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
@@ -49,9 +49,7 @@ TEST(TEST_CATEGORY, graph_get_native_return_types_are_references) {
 // This test checks the promises of Kokkos::Graph against its
 // underlying SYCL native objects.
 TEST(TEST_CATEGORY, graph_promises_on_native_objects) {
-  auto graph = Kokkos::Experimental::create_graph<Kokkos::SYCL>();
-
-  auto root = Kokkos::Impl::GraphAccess::create_root_ref(graph);
+  Kokkos::Experimental::Graph<Kokkos::SYCL> graph{};
 
   // Before instantiation, the SYCL graph is valid, but the SYCL executable
   // graph is still null. Since the SYCL command graph is a regular object,
@@ -74,11 +72,9 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 
   view_t data(Kokkos::view_alloc(exec, "witness"));
 
-  auto graph = Kokkos::Experimental::create_graph(exec);
+  Kokkos::Experimental::Graph graph{exec};
 
-  auto root = Kokkos::Impl::GraphAccess::create_root_ref(graph);
-
-  root.then_parallel_for(1, Increment<view_t>{data});
+  graph.root_node().then_parallel_for(1, Increment<view_t>{data});
 
   graph.instantiate();
 
@@ -127,14 +123,11 @@ TEST(TEST_CATEGORY, graph_construct_from_native) {
   native_graph_t native_graph(exec.sycl_queue().get_context(),
                               exec.sycl_queue().get_device());
 
-  auto graph_from_native = Kokkos::Experimental::create_graph_from_native(
-      exec, std::move(native_graph));
-
-  auto root = Kokkos::Impl::GraphAccess::create_root_ref(graph_from_native);
+  Kokkos::Experimental::Graph graph_from_native(exec, std::move(native_graph));
 
   const view_t data(Kokkos::view_alloc(exec, "witness"));
 
-  root.then_parallel_for(1, Increment<view_t>{data});
+  graph_from_native.root_node().then_parallel_for(1, Increment<view_t>{data});
 
   graph_from_native.submit(exec);
 


### PR DESCRIPTION
This PR allows building a `Kokkos::Graph` object directly.

The free function `create_graph(exec, closure)` is envisioned to only allow creating a graph "in one shot", and the graph definition should be locked afterwards.

<details>

<summary>
:warning: This is the old PR description.
</summary>

This is a followup of:
* #7248

At the time, we partially addressed the envisioned use case:
> This helps supporting advanced use cases for which creating the graph "in one shot" is not satisfactory.

because it would still require the user to do:
```c++
  auto graph  = Kokkos::Experimental::create_graph(TEST_EXECSPACE{});
  auto root   = Kokkos::Impl::GraphAccess::create_root_ref(graph);
```
*i.e.* use some `Kokkos::Impl` stuff :vomiting_face:

This PR rectifies this by returning both the graph and the root node:
```c++
auto [graph, root]  = Kokkos::Experimental::create_graph(TEST_EXECSPACE{});
```

I'm not sure this is the best design, *e.g.* we could expose a `Kokkos::Experimental::Graph::get_root()` method. My thoughts:
- If getting the root is the overwhelmingly common use case (which I think it is), returning a tuple with both graph and root is a good choice.
- If advanced usages often don’t need the root (which I think never happens), exposing a `get_root()` method is more idiomatic. It also makes the API easier to extend in the future.

</details>