### PR TITLE
Add CMake install testing

### DIFF
--- a/.github/workflows/continuous-integration-linux.yml
+++ b/.github/workflows/continuous-integration-linux.yml
@@ -178,7 +178,7 @@ jobs:
         run: sudo cmake --build builddir --target install
       - name: Test install
         if: ${{ !contains(matrix.cxx_extra_flags, '-fsanitize=address') && matrix.arch != 'x86' }}
-        working-directory: example/build_cmake_installed
+        working-directory: cmake_test
         run: |
           cmake -B builddir -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
           cmake --build builddir

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -95,8 +95,17 @@ pipeline {
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_BENCHMARKS=ON \
                                 -DKokkos_ENABLE_HIP=ON \
+                                -DCMAKE_INSTALL_PREFIX=${PWD}/../install \
                               .. && \
-                              make -j16 && ctest --no-compress-output -T Test --verbose'''
+                              make -j16 && ctest --no-compress-output -T Test --verbose && \
+                              make install && \
+                              export CMAKE_PREFIX_PATH=${PWD}/../install && \
+                              cd ../cmake_test && \
+                              rm -rf build && mkdir -p build && cd build && \
+                              cmake -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_COMPILER=hipcc .. && make -j8 && ctest --verbose && \
+                              cd ../../../examples/build_in_tree && \
+                              rm -rf build && mkdir -p build && cd build && \
+                              cmake -DCMAKE_CXX_STANDARD=20 .. && make -j8 && ctest --verbose'''
                     }
                     post {
                         always {
@@ -158,18 +167,14 @@ pipeline {
                                 -DKokkos_INSTALL_TESTING=ON \
                               .. && \
                               make -j8 && ctest --no-compress-output -T Test --verbose && \
-                              cd ../example/build_cmake_installed && \
+                              cd ../cmake_test && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_CXX_COMPILER=g++-8 \
                                 -DCMAKE_CXX_FLAGS=-Werror \
                                 -DCMAKE_CXX_STANDARD=17 \
                               .. && \
-                              make -j8 && ctest --verbose && \
-                              cd ../.. && \
-                              cmake -B build_cmake_installed_different_compiler/build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-Werror -DCMAKE_CXX_STANDARD=17 build_cmake_installed_different_compiler && \
-                              cmake --build build_cmake_installed_different_compiler/build --target all && \
-                              cmake --build build_cmake_installed_different_compiler/build --target test'''
+                              make -j8 && ctest --verbose '''
                     }
                     post {
                         always {
@@ -570,9 +575,15 @@ pipeline {
                                 -DKokkos_ENABLE_OPENMP=ON \
                                 -DKokkos_ENABLE_IMPL_MDSPAN=OFF \
                                 -DKokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=ON \
+                                -DCMAKE_INSTALL_PREFIX=${PWD}/../install \
                               .. && \
                               make -j8 && ctest --no-compress-output -T Test --verbose && \
-                              cd ../example/build_cmake_in_tree && \
+                              make install && \
+                              export CMAKE_PREFIX_PATH=${PWD}/../install && \
+                              cd ../cmake_test && \
+                              rm -rf build && mkdir -p build && cd build && \
+                              cmake -DCMAKE_CXX_STANDARD=17 .. &&  make -j8 && ctest --verbose && \
+                              cd ../../../examples/build_in_tree && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake -DCMAKE_CXX_STANDARD=17 .. && make -j8 && ctest --verbose'''
                     }

--- a/cmake_test/CMakeLists.txt
+++ b/cmake_test/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Kokkos minimally requires 3.21 right now,
+# but your project can set it higher
+cmake_minimum_required(VERSION 3.21)
+
+# Projects can safely mix languages - must have C++ support
+project(KokkosCMakeTesting CXX)
+
+enable_testing()
+add_subdirectory(complex)
+add_subdirectory(launch_compiler)

--- a/cmake_test/CMakeLists.txt
+++ b/cmake_test/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Kokkos minimally requires 3.21 right now,
+# Kokkos minimally requires 3.16 right now,
 # but your project can set it higher
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.16)
 
 # Projects can safely mix languages - must have C++ support
 project(KokkosCMakeTesting CXX)

--- a/cmake_test/complex/CMakeLists.txt
+++ b/cmake_test/complex/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Kokkos minimally requires 3.21 right now,
+# Kokkos minimally requires 3.16 right now,
 # but your project can set it higher
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.16)
 
 # Projects can safely mix languages - must have C++ support
 project(KokkosCMakeTestingComplex CXX Fortran)

--- a/cmake_test/complex/CMakeLists.txt
+++ b/cmake_test/complex/CMakeLists.txt
@@ -1,0 +1,301 @@
+# Kokkos minimally requires 3.21 right now,
+# but your project can set it higher
+cmake_minimum_required(VERSION 3.21)
+
+# Projects can safely mix languages - must have C++ support
+project(KokkosCMakeTestingComplex CXX Fortran)
+
+######
+# In this test we let find_package(Kokkos) set source and target properties automatically.
+# There are tree sections:
+#   - Targets without Kokkos dependency
+#   - Targets dependent on a library that has a Kokkos dependency
+#   - Targets dependent on a library that depends on a library that has a Kokkos dependency
+# Although the test stops at two layers, find_package(Kokkos) sets the source and target properties independent of
+# depth of the dependency tree.
+
+###### Targets that don't depend on Kokkos are not manipulated by us
+add_subdirectory(lib_without_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_without ../test_source/test_without.cpp ../test_source/source_plain_cxx.cpp
+                                     ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(${PROJECT_NAME}_executable_without ${PROJECT_NAME}_Lib_without_kokkos_dependency)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_without PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_without PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosWithout_Verify COMMAND ${PROJECT_NAME}_executable_without 10)
+
+###### Libraries that have direct dependency on Kokkos
+###### PUBLIC dependency
+add_subdirectory(lib_with_public_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_public ../test_source/test_public.cpp ../test_source/source_plain_cxx.cpp
+                                    ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_public ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_public_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_public PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_public PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPublic_Verify COMMAND ${PROJECT_NAME}_executable_public 10)
+
+###### INTERFACE dependency
+add_subdirectory(lib_with_interface_kokkos_dependency)
+add_executable(
+  ${PROJECT_NAME}_executable_interface ../test_source/test_interface.cpp ../test_source/source_plain_cxx.cpp
+                                       ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_interface ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_interface_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_interface PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_interface PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosInterface_Verify COMMAND ${PROJECT_NAME}_executable_interface 10)
+
+###### PRIVATE dependency
+add_subdirectory(lib_with_private_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_private ../test_source/test_private.cpp ../test_source/source_plain_cxx.cpp
+                                     ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_private ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_private_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_private PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_private PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPrivate_Verify COMMAND ${PROJECT_NAME}_executable_private 10)
+
+###### Libraries that have indirect dependency on Kokkos
+###### PUBLIC dependency on INTERFACE dependency
+add_subdirectory(lib_with_public_dependency_on_lib_with_interface_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_public_interface ../test_source/test_public_interface.cpp
+                                              ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_public_interface ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_interface_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_public_interface PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_public_interface PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPublic_interface_Verify COMMAND ${PROJECT_NAME}_executable_public_interface 10)
+
+###### PUBLIC dependency on PUBLIC dependency
+add_subdirectory(lib_with_public_dependency_on_lib_with_public_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_public_public ../test_source/test_public_public.cpp ../test_source/source_plain_cxx.cpp
+                                           ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_public_public ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_public_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_public_public PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_public_public PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPublic_public_Verify COMMAND ${PROJECT_NAME}_executable_public_public 10)
+
+###### PUBLIC dependency on PRIVATE dependency
+add_subdirectory(lib_with_public_dependency_on_lib_with_private_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_public_private ../test_source/test_public_private.cpp ../test_source/source_plain_cxx.cpp
+                                            ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_public_private ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_private_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_public_private PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_public_private PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPublic_private_Verify COMMAND ${PROJECT_NAME}_executable_public_private 10)
+
+###### PRIVATE dependency on INTERFACE dependency
+add_subdirectory(lib_with_private_dependency_on_lib_with_interface_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_private_interface
+  ../test_source/test_private_interface.cpp ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_private_interface ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_interface_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_private_interface PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_private_interface PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPrivate_interface_Verify COMMAND ${PROJECT_NAME}_executable_private_interface 10)
+
+###### PRIVATE dependency on PUBLIC dependency
+add_subdirectory(lib_with_private_dependency_on_lib_with_public_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_private_public ../test_source/test_private_public.cpp ../test_source/source_plain_cxx.cpp
+                                            ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_private_public ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_public_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_private_public PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_private_public PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPrivate_public_Verify COMMAND ${PROJECT_NAME}_executable_private_public 10)
+
+###### PRIVATE dependency on PRIVATE dependency
+add_subdirectory(lib_with_private_dependency_on_lib_with_private_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_private_private ../test_source/test_private_private.cpp
+                                             ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_private_private ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_private_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_private_private PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_private_private PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPrivate_private_Verify COMMAND ${PROJECT_NAME}_executable_private_private 10)
+
+###### INTERFACE dependency on INTERFACE dependency
+add_subdirectory(lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_interface_interface
+  ../test_source/test_interface_interface.cpp ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_interface_interface ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_interface_interface PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_interface_interface PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosInterface_interface_Verify COMMAND ${PROJECT_NAME}_executable_interface_interface
+                                                                       10
+)
+
+###### INTERFACE dependency on PUBLIC dependency
+add_subdirectory(lib_with_interface_dependency_on_lib_with_public_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_interface_public ../test_source/test_interface_public.cpp
+                                              ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_interface_public ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_public_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_interface_public PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_interface_public PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosInterface_public_Verify COMMAND ${PROJECT_NAME}_executable_interface_public 10)
+
+###### INTERFACE dependency on PRIVATE dependency
+add_subdirectory(lib_with_interface_dependency_on_lib_with_private_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_interface_private
+  ../test_source/test_interface_private.cpp ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_interface_private ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_private_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_interface_private PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_interface_private PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosInterface_private_Verify COMMAND ${PROJECT_NAME}_executable_interface_private 10)

--- a/cmake_test/complex/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency INTERFACE)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency
+  INTERFACE ../../test_source/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency
+  INTERFACE ${PROJECT_NAME}_Lib_with_interface_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_private_kokkos_dependency INTERFACE)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_private_kokkos_dependency
+  INTERFACE ../../test_source/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_private_kokkos_dependency
+  INTERFACE ${PROJECT_NAME}_Lib_with_private_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_public_kokkos_dependency INTERFACE)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_public_kokkos_dependency
+  INTERFACE ../../test_source/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_public_kokkos_dependency
+  INTERFACE ${PROJECT_NAME}_Lib_with_public_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_interface_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_interface_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,8 @@
+find_package(Kokkos)
+
+add_library(${PROJECT_NAME}_Lib_with_interface_kokkos_dependency INTERFACE)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_interface_kokkos_dependency INTERFACE ../../test_source/lib_with_interface_kokkos_dependency
+)
+
+target_link_libraries(${PROJECT_NAME}_Lib_with_interface_kokkos_dependency INTERFACE Kokkos::kokkos)

--- a/cmake_test/complex/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_interface_kokkos_dependency
+  ../../test_source/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/source_with_private_dependency_on_lib_with_interface_kokkos_dependency.cpp
+)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_interface_kokkos_dependency
+  PUBLIC ../../test_source/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_interface_kokkos_dependency
+  PRIVATE ${PROJECT_NAME}_Lib_with_interface_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_private_kokkos_dependency
+  ../../test_source/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/source_with_private_dependency_on_lib_with_private_kokkos_dependency.cpp
+)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_private_kokkos_dependency
+  PUBLIC ../../test_source/lib_with_private_dependency_on_lib_with_private_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_private_kokkos_dependency
+  PRIVATE ${PROJECT_NAME}_Lib_with_private_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_public_kokkos_dependency
+  ../../test_source/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/source_with_private_dependency_on_lib_with_public_kokkos_dependency.cpp
+)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_public_kokkos_dependency
+  PUBLIC ../../test_source/lib_with_private_dependency_on_lib_with_public_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_public_kokkos_dependency
+  PRIVATE ${PROJECT_NAME}_Lib_with_public_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_private_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_private_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,26 @@
+find_package(Kokkos)
+
+add_library(
+  ${PROJECT_NAME}_Lib_with_private_kokkos_dependency
+  ../../test_source/lib_with_private_kokkos_dependency/source_with_public_kokkos_dependency.cpp
+  ../../test_source/lib_with_private_kokkos_dependency/source_without_kokkos_dependency.cpp
+  ../../test_source/lib_with_private_kokkos_dependency/source_merging_prints.cpp
+)
+
+if((CUDA IN_LIST Kokkos_DEVICES) OR (HIP IN_LIST Kokkos_DEVICES))
+  target_sources(
+    ${PROJECT_NAME}_Lib_with_private_kokkos_dependency
+    PRIVATE ../../test_source/lib_with_private_kokkos_dependency/cuda_hip_source_without_kokkos_dependency.cu
+  )
+  #for builds without CUDA/HIP language support we need to mark the cuda file as CXX. With language support it marks the file in the appropriate language
+  set_property(
+    SOURCE ../../test_source/lib_with_private_kokkos_dependency/cuda_hip_source_without_kokkos_dependency.cu
+           TARGET_DIRECTORY ${PROJECT_NAME}_Lib_with_private_kokkos_dependency PROPERTY LANGUAGE
+                                                                                        ${Kokkos_COMPILE_LANGUAGE}
+  )
+endif()
+
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_private_kokkos_dependency PUBLIC ../../test_source/lib_with_private_kokkos_dependency
+)
+target_link_libraries(${PROJECT_NAME}_Lib_with_private_kokkos_dependency PRIVATE Kokkos::kokkos)

--- a/cmake_test/complex/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_interface_kokkos_dependency
+  ../../test_source/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/source_with_public_dependency_on_lib_with_interface_kokkos_dependency.cpp
+)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_interface_kokkos_dependency
+  PUBLIC ../../test_source/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_interface_kokkos_dependency
+  PUBLIC ${PROJECT_NAME}_Lib_with_interface_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_private_kokkos_dependency
+  ../../test_source/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/source_with_public_dependency_on_lib_with_private_kokkos_dependency.cpp
+)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_private_kokkos_dependency
+  PUBLIC ../../test_source/lib_with_public_dependency_on_lib_with_private_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_private_kokkos_dependency
+  PUBLIC ${PROJECT_NAME}_Lib_with_private_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_public_kokkos_dependency
+  ../../test_source/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/source_with_public_dependency_on_lib_with_public_kokkos_dependency.cpp
+)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_public_kokkos_dependency
+  PUBLIC ../../test_source/lib_with_public_dependency_on_lib_with_public_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_public_kokkos_dependency
+  PUBLIC ${PROJECT_NAME}_Lib_with_public_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_public_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_public_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,24 @@
+find_package(Kokkos)
+
+add_library(
+  ${PROJECT_NAME}_Lib_with_public_kokkos_dependency
+  ../../test_source/lib_with_public_kokkos_dependency/source_with_public_kokkos_dependency.cpp
+)
+
+if((CUDA IN_LIST Kokkos_DEVICES) OR (HIP IN_LIST Kokkos_DEVICES))
+  target_sources(
+    ${PROJECT_NAME}_Lib_with_public_kokkos_dependency
+    PRIVATE ../../test_source/lib_with_public_kokkos_dependency/cuda_hip_source_without_kokkos_dependency.cu
+  )
+  #for builds without CUDA/HIP language support we need to mark the cuda file as CXX. For language support it marks the file in the appropriate language
+  set_property(
+    SOURCE ../../test_source/lib_with_public_kokkos_dependency/cuda_hip_source_without_kokkos_dependency.cu
+           TARGET_DIRECTORY ${PROJECT_NAME}_Lib_with_public_kokkos_dependency PROPERTY LANGUAGE
+                                                                                       ${Kokkos_COMPILE_LANGUAGE}
+  )
+endif()
+
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_public_kokkos_dependency PUBLIC ../../test_source/lib_with_public_kokkos_dependency
+)
+target_link_libraries(${PROJECT_NAME}_Lib_with_public_kokkos_dependency PUBLIC Kokkos::kokkos)

--- a/cmake_test/complex/lib_without_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_without_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(
+  ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ../../test_source/lib_without_kokkos_dependency/source_without_kokkos_dependency.cpp
+)
+
+target_include_directories(
+  ${PROJECT_NAME}_Lib_without_kokkos_dependency PUBLIC ../../test_source/lib_without_kokkos_dependency
+)

--- a/cmake_test/launch_compiler/CMakeLists.txt
+++ b/cmake_test/launch_compiler/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Kokkos minimally requires 3.21 right now,
+# Kokkos minimally requires 3.16 right now,
 # but your project can set it higher
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.16)
 
 # Projects can safely mix languages - must have C++ support
 # Kokkos flags will only apply to C++ files

--- a/cmake_test/launch_compiler/CMakeLists.txt
+++ b/cmake_test/launch_compiler/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Kokkos minimally requires 3.21 right now,
+# but your project can set it higher
+cmake_minimum_required(VERSION 3.21)
+
+# Projects can safely mix languages - must have C++ support
+# Kokkos flags will only apply to C++ files
+project(KokkosCMakeTestingLaunchCompiler CXX Fortran)
+
+# this does not work when compiling with language support (Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE)
+find_package(Kokkos REQUIRED COMPONENTS launch_compiler)
+
+add_executable(${PROJECT_NAME}_with_kokkos test_with_kokkos.cpp source_plain_fortran.f)
+add_executable(${PROJECT_NAME}_no_kokkos test_no_kokkos.cpp source_plain_fortran.f)
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_with_kokkos PROPERTIES LINKER_LANGUAGE Fortran)
+  set_target_properties(${PROJECT_NAME}_no_kokkos PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_with_kokkos PRIVATE -fno-fortran-main)
+    target_link_options(${PROJECT_NAME}_no_kokkos PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+# This is the only thing required to set up compiler/linker flags
+target_link_libraries(${PROJECT_NAME}_with_kokkos Kokkos::kokkos)
+
+enable_testing()
+add_test(NAME ExampleDifferentCompiler_Kokkos_Verify COMMAND ${PROJECT_NAME}_with_kokkos 10)
+add_test(NAME ExampleDifferentCompiler_NoKokkos_Verify COMMAND ${PROJECT_NAME}_no_kokkos 10)

--- a/cmake_test/launch_compiler/source_plain_fortran.f
+++ b/cmake_test/launch_compiler/source_plain_fortran.f
@@ -1,0 +1,4 @@
+        FUNCTION print_fortran()
+          PRINT *, 'Hello World from Fortran'
+          RETURN
+        END

--- a/cmake_test/launch_compiler/test_no_kokkos.cpp
+++ b/cmake_test/launch_compiler/test_no_kokkos.cpp
@@ -1,0 +1,25 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <cstdio>
+
+extern "C" void print_fortran_();
+
+int main(int argc, char* argv[]) {
+  printf(
+      "This executable does nothing and is just for build system demonstration "
+      "\n");
+}

--- a/cmake_test/launch_compiler/test_with_kokkos.cpp
+++ b/cmake_test/launch_compiler/test_with_kokkos.cpp
@@ -1,0 +1,71 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+
+struct CountFunctor {
+  KOKKOS_FUNCTION void operator()(const long i, long& lcount) const {
+    lcount += (i % 2) == 0;
+  }
+};
+
+int main(int argc, char* argv[]) {
+  Kokkos::initialize(argc, argv);
+  Kokkos::DefaultExecutionSpace().print_configuration(std::cout);
+
+  if (argc < 2) {
+    fprintf(stderr, "Usage: %s [<kokkos_options>] <size>\n", argv[0]);
+    Kokkos::finalize();
+    exit(1);
+  }
+
+  const long n = strtol(argv[1], nullptr, 10);
+
+  printf("Number of even integers from 0 to %ld\n", n - 1);
+
+  Kokkos::Timer timer;
+  timer.reset();
+
+  // Compute the number of even integers from 0 to n-1, in parallel.
+  long count = 0;
+  CountFunctor functor;
+  Kokkos::parallel_reduce(n, functor, count);
+
+  double count_time = timer.seconds();
+  printf("  Parallel: %ld    %10.6f\n", count, count_time);
+
+  timer.reset();
+
+  // Compare to a sequential loop.
+  long seq_count = 0;
+  for (long i = 0; i < n; ++i) {
+    seq_count += (i % 2) == 0;
+  }
+
+  count_time = timer.seconds();
+  printf("Sequential: %ld    %10.6f\n", seq_count, count_time);
+
+  print_fortran_();
+
+  Kokkos::finalize();
+
+  return (count == seq_count) ? 0 : -1;
+}

--- a/cmake_test/test_source/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency.h
@@ -1,0 +1,39 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_INTERFACE_DEPENDENCY_ON_LIB_WITH_INTERFACE_KOKKOS_DEPENDENCY
+#define LIB_WITH_INTERFACE_DEPENDENCY_ON_LIB_WITH_INTERFACE_KOKKOS_DEPENDENCY
+
+#include <lib_with_interface_kokkos_dependency.h>
+#include <iostream>
+
+namespace lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency {
+
+template <typename ViewType>
+void print(lib_with_interface_kokkos_dependency::
+               StructOfLibWithInterfaceKokkosDependency<ViewType>
+                   in) {
+  std::cout << "Hello from "
+               "lib_with_interface_dependency_on_lib_with_interface_kokkos_"
+               "dependency\n";
+  std::cout << "Will call lib_with_interface_kokkos_dependency now:\n";
+  lib_with_interface_kokkos_dependency::print(in.value);
+  std::cout << "Done\n";
+}
+
+}  // namespace
+   // lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency.h
@@ -1,0 +1,38 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_INTERFACE_DEPENDENCY_ON_LIB_WITH_PRIVATE_KOKKOS_DEPENDENCY
+#define LIB_WITH_INTERFACE_DEPENDENCY_ON_LIB_WITH_PRIVATE_KOKKOS_DEPENDENCY
+
+#include <lib_with_private_kokkos_dependency.h>
+#include <iostream>
+
+namespace lib_with_interface_dependency_on_lib_with_private_kokkos_dependency {
+
+void print(
+    lib_with_private_kokkos_dependency::StructOfLibWithPrivateKokkosDependency
+        in) {
+  std::cout << "Hello from "
+               "lib_with_interface_dependency_on_lib_with_private_kokkos_"
+               "dependency\n";
+  std::cout << "Will call lib_with_private_kokkos_dependency now:\n";
+  lib_with_private_kokkos_dependency::print(in);
+  std::cout << "Done\n";
+}
+
+}  // namespace
+   // lib_with_interface_dependency_on_lib_with_private_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency.h
@@ -1,0 +1,38 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_INTERFACE_DEPENDENCY_ON_LIB_WITH_PUBLIC_KOKKOS_DEPENDENCY
+#define LIB_WITH_INTERFACE_DEPENDENCY_ON_LIB_WITH_PUBLIC_KOKKOS_DEPENDENCY
+
+#include <lib_with_public_kokkos_dependency.h>
+#include <iostream>
+
+namespace lib_with_interface_dependency_on_lib_with_public_kokkos_dependency {
+
+void print(
+    lib_with_public_kokkos_dependency::StructOfLibWithPublicKokkosDependency
+        in) {
+  std::cout << "Hello from "
+               "lib_with_interface_dependency_on_lib_with_interface_kokkos_"
+               "dependency\n";
+  std::cout << "Will call lib_with_interface_kokkos_dependency now:\n";
+  lib_with_public_kokkos_dependency::print(in.value);
+  std::cout << "Done\n";
+}
+
+}  // namespace
+   // lib_with_interface_dependency_on_lib_with_public_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_interface_kokkos_dependency/cuda_hip_header_without_kokkos_dependency.cuh
+++ b/cmake_test/test_source/lib_with_interface_kokkos_dependency/cuda_hip_header_without_kokkos_dependency.cuh
@@ -1,0 +1,32 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef CUDA_HIP_HEADER_WITHOUT_KOKKOS_DEPENDENCY
+#define CUDA_HIP_HEADER_WITHOUT_KOKKOS_DEPENDENCY
+
+#include <stdio.h>
+#ifdef __HIPCC__
+#include <hip/hip_runtime.h>
+#endif
+
+namespace cuda_hip_header_without_kokkos_dependency {
+
+template <typename T>
+__global__ void print_from_device([[maybe_unused]] T value) { printf("Hello, from a cuda function!\n"); }
+
+}  // namespace cuda_hip_header_without_kokkos_dependency
+
+#endif

--- a/cmake_test/test_source/lib_with_interface_kokkos_dependency/lib_with_interface_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_interface_kokkos_dependency/lib_with_interface_kokkos_dependency.h
@@ -1,0 +1,47 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_INTERFACE_KOKKOS_DEPENDENCY
+#define LIB_WITH_INTERFACE_KOKKOS_DEPENDENCY
+
+#include <Kokkos_Core.hpp>
+#if defined __CUDACC__ || defined __HIPCC__
+#include <cuda_hip_header_without_kokkos_dependency.cuh>
+#endif
+
+#include <iostream>
+
+namespace lib_with_interface_kokkos_dependency {
+
+template <typename ViewType>
+void print([[maybe_unused]] ViewType a) {
+  static_assert(std::is_same_v<Kokkos::View<int*>, ViewType>,
+                "ViewType must match Kokkos::View<int*>");
+  std::cout << "Hello from lib_with_interface_kokkos_dependency \n";
+#if defined __CUDACC__ || defined __HIPCC__
+  std::cout << "Calling additional device function without kokkos dependency\n";
+  cuda_hip_header_without_kokkos_dependency::print_from_device<<<1, 1>>>(1.0);
+#endif
+}
+
+template <typename ViewType>
+struct StructOfLibWithInterfaceKokkosDependency {
+  ViewType value;
+};
+
+}  // namespace lib_with_interface_kokkos_dependency
+
+#endif

--- a/cmake_test/test_source/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency.h
@@ -1,0 +1,30 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_PRIVATE_DEPENDENCY_ON_LIB_WITH_INTERFACE_KOKKOS_DEPENDENCY
+#define LIB_WITH_PRIVATE_DEPENDENCY_ON_LIB_WITH_INTERFACE_KOKKOS_DEPENDENCY
+
+namespace lib_with_private_dependency_on_lib_with_interface_kokkos_dependency {
+
+void initialize();
+
+void finalize();
+
+void print();
+
+}  // namespace
+   // lib_with_private_dependency_on_lib_with_interface_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/source_with_private_dependency_on_lib_with_interface_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/source_with_private_dependency_on_lib_with_interface_kokkos_dependency.cpp
@@ -1,0 +1,48 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "lib_with_private_dependency_on_lib_with_interface_kokkos_dependency.h"
+#include <lib_with_interface_kokkos_dependency.h>
+#include <iostream>
+
+namespace lib_with_private_dependency_on_lib_with_interface_kokkos_dependency {
+
+static bool i_initialized_lib_with_interface_kokkos_dependency = false;
+
+void initialize() {
+  if (!Kokkos::is_initialized()) {
+    Kokkos::initialize();
+    i_initialized_lib_with_interface_kokkos_dependency = true;
+  }
+}
+
+void finalize() {
+  if (i_initialized_lib_with_interface_kokkos_dependency and
+      !Kokkos::is_finalized())
+    Kokkos::finalize();
+}
+
+void print() {
+  std::cout << "Hello from "
+               "lib_with_private_dependency_on_lib_with_interface_kokkos_"
+               "dependency\n";
+  std::cout << "Will call lib_with_interface_kokkos_dependency now:\n";
+  lib_with_interface_kokkos_dependency::print(Kokkos::View<int*>{"a", 10});
+  std::cout << "Done\n";
+}
+
+}  // namespace
+   // lib_with_private_dependency_on_lib_with_interface_kokkos_dependency

--- a/cmake_test/test_source/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/lib_with_private_dependency_on_lib_with_private_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/lib_with_private_dependency_on_lib_with_private_kokkos_dependency.h
@@ -1,0 +1,30 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_PRIVATE_DEPENDENCY_ON_LIB_WITH_PRIVATE_KOKKOS_DEPENDENCY
+#define LIB_WITH_PRIVATE_DEPENDENCY_ON_LIB_WITH_PRIVATE_KOKKOS_DEPENDENCY
+
+namespace lib_with_private_dependency_on_lib_with_private_kokkos_dependency {
+
+void initialize();
+
+void finalize();
+
+void print();
+
+}  // namespace
+   // lib_with_private_dependency_on_lib_with_private_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/source_with_private_dependency_on_lib_with_private_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/source_with_private_dependency_on_lib_with_private_kokkos_dependency.cpp
@@ -1,0 +1,50 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "lib_with_private_dependency_on_lib_with_private_kokkos_dependency.h"
+#include <lib_with_private_kokkos_dependency.h>
+#include <iostream>
+
+namespace lib_with_private_dependency_on_lib_with_private_kokkos_dependency {
+
+static bool i_initialized_lib_with_private_kokkos_dependency = false;
+
+void initialize() {
+  if (!lib_with_private_kokkos_dependency::is_initialized()) {
+    lib_with_private_kokkos_dependency::initialize();
+    i_initialized_lib_with_private_kokkos_dependency = true;
+  }
+}
+
+void finalize() {
+  if (i_initialized_lib_with_private_kokkos_dependency and
+      !lib_with_private_kokkos_dependency::is_finalized())
+    lib_with_private_kokkos_dependency::finalize();
+}
+
+void print() {
+  std::cout
+      << "Hello from "
+         "lib_with_private_dependency_on_lib_with_private_kokkos_dependency\n";
+  std::cout << "Will call lib_with_private_kokkos_dependency now:\n";
+  lib_with_private_kokkos_dependency::print(
+      lib_with_private_kokkos_dependency::
+          StructOfLibWithPrivateKokkosDependency{});
+  std::cout << "Done\n";
+}
+
+}  // namespace
+   // lib_with_private_dependency_on_lib_with_private_kokkos_dependency

--- a/cmake_test/test_source/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/lib_with_private_dependency_on_lib_with_public_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/lib_with_private_dependency_on_lib_with_public_kokkos_dependency.h
@@ -1,0 +1,29 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_PRIVATE_DEPENDENCY_ON_LIB_WITH_PUBLIC_KOKKOS_DEPENDENCY
+#define LIB_WITH_PRIVATE_DEPENDENCY_ON_LIB_WITH_PUBLIC_KOKKOS_DEPENDENCY
+
+namespace lib_with_private_dependency_on_lib_with_public_kokkos_dependency {
+
+void initialize();
+
+void finalize();
+
+void print();
+
+}  // namespace lib_with_private_dependency_on_lib_with_public_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/source_with_private_dependency_on_lib_with_public_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/source_with_private_dependency_on_lib_with_public_kokkos_dependency.cpp
@@ -1,0 +1,47 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "lib_with_private_dependency_on_lib_with_public_kokkos_dependency.h"
+#include <lib_with_public_kokkos_dependency.h>
+#include <iostream>
+
+namespace lib_with_private_dependency_on_lib_with_public_kokkos_dependency {
+
+static bool i_initialized_lib_with_public_kokkos_dependency = false;
+
+void initialize() {
+  if (!Kokkos::is_initialized()) {
+    Kokkos::initialize();
+    i_initialized_lib_with_public_kokkos_dependency = true;
+  }
+}
+
+void finalize() {
+  if (i_initialized_lib_with_public_kokkos_dependency and
+      !Kokkos::is_finalized())
+    Kokkos::finalize();
+}
+
+void print() {
+  std::cout
+      << "Hello from "
+         "lib_with_private_dependency_on_lib_with_public_kokkos_dependency\n";
+  std::cout << "Will call lib_with_public_kokkos_dependency now:\n";
+  lib_with_public_kokkos_dependency::print(Kokkos::View<int*>{"a", 10});
+  std::cout << "Done\n";
+}
+
+}  // namespace lib_with_private_dependency_on_lib_with_public_kokkos_dependency

--- a/cmake_test/test_source/lib_with_private_kokkos_dependency/cuda_hip_source_without_kokkos_dependency.cu
+++ b/cmake_test/test_source/lib_with_private_kokkos_dependency/cuda_hip_source_without_kokkos_dependency.cu
@@ -1,0 +1,26 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <cstdio>
+#ifdef __HIPCC__
+#include <hip/hip_runtime.h>
+#endif
+
+namespace cuda_hip_functions_without_kokkos_dependency {
+
+__global__ void print_from_device() { printf("Hello, from a cuda function!\n"); }
+
+}  // namespace cuda_hip_functions_without_kokkos_dependency

--- a/cmake_test/test_source/lib_with_private_kokkos_dependency/header_with_private_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_private_kokkos_dependency/header_with_private_kokkos_dependency.h
@@ -1,0 +1,33 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef HEADER_WITH_PRIVATE_KOKKOS_DEPENDENCY
+#define HEADER_WITH_PRIVATE_KOKKOS_DEPENDENCY
+
+namespace lib_with_private_kokkos_dependency {
+
+bool is_initialized();
+
+bool is_finalized();
+
+void initialize();
+
+void finalize();
+
+void print_kokkos();
+
+}  // namespace lib_with_private_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_private_kokkos_dependency/header_without_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_private_kokkos_dependency/header_without_kokkos_dependency.h
@@ -1,0 +1,27 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef HEADER_WITHOUT_KOKKOS_DEPENDENCY
+#define HEADER_WITHOUT_KOKKOS_DEPENDENCY
+
+namespace lib_with_private_kokkos_dependency {
+
+void print_non_kokkos();
+
+struct StructOfLibWithPrivateKokkosDependency {};
+
+}  // namespace lib_with_private_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_private_kokkos_dependency/lib_with_private_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_private_kokkos_dependency/lib_with_private_kokkos_dependency.h
@@ -1,0 +1,28 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_PRIVATE_KOKKOS_DEPENDENCY
+#define LIB_WITH_PRIVATE_KOKKOS_DEPENDENCY
+
+#include "header_with_private_kokkos_dependency.h"
+#include "header_without_kokkos_dependency.h"
+
+namespace lib_with_private_kokkos_dependency {
+
+void print([[maybe_unused]] StructOfLibWithPrivateKokkosDependency in);
+
+}  // namespace lib_with_private_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_private_kokkos_dependency/source_merging_prints.cpp
+++ b/cmake_test/test_source/lib_with_private_kokkos_dependency/source_merging_prints.cpp
@@ -1,0 +1,26 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "lib_with_private_kokkos_dependency.h"
+
+namespace lib_with_private_kokkos_dependency {
+
+void print([[maybe_unused]] StructOfLibWithPrivateKokkosDependency in) {
+  print_non_kokkos();
+  print_kokkos();
+}
+
+}  // namespace lib_with_private_kokkos_dependency

--- a/cmake_test/test_source/lib_with_private_kokkos_dependency/source_with_public_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_private_kokkos_dependency/source_with_public_kokkos_dependency.cpp
@@ -1,0 +1,48 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "header_with_private_kokkos_dependency.h"
+#include <Kokkos_Core.hpp>
+#include <iostream>
+
+namespace lib_with_private_kokkos_dependency {
+
+static bool i_initialized_kokkos = false;
+
+bool is_initialized() { return Kokkos::is_initialized(); }
+bool is_finalized() { return Kokkos::is_finalized(); }
+
+void initialize() {
+  // if I have to initialize kokkos, I assume I also have to finalize after I
+  // did what I needed Kokkos for
+  if (!Kokkos::is_initialized()) {
+    Kokkos::initialize();
+    i_initialized_kokkos = true;
+  }
+}
+
+void finalize() {
+  if (i_initialized_kokkos and !Kokkos::is_finalized()) {
+    Kokkos::finalize();
+  }
+}
+
+void print_kokkos() {
+  std::cout << "Hello from a kokkos function within "
+               "lib_with_private_kokkos_dependency\n";
+  Kokkos::print_configuration(std::cout);
+}
+}  // namespace lib_with_private_kokkos_dependency

--- a/cmake_test/test_source/lib_with_private_kokkos_dependency/source_without_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_private_kokkos_dependency/source_without_kokkos_dependency.cpp
@@ -1,0 +1,40 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "header_without_kokkos_dependency.h"
+#ifdef __HIPCC__
+#include <hip/hip_runtime.h>
+#endif
+#include <iostream>
+
+#if defined __CUDACC__ || defined __HIPCC__
+namespace cuda_hip_functions_without_kokkos_dependency {
+__global__ void print_from_device();
+}
+#endif
+
+namespace lib_with_private_kokkos_dependency {
+
+void print_non_kokkos() {
+  std::cout << "Hello from non-kokkos function inside "
+               "lib_with_private_kokkos_dependency\n";
+#if defined __CUDACC__ || defined __HIPCC__
+  std::cout << "Calling additional device function without kokkos dependency\n";
+  cuda_hip_functions_without_kokkos_dependency::print_from_device<<<1, 1>>>();
+#endif
+}
+
+}  // namespace lib_with_private_kokkos_dependency

--- a/cmake_test/test_source/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency.h
@@ -1,0 +1,30 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_PUBLIC_DEPENDENCY_ON_LIB_WITH_INTERFACE_KOKKOS_DEPENDENCY
+#define LIB_WITH_PUBLIC_DEPENDENCY_ON_LIB_WITH_INTERFACE_KOKKOS_DEPENDENCY
+
+#include <lib_with_interface_kokkos_dependency.h>
+
+namespace lib_with_public_dependency_on_lib_with_interface_kokkos_dependency {
+
+void print(lib_with_interface_kokkos_dependency::
+               StructOfLibWithInterfaceKokkosDependency<Kokkos::View<int*>>
+                   in);
+
+}  // namespace
+   // lib_with_public_dependency_on_lib_with_interface_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/source_with_public_dependency_on_lib_with_interface_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/source_with_public_dependency_on_lib_with_interface_kokkos_dependency.cpp
@@ -1,0 +1,34 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "lib_with_public_dependency_on_lib_with_interface_kokkos_dependency.h"
+#include <iostream>
+
+namespace lib_with_public_dependency_on_lib_with_interface_kokkos_dependency {
+
+void print(lib_with_interface_kokkos_dependency::
+               StructOfLibWithInterfaceKokkosDependency<Kokkos::View<int*>>
+                   in) {
+  std::cout
+      << "Hello from "
+         "lib_with_public_dependency_on_lib_with_interface_kokkos_dependency\n";
+  std::cout << "Will call lib_with_interface_kokkos_dependency now:\n";
+  lib_with_interface_kokkos_dependency::print(in.value);
+  std::cout << "Done\n";
+}
+
+}  // namespace
+   // lib_with_public_dependency_on_lib_with_interface_kokkos_dependency

--- a/cmake_test/test_source/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/lib_with_public_dependency_on_lib_with_private_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/lib_with_public_dependency_on_lib_with_private_kokkos_dependency.h
@@ -1,0 +1,32 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_PUBLIC_DEPENDENCY_ON_LIB_WITH_PRIVATE_KOKKOS_DEPENDENCY
+#define LIB_WITH_PUBLIC_DEPENDENCY_ON_LIB_WITH_PRIVATE_KOKKOS_DEPENDENCY
+
+#include <lib_with_private_kokkos_dependency.h>
+
+namespace lib_with_public_dependency_on_lib_with_private_kokkos_dependency {
+
+void initialize();
+
+void finalize();
+
+void print(
+    lib_with_private_kokkos_dependency::StructOfLibWithPrivateKokkosDependency);
+
+}  // namespace lib_with_public_dependency_on_lib_with_private_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/source_with_public_dependency_on_lib_with_private_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/source_with_public_dependency_on_lib_with_private_kokkos_dependency.cpp
@@ -1,0 +1,48 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "lib_with_public_dependency_on_lib_with_private_kokkos_dependency.h"
+#include <iostream>
+
+namespace lib_with_public_dependency_on_lib_with_private_kokkos_dependency {
+
+static bool i_initialized_lib_with_private_kokkos_dependency = false;
+
+void initialize() {
+  if (!lib_with_private_kokkos_dependency::is_initialized()) {
+    lib_with_private_kokkos_dependency::initialize();
+    i_initialized_lib_with_private_kokkos_dependency = true;
+  }
+}
+
+void finalize() {
+  if (i_initialized_lib_with_private_kokkos_dependency and
+      !lib_with_private_kokkos_dependency::is_finalized())
+    lib_with_private_kokkos_dependency::finalize();
+}
+
+void print(
+    lib_with_private_kokkos_dependency::StructOfLibWithPrivateKokkosDependency
+        in) {
+  std::cout
+      << "Hello from "
+         "lib_with_public_dependency_on_lib_with_private_kokkos_dependency\n";
+  std::cout << "Will call lib_with_private_kokkos_dependency now:\n";
+  lib_with_private_kokkos_dependency::print(in);
+  std::cout << "Done\n";
+}
+
+}  // namespace lib_with_public_dependency_on_lib_with_private_kokkos_dependency

--- a/cmake_test/test_source/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/lib_with_public_dependency_on_lib_with_public_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/lib_with_public_dependency_on_lib_with_public_kokkos_dependency.h
@@ -1,0 +1,29 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_PUBLIC_DEPENDENCY_ON_LIB_WITH_PUBLIC_KOKKOS_DEPENDENCY
+#define LIB_WITH_PUBLIC_DEPENDENCY_ON_LIB_WITH_PUBLIC_KOKKOS_DEPENDENCY
+
+#include <lib_with_public_kokkos_dependency.h>
+
+namespace lib_with_public_dependency_on_lib_with_public_kokkos_dependency {
+
+void print(
+    lib_with_public_kokkos_dependency::StructOfLibWithPublicKokkosDependency
+        in);
+
+}  // namespace lib_with_public_dependency_on_lib_with_public_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/source_with_public_dependency_on_lib_with_public_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/source_with_public_dependency_on_lib_with_public_kokkos_dependency.cpp
@@ -1,0 +1,33 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "lib_with_public_dependency_on_lib_with_public_kokkos_dependency.h"
+#include <iostream>
+
+namespace lib_with_public_dependency_on_lib_with_public_kokkos_dependency {
+
+void print(
+    lib_with_public_kokkos_dependency::StructOfLibWithPublicKokkosDependency
+        in) {
+  std::cout
+      << "Hello from "
+         "lib_with_public_dependency_on_lib_with_public_kokkos_dependency\n";
+  std::cout << "Will call lib_with_public_kokkos_dependency now:\n";
+  lib_with_public_kokkos_dependency::print(in.value);
+  std::cout << "Done\n";
+}
+
+}  // namespace lib_with_public_dependency_on_lib_with_public_kokkos_dependency

--- a/cmake_test/test_source/lib_with_public_kokkos_dependency/cuda_hip_source_without_kokkos_dependency.cu
+++ b/cmake_test/test_source/lib_with_public_kokkos_dependency/cuda_hip_source_without_kokkos_dependency.cu
@@ -1,0 +1,26 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <cstdio>
+#ifdef __HIPCC__
+#include <hip/hip_runtime.h>
+#endif
+
+namespace cuda_hip_functions_without_kokkos_dependency {
+
+__global__ void print_from_device() { printf("Hello, from a cuda function!\n"); }
+
+}  // namespace cuda_hip_functions_without_kokkos_dependency

--- a/cmake_test/test_source/lib_with_public_kokkos_dependency/lib_with_public_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_public_kokkos_dependency/lib_with_public_kokkos_dependency.h
@@ -1,0 +1,32 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_PUBLIC_KOKKOS_DEPENDENCY
+#define LIB_WITH_PUBLIC_KOKKOS_DEPENDENCY
+
+#include <Kokkos_Core.hpp>
+
+namespace lib_with_public_kokkos_dependency {
+
+void print(Kokkos::View<int*> a);
+
+struct StructOfLibWithPublicKokkosDependency {
+  Kokkos::View<int*> value;
+};
+
+}  // namespace lib_with_public_kokkos_dependency
+
+#endif

--- a/cmake_test/test_source/lib_with_public_kokkos_dependency/source_with_public_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_public_kokkos_dependency/source_with_public_kokkos_dependency.cpp
@@ -1,0 +1,39 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "lib_with_public_kokkos_dependency.h"
+#ifdef __HIPCC__
+#include <hip/hip_runtime.h>
+#endif
+#include <iostream>
+
+#if defined __CUDACC__ || defined __HIPCC__
+namespace cuda_hip_functions_without_kokkos_dependency {
+__global__ void print_from_device();
+}
+#endif
+
+namespace lib_with_public_kokkos_dependency {
+
+void print([[maybe_unused]] Kokkos::View<int*> a) {
+  std::cout << "Hello from lib_with_public_kokkos_dependency \n";
+#if defined __CUDACC__ || defined __HIPCC__
+  std::cout << "Calling additional device function without kokkos dependency\n";
+  cuda_hip_functions_without_kokkos_dependency::print_from_device<<<1, 1>>>();
+#endif
+}
+
+}  // namespace lib_with_public_kokkos_dependency

--- a/cmake_test/test_source/lib_without_kokkos_dependency/lib_without_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_without_kokkos_dependency/lib_without_kokkos_dependency.h
@@ -1,0 +1,25 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITHOUT_KOKKOS_DEPENDENCY
+#define LIB_WITHOUT_KOKKOS_DEPENDENCY
+
+namespace lib_without_kokkos_dependency {
+
+void print();
+
+}
+#endif

--- a/cmake_test/test_source/lib_without_kokkos_dependency/source_without_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_without_kokkos_dependency/source_without_kokkos_dependency.cpp
@@ -1,0 +1,23 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <iostream>
+
+namespace lib_without_kokkos_dependency {
+
+void print() { std::cout << "Hello from lib_without_kokkos_dependency\n"; }
+
+}  // namespace lib_without_kokkos_dependency

--- a/cmake_test/test_source/source_plain_cxx.cpp
+++ b/cmake_test/test_source/source_plain_cxx.cpp
@@ -1,0 +1,19 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <iostream>
+
+void print_plain_cxx() { std::cout << "Hello From C++\n"; }

--- a/cmake_test/test_source/source_plain_fortran.f
+++ b/cmake_test/test_source/source_plain_fortran.f
@@ -1,0 +1,4 @@
+        FUNCTION print_fortran()
+          PRINT *, 'Hello World from Fortran'
+          RETURN
+        END

--- a/cmake_test/test_source/test_interface.cpp
+++ b/cmake_test/test_source/test_interface.cpp
@@ -1,0 +1,36 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_interface_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) {
+  lib_without_kokkos_dependency::print();
+  Kokkos::initialize(argc, argv);
+  {
+    print_fortran_();
+    print_plain_cxx();
+    lib_with_interface_kokkos_dependency::print(
+        Kokkos::View<int*>{"testview", 10});
+  }
+  Kokkos::finalize();
+}

--- a/cmake_test/test_source/test_interface_interface.cpp
+++ b/cmake_test/test_source/test_interface_interface.cpp
@@ -1,0 +1,38 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) {
+  lib_without_kokkos_dependency::print();
+  Kokkos::initialize(argc, argv);
+  {
+    print_fortran_();
+    print_plain_cxx();
+    lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency::
+        print(
+            lib_with_interface_kokkos_dependency::
+                StructOfLibWithInterfaceKokkosDependency<Kokkos::View<int*>>{});
+  }
+  Kokkos::finalize();
+}

--- a/cmake_test/test_source/test_interface_private.cpp
+++ b/cmake_test/test_source/test_interface_private.cpp
@@ -1,0 +1,37 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_interface_dependency_on_lib_with_private_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) {
+  lib_without_kokkos_dependency::print();
+  lib_with_private_kokkos_dependency::initialize();
+  {
+    print_fortran_();
+    print_plain_cxx();
+    lib_with_interface_dependency_on_lib_with_private_kokkos_dependency::print(
+        lib_with_private_kokkos_dependency::
+            StructOfLibWithPrivateKokkosDependency{});
+  }
+  lib_with_private_kokkos_dependency::finalize();
+}

--- a/cmake_test/test_source/test_interface_public.cpp
+++ b/cmake_test/test_source/test_interface_public.cpp
@@ -1,0 +1,37 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_interface_dependency_on_lib_with_public_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) {
+  lib_without_kokkos_dependency::print();
+  Kokkos::initialize(argc, argv);
+  {
+    print_fortran_();
+    print_plain_cxx();
+    lib_with_interface_dependency_on_lib_with_public_kokkos_dependency::print(
+        lib_with_public_kokkos_dependency::
+            StructOfLibWithPublicKokkosDependency{});
+  }
+  Kokkos::finalize();
+}

--- a/cmake_test/test_source/test_private.cpp
+++ b/cmake_test/test_source/test_private.cpp
@@ -1,0 +1,39 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_private_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main() {
+  lib_without_kokkos_dependency::print();
+
+  lib_with_private_kokkos_dependency::initialize();
+  {
+    lib_with_private_kokkos_dependency::print(
+        lib_with_private_kokkos_dependency::
+            StructOfLibWithPrivateKokkosDependency{});
+  }
+  lib_with_private_kokkos_dependency::finalize();
+
+  print_fortran_();
+  print_plain_cxx();
+}

--- a/cmake_test/test_source/test_private_interface.cpp
+++ b/cmake_test/test_source/test_private_interface.cpp
@@ -1,0 +1,40 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_private_dependency_on_lib_with_interface_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main() {
+  lib_without_kokkos_dependency::print();
+
+  lib_with_private_dependency_on_lib_with_interface_kokkos_dependency::
+      initialize();
+  {
+    lib_with_private_dependency_on_lib_with_interface_kokkos_dependency::
+        print();
+  }
+  lib_with_private_dependency_on_lib_with_interface_kokkos_dependency::
+      finalize();
+
+  print_fortran_();
+  print_plain_cxx();
+}

--- a/cmake_test/test_source/test_private_private.cpp
+++ b/cmake_test/test_source/test_private_private.cpp
@@ -1,0 +1,38 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_private_dependency_on_lib_with_private_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main() {
+  lib_without_kokkos_dependency::print();
+
+  lib_with_private_dependency_on_lib_with_private_kokkos_dependency::
+      initialize();
+  {
+    lib_with_private_dependency_on_lib_with_private_kokkos_dependency::print();
+  }
+  lib_with_private_dependency_on_lib_with_private_kokkos_dependency::finalize();
+
+  print_fortran_();
+  print_plain_cxx();
+}

--- a/cmake_test/test_source/test_private_public.cpp
+++ b/cmake_test/test_source/test_private_public.cpp
@@ -1,0 +1,36 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_private_dependency_on_lib_with_public_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main() {
+  lib_without_kokkos_dependency::print();
+
+  lib_with_private_dependency_on_lib_with_public_kokkos_dependency::
+      initialize();
+  { lib_with_private_dependency_on_lib_with_public_kokkos_dependency::print(); }
+  lib_with_private_dependency_on_lib_with_public_kokkos_dependency::finalize();
+
+  print_fortran_();
+  print_plain_cxx();
+}

--- a/cmake_test/test_source/test_public.cpp
+++ b/cmake_test/test_source/test_public.cpp
@@ -1,0 +1,36 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_with_public_kokkos_dependency.h>
+
+#include <Kokkos_Core.hpp>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) {
+  Kokkos::initialize(argc, argv);
+  {
+    print_fortran_();
+    print_plain_cxx();
+    lib_with_public_kokkos_dependency::print(
+        Kokkos::View<int*>{"testview", 10});
+  }
+  Kokkos::finalize();
+}

--- a/cmake_test/test_source/test_public_interface.cpp
+++ b/cmake_test/test_source/test_public_interface.cpp
@@ -1,0 +1,37 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_public_dependency_on_lib_with_interface_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) {
+  lib_without_kokkos_dependency::print();
+  Kokkos::initialize(argc, argv);
+  {
+    print_fortran_();
+    print_plain_cxx();
+    lib_with_public_dependency_on_lib_with_interface_kokkos_dependency::print(
+        lib_with_interface_kokkos_dependency::
+            StructOfLibWithInterfaceKokkosDependency<Kokkos::View<int*>>{});
+  }
+  Kokkos::finalize();
+}

--- a/cmake_test/test_source/test_public_private.cpp
+++ b/cmake_test/test_source/test_public_private.cpp
@@ -1,0 +1,37 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_public_dependency_on_lib_with_private_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) {
+  lib_without_kokkos_dependency::print();
+  lib_with_private_kokkos_dependency::initialize();
+  {
+    print_fortran_();
+    print_plain_cxx();
+    lib_with_public_dependency_on_lib_with_private_kokkos_dependency::print(
+        lib_with_private_kokkos_dependency::
+            StructOfLibWithPrivateKokkosDependency{});
+  }
+  lib_with_private_kokkos_dependency::finalize();
+}

--- a/cmake_test/test_source/test_public_public.cpp
+++ b/cmake_test/test_source/test_public_public.cpp
@@ -1,0 +1,37 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_public_dependency_on_lib_with_public_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) {
+  lib_without_kokkos_dependency::print();
+  Kokkos::initialize(argc, argv);
+  {
+    print_fortran_();
+    print_plain_cxx();
+    lib_with_public_dependency_on_lib_with_public_kokkos_dependency::print(
+        lib_with_public_kokkos_dependency::
+            StructOfLibWithPublicKokkosDependency{});
+  }
+  Kokkos::finalize();
+}

--- a/cmake_test/test_source/test_without.cpp
+++ b/cmake_test/test_source/test_without.cpp
@@ -1,0 +1,25 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) { lib_without_kokkos_dependency::print(); }


### PR DESCRIPTION
We do not have testing if what we export when Kokkos is installed allows building downstream projects correctly.
Since downstream Kokkos can be required deep in a library dependency hierarchy, we need to test if our compiler and linker settings correctly propagate to the end application that gets compiled.

To test this, this PR adds a new directory `cmake_test` that gets built against an installed Kokkos by the CI. In order to test independently of the dependency hierarchy, we test for the levels 0 (executable depends directly on Kokkos), 1 (executable depends on library that depends on Kokkos), and 2 (executable depends on library that depends on library that depends on Kokkos). Level 0 is a special case for linking static libraries into an executable (the runtime gets linked in the executable linking step). But level 1 and 2 can be seen as a mathematical induction, showing that the test is valid for Kokkos setting the properties recursively, as e.g. in https://github.com/kokkos/kokkos/pull/7582. As for now Kokkos sets the properties globally, which is also covered by this test, thus this pr is orthogonal to #7582 