### PR TITLE
core(graph): add memset node

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -158,6 +158,21 @@ struct GraphImpl<Kokkos::Cuda> {
     m_nodes.push_back(std::move(arg_node_ptr));
   }
 
+  template <class NodeImpl>
+  std::enable_if_t<
+      Kokkos::Impl::is_graph_memset_v<typename NodeImpl::kernel_type>>
+  add_node(std::shared_ptr<NodeImpl> arg_node_ptr) {
+    static_assert(
+        Kokkos::Impl::is_specialization_of_v<NodeImpl, GraphNodeImpl>);
+    KOKKOS_EXPECTS(bool(arg_node_ptr));
+
+    auto& kernel = arg_node_ptr->get_kernel();
+    kernel.add(m_graph);
+    static_cast<node_details_t*>(arg_node_ptr.get())->node = kernel.m_node;
+
+    m_nodes.push_back(std::move(arg_node_ptr));
+  }
+
   template <class NodeImplPtr, class PredecessorRef>
   // requires PredecessorRef is a specialization of GraphNodeRef that has
   // already been added to this graph and NodeImpl is a specialization of

--- a/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
@@ -71,6 +71,11 @@ class GraphImpl<Kokkos::SYCL> {
       Kokkos::Impl::is_graph_capture_v<typename NodeImpl::kernel_type>>
   add_node(const Kokkos::SYCL& exec, std::shared_ptr<NodeImpl> arg_node_ptr);
 
+  template <class NodeImpl>
+  std::enable_if_t<
+      Kokkos::Impl::is_graph_memset_v<typename NodeImpl::kernel_type>>
+  add_node(std::shared_ptr<NodeImpl> arg_node_ptr);
+
   template <class NodeImplPtr, class PredecessorRef>
   void add_predecessor(NodeImplPtr arg_node_ptr, PredecessorRef arg_pred_ref);
 
@@ -149,6 +154,20 @@ GraphImpl<Kokkos::SYCL>::add_node(const Kokkos::SYCL& exec,
 
   auto& kernel = arg_node_ptr->get_kernel();
   kernel.capture(exec, m_graph);
+  static_cast<node_details_t*>(arg_node_ptr.get())->node = kernel.m_node;
+
+  m_nodes.push_back(std::move(arg_node_ptr));
+}
+
+template <class NodeImpl>
+std::enable_if_t<
+    Kokkos::Impl::is_graph_memset_v<typename NodeImpl::kernel_type>>
+GraphImpl<Kokkos::SYCL>::add_node(std::shared_ptr<NodeImpl> arg_node_ptr) {
+  static_assert(Kokkos::Impl::is_specialization_of_v<NodeImpl, GraphNodeImpl>);
+  KOKKOS_EXPECTS(arg_node_ptr);
+
+  auto& kernel = arg_node_ptr->get_kernel();
+  kernel.add(m_graph);
   static_cast<node_details_t*>(arg_node_ptr.get())->node = kernel.m_node;
 
   m_nodes.push_back(std::move(arg_node_ptr));

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -37,6 +37,11 @@ struct is_graph_capture<
            Kokkos::Impl::is_specialization_of_v<T, GraphNodeCaptureImpl>>>
     : public std::true_type {};
 
+template <typename T>
+struct is_graph_memset<T, std::enable_if_t<Kokkos::Impl::is_specialization_of_v<
+                              T, GraphNodeMemsetImpl>>>
+    : public std::true_type {};
+
 struct GraphAccess {
   template <class ExecutionSpace>
   static Kokkos::Experimental::Graph<ExecutionSpace> construct_graph(

--- a/core/src/impl/Kokkos_GraphImpl_fwd.hpp
+++ b/core/src/impl/Kokkos_GraphImpl_fwd.hpp
@@ -44,8 +44,18 @@ struct is_graph_capture : public std::false_type {};
 template <typename T>
 inline constexpr bool is_graph_capture_v = is_graph_capture<T>::value;
 
+template <typename ExecutionSpace, typename ViewType>
+struct GraphNodeMemsetImpl;
+
+template <typename T, class Enable = void>
+struct is_graph_memset : public std::false_type {};
+
+template <typename T>
+inline constexpr bool is_graph_memset_v = is_graph_memset<T>::value;
+
 struct _graph_node_kernel_ctor_tag {};
 struct _graph_node_capture_ctor_tag {};
+struct _graph_node_memset_ctor_tag {};
 struct _graph_node_predecessor_ctor_tag {};
 struct _graph_node_is_root_ctor_tag {};
 

--- a/core/src/impl/Kokkos_GraphNodeImpl.hpp
+++ b/core/src/impl/Kokkos_GraphNodeImpl.hpp
@@ -142,7 +142,8 @@ struct GraphNodeImpl<ExecutionSpace, Kernel,
   template <class KernelDeduced, class Tag,
             typename = std::enable_if_t<
                 std::is_same_v<Tag, _graph_node_kernel_ctor_tag> ||
-                std::is_same_v<Tag, _graph_node_capture_ctor_tag>>>
+                std::is_same_v<Tag, _graph_node_capture_ctor_tag> ||
+                std::is_same_v<Tag, _graph_node_memset_ctor_tag>>>
   GraphNodeImpl(ExecutionSpace const& ex, Tag, KernelDeduced&& arg_kernel)
       : base_t(ex), m_kernel{(KernelDeduced&&)arg_kernel} {}
 
@@ -239,7 +240,8 @@ struct GraphNodeImpl
   template <class KernelDeduced, class PredecessorPtrDeduced, class Tag,
             typename = std::enable_if_t<
                 std::is_same_v<Tag, _graph_node_kernel_ctor_tag> ||
-                std::is_same_v<Tag, _graph_node_capture_ctor_tag>>>
+                std::is_same_v<Tag, _graph_node_capture_ctor_tag> ||
+                std::is_same_v<Tag, _graph_node_memset_ctor_tag>>>
   GraphNodeImpl(ExecutionSpace const& ex, Tag, KernelDeduced&& arg_kernel,
                 _graph_node_predecessor_ctor_tag,
                 PredecessorPtrDeduced&& arg_predecessor)


### PR DESCRIPTION
This PR adds a *memset* node to `Kokkos::Graph`.

The node will behave like `std::memset`.

It's especially useful for algorithms that need to reset some data buffer within the graph. For instance, FEM assembly.