### PR TITLE
Fix copyright in cmake/compile_tests/get_sve_hw_vl.cpp

### DIFF
--- a/cmake/compile_tests/get_sve_hw_vl.cpp
+++ b/cmake/compile_tests/get_sve_hw_vl.cpp
@@ -1,3 +1,19 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
 #include <iostream>
 #include <arm_sve.h>
 

--- a/scripts/diff_files
+++ b/scripts/diff_files
@@ -1,2 +1,1 @@
 
-cmake/compile_tests/get_sve_hw_vl.cpp


### PR DESCRIPTION
We missed that `diff_files` wasn't empty in https://github.com/kokkos/kokkos/pull/7807.