### PR TITLE
Deprecate `View::stride_N()` in favor of `View::stride(N)`

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -585,7 +585,7 @@ struct Random_XorShift1024_State<false> {
   template <class StateViewType>
   KOKKOS_FUNCTION Random_XorShift1024_State(const StateViewType& v,
                                             int state_idx)
-      : state_(&v(state_idx, 0)), stride_(v.stride_1()) {}
+      : state_(&v(state_idx, 0)), stride_(v.stride(1)) {}
 
   // NOLINTBEGIN(bugprone-implicit-widening-of-multiplication-result)
   KOKKOS_FUNCTION

--- a/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_RandomAccessIterator.hpp
@@ -67,11 +67,11 @@ class RandomAccessIterator<::Kokkos::View<DataType, Args...>> {
   KOKKOS_DEFAULTED_FUNCTION RandomAccessIterator() = default;
 
   explicit KOKKOS_FUNCTION RandomAccessIterator(const view_type view)
-      : m_data(view.data()), m_stride(view.stride_0()) {}
+      : m_data(view.data()), m_stride(view.stride(0)) {}
   explicit KOKKOS_FUNCTION RandomAccessIterator(const view_type view,
                                                 ptrdiff_t current_index)
-      : m_data(view.data() + current_index * view.stride_0()),
-        m_stride(view.stride_0()) {}
+      : m_data(view.data() + current_index * view.stride(0)),
+        m_stride(view.stride(0)) {}
 
 #ifndef KOKKOS_ENABLE_CXX17  // C++20 and beyond
   template <class OtherViewType>

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -607,14 +607,16 @@ class DynRankView : private View<DataType*******, Properties...> {
   using view_type::span;
   using view_type::span_is_contiguous;  // FIXME: not tested
   using view_type::stride;              // FIXME: not tested
-  using view_type::stride_0;            // FIXME: not tested
-  using view_type::stride_1;            // FIXME: not tested
-  using view_type::stride_2;            // FIXME: not tested
-  using view_type::stride_3;            // FIXME: not tested
-  using view_type::stride_4;            // FIXME: not tested
-  using view_type::stride_5;            // FIXME: not tested
-  using view_type::stride_6;            // FIXME: not tested
-  using view_type::stride_7;            // FIXME: not tested
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  using view_type::stride_0;  // FIXME: not tested
+  using view_type::stride_1;  // FIXME: not tested
+  using view_type::stride_2;  // FIXME: not tested
+  using view_type::stride_3;  // FIXME: not tested
+  using view_type::stride_4;  // FIXME: not tested
+  using view_type::stride_5;  // FIXME: not tested
+  using view_type::stride_6;  // FIXME: not tested
+  using view_type::stride_7;  // FIXME: not tested
+#endif
   using view_type::use_count;
 
 #ifdef KOKKOS_ENABLE_CUDA

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -334,14 +334,18 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
     return r == 0 ? size() : 1;
   }
 
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_0() const { return 0; }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_1() const { return 0; }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_2() const { return 0; }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_3() const { return 0; }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_4() const { return 0; }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_5() const { return 0; }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_6() const { return 0; }
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_7() const { return 0; }
+  // clang-format off
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(0) instead") KOKKOS_FUNCTION constexpr size_t stride_0() const { return stride(0); }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(1) instead") KOKKOS_FUNCTION constexpr size_t stride_1() const { return stride(1); }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(2) instead") KOKKOS_FUNCTION constexpr size_t stride_2() const { return stride(2); }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(3) instead") KOKKOS_FUNCTION constexpr size_t stride_3() const { return stride(3); }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(4) instead") KOKKOS_FUNCTION constexpr size_t stride_4() const { return stride(4); }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(5) instead") KOKKOS_FUNCTION constexpr size_t stride_5() const { return stride(5); }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(6) instead") KOKKOS_FUNCTION constexpr size_t stride_6() const { return stride(6); }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(7) instead") KOKKOS_FUNCTION constexpr size_t stride_7() const { return stride(7); }
+#endif
+  // clang-format on
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION void stride(iType* const s) const {

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1222,14 +1222,14 @@ inline void deep_copy(
                       typename src_type::array_layout> ||
        (dst_type::rank == 1 && src_type::rank == 1)) &&
       dst.span_is_contiguous() && src.span_is_contiguous() &&
-      ((dst_type::rank < 1) || (dst.stride_0() == src.stride_0())) &&
-      ((dst_type::rank < 2) || (dst.stride_1() == src.stride_1())) &&
-      ((dst_type::rank < 3) || (dst.stride_2() == src.stride_2())) &&
-      ((dst_type::rank < 4) || (dst.stride_3() == src.stride_3())) &&
-      ((dst_type::rank < 5) || (dst.stride_4() == src.stride_4())) &&
-      ((dst_type::rank < 6) || (dst.stride_5() == src.stride_5())) &&
-      ((dst_type::rank < 7) || (dst.stride_6() == src.stride_6())) &&
-      ((dst_type::rank < 8) || (dst.stride_7() == src.stride_7()))) {
+      ((dst_type::rank < 1) || (dst.stride(0) == src.stride(0))) &&
+      ((dst_type::rank < 2) || (dst.stride(1) == src.stride(1))) &&
+      ((dst_type::rank < 3) || (dst.stride(2) == src.stride(2))) &&
+      ((dst_type::rank < 4) || (dst.stride(3) == src.stride(3))) &&
+      ((dst_type::rank < 5) || (dst.stride(4) == src.stride(4))) &&
+      ((dst_type::rank < 6) || (dst.stride(5) == src.stride(5))) &&
+      ((dst_type::rank < 7) || (dst.stride(6) == src.stride(6))) &&
+      ((dst_type::rank < 8) || (dst.stride(7) == src.stride(7)))) {
 #ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
     const size_t nbytes = allocation_size_from_mapping_and_accessor(
                               src.mapping(), src.accessor()) *
@@ -2422,14 +2422,14 @@ inline void deep_copy(
                       typename src_type::array_layout> ||
        (dst_type::rank == 1 && src_type::rank == 1)) &&
       dst.span_is_contiguous() && src.span_is_contiguous() &&
-      ((dst_type::rank < 1) || (dst.stride_0() == src.stride_0())) &&
-      ((dst_type::rank < 2) || (dst.stride_1() == src.stride_1())) &&
-      ((dst_type::rank < 3) || (dst.stride_2() == src.stride_2())) &&
-      ((dst_type::rank < 4) || (dst.stride_3() == src.stride_3())) &&
-      ((dst_type::rank < 5) || (dst.stride_4() == src.stride_4())) &&
-      ((dst_type::rank < 6) || (dst.stride_5() == src.stride_5())) &&
-      ((dst_type::rank < 7) || (dst.stride_6() == src.stride_6())) &&
-      ((dst_type::rank < 8) || (dst.stride_7() == src.stride_7()))) {
+      ((dst_type::rank < 1) || (dst.stride(0) == src.stride(0))) &&
+      ((dst_type::rank < 2) || (dst.stride(1) == src.stride(1))) &&
+      ((dst_type::rank < 3) || (dst.stride(2) == src.stride(2))) &&
+      ((dst_type::rank < 4) || (dst.stride(3) == src.stride(3))) &&
+      ((dst_type::rank < 5) || (dst.stride(4) == src.stride(4))) &&
+      ((dst_type::rank < 6) || (dst.stride(5) == src.stride(5))) &&
+      ((dst_type::rank < 7) || (dst.stride(6) == src.stride(6))) &&
+      ((dst_type::rank < 8) || (dst.stride(7) == src.stride(7)))) {
     const size_t nbytes = sizeof(typename dst_type::value_type) * dst.span();
     if ((void*)dst.data() != (void*)src.data() && 0 < nbytes) {
       Kokkos::Impl::DeepCopy<dst_memory_space, src_memory_space, ExecSpace>(

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -266,14 +266,18 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
         base_t::mapping());
   }
 
-  KOKKOS_FUNCTION constexpr size_t stride_0() const { return stride(0); }
-  KOKKOS_FUNCTION constexpr size_t stride_1() const { return stride(1); }
-  KOKKOS_FUNCTION constexpr size_t stride_2() const { return stride(2); }
-  KOKKOS_FUNCTION constexpr size_t stride_3() const { return stride(3); }
-  KOKKOS_FUNCTION constexpr size_t stride_4() const { return stride(4); }
-  KOKKOS_FUNCTION constexpr size_t stride_5() const { return stride(5); }
-  KOKKOS_FUNCTION constexpr size_t stride_6() const { return stride(6); }
-  KOKKOS_FUNCTION constexpr size_t stride_7() const { return stride(7); }
+  // clang-format off
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(0) instead") KOKKOS_FUNCTION constexpr size_t stride_0() const { return stride(0); }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(1) instead") KOKKOS_FUNCTION constexpr size_t stride_1() const { return stride(1); }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(2) instead") KOKKOS_FUNCTION constexpr size_t stride_2() const { return stride(2); }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(3) instead") KOKKOS_FUNCTION constexpr size_t stride_3() const { return stride(3); }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(4) instead") KOKKOS_FUNCTION constexpr size_t stride_4() const { return stride(4); }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(5) instead") KOKKOS_FUNCTION constexpr size_t stride_5() const { return stride(5); }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(6) instead") KOKKOS_FUNCTION constexpr size_t stride_6() const { return stride(6); }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(7) instead") KOKKOS_FUNCTION constexpr size_t stride_7() const { return stride(7); }
+#endif
+  // clang-format on
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>,

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -357,30 +357,40 @@ class View : public ViewTraits<DataType, Properties...> {
            m_map.dimension_6() * m_map.dimension_7();
   }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(0) instead")
   KOKKOS_INLINE_FUNCTION constexpr size_t stride_0() const {
     return m_map.stride_0();
   }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(1) instead")
   KOKKOS_INLINE_FUNCTION constexpr size_t stride_1() const {
     return m_map.stride_1();
   }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(2) instead")
   KOKKOS_INLINE_FUNCTION constexpr size_t stride_2() const {
     return m_map.stride_2();
   }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(3) instead")
   KOKKOS_INLINE_FUNCTION constexpr size_t stride_3() const {
     return m_map.stride_3();
   }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(4) instead")
   KOKKOS_INLINE_FUNCTION constexpr size_t stride_4() const {
     return m_map.stride_4();
   }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(5) instead")
   KOKKOS_INLINE_FUNCTION constexpr size_t stride_5() const {
     return m_map.stride_5();
   }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(6) instead")
   KOKKOS_INLINE_FUNCTION constexpr size_t stride_6() const {
     return m_map.stride_6();
   }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(7) instead")
   KOKKOS_INLINE_FUNCTION constexpr size_t stride_7() const {
     return m_map.stride_7();
   }
