### PR TITLE
Implement nextafter for fp16

### DIFF
--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -355,7 +355,7 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_impl(fp16_t from, fp16_t to) {
    // Determine direction and sign of 'from'
    // True if moving to positive infinity
    bool to_positive_infinity = (to > from);
-   bool from_is_negative     = ((uint_from & FP16_SIGN_MASK) != 0);
+   bool from_is_negative     = (uint_from & FP16_SIGN_MASK);
 
    std::uint16_t uint_result = uint_from + 2 * (to_positive_infinity ^ from_is_negative) - 1;
    // This is equivalent to the following operations.

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -323,8 +323,9 @@ KOKKOS_INLINE_FUNCTION bool isnan(Kokkos::Experimental::bhalf_t x) {
 #endif
 
 #if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
+namespace Impl {
 template <typename fp16_t>
-KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_impl(fp16_t from, fp16_t to) {
+KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_helper(fp16_t from, fp16_t to) {
   static_assert((std::is_same_v<fp16_t, Kokkos::Experimental::half_t> ||
                  std::is_same_v<fp16_t, Kokkos::Experimental::bhalf_t>)
                  && sizeof(fp16_t) == 2, "nextafter_half_impl only supports half_t and bhalf_t");
@@ -386,31 +387,36 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_impl(fp16_t from, fp16_t to) {
    //   }
    // }
    fp16_t result = bit_cast<fp16_t>(uint_result);
-   KOKKOS_IF_ON_HOST((
-       if (isinf(result)) {
-         // if from is finite, but the expected result is an infinity, raises FE_INEXACT and FE_OVERFLOW.
-         std::feraiseexcept(FE_INEXACT | FE_OVERFLOW);
-       };
-       if (result == fp16_t(0) || uint_result == FP16_SMALLEST_POS_DN ||
-           uint_result == FP16_SMALLEST_NEG_DN) {
-         // if from does not equal to and the result is subnormal or zero, raises FE_INEXACT and FE_UNDERFLOW.
-         std::feraiseexcept(FE_INEXACT | FE_UNDERFLOW);
-       };))
+   // We can technically raise math_errhandling on Host, but we decided not to.
+   // This makes the behavior of the function on Host and Device inconsistent.
+   // In addition, the unit-test function gets unreadable with even more macros.
+   //
+   // KOKKOS_IF_ON_HOST((
+   //     if (isinf(result)) {
+   //       // if from is finite, but the expected result is an infinity, raises FE_INEXACT and FE_OVERFLOW.
+   //       std::feraiseexcept(FE_INEXACT | FE_OVERFLOW);
+   //     };
+   //     if (result == fp16_t(0) || uint_result == FP16_SMALLEST_POS_DN ||
+   //         uint_result == FP16_SMALLEST_NEG_DN) {
+   //       // if from does not equal to and the result is subnormal or zero, raises FE_INEXACT and FE_UNDERFLOW.
+   //       std::feraiseexcept(FE_INEXACT | FE_UNDERFLOW);
+   //     };))
 
    return result;
 }
+} // namespace Impl
 
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t nextafter(Kokkos::Experimental::half_t from,
                                                               Kokkos::Experimental::half_t to) {
-  return nextafter_half_impl(from, to);
+  return Impl::nextafter_half_helper(from, to);
 }
 #endif
 
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t nextafter(Kokkos::Experimental::bhalf_t from,
                                                                Kokkos::Experimental::bhalf_t to) {
-  return nextafter_half_impl(from, to);
+  return Impl::nextafter_half_helper(from, to);
 }
 #endif
 #endif  // !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_HALF_MATHEMATICAL_FUNCTIONS_HPP_
 #define KOKKOS_HALF_MATHEMATICAL_FUNCTIONS_HPP_
 
+#include <cstdint>                           // For std::uint16_t
 #include <Kokkos_MathematicalFunctions.hpp>  // For the float overloads
 #include <Kokkos_BitManipulation.hpp>        // bit_cast
 

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -335,7 +335,7 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_impl(fp16_t from, fp16_t to) {
    if (from == to) return to;
 
    // Get unsigned integer representation of from
-   std::uint16_t uint_from = bit_cast<std::uint16_t>(from);
+   std::uint16_t uint_from = bit_cast<std::uint16_t, fp16_t>(from);
 
    // Handle zeros
    if (uint_from == FP16_POS_ZERO) {  // from is +0.0
@@ -343,14 +343,14 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_impl(fp16_t from, fp16_t to) {
      // Return smallest magnitude number with the sign of 'to'.
      // However, standard nextafter(+0, negative) -> smallest_negative
      // And nextafter(+0, positive) -> smallest_positive
-     return bit_cast<fp16_t>((to > from) ? FP16_SMALLEST_POS_DN
+     return bit_cast<fp16_t, std::uint16_t>((to > from) ? FP16_SMALLEST_POS_DN
                                                  : FP16_SMALLEST_NEG_DN);
    }
    if (uint_from == FP16_NEG_ZERO) {  // from is -0.0
      // Return smallest magnitude number with the sign of 'to'.
      // Standard nextafter(-0, negative) -> smallest_negative
      // And nextafter(-0, positive) -> smallest_positive
-     return bit_cast<fp16_t>((to > from) ? FP16_SMALLEST_POS_DN
+     return bit_cast<fp16_t, std::uint16_t>((to > from) ? FP16_SMALLEST_POS_DN
                                                  : FP16_SMALLEST_NEG_DN);
    }
 
@@ -383,7 +383,7 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_impl(fp16_t from, fp16_t to) {
        uint_result = uint_from - 1;
      }
    }
-   return bit_cast<fp16_t>(uint_result);
+   return bit_cast<fp16_t, std::uint16_t>(uint_result);
 }
 
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -358,7 +358,7 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_impl(fp16_t from, fp16_t to) {
 
    // Determine direction and sign of 'from'
    // True if moving to positive infinity
-   bool to_poisitive_infinity = (to > from);
+   bool to_positive_infinity = (to > from);
    bool from_is_negative      = ((uint_from & FP16_SIGN_MASK) != 0);
 
    std::uint16_t uint_result;
@@ -366,7 +366,7 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_impl(fp16_t from, fp16_t to) {
      // For negative numbers, increasing magnitude means moving towards -inf
      // (larger uint value) Decreasing magnitude means moving towards zero
      // (smaller uint value)
-     if (to_poisitive_infinity) {
+     if (to_positive_infinity) {
        // Moving toward zero or positive
        uint_result = uint_from - 1;
      } else {
@@ -377,7 +377,7 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_impl(fp16_t from, fp16_t to) {
      // For positive numbers, increasing magnitude means moving towards +inf
      // (larger uint value) Decreasing magnitude means moving towards zero
      // (smaller uint value)
-     if (to_poisitive_infinity) {
+     if (to_positive_infinity) {
        // Moving toward positive infinity
        uint_result = uint_from + 1;
      } else {

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -326,7 +326,7 @@ template <typename fp16_t>
 KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_impl(fp16_t from, fp16_t to) {
   static_assert((std::is_same_v<fp16_t, Kokkos::Experimental::half_t> ||
                  std::is_same_v<fp16_t, Kokkos::Experimental::bhalf_t>)
-                 && sizeof(fp16_t) == 2, "nextafter_impl only supports half_t and bhalf_t");
+                 && sizeof(fp16_t) == 2, "nextafter_half_impl only supports half_t and bhalf_t");
   constexpr std::uint16_t FP16_SIGN_MASK = 0x8000;
   constexpr std::uint16_t FP16_POS_ZERO  = 0x0000;
   constexpr std::uint16_t FP16_NEG_ZERO  = 0x8000;
@@ -342,7 +342,7 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_impl(fp16_t from, fp16_t to) {
    if (from == to) return to;
 
    // Get unsigned integer representation of from
-   std::uint16_t uint_from = bit_cast<std::uint16_t, fp16_t>(from);
+   std::uint16_t uint_from = bit_cast<std::uint16_t>(from);
 
    // Handle zeros
    if (uint_from == FP16_POS_ZERO || uint_from == FP16_NEG_ZERO) {
@@ -350,8 +350,8 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_impl(fp16_t from, fp16_t to) {
      // Return smallest magnitude number with the sign of 'to'.
      // nextafter(±0, negative) -> smallest_negative
      // nextafter(±0, positive) -> smallest_positive
-     return bit_cast<fp16_t, std::uint16_t>((to > from) ? FP16_SMALLEST_POS_DN
-                                                        : FP16_SMALLEST_NEG_DN);
+     return bit_cast<fp16_t>((to > from) ? FP16_SMALLEST_POS_DN
+                                         : FP16_SMALLEST_NEG_DN);
    }
 
    // Determine direction and sign of 'from'
@@ -383,7 +383,7 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_impl(fp16_t from, fp16_t to) {
        uint_result = uint_from - 1;
      }
    }
-   return bit_cast<fp16_t, std::uint16_t>(uint_result);
+   return bit_cast<fp16_t>(uint_result);
 }
 
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -349,9 +349,6 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_impl(fp16_t from, fp16_t to) {
      // Return smallest magnitude number with the sign of 'to'.
      // nextafter(±0, negative) -> smallest_negative
      // nextafter(±0, positive) -> smallest_positive
-     KOKKOS_IF_ON_HOST((
-         // if from does not equal to and the result is subnormal or zero, raises FE_INEXACT and FE_UNDERFLOW.
-         std::feraiseexcept(FE_INEXACT | FE_UNDERFLOW);))
      return bit_cast<fp16_t>((to > from) ? FP16_SMALLEST_POS_DN
                                          : FP16_SMALLEST_NEG_DN);
    }

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -197,7 +197,11 @@ KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_UNARY_FUNCTION_HALF_TYPE, ne
 // scalbln
 // ilog
 KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_UNARY_FUNCTION_HALF_TYPE, logb)
-// nextafter
+
+// FIXME nextafter for fp16 is unavailable for MSVC CUDA builds
+#if (defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
+KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_UNARY_FUNCTION_HALF_TYPE, nextafter)
+#endif
 // nexttoward
 KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF, copysign)
 // Classification and comparison functions
@@ -317,8 +321,9 @@ KOKKOS_INLINE_FUNCTION bool isnan(Kokkos::Experimental::bhalf_t x) {
 }
 #endif
 
+#if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
 template <typename fp16_t>
-KOKKOS_INLINE_FUNCTION fp16_t nextafter_impl(fp16_t from, fp16_t to) {
+KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_impl(fp16_t from, fp16_t to) {
   static_assert((std::is_same_v<fp16_t, Kokkos::Experimental::half_t> ||
                  std::is_same_v<fp16_t, Kokkos::Experimental::bhalf_t>)
                  && sizeof(fp16_t) == 2, "nextafter_impl only supports half_t and bhalf_t");
@@ -391,16 +396,17 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_impl(fp16_t from, fp16_t to) {
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t nextafter(Kokkos::Experimental::half_t from,
                                                               Kokkos::Experimental::half_t to) {
-  return nextafter_impl(from, to);
+  return nextafter_half_impl(from, to);
 }
 #endif
 
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t nextafter(Kokkos::Experimental::bhalf_t from,
                                                                Kokkos::Experimental::bhalf_t to) {
-  return nextafter_impl(from, to);
+  return nextafter_half_impl(from, to);
 }
 #endif
+#endif  // !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
 
 // isnormal
 KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_UNARY_PREDICATE_HALF, signbit)

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -18,7 +18,6 @@
 #define KOKKOS_HALF_MATHEMATICAL_FUNCTIONS_HPP_
 
 #include <cstdint>                           // For std::uint16_t
-#include <cfenv>                             // For std::feraiseexcept
 #include <Kokkos_MathematicalFunctions.hpp>  // For the float overloads
 #include <Kokkos_BitManipulation.hpp>        // bit_cast
 
@@ -386,23 +385,7 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_helper(fp16_t from, fp16_t to) {
    //     uint_result = uint_from - 1;
    //   }
    // }
-   fp16_t result = bit_cast<fp16_t>(uint_result);
-   // We can technically raise math_errhandling on Host, but we decided not to.
-   // This makes the behavior of the function on Host and Device inconsistent.
-   // In addition, the unit-test function gets unreadable with even more macros.
-   //
-   // KOKKOS_IF_ON_HOST((
-   //     if (isinf(result)) {
-   //       // if from is finite, but the expected result is an infinity, raises FE_INEXACT and FE_OVERFLOW.
-   //       std::feraiseexcept(FE_INEXACT | FE_OVERFLOW);
-   //     };
-   //     if (result == fp16_t(0) || uint_result == FP16_SMALLEST_POS_DN ||
-   //         uint_result == FP16_SMALLEST_NEG_DN) {
-   //       // if from does not equal to and the result is subnormal or zero, raises FE_INEXACT and FE_UNDERFLOW.
-   //       std::feraiseexcept(FE_INEXACT | FE_UNDERFLOW);
-   //     };))
-
-   return result;
+   return bit_cast<fp16_t>(uint_result);
 }
 } // namespace Impl
 

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -319,7 +319,9 @@ KOKKOS_INLINE_FUNCTION bool isnan(Kokkos::Experimental::bhalf_t x) {
 
 template <typename fp16_t>
 KOKKOS_INLINE_FUNCTION fp16_t nextafter_impl(fp16_t from, fp16_t to) {
-  static_assert(sizeof(fp16_t) == 2, "nextafter_impl only supports half_t and bhalf_t");
+  static_assert((std::is_same_v<fp16_t, Kokkos::Experimental::half_t> ||
+                 std::is_same_v<fp16_t, Kokkos::Experimental::bhalf_t>)
+                 && sizeof(fp16_t) == 2, "nextafter_impl only supports half_t and bhalf_t");
   constexpr std::uint16_t FP16_SIGN_MASK = 0x8000;
   constexpr std::uint16_t FP16_POS_ZERO  = 0x0000;
   constexpr std::uint16_t FP16_NEG_ZERO  = 0x8000;
@@ -356,15 +358,15 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_impl(fp16_t from, fp16_t to) {
 
    // Determine direction and sign of 'from'
    // True if moving to positive infinity
-   bool increase_magnitude = (to > from);
-   bool from_is_negative   = ((uint_from & FP16_SIGN_MASK) != 0);
+   bool to_poisitive_infinity = (to > from);
+   bool from_is_negative      = ((uint_from & FP16_SIGN_MASK) != 0);
 
    std::uint16_t uint_result;
    if (from_is_negative) {
      // For negative numbers, increasing magnitude means moving towards -inf
      // (larger uint value) Decreasing magnitude means moving towards zero
      // (smaller uint value)
-     if (increase_magnitude) {
+     if (to_poisitive_infinity) {
        // Moving toward zero or positive
        uint_result = uint_from - 1;
      } else {
@@ -375,7 +377,7 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_impl(fp16_t from, fp16_t to) {
      // For positive numbers, increasing magnitude means moving towards +inf
      // (larger uint value) Decreasing magnitude means moving towards zero
      // (smaller uint value)
-     if (increase_magnitude) {
+     if (to_poisitive_infinity) {
        // Moving toward positive infinity
        uint_result = uint_from + 1;
      } else {
@@ -395,7 +397,7 @@ KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t nextafter(Kokkos::Experiment
 
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t nextafter(Kokkos::Experimental::bhalf_t from,
-                                                                 Kokkos::Experimental::bhalf_t to) {
+                                                               Kokkos::Experimental::bhalf_t to) {
   return nextafter_impl(from, to);
 }
 #endif

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -359,30 +359,33 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_impl(fp16_t from, fp16_t to) {
    bool to_positive_infinity = (to > from);
    bool from_is_negative     = ((uint_from & FP16_SIGN_MASK) != 0);
 
-   std::uint16_t uint_result;
-   if (from_is_negative) {
-     // For negative numbers, increasing magnitude means moving towards -inf
-     // (larger uint value) Decreasing magnitude means moving towards zero
-     // (smaller uint value)
-     if (to_positive_infinity) {
-       // Moving toward zero or positive
-       uint_result = uint_from - 1;
-     } else {
-       // Moving toward negative infinity
-       uint_result = uint_from + 1;
-     }
-   } else {
-     // For positive numbers, increasing magnitude means moving towards +inf
-     // (larger uint value) Decreasing magnitude means moving towards zero
-     // (smaller uint value)
-     if (to_positive_infinity) {
-       // Moving toward positive infinity
-       uint_result = uint_from + 1;
-     } else {
-       // Moving toward zero or negative infinity
-       uint_result = uint_from - 1;
-     }
-   }
+   std::uint16_t uint_result = uint_from + 2 * (to_positive_infinity ^ from_is_negative) - 1;
+   // This is equivalent to the following operations.
+   //std::uint16_t uint_result;
+   //
+   //if (from_is_negative) {
+   //  // For negative numbers, increasing magnitude means moving towards -inf
+   //  // (larger uint value) Decreasing magnitude means moving towards zero
+   //  // (smaller uint value)
+   //  if (to_positive_infinity) {
+   //    // Moving toward zero or positive
+   //    uint_result = uint_from - 1;
+   //  } else {
+   //    // Moving toward negative infinity
+   //    uint_result = uint_from + 1;
+   //  }
+   //} else {
+   //  // For positive numbers, increasing magnitude means moving towards +inf
+   //  // (larger uint value) Decreasing magnitude means moving towards zero
+   //  // (smaller uint value)
+   //  if (to_positive_infinity) {
+   //    // Moving toward positive infinity
+   //    uint_result = uint_from + 1;
+   //  } else {
+   //    // Moving toward zero or negative infinity
+   //    uint_result = uint_from - 1;
+   //  }
+   //}
    return bit_cast<fp16_t>(uint_result);
 }
 

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -328,8 +328,6 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_impl(fp16_t from, fp16_t to) {
                  std::is_same_v<fp16_t, Kokkos::Experimental::bhalf_t>)
                  && sizeof(fp16_t) == 2, "nextafter_half_impl only supports half_t and bhalf_t");
   constexpr std::uint16_t FP16_SIGN_MASK = 0x8000;
-  constexpr std::uint16_t FP16_POS_ZERO  = 0x0000;
-  constexpr std::uint16_t FP16_NEG_ZERO  = 0x8000;
   constexpr std::uint16_t FP16_SMALLEST_POS_DN = 0x0001;  // Smallest positive denormal
   constexpr std::uint16_t FP16_SMALLEST_NEG_DN = 0x8001;  // Smallest negative denormal (magnitude)
 
@@ -345,7 +343,7 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_impl(fp16_t from, fp16_t to) {
    std::uint16_t uint_from = bit_cast<std::uint16_t>(from);
 
    // Handle zeros
-   if (uint_from == FP16_POS_ZERO || uint_from == FP16_NEG_ZERO) {
+   if (from == fp16_t(0)) {
      // from is +0.0 or -0.0
      // Return smallest magnitude number with the sign of 'to'.
      // nextafter(±0, negative) -> smallest_negative
@@ -361,31 +359,31 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_impl(fp16_t from, fp16_t to) {
 
    std::uint16_t uint_result = uint_from + 2 * (to_positive_infinity ^ from_is_negative) - 1;
    // This is equivalent to the following operations.
-   //std::uint16_t uint_result;
+   // std::uint16_t uint_result;
    //
-   //if (from_is_negative) {
-   //  // For negative numbers, increasing magnitude means moving towards -inf
-   //  // (larger uint value) Decreasing magnitude means moving towards zero
-   //  // (smaller uint value)
-   //  if (to_positive_infinity) {
-   //    // Moving toward zero or positive
-   //    uint_result = uint_from - 1;
-   //  } else {
-   //    // Moving toward negative infinity
-   //    uint_result = uint_from + 1;
-   //  }
-   //} else {
-   //  // For positive numbers, increasing magnitude means moving towards +inf
-   //  // (larger uint value) Decreasing magnitude means moving towards zero
-   //  // (smaller uint value)
-   //  if (to_positive_infinity) {
-   //    // Moving toward positive infinity
-   //    uint_result = uint_from + 1;
-   //  } else {
-   //    // Moving toward zero or negative infinity
-   //    uint_result = uint_from - 1;
-   //  }
-   //}
+   // if (from_is_negative) {
+   //   // For negative numbers, increasing magnitude means moving towards -inf
+   //   // (larger uint value) Decreasing magnitude means moving towards zero
+   //   // (smaller uint value)
+   //   if (to_positive_infinity) {
+   //     // Moving toward zero or positive
+   //     uint_result = uint_from - 1;
+   //   } else {
+   //     // Moving toward negative infinity
+   //     uint_result = uint_from + 1;
+   //   }
+   // } else {
+   //   // For positive numbers, increasing magnitude means moving towards +inf
+   //   // (larger uint value) Decreasing magnitude means moving towards zero
+   //   // (smaller uint value)
+   //   if (to_positive_infinity) {
+   //     // Moving toward positive infinity
+   //     uint_result = uint_from + 1;
+   //   } else {
+   //     // Moving toward zero or negative infinity
+   //     uint_result = uint_from - 1;
+   //   }
+   // }
    return bit_cast<fp16_t>(uint_result);
 }
 

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1962,7 +1962,7 @@ TEST(TEST_CATEGORY, mathematical_functions_nextafter_fp16) {
   TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::half_t>();
 #endif
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
-  skipped      = false;
+  skipped = false;
   TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t>();
 #endif
   if (skipped) GTEST_SKIP() << "no 16-bit floating-point precision support";

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1926,7 +1926,7 @@ struct TestNextAfter {
     const FP16Type after_pos_one = Kokkos::bit_cast<FP16Type>(
         std::uint16_t(Kokkos::bit_cast<std::uint16_t>(pos_one) + 1));
     const FP16Type before_pos_one = Kokkos::bit_cast<FP16Type>(
-        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(neg_one) - 1));
+        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(pos_one) - 1));
     if (nextafter(pos_smallest, neg_zero) != pos_zero ||
         nextafter(pos_one, neg_one) != before_pos_one ||
         nextafter(pos_one, pos_two) != after_pos_one ||
@@ -1937,7 +1937,9 @@ struct TestNextAfter {
 
     // From Inf Handling
     if (nextafter(pos_inf, pos_one) != pos_max ||
-        nextafter(neg_inf, neg_one) != neg_max) {
+        nextafter(neg_inf, neg_one) != neg_max ||
+        nextafter(pos_inf, pos_inf) != pos_inf ||
+        nextafter(neg_inf, neg_inf) != neg_inf) {
       ++e;
       Kokkos::printf("failed nextafter(inf)\n");
     }

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1949,17 +1949,21 @@ struct TestNextAfterHalf {
 };
 
 TEST(TEST_CATEGORY, mathematical_functions_nextafter_fp16) {
-#if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
-  TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::half_t>();
-#endif
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
-  TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t>();
-#endif
-#else
+#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC)
   GTEST_SKIP() << "FIXME MSVC nextafter for half precision "
                   "not implemented yet";
 #endif
+
+  bool skipped = true;
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+  skipped = false;
+  TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::half_t>();
+#endif
+#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+  skipped = false;
+  TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t>();
+#endif
+  if (skipped) GTEST_SKIP() << "no 16-bit floating-point precision support";
 }
 #endif
 

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1901,10 +1901,12 @@ struct TestNextAfterHalf {
     }
 
     // Zero Handling
-    if (nextafter(pos_zero, pos_one) != pos_smallest ||
-        nextafter(pos_zero, neg_one) != neg_smallest ||
-        nextafter(neg_zero, pos_one) != pos_smallest ||
-        nextafter(neg_zero, neg_one) != neg_smallest) {
+    if (nextafter(pos_zero, pos_one)  != pos_smallest ||
+        nextafter(pos_zero, neg_one)  != neg_smallest ||
+        nextafter(pos_zero, neg_zero) != neg_zero     ||
+        nextafter(neg_zero, pos_one)  != pos_smallest ||
+        nextafter(neg_zero, neg_one)  != neg_smallest ||
+        nextafter(neg_zero, pos_zero) != pos_zero) {
       ++e;
       Kokkos::printf("failed half precision nextafter(zero)\n");
     }

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1958,11 +1958,11 @@ TEST(TEST_CATEGORY, mathematical_functions_nextafter_fp16) {
 #else
   bool skipped = true;
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
-  skipped = false;
+  skipped      = false;
   TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::half_t>();
 #endif
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
-  skipped = false;
+  skipped      = false;
   TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t>();
 #endif
   if (skipped) GTEST_SKIP() << "no 16-bit floating-point precision support";

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -20,7 +20,7 @@
 #include <algorithm>
 #include <initializer_list>
 #include <type_traits>
-
+#include <cstdint>
 #include <cfloat>
 
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) ||          \

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1938,6 +1938,9 @@ struct TestNextAfterHalf {
     }
 
     // From Inf Handling
+    // Note: The behavior of nextafter with infinities is
+    // implementation-defined, but in Kokkos it returns the maximum
+    // finite value when moving towards a finite value.
     if (nextafter(pos_inf, pos_one) != pos_max ||
         nextafter(neg_inf, neg_one) != neg_max ||
         nextafter(pos_inf, pos_inf) != pos_inf ||
@@ -1952,8 +1955,7 @@ TEST(TEST_CATEGORY, mathematical_functions_nextafter_fp16) {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC)
   GTEST_SKIP() << "FIXME MSVC nextafter for half precision "
                   "not implemented yet";
-#endif
-
+#else
   bool skipped = true;
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
   skipped = false;
@@ -1964,6 +1966,7 @@ TEST(TEST_CATEGORY, mathematical_functions_nextafter_fp16) {
   TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t>();
 #endif
   if (skipped) GTEST_SKIP() << "no 16-bit floating-point precision support";
+#endif
 }
 #endif
 

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1841,8 +1841,8 @@ TEST(TEST_CATEGORY, mathematical_functions_impl_half_fallback) {
 }
 
 template <class Space, class FP16Type>
-struct TestNextAfter {
-  TestNextAfter() { run(); }
+struct TestNextAfterHalf {
+  TestNextAfterHalf() { run(); }
   void run() const {
     int errors = 0;
     Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
@@ -1887,7 +1887,7 @@ struct TestNextAfter {
         !isnan(nextafter(signaling_NaN<FP16Type>::value,
                          signaling_NaN<FP16Type>::value))) {
       ++e;
-      Kokkos::printf("failed nextafter(NaN)\n");
+      Kokkos::printf("failed half precision nextafter(NaN)\n");
     }
 
     // Equality (from==toward) Handling
@@ -1897,7 +1897,7 @@ struct TestNextAfter {
         nextafter(pos_inf, pos_inf) != pos_inf ||
         nextafter(neg_inf, neg_inf) != neg_inf) {
       ++e;
-      Kokkos::printf("failed nextafter(equality)\n");
+      Kokkos::printf("failed half precision nextafter(equality)\n");
     }
 
     // Zero Handling
@@ -1906,7 +1906,7 @@ struct TestNextAfter {
         nextafter(neg_zero, pos_one) != pos_smallest ||
         nextafter(neg_zero, neg_one) != neg_smallest) {
       ++e;
-      Kokkos::printf("failed nextafter(zero)\n");
+      Kokkos::printf("failed half precision nextafter(zero)\n");
     }
 
     // From Negative Non Zero Handling
@@ -1919,7 +1919,7 @@ struct TestNextAfter {
         nextafter(neg_one, neg_two) != before_neg_one ||
         nextafter(neg_max, neg_inf) != neg_inf) {
       ++e;
-      Kokkos::printf("failed nextafter(negative)\n");
+      Kokkos::printf("failed half precision nextafter(negative)\n");
     }
 
     // From Positive Non Zero Handling
@@ -1932,7 +1932,7 @@ struct TestNextAfter {
         nextafter(pos_one, pos_two) != after_pos_one ||
         nextafter(pos_max, pos_inf) != pos_inf) {
       ++e;
-      Kokkos::printf("failed nextafter(positive)\n");
+      Kokkos::printf("failed half precision nextafter(positive)\n");
     }
 
     // From Inf Handling
@@ -1941,17 +1941,22 @@ struct TestNextAfter {
         nextafter(pos_inf, pos_inf) != pos_inf ||
         nextafter(neg_inf, neg_inf) != neg_inf) {
       ++e;
-      Kokkos::printf("failed nextafter(inf)\n");
+      Kokkos::printf("failed half precision nextafter(inf)\n");
     }
   }
 };
 
 TEST(TEST_CATEGORY, mathematical_functions_nextafter_fp16) {
+#if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
-  TestNextAfter<TEST_EXECSPACE, Kokkos::Experimental::half_t>();
+  TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::half_t>();
 #endif
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
-  TestNextAfter<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t>();
+  TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t>();
+#endif
+#else
+  GTEST_SKIP() << "FIXME MSVC nextafter for half precision "
+                  "not implemented yet";
 #endif
 }
 #endif

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1901,11 +1901,11 @@ struct TestNextAfterHalf {
     }
 
     // Zero Handling
-    if (nextafter(pos_zero, pos_one)  != pos_smallest ||
-        nextafter(pos_zero, neg_one)  != neg_smallest ||
-        nextafter(pos_zero, neg_zero) != neg_zero     ||
-        nextafter(neg_zero, pos_one)  != pos_smallest ||
-        nextafter(neg_zero, neg_one)  != neg_smallest ||
+    if (nextafter(pos_zero, pos_one) != pos_smallest ||
+        nextafter(pos_zero, neg_one) != neg_smallest ||
+        nextafter(pos_zero, neg_zero) != neg_zero ||
+        nextafter(neg_zero, pos_one) != pos_smallest ||
+        nextafter(neg_zero, neg_one) != neg_smallest ||
         nextafter(neg_zero, pos_zero) != pos_zero) {
       ++e;
       Kokkos::printf("failed half precision nextafter(zero)\n");

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1255,14 +1255,18 @@ TEST(TEST_CATEGORY,
   TEST_MATH_FUNCTION(logb)({123.45l, 6789.0l});
 #endif
 
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && KOKKOS_HALF_T_IS_FLOAT
   do_test_math_binary_function<TEST_EXECSPACE, kk_nextafter>(
       0, static_cast<KE::half_t>(1.f));
   do_test_math_binary_function<TEST_EXECSPACE, kk_nextafter>(
       1, static_cast<KE::half_t>(2.f));
+#endif
+#if defined(KOKKOS_BHALF_T_IS_FLOAT) && KOKKOS_BHALF_T_IS_FLOAT
   do_test_math_binary_function<TEST_EXECSPACE, kk_nextafter>(
       0, static_cast<KE::bhalf_t>(1.f));
   do_test_math_binary_function<TEST_EXECSPACE, kk_nextafter>(
       1, static_cast<KE::bhalf_t>(2.f));
+#endif
   do_test_math_binary_function<TEST_EXECSPACE, kk_nextafter>(0, 1.f);
   do_test_math_binary_function<TEST_EXECSPACE, kk_nextafter>(1, 2.f);
   do_test_math_binary_function<TEST_EXECSPACE, kk_nextafter>(0.1, 0);
@@ -1836,6 +1840,118 @@ TEST(TEST_CATEGORY, mathematical_functions_impl_half_fallback) {
                         KE::bhalf_t, 1>({KE::bhalf_t(1.f)});
 }
 
+template <class Space, class FP16Type>
+struct TestNextAfter {
+  TestNextAfter() { run(); }
+  void run() const {
+    int errors = 0;
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
+    ASSERT_EQ(errors, 0);
+  }
+  KOKKOS_FUNCTION void operator()(int, int& e) const {
+    using KE::infinity;
+    using KE::quiet_NaN;
+    using KE::signaling_NaN;
+    using Kokkos::isnan;
+    using Kokkos::nextafter;
+
+    // Define useful constants
+    const std::uint16_t FP16_POS_ZERO     = 0x0000;
+    const std::uint16_t FP16_NEG_ZERO     = 0x8000;
+    const std::uint16_t FP16_SMALLEST_POS = 0x0001;
+    const std::uint16_t FP16_SMALLEST_NEG = 0x8001;
+
+    const FP16Type pos_one{1.0f}, pos_two{2.0f};
+    const FP16Type neg_one{-1.0f}, neg_two{-2.0f};
+    const FP16Type pos_zero     = Kokkos::bit_cast<FP16Type>(FP16_POS_ZERO);
+    const FP16Type neg_zero     = Kokkos::bit_cast<FP16Type>(FP16_NEG_ZERO);
+    const FP16Type pos_smallest = Kokkos::bit_cast<FP16Type>(FP16_SMALLEST_POS);
+    const FP16Type neg_smallest = Kokkos::bit_cast<FP16Type>(FP16_SMALLEST_NEG);
+    const FP16Type pos_max = Kokkos::Experimental::finite_max<FP16Type>::value;
+    const FP16Type neg_max = Kokkos::Experimental::finite_min<FP16Type>::value;
+    const FP16Type pos_inf = Kokkos::Experimental::infinity<FP16Type>::value;
+    const FP16Type neg_inf =
+        -static_cast<FP16Type>(Kokkos::Experimental::infinity<FP16Type>::value);
+
+    // NaN Handling
+    if (!isnan(nextafter(quiet_NaN<FP16Type>::value, pos_one)) ||
+        !isnan(nextafter(signaling_NaN<FP16Type>::value, pos_one)) ||
+        !isnan(nextafter(pos_one, quiet_NaN<FP16Type>::value)) ||
+        !isnan(nextafter(pos_one, signaling_NaN<FP16Type>::value)) ||
+        !isnan(nextafter(quiet_NaN<FP16Type>::value,
+                         quiet_NaN<FP16Type>::value)) ||
+        !isnan(nextafter(quiet_NaN<FP16Type>::value,
+                         signaling_NaN<FP16Type>::value)) ||
+        !isnan(nextafter(signaling_NaN<FP16Type>::value,
+                         quiet_NaN<FP16Type>::value)) ||
+        !isnan(nextafter(signaling_NaN<FP16Type>::value,
+                         signaling_NaN<FP16Type>::value))) {
+      ++e;
+      Kokkos::printf("failed nextafter(NaN)\n");
+    }
+
+    // Equality (from==toward) Handling
+    if (nextafter(pos_one, pos_one) != pos_one ||
+        nextafter(pos_zero, pos_zero) != pos_zero ||
+        nextafter(neg_zero, neg_zero) != neg_zero ||
+        nextafter(pos_inf, pos_inf) != pos_inf ||
+        nextafter(neg_inf, neg_inf) != neg_inf) {
+      ++e;
+      Kokkos::printf("failed nextafter(equality)\n");
+    }
+
+    // Zero Handling
+    if (nextafter(pos_zero, pos_one) != pos_smallest ||
+        nextafter(pos_zero, neg_one) != neg_smallest ||
+        nextafter(neg_zero, pos_one) != pos_smallest ||
+        nextafter(neg_zero, neg_one) != neg_smallest) {
+      ++e;
+      Kokkos::printf("failed nextafter(zero)\n");
+    }
+
+    // From Negative Non Zero Handling
+    const FP16Type after_neg_one = Kokkos::bit_cast<FP16Type>(
+        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(neg_one) - 1));
+    const FP16Type before_neg_one = Kokkos::bit_cast<FP16Type>(
+        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(neg_one) + 1));
+    if (nextafter(neg_smallest, pos_zero) != neg_zero ||
+        nextafter(neg_one, pos_one) != after_neg_one ||
+        nextafter(neg_one, neg_two) != before_neg_one ||
+        nextafter(neg_max, neg_inf) != neg_inf) {
+      ++e;
+      Kokkos::printf("failed nextafter(negative)\n");
+    }
+
+    // From Positive Non Zero Handling
+    const FP16Type after_pos_one = Kokkos::bit_cast<FP16Type>(
+        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(pos_one) + 1));
+    const FP16Type before_pos_one = Kokkos::bit_cast<FP16Type>(
+        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(neg_one) - 1));
+    if (nextafter(pos_smallest, neg_zero) != pos_zero ||
+        nextafter(pos_one, neg_one) != before_pos_one ||
+        nextafter(pos_one, pos_two) != after_pos_one ||
+        nextafter(pos_max, pos_inf) != pos_inf) {
+      ++e;
+      Kokkos::printf("failed nextafter(positive)\n");
+    }
+
+    // From Inf Handling
+    if (nextafter(pos_inf, pos_one) != pos_max ||
+        nextafter(neg_inf, neg_one) != neg_max) {
+      ++e;
+      Kokkos::printf("failed nextafter(inf)\n");
+    }
+  }
+};
+
+TEST(TEST_CATEGORY, mathematical_functions_nextafter_fp16) {
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+  TestNextAfter<TEST_EXECSPACE, Kokkos::Experimental::half_t>();
+#endif
+#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+  TestNextAfter<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t>();
+#endif
+}
 #endif
 
 // TODO: TestSignBit, see https://github.com/kokkos/kokkos/issues/6279


### PR DESCRIPTION
This PR aims at introducing [`nextafter`](https://en.cppreference.com/w/cpp/numeric/math/nextafter) for fp16 types with specialized tests.
In the current implementation, `Kokkos::nextafter` manipulates the fp32 type internally, and thus `Kokkos::nextafter` on fp16 type does not return the correct value. In the following example, `a` and `b` are equal. This PR addresses this issue.

```C++
using half_t = Kokkos::Experimental::half_t;
half_t a = 1.0, t = 2.0;
half_t b = Kokkos::nextafter(a, t);
std::uint16_t a_int = Kokkos::bit_cast<std::uint16_t>(a);
std::uint16_t b_int = Kokkos::bit_cast<std::uint16_t>(b);
```