### PR TITLE
Test ABI and flag compatibility of CXX compiler in `find_package(Kokkos)`

### DIFF
--- a/cmake/KokkosConfig.cmake.in
+++ b/cmake/KokkosConfig.cmake.in
@@ -29,44 +29,38 @@ if("launch_compiler" IN_LIST Kokkos_FIND_COMPONENTS AND "separable_compilation" 
   message(FATAL_ERROR "Conflicting COMPONENTS: 'launch_compiler' and 'separable_compilation'")
 endif()
 
-if("launch_compiler" IN_LIST Kokkos_FIND_COMPONENTS)
-  #
-  # if find_package(Kokkos COMPONENTS launch_compiler) then rely on the
-  # RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK to always redirect to the
-  # appropriate compiler for Kokkos
-  #
-
-  message(
-    STATUS
-      "kokkos_launch_compiler is enabled globally. C++ compiler commands with -DKOKKOS_DEPENDENCE will be redirected to the appropriate compiler for Kokkos"
-  )
-  kokkos_compilation(GLOBAL CHECK_CUDA_COMPILES)
-
-elseif(@Kokkos_ENABLE_CUDA@ AND NOT @KOKKOS_COMPILE_LANGUAGE@ STREQUAL CUDA AND NOT "separable_compilation" IN_LIST
-                                                                                Kokkos_FIND_COMPONENTS
-)
-  #
-  # if CUDA was enabled, the compilation language was not set to CUDA, and separable compilation was not
-  # specified, then set the RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK globally and
-  # kokkos_launch_compiler will re-direct to the compiler used to compile CUDA code during installation.
-  # kokkos_launch_compiler will re-direct if ${CMAKE_CXX_COMPILER} and -DKOKKOS_DEPENDENCE is present,
-  # otherwise, the original command will be executed
-  #
-
-  # run test to see if CMAKE_CXX_COMPILER=nvcc_wrapper
-  kokkos_compiler_is_nvcc(IS_NVCC ${CMAKE_CXX_COMPILER})
-
-  # if not nvcc_wrapper and Kokkos_LAUNCH_COMPILER was not set to OFF
-  if(NOT IS_NVCC AND (NOT DEFINED Kokkos_LAUNCH_COMPILER OR Kokkos_LAUNCH_COMPILER))
-    message(
-      STATUS
-        "kokkos_launch_compiler is enabled globally. C++ compiler commands with -DKOKKOS_DEPENDENCE will be redirected to the appropriate compiler for Kokkos"
+if(NOT @Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE)
+  if(NOT KOKKOS_CXX_COMPILER_IS_COMPATIBLE)
+    #we compile a small test program using kokkos to check if the flags and ABI the CXX compiler uses is compatible with the library
+    kokkos_cxx_compiler_is_compatible(RESULT KOKKOS_COMPILER_IS_COMPATIBLE)
+    set(KOKKOS_CXX_COMPILER_IS_COMPATIBLE ${KOKKOS_COMPILER_IS_COMPATIBLE}
+        CACHE STRING "CMAKE_CXX_COMPILER can compile Kokkos code"
     )
-    kokkos_compilation(GLOBAL)
-  endif()
 
-  # be mindful of the environment, pollution is bad
-  unset(IS_NVCC)
+    if((@KOKKOS_ENABLE_CUDA@ AND NOT KOKKOS_CXX_COMPILER_IS_COMPATIBLE) OR "launch_compiler" IN_LIST
+                                                                           Kokkos_FIND_COMPONENTS
+    )
+      #
+      # if find_package(Kokkos COMPONENTS launch_compiler) then rely on the
+      # RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK to always redirect to the
+      # appropriate compiler for Kokkos
+      #
+
+      message(
+        STATUS
+          "kokkos_launch_compiler is enabled globally. C++ compiler commands with -DKOKKOS_DEPENDENCE will be redirected to the appropriate compiler for Kokkos"
+      )
+      kokkos_compilation(GLOBAL)
+
+    else()
+      if(NOT KOKKOS_CXX_COMPILER_IS_COMPATIBLE)
+        message(
+          WARNING
+            "Kokkos can not compile a simple test program with the given CXX compiler ${CMAKE_CXX_COMPILER}. This might be due to incompatible flags or ABI."
+        )
+      endif()
+    endif()
+  endif()
 endif()
 
 set(Kokkos_COMPILE_LANGUAGE @KOKKOS_COMPILE_LANGUAGE@)

--- a/cmake/KokkosConfig.cmake.in
+++ b/cmake/KokkosConfig.cmake.in
@@ -30,37 +30,33 @@ if("launch_compiler" IN_LIST Kokkos_FIND_COMPONENTS AND "separable_compilation" 
 endif()
 
 if(NOT @Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE)
-  if(NOT KOKKOS_CXX_COMPILER_IS_COMPATIBLE)
-    #we compile a small test program using kokkos to check if the flags and ABI the CXX compiler uses is compatible with the library
-    kokkos_cxx_compiler_is_compatible(RESULT KOKKOS_COMPILER_IS_COMPATIBLE)
-    set(KOKKOS_CXX_COMPILER_IS_COMPATIBLE ${KOKKOS_COMPILER_IS_COMPATIBLE}
-        CACHE STRING "CMAKE_CXX_COMPILER can compile Kokkos code"
-    )
+  #we compile a small test program using kokkos to check if the flags and ABI the CXX compiler uses is compatible with the library
+  kokkos_check_cxx_compiler_is_compatible()
 
-    if((@KOKKOS_ENABLE_CUDA@ AND NOT KOKKOS_CXX_COMPILER_IS_COMPATIBLE) OR "launch_compiler" IN_LIST
-                                                                           Kokkos_FIND_COMPONENTS
-    )
-      #
-      # if find_package(Kokkos COMPONENTS launch_compiler) then rely on the
-      # RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK to always redirect to the
-      # appropriate compiler for Kokkos
-      #
+  if((@KOKKOS_ENABLE_CUDA@ AND NOT KOKKOS_CXX_COMPILER_IS_COMPATIBLE) OR "launch_compiler" IN_LIST
+                                                                         Kokkos_FIND_COMPONENTS
+  )
+    #
+    # if find_package(Kokkos COMPONENTS launch_compiler) then rely on the
+    # RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK to always redirect to the
+    # appropriate compiler for Kokkos
+    #
 
+    message(
+      STATUS
+        "kokkos_launch_compiler is enabled globally. C++ compiler commands with -DKOKKOS_DEPENDENCE will be redirected to the appropriate compiler for Kokkos"
+    )
+    kokkos_compilation(GLOBAL)
+
+  else()
+    if(NOT KOKKOS_CXX_COMPILER_IS_COMPATIBLE)
       message(
-        STATUS
-          "kokkos_launch_compiler is enabled globally. C++ compiler commands with -DKOKKOS_DEPENDENCE will be redirected to the appropriate compiler for Kokkos"
+        WARNING
+          "Kokkos can not compile a simple test program with the given CXX compiler ${CMAKE_CXX_COMPILER}. This might be due to incompatible flags or ABI."
       )
-      kokkos_compilation(GLOBAL)
-
-    else()
-      if(NOT KOKKOS_CXX_COMPILER_IS_COMPATIBLE)
-        message(
-          WARNING
-            "Kokkos can not compile a simple test program with the given CXX compiler ${CMAKE_CXX_COMPILER}. This might be due to incompatible flags or ABI."
-        )
-      endif()
     endif()
   endif()
+endif()
 endif()
 
 set(Kokkos_COMPILE_LANGUAGE @KOKKOS_COMPILE_LANGUAGE@)

--- a/cmake/KokkosConfig.cmake.in
+++ b/cmake/KokkosConfig.cmake.in
@@ -57,6 +57,5 @@ if(NOT @Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE)
     endif()
   endif()
 endif()
-endif()
 
 set(Kokkos_COMPILE_LANGUAGE @KOKKOS_COMPILE_LANGUAGE@)

--- a/cmake/KokkosConfigCommon.cmake.in
+++ b/cmake/KokkosConfigCommon.cmake.in
@@ -203,6 +203,45 @@ int main()
   set(${_VAR} ${_RET} PARENT_SCOPE)
 endfunction()
 
+# this function checks whether the current CXX compiler supports building Kokkos
+#
+#       RESULT      --> result (bool)
+#
+function(kokkos_cxx_compiler_is_compatible)
+  cmake_parse_arguments(INP "" "RESULT" "" ${ARGN})
+
+  file(
+    WRITE ${PROJECT_BINARY_DIR}/compile_tests/compiles_kokkos.cpp
+    "
+// include Kokkos_Core to check if header is working with the compiler
+#include <Kokkos_Core.hpp>
+
+int main()
+{
+Kokkos::initialize();
+{ // instantiate a view and a parallel_for to check requirements for template instantiation
+    Kokkos::View<int*> V(\"V\", 10);
+    Kokkos::parallel_for(\"increment\", 10, KOKKOS_LAMBDA ( int j) {
+        ++V(j);
+    });
+    Kokkos::fence();
+}
+Kokkos::finalize();
+return EXIT_SUCCESS;
+}
+"
+  )
+
+  try_compile(
+    COMPILER_CAN_COMPILE_KOKKOS ${PROJECT_BINARY_DIR}/compile_tests
+    ${PROJECT_BINARY_DIR}/compile_tests/compiles_kokkos.cpp
+    OUTPUT_VARIABLE COMPILER_ERROR_MESSAGE
+    LINK_LIBRARIES Kokkos::kokkos
+  )
+
+  set(${INP_RESULT} ${COMPILER_CAN_COMPILE_KOKKOS} PARENT_SCOPE)
+endfunction()
+
 # this function is provided to easily select which files use the same compiler as Kokkos
 # when it was installed (or nvcc_wrapper):
 #

--- a/cmake/KokkosConfigCommon.cmake.in
+++ b/cmake/KokkosConfigCommon.cmake.in
@@ -203,15 +203,14 @@ int main()
   set(${_VAR} ${_RET} PARENT_SCOPE)
 endfunction()
 
-# this function checks whether the current CXX compiler supports building Kokkos
+# this function checks whether the current CXX compiler supports building Kokkos and sets KOKKOS_CXX_COMPILER_IS_COMPATIBLE
 #
-#       RESULT      --> result (bool)
 #
-function(kokkos_cxx_compiler_is_compatible)
-  cmake_parse_arguments(INP "" "RESULT" "" ${ARGN})
+function(kokkos_check_cxx_compiler_is_compatible)
 
-  file(
-    WRITE ${PROJECT_BINARY_DIR}/compile_tests/compiles_kokkos.cpp
+  set(CMAKE_REQUIRED_LIBRARIES "Kokkos::kokkos")
+
+  check_cxx_source_compiles(
     "
 // include Kokkos_Core to check if header is working with the compiler
 #include <Kokkos_Core.hpp>
@@ -230,16 +229,8 @@ Kokkos::finalize();
 return EXIT_SUCCESS;
 }
 "
+    KOKKOS_CXX_COMPILER_IS_COMPATIBLE
   )
-
-  try_compile(
-    COMPILER_CAN_COMPILE_KOKKOS ${PROJECT_BINARY_DIR}/compile_tests
-    ${PROJECT_BINARY_DIR}/compile_tests/compiles_kokkos.cpp
-    OUTPUT_VARIABLE COMPILER_ERROR_MESSAGE
-    LINK_LIBRARIES Kokkos::kokkos
-  )
-
-  set(${INP_RESULT} ${COMPILER_CAN_COMPILE_KOKKOS} PARENT_SCOPE)
 endfunction()
 
 # this function is provided to easily select which files use the same compiler as Kokkos


### PR DESCRIPTION
When we are found by a downstream package, we don't know if the CXX compiler that this downstream package uses can compile Kokkos. There might be incompatibilities in the ABI or the CXX compiler might not be able to consume the flags that the found Kokkos is adding. 

To check both, this PR introduces the compilation and linkage of a minimal Kokkos program to the `find_package(Kokkos)` call. This allows to warn the user if incompatibilities are detected. Furthermore, the information allows reducing the logic for setting our compiler launcher script.

For `nvcc_wrapper` the check adds ~7s of configure time on docker on my Macbook.