+#endif
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>,

--- a/core/unit_test/TestViewMapping_subview.hpp
+++ b/core/unit_test/TestViewMapping_subview.hpp
@@ -162,9 +162,17 @@ struct TestViewMappingSubview {
     ASSERT_EQ(Db.extent(1), (size_t)DN2 - 2);
     ASSERT_EQ(Db.extent(2), (size_t)DN3 - 2);
 
-    ASSERT_EQ(Da.stride_1(), Db.stride_0());
-    ASSERT_EQ(Da.stride_2(), Db.stride_1());
-    ASSERT_EQ(Da.stride_3(), Db.stride_2());
+    ASSERT_EQ(Da.stride(1), Db.stride(0));
+    ASSERT_EQ(Da.stride(2), Db.stride(1));
+    ASSERT_EQ(Da.stride(3), Db.stride(2));
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
+    ASSERT_EQ(Da.stride_1(), Db.stride_0());  // NOLINT
+    ASSERT_EQ(Da.stride_2(), Db.stride_1());  // NOLINT
+    ASSERT_EQ(Da.stride_3(), Db.stride_2());  // NOLINT
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+#endif
 
     long error_count = -1;
     Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 1), *this,


### PR DESCRIPTION
Closes  #7956

I implemented a `kokkos-replace-view-stride-underscore` check with a fix-it hint at https://github.com/dalg24/kokkos-clang-tidy-module.  You may use it to apply changes on a code base.
```
run-clang-tidy -fix -load /path/to/KokkosClangTidyModule.so -checks="-*,kokkos-replace-view-stride-underscore" -p builddir
```