### PR TITLE
GitHub windows workflow: updating serial runner image

### DIFF
--- a/.github/workflows/continuous-integration-windows.yml
+++ b/.github/workflows/continuous-integration-windows.yml
@@ -31,8 +31,8 @@ jobs:
         cmake --build build --parallel 4 --config Release
   windows-serial:
     # Serial build on Windows
-    name: Serial VS-2022
-    runs-on: windows-2022
+    name: Serial VS-2025
+    runs-on: windows-2025
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/continuous-integration-windows.yml
+++ b/.github/workflows/continuous-integration-windows.yml
@@ -31,8 +31,8 @@ jobs:
         cmake --build build --parallel 4 --config Release
   windows-serial:
     # Serial build on Windows
-    name: Serial VS-2019
-    runs-on: windows-2019
+    name: Serial VS-2022
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/continuous-integration-windows.yml
+++ b/.github/workflows/continuous-integration-windows.yml
@@ -31,7 +31,7 @@ jobs:
         cmake --build build --parallel 4 --config Release
   windows-serial:
     # Serial build on Windows
-    name: Serial VS-2025
+    name: Serial VS-2022
     runs-on: windows-2025
 
     steps:


### PR DESCRIPTION
As announced on github here: https://github.com/actions/runner-images/issues/12045 the 2019 images will no longer be supported by the end of June so we need to upgrade this action to 2022 at least. There are runners with windows 2024 that we could also consider using for additional coverage?