### PR TITLE
Fix stray bugprone-branch-clone warnings

### DIFF
--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -789,9 +789,7 @@ inline void deep_copy(const Kokkos::Experimental::DynamicView<T, DP...>& dst,
       Kokkos::SpaceAccessibility<src_execution_space,
                                  dst_memory_space>::accessible;
 
-  if (DstExecCanAccessSrc)
-    Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
-  else if (SrcExecCanAccessDst)
+  if (DstExecCanAccessSrc || SrcExecCanAccessDst)
     Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
   else
     src.impl_get_chunks().deep_copy_to(dst_execution_space{},
@@ -819,9 +817,7 @@ inline void deep_copy(const ExecutionSpace& exec,
                                  dst_memory_space>::accessible;
 
   // FIXME use execution space
-  if (DstExecCanAccessSrc)
-    Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
-  else if (SrcExecCanAccessDst)
+  if (DstExecCanAccessSrc || SrcExecCanAccessDst)
     Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
   else
     src.impl_get_chunks().deep_copy_to(exec, dst.impl_get_chunks());


### PR DESCRIPTION
Fixup for #8106 

Seen in the CI
```
/var/jenkins/workspace/Kokkos_PR-7698/containers/unit_tests/../src/Kokkos_DynamicView.hpp:793:5: error: repeated branch body in conditional chain [bugprone-branch-clone,-warnings-as-errors]
    Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
    ^
/var/jenkins/workspace/Kokkos_PR-7698/containers/unit_tests/../src/Kokkos_DynamicView.hpp:793:58: note: end of the original
    Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
                                                         ^
/var/jenkins/workspace/Kokkos_PR-7698/containers/unit_tests/../src/Kokkos_DynamicView.hpp:795:5: note: clone 1 starts here
    Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
    ^
/var/jenkins/workspace/Kokkos_PR-7698/containers/unit_tests/../src/Kokkos_DynamicView.hpp:823:5: error: repeated branch body in conditional chain [bugprone-branch-clone,-warnings-as-errors]
    Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
    ^