### PR TITLE
Type constraints for template parameters of non-member overloaded operators with Kokkos::complex

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -495,7 +495,10 @@ KOKKOS_FUNCTION constexpr const RealType&& get(
 // to do it this way now.
 
 //! Binary == operator for complex complex.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 KOKKOS_INLINE_FUNCTION bool operator==(complex<RealType1> const& x,
                                        complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
@@ -506,7 +509,10 @@ KOKKOS_INLINE_FUNCTION bool operator==(complex<RealType1> const& x,
 // TODO (here and elsewhere) decide if we should convert to a Kokkos::complex
 //      and do the comparison in a device-marked function
 //! Binary == operator for std::complex complex.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 inline bool operator==(std::complex<RealType1> const& x,
                        complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
@@ -515,7 +521,10 @@ inline bool operator==(std::complex<RealType1> const& x,
 }
 
 //! Binary == operator for complex std::complex.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 inline bool operator==(complex<RealType1> const& x,
                        std::complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
@@ -548,7 +557,10 @@ KOKKOS_INLINE_FUNCTION bool operator==(RealType1 const& x,
 }
 
 //! Binary != operator for complex complex.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 KOKKOS_INLINE_FUNCTION bool operator!=(complex<RealType1> const& x,
                                        complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
@@ -557,7 +569,10 @@ KOKKOS_INLINE_FUNCTION bool operator!=(complex<RealType1> const& x,
 }
 
 //! Binary != operator for std::complex complex.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 inline bool operator!=(std::complex<RealType1> const& x,
                        complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
@@ -566,7 +581,10 @@ inline bool operator!=(std::complex<RealType1> const& x,
 }
 
 //! Binary != operator for complex std::complex.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 inline bool operator!=(complex<RealType1> const& x,
                        std::complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
@@ -602,7 +620,10 @@ KOKKOS_INLINE_FUNCTION bool operator!=(RealType1 const& x,
 //==============================================================================
 
 //! Binary + operator for complex complex.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
 operator+(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x.real() + y.real(),
@@ -610,7 +631,10 @@ operator+(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
 }
 
 //! Binary + operator for complex scalar.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
 operator+(const complex<RealType1>& x, const RealType2& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x.real() + y,
@@ -618,7 +642,10 @@ operator+(const complex<RealType1>& x, const RealType2& y) noexcept {
 }
 
 //! Binary + operator for scalar complex.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
 operator+(const RealType1& x, const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x + y.real(),
@@ -626,14 +653,18 @@ operator+(const RealType1& x, const complex<RealType2>& y) noexcept {
 }
 
 //! Unary + operator for complex.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION complex<RealType> operator+(
     const complex<RealType>& x) noexcept {
   return complex<RealType>{+x.real(), +x.imag()};
 }
 
 //! Binary - operator for complex.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
 operator-(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x.real() - y.real(),
@@ -641,7 +672,10 @@ operator-(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
 }
 
 //! Binary - operator for complex scalar.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
 operator-(const complex<RealType1>& x, const RealType2& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x.real() - y,
@@ -649,7 +683,10 @@ operator-(const complex<RealType1>& x, const RealType2& y) noexcept {
 }
 
 //! Binary - operator for scalar complex.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
 operator-(const RealType1& x, const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x - y.real(),
@@ -657,14 +694,18 @@ operator-(const RealType1& x, const complex<RealType2>& y) noexcept {
 }
 
 //! Unary - operator for complex.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION complex<RealType> operator-(
     const complex<RealType>& x) noexcept {
   return complex<RealType>(-x.real(), -x.imag());
 }
 
 //! Binary * operator for complex.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
 operator*(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(
@@ -680,7 +721,10 @@ operator*(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
 /// This function cannot be called in a CUDA device function, because
 /// std::complex's methods and nonmember functions are not marked as
 /// CUDA device functions.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 inline complex<std::common_type_t<RealType1, RealType2>> operator*(
     const std::complex<RealType1>& x, const complex<RealType2>& y) {
   return complex<std::common_type_t<RealType1, RealType2>>(
@@ -692,7 +736,10 @@ inline complex<std::common_type_t<RealType1, RealType2>> operator*(
 ///
 /// This function exists because the compiler doesn't know that
 /// RealType and complex<RealType> commute with respect to operator*.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
 operator*(const RealType1& x, const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x * y.real(),
@@ -703,7 +750,10 @@ operator*(const RealType1& x, const complex<RealType2>& y) noexcept {
 ///
 /// This function exists because the compiler doesn't know that
 /// RealType and complex<RealType> commute with respect to operator*.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
 operator*(const complex<RealType1>& y, const RealType2& x) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x * y.real(),
@@ -711,56 +761,61 @@ operator*(const complex<RealType1>& y, const RealType2& x) noexcept {
 }
 
 //! Imaginary part of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION RealType imag(const complex<RealType>& x) noexcept {
   return x.imag();
 }
 
-template <class ArithmeticType>
+template <class ArithmeticType,
+          std::enable_if_t<std::is_arithmetic_v<ArithmeticType>, int> = 0>
 KOKKOS_INLINE_FUNCTION constexpr Impl::promote_t<ArithmeticType> imag(
     ArithmeticType) {
   return ArithmeticType();
 }
 
 //! Real part of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION RealType real(const complex<RealType>& x) noexcept {
   return x.real();
 }
 
-template <class ArithmeticType>
+template <class ArithmeticType,
+          std::enable_if_t<std::is_arithmetic_v<ArithmeticType>, int> = 0>
 KOKKOS_INLINE_FUNCTION constexpr Impl::promote_t<ArithmeticType> real(
     ArithmeticType x) {
   return x;
 }
 
 //! Constructs a complex number from magnitude and phase angle
-template <class T>
+template <class T, std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
 KOKKOS_INLINE_FUNCTION complex<T> polar(const T& r, const T& theta = T()) {
   KOKKOS_EXPECTS(r >= 0);
   return complex<T>(r * cos(theta), r * sin(theta));
 }
 
 //! Absolute value (magnitude) of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION RealType abs(const complex<RealType>& x) {
   return hypot(x.real(), x.imag());
 }
 
 //! Power of a complex number
-template <class T>
+template <class T, std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
 KOKKOS_INLINE_FUNCTION complex<T> pow(const complex<T>& x, const T& y) {
   T r     = abs(x);
   T theta = atan2(x.imag(), x.real());
   return polar(pow(r, y), y * theta);
 }
 
-template <class T>
+template <class T, std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
 KOKKOS_INLINE_FUNCTION complex<T> pow(const T& x, const complex<T>& y) {
   return pow(complex<T>(x), y);
 }
 
-template <class T>
+template <class T, std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
 KOKKOS_INLINE_FUNCTION complex<T> pow(const complex<T>& x,
                                       const complex<T>& y) {
   return x == T() ? T() : exp(y * log(x));
@@ -789,7 +844,8 @@ KOKKOS_INLINE_FUNCTION complex<Impl::promote_2_t<T, U>> pow(
 
 //! Square root of a complex number. This is intended to match the stdc++
 //! implementation, which returns sqrt(z*z) = z; where z is complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sqrt(
     const complex<RealType>& x) {
   RealType r = x.real();
@@ -808,13 +864,15 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sqrt(
 }
 
 //! Conjugate of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION complex<RealType> conj(
     const complex<RealType>& x) noexcept {
   return complex<RealType>(real(x), -imag(x));
 }
 
-template <class ArithmeticType>
+template <class ArithmeticType,
+          std::enable_if_t<std::is_arithmetic_v<ArithmeticType>, int> = 0>
 KOKKOS_INLINE_FUNCTION constexpr complex<Impl::promote_t<ArithmeticType>> conj(
     ArithmeticType x) {
   using type = Impl::promote_t<ArithmeticType>;
@@ -822,13 +880,15 @@ KOKKOS_INLINE_FUNCTION constexpr complex<Impl::promote_t<ArithmeticType>> conj(
 }
 
 //! Exponential of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION complex<RealType> exp(const complex<RealType>& x) {
   return exp(x.real()) * complex<RealType>(cos(x.imag()), sin(x.imag()));
 }
 
 //! natural log of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> log(
     const complex<RealType>& x) {
   RealType phi = atan2(x.imag(), x.real());
@@ -836,14 +896,16 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> log(
 }
 
 //! base 10 log of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> log10(
     const complex<RealType>& x) {
   return log(x) / log(RealType(10));
 }
 
 //! sine of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sin(
     const complex<RealType>& x) {
   return Kokkos::complex<RealType>(sin(x.real()) * cosh(x.imag()),
@@ -851,7 +913,8 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sin(
 }
 
 //! cosine of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> cos(
     const complex<RealType>& x) {
   return Kokkos::complex<RealType>(cos(x.real()) * cosh(x.imag()),
@@ -859,14 +922,16 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> cos(
 }
 
 //! tangent of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> tan(
     const complex<RealType>& x) {
   return sin(x) / cos(x);
 }
 
 //! hyperbolic sine of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sinh(
     const complex<RealType>& x) {
   return Kokkos::complex<RealType>(sinh(x.real()) * cos(x.imag()),
@@ -874,7 +939,8 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sinh(
 }
 
 //! hyperbolic cosine of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> cosh(
     const complex<RealType>& x) {
   return Kokkos::complex<RealType>(cosh(x.real()) * cos(x.imag()),
@@ -882,21 +948,24 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> cosh(
 }
 
 //! hyperbolic tangent of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> tanh(
     const complex<RealType>& x) {
   return sinh(x) / cosh(x);
 }
 
 //! inverse hyperbolic sine of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> asinh(
     const complex<RealType>& x) {
   return log(x + sqrt(x * x + RealType(1.0)));
 }
 
 //! inverse hyperbolic cosine of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> acosh(
     const complex<RealType>& x) {
   return RealType(2.0) * log(sqrt(RealType(0.5) * (x + RealType(1.0))) +
@@ -904,7 +973,8 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> acosh(
 }
 
 //! inverse hyperbolic tangent of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> atanh(
     const complex<RealType>& x) {
   const RealType i2 = x.imag() * x.imag();
@@ -922,7 +992,8 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> atanh(
 }
 
 //! inverse sine of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> asin(
     const complex<RealType>& x) {
   Kokkos::complex<RealType> t =
@@ -931,7 +1002,8 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> asin(
 }
 
 //! inverse cosine of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> acos(
     const complex<RealType>& x) {
   Kokkos::complex<RealType> t = asin(x);
@@ -940,7 +1012,8 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> acos(
 }
 
 //! inverse tangent of a complex number.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> atan(
     const complex<RealType>& x) {
   const RealType r2 = x.real() * x.real();
@@ -960,14 +1033,18 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> atan(
 /// This function cannot be called in a CUDA device function,
 /// because std::complex's methods and nonmember functions are not
 /// marked as CUDA device functions.
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 inline complex<RealType> exp(const std::complex<RealType>& c) {
   return complex<RealType>(std::exp(c.real()) * std::cos(c.imag()),
                            std::exp(c.real()) * std::sin(c.imag()));
 }
 
 //! Binary operator / for complex and real numbers
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
 operator/(const complex<RealType1>& x,
           const RealType2& y) noexcept(noexcept(RealType1{} / RealType2{})) {
@@ -976,7 +1053,10 @@ operator/(const complex<RealType1>& x,
 }
 
 //! Binary operator / for complex.
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
 operator/(const complex<RealType1>& x,
           const complex<RealType2>& y) noexcept(noexcept(RealType1{} /
@@ -1005,7 +1085,10 @@ operator/(const complex<RealType1>& x,
 }
 
 //! Binary operator / for complex and real numbers
-template <class RealType1, class RealType2>
+template <class RealType1, class RealType2,
+          std::enable_if_t<std::is_arithmetic_v<RealType1> &&
+                               std::is_arithmetic_v<RealType2>,
+                           int> = 0>
 KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
 operator/(const RealType1& x,
           const complex<RealType2>& y) noexcept(noexcept(RealType1{} /
@@ -1013,14 +1096,16 @@ operator/(const RealType1& x,
   return complex<std::common_type_t<RealType1, RealType2>>(x) / y;
 }
 
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 std::ostream& operator<<(std::ostream& os, const complex<RealType>& x) {
   const std::complex<RealType> x_std(Kokkos::real(x), Kokkos::imag(x));
   os << x_std;
   return os;
 }
 
-template <class RealType>
+template <class RealType,
+          std::enable_if_t<std::is_arithmetic_v<RealType>, int> = 0>
 std::istream& operator>>(std::istream& is, complex<RealType>& x) {
   std::complex<RealType> x_std;
   is >> x_std;


### PR DESCRIPTION
The lack of constraints on the template parameters for the non-member overloaded operators for Kokkos::complex can create issues when defining overloads between Kokkos::complex and user-defined classes. An example of where this can arise is with expression templates, e.g a scaling of an user-defined class:

alpha * x

with alpha a Kokkos::complex and x an user-defined class. The compiler tries to force an object of the user defined class into the constructor of Kokkos::complex when returning the result of the operation.

This PR constrains the template parameters of the non-member operator overloads to only accept arithmetic types, which resolves the aforementioned issue.