### PR TITLE
simd: Fix simd reduction

### DIFF
--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -97,17 +97,31 @@ template <
     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 reduce(basic_simd<T, Abi> const& v,
-       typename basic_simd<T, Abi>::mask_type const& m, T identity,
-       BinaryOperation op = {}) {
+       typename basic_simd<T, Abi>::mask_type const& m, BinaryOperation op = {},
+       T identity = Impl::Identity<T, BinaryOperation>()) {
   if (none_of(m)) {
     return identity;
   }
-  T result = Impl::Identity<T, BinaryOperation>();
+  T result = identity;
   for (std::size_t i = 0; i < v.size(); ++i) {
     if (m[i]) result = op(result, v[i]);
   }
   return result;
 }
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+template <
+    class T, class Abi, class BinaryOperation = std::plus<>,
+    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use reduce(basic_simd, basic_simd_mask, op, identity) instead")
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+    reduce(basic_simd<T, Abi> const& v,
+           typename basic_simd<T, Abi>::mask_type const& m, T identity,
+           BinaryOperation op = {}) {
+  return reduce(v, m, op, identity);
+}
+#endif
 
 }  // namespace Experimental
 

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -437,25 +437,36 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd<T, simd_abi::scalar> condition(
       static_cast<bool>(a) ? static_cast<T>(b) : static_cast<T>(c));
 }
 
-template <class T, class BinaryOperation>
+template <class T, class BinaryOperation = std::plus<>>
+KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
+    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
+    BinaryOperation = {}) noexcept {
+  return x[0];
+}
+
+template <class T, class BinaryOperation = std::plus<>>
 KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
     Experimental::basic_simd_mask<T, Experimental::simd_abi::scalar> const&
         mask,
-    T identity, BinaryOperation) noexcept {
+    BinaryOperation = {},
+    T identity      = Impl::Identity<T, BinaryOperation>()) noexcept {
   if (!mask) return identity;
   return x[0];
 }
 
-template <class T, class BinaryOperation>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+template <class T, class BinaryOperation = std::plus<>>
+KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use reduce(basic_simd, basic_simd_mask, op, identity) instead")
 KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
-    BinaryOperation binary_op) noexcept {
-  return reduce(x,
-                typename Experimental::basic_simd<
-                    T, Experimental::simd_abi::scalar>::mask_type(true),
-                T(Impl::Identity<T, BinaryOperation>()), binary_op);
+    Experimental::basic_simd_mask<T, Experimental::simd_abi::scalar> const&
+        mask,
+    T, BinaryOperation = {}) noexcept {
+  return reduce(x, mask);
 }
