### PR TITLE
Enable structured binding return for Experimental::partition_space()

### DIFF
--- a/core/perf_test/PerfTest_ExecSpacePartitioning.cpp
+++ b/core/perf_test/PerfTest_ExecSpacePartitioning.cpp
@@ -159,10 +159,7 @@ static void OverlapRangePolicy(benchmark::State& state) {
   int R = state.range(2);
 
   TEST_EXECSPACE space;
-  std::vector<TEST_EXECSPACE> execution_space_instances =
-      Kokkos::Experimental::partition_space(space, 1, 1);
-  TEST_EXECSPACE space1 = execution_space_instances[0];
-  TEST_EXECSPACE space2 = execution_space_instances[1];
+  auto [space1, space2] = Kokkos::Experimental::partition_space(space, 1, 1);
 
   for (auto _ : state) {
     Kokkos::View<double**, TEST_EXECSPACE> a("A", N, M);
@@ -332,10 +329,7 @@ static void OverlapMDRangePolicy(benchmark::State& state) {
   int R = state.range(2);
 
   TEST_EXECSPACE space;
-  std::vector<TEST_EXECSPACE> execution_space_instances =
-      Kokkos::Experimental::partition_space(space, 1, 1);
-  TEST_EXECSPACE space1 = execution_space_instances[0];
-  TEST_EXECSPACE space2 = execution_space_instances[1];
+  auto [space1, space2] = Kokkos::Experimental::partition_space(space, 1, 1);
 
   for (auto _ : state) {
     Kokkos::View<double**, TEST_EXECSPACE> a("A", N, M);
@@ -524,10 +518,7 @@ static void OverlapTeamPolicy(benchmark::State& state) {
   int R = state.range(2);
 
   TEST_EXECSPACE space;
-  std::vector<TEST_EXECSPACE> execution_space_instances =
-      Kokkos::Experimental::partition_space(space, 1, 1);
-  TEST_EXECSPACE space1 = execution_space_instances[0];
-  TEST_EXECSPACE space2 = execution_space_instances[1];
+  auto [space1, space2] = Kokkos::Experimental::partition_space(space, 1, 1);
 
   for (auto _ : state) {
     Kokkos::View<double**, Kokkos::LayoutRight, TEST_EXECSPACE> a("A", N, M);

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -758,13 +758,19 @@ std::map<int, std::mutex> CudaInternal::constantMemMutexPerDevice     = {};
 
 }  // namespace Kokkos
 
-void Kokkos::Impl::create_Cuda_instance(Cuda &instance) {
+namespace Kokkos {
+namespace Impl {
+
+Cuda create_Cuda_instance(Cuda &cuda_space) {
   cudaStream_t stream;
   KOKKOS_IMPL_CUDA_SAFE_CALL(
-      (instance.impl_internal_space_instance()->cuda_stream_create_wrapper(
+      (cuda_space.impl_internal_space_instance()->cuda_stream_create_wrapper(
           &stream)));
-  instance = Cuda(stream, ManageStream::yes);
+  return Cuda(stream, ManageStream::yes);
 }
+
+}  // namespace Impl
+}  // namespace Kokkos
 
 #else
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -758,14 +758,12 @@ std::map<int, std::mutex> CudaInternal::constantMemMutexPerDevice     = {};
 
 }  // namespace Kokkos
 
-void Kokkos::Impl::create_Cuda_instances(std::vector<Cuda> &instances) {
-  for (int s = 0; s < int(instances.size()); s++) {
-    cudaStream_t stream;
-    KOKKOS_IMPL_CUDA_SAFE_CALL((
-        instances[s].impl_internal_space_instance()->cuda_stream_create_wrapper(
-            &stream)));
-    instances[s] = Cuda(stream, ManageStream::yes);
-  }
+void Kokkos::Impl::create_Cuda_instance(Cuda &instance) {
+  cudaStream_t stream;
+  KOKKOS_IMPL_CUDA_SAFE_CALL(
+      (instance.impl_internal_space_instance()->cuda_stream_create_wrapper(
+          &stream)));
+  instance = Cuda(stream, ManageStream::yes);
 }
 
 #else

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -758,20 +758,6 @@ std::map<int, std::mutex> CudaInternal::constantMemMutexPerDevice     = {};
 
 }  // namespace Kokkos
 
-namespace Kokkos {
-namespace Impl {
-
-Cuda create_Cuda_instance(Cuda &cuda_space) {
-  cudaStream_t stream;
-  KOKKOS_IMPL_CUDA_SAFE_CALL(
-      (cuda_space.impl_internal_space_instance()->cuda_stream_create_wrapper(
-          &stream)));
-  return Cuda(stream, ManageStream::yes);
-}
-
-}  // namespace Impl
-}  // namespace Kokkos
-
 #else
 
 void KOKKOS_CORE_SRC_CUDA_IMPL_PREVENT_LINK_ERROR() {}

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -364,7 +364,7 @@ class CudaInternal {
   void release_team_scratch_space(int scratch_pool_id);
 };
 
-void create_Cuda_instances(std::vector<Cuda>& instances);
+void create_Cuda_instance(Cuda& instance);
 }  // Namespace Impl
 
 namespace Experimental {
@@ -374,12 +374,14 @@ namespace Experimental {
 //   Default behavior is to return the passed in instance
 
 template <class... Args>
-std::vector<Cuda> partition_space(const Cuda&, Args...) {
+std::array<Cuda, sizeof...(Args)> partition_space(const Cuda&, Args...) {
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
-  std::vector<Cuda> instances(sizeof...(Args));
-  Kokkos::Impl::create_Cuda_instances(instances);
+  std::array<Cuda, sizeof...(Args)> instances;
+  for (auto& instance : instances) {
+    Kokkos::Impl::create_Cuda_instance(instance);
+  }
   return instances;
 }
 
@@ -392,7 +394,9 @@ std::vector<Cuda> partition_space(const Cuda&, std::vector<T> const& weights) {
   // We only care about the number of instances to create and ignore weights
   // otherwise.
   std::vector<Cuda> instances(weights.size());
-  Kokkos::Impl::create_Cuda_instances(instances);
+  for (auto& instance : instances) {
+    Kokkos::Impl::create_Cuda_instance(instance);
+  }
   return instances;
 }
 }  // namespace Experimental

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -384,11 +384,14 @@ inline Cuda create_cuda_space(const Cuda& base_space) {
 
 template <class... Args>
 std::array<Cuda, sizeof...(Args)> partition_space(const Cuda& cuda_space,
-                                                  Args... ignored) {
+                                                  Args...) {
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
-  return {((ignored, Impl::create_cuda_space(cuda_space)), ...)};
+
+  std::array<Cuda, sizeof...(Args)> instances;
+  for (auto& in : instances) in = Impl::create_cuda_space(cuda_space);
+  return instances;
 }
 
 template <class T>

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -459,12 +459,10 @@ void hip_internal_error_throw(hipError_t e, const char *name, const char *file,
 
 //----------------------------------------------------------------------------
 
-void Kokkos::Impl::create_HIP_instances(std::vector<HIP> &instances) {
-  for (int s = 0; s < int(instances.size()); s++) {
-    hipStream_t stream;
-    KOKKOS_IMPL_HIP_SAFE_CALL(
-        instances[s].impl_internal_space_instance()->hip_stream_create_wrapper(
-            &stream));
-    instances[s] = HIP(stream, ManageStream::yes);
-  }
+void Kokkos::Impl::create_HIP_instance(HIP &instance) {
+  hipStream_t stream;
+  KOKKOS_IMPL_HIP_SAFE_CALL(
+      instance.impl_internal_space_instance()->hip_stream_create_wrapper(
+          &stream));
+  instance = HIP(stream, ManageStream::yes);
 }

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -458,16 +458,3 @@ void hip_internal_error_throw(hipError_t e, const char *name, const char *file,
 }  // namespace Kokkos
 
 //----------------------------------------------------------------------------
-
-namespace Kokkos {
-namespace Impl {
-
-HIP create_HIP_instance(HIP &hip_space) {
-  hipStream_t stream;
-  KOKKOS_IMPL_HIP_SAFE_CALL(
-      hip_space.impl_internal_space_instance()->hip_stream_create_wrapper(
-          &stream));
-  return HIP(stream, ManageStream::yes);
-}
-}  // namespace Impl
-}  // namespace Kokkos

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -459,10 +459,15 @@ void hip_internal_error_throw(hipError_t e, const char *name, const char *file,
 
 //----------------------------------------------------------------------------
 
-void Kokkos::Impl::create_HIP_instance(HIP &instance) {
+namespace Kokkos {
+namespace Impl {
+
+HIP create_HIP_instance(HIP &hip_space) {
   hipStream_t stream;
   KOKKOS_IMPL_HIP_SAFE_CALL(
-      instance.impl_internal_space_instance()->hip_stream_create_wrapper(
+      hip_space.impl_internal_space_instance()->hip_stream_create_wrapper(
           &stream));
-  instance = HIP(stream, ManageStream::yes);
+  return HIP(stream, ManageStream::yes);
 }
+}  // namespace Impl
+}  // namespace Kokkos

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -276,7 +276,7 @@ class HIPInternal {
   void release_team_scratch_space(int scratch_pool_id);
 };
 
-void create_HIP_instances(std::vector<HIP> &instances);
+void create_HIP_instance(HIP &instance);
 }  // namespace Impl
 
 namespace Experimental {
@@ -286,13 +286,15 @@ namespace Experimental {
 //   Default behavior is to return the passed in instance
 
 template <class... Args>
-std::vector<HIP> partition_space(const HIP &, Args...) {
+std::array<HIP, sizeof...(Args)> partition_space(const HIP &, Args...) {
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
 
-  std::vector<HIP> instances(sizeof...(Args));
-  Kokkos::Impl::create_HIP_instances(instances);
+  std::array<HIP, sizeof...(Args)> instances;
+  for (auto &instance : instances) {
+    Kokkos::Impl::create_HIP_instance(instance);
+  }
   return instances;
 }
 
@@ -305,7 +307,9 @@ std::vector<HIP> partition_space(const HIP &, std::vector<T> const &weights) {
   // We only care about the number of instances to create and ignore weights
   // otherwise.
   std::vector<HIP> instances(weights.size());
-  Kokkos::Impl::create_HIP_instances(instances);
+  for (auto &instance : instances) {
+    Kokkos::Impl::create_HIP_instance(instance);
+  }
   return instances;
 }
 }  // namespace Experimental

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -296,11 +296,14 @@ inline HIP create_hip_space(const HIP &base_space) {
 
 template <class... Args>
 std::array<HIP, sizeof...(Args)> partition_space(const HIP &hip_space,
-                                                 Args... ignored) {
+                                                 Args...) {
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
-  return {((ignored, Impl::create_hip_space(hip_space)), ...)};
+
+  std::array<HIP, sizeof...(Args)> instances;
+  for (auto &in : instances) in = Impl::create_hip_space(hip_space);
+  return instances;
 }
 
 template <class T>

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -457,11 +457,14 @@ class HPX {
 };
 
 template <typename... Args>
-std::array<HPX, sizeof...(Args)> partition_space(HPX const &, Args... ignored) {
+std::array<HPX, sizeof...(Args)> partition_space(HPX const &, Args...) {
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
-  return {((ignored, HPX(HPX::instance_mode::independent)), ...)};
+
+  std::array<HPX, sizeof...(Args)> instances;
+  for (auto &in : instances) in = HPX(HPX::instance_mode::independent);
+  return instances;
 }
 
 template <typename T>

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -456,30 +456,14 @@ class HPX {
   }
 };
 
-template <typename... Args>
-std::array<HPX, sizeof...(Args)> partition_space(HPX const &, Args...) {
-  static_assert(
-      (... && std::is_arithmetic_v<Args>),
-      "Kokkos Error: partitioning arguments must be integers or floats");
-
-  std::array<HPX, sizeof...(Args)> instances;
+namespace Impl {
+// Create new, independent of HPX execution space for each partition
+template <class T, class Container>
+void impl_partition_space(const Serial &, const std::vector<T> &,
+                          Container &instances) {
   for (auto &in : instances) in = HPX(HPX::instance_mode::independent);
-  return instances;
 }
-
-template <typename T>
-std::vector<HPX> partition_space(HPX const &, std::vector<T> const &weights) {
-  static_assert(
-      std::is_arithmetic_v<T>,
-      "Kokkos Error: partitioning arguments must be integers or floats");
-
-  std::vector<HPX> instances;
-  instances.reserve(weights.size());
-  for (int i = 0; i < int(weights.size()); ++i) {
-    instances.emplace_back(HPX(HPX::instance_mode::independent));
-  }
-  return instances;
-}
+}  // namespace Impl
 
 extern template void HPX::impl_bulk_plain_erased<int>(
     bool, bool, std::function<void(int)> &&, int const,

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -457,11 +457,17 @@ class HPX {
 };
 
 namespace Impl {
-// Create new, independent of HPX execution space for each partition
-template <class T, class Container>
-void impl_partition_space(const Serial &, const std::vector<T> &,
-                          Container &instances) {
-  for (auto &in : instances) in = HPX(HPX::instance_mode::independent);
+// Create new, independent instance of HPX execution space for each partition,
+// ignoring weights
+template <class T>
+std::vector<HPX> impl_partition_space(const HPX &,
+                                      const std::vector<T> &weights) {
+  std::vector<HPX> instances;
+  instances.reserve(weights.size());
+  std::generate_n(std::back_inserter(instances), weights.size(),
+                  []() { return HPX(HPX::instance_mode::independent); });
+
+  return instances;
 }
 }  // namespace Impl
 

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -457,8 +457,8 @@ class HPX {
 };
 
 template <typename... Args>
-std::vector<HPX> partition_space(HPX const &, Args... args) {
-  std::vector<HPX> instances(sizeof...(args));
+std::array<HPX, sizeof...(Args)> partition_space(HPX const &, Args...) {
+  std::array<HPX, sizeof...(Args)> instances;
   for (auto &in : instances) in = HPX(HPX::instance_mode::independent);
   return instances;
 }

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -458,11 +458,18 @@ class HPX {
 
 template <typename... Args>
 std::array<HPX, sizeof...(Args)> partition_space(HPX const &, Args... ignored) {
+  static_assert(
+      (... && std::is_arithmetic_v<Args>),
+      "Kokkos Error: partitioning arguments must be integers or floats");
   return {((ignored, HPX(HPX::instance_mode::independent)), ...)};
 }
 
 template <typename T>
 std::vector<HPX> partition_space(HPX const &, std::vector<T> const &weights) {
+  static_assert(
+      std::is_arithmetic_v<T>,
+      "Kokkos Error: partitioning arguments must be integers or floats");
+
   std::vector<HPX> instances;
   instances.reserve(weights.size());
   for (int i = 0; i < int(weights.size()); ++i) {

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -457,16 +457,17 @@ class HPX {
 };
 
 template <typename... Args>
-std::array<HPX, sizeof...(Args)> partition_space(HPX const &, Args...) {
-  std::array<HPX, sizeof...(Args)> instances;
-  for (auto &in : instances) in = HPX(HPX::instance_mode::independent);
-  return instances;
+std::array<HPX, sizeof...(Args)> partition_space(HPX const &, Args... ignored) {
+  return {((ignored, HPX(HPX::instance_mode::independent)), ...)};
 }
 
 template <typename T>
 std::vector<HPX> partition_space(HPX const &, std::vector<T> const &weights) {
-  std::vector<HPX> instances(weights.size());
-  for (auto &in : instances) in = HPX(HPX::instance_mode::independent);
+  std::vector<HPX> instances;
+  instances.reserve(weights.size());
+  for (int i = 0; i < int(weights.size()); ++i) {
+    instances.emplace_back(HPX(HPX::instance_mode::independent));
+  }
   return instances;
 }
 

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -294,16 +294,14 @@ namespace Experimental {
 //   Default behavior is to return the passed in instance
 template <class ExecSpace, class... Args>
 std::array<ExecSpace, sizeof...(Args)> partition_space(ExecSpace const& space,
-                                                       Args...) {
+                                                       Args... ignored) {
   static_assert(is_execution_space<ExecSpace>::value,
                 "Kokkos Error: partition_space expects an Execution Space as "
                 "first argument");
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
-  std::array<ExecSpace, sizeof...(Args)> instances;
-  for (auto& instance : instances) instance = space;
-  return instances;
+  return {((ignored, space), ...)};
 }
 
 template <class ExecSpace, class T>
@@ -316,8 +314,9 @@ std::vector<ExecSpace> partition_space(ExecSpace const& space,
       std::is_arithmetic_v<T>,
       "Kokkos Error: partitioning arguments must be integers or floats");
 
-  std::vector<ExecSpace> instances(weights.size());
-  for (int s = 0; s < int(weights.size()); s++) instances[s] = space;
+  std::vector<ExecSpace> instances;
+  instances.reserve(weights.size());
+  for (int s = 0; s < int(weights.size()); s++) instances.emplace_back(space);
   return instances;
 }
 }  // namespace Experimental

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -293,15 +293,16 @@ namespace Experimental {
 //   Customization point for backends
 //   Default behavior is to return the passed in instance
 template <class ExecSpace, class... Args>
-std::vector<ExecSpace> partition_space(ExecSpace const& space, Args...) {
+std::array<ExecSpace, sizeof...(Args)> partition_space(ExecSpace const& space,
+                                                       Args...) {
   static_assert(is_execution_space<ExecSpace>::value,
                 "Kokkos Error: partition_space expects an Execution Space as "
                 "first argument");
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
-  std::vector<ExecSpace> instances(sizeof...(Args));
-  for (int s = 0; s < int(sizeof...(Args)); s++) instances[s] = space;
+  std::array<ExecSpace, sizeof...(Args)> instances;
+  for (auto& instance : instances) instance = space;
   return instances;
 }
 

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -294,14 +294,17 @@ namespace Experimental {
 //   Default behavior is to return the passed in instance
 template <class ExecSpace, class... Args>
 std::array<ExecSpace, sizeof...(Args)> partition_space(ExecSpace const& space,
-                                                       Args... ignored) {
+                                                       Args...) {
   static_assert(is_execution_space<ExecSpace>::value,
                 "Kokkos Error: partition_space expects an Execution Space as "
                 "first argument");
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
-  return {((ignored, space), ...)};
+
+  std::array<ExecSpace, sizeof...(Args)> instances;
+  for (auto& in : instances) in = space;
+  return instances;
 }
 
 template <class ExecSpace, class T>

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -301,15 +301,6 @@ std::vector<ExecSpace> impl_partition_space(const ExecSpace& base_instance,
 
   return instances;
 }
-
-// Helper function for converting std::vector -> std::array that avoids
-// declaring an std::array which is default constructed.
-template <class ExecSpace, size_t... Indices>
-std::array<ExecSpace, sizeof...(Indices)> create_partitions_array(
-    const std::vector<ExecSpace>& instances_vec,
-    std::index_sequence<Indices...>) {
-  return std::array<ExecSpace, sizeof...(Indices)>{instances_vec[Indices]...};
-}
 }  // namespace Impl
 
 // Partitioning an Execution Space
@@ -334,8 +325,9 @@ std::array<ExecSpace, sizeof...(Args)> partition_space(
   auto instances_vec = Impl::impl_partition_space(base_instance, weights);
 
   // Convert to std::array and return
-  return Impl::create_partitions_array(
-      instances_vec, std::make_index_sequence<sizeof...(Args)>{});
+  std::array<ExecSpace, sizeof...(Args)> instances;
+  std::copy(instances_vec.begin(), instances_vec.end(), instances.begin());
+  return instances;
 }
 
 template <class ExecSpace, class T>

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -181,12 +181,11 @@ std::array<OpenMP, sizeof...(Args)> partition_space(OpenMP const& main_instance,
       Impl::calculate_omp_pool_sizes(main_instance, weights);
 
   // Create array of OpenMP instances from pool sizes
-  auto create_partitions = [&pool_sizes]<std::size_t... Indices>(
-                               std::index_sequence<Indices...>) {
-    return std::array<OpenMP, sizeof...(Args)>{OpenMP(pool_sizes[Indices])...};
-  };
-
-  return create_partitions(std::make_index_sequence<sizeof...(Args)>{});
+  std::array<OpenMP, sizeof...(Args)> instances;
+  for (int i = 0; i < int(pool_sizes.size()); ++i) {
+    instances[i] = OpenMP(pool_sizes[i]);
+  }
+  return instances;
 }
 
 template <typename T>

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -166,16 +166,20 @@ inline std::vector<int> calculate_omp_pool_sizes(
   return pool_sizes;
 }
 
-// Create new OpenMP instances with pool sizes relative to
-// input weights
-template <class T, class Container>
-void impl_partition_space(const OpenMP& base_instance,
-                          const std::vector<T>& weights, Container& instances) {
+// Create new OpenMP instances with pool sizes relative to input weights
+template <class T>
+std::vector<OpenMP> impl_partition_space(const OpenMP& base_instance,
+                                         const std::vector<T>& weights) {
   const auto pool_sizes =
       Impl::calculate_omp_pool_sizes(base_instance, weights);
+
+  std::vector<OpenMP> instances;
+  instances.reserve(pool_sizes.size());
   for (size_t i = 0; i < pool_sizes.size(); ++i) {
-    instances[i] = OpenMP(pool_sizes[i]);
+    instances.emplace_back(OpenMP(pool_sizes[i]));
   }
+
+  return instances;
 }
 }  // namespace Experimental::Impl
 }  // namespace Kokkos

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -181,12 +181,12 @@ std::array<OpenMP, sizeof...(Args)> partition_space(OpenMP const& main_instance,
       Impl::calculate_omp_pool_sizes(main_instance, weights);
 
   // Create array of OpenMP instances from pool sizes
-  std::array<OpenMP, sizeof...(Args)> instances;
-  for (int i = 0; i < int(pool_sizes.size()); ++i) {
-    instances[i] = OpenMP(pool_sizes[i]);
-  }
+  auto create_partitions = [&pool_sizes]<std::size_t... Indices>(
+                               std::index_sequence<Indices...>) {
+    return std::array<OpenMP, sizeof...(Args)>{OpenMP(pool_sizes[Indices])...};
+  };
 
-  return instances;
+  return create_partitions(std::make_index_sequence<sizeof...(Args)>{});
 }
 
 template <typename T>
@@ -196,10 +196,11 @@ std::vector<OpenMP> partition_space(OpenMP const& main_instance,
   const auto pool_sizes =
       Impl::calculate_omp_pool_sizes(main_instance, weights);
 
-  // Create array of OpenMP instances from pool sizes
-  std::vector<OpenMP> instances(weights.size());
+  // Create vector of OpenMP instances from pool sizes
+  std::vector<OpenMP> instances;
+  instances.reserve(pool_sizes.size());
   for (int i = 0; i < int(pool_sizes.size()); ++i) {
-    instances[i] = OpenMP(pool_sizes[i]);
+    instances.emplace_back(OpenMP(pool_sizes[i]));
   }
 
   return instances;

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -145,18 +145,18 @@ struct DeviceTypeTraits<Kokkos::SYCL> {
 
 namespace Experimental {
 template <class... Args>
-std::vector<SYCL> partition_space(const SYCL& sycl_space, Args...) {
+std::array<SYCL, sizeof...(Args)> partition_space(const SYCL& sycl_space,
+                                                  Args...) {
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
 
   sycl::context context = sycl_space.sycl_queue().get_context();
   sycl::device device   = sycl_space.sycl_queue().get_device();
-  std::vector<SYCL> instances;
-  instances.reserve(sizeof...(Args));
-  for (unsigned int i = 0; i < sizeof...(Args); ++i)
-    instances.emplace_back(
-        sycl::queue(context, device, sycl::property::queue::in_order()));
+  std::array<SYCL, sizeof...(Args)> instances;
+  for (auto& instance : instances) {
+    instance = sycl::queue(context, device, sycl::property::queue::in_order());
+  }
   return instances;
 }
 

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -145,15 +145,22 @@ struct DeviceTypeTraits<Kokkos::SYCL> {
 
 namespace Experimental::Impl {
 // For each space in partition, create new queue on the same device as
-// base_instance
-template <class T, class Container>
-void impl_partition_space(const SYCL& base_instance, const std::vector<T>&,
-                          Container& instances) {
+// base_instance, ignoring weights
+template <class T>
+std::vector<SYCL> impl_partition_space(const SYCL& base_instance,
+                                       const std::vector<T>& weights) {
   sycl::context context = base_instance.sycl_queue().get_context();
   sycl::device device   = base_instance.sycl_queue().get_device();
-  for (auto& in : instances) {
-    in = SYCL(sycl::queue(context, device, sycl::property::queue::in_order()));
-  }
+
+  std::vector<SYCL> instances;
+  instances.reserve(weights.size());
+  std::generate_n(
+      std::back_inserter(instances), weights.size(), [&context, &device]() {
+        return SYCL(
+            sycl::queue(context, device, sycl::property::queue::in_order()));
+      });
+
+  return instances;
 }
 }  // namespace Experimental::Impl
 

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -146,18 +146,17 @@ struct DeviceTypeTraits<Kokkos::SYCL> {
 namespace Experimental {
 template <class... Args>
 std::array<SYCL, sizeof...(Args)> partition_space(const SYCL& sycl_space,
-                                                  Args...) {
+                                                  Args... ignored) {
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
 
   sycl::context context = sycl_space.sycl_queue().get_context();
   sycl::device device   = sycl_space.sycl_queue().get_device();
-  std::array<SYCL, sizeof...(Args)> instances;
-  for (auto& instance : instances) {
-    instance = sycl::queue(context, device, sycl::property::queue::in_order());
-  }
-  return instances;
+
+  return {((ignored,
+            sycl::queue(context, device, sycl::property::queue::in_order())),
+           ...)};
 }
 
 template <class T>

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -146,7 +146,7 @@ struct DeviceTypeTraits<Kokkos::SYCL> {
 namespace Experimental {
 template <class... Args>
 std::array<SYCL, sizeof...(Args)> partition_space(const SYCL& sycl_space,
-                                                  Args... ignored) {
+                                                  Args...) {
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
@@ -154,9 +154,11 @@ std::array<SYCL, sizeof...(Args)> partition_space(const SYCL& sycl_space,
   sycl::context context = sycl_space.sycl_queue().get_context();
   sycl::device device   = sycl_space.sycl_queue().get_device();
 
-  return {((ignored,
-            sycl::queue(context, device, sycl::property::queue::in_order())),
-           ...)};
+  std::array<SYCL, sizeof...(Args)> instances;
+  for (auto& in : instances) {
+    in = sycl::queue(context, device, sycl::property::queue::in_order());
+  }
+  return instances;
 }
 
 template <class T>

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -156,7 +156,7 @@ std::array<SYCL, sizeof...(Args)> partition_space(const SYCL& sycl_space,
 
   std::array<SYCL, sizeof...(Args)> instances;
   for (auto& in : instances) {
-    in = sycl::queue(context, device, sycl::property::queue::in_order());
+    in = SYCL(sycl::queue(context, device, sycl::property::queue::in_order()));
   }
   return instances;
 }

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -270,36 +270,14 @@ struct MemorySpaceAccess<Kokkos::Serial::memory_space,
 }  // namespace Impl
 }  // namespace Kokkos
 
-namespace Kokkos::Experimental {
-
-template <class... Args>
-std::array<Serial, sizeof...(Args)> partition_space(const Serial&, Args...) {
-  static_assert(
-      (... && std::is_arithmetic_v<Args>),
-      "Kokkos Error: partitioning arguments must be integers or floats");
-
-  std::array<Serial, sizeof...(Args)> instances;
+namespace Kokkos::Experimental::Impl {
+// Create new instance of Serial execution space for each partition
+template <class T, class Container>
+void impl_partition_space(const Serial&, const std::vector<T>&,
+                          Container& instances) {
   for (auto& in : instances) in = Serial(NewInstance{});
-  return instances;
 }
-
-template <class T>
-std::vector<Serial> partition_space(const Serial&,
-                                    std::vector<T> const& weights) {
-  static_assert(
-      std::is_arithmetic_v<T>,
-      "Kokkos Error: partitioning arguments must be integers or floats");
-
-  // We only care about the number of instances to create and ignore weights
-  // otherwise.
-  std::vector<Serial> instances;
-  instances.reserve(weights.size());
-  std::generate_n(std::back_inserter(instances), weights.size(),
-                  []() { return Serial{NewInstance{}}; });
-  return instances;
-}
-
-}  // namespace Kokkos::Experimental
+}  // namespace Kokkos::Experimental::Impl
 
 #include <Serial/Kokkos_Serial_Parallel_Range.hpp>
 #include <Serial/Kokkos_Serial_Parallel_MDRange.hpp>

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -273,13 +273,12 @@ struct MemorySpaceAccess<Kokkos::Serial::memory_space,
 namespace Kokkos::Experimental {
 
 template <class... Args>
-std::vector<Serial> partition_space(const Serial&, Args...) {
+std::array<Serial, sizeof...(Args)> partition_space(const Serial&, Args...) {
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
-  std::vector<Serial> instances;
-  instances.reserve(sizeof...(Args));
-  std::generate_n(std::back_inserter(instances), sizeof...(Args),
+  std::array<Serial, sizeof...(Args)> instances;
+  std::generate_n(instances.begin(), sizeof...(Args),
                   []() { return Serial{NewInstance{}}; });
   return instances;
 }

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -273,14 +273,12 @@ struct MemorySpaceAccess<Kokkos::Serial::memory_space,
 namespace Kokkos::Experimental {
 
 template <class... Args>
-std::array<Serial, sizeof...(Args)> partition_space(const Serial&, Args...) {
+std::array<Serial, sizeof...(Args)> partition_space(const Serial&,
+                                                    Args... ignored) {
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
-  std::array<Serial, sizeof...(Args)> instances;
-  std::generate_n(instances.begin(), sizeof...(Args),
-                  []() { return Serial{NewInstance{}}; });
-  return instances;
+  return {((ignored, Serial(NewInstance{})), ...)};
 }
 
 template <class T>

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -273,12 +273,14 @@ struct MemorySpaceAccess<Kokkos::Serial::memory_space,
 namespace Kokkos::Experimental {
 
 template <class... Args>
-std::array<Serial, sizeof...(Args)> partition_space(const Serial&,
-                                                    Args... ignored) {
+std::array<Serial, sizeof...(Args)> partition_space(const Serial&, Args...) {
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
-  return {((ignored, Serial(NewInstance{})), ...)};
+
+  std::array<Serial, sizeof...(Args)> instances;
+  for (auto& in : instances) in = Serial(NewInstance{});
+  return instances;
 }
 
 template <class T>

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -271,11 +271,17 @@ struct MemorySpaceAccess<Kokkos::Serial::memory_space,
 }  // namespace Kokkos
 
 namespace Kokkos::Experimental::Impl {
-// Create new instance of Serial execution space for each partition
-template <class T, class Container>
-void impl_partition_space(const Serial&, const std::vector<T>&,
-                          Container& instances) {
-  for (auto& in : instances) in = Serial(NewInstance{});
+// Create new instance of Serial execution space for each partition, ignoring
+// weights
+template <class T>
+std::vector<Serial> impl_partition_space(const Serial&,
+                                         const std::vector<T>& weights) {
+  std::vector<Serial> instances;
+  instances.reserve(weights.size());
+  std::generate_n(std::back_inserter(instances), weights.size(),
+                  []() { return Serial(NewInstance{}); });
+
+  return instances;
 }
 }  // namespace Kokkos::Experimental::Impl
 

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -105,23 +105,23 @@ void run_threaded_test(const Lambda1 l1, const Lambda2 l2) {
 }
 #endif
 
-void test_partitioning(std::vector<TEST_EXECSPACE>& instances) {
-  check_distinctive(instances[0], instances[1]);
-  check_space_member_for_policies(instances[0]);
-  check_space_member_for_policies(instances[1]);
+void test_partitioning(TEST_EXECSPACE& instance0, TEST_EXECSPACE& instance1) {
+  check_distinctive(instance0, instance1);
+  check_space_member_for_policies(instance0);
+  check_space_member_for_policies(instance1);
 
   int sum1, sum2;
   int N = 3910;
   run_threaded_test(
       [&]() {
         Kokkos::parallel_reduce(
-            Kokkos::RangePolicy<TEST_EXECSPACE>(instances[0], 0, N),
-            SumFunctor(), sum1);
+            Kokkos::RangePolicy<TEST_EXECSPACE>(instance0, 0, N), SumFunctor(),
+            sum1);
       },
       [&]() {
         Kokkos::parallel_reduce(
-            Kokkos::RangePolicy<TEST_EXECSPACE>(instances[1], 0, N),
-            SumFunctor(), sum2);
+            Kokkos::RangePolicy<TEST_EXECSPACE>(instance1, 0, N), SumFunctor(),
+            sum2);
       });
   ASSERT_EQ(sum1, sum2);
   ASSERT_EQ(sum1, N * (N - 1) / 2);
@@ -131,7 +131,7 @@ TEST(TEST_CATEGORY, partitioning_by_args) {
   auto instances =
       Kokkos::Experimental::partition_space(TEST_EXECSPACE(), 1, 1);
   ASSERT_EQ(int(instances.size()), 2);
-  test_partitioning(instances);
+  test_partitioning(instances[0], instances[1]);
 }
 
 TEST(TEST_CATEGORY, partitioning_by_vector) {
@@ -139,6 +139,6 @@ TEST(TEST_CATEGORY, partitioning_by_vector) {
   auto instances = Kokkos::Experimental::partition_space(
       TEST_EXECSPACE(), std::vector<int> /*weights*/ {1, 1});
   ASSERT_EQ(int(instances.size()), 2);
-  test_partitioning(instances);
+  test_partitioning(instances[0], instances[1]);
 }
 }  // namespace Test

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -55,11 +55,15 @@ void check_distinctive([[maybe_unused]] ExecSpace exec1,
 #ifdef KOKKOS_ENABLE_CUDA
   if constexpr (std::is_same_v<ExecSpace, Kokkos::Cuda>) {
     ASSERT_NE(exec1.cuda_stream(), exec2.cuda_stream());
+    ASSERT_EQ(exec1.cuda_device(), ExecSpace().cuda_device());
+    ASSERT_EQ(exec2.cuda_device(), ExecSpace().cuda_device());
   }
 #endif
 #ifdef KOKKOS_ENABLE_HIP
   if constexpr (std::is_same_v<ExecSpace, Kokkos::HIP>) {
     ASSERT_NE(exec1.hip_stream(), exec2.hip_stream());
+    ASSERT_EQ(exec1.hip_device(), ExecSpace().hip_device());
+    ASSERT_EQ(exec2.hip_device(), ExecSpace().hip_device());
   }
 #endif
 #ifdef KOKKOS_ENABLE_SYCL
@@ -131,13 +135,23 @@ TEST(TEST_CATEGORY, partitioning_by_args) {
   auto instances =
       Kokkos::Experimental::partition_space(TEST_EXECSPACE(), 1, 1);
   ASSERT_EQ(int(instances.size()), 2);
+  static_assert(
+      std::is_same_v<decltype(instances), std::array<TEST_EXECSPACE, 2>>);
   test_partitioning(instances[0], instances[1]);
+}
+
+TEST(TEST_CATEGORY, partitioning_by_args_with_structured_bindings) {
+  auto [instance0, instance1] =
+      Kokkos::Experimental::partition_space(TEST_EXECSPACE(), 1, 1);
+  test_partitioning(instance0, instance1);
 }
 
 TEST(TEST_CATEGORY, partitioning_by_vector) {
   // Make sure we can use a temporary as argument for weights
   auto instances = Kokkos::Experimental::partition_space(
       TEST_EXECSPACE(), std::vector<int> /*weights*/ {1, 1});
+  static_assert(
+      std::is_same_v<decltype(instances), std::vector<TEST_EXECSPACE>>);
   ASSERT_EQ(int(instances.size()), 2);
   test_partitioning(instances[0], instances[1]);
 }

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -50,8 +50,8 @@ void check_distinctive([[maybe_unused]] ExecSpace exec1,
 #ifdef KOKKOS_ENABLE_OPENMP
   if constexpr (std::is_same_v<ExecSpace, Kokkos::OpenMP>) {
     ASSERT_NE(exec1, exec2);
-    ASSERT_EQ(ExecSpace().impl_thread_pool_size(),
-              exec1.impl_thread_pool_size() + exec2.impl_thread_pool_size());
+    ASSERT_EQ(ExecSpace().concurrency(),
+              exec1.concurrency() + exec2.concurrency());
   }
 #endif
 #ifdef KOKKOS_ENABLE_CUDA

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -50,7 +50,9 @@ void check_distinctive([[maybe_unused]] ExecSpace exec1,
 #ifdef KOKKOS_ENABLE_OPENMP
   if constexpr (std::is_same_v<ExecSpace, Kokkos::OpenMP>) {
     ASSERT_NE(exec1, exec2);
-    ASSERT_EQ(ExecSpace().concurrency(),
+    // FIXME_OPENMP exec.concurrency() does not return thread pool size outside
+    // of parallel regions
+    ASSERT_EQ(ExecSpace().impl_internal_space_instance()->thread_pool_size(),
               exec1.impl_internal_space_instance()->thread_pool_size() +
                   exec2.impl_internal_space_instance()->thread_pool_size());
   }

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -50,6 +50,8 @@ void check_distinctive([[maybe_unused]] ExecSpace exec1,
 #ifdef KOKKOS_ENABLE_OPENMP
   if constexpr (std::is_same_v<ExecSpace, Kokkos::OpenMP>) {
     ASSERT_NE(exec1, exec2);
+    ASSERT_EQ(ExecSpace().impl_thread_pool_size(),
+              exec1.impl_thread_pool_size() + exec2.impl_thread_pool_size());
   }
 #endif
 #ifdef KOKKOS_ENABLE_CUDA

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -51,7 +51,8 @@ void check_distinctive([[maybe_unused]] ExecSpace exec1,
   if constexpr (std::is_same_v<ExecSpace, Kokkos::OpenMP>) {
     ASSERT_NE(exec1, exec2);
     ASSERT_EQ(ExecSpace().concurrency(),
-              exec1.concurrency() + exec2.concurrency());
+              exec1.impl_internal_space_instance()->thread_pool_size() +
+                  exec2.impl_internal_space_instance()->thread_pool_size());
   }
 #endif
 #ifdef KOKKOS_ENABLE_CUDA

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -208,19 +208,22 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph),
     GTEST_SKIP() << "insufficient number of supported concurrent threads";
 #endif
 
-  const auto [exec_0, exec_1] = Kokkos::Experimental::partition_space(ex, 1, 1);
+  const auto execution_space_instances =
+      Kokkos::Experimental::partition_space(ex, 1, 1);
 
-  auto graph = Kokkos::Experimental::create_graph(exec_0, [&](auto root) {
-    root.then_parallel_for(1, count_functor{count, bugs, 0, 0});
-  });
+  auto graph = Kokkos::Experimental::create_graph(
+      execution_space_instances.at(0), [&](auto root) {
+        root.then_parallel_for(1, count_functor{count, bugs, 0, 0});
+      });
   graph.instantiate();
 
-  exec_0.fence("The graph might make async copies to device.");
+  execution_space_instances.at(0).fence(
+      "The graph might make async copies to device.");
 
-  graph.submit(exec_1);
+  graph.submit(execution_space_instances.at(1));
 
-  ASSERT_TRUE(contains(exec_1, count, 1));
-  ASSERT_TRUE(contains(exec_1, bugs, 0));
+  ASSERT_TRUE(contains(execution_space_instances.at(1), count, 1));
+  ASSERT_TRUE(contains(execution_space_instances.at(1), bugs, 0));
 }
 
 // This test ensures that it's possible to build a Kokkos::Graph using
@@ -629,8 +632,13 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), diamond) {
     GTEST_SKIP() << "test needs at least 4 OpenMP threads";
 #endif
 
-  const auto [exec_0, exec_1, exec_2, exec_3] =
+  const auto execution_space_instances =
       Kokkos::Experimental::partition_space(ex, 1, 1, 1, 1);
+
+  const auto exec_0 = execution_space_instances.at(0);
+  const auto exec_1 = execution_space_instances.at(1);
+  const auto exec_2 = execution_space_instances.at(2);
+  const auto exec_3 = execution_space_instances.at(3);
 
   using policy_t = Kokkos::RangePolicy<TEST_EXECSPACE>;
   using view_t   = Kokkos::View<int*, TEST_EXECSPACE>;
@@ -701,8 +709,13 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), end_of_submit_control_flow) {
     GTEST_SKIP() << "insufficient number of supported concurrent threads";
 #endif
 
-  const auto [exec_0, exec_1, exec_2, exec_3] =
+  const auto execution_space_instances =
       Kokkos::Experimental::partition_space(ex, 1, 1, 1, 1);
+
+  const auto exec_0 = execution_space_instances.at(0);
+  const auto exec_1 = execution_space_instances.at(1);
+  const auto exec_2 = execution_space_instances.at(2);
+  const auto exec_3 = execution_space_instances.at(3);
 
   using policy_t = Kokkos::RangePolicy<TEST_EXECSPACE>;
   using view_t   = Kokkos::View<int*, TEST_EXECSPACE>;


### PR DESCRIPTION
Addresses https://github.com/kokkos/kokkos/issues/8100. In case of weights being provided as compile-time variable number of inputs, return a `std::array<ExecSpace, sizeof...(Args)>` instead of a vector. This allows structured binding of return array
```
auto [exec0, exec1] = Experimental::partition_space(ExecSpace, 1, 1);
```