### PR TITLE
Use the same name for team handles in team policies

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Task.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Task.hpp
@@ -896,7 +896,7 @@ i+=loop_boundaries.increment) { lambda(i,result);
   strided_shfl_warp_reduction<ValueType, JoinType>(
                           join,
                           initialized_result,
-                          loop_boundaries.thread.team_size(),
+                          loop_boundaries.member.team_size(),
                           blockDim.x);
   initialized_result = shfl_warp_broadcast<ValueType>( initialized_result,
 threadIdx.x, Impl::CudaTraits::WarpSize );
@@ -922,10 +922,10 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
   }
   initialized_result = result;
 
-  if (1 < loop_boundaries.thread.team_size()) {
+  if (1 < loop_boundaries.member.team_size()) {
     strided_shfl_warp_reduction(
         [&](ValueType& val1, const ValueType& val2) { val1 += val2; },
-        initialized_result, loop_boundaries.thread.team_size(), blockDim.x);
+        initialized_result, loop_boundaries.member.team_size(), blockDim.x);
 
     initialized_result = shfl_warp_broadcast<ValueType>(
         initialized_result, threadIdx.x, Impl::CudaTraits::WarpSize);
@@ -947,12 +947,12 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
     lambda(i, result);
   }
 
-  if (1 < loop_boundaries.thread.team_size()) {
+  if (1 < loop_boundaries.member.team_size()) {
     strided_shfl_warp_reduction(
         [&](ValueType& val1, const ValueType& val2) {
           reducer.join(val1, val2);
         },
-        result, loop_boundaries.thread.team_size(), blockDim.x);
+        result, loop_boundaries.member.team_size(), blockDim.x);
 
     reducer.reference() = shfl_warp_broadcast<ValueType>(
         result, threadIdx.x, Impl::CudaTraits::WarpSize);
@@ -1005,7 +1005,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
 
   initialized_result = result;
 
-  if (1 < loop_boundaries.thread.team_size()) {
+  if (1 < loop_boundaries.member.team_size()) {
     // initialized_result = multi_shfl_warp_reduction(
     multi_shfl_warp_reduction(
         [&](ValueType& val1, const ValueType& val2) { val1 += val2; },
@@ -1031,7 +1031,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
     lambda(i, result);
   }
 
-  if (1 < loop_boundaries.thread.team_size()) {
+  if (1 < loop_boundaries.member.team_size()) {
     multi_shfl_warp_reduction(
         [&](ValueType& val1, const ValueType& val2) {
           reducer.join(val1, val2);
@@ -1060,7 +1060,7 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
       Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure,
       void>::value_type;
 
-  if (1 < loop_boundaries.thread.team_size()) {
+  if (1 < loop_boundaries.member.team_size()) {
     // make sure all threads perform all loop iterations
     const iType bound = loop_boundaries.end + loop_boundaries.start;
     const int lane    = threadIdx.y * blockDim.x;
@@ -1127,7 +1127,7 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
       Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure,
       void>::value_type;
 
-  if (1 < loop_boundaries.thread.team_size()) {
+  if (1 < loop_boundaries.member.team_size()) {
     // make sure all threads perform all loop iterations
     const iType bound = loop_boundaries.end + loop_boundaries.start;
 

--- a/core/src/Cuda/Kokkos_Cuda_Task.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Task.hpp
@@ -674,7 +674,7 @@ struct TeamThreadRangeBoundariesStruct<iType,
   const iType start;
   const iType end;
   const iType increment;
-  member_type const& thread;
+  member_type const& member;
 
 #if defined(__CUDA_ARCH__)
 
@@ -683,7 +683,7 @@ struct TeamThreadRangeBoundariesStruct<iType,
       : start(threadIdx.y),
         end(arg_count),
         increment(blockDim.y),
-        thread(arg_thread) {}
+        member(arg_thread) {}
 
   __device__ inline TeamThreadRangeBoundariesStruct(
       member_type const& arg_thread, const iType& arg_start,
@@ -691,7 +691,7 @@ struct TeamThreadRangeBoundariesStruct<iType,
       : start(arg_start + threadIdx.y),
         end(arg_end),
         increment(blockDim.y),
-        thread(arg_thread) {}
+        member(arg_thread) {}
 
 #else
 
@@ -715,7 +715,7 @@ struct ThreadVectorRangeBoundariesStruct<iType,
   const index_type start;
   const index_type end;
   const index_type increment;
-  const member_type& thread;
+  const member_type& member;
 
 #if defined(__CUDA_ARCH__)
 
@@ -724,7 +724,7 @@ struct ThreadVectorRangeBoundariesStruct<iType,
       : start(threadIdx.x),
         end(arg_count),
         increment(blockDim.x),
-        thread(arg_thread) {}
+        member(arg_thread) {}
 
   __device__ inline ThreadVectorRangeBoundariesStruct(
       member_type const& arg_thread, const index_type& arg_begin,
@@ -732,7 +732,7 @@ struct ThreadVectorRangeBoundariesStruct<iType,
       : start(arg_begin + threadIdx.x),
         end(arg_end),
         increment(blockDim.x),
-        thread(arg_thread) {}
+        member(arg_thread) {}
 
 #else
 

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -373,13 +373,14 @@ struct TeamThreadRangeBoundariesStruct<iType, CudaTeamMember> {
   const iType end;
 
   KOKKOS_INLINE_FUNCTION
-  TeamThreadRangeBoundariesStruct(const CudaTeamMember& thread_, iType count)
-      : member(thread_), start(0), end(count) {}
+  TeamThreadRangeBoundariesStruct(const CudaTeamMember& arg_thread,
+                                  iType arg_count)
+      : member(arg_thread), start(0), end(arg_count) {}
 
   KOKKOS_INLINE_FUNCTION
-  TeamThreadRangeBoundariesStruct(const CudaTeamMember& thread_, iType begin_,
-                                  iType end_)
-      : member(thread_), start(begin_), end(end_) {}
+  TeamThreadRangeBoundariesStruct(const CudaTeamMember& arg_thread,
+                                  iType arg_begin, iType arg_end)
+      : member(arg_thread), start(arg_begin), end(arg_end) {}
 };
 
 template <typename iType>
@@ -390,14 +391,14 @@ struct TeamVectorRangeBoundariesStruct<iType, CudaTeamMember> {
   const iType end;
 
   KOKKOS_INLINE_FUNCTION
-  TeamVectorRangeBoundariesStruct(const CudaTeamMember& thread_,
-                                  const iType& count)
-      : member(thread_), start(0), end(count) {}
+  TeamVectorRangeBoundariesStruct(const CudaTeamMember& arg_thread,
+                                  const iType& arg_count)
+      : member(arg_thread), start(0), end(arg_count) {}
 
   KOKKOS_INLINE_FUNCTION
-  TeamVectorRangeBoundariesStruct(const CudaTeamMember& thread_,
-                                  const iType& begin_, const iType& end_)
-      : member(thread_), start(begin_), end(end_) {}
+  TeamVectorRangeBoundariesStruct(const CudaTeamMember& arg_thread,
+                                  const iType& arg_begin, const iType& arg_end)
+      : member(arg_thread), start(arg_begin), end(arg_end) {}
 };
 
 template <typename iType>
@@ -407,8 +408,8 @@ struct ThreadVectorRangeBoundariesStruct<iType, CudaTeamMember> {
   const index_type end;
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const CudaTeamMember, index_type count)
-      : start(static_cast<index_type>(0)), end(count) {}
+  ThreadVectorRangeBoundariesStruct(const CudaTeamMember, index_type arg_count)
+      : start(static_cast<index_type>(0)), end(arg_count) {}
 
   KOKKOS_INLINE_FUNCTION
   ThreadVectorRangeBoundariesStruct(const CudaTeamMember, index_type arg_begin,

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -403,17 +403,19 @@ struct TeamVectorRangeBoundariesStruct<iType, CudaTeamMember> {
 template <typename iType>
 struct ThreadVectorRangeBoundariesStruct<iType, CudaTeamMember> {
   using index_type = iType;
+  const CudaTeamMember& member;
   const index_type start;
   const index_type end;
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const CudaTeamMember, index_type count)
-      : start(static_cast<index_type>(0)), end(count) {}
+  ThreadVectorRangeBoundariesStruct(const CudaTeamMember& thread_,
+                                    index_type count)
+      : member(thread_), start(static_cast<index_type>(0)), end(count) {}
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const CudaTeamMember, index_type arg_begin,
-                                    index_type arg_end)
-      : start(arg_begin), end(arg_end) {}
+  ThreadVectorRangeBoundariesStruct(const CudaTeamMember& thread_,
+                                    index_type arg_begin, index_type arg_end)
+      : member(thread_), start(arg_begin), end(arg_end) {}
 };
 
 }  // namespace Impl

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -414,8 +414,8 @@ struct ThreadVectorRangeBoundariesStruct<iType, CudaTeamMember> {
 
   KOKKOS_INLINE_FUNCTION
   ThreadVectorRangeBoundariesStruct(const CudaTeamMember& thread_,
-                                    index_type arg_begin, index_type arg_end)
-      : member(thread_), start(arg_begin), end(arg_end) {}
+                                    index_type begin_, index_type end_)
+      : member(thread_), start(begin_), end(end_) {}
 };
 
 }  // namespace Impl

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -403,19 +403,17 @@ struct TeamVectorRangeBoundariesStruct<iType, CudaTeamMember> {
 template <typename iType>
 struct ThreadVectorRangeBoundariesStruct<iType, CudaTeamMember> {
   using index_type = iType;
-  const CudaTeamMember& member;
   const index_type start;
   const index_type end;
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const CudaTeamMember& thread_,
-                                    index_type count)
-      : member(thread_), start(static_cast<index_type>(0)), end(count) {}
+  ThreadVectorRangeBoundariesStruct(const CudaTeamMember, index_type count)
+      : start(static_cast<index_type>(0)), end(count) {}
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const CudaTeamMember& thread_,
-                                    index_type begin_, index_type end_)
-      : member(thread_), start(begin_), end(end_) {}
+  ThreadVectorRangeBoundariesStruct(const CudaTeamMember, index_type arg_begin,
+                                    index_type arg_end)
+      : start(arg_begin), end(arg_end) {}
 };
 
 }  // namespace Impl

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -362,13 +362,14 @@ struct TeamThreadRangeBoundariesStruct<iType, HIPTeamMember> {
   const iType end;
 
   KOKKOS_INLINE_FUNCTION
-  TeamThreadRangeBoundariesStruct(const HIPTeamMember& thread_, iType count)
-      : member(thread_), start(0), end(count) {}
+  TeamThreadRangeBoundariesStruct(const HIPTeamMember& arg_thread,
+                                  iType arg_count)
+      : member(arg_thread), start(0), end(arg_count) {}
 
   KOKKOS_INLINE_FUNCTION
-  TeamThreadRangeBoundariesStruct(const HIPTeamMember& thread_, iType begin_,
-                                  iType end_)
-      : member(thread_), start(begin_), end(end_) {}
+  TeamThreadRangeBoundariesStruct(const HIPTeamMember& arg_thread,
+                                  iType arg_begin, iType arg_end)
+      : member(arg_thread), start(arg_begin), end(arg_end) {}
 };
 
 template <typename iType>
@@ -379,14 +380,14 @@ struct TeamVectorRangeBoundariesStruct<iType, HIPTeamMember> {
   const iType end;
 
   KOKKOS_INLINE_FUNCTION
-  TeamVectorRangeBoundariesStruct(const HIPTeamMember& thread_,
-                                  const iType& count)
-      : member(thread_), start(0), end(count) {}
+  TeamVectorRangeBoundariesStruct(const HIPTeamMember& arg_thread,
+                                  const iType& arg_count)
+      : member(arg_thread), start(0), end(arg_count) {}
 
   KOKKOS_INLINE_FUNCTION
-  TeamVectorRangeBoundariesStruct(const HIPTeamMember& thread_,
-                                  const iType& begin_, const iType& end_)
-      : member(thread_), start(begin_), end(end_) {}
+  TeamVectorRangeBoundariesStruct(const HIPTeamMember& arg_thread,
+                                  const iType& arg_begin, const iType& arg_end)
+      : member(arg_thread), start(arg_begin), end(arg_end) {}
 };
 
 template <typename iType>
@@ -396,8 +397,8 @@ struct ThreadVectorRangeBoundariesStruct<iType, HIPTeamMember> {
   const index_type end;
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const HIPTeamMember, index_type count)
-      : start(static_cast<index_type>(0)), end(count) {}
+  ThreadVectorRangeBoundariesStruct(const HIPTeamMember, index_type arg_count)
+      : start(static_cast<index_type>(0)), end(arg_count) {}
 
   KOKKOS_INLINE_FUNCTION
   ThreadVectorRangeBoundariesStruct(const HIPTeamMember, index_type arg_begin,

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -403,8 +403,8 @@ struct ThreadVectorRangeBoundariesStruct<iType, HIPTeamMember> {
 
   KOKKOS_INLINE_FUNCTION
   ThreadVectorRangeBoundariesStruct(const HIPTeamMember& thread_,
-                                    index_type arg_begin, index_type arg_end)
-      : member(thread_), start(arg_begin), end(arg_end) {}
+                                    index_type begin_, index_type end_)
+      : member(thread_), start(begin_), end(end_) {}
 };
 
 }  // namespace Impl

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -392,19 +392,17 @@ struct TeamVectorRangeBoundariesStruct<iType, HIPTeamMember> {
 template <typename iType>
 struct ThreadVectorRangeBoundariesStruct<iType, HIPTeamMember> {
   using index_type = iType;
-  const HIPTeamMember& member;
   const index_type start;
   const index_type end;
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const HIPTeamMember& thread_,
-                                    index_type count)
-      : member(thread_), start(static_cast<index_type>(0)), end(count) {}
+  ThreadVectorRangeBoundariesStruct(const HIPTeamMember, index_type count)
+      : start(static_cast<index_type>(0)), end(count) {}
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const HIPTeamMember& thread_,
-                                    index_type begin_, index_type end_)
-      : member(thread_), start(begin_), end(end_) {}
+  ThreadVectorRangeBoundariesStruct(const HIPTeamMember, index_type arg_begin,
+                                    index_type arg_end)
+      : start(arg_begin), end(arg_end) {}
 };
 
 }  // namespace Impl

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -392,17 +392,19 @@ struct TeamVectorRangeBoundariesStruct<iType, HIPTeamMember> {
 template <typename iType>
 struct ThreadVectorRangeBoundariesStruct<iType, HIPTeamMember> {
   using index_type = iType;
+  const HIPTeamMember& member;
   const index_type start;
   const index_type end;
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const HIPTeamMember, index_type count)
-      : start(static_cast<index_type>(0)), end(count) {}
+  ThreadVectorRangeBoundariesStruct(const HIPTeamMember& thread_,
+                                    index_type count)
+      : member(thread_), start(static_cast<index_type>(0)), end(count) {}
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const HIPTeamMember, index_type arg_begin,
-                                    index_type arg_end)
-      : start(arg_begin), end(arg_end) {}
+  ThreadVectorRangeBoundariesStruct(const HIPTeamMember& thread_,
+                                    index_type arg_begin, index_type arg_end)
+      : member(thread_), start(arg_begin), end(arg_end) {}
 };
 
 }  // namespace Impl

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -1943,7 +1943,7 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
   }
 
   // 'scan_val' output is the exclusive prefix sum
-  scan_val = loop_boundaries.thread.team_scan(scan_val);
+  scan_val = loop_boundaries.member.team_scan(scan_val);
 
   for (iType i = loop_boundaries.start; i < loop_boundaries.end;
        i += loop_boundaries.increment) {

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -808,10 +808,10 @@ struct TeamThreadRangeBoundariesStruct {
 
   KOKKOS_INLINE_FUNCTION
   TeamThreadRangeBoundariesStruct(const TeamMemberType& arg_thread,
-                                  const iType& arg_end)
-      : start(
-            ibegin(0, arg_end, arg_thread.team_rank(), arg_thread.team_size())),
-        end(iend(0, arg_end, arg_thread.team_rank(), arg_thread.team_size())),
+                                  const iType& arg_count)
+      : start(ibegin(0, arg_count, arg_thread.team_rank(),
+                     arg_thread.team_size())),
+        end(iend(0, arg_count, arg_thread.team_rank(), arg_thread.team_size())),
         member(arg_thread) {}
 
   KOKKOS_INLINE_FUNCTION
@@ -854,10 +854,10 @@ struct TeamVectorRangeBoundariesStruct {
 
   KOKKOS_INLINE_FUNCTION
   TeamVectorRangeBoundariesStruct(const TeamMemberType& arg_thread,
-                                  const iType& arg_end)
-      : start(
-            ibegin(0, arg_end, arg_thread.team_rank(), arg_thread.team_size())),
-        end(iend(0, arg_end, arg_thread.team_rank(), arg_thread.team_size())),
+                                  const iType& arg_count)
+      : start(ibegin(0, arg_count, arg_thread.team_rank(),
+                     arg_thread.team_size())),
+        end(iend(0, arg_count, arg_thread.team_rank(), arg_thread.team_size())),
         member(arg_thread) {}
 
   KOKKOS_INLINE_FUNCTION
@@ -880,8 +880,8 @@ struct ThreadVectorRangeBoundariesStruct {
 
   KOKKOS_INLINE_FUNCTION
   ThreadVectorRangeBoundariesStruct(const TeamMemberType& arg_thread,
-                                    const index_type& count) noexcept
-      : start(static_cast<index_type>(0)), end(count), member(arg_thread) {}
+                                    const index_type& arg_count) noexcept
+      : start(static_cast<index_type>(0)), end(arg_count), member(arg_thread) {}
 
   KOKKOS_INLINE_FUNCTION
   ThreadVectorRangeBoundariesStruct(const TeamMemberType& arg_thread,

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -876,20 +876,17 @@ struct ThreadVectorRangeBoundariesStruct {
   const index_type start;
   const index_type end;
   enum { increment = 1 };
-  const TeamMemberType& member;
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const TeamMemberType& arg_thread,
-                                    const index_type& arg_count) noexcept
-      : start(static_cast<index_type>(0)), end(arg_count), member(arg_thread) {}
+  constexpr ThreadVectorRangeBoundariesStruct(
+      const TeamMemberType, const index_type& arg_count) noexcept
+      : start(static_cast<index_type>(0)), end(arg_count) {}
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const TeamMemberType& arg_thread,
-                                    const index_type& arg_begin,
-                                    const index_type& arg_end) noexcept
-      : start(static_cast<index_type>(arg_begin)),
-        end(arg_end),
-        member(arg_thread) {}
+  constexpr ThreadVectorRangeBoundariesStruct(
+      const TeamMemberType, const index_type& arg_begin,
+      const index_type& arg_end) noexcept
+      : start(static_cast<index_type>(arg_begin)), end(arg_end) {}
 };
 
 template <class TeamMemberType>

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -804,7 +804,7 @@ struct TeamThreadRangeBoundariesStruct {
   const iType start;
   const iType end;
   enum { increment = 1 };
-  const TeamMemberType& thread;
+  const TeamMemberType& member;
 
   KOKKOS_INLINE_FUNCTION
   TeamThreadRangeBoundariesStruct(const TeamMemberType& arg_thread,
@@ -812,7 +812,7 @@ struct TeamThreadRangeBoundariesStruct {
       : start(
             ibegin(0, arg_end, arg_thread.team_rank(), arg_thread.team_size())),
         end(iend(0, arg_end, arg_thread.team_rank(), arg_thread.team_size())),
-        thread(arg_thread) {}
+        member(arg_thread) {}
 
   KOKKOS_INLINE_FUNCTION
   TeamThreadRangeBoundariesStruct(const TeamMemberType& arg_thread,
@@ -821,7 +821,7 @@ struct TeamThreadRangeBoundariesStruct {
                      arg_thread.team_size())),
         end(iend(arg_begin, arg_end, arg_thread.team_rank(),
                  arg_thread.team_size())),
-        thread(arg_thread) {}
+        member(arg_thread) {}
 };
 
 template <typename iType, class TeamMemberType>
@@ -850,7 +850,7 @@ struct TeamVectorRangeBoundariesStruct {
   const iType start;
   const iType end;
   enum { increment = 1 };
-  const TeamMemberType& thread;
+  const TeamMemberType& member;
 
   KOKKOS_INLINE_FUNCTION
   TeamVectorRangeBoundariesStruct(const TeamMemberType& arg_thread,
@@ -858,7 +858,7 @@ struct TeamVectorRangeBoundariesStruct {
       : start(
             ibegin(0, arg_end, arg_thread.team_rank(), arg_thread.team_size())),
         end(iend(0, arg_end, arg_thread.team_rank(), arg_thread.team_size())),
-        thread(arg_thread) {}
+        member(arg_thread) {}
 
   KOKKOS_INLINE_FUNCTION
   TeamVectorRangeBoundariesStruct(const TeamMemberType& arg_thread,
@@ -867,7 +867,7 @@ struct TeamVectorRangeBoundariesStruct {
                      arg_thread.team_size())),
         end(iend(arg_begin, arg_end, arg_thread.team_rank(),
                  arg_thread.team_size())),
-        thread(arg_thread) {}
+        member(arg_thread) {}
 };
 
 template <typename iType, class TeamMemberType>
@@ -876,17 +876,20 @@ struct ThreadVectorRangeBoundariesStruct {
   const index_type start;
   const index_type end;
   enum { increment = 1 };
+  const TeamMemberType& member;
 
   KOKKOS_INLINE_FUNCTION
-  constexpr ThreadVectorRangeBoundariesStruct(const TeamMemberType,
-                                              const index_type& count) noexcept
-      : start(static_cast<index_type>(0)), end(count) {}
+  ThreadVectorRangeBoundariesStruct(const TeamMemberType& arg_thread,
+                                    const index_type& count) noexcept
+      : start(static_cast<index_type>(0)), end(count), member(arg_thread) {}
 
   KOKKOS_INLINE_FUNCTION
-  constexpr ThreadVectorRangeBoundariesStruct(
-      const TeamMemberType, const index_type& arg_begin,
-      const index_type& arg_end) noexcept
-      : start(static_cast<index_type>(arg_begin)), end(arg_end) {}
+  ThreadVectorRangeBoundariesStruct(const TeamMemberType& arg_thread,
+                                    const index_type& arg_begin,
+                                    const index_type& arg_end) noexcept
+      : start(static_cast<index_type>(arg_begin)),
+        end(arg_end),
+        member(arg_thread) {}
 };
 
 template <class TeamMemberType>

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp
@@ -71,10 +71,10 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
     const Impl::TeamThreadRangeBoundariesStruct<iType, Impl::OpenACCTeamMember>&
         loop_boundaries,
     const Lambda& lambda) {
-  iType j_start =
-      loop_boundaries.team.team_rank() / loop_boundaries.team.vector_length();
+  iType j_start = loop_boundaries.member.team_rank() /
+                  loop_boundaries.member.vector_length();
   iType j_end  = loop_boundaries.end;
-  iType j_step = loop_boundaries.team.team_size();
+  iType j_step = loop_boundaries.member.team_size();
   if (j_start >= loop_boundaries.start) {
 #pragma acc loop seq
     for (iType j = j_start; j < j_end; j += j_step) {
@@ -90,10 +90,10 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
     const Impl::ThreadVectorRangeBoundariesStruct<
         iType, Impl::OpenACCTeamMember>& loop_boundaries,
     const Lambda& lambda) {
-  iType j_start =
-      loop_boundaries.team.team_rank() % loop_boundaries.team.vector_length();
+  iType j_start = loop_boundaries.member.team_rank() %
+                  loop_boundaries.member.vector_length();
   iType j_end  = loop_boundaries.end;
-  iType j_step = loop_boundaries.team.vector_length();
+  iType j_step = loop_boundaries.member.vector_length();
   if (j_start >= loop_boundaries.start) {
 #pragma acc loop seq
     for (iType j = j_start; j < j_end; j += j_step) {
@@ -109,10 +109,10 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
     const Impl::TeamVectorRangeBoundariesStruct<iType, Impl::OpenACCTeamMember>&
         loop_boundaries,
     const Lambda& lambda) {
-  iType j_start =
-      loop_boundaries.team.team_rank() % loop_boundaries.team.vector_length();
+  iType j_start = loop_boundaries.member.team_rank() %
+                  loop_boundaries.member.vector_length();
   iType j_end  = loop_boundaries.end;
-  iType j_step = loop_boundaries.team.vector_length();
+  iType j_step = loop_boundaries.member.vector_length();
   if (j_start >= loop_boundaries.start) {
 #pragma acc loop seq
     for (iType j = j_start; j < j_end; j += j_step) {

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
@@ -174,8 +174,8 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
   value_type tmp;
   wrapped_reducer.init(&tmp);
 
-  iType j_start =
-      loop_boundaries.team.team_rank() / loop_boundaries.team.vector_length();
+  iType j_start = loop_boundaries.member.team_rank() /
+                  loop_boundaries.member.vector_length();
   if (j_start == 0) {
 #pragma acc loop seq
     for (iType i = loop_boundaries.start; i < loop_boundaries.end; i++)
@@ -202,8 +202,8 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
   value_type tmp;
   wrapped_reducer.init(&tmp);
 
-  iType j_start =
-      loop_boundaries.team.team_rank() / loop_boundaries.team.vector_length();
+  iType j_start = loop_boundaries.member.team_rank() /
+                  loop_boundaries.member.vector_length();
   if (j_start == 0) {
 #pragma acc loop seq
     for (iType i = loop_boundaries.start; i < loop_boundaries.end; i++)
@@ -232,8 +232,8 @@ parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
   value_type tmp;
   wrapped_reducer.init(&tmp);
 
-  iType j_start =
-      loop_boundaries.team.team_rank() % loop_boundaries.team.vector_length();
+  iType j_start = loop_boundaries.member.team_rank() %
+                  loop_boundaries.member.vector_length();
   if (j_start == 0) {
 #pragma acc loop seq
     for (iType i = loop_boundaries.start; i < loop_boundaries.end; i++) {
@@ -261,8 +261,8 @@ parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
   value_type tmp;
   wrapped_reducer.init(&tmp);
 
-  iType j_start =
-      loop_boundaries.team.team_rank() % loop_boundaries.team.vector_length();
+  iType j_start = loop_boundaries.member.team_rank() %
+                  loop_boundaries.member.vector_length();
   if (j_start == 0) {
 #pragma acc loop seq
     for (iType i = loop_boundaries.start; i < loop_boundaries.end; i++) {
@@ -292,8 +292,8 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
   value_type tmp;
   wrapped_reducer.init(&tmp);
 
-  iType j_start =
-      loop_boundaries.team.team_rank() % loop_boundaries.team.vector_length();
+  iType j_start = loop_boundaries.member.team_rank() %
+                  loop_boundaries.member.vector_length();
   if (j_start == 0) {
 #pragma acc loop seq
     for (iType i = loop_boundaries.start; i < loop_boundaries.end; i++) {

--- a/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
@@ -428,13 +428,13 @@ struct TeamThreadRangeBoundariesStruct<iType, OpenACCTeamMember> {
   using index_type = iType;
   const iType start;
   const iType end;
-  const OpenACCTeamMember& team;
+  const OpenACCTeamMember& member;
 
   TeamThreadRangeBoundariesStruct(const OpenACCTeamMember& thread_, iType count)
-      : start(0), end(count), team(thread_) {}
+      : start(0), end(count), member(thread_) {}
   TeamThreadRangeBoundariesStruct(const OpenACCTeamMember& thread_,
                                   iType begin_, iType end_)
-      : start(begin_), end(end_), team(thread_) {}
+      : start(begin_), end(end_), member(thread_) {}
 };
 
 template <typename iType>
@@ -442,14 +442,14 @@ struct ThreadVectorRangeBoundariesStruct<iType, OpenACCTeamMember> {
   using index_type = iType;
   const index_type start;
   const index_type end;
-  const OpenACCTeamMember& team;
+  const OpenACCTeamMember& member;
 
   ThreadVectorRangeBoundariesStruct(const OpenACCTeamMember& thread_,
                                     index_type count)
-      : start(0), end(count), team(thread_) {}
+      : start(0), end(count), member(thread_) {}
   ThreadVectorRangeBoundariesStruct(const OpenACCTeamMember& thread_,
                                     index_type begin_, index_type end_)
-      : start(begin_), end(end_), team(thread_) {}
+      : start(begin_), end(end_), member(thread_) {}
 };
 
 template <typename iType>
@@ -457,14 +457,14 @@ struct TeamVectorRangeBoundariesStruct<iType, OpenACCTeamMember> {
   using index_type = iType;
   const index_type start;
   const index_type end;
-  const OpenACCTeamMember& team;
+  const OpenACCTeamMember& member;
 
   TeamVectorRangeBoundariesStruct(const OpenACCTeamMember& thread_,
                                   index_type count)
-      : start(0), end(count), team(thread_) {}
+      : start(0), end(count), member(thread_) {}
   TeamVectorRangeBoundariesStruct(const OpenACCTeamMember& thread_,
                                   index_type begin_, index_type end_)
-      : start(begin_), end(end_), team(thread_) {}
+      : start(begin_), end(end_), member(thread_) {}
 };
 
 }  // namespace Impl

--- a/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
@@ -430,11 +430,12 @@ struct TeamThreadRangeBoundariesStruct<iType, OpenACCTeamMember> {
   const iType end;
   const OpenACCTeamMember& member;
 
-  TeamThreadRangeBoundariesStruct(const OpenACCTeamMember& thread_, iType count)
-      : start(0), end(count), member(thread_) {}
-  TeamThreadRangeBoundariesStruct(const OpenACCTeamMember& thread_,
-                                  iType begin_, iType end_)
-      : start(begin_), end(end_), member(thread_) {}
+  TeamThreadRangeBoundariesStruct(const OpenACCTeamMember& arg_thread,
+                                  iType arg_count)
+      : start(0), end(arg_count), member(arg_thread) {}
+  TeamThreadRangeBoundariesStruct(const OpenACCTeamMember& arg_thread,
+                                  iType arg_begin, iType arg_end)
+      : start(arg_begin), end(arg_end), member(arg_thread) {}
 };
 
 template <typename iType>
@@ -444,12 +445,12 @@ struct ThreadVectorRangeBoundariesStruct<iType, OpenACCTeamMember> {
   const index_type end;
   const OpenACCTeamMember& member;
 
-  ThreadVectorRangeBoundariesStruct(const OpenACCTeamMember& thread_,
-                                    index_type count)
-      : start(0), end(count), member(thread_) {}
-  ThreadVectorRangeBoundariesStruct(const OpenACCTeamMember& thread_,
-                                    index_type begin_, index_type end_)
-      : start(begin_), end(end_), member(thread_) {}
+  ThreadVectorRangeBoundariesStruct(const OpenACCTeamMember& arg_thread,
+                                    index_type arg_count)
+      : start(0), end(arg_count), member(arg_thread) {}
+  ThreadVectorRangeBoundariesStruct(const OpenACCTeamMember& arg_thread,
+                                    index_type arg_begin, index_type arg_end)
+      : start(arg_begin), end(arg_end), member(arg_thread) {}
 };
 
 template <typename iType>
@@ -459,12 +460,12 @@ struct TeamVectorRangeBoundariesStruct<iType, OpenACCTeamMember> {
   const index_type end;
   const OpenACCTeamMember& member;
 
-  TeamVectorRangeBoundariesStruct(const OpenACCTeamMember& thread_,
-                                  index_type count)
-      : start(0), end(count), member(thread_) {}
-  TeamVectorRangeBoundariesStruct(const OpenACCTeamMember& thread_,
-                                  index_type begin_, index_type end_)
-      : start(begin_), end(end_), member(thread_) {}
+  TeamVectorRangeBoundariesStruct(const OpenACCTeamMember& arg_thread,
+                                  index_type arg_count)
+      : start(0), end(arg_count), member(arg_thread) {}
+  TeamVectorRangeBoundariesStruct(const OpenACCTeamMember& arg_thread,
+                                  index_type arg_begin, index_type arg_end)
+      : start(arg_begin), end(arg_end), member(arg_thread) {}
 };
 
 }  // namespace Impl

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -700,14 +700,14 @@ struct TeamThreadRangeBoundariesStruct<iType, OpenMPTargetExecTeamMember> {
   using index_type = iType;
   const iType start;
   const iType end;
-  const OpenMPTargetExecTeamMember& team;
+  const OpenMPTargetExecTeamMember& member;
 
   TeamThreadRangeBoundariesStruct(const OpenMPTargetExecTeamMember& thread_,
                                   iType count)
-      : start(0), end(count), team(thread_) {}
+      : start(0), end(count), member(thread_) {}
   TeamThreadRangeBoundariesStruct(const OpenMPTargetExecTeamMember& thread_,
                                   iType begin_, iType end_)
-      : start(begin_), end(end_), team(thread_) {}
+      : start(begin_), end(end_), member(thread_) {}
 };
 
 template <typename iType>
@@ -715,14 +715,14 @@ struct ThreadVectorRangeBoundariesStruct<iType, OpenMPTargetExecTeamMember> {
   using index_type = iType;
   const index_type start;
   const index_type end;
-  const OpenMPTargetExecTeamMember& team;
+  const OpenMPTargetExecTeamMember& member;
 
   ThreadVectorRangeBoundariesStruct(const OpenMPTargetExecTeamMember& thread_,
                                     index_type count)
-      : start(0), end(count), team(thread_) {}
+      : start(0), end(count), member(thread_) {}
   ThreadVectorRangeBoundariesStruct(const OpenMPTargetExecTeamMember& thread_,
                                     index_type begin_, index_type end_)
-      : start(begin_), end(end_), team(thread_) {}
+      : start(begin_), end(end_), member(thread_) {}
 };
 
 template <typename iType>
@@ -730,14 +730,14 @@ struct TeamVectorRangeBoundariesStruct<iType, OpenMPTargetExecTeamMember> {
   using index_type = iType;
   const index_type start;
   const index_type end;
-  const OpenMPTargetExecTeamMember& team;
+  const OpenMPTargetExecTeamMember& member;
 
   TeamVectorRangeBoundariesStruct(const OpenMPTargetExecTeamMember& thread_,
                                   index_type count)
-      : start(0), end(count), team(thread_) {}
+      : start(0), end(count), member(thread_) {}
   TeamVectorRangeBoundariesStruct(const OpenMPTargetExecTeamMember& thread_,
                                   index_type begin_, index_type end_)
-      : start(begin_), end(end_), team(thread_) {}
+      : start(begin_), end(end_), member(thread_) {}
 };
 
 }  // namespace Impl

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -702,12 +702,12 @@ struct TeamThreadRangeBoundariesStruct<iType, OpenMPTargetExecTeamMember> {
   const iType end;
   const OpenMPTargetExecTeamMember& member;
 
-  TeamThreadRangeBoundariesStruct(const OpenMPTargetExecTeamMember& thread_,
-                                  iType count)
-      : start(0), end(count), member(thread_) {}
-  TeamThreadRangeBoundariesStruct(const OpenMPTargetExecTeamMember& thread_,
-                                  iType begin_, iType end_)
-      : start(begin_), end(end_), member(thread_) {}
+  TeamThreadRangeBoundariesStruct(const OpenMPTargetExecTeamMember& arg_thread,
+                                  iType arg_count)
+      : start(0), end(arg_count), member(arg_thread) {}
+  TeamThreadRangeBoundariesStruct(const OpenMPTargetExecTeamMember& arg_thread,
+                                  iType arg_begin, iType arg_end)
+      : start(arg_begin), end(arg_end), member(arg_thread) {}
 };
 
 template <typename iType>
@@ -717,12 +717,13 @@ struct ThreadVectorRangeBoundariesStruct<iType, OpenMPTargetExecTeamMember> {
   const index_type end;
   const OpenMPTargetExecTeamMember& member;
 
-  ThreadVectorRangeBoundariesStruct(const OpenMPTargetExecTeamMember& thread_,
-                                    index_type count)
-      : start(0), end(count), member(thread_) {}
-  ThreadVectorRangeBoundariesStruct(const OpenMPTargetExecTeamMember& thread_,
-                                    index_type begin_, index_type end_)
-      : start(begin_), end(end_), member(thread_) {}
+  ThreadVectorRangeBoundariesStruct(
+      const OpenMPTargetExecTeamMember& arg_thread, index_type arg_count)
+      : start(0), end(arg_count), member(arg_thread) {}
+  ThreadVectorRangeBoundariesStruct(
+      const OpenMPTargetExecTeamMember& arg_thread, index_type arg_begin,
+      index_type arg_end)
+      : start(arg_begin), end(arg_end), member(arg_thread) {}
 };
 
 template <typename iType>
@@ -732,12 +733,12 @@ struct TeamVectorRangeBoundariesStruct<iType, OpenMPTargetExecTeamMember> {
   const index_type end;
   const OpenMPTargetExecTeamMember& member;
 
-  TeamVectorRangeBoundariesStruct(const OpenMPTargetExecTeamMember& thread_,
-                                  index_type count)
-      : start(0), end(count), member(thread_) {}
-  TeamVectorRangeBoundariesStruct(const OpenMPTargetExecTeamMember& thread_,
-                                  index_type begin_, index_type end_)
-      : start(begin_), end(end_), member(thread_) {}
+  TeamVectorRangeBoundariesStruct(const OpenMPTargetExecTeamMember& arg_thread,
+                                  index_type arg_count)
+      : start(0), end(arg_count), member(arg_thread) {}
+  TeamVectorRangeBoundariesStruct(const OpenMPTargetExecTeamMember& arg_thread,
+                                  index_type arg_begin, index_type arg_end)
+      : start(arg_begin), end(arg_end), member(arg_thread) {}
 };
 
 }  // namespace Impl

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Team.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Team.hpp
@@ -52,7 +52,7 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
                 Impl::OpenMPTargetExecTeamMember::TEAM_REDUCE_SIZE);
 
   ValueType* TeamThread_scratch =
-      static_cast<ValueType*>(loop_boundaries.team.impl_reduce_scratch());
+      static_cast<ValueType*>(loop_boundaries.member.impl_reduce_scratch());
 
 #pragma omp barrier
   TeamThread_scratch[0] = ValueType();
@@ -102,7 +102,7 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
                 Impl::OpenMPTargetExecTeamMember::TEAM_REDUCE_SIZE);
 
   ValueType* TeamThread_scratch =
-      static_cast<ValueType*>(loop_boundaries.team.impl_reduce_scratch());
+      static_cast<ValueType*>(loop_boundaries.member.impl_reduce_scratch());
 
 #pragma omp barrier
   Impl::OpenMPTargetReducerWrapper<ReducerType>::init(TeamThread_scratch[0]);
@@ -129,7 +129,7 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
                 Impl::OpenMPTargetExecTeamMember::TEAM_REDUCE_SIZE);
 
   ValueType* TeamThread_scratch =
-      static_cast<ValueType*>(loop_boundaries.team.impl_reduce_scratch());
+      static_cast<ValueType*>(loop_boundaries.member.impl_reduce_scratch());
 
 #pragma omp declare reduction(omp_red_teamthread_reducer                      \
 :ValueType : Impl::OpenMPTargetReducerWrapper<ReducerType>::join(omp_out,     \
@@ -183,7 +183,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
         iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
     const Lambda& lambda, const JoinType& join, ValueType& init_result) {
   ValueType* TeamThread_scratch =
-      static_cast<ValueType*>(loop_boundaries.team.impl_reduce_scratch());
+      static_cast<ValueType*>(loop_boundaries.member.impl_reduce_scratch());
 
   // FIXME_OPENMPTARGET - Make sure that if its an array reduction, number of
   // elements in the array <= 32. For reduction we allocate, 16 bytes per
@@ -320,7 +320,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
                 Impl::OpenMPTargetExecTeamMember::TEAM_REDUCE_SIZE);
 
   ValueType* TeamVector_scratch =
-      static_cast<ValueType*>(loop_boundaries.team.impl_reduce_scratch());
+      static_cast<ValueType*>(loop_boundaries.member.impl_reduce_scratch());
 
 #pragma omp barrier
   TeamVector_scratch[0] = ValueType();
@@ -367,7 +367,7 @@ parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
     initializer(Impl::OpenMPTargetReducerWrapper<ReducerType>::init(omp_priv))
 
   ValueType* TeamVector_scratch =
-      static_cast<ValueType*>(loop_boundaries.team.impl_reduce_scratch());
+      static_cast<ValueType*>(loop_boundaries.member.impl_reduce_scratch());
 
 #pragma omp barrier
   Impl::OpenMPTargetReducerWrapper<ReducerType>::init(TeamVector_scratch[0]);
@@ -395,7 +395,7 @@ parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
                 Impl::OpenMPTargetExecTeamMember::TEAM_REDUCE_SIZE);
 
   ValueType* TeamVector_scratch =
-      static_cast<ValueType*>(loop_boundaries.team.impl_reduce_scratch());
+      static_cast<ValueType*>(loop_boundaries.member.impl_reduce_scratch());
 
 #pragma omp declare reduction(omp_red_teamthread_reducer                      \
 :ValueType : Impl::OpenMPTargetReducerWrapper<ReducerType>::join(omp_out,     \

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Team.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Team.hpp
@@ -44,11 +44,9 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
   static_assert(std::is_same_v<analysis_value_type, ValueType>,
                 "Non-matching value types of functor and return type");
 
-  const auto start = loop_bounds.start;
-  const auto end   = loop_bounds.end;
-  //   Note this thing is called .member in the CUDA specialization of
-  //   TeamThreadRangeBoundariesStruct
-  auto& member         = loop_bounds.team;
+  const auto start     = loop_bounds.start;
+  const auto end       = loop_bounds.end;
+  auto& member         = loop_bounds.member;
   const auto team_rank = member.team_rank();
 
 #if defined(KOKKOS_IMPL_TEAM_SCAN_WORKAROUND)

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -408,13 +408,14 @@ struct TeamThreadRangeBoundariesStruct<iType, SYCLTeamMember> {
   const iType end;
 
   KOKKOS_INLINE_FUNCTION
-  TeamThreadRangeBoundariesStruct(const SYCLTeamMember& thread_, iType count)
-      : member(thread_), start(0), end(count) {}
+  TeamThreadRangeBoundariesStruct(const SYCLTeamMember& arg_thread,
+                                  iType arg_count)
+      : member(arg_thread), start(0), end(arg_count) {}
 
   KOKKOS_INLINE_FUNCTION
-  TeamThreadRangeBoundariesStruct(const SYCLTeamMember& thread_, iType begin_,
-                                  iType end_)
-      : member(thread_), start(begin_), end(end_) {}
+  TeamThreadRangeBoundariesStruct(const SYCLTeamMember& arg_thread,
+                                  iType arg_begin, iType arg_end)
+      : member(arg_thread), start(arg_begin), end(arg_end) {}
 };
 
 template <typename iType>
@@ -425,14 +426,14 @@ struct TeamVectorRangeBoundariesStruct<iType, SYCLTeamMember> {
   const iType end;
 
   KOKKOS_INLINE_FUNCTION
-  TeamVectorRangeBoundariesStruct(const SYCLTeamMember& thread_,
-                                  const iType& count)
-      : member(thread_), start(0), end(count) {}
+  TeamVectorRangeBoundariesStruct(const SYCLTeamMember& arg_thread,
+                                  const iType& arg_count)
+      : member(arg_thread), start(0), end(arg_count) {}
 
   KOKKOS_INLINE_FUNCTION
-  TeamVectorRangeBoundariesStruct(const SYCLTeamMember& thread_,
-                                  const iType& begin_, const iType& end_)
-      : member(thread_), start(begin_), end(end_) {}
+  TeamVectorRangeBoundariesStruct(const SYCLTeamMember& arg_thread,
+                                  const iType& arg_begin, const iType& arg_end)
+      : member(arg_thread), start(arg_begin), end(arg_end) {}
 };
 
 template <typename iType>
@@ -443,14 +444,14 @@ struct ThreadVectorRangeBoundariesStruct<iType, SYCLTeamMember> {
   const index_type end;
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const SYCLTeamMember& thread,
-                                    index_type count)
-      : member(thread), start(static_cast<index_type>(0)), end(count) {}
+  ThreadVectorRangeBoundariesStruct(const SYCLTeamMember& arg_thread,
+                                    index_type arg_count)
+      : member(arg_thread), start(static_cast<index_type>(0)), end(arg_count) {}
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const SYCLTeamMember& thread,
+  ThreadVectorRangeBoundariesStruct(const SYCLTeamMember& arg_thread,
                                     index_type arg_begin, index_type arg_end)
-      : member(thread), start(arg_begin), end(arg_end) {}
+      : member(arg_thread), start(arg_begin), end(arg_end) {}
 };
 
 }  // namespace Impl

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -918,7 +918,7 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
     lambda(i, value);
   }
 
-  loop_boundaries.thread.impl_team_reduce(wrapped_reducer, value);
+  loop_boundaries.member.impl_team_reduce(wrapped_reducer, value);
   wrapped_reducer.final(&value);
   result = value;
 }
@@ -944,7 +944,7 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
     lambda(i, value);
   }
 
-  loop_boundaries.thread.impl_team_reduce(wrapped_reducer, value);
+  loop_boundaries.member.impl_team_reduce(wrapped_reducer, value);
   wrapped_reducer.final(&value);
   reducer.reference() = value;
 }
@@ -1053,7 +1053,7 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     lambda(i, scan_val, false);
   }
 
-  auto& team_member = loop_bounds.thread;
+  auto& team_member = loop_bounds.member;
 
   // 'scan_val' output is the exclusive prefix sum
   scan_val = team_member.team_scan(scan_val);

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -884,7 +884,7 @@ Impl::TeamThreadRangeBoundariesStruct<iType,Impl::HostThreadTeamMember<Space> >
     closure( i , reducer.reference() );
   }
 
-  loop_boundaries.thread.team_reduce( reducer );
+  loop_boundaries.member.team_reduce( reducer );
 }*/
 
 //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -829,7 +829,7 @@ KOKKOS_INLINE_FUNCTION
     closure(i, value);
   }
 
-  loop_boundaries.thread.impl_team_reduce(wrapped_reducer, value);
+  loop_boundaries.member.impl_team_reduce(wrapped_reducer, value);
 
   wrapped_reducer.final(&value);
   reducer.reference() = value;
@@ -857,7 +857,7 @@ KOKKOS_INLINE_FUNCTION
     closure(i, value);
   }
 
-  loop_boundaries.thread.impl_team_reduce(wrapped_reducer, value);
+  loop_boundaries.member.impl_team_reduce(wrapped_reducer, value);
   wrapped_reducer.final(&value);
   result = value;
 }
@@ -972,7 +972,7 @@ KOKKOS_INLINE_FUNCTION
     closure(i, accum, false);
   }
 
-  auto& team_member = loop_boundaries.thread;
+  auto& team_member = loop_boundaries.member;
 
   // 'accum' output is the exclusive prefix sum
   accum = team_member.team_scan(accum);


### PR DESCRIPTION
This PR aims to improve the usability of team policies in generic contexts by renaming the team member variable for all specializations of team policies to `member`.

Currently, the team member stored in the `*RangeBoundariesStruct` returned by team policies is called `member`, `thread` or `team` depending on the backend, which is not convenient when implementing something that takes any team policy as argument (for context, it is needed for an implementation of local deep copy I am working on).