+#endif
 
 template <class T>
 KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -542,10 +542,7 @@ class masked_reduce {
     auto w        = Kokkos::Experimental::where(mask, a);
     auto const& v = w.impl_get_value();
     auto const& m = w.impl_get_mask();
-    U result =
-        Kokkos::Experimental::Impl::is_basic_reduction_op_v<BinaryOperation>
-            ? Kokkos::Experimental::Impl::Identity<U, BinaryOperation>()
-            : identity;
+    U result      = identity;
     for (std::size_t i = 0; i < v.size(); ++i) {
       if (m[i]) result = BinaryOperation()(result, v[i]);
     }
@@ -564,10 +561,7 @@ class masked_reduce {
     auto w        = Kokkos::Experimental::where(mask, a);
     auto const& v = w.impl_get_value();
     auto const& m = w.impl_get_mask();
-    U result =
-        Kokkos::Experimental::Impl::is_basic_reduction_op_v<BinaryOperation>
-            ? Kokkos::Experimental::Impl::Identity<U, BinaryOperation>()
-            : identity;
+    U result      = identity;
     for (std::size_t i = 0; i < v.size(); ++i) {
       if constexpr (std::is_same_v<BinaryOperation, std::plus<>>) {
         if (m[i]) result = result + v[i];

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -311,6 +311,11 @@ class minimum {
   KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
     return Kokkos::min(a, b);
   }
+
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION T operator()(T const& a, T const& b) const {
+    return Kokkos::min(a, b);
+  }
 };
 
 class maximum {
@@ -335,6 +340,11 @@ class maximum {
   }
   template <typename T>
   KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
+    return Kokkos::max(a, b);
+  }
+
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION T operator()(T const& a, T const& b) const {
     return Kokkos::max(a, b);
   }
 };
@@ -406,8 +416,8 @@ class reduce {
   }
   template <typename T, typename U, typename MaskType>
   auto on_host_serial(T const& a, U, MaskType) const {
-    U result = Kokkos::Experimental::Impl::Identity<U, BinaryOperation>();
-    for (std::size_t i = 0; i < a.size(); ++i) {
+    U result = a[0];
+    for (std::size_t i = 1; i < a.size(); ++i) {
       result = BinaryOperation()(result, a[i]);
     }
     return result;
@@ -419,8 +429,8 @@ class reduce {
   }
   template <typename T, typename U, typename MaskType>
   KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a, U, MaskType) const {
-    U result = Kokkos::Experimental::Impl::Identity<U, BinaryOperation>();
-    for (std::size_t i = 0; i < a.size(); ++i) {
+    U result = a[0];
+    for (std::size_t i = 1; i < a.size(); ++i) {
       if constexpr (std::is_same_v<BinaryOperation, std::plus<>>) {
         result = result + a[i];
       } else if constexpr (std::is_same_v<BinaryOperation, std::multiplies<>>) {
@@ -432,7 +442,7 @@ class reduce {
       } else if constexpr (std::is_same_v<BinaryOperation, std::bit_xor<>>) {
         result = result ^ a[i];
       } else {
-        Kokkos::abort("Unsupported reduce operation");
+        result = BinaryOperation()(result, a[i]);
       }
     }
     return result;
@@ -524,7 +534,7 @@ class masked_reduce {
  public:
   template <typename T, typename U, typename MaskType>
   auto on_host(T const& a, U const& identity, MaskType mask) const {
-    return Kokkos::Experimental::reduce(a, mask, identity, BinaryOperation());
+    return Kokkos::Experimental::reduce(a, mask, BinaryOperation(), identity);
   }
   template <typename T, typename U, typename MaskType>
   auto on_host_serial(T const& a, U const& identity, MaskType mask) const {
@@ -532,7 +542,10 @@ class masked_reduce {
     auto w        = Kokkos::Experimental::where(mask, a);
     auto const& v = w.impl_get_value();
     auto const& m = w.impl_get_mask();
-    U result      = Kokkos::Experimental::Impl::Identity<U, BinaryOperation>();
+    U result =
+        Kokkos::Experimental::Impl::is_basic_reduction_op_v<BinaryOperation>
+            ? Kokkos::Experimental::Impl::Identity<U, BinaryOperation>()
+            : identity;
     for (std::size_t i = 0; i < v.size(); ++i) {
       if (m[i]) result = BinaryOperation()(result, v[i]);
     }
@@ -542,7 +555,7 @@ class masked_reduce {
   template <typename T, typename U, typename MaskType>
   KOKKOS_INLINE_FUNCTION auto on_device(T const& a, U const& identity,
                                         MaskType mask) const {
-    return Kokkos::Experimental::reduce(a, mask, identity, BinaryOperation());
+    return Kokkos::Experimental::reduce(a, mask, BinaryOperation(), identity);
   }
   template <typename T, typename U, typename MaskType>
   KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a, U const& identity,
@@ -551,7 +564,10 @@ class masked_reduce {
     auto w        = Kokkos::Experimental::where(mask, a);
     auto const& v = w.impl_get_value();
     auto const& m = w.impl_get_mask();
-    U result      = Kokkos::Experimental::Impl::Identity<U, BinaryOperation>();
+    U result =
+        Kokkos::Experimental::Impl::is_basic_reduction_op_v<BinaryOperation>
+            ? Kokkos::Experimental::Impl::Identity<U, BinaryOperation>()
+            : identity;
     for (std::size_t i = 0; i < v.size(); ++i) {
       if constexpr (std::is_same_v<BinaryOperation, std::plus<>>) {
         if (m[i]) result = result + v[i];
@@ -564,7 +580,7 @@ class masked_reduce {
       } else if constexpr (std::is_same_v<BinaryOperation, std::bit_xor<>>) {
         if (m[i]) result = result ^ v[i];
       } else {
-        Kokkos::abort("Unsupported reduce operation");
+        if (m[i]) result = BinaryOperation()(result, v[i]);
       }
     }
     return result;


### PR DESCRIPTION
The fallback implementation of `Kokkos::Experimental::reduce()` uses an identity element as an initial value to perform binary operations on each vector lane in serial. This is erroneous for some operations (i.e. `min`, `max`). Modified the fallback reduction implementations to correctly set its initial value.

Also, the function signature of masked reduce
```
template <class T, class BinaryOperation = plus<>>
T Kokkos::Experimental::reduce(const simd&, const simd_mask&, T, BinaryOperation = {})
```
doesn't align with `std::simd`.

Deprecated this function in favor of:
```
template <class T, class BinaryOperation = plus<>>
T Kokkos::Experimental::reduce(const simd&, const simd_mask&, BinaryOperation = {}, T = identity_element)
```