### PR TITLE
Cmake use `kokkos_launch_compiler` only for kokkos targets

### DIFF
--- a/.github/workflows/continuous-integration-linux.yml
+++ b/.github/workflows/continuous-integration-linux.yml
@@ -178,7 +178,7 @@ jobs:
         run: sudo cmake --build builddir --target install
       - name: Test install
         if: ${{ !contains(matrix.cxx_extra_flags, '-fsanitize=address') && matrix.arch != 'x86' }}
-        working-directory: example/build_cmake_installed
+        working-directory: cmake_test
         run: |
           cmake -B builddir -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
           cmake --build builddir

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -95,8 +95,17 @@ pipeline {
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_BENCHMARKS=ON \
                                 -DKokkos_ENABLE_HIP=ON \
+                                -DCMAKE_INSTALL_PREFIX=${PWD}/../install \
                               .. && \
-                              make -j16 && ctest --no-compress-output -T Test --verbose'''
+                              make -j16 && ctest --no-compress-output -T Test --verbose && \
+                              make install && \
+                              export CMAKE_PREFIX_PATH=${PWD}/../install && \
+                              cd ../cmake_test && \
+                              rm -rf build && mkdir -p build && cd build && \
+                              cmake -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_COMPILER=hipcc .. && make -j8 && ctest --verbose && \
+                              cd ../../../examples/build_in_tree && \
+                              rm -rf build && mkdir -p build && cd build && \
+                              cmake -DCMAKE_CXX_STANDARD=20 .. && make -j8 && ctest --verbose'''
                     }
                     post {
                         always {
@@ -158,18 +167,14 @@ pipeline {
                                 -DKokkos_INSTALL_TESTING=ON \
                               .. && \
                               make -j8 && ctest --no-compress-output -T Test --verbose && \
-                              cd ../example/build_cmake_installed && \
+                              cd ../cmake_test && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_CXX_COMPILER=g++-8 \
                                 -DCMAKE_CXX_FLAGS=-Werror \
                                 -DCMAKE_CXX_STANDARD=17 \
                               .. && \
-                              make -j8 && ctest --verbose && \
-                              cd ../.. && \
-                              cmake -B build_cmake_installed_different_compiler/build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-Werror -DCMAKE_CXX_STANDARD=17 build_cmake_installed_different_compiler && \
-                              cmake --build build_cmake_installed_different_compiler/build --target all && \
-                              cmake --build build_cmake_installed_different_compiler/build --target test'''
+                              make -j8 && ctest --verbose '''
                     }
                     post {
                         always {
@@ -570,9 +575,15 @@ pipeline {
                                 -DKokkos_ENABLE_OPENMP=ON \
                                 -DKokkos_ENABLE_IMPL_MDSPAN=OFF \
                                 -DKokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=ON \
+                                -DCMAKE_INSTALL_PREFIX=${PWD}/../install \
                               .. && \
                               make -j8 && ctest --no-compress-output -T Test --verbose && \
-                              cd ../example/build_cmake_in_tree && \
+                              make install && \
+                              export CMAKE_PREFIX_PATH=${PWD}/../install && \
+                              cd ../cmake_test && \
+                              rm -rf build && mkdir -p build && cd build && \
+                              cmake -DCMAKE_CXX_STANDARD=17 .. &&  make -j8 && ctest --verbose && \
+                              cd ../../../examples/build_in_tree && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake -DCMAKE_CXX_STANDARD=17 .. && make -j8 && ctest --verbose'''
                     }

--- a/cmake/KokkosConfig.cmake.in
+++ b/cmake/KokkosConfig.cmake.in
@@ -29,44 +29,38 @@ if("launch_compiler" IN_LIST Kokkos_FIND_COMPONENTS AND "separable_compilation" 
   message(FATAL_ERROR "Conflicting COMPONENTS: 'launch_compiler' and 'separable_compilation'")
 endif()
 
-if("launch_compiler" IN_LIST Kokkos_FIND_COMPONENTS)
-  #
-  # if find_package(Kokkos COMPONENTS launch_compiler) then rely on the
-  # RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK to always redirect to the
-  # appropriate compiler for Kokkos
-  #
-
-  message(
-    STATUS
-      "kokkos_launch_compiler is enabled globally. C++ compiler commands with -DKOKKOS_DEPENDENCE will be redirected to the appropriate compiler for Kokkos"
-  )
-  kokkos_compilation(GLOBAL CHECK_CUDA_COMPILES)
-
-elseif(@Kokkos_ENABLE_CUDA@ AND NOT @KOKKOS_COMPILE_LANGUAGE@ STREQUAL CUDA AND NOT "separable_compilation" IN_LIST
-                                                                                Kokkos_FIND_COMPONENTS
-)
-  #
-  # if CUDA was enabled, the compilation language was not set to CUDA, and separable compilation was not
-  # specified, then set the RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK globally and
-  # kokkos_launch_compiler will re-direct to the compiler used to compile CUDA code during installation.
-  # kokkos_launch_compiler will re-direct if ${CMAKE_CXX_COMPILER} and -DKOKKOS_DEPENDENCE is present,
-  # otherwise, the original command will be executed
-  #
-
-  # run test to see if CMAKE_CXX_COMPILER=nvcc_wrapper
-  kokkos_compiler_is_nvcc(IS_NVCC ${CMAKE_CXX_COMPILER})
-
-  # if not nvcc_wrapper and Kokkos_LAUNCH_COMPILER was not set to OFF
-  if(NOT IS_NVCC AND (NOT DEFINED Kokkos_LAUNCH_COMPILER OR Kokkos_LAUNCH_COMPILER))
-    message(
-      STATUS
-        "kokkos_launch_compiler is enabled globally. C++ compiler commands with -DKOKKOS_DEPENDENCE will be redirected to the appropriate compiler for Kokkos"
+if(NOT @Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE)
+  if(NOT KOKKOS_CXX_COMPILER_IS_COMPATIBLE)
+    #we compile a small test program using kokkos to check if the flags and ABI the CXX compiler uses is compatible with the library
+    kokkos_cxx_compiler_is_compatible(RESULT KOKKOS_COMPILER_IS_COMPATIBLE)
+    set(KOKKOS_CXX_COMPILER_IS_COMPATIBLE ${KOKKOS_COMPILER_IS_COMPATIBLE}
+        CACHE STRING "CMAKE_CXX_COMPILER can compile Kokkos code"
     )
-    kokkos_compilation(GLOBAL)
-  endif()
 
-  # be mindful of the environment, pollution is bad
-  unset(IS_NVCC)
+    if((@KOKKOS_ENABLE_CUDA@ AND NOT KOKKOS_CXX_COMPILER_IS_COMPATIBLE) OR "launch_compiler" IN_LIST
+                                                                           Kokkos_FIND_COMPONENTS
+    )
+      #
+      # if find_package(Kokkos COMPONENTS launch_compiler) then rely on the
+      # RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK to always redirect to the
+      # appropriate compiler for Kokkos
+      #
+
+      message(
+        STATUS
+          "kokkos_launch_compiler is enabled globally. C++ compiler commands with -DKOKKOS_DEPENDENCE will be redirected to the appropriate compiler for Kokkos"
+      )
+      kokkos_compilation(GLOBAL)
+
+    else()
+      if(NOT KOKKOS_CXX_COMPILER_IS_COMPATIBLE)
+        message(
+          WARNING
+            "Kokkos can not compile a simple test program with the given CXX compiler ${CMAKE_CXX_COMPILER}. This might be due to incompatible flags or ABI."
+        )
+      endif()
+    endif()
+  endif()
 endif()
 
 set(Kokkos_COMPILE_LANGUAGE @KOKKOS_COMPILE_LANGUAGE@)

--- a/cmake/KokkosConfig.cmake.in
+++ b/cmake/KokkosConfig.cmake.in
@@ -1,3 +1,9 @@
+if(@Kokkos_ENABLE_DEPRECATED_BUILD_STRATEGY@)
+  cmake_minimum_required(VERSION 3.16)
+else()
+  cmake_minimum_required(VERSION 3.21)
+endif()
+
 # No need for policy push/pop. CMake also manages a new entry for scripts
 # loaded by include() and find_package() commands except when invoked with
 # the NO_POLICY_SCOPE option
@@ -17,16 +23,21 @@ include(CMakeFindDependencyMacro)
 get_filename_component(Kokkos_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 include("${Kokkos_CMAKE_DIR}/KokkosTargets.cmake")
 include("${Kokkos_CMAKE_DIR}/KokkosConfigCommon.cmake")
+set(Kokkos_FOUND_INSTALL_DIR ${Kokkos_CMAKE_DIR}/../../..)
 unset(Kokkos_CMAKE_DIR)
 
-# check for conflicts
-if("launch_compiler" IN_LIST Kokkos_FIND_COMPONENTS AND "separable_compilation" IN_LIST Kokkos_FIND_COMPONENTS)
-  message(STATUS "'launch_compiler' implies global redirection of targets depending on Kokkos to appropriate compiler.")
-  message(
-    STATUS
-      "'separable_compilation' implies explicitly defining where redirection occurs via 'kokkos_compilation(PROJECT|TARGET|SOURCE|DIRECTORY ...)'"
-  )
-  message(FATAL_ERROR "Conflicting COMPONENTS: 'launch_compiler' and 'separable_compilation'")
+if(@Kokkos_ENABLE_DEPRECATED_BUILD_STRATEGY@)
+  # check for conflicts
+  if("launch_compiler" IN_LIST Kokkos_FIND_COMPONENTS AND "separable_compilation" IN_LIST Kokkos_FIND_COMPONENTS)
+    message(
+      STATUS "'launch_compiler' implies global redirection of targets depending on Kokkos to appropriate compiler."
+    )
+    message(
+      STATUS
+        "'separable_compilation' implies explicitly defining where redirection occurs via 'kokkos_compilation(PROJECT|TARGET|SOURCE|DIRECTORY ...)'"
+    )
+    message(FATAL_ERROR "Conflicting COMPONENTS: 'launch_compiler' and 'separable_compilation'")
+  endif()
 endif()
 
 if(NOT @Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE)
@@ -37,26 +48,65 @@ if(NOT @Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE)
         CACHE STRING "CMAKE_CXX_COMPILER can compile Kokkos code"
     )
 
-    if((@KOKKOS_ENABLE_CUDA@ AND NOT KOKKOS_CXX_COMPILER_IS_COMPATIBLE) OR "launch_compiler" IN_LIST
-                                                                           Kokkos_FIND_COMPONENTS
-    )
-      #
-      # if find_package(Kokkos COMPONENTS launch_compiler) then rely on the
-      # RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK to always redirect to the
-      # appropriate compiler for Kokkos
-      #
-
-      message(
-        STATUS
-          "kokkos_launch_compiler is enabled globally. C++ compiler commands with -DKOKKOS_DEPENDENCE will be redirected to the appropriate compiler for Kokkos"
+    if(@Kokkos_ENABLE_DEPRECATED_BUILD_STRATEGY@)
+      if((@KOKKOS_ENABLE_CUDA@ AND NOT KOKKOS_CXX_COMPILER_IS_COMPATIBLE) OR "launch_compiler" IN_LIST
+                                                                             Kokkos_FIND_COMPONENTS
       )
-      kokkos_compilation(GLOBAL)
+        #
+        # if find_package(Kokkos COMPONENTS launch_compiler) then rely on the
+        # RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK to always redirect to the
+        # appropriate compiler for Kokkos
+        #
 
-    else()
-      if(NOT KOKKOS_CXX_COMPILER_IS_COMPATIBLE)
         message(
-          WARNING
-            "Kokkos can not compile a simple test program with the given CXX compiler ${CMAKE_CXX_COMPILER}. This might be due to incompatible flags or ABI."
+          STATUS
+            "kokkos_launch_compiler is enabled globally. C++ compiler commands with -DKOKKOS_DEPENDENCE will be redirected to the appropriate compiler for Kokkos"
+        )
+        kokkos_compilation(GLOBAL)
+
+      else()
+        if(NOT KOKKOS_CXX_COMPILER_IS_COMPATIBLE)
+          message(
+            WARNING
+              "Kokkos can not compile a simple test program with the given CXX compiler ${CMAKE_CXX_COMPILER}. This might be due to incompatible flags or ABI."
+          )
+        endif()
+      endif()
+      #new build strategy
+    else()
+      #To run the following block only once even if Kokkos is found in different subscopes, we guard it by a cache variable.
+      #Cache vars defined by find_package getting here are already in a valid state thus we can not use them here.
+      #Thus a new cache variable is defined in the Kokkos namespace
+      if(NOT DEFINED CACHE{Kokkos_HAS_SET_GLOBAL_BUILD_PROPERTIES})
+        set(Kokkos_HAS_SET_GLOBAL_BUILD_PROPERTIES ON
+            CACHE BOOL "Whether Kokkos traversed all targets and sets source and target properties"
+        )
+        #status message of begin
+        cmake_language(
+          DEFER
+          DIRECTORY
+          ${CMAKE_SOURCE_DIR}
+          CALL
+          message
+          STATUS
+          "Kokkos setting target and source properties"
+        )
+        # defer a call to set source and target properties of all dirs excluding Kokkos_EXCLUDE_BUILD_DIR after the complete project has been processed by CMake
+        cmake_language(
+          EVAL
+          CODE
+          "
+      cmake_language(DEFER DIRECTORY ${CMAKE_SOURCE_DIR} CALL kokkos_set_target_properties GLOBAL Kokkos_FOUND_DIR ${Kokkos_FOUND_INSTALL_DIR})
+      "
+        )
+        cmake_language(
+          DEFER
+          DIRECTORY
+          ${CMAKE_SOURCE_DIR}
+          CALL
+          message
+          STATUS
+          "Kokkos setting target and source properties ... done"
         )
       endif()
     endif()
@@ -64,3 +114,4 @@ if(NOT @Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE)
 endif()
 
 set(Kokkos_COMPILE_LANGUAGE @KOKKOS_COMPILE_LANGUAGE@)
+unset(Kokkos_FOUND_INSTALL_DIR)

--- a/cmake/KokkosConfigCommon.cmake.in
+++ b/cmake/KokkosConfigCommon.cmake.in
@@ -203,6 +203,45 @@ int main()
   set(${_VAR} ${_RET} PARENT_SCOPE)
 endfunction()
 
+# this function checks whether the current CXX compiler supports building Kokkos
+#
+#       RESULT      --> result (bool)
+#
+function(kokkos_cxx_compiler_is_compatible)
+  cmake_parse_arguments(INP "" "RESULT" "" ${ARGN})
+
+  file(
+    WRITE ${PROJECT_BINARY_DIR}/compile_tests/compiles_kokkos.cpp
+    "
+// include Kokkos_Core to check if header is working with the compiler
+#include <Kokkos_Core.hpp>
+
+int main()
+{
+Kokkos::initialize();
+{ // instantiate a view and a parallel_for to check requirements for template instantiation
+    Kokkos::View<int*> V(\"V\", 10);
+    Kokkos::parallel_for(\"increment\", 10, KOKKOS_LAMBDA ( int j) {
+        ++V(j);
+    });
+    Kokkos::fence();
+}
+Kokkos::finalize();
+return EXIT_SUCCESS;
+}
+"
+  )
+
+  try_compile(
+    COMPILER_CAN_COMPILE_KOKKOS ${PROJECT_BINARY_DIR}/compile_tests
+    ${PROJECT_BINARY_DIR}/compile_tests/compiles_kokkos.cpp
+    OUTPUT_VARIABLE COMPILER_ERROR_MESSAGE
+    LINK_LIBRARIES Kokkos::kokkos
+  )
+
+  set(${INP_RESULT} ${COMPILER_CAN_COMPILE_KOKKOS} PARENT_SCOPE)
+endfunction()
+
 # this function is provided to easily select which files use the same compiler as Kokkos
 # when it was installed (or nvcc_wrapper):
 #

--- a/cmake/KokkosConfigCommon.cmake.in
+++ b/cmake/KokkosConfigCommon.cmake.in
@@ -3,6 +3,7 @@ set(Kokkos_OPTIONS @KOKKOS_ENABLED_OPTIONS@)
 set(Kokkos_TPLS @KOKKOS_ENABLED_TPLS@)
 set(Kokkos_ARCH @KOKKOS_ENABLED_ARCH_LIST@)
 set(Kokkos_CXX_COMPILER "@CMAKE_CXX_COMPILER@")
+set(Kokkos_BACKEND_COMPILER "@KOKKOS_BACKEND_COMPILER@")
 set(Kokkos_CXX_COMPILER_ID "@KOKKOS_CXX_COMPILER_ID@")
 set(Kokkos_CXX_COMPILER_VERSION "@KOKKOS_CXX_COMPILER_VERSION@")
 set(Kokkos_CXX_STANDARD @KOKKOS_CXX_STANDARD@)
@@ -240,6 +241,424 @@ return EXIT_SUCCESS;
   )
 
   set(${INP_RESULT} ${COMPILER_CAN_COMPILE_KOKKOS} PARENT_SCOPE)
+endfunction()
+
+# this function finds the kokkos_launch_compiler script and prepends it to the compiler and linker launcher
+#
+#       SEARCH_PATH       --> input: search path for kokkos_launch_compiler (optional)
+#       BACKEND_COMPILER  --> input: compiler to be mapped to by the launcher (optional)
+#
+function(kokkos_use_launch_compiler)
+  cmake_parse_arguments(INP "" "SEARCH_PATH;BACKEND_COMPILER" "" ${ARGN})
+  if(@Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE@)
+    message(
+      FATAL_ERROR "Setting kokkos_launch_compiler works only with `-DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=OFF`"
+    )
+  endif()
+  find_program(
+    Kokkos_COMPILE_LAUNCHER
+    NAMES kokkos_launch_compiler
+    HINTS ${Kokkos_ROOT};${INP_SEARCH_PATH}
+    PATHS ${Kokkos_ROOT};${INP_SEARCH_PATH}
+    PATH_SUFFIXES bin
+  )
+  if(NOT Kokkos_COMPILE_LAUNCHER)
+    message(
+      FATAL_ERROR
+        "Kokkos could not find 'kokkos_launch_compiler'. Please set '-DKokkos_COMPILE_LAUNCHER=/path/to/launcher' or '-DKokkos_ROOT=/path/to/install'"
+    )
+  endif()
+  if(NOT INP_BACKEND_COMPILER)
+    set(INP_BACKEND_COMPILER ${Kokkos_BACKEND_COMPILER})
+  endif()
+  set(CMAKE_CXX_COMPILER_LAUNCHER
+      ${CMAKE_CXX_COMPILER_LAUNCHER};${Kokkos_COMPILE_LAUNCHER};${INP_BACKEND_COMPILER};${CMAKE_CXX_COMPILER}
+      PARENT_SCOPE
+  )
+  set(CMAKE_CXX_LINKER_LAUNCHER
+      ${CMAKE_CXX_LINKER_LAUNCHER};${Kokkos_COMPILE_LAUNCHER};${INP_BACKEND_COMPILER};${CMAKE_CXX_COMPILER}
+      PARENT_SCOPE
+  )
+
+endfunction()
+
+# this function searches a list and checks if any of a given list of items is contained
+#
+#       LIST         --> input: the list to search
+#       ITEMLIST     --> input: the list of items to find
+#       RETURN_VAR   --> output: ON if any of the items in itemlist are contained in list
+#
+function(kokkos_any_item_in_list)
+  cmake_parse_arguments(ARG "" "RETURN_VAR" "LIST;ITEMLIST" ${ARGN})
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "'kokkos_any_item_in_list' has unrecognized arguments: ${ARG_UNPARSED_ARGUMENTS}")
+  endif()
+
+  set(${ARG_RETURN_VAR} OFF PARENT_SCOPE)
+  foreach(ITEM IN LISTS ARG_ITEMLIST)
+    if(${ITEM} IN_LIST ARG_LIST)
+      set(${ARG_RETURN_VAR} ON PARENT_SCOPE)
+      return()
+    endif()
+  endforeach()
+endfunction()
+
+# this function searches a given target recursively looking for a transitive compile dependency to DEPENDENT_LIBRARY
+#
+#       COMPILE_DEPENDENCY                  --> output: is set to ON if the target needs to be compiled with the requirements of DEPENDENT_LIBRARY
+#       TRANSITIVE_COMPILE_DEPENDENCY       --> output: is set to ON if the target infects targets that depend PUBLIC on it to need to be compiled with the requirements of DEPENDENT_LIBRARY
+#       DEPENDENT_LIBRARY                   --> input: The library to search for in the target properties
+#       INVESTIGATED_TARGET                 --> input: target to be checked for transitive dependency
+#       COMPILE_DEPENDENCY_CACHE            --> in/out: cache of targetnames that have a compile dependency on INVESTIGATED_TARGET
+#       TRANSITIVE_COMPILE_DEPENDENCY_CACHE --> in/out: cache of targetnames that have a transient compile dependency on INVESTIGATED_TARGET
+#
+function(
+  kokkos_check_compile_dependency
+  COMPILE_DEPENDENCY
+  TRANSITIVE_COMPILE_DEPENDENCY
+  LINK_DEPENDENCY
+  DEPENDENT_LIBRARY
+  INVESTIGATED_TARGET
+  COMPILE_DEPENDENCY_CACHE
+  TRANSITIVE_COMPILE_DEPENDENCY_CACHE
+)
+  set(transitive_dependency OFF)
+  set(compile_dependency OFF)
+  set(link_dependency OFF)
+  if(TARGET ${INVESTIGATED_TARGET})
+    set(dependencies "")
+    get_target_property(target_link_dependencies_genex ${INVESTIGATED_TARGET} LINK_LIBRARIES)
+    string(GENEX_STRIP "${target_link_dependencies_genex}" target_link_dependencies)
+    if(target_link_dependencies)
+      list(APPEND dependencies ${target_link_dependencies})
+    endif()
+    get_target_property(target_interface_dependencies_genex ${INVESTIGATED_TARGET} INTERFACE_LINK_LIBRARIES)
+    string(GENEX_STRIP "${target_interface_dependencies_genex}" target_interface_dependencies)
+    if(target_interface_dependencies)
+      list(APPEND dependencies ${target_interface_dependencies})
+    endif()
+    list(REMOVE_DUPLICATES dependencies)
+    if(dependencies)
+      #check the target directly
+      kokkos_any_item_in_list(LIST ${dependencies} ITEMLIST ${DEPENDENT_LIBRARY} RETURN_VAR MATCH_FOUND)
+      if(MATCH_FOUND)
+        set(compile_dependency ON)
+        set(link_dependency ON)
+        if(target_interface_dependencies)
+          kokkos_any_item_in_list(
+            LIST ${target_interface_dependencies} ITEMLIST ${DEPENDENT_LIBRARY} RETURN_VAR MATCH_FOUND
+          )
+          if(MATCH_FOUND)
+            set(transitive_dependency ON)
+          endif()
+        endif()
+        #if no direct dependency is found check all dependencies
+      else()
+        # check cache
+        set(cache_hit OFF)
+        foreach(dependency IN LISTS dependencies)
+          if(${dependency} IN_LIST ${COMPILE_DEPENDENCY_CACHE})
+            set(link_dependency ON)
+          endif()
+          if(${dependency} IN_LIST ${TRANSITIVE_COMPILE_DEPENDENCY_CACHE})
+            set(compile_dependency ON)
+            #and if we link PUBLIC to it we get infectious, too
+            if(target_interface_dependencies)
+              if(${dependency} IN_LIST target_interface_dependencies)
+                set(transitive_dependency ON)
+                set(cache_hit ON)
+                break() #we can end the cache checking
+              endif()
+            endif()
+          endif()
+        endforeach()
+        # do recursion
+        if(NOT cache_hit)
+          foreach(dependency IN LISTS dependencies)
+            kokkos_check_compile_dependency(
+              depends_direct
+              depends_transitively
+              depends_linking
+              "${DEPENDENT_LIBRARY}"
+              ${dependency}
+              ${COMPILE_DEPENDENCY_CACHE}
+              ${TRANSITIVE_COMPILE_DEPENDENCY_CACHE}
+            )
+            if(depends_linking)
+              set(link_dependency ON)
+            endif()
+
+            #if a dependency is infectious
+            if(depends_transitively)
+              set(compile_dependency ON)
+              #and if we link PUBLIC to it we get infectious, too
+              if(target_interface_dependencies)
+                if(${dependency} IN_LIST target_interface_dependencies)
+                  set(transitive_dependency ON)
+                endif()
+              endif()
+            endif()
+          endforeach()
+        endif()
+      endif()
+    endif()
+  endif()
+
+  set(${COMPILE_DEPENDENCY} ${compile_dependency} PARENT_SCOPE)
+  set(${TRANSITIVE_COMPILE_DEPENDENCY} ${transitive_dependency} PARENT_SCOPE)
+  set(${LINK_DEPENDENCY} ${link_dependency} PARENT_SCOPE)
+
+  if(link_dependency)
+    list(APPEND ${COMPILE_DEPENDENCY_CACHE} ${INVESTIGATED_TARGET})
+  endif()
+  set(${COMPILE_DEPENDENCY_CACHE} "${${COMPILE_DEPENDENCY_CACHE}}" PARENT_SCOPE)
+
+  if(transitive_dependency)
+    list(APPEND ${TRANSITIVE_COMPILE_DEPENDENCY_CACHE} ${INVESTIGATED_TARGET})
+  endif()
+  set(${TRANSITIVE_COMPILE_DEPENDENCY_CACHE} "${${TRANSITIVE_COMPILE_DEPENDENCY_CACHE}}" PARENT_SCOPE)
+endfunction()
+
+# this function searches a given directory recursively finding all targets that link to DEPENDENT_LIBRARY
+#
+#       FOUND_TARGETS         --> output: list of all found targets that link to kokkos and need our compiler
+#       DEPENDENT_LIBRARY     --> input: The library to search for in the target properties
+#       SEARCH_DIR            --> input: the root dir to start the recursion from
+#       EXCLUDE_DIRS          --> input: list of directories that should be excluded
+#
+function(kokkos_get_directory_targets)
+  cmake_parse_arguments(INP "" "SEARCH_DIR" "FOUND_TARGETS;EXCLUDE_DIRS" ${ARGN})
+  set(targets "")
+  set(subdirs "")
+
+  if(${INP_SEARCH_DIR} IN_LIST INP_EXCLUDE_DIRS)
+    message(
+      DEBUG
+      "Kokkos excludes dir ${INP_SEARCH_DIR} from setting build options as it was marked to be excluded by `kokkos_exclude_from_setting_build_properties`"
+    )
+  else()
+    get_property(targets DIRECTORY ${INP_SEARCH_DIR} PROPERTY BUILDSYSTEM_TARGETS)
+    get_property(subdirs DIRECTORY ${INP_SEARCH_DIR} PROPERTY SUBDIRECTORIES)
+  endif()
+
+  # recursively visit subdirs
+  if(subdirs)
+    foreach(subdir ${subdirs})
+      kokkos_get_directory_targets(FOUND_TARGETS subdir_targets SEARCH_DIR ${subdir} EXCLUDE_DIRS ${INP_EXCLUDE_DIRS})
+      list(APPEND targets ${subdir_targets})
+    endforeach()
+  endif()
+
+  # push results out of recursive function
+  set(${INP_FOUND_TARGETS} ${targets} PARENT_SCOPE)
+endfunction()
+
+# this function searches a given directory recursively finding all targets that link to DEPENDENT_LIBRARY
+#
+#       GLOBAL         --> input: exclude everything from Kokkos setting build properties
+#       DIRECTORY      --> input: list of directories that should be excluded
+#
+function(kokkos_exclude_from_setting_build_properties)
+  cmake_parse_arguments(INP "GLOBAL" "" "DIRECTORY" ${ARGN})
+
+  if(INP_GLOBAL)
+    kokkos_exclude_from_setting_build_properties(DIRECTORY ${CMAKE_SOURCE_DIR})
+  else()
+    set(Kokkos_EXCLUDE_BUILD_DIRS
+        "${INP_DIRECTORY};${Kokkos_EXCLUDE_DIRS}"
+        CACHE
+          STRING
+          "List of directories Kokkos that are excluded from Kokkos setting build properties on source and target properties via a deferred call"
+          FORCE
+    )
+  endif()
+endfunction()
+
+# this function sets the source and target properties for all targets that link to a given library
+#
+#       LIBRARY                 --> input: name of the library downstream targets need to link to for this function to set the properties.
+#
+function(kokkos_set_dependent_library_properties)
+  cmake_parse_arguments(INP "" "" "LIBRARY" ${ARGN})
+
+  if(INP_UNPARSED_ARGUMENTS)
+    message(
+      FATAL_ERROR "'kokkos_set_dependent_library_properties' has unrecognized arguments: ${INP_UNPARSED_ARGUMENTS}"
+    )
+  endif()
+
+  if(NOT INP_LIBRARY)
+    message(FATAL_ERROR "'kokkos_set_dependent_library_properties' needs a LIBRARY argument")
+  endif()
+
+  kokkos_get_directory_targets(FOUND_TARGETS DIRECTORY_TARGETS SEARCH_DIR ${CMAKE_SOURCE_DIR})
+
+  foreach(directory_target IN LISTS DIRECTORY_TARGETS)
+    kokkos_check_compile_dependency(
+      compile_dependency
+      transitive_compile_dependency
+      link_dependency
+      "${INP_LIBRARY}"
+      ${directory_target}
+      ${INP_LIBRARY}_LINK_DEPENDENCY_CACHE
+      ${INP_LIBRARY}_PUBLIC_DEPENDENCY_CACHE
+    )
+    if(compile_dependency)
+      list(APPEND COMPILE_TARGETS ${directory_target})
+    endif()
+
+    if(link_dependency)
+      list(APPEND LINK_TARGETS ${directory_target})
+    endif()
+  endforeach()
+
+  if(library_transitive_compile_dependency)
+    kokkos_set_target_properties(TARGET ${COMPILE_TARGETS})
+  endif()
+
+  kokkos_set_target_properties(LINK_ONLY_TARGET ${LINK_TARGETS})
+endfunction()
+
+# this function sets the source and target properties for all targets that link to a given library but deferred to the end of the CMake setup
+#
+#       LIBRARY                 --> input: name of the library downstream targets need to link to for this function to set the properties.
+#
+function(kokkos_defer_set_dependent_library_properties)
+  cmake_parse_arguments(ARG "" "" "LIBRARY" ${ARGN})
+
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(
+      FATAL_ERROR
+        "'kokkos_defer_set_dependent_library_properties' has unrecognized arguments: ${ARG_UNPARSED_ARGUMENTS}"
+    )
+  endif()
+
+  if(NOT ARG_LIBRARY)
+    message(FATAL_ERROR "'kokkos_defer_set_dependent_library_properties' needs a LIBRARY argument")
+  endif()
+
+  cmake_language(
+    EVAL
+    CODE
+    "cmake_language(DEFER DIRECTORY ${CMAKE_SOURCE_DIR} CALL kokkos_set_dependent_library_properties LIBRARY ${ARG_LIBRARY})"
+  )
+
+endfunction()
+
+# this function sets the source and target properties that Kokkos requires
+#
+#       GLOBAL                  --> all targets that link to kokkos in the project
+#       DIRECTORY               --> all targets that link to kokkos in given directories
+#       TARGET                  --> on the given targets (that need compilation and link settings)
+#       LINK_ONLY_TARGET        --> on the given targets (that only need link settings)
+#       Kokkos_FOUND_DIR        --> hint on where Kokkos was installed (important for CMake contexts that don't know this but depend on Kokkos)
+#
+function(kokkos_set_target_properties)
+  cmake_parse_arguments(INP "GLOBAL" "Kokkos_FOUND_DIR" "DIRECTORY;TARGET;LINK_ONLY_TARGET" ${ARGN})
+
+  if(INP_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "'kokkos_set_target_properties' has unrecognized arguments: ${INP_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(KOKKOS_CXX_COMPILER_IS_COMPATIBLE OR @Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE@)
+    return()
+  endif()
+
+  if(NOT Kokkos_COMPILE_LAUNCHER)
+    # find kokkos_launch_compiler
+    find_program(
+      Kokkos_COMPILE_LAUNCHER
+      NAMES kokkos_launch_compiler
+      HINTS ${INP_Kokkos_FOUND_DIR};${Kokkos_ROOT}
+      PATHS ${INP_Kokkos_FOUND_DIR};${Kokkos_ROOT}
+      PATH_SUFFIXES bin
+    )
+  endif()
+
+  if(NOT Kokkos_COMPILE_LAUNCHER)
+    message(
+      FATAL_ERROR
+        "Kokkos could not find 'kokkos_launch_compiler'. Please set '-DKokkos_COMPILE_LAUNCHER=/path/to/launcher' or '-DKokkos_ROOT=/path/to/install'"
+    )
+  endif()
+
+  if(NOT Kokkos_NVCC_WRAPPER)
+    # find nvcc_wrapper
+    find_program(
+      Kokkos_NVCC_WRAPPER
+      NAMES nvcc_wrapper
+      HINTS ${INP_Kokkos_FOUND_DIR};${Kokkos_ROOT}
+      PATHS ${INP_Kokkos_FOUND_DIR};${Kokkos_ROOT}
+      PATH_SUFFIXES bin
+    )
+  endif()
+  # fatal if we can't nvcc_wrapper
+  if(NOT Kokkos_NVCC_WRAPPER)
+    message(
+      FATAL_ERROR
+        "Kokkos could not find nvcc_wrapper. Please set '-DKokkos_NVCC_WRAPPER=/path/to/nvcc_wrapper' or '-DKokkos_ROOT=/path/to/install'"
+    )
+  endif()
+
+  set(COMPILER_LAUNCHER
+      ${CMAKE_CXX_COMPILER_LAUNCHER};${Kokkos_COMPILE_LAUNCHER};${Kokkos_NVCC_WRAPPER};${CMAKE_CXX_COMPILER}
+  )
+  set(LINKER_LAUNCHER
+      ${CMAKE_CXX_LINKER_LAUNCHER};${Kokkos_COMPILE_LAUNCHER};${Kokkos_NVCC_WRAPPER};${CMAKE_CXX_COMPILER}
+  )
+
+  set(COMPILE_TARGETS ${INP_TARGET})
+  set(LINK_TARGETS ${INP_TARGET};${INP_LINK_ONLY_TARGET})
+
+  #resolve projects to directory
+  if(INP_GLOBAL)
+    message(DEBUG "Kokkos marking directory ${PROJECT_SOURCE_DIR} to contain kokkos targets")
+    list(APPEND INP_DIRECTORY ${CMAKE_SOURCE_DIR})
+    unset(INP_GLOBAL)
+  endif()
+
+  #set properties on directories
+  foreach(directory IN LISTS INP_DIRECTORY)
+    kokkos_get_directory_targets(
+      FOUND_TARGETS DIRECTORY_TARGETS SEARCH_DIR ${directory} EXCLUDE_DIRS ${Kokkos_EXCLUDE_BUILD_DIRS}
+    )
+
+    foreach(directory_target IN LISTS DIRECTORY_TARGETS)
+      #FIXME the list of libs "Kokkos::..." that is hardcoded below should be automatically generated to reduce mainteneance burden
+      kokkos_check_compile_dependency(
+        compile_dependency
+        transitive_compile_dependency
+        link_dependency
+        "Kokkos::kokkoscore;Kokkos::kokkoscontainers;Kokkos::kokkosalgorithms;Kokkos::kokkossimd;Kokkos::kokkos"
+        ${directory_target}
+        KOKKOS_LINK_DEPENDENCY_CACHE
+        KOKKOS_PUBLIC_DEPENDENCY_CACHE
+      )
+      if(compile_dependency)
+        list(APPEND DIRECTORY_COMPILE_TARGETS ${directory_target})
+        list(APPEND COMPILE_TARGETS ${directory_target})
+      endif()
+
+      if(link_dependency)
+        list(APPEND LINK_TARGETS ${directory_target})
+      endif()
+    endforeach()
+  endforeach()
+
+  if(COMPILER_LAUNCHER)
+    foreach(target IN LISTS COMPILE_TARGETS)
+      message(DEBUG "Kokkos setting compiler launcher ${COMPILER_LAUNCHER} on target ${target}")
+      set_property(TARGET ${target} PROPERTY CXX_COMPILER_LAUNCHER ${COMPILER_LAUNCHER})
+    endforeach()
+  endif()
+
+  foreach(target IN LISTS LINK_TARGETS)
+    # use launcher on targets
+    if(LINKER_LAUNCHER)
+      message(DEBUG "Kokkos setting linker launcher ${LINKER_LAUNCHER} on target ${target}")
+      set_property(TARGET ${target} PROPERTY CXX_LINKER_LAUNCHER ${LINKER_LAUNCHER})
+    endif()
+  endforeach()
 endfunction()
 
 # this function is provided to easily select which files use the same compiler as Kokkos

--- a/cmake/kokkos_compiler_id.cmake
+++ b/cmake/kokkos_compiler_id.cmake
@@ -3,6 +3,7 @@ kokkos_cfg_depends(COMPILER_ID NONE)
 set(KOKKOS_CXX_COMPILER ${CMAKE_CXX_COMPILER})
 set(KOKKOS_CXX_COMPILER_ID ${CMAKE_CXX_COMPILER_ID})
 set(KOKKOS_CXX_COMPILER_VERSION ${CMAKE_CXX_COMPILER_VERSION})
+set(KOKKOS_BACKEND_COMPILER ${CMAKE_CXX_COMPILER})
 
 macro(kokkos_internal_have_compiler_nvcc)
   # Check if the compiler is nvcc (which really means nvcc_wrapper).
@@ -59,6 +60,7 @@ if(Kokkos_ENABLE_CUDA)
         -DKOKKOS_DEPENDENCE
       )
       set(INTERNAL_USE_COMPILER_LAUNCHER true)
+      set(KOKKOS_BACKEND_COMPILER ${Kokkos_NVCC_WRAPPER})
     endif()
   endif()
 endif()

--- a/cmake/kokkos_enable_options.cmake
+++ b/cmake/kokkos_enable_options.cmake
@@ -159,6 +159,10 @@ if(NOT KOKKOS_ENABLE_TESTS AND KOKKOS_ENABLE_HEADER_SELF_CONTAINMENT_TESTS)
   )
 endif()
 
+kokkos_enable_option(
+  DEPRECATED_BUILD_STRATEGY ON "Whether globally set properties on targets/files that link to kokkos"
+)
+
 if(KOKKOS_ENABLE_CUDA AND (KOKKOS_CXX_COMPILER_ID STREQUAL Clang))
   set(CUDA_CONSTEXPR_DEFAULT ON)
 else()

--- a/cmake_test/CMakeLists.txt
+++ b/cmake_test/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Kokkos minimally requires 3.21 right now,
+# but your project can set it higher
+cmake_minimum_required(VERSION 3.21)
+
+# Projects can safely mix languages - must have C++ support
+project(KokkosCMakeTesting CXX)
+
+enable_testing()
+add_subdirectory(complex)
+add_subdirectory(launch_compiler)

--- a/cmake_test/CMakeLists.txt
+++ b/cmake_test/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Kokkos minimally requires 3.21 right now,
+# Kokkos minimally requires 3.16 right now,
 # but your project can set it higher
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.16)
 
 # Projects can safely mix languages - must have C++ support
 project(KokkosCMakeTesting CXX)

--- a/cmake_test/CMakeLists.txt
+++ b/cmake_test/CMakeLists.txt
@@ -1,10 +1,19 @@
-# Kokkos minimally requires 3.16 right now,
+# Kokkos minimally requires 3.21 right now,
 # but your project can set it higher
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.21)
 
 # Projects can safely mix languages - must have C++ support
 project(KokkosCMakeTesting CXX)
 
+set(Kokkos_EXCLUDE_BUILD_DIRS
+  "${CMAKE_CURRENT_SOURCE_DIR}/complex_mark_library;${CMAKE_CURRENT_SOURCE_DIR}/launch_compiler"
+    CACHE
+      STRING
+      "List of directories Kokkos that are excluded from Kokkos setting build properties on source and target properties via a deferred call"
+)
+
 enable_testing()
 add_subdirectory(complex)
+add_subdirectory(complex_mark_kokkos_files)
+add_subdirectory(complex_mark_library)
 add_subdirectory(launch_compiler)

--- a/cmake_test/complex/CMakeLists.txt
+++ b/cmake_test/complex/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Kokkos minimally requires 3.21 right now,
+# Kokkos minimally requires 3.16 right now,
 # but your project can set it higher
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.16)
 
 # Projects can safely mix languages - must have C++ support
 project(KokkosCMakeTestingComplex CXX Fortran)

--- a/cmake_test/complex/CMakeLists.txt
+++ b/cmake_test/complex/CMakeLists.txt
@@ -1,0 +1,301 @@
+# Kokkos minimally requires 3.21 right now,
+# but your project can set it higher
+cmake_minimum_required(VERSION 3.21)
+
+# Projects can safely mix languages - must have C++ support
+project(KokkosCMakeTestingComplex CXX Fortran)
+
+######
+# In this test we let find_package(Kokkos) set source and target properties automatically.
+# There are tree sections:
+#   - Targets without Kokkos dependency
+#   - Targets dependent on a library that has a Kokkos dependency
+#   - Targets dependent on a library that depends on a library that has a Kokkos dependency
+# Although the test stops at two layers, find_package(Kokkos) sets the source and target properties independent of
+# depth of the dependency tree.
+
+###### Targets that don't depend on Kokkos are not manipulated by us
+add_subdirectory(lib_without_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_without ../test_source/test_without.cpp ../test_source/source_plain_cxx.cpp
+                                     ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(${PROJECT_NAME}_executable_without ${PROJECT_NAME}_Lib_without_kokkos_dependency)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_without PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_without PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosWithout_Verify COMMAND ${PROJECT_NAME}_executable_without 10)
+
+###### Libraries that have direct dependency on Kokkos
+###### PUBLIC dependency
+add_subdirectory(lib_with_public_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_public ../test_source/test_public.cpp ../test_source/source_plain_cxx.cpp
+                                    ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_public ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_public_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_public PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_public PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPublic_Verify COMMAND ${PROJECT_NAME}_executable_public 10)
+
+###### INTERFACE dependency
+add_subdirectory(lib_with_interface_kokkos_dependency)
+add_executable(
+  ${PROJECT_NAME}_executable_interface ../test_source/test_interface.cpp ../test_source/source_plain_cxx.cpp
+                                       ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_interface ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_interface_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_interface PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_interface PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosInterface_Verify COMMAND ${PROJECT_NAME}_executable_interface 10)
+
+###### PRIVATE dependency
+add_subdirectory(lib_with_private_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_private ../test_source/test_private.cpp ../test_source/source_plain_cxx.cpp
+                                     ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_private ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_private_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_private PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_private PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPrivate_Verify COMMAND ${PROJECT_NAME}_executable_private 10)
+
+###### Libraries that have indirect dependency on Kokkos
+###### PUBLIC dependency on INTERFACE dependency
+add_subdirectory(lib_with_public_dependency_on_lib_with_interface_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_public_interface ../test_source/test_public_interface.cpp
+                                              ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_public_interface ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_interface_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_public_interface PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_public_interface PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPublic_interface_Verify COMMAND ${PROJECT_NAME}_executable_public_interface 10)
+
+###### PUBLIC dependency on PUBLIC dependency
+add_subdirectory(lib_with_public_dependency_on_lib_with_public_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_public_public ../test_source/test_public_public.cpp ../test_source/source_plain_cxx.cpp
+                                           ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_public_public ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_public_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_public_public PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_public_public PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPublic_public_Verify COMMAND ${PROJECT_NAME}_executable_public_public 10)
+
+###### PUBLIC dependency on PRIVATE dependency
+add_subdirectory(lib_with_public_dependency_on_lib_with_private_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_public_private ../test_source/test_public_private.cpp ../test_source/source_plain_cxx.cpp
+                                            ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_public_private ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_private_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_public_private PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_public_private PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPublic_private_Verify COMMAND ${PROJECT_NAME}_executable_public_private 10)
+
+###### PRIVATE dependency on INTERFACE dependency
+add_subdirectory(lib_with_private_dependency_on_lib_with_interface_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_private_interface
+  ../test_source/test_private_interface.cpp ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_private_interface ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_interface_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_private_interface PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_private_interface PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPrivate_interface_Verify COMMAND ${PROJECT_NAME}_executable_private_interface 10)
+
+###### PRIVATE dependency on PUBLIC dependency
+add_subdirectory(lib_with_private_dependency_on_lib_with_public_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_private_public ../test_source/test_private_public.cpp ../test_source/source_plain_cxx.cpp
+                                            ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_private_public ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_public_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_private_public PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_private_public PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPrivate_public_Verify COMMAND ${PROJECT_NAME}_executable_private_public 10)
+
+###### PRIVATE dependency on PRIVATE dependency
+add_subdirectory(lib_with_private_dependency_on_lib_with_private_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_private_private ../test_source/test_private_private.cpp
+                                             ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_private_private ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_private_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_private_private PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_private_private PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPrivate_private_Verify COMMAND ${PROJECT_NAME}_executable_private_private 10)
+
+###### INTERFACE dependency on INTERFACE dependency
+add_subdirectory(lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_interface_interface
+  ../test_source/test_interface_interface.cpp ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_interface_interface ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_interface_interface PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_interface_interface PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosInterface_interface_Verify COMMAND ${PROJECT_NAME}_executable_interface_interface
+                                                                       10
+)
+
+###### INTERFACE dependency on PUBLIC dependency
+add_subdirectory(lib_with_interface_dependency_on_lib_with_public_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_interface_public ../test_source/test_interface_public.cpp
+                                              ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_interface_public ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_public_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_interface_public PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_interface_public PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosInterface_public_Verify COMMAND ${PROJECT_NAME}_executable_interface_public 10)
+
+###### INTERFACE dependency on PRIVATE dependency
+add_subdirectory(lib_with_interface_dependency_on_lib_with_private_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_interface_private
+  ../test_source/test_interface_private.cpp ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_interface_private ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_private_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_interface_private PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_interface_private PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosInterface_private_Verify COMMAND ${PROJECT_NAME}_executable_interface_private 10)

--- a/cmake_test/complex/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency INTERFACE)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency
+  INTERFACE ../../test_source/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency
+  INTERFACE ${PROJECT_NAME}_Lib_with_interface_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_private_kokkos_dependency INTERFACE)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_private_kokkos_dependency
+  INTERFACE ../../test_source/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_private_kokkos_dependency
+  INTERFACE ${PROJECT_NAME}_Lib_with_private_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_public_kokkos_dependency INTERFACE)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_public_kokkos_dependency
+  INTERFACE ../../test_source/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_public_kokkos_dependency
+  INTERFACE ${PROJECT_NAME}_Lib_with_public_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_interface_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_interface_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,8 @@
+find_package(Kokkos)
+
+add_library(${PROJECT_NAME}_Lib_with_interface_kokkos_dependency INTERFACE)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_interface_kokkos_dependency INTERFACE ../../test_source/lib_with_interface_kokkos_dependency
+)
+
+target_link_libraries(${PROJECT_NAME}_Lib_with_interface_kokkos_dependency INTERFACE Kokkos::kokkos)

--- a/cmake_test/complex/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_interface_kokkos_dependency
+  ../../test_source/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/source_with_private_dependency_on_lib_with_interface_kokkos_dependency.cpp
+)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_interface_kokkos_dependency
+  PUBLIC ../../test_source/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_interface_kokkos_dependency
+  PRIVATE ${PROJECT_NAME}_Lib_with_interface_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_private_kokkos_dependency
+  ../../test_source/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/source_with_private_dependency_on_lib_with_private_kokkos_dependency.cpp
+)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_private_kokkos_dependency
+  PUBLIC ../../test_source/lib_with_private_dependency_on_lib_with_private_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_private_kokkos_dependency
+  PRIVATE ${PROJECT_NAME}_Lib_with_private_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_public_kokkos_dependency
+  ../../test_source/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/source_with_private_dependency_on_lib_with_public_kokkos_dependency.cpp
+)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_public_kokkos_dependency
+  PUBLIC ../../test_source/lib_with_private_dependency_on_lib_with_public_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_public_kokkos_dependency
+  PRIVATE ${PROJECT_NAME}_Lib_with_public_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_private_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_private_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,26 @@
+find_package(Kokkos)
+
+add_library(
+  ${PROJECT_NAME}_Lib_with_private_kokkos_dependency
+  ../../test_source/lib_with_private_kokkos_dependency/source_with_public_kokkos_dependency.cpp
+  ../../test_source/lib_with_private_kokkos_dependency/source_without_kokkos_dependency.cpp
+  ../../test_source/lib_with_private_kokkos_dependency/source_merging_prints.cpp
+)
+
+if((CUDA IN_LIST Kokkos_DEVICES) OR (HIP IN_LIST Kokkos_DEVICES))
+  target_sources(
+    ${PROJECT_NAME}_Lib_with_private_kokkos_dependency
+    PRIVATE ../../test_source/lib_with_private_kokkos_dependency/cuda_hip_source_without_kokkos_dependency.cu
+  )
+  #for builds without CUDA/HIP language support we need to mark the cuda file as CXX. With language support it marks the file in the appropriate language
+  set_property(
+    SOURCE ../../test_source/lib_with_private_kokkos_dependency/cuda_hip_source_without_kokkos_dependency.cu
+           TARGET_DIRECTORY ${PROJECT_NAME}_Lib_with_private_kokkos_dependency PROPERTY LANGUAGE
+                                                                                        ${Kokkos_COMPILE_LANGUAGE}
+  )
+endif()
+
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_private_kokkos_dependency PUBLIC ../../test_source/lib_with_private_kokkos_dependency
+)
+target_link_libraries(${PROJECT_NAME}_Lib_with_private_kokkos_dependency PRIVATE Kokkos::kokkos)

--- a/cmake_test/complex/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_interface_kokkos_dependency
+  ../../test_source/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/source_with_public_dependency_on_lib_with_interface_kokkos_dependency.cpp
+)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_interface_kokkos_dependency
+  PUBLIC ../../test_source/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_interface_kokkos_dependency
+  PUBLIC ${PROJECT_NAME}_Lib_with_interface_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_private_kokkos_dependency
+  ../../test_source/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/source_with_public_dependency_on_lib_with_private_kokkos_dependency.cpp
+)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_private_kokkos_dependency
+  PUBLIC ../../test_source/lib_with_public_dependency_on_lib_with_private_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_private_kokkos_dependency
+  PUBLIC ${PROJECT_NAME}_Lib_with_private_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_public_kokkos_dependency
+  ../../test_source/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/source_with_public_dependency_on_lib_with_public_kokkos_dependency.cpp
+)
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_public_kokkos_dependency
+  PUBLIC ../../test_source/lib_with_public_dependency_on_lib_with_public_kokkos_dependency
+)
+target_link_libraries(
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_public_kokkos_dependency
+  PUBLIC ${PROJECT_NAME}_Lib_with_public_kokkos_dependency
+)

--- a/cmake_test/complex/lib_with_public_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_with_public_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,24 @@
+find_package(Kokkos)
+
+add_library(
+  ${PROJECT_NAME}_Lib_with_public_kokkos_dependency
+  ../../test_source/lib_with_public_kokkos_dependency/source_with_public_kokkos_dependency.cpp
+)
+
+if((CUDA IN_LIST Kokkos_DEVICES) OR (HIP IN_LIST Kokkos_DEVICES))
+  target_sources(
+    ${PROJECT_NAME}_Lib_with_public_kokkos_dependency
+    PRIVATE ../../test_source/lib_with_public_kokkos_dependency/cuda_hip_source_without_kokkos_dependency.cu
+  )
+  #for builds without CUDA/HIP language support we need to mark the cuda file as CXX. For language support it marks the file in the appropriate language
+  set_property(
+    SOURCE ../../test_source/lib_with_public_kokkos_dependency/cuda_hip_source_without_kokkos_dependency.cu
+           TARGET_DIRECTORY ${PROJECT_NAME}_Lib_with_public_kokkos_dependency PROPERTY LANGUAGE
+                                                                                       ${Kokkos_COMPILE_LANGUAGE}
+  )
+endif()
+
+target_include_directories(
+  ${PROJECT_NAME}_Lib_with_public_kokkos_dependency PUBLIC ../../test_source/lib_with_public_kokkos_dependency
+)
+target_link_libraries(${PROJECT_NAME}_Lib_with_public_kokkos_dependency PUBLIC Kokkos::kokkos)

--- a/cmake_test/complex/lib_without_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex/lib_without_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(
+  ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ../../test_source/lib_without_kokkos_dependency/source_without_kokkos_dependency.cpp
+)
+
+target_include_directories(
+  ${PROJECT_NAME}_Lib_without_kokkos_dependency PUBLIC ../../test_source/lib_without_kokkos_dependency
+)

--- a/cmake_test/complex_mark_kokkos_files/CMakeLists.txt
+++ b/cmake_test/complex_mark_kokkos_files/CMakeLists.txt
@@ -1,0 +1,334 @@
+# Kokkos minimally requires 3.21 right now,
+# but your project can set it higher
+cmake_minimum_required(VERSION 3.21)
+
+# Projects can safely mix languages - must have C++ support
+project(KokkosCMakeTestingComplexMarkKokkosFiles CXX Fortran)
+
+######
+# This test searches for Kokkos at the top level and deactivates automatically marking source files and libs
+# Then individual sources and targets are opt-in to have Kokkos dependency
+find_package(Kokkos)
+# Opt out of kokkos setting the source and target flags automatically by excluding the whole project.
+kokkos_exclude_from_setting_build_properties(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+######
+# This test can be used like a library, just scroll to the section that mimics how Kokkos is used in your project.
+# There are tree sections:
+#   - Targets without Kokkos dependency
+#   - Targets dependent on a library that has a Kokkos dependency
+#   - Targets dependent on a library that depends on a library that has a Kokkos dependency
+# Although the test stops at two layers, find_package(Kokkos) sets the source and target properties independent of
+# depth of the dependency tree.
+
+###### Targets that don't depend on Kokkos are not manipulated by us
+add_subdirectory(lib_without_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_without ../test_source/test_without.cpp ../test_source/source_plain_cxx.cpp
+                                     ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(${PROJECT_NAME}_executable_without ${PROJECT_NAME}_Lib_without_kokkos_dependency)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_without PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_without PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosWithout_Verify COMMAND ${PROJECT_NAME}_executable_without 10)
+
+###### Libraries that have direct dependency on Kokkos
+###### PUBLIC dependency
+add_subdirectory(lib_with_public_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_public ../test_source/test_public.cpp ../test_source/source_plain_cxx.cpp
+                                    ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_public ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_public_kokkos_dependency
+)
+#for the target
+kokkos_set_target_properties(TARGET ${PROJECT_NAME}_executable_public)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_public PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_public PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPublic_Verify COMMAND ${PROJECT_NAME}_executable_public 10)
+
+###### INTERFACE dependency
+add_subdirectory(lib_with_interface_kokkos_dependency)
+add_executable(
+  ${PROJECT_NAME}_executable_interface ../test_source/test_interface.cpp ../test_source/source_plain_cxx.cpp
+                                       ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_interface ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_interface_kokkos_dependency
+)
+#for the target
+kokkos_set_target_properties(TARGET ${PROJECT_NAME}_executable_interface)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_interface PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_interface PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosInterface_Verify COMMAND ${PROJECT_NAME}_executable_interface 10)
+
+###### PRIVATE dependency
+add_subdirectory(lib_with_private_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_private ../test_source/test_private.cpp ../test_source/source_plain_cxx.cpp
+                                     ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_private ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_private_kokkos_dependency
+)
+#as the target need to know which runtime to link, it needs to be marked
+kokkos_set_target_properties(LINK_ONLY_TARGET ${PROJECT_NAME}_executable_private)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_private PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_private PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPrivate_Verify COMMAND ${PROJECT_NAME}_executable_private 10)
+
+##### Libraries that have indirect dependency on Kokkos
+##### PUBLIC dependency on INTERFACE dependency
+add_subdirectory(lib_with_public_dependency_on_lib_with_interface_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_public_interface ../test_source/test_public_interface.cpp
+                                              ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_public_interface ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_interface_kokkos_dependency
+)
+#for the target
+kokkos_set_target_properties(TARGET ${PROJECT_NAME}_executable_public_interface)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_public_interface PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_public_interface PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPublic_interface_Verify COMMAND ${PROJECT_NAME}_executable_public_interface 10)
+
+###### PUBLIC dependency on PUBLIC dependency
+add_subdirectory(lib_with_public_dependency_on_lib_with_public_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_public_public ../test_source/test_public_public.cpp ../test_source/source_plain_cxx.cpp
+                                           ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_public_public ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_public_kokkos_dependency
+)
+# for the target
+kokkos_set_target_properties(TARGET ${PROJECT_NAME}_executable_public_public)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_public_public PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_public_public PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPublic_public_Verify COMMAND ${PROJECT_NAME}_executable_public_public 10)
+
+###### PUBLIC dependency on PRIVATE dependency
+add_subdirectory(lib_with_public_dependency_on_lib_with_private_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_public_private ../test_source/test_public_private.cpp ../test_source/source_plain_cxx.cpp
+                                            ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_public_private ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_private_kokkos_dependency
+)
+# the target needs kokkos linker settings
+kokkos_set_target_properties(LINK_ONLY_TARGET ${PROJECT_NAME}_executable_public_private)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_public_private PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_public_private PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPublic_private_Verify COMMAND ${PROJECT_NAME}_executable_public_private 10)
+
+###### PRIVATE dependency on INTERFACE dependency
+add_subdirectory(lib_with_private_dependency_on_lib_with_interface_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_private_interface
+  ../test_source/test_private_interface.cpp ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_private_interface ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_interface_kokkos_dependency
+)
+# the target needs kokkos linker settings
+kokkos_set_target_properties(LINK_ONLY_TARGET ${PROJECT_NAME}_executable_private_interface)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_private_interface PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_private_interface PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPrivate_interface_Verify COMMAND ${PROJECT_NAME}_executable_private_interface 10)
+
+###### PRIVATE dependency on PUBLIC dependency
+add_subdirectory(lib_with_private_dependency_on_lib_with_public_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_private_public ../test_source/test_private_public.cpp ../test_source/source_plain_cxx.cpp
+                                            ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_private_public ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_public_kokkos_dependency
+)
+# the target needs kokkos linker settings
+kokkos_set_target_properties(LINK_ONLY_TARGET ${PROJECT_NAME}_executable_private_public)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_private_public PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_private_public PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPrivate_public_Verify COMMAND ${PROJECT_NAME}_executable_private_public 10)
+
+###### PRIVATE dependency on PRIVATE dependency
+add_subdirectory(lib_with_private_dependency_on_lib_with_private_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_private_private ../test_source/test_private_private.cpp
+                                             ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_private_private ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_private_kokkos_dependency
+)
+# the target needs kokkos linker settings
+kokkos_set_target_properties(LINK_ONLY_TARGET ${PROJECT_NAME}_executable_private_private)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_private_private PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_private_private PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPrivate_private_Verify COMMAND ${PROJECT_NAME}_executable_private_private 10)
+
+###### INTERFACE dependency on INTERFACE dependency
+add_subdirectory(lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_interface_interface
+  ../test_source/test_interface_interface.cpp ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_interface_interface ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency
+)
+
+#for the target
+kokkos_set_target_properties(TARGET ${PROJECT_NAME}_executable_interface_interface)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_interface_interface PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_interface_interface PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosInterface_interface_Verify COMMAND ${PROJECT_NAME}_executable_interface_interface
+                                                                       10
+)
+
+###### INTERFACE dependency on PUBLIC dependency
+add_subdirectory(lib_with_interface_dependency_on_lib_with_public_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_interface_public ../test_source/test_interface_public.cpp
+                                              ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_interface_public ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_public_kokkos_dependency
+)
+#for the target
+kokkos_set_target_properties(TARGET ${PROJECT_NAME}_executable_interface_public)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_interface_public PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_interface_public PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosInterface_public_Verify COMMAND ${PROJECT_NAME}_executable_interface_public 10)
+
+###### INTERFACE dependency on PRIVATE dependency
+add_subdirectory(lib_with_interface_dependency_on_lib_with_private_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_interface_private
+  ../test_source/test_interface_private.cpp ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_interface_private ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_private_kokkos_dependency
+)
+
+# the target needs to link with kokkos settings
+kokkos_set_target_properties(LINK_ONLY_TARGET ${PROJECT_NAME}_executable_interface_private)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_interface_private PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_interface_private PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosInterface_private_Verify COMMAND ${PROJECT_NAME}_executable_interface_private 10)

--- a/cmake_test/complex_mark_kokkos_files/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_kokkos_files/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,6 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+)
+
+# for pure interface libraries nothing needs to be marked manually

--- a/cmake_test/complex_mark_kokkos_files/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_kokkos_files/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,6 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+)
+
+# for pure interface libraries nothing needs to be marked manually

--- a/cmake_test/complex_mark_kokkos_files/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_kokkos_files/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,6 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+)
+
+# for pure interface libraries nothing needs to be marked manually

--- a/cmake_test/complex_mark_kokkos_files/lib_with_interface_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_kokkos_files/lib_with_interface_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,4 @@
+#this include is done to show the difference to the complex test
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_interface_kokkos_dependency/CMakeLists.txt)
+
+# for pure interface libraries nothing needs to be marked manually

--- a/cmake_test/complex_mark_kokkos_files/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_kokkos_files/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+)
+
+# the target needs the correct linker flags
+kokkos_set_target_properties(
+  TARGET ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_interface_kokkos_dependency
+)

--- a/cmake_test/complex_mark_kokkos_files/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_kokkos_files/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+)
+
+# the target needs the correct linker flags
+kokkos_set_target_properties(
+  LINK_ONLY_TARGET ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_private_kokkos_dependency
+)

--- a/cmake_test/complex_mark_kokkos_files/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_kokkos_files/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+)
+
+# the target needs the correct linker flags
+kokkos_set_target_properties(
+  TARGET ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_public_kokkos_dependency
+)

--- a/cmake_test/complex_mark_kokkos_files/lib_with_private_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_kokkos_files/lib_with_private_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,5 @@
+#this include is done to show the difference to the complex test
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_private_kokkos_dependency/CMakeLists.txt)
+
+#for the target
+kokkos_set_target_properties(TARGET ${PROJECT_NAME}_Lib_with_private_kokkos_dependency)

--- a/cmake_test/complex_mark_kokkos_files/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_kokkos_files/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+)
+
+#for the target
+kokkos_set_target_properties(
+  TARGET ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_interface_kokkos_dependency
+)

--- a/cmake_test/complex_mark_kokkos_files/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_kokkos_files/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+)
+
+# the target still needs to be linked with kokkos
+kokkos_set_target_properties(
+  LINK_ONLY_TARGET ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_private_kokkos_dependency
+)

--- a/cmake_test/complex_mark_kokkos_files/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_kokkos_files/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+)
+
+#for the target
+kokkos_set_target_properties(
+  TARGET ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_public_kokkos_dependency
+)

--- a/cmake_test/complex_mark_kokkos_files/lib_with_public_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_kokkos_files/lib_with_public_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,5 @@
+#this include is done to show the difference to the complex test
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_public_kokkos_dependency/CMakeLists.txt)
+
+#for the target
+kokkos_set_target_properties(TARGET ${PROJECT_NAME}_Lib_with_public_kokkos_dependency)

--- a/cmake_test/complex_mark_kokkos_files/lib_without_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_kokkos_files/lib_without_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,2 @@
+#this include is done to show the difference to the complex test
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_without_kokkos_dependency/CMakeLists.txt)

--- a/cmake_test/complex_mark_library/CMakeLists.txt
+++ b/cmake_test/complex_mark_library/CMakeLists.txt
@@ -1,0 +1,305 @@
+# Kokkos minimally requires 3.21 right now,
+# but your project can set it higher
+cmake_minimum_required(VERSION 3.21)
+
+# Projects can safely mix languages - must have C++ support
+project(KokkosCMakeTestingComplexMarkLibrary CXX Fortran)
+
+######
+# This test has the libs defer calls to set the kokkos flags downstream.
+# This will work independently of other libs in the project that have Kokkos automatically setting the properties
+
+######
+# This test can be used like a library, just scroll to the section that mimics how Kokkos is used in your project.
+# There are tree sections:
+#   - Targets without Kokkos dependency
+#   - Targets dependent on a library that has a Kokkos dependency
+#   - Targets dependent on a library that depends on a library that has a Kokkos dependency
+# Although the test stops at two layers, find_package(Kokkos) sets the source and target properties independent of
+# depth of the dependency tree.
+
+###### Targets that don't depend on Kokkos are not manipulated by us
+add_subdirectory(lib_without_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_without ../test_source/test_without.cpp ../test_source/source_plain_cxx.cpp
+                                     ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(${PROJECT_NAME}_executable_without ${PROJECT_NAME}_Lib_without_kokkos_dependency)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_without PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_without PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosWithout_Verify COMMAND ${PROJECT_NAME}_executable_without 10)
+
+###### Libraries that have direct dependency on Kokkos
+###### PUBLIC dependency
+add_subdirectory(lib_with_public_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_public ../test_source/test_public.cpp ../test_source/source_plain_cxx.cpp
+                                    ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_public ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_public_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_public PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_public PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPublic_Verify COMMAND ${PROJECT_NAME}_executable_public 10)
+
+###### INTERFACE dependency
+add_subdirectory(lib_with_interface_kokkos_dependency)
+add_executable(
+  ${PROJECT_NAME}_executable_interface ../test_source/test_interface.cpp ../test_source/source_plain_cxx.cpp
+                                       ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_interface ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_interface_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_interface PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_interface PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosInterface_Verify COMMAND ${PROJECT_NAME}_executable_interface 10)
+
+###### PRIVATE dependency
+add_subdirectory(lib_with_private_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_private ../test_source/test_private.cpp ../test_source/source_plain_cxx.cpp
+                                     ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_private ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_private_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_private PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_private PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPrivate_Verify COMMAND ${PROJECT_NAME}_executable_private 10)
+
+##### Libraries that have indirect dependency on Kokkos
+##### PUBLIC dependency on INTERFACE dependency
+add_subdirectory(lib_with_public_dependency_on_lib_with_interface_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_public_interface ../test_source/test_public_interface.cpp
+                                              ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_public_interface ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_interface_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_public_interface PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_public_interface PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPublic_interface_Verify COMMAND ${PROJECT_NAME}_executable_public_interface 10)
+
+###### PUBLIC dependency on PUBLIC dependency
+add_subdirectory(lib_with_public_dependency_on_lib_with_public_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_public_public ../test_source/test_public_public.cpp ../test_source/source_plain_cxx.cpp
+                                           ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_public_public ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_public_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_public_public PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_public_public PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPublic_public_Verify COMMAND ${PROJECT_NAME}_executable_public_public 10)
+
+###### PUBLIC dependency on PRIVATE dependency
+add_subdirectory(lib_with_public_dependency_on_lib_with_private_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_public_private ../test_source/test_public_private.cpp ../test_source/source_plain_cxx.cpp
+                                            ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_public_private ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_private_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_public_private PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_public_private PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPublic_private_Verify COMMAND ${PROJECT_NAME}_executable_public_private 10)
+
+###### PRIVATE dependency on INTERFACE dependency
+add_subdirectory(lib_with_private_dependency_on_lib_with_interface_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_private_interface
+  ../test_source/test_private_interface.cpp ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_private_interface ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_interface_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_private_interface PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_private_interface PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPrivate_interface_Verify COMMAND ${PROJECT_NAME}_executable_private_interface 10)
+
+###### PRIVATE dependency on PUBLIC dependency
+add_subdirectory(lib_with_private_dependency_on_lib_with_public_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_private_public ../test_source/test_private_public.cpp ../test_source/source_plain_cxx.cpp
+                                            ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_private_public ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_public_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_private_public PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_private_public PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPrivate_public_Verify COMMAND ${PROJECT_NAME}_executable_private_public 10)
+
+###### PRIVATE dependency on PRIVATE dependency
+add_subdirectory(lib_with_private_dependency_on_lib_with_private_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_private_private ../test_source/test_private_private.cpp
+                                             ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_private_private ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_private_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_private_private PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_private_private PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosPrivate_private_Verify COMMAND ${PROJECT_NAME}_executable_private_private 10)
+
+###### INTERFACE dependency on INTERFACE dependency
+add_subdirectory(lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_interface_interface
+  ../test_source/test_interface_interface.cpp ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_interface_interface ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_interface_interface PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_interface_interface PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosInterface_interface_Verify COMMAND ${PROJECT_NAME}_executable_interface_interface
+                                                                       10
+)
+
+###### INTERFACE dependency on PUBLIC dependency
+add_subdirectory(lib_with_interface_dependency_on_lib_with_public_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_interface_public ../test_source/test_interface_public.cpp
+                                              ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_interface_public ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_public_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_interface_public PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_interface_public PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosInterface_public_Verify COMMAND ${PROJECT_NAME}_executable_interface_public 10)
+
+###### INTERFACE dependency on PRIVATE dependency
+add_subdirectory(lib_with_interface_dependency_on_lib_with_private_kokkos_dependency)
+
+add_executable(
+  ${PROJECT_NAME}_executable_interface_private
+  ../test_source/test_interface_private.cpp ../test_source/source_plain_cxx.cpp ../test_source/source_plain_fortran.f
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_executable_interface_private ${PROJECT_NAME}_Lib_without_kokkos_dependency
+  ${PROJECT_NAME}_Lib_with_interface_dependency_on_lib_with_private_kokkos_dependency
+)
+
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_executable_interface_private PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_executable_interface_private PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+add_test(NAME ${PROJECT_NAME}_KokkosInterface_private_Verify COMMAND ${PROJECT_NAME}_executable_interface_private 10)

--- a/cmake_test/complex_mark_library/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_library/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,6 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+)
+
+# for pure interface libraries nothing needs to be marked manually

--- a/cmake_test/complex_mark_library/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_library/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,6 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+)
+
+# for pure interface libraries nothing needs to be marked manually

--- a/cmake_test/complex_mark_library/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_library/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,6 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+)
+
+# for pure interface libraries nothing needs to be marked manually

--- a/cmake_test/complex_mark_library/lib_with_interface_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_library/lib_with_interface_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,5 @@
+#this include is done to show the difference to the complex test
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_interface_kokkos_dependency/CMakeLists.txt)
+
+# build all targets with kokkos settings if they link to the library downstream
+kokkos_defer_set_dependent_library_properties(LIBRARY ${PROJECT_NAME}_Lib_with_interface_kokkos_dependency)

--- a/cmake_test/complex_mark_library/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_library/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+)
+
+# the target needs the correct linker flags
+kokkos_set_target_properties(
+  TARGET ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_interface_kokkos_dependency
+)

--- a/cmake_test/complex_mark_library/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_library/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+)
+
+# the target needs the correct linker flags
+kokkos_set_target_properties(
+  LINK_ONLY_TARGET ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_private_kokkos_dependency
+)

--- a/cmake_test/complex_mark_library/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_library/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+)
+
+# the target needs the correct linker flags
+kokkos_set_target_properties(
+  TARGET ${PROJECT_NAME}_Lib_with_private_dependency_on_lib_with_public_kokkos_dependency
+)

--- a/cmake_test/complex_mark_library/lib_with_private_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_library/lib_with_private_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,8 @@
+#this include is done to show the difference to the complex test
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_private_kokkos_dependency/CMakeLists.txt)
+
+# mark target as a kokkos target
+kokkos_set_target_properties(TARGET ${PROJECT_NAME}_Lib_with_private_kokkos_dependency)
+
+# link all targets with kokkos settings if they link to the current library downstream
+kokkos_defer_set_dependent_library_properties(LIBRARY ${PROJECT_NAME}_Lib_with_private_kokkos_dependency)

--- a/cmake_test/complex_mark_library/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_library/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/CMakeLists.txt
+)
+
+#for the target
+kokkos_set_target_properties(
+  TARGET ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_interface_kokkos_dependency
+)

--- a/cmake_test/complex_mark_library/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_library/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/CMakeLists.txt
+)
+
+# the target still needs to be linked with kokkos
+kokkos_set_target_properties(
+  LINK_ONLY_TARGET ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_private_kokkos_dependency
+)

--- a/cmake_test/complex_mark_library/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_library/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,9 @@
+#this include is done to show the difference to the complex test
+include(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/CMakeLists.txt
+)
+
+#for the target
+kokkos_set_target_properties(
+  TARGET ${PROJECT_NAME}_Lib_with_public_dependency_on_lib_with_public_kokkos_dependency
+)

--- a/cmake_test/complex_mark_library/lib_with_public_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_library/lib_with_public_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,8 @@
+#this include is done to show the difference to the complex test
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_with_public_kokkos_dependency/CMakeLists.txt)
+
+# mark dir as having kokkos targets
+kokkos_set_target_properties(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+# build all targets with kokkos settings if they link to the library downstream
+kokkos_defer_set_dependent_library_properties(LIBRARY ${PROJECT_NAME}_Lib_with_public_kokkos_dependency)

--- a/cmake_test/complex_mark_library/lib_without_kokkos_dependency/CMakeLists.txt
+++ b/cmake_test/complex_mark_library/lib_without_kokkos_dependency/CMakeLists.txt
@@ -1,0 +1,2 @@
+#this include is done to show the difference to the complex test
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../complex/lib_without_kokkos_dependency/CMakeLists.txt)

--- a/cmake_test/launch_compiler/CMakeLists.txt
+++ b/cmake_test/launch_compiler/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Kokkos minimally requires 3.21 right now,
+# Kokkos minimally requires 3.16 right now,
 # but your project can set it higher
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.16)
 
 # Projects can safely mix languages - must have C++ support
 # Kokkos flags will only apply to C++ files

--- a/cmake_test/launch_compiler/CMakeLists.txt
+++ b/cmake_test/launch_compiler/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Kokkos minimally requires 3.21 right now,
+# but your project can set it higher
+cmake_minimum_required(VERSION 3.21)
+
+# Projects can safely mix languages - must have C++ support
+# Kokkos flags will only apply to C++ files
+project(KokkosCMakeTestingLaunchCompiler CXX Fortran)
+
+# this does not work when compiling with language support (Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE)
+find_package(Kokkos REQUIRED COMPONENTS launch_compiler)
+
+add_executable(${PROJECT_NAME}_with_kokkos test_with_kokkos.cpp source_plain_fortran.f)
+add_executable(${PROJECT_NAME}_no_kokkos test_no_kokkos.cpp source_plain_fortran.f)
+if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+  set_target_properties(${PROJECT_NAME}_with_kokkos PROPERTIES LINKER_LANGUAGE Fortran)
+  set_target_properties(${PROJECT_NAME}_no_kokkos PROPERTIES LINKER_LANGUAGE Fortran)
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
+    target_link_options(${PROJECT_NAME}_with_kokkos PRIVATE -fno-fortran-main)
+    target_link_options(${PROJECT_NAME}_no_kokkos PRIVATE -fno-fortran-main)
+  endif()
+endif()
+
+# This is the only thing required to set up compiler/linker flags
+target_link_libraries(${PROJECT_NAME}_with_kokkos Kokkos::kokkos)
+
+enable_testing()
+add_test(NAME ExampleDifferentCompiler_Kokkos_Verify COMMAND ${PROJECT_NAME}_with_kokkos 10)
+add_test(NAME ExampleDifferentCompiler_NoKokkos_Verify COMMAND ${PROJECT_NAME}_no_kokkos 10)

--- a/cmake_test/launch_compiler/source_plain_fortran.f
+++ b/cmake_test/launch_compiler/source_plain_fortran.f
@@ -1,0 +1,4 @@
+        FUNCTION print_fortran()
+          PRINT *, 'Hello World from Fortran'
+          RETURN
+        END

--- a/cmake_test/launch_compiler/test_no_kokkos.cpp
+++ b/cmake_test/launch_compiler/test_no_kokkos.cpp
@@ -1,0 +1,25 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <cstdio>
+
+extern "C" void print_fortran_();
+
+int main(int argc, char* argv[]) {
+  printf(
+      "This executable does nothing and is just for build system demonstration "
+      "\n");
+}

--- a/cmake_test/launch_compiler/test_with_kokkos.cpp
+++ b/cmake_test/launch_compiler/test_with_kokkos.cpp
@@ -1,0 +1,71 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+
+struct CountFunctor {
+  KOKKOS_FUNCTION void operator()(const long i, long& lcount) const {
+    lcount += (i % 2) == 0;
+  }
+};
+
+int main(int argc, char* argv[]) {
+  Kokkos::initialize(argc, argv);
+  Kokkos::DefaultExecutionSpace().print_configuration(std::cout);
+
+  if (argc < 2) {
+    fprintf(stderr, "Usage: %s [<kokkos_options>] <size>\n", argv[0]);
+    Kokkos::finalize();
+    exit(1);
+  }
+
+  const long n = strtol(argv[1], nullptr, 10);
+
+  printf("Number of even integers from 0 to %ld\n", n - 1);
+
+  Kokkos::Timer timer;
+  timer.reset();
+
+  // Compute the number of even integers from 0 to n-1, in parallel.
+  long count = 0;
+  CountFunctor functor;
+  Kokkos::parallel_reduce(n, functor, count);
+
+  double count_time = timer.seconds();
+  printf("  Parallel: %ld    %10.6f\n", count, count_time);
+
+  timer.reset();
+
+  // Compare to a sequential loop.
+  long seq_count = 0;
+  for (long i = 0; i < n; ++i) {
+    seq_count += (i % 2) == 0;
+  }
+
+  count_time = timer.seconds();
+  printf("Sequential: %ld    %10.6f\n", seq_count, count_time);
+
+  print_fortran_();
+
+  Kokkos::finalize();
+
+  return (count == seq_count) ? 0 : -1;
+}

--- a/cmake_test/test_source/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency/lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency.h
@@ -1,0 +1,39 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_INTERFACE_DEPENDENCY_ON_LIB_WITH_INTERFACE_KOKKOS_DEPENDENCY
+#define LIB_WITH_INTERFACE_DEPENDENCY_ON_LIB_WITH_INTERFACE_KOKKOS_DEPENDENCY
+
+#include <lib_with_interface_kokkos_dependency.h>
+#include <iostream>
+
+namespace lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency {
+
+template <typename ViewType>
+void print(lib_with_interface_kokkos_dependency::
+               StructOfLibWithInterfaceKokkosDependency<ViewType>
+                   in) {
+  std::cout << "Hello from "
+               "lib_with_interface_dependency_on_lib_with_interface_kokkos_"
+               "dependency\n";
+  std::cout << "Will call lib_with_interface_kokkos_dependency now:\n";
+  lib_with_interface_kokkos_dependency::print(in.value);
+  std::cout << "Done\n";
+}
+
+}  // namespace
+   // lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency/lib_with_interface_dependency_on_lib_with_private_kokkos_dependency.h
@@ -1,0 +1,38 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_INTERFACE_DEPENDENCY_ON_LIB_WITH_PRIVATE_KOKKOS_DEPENDENCY
+#define LIB_WITH_INTERFACE_DEPENDENCY_ON_LIB_WITH_PRIVATE_KOKKOS_DEPENDENCY
+
+#include <lib_with_private_kokkos_dependency.h>
+#include <iostream>
+
+namespace lib_with_interface_dependency_on_lib_with_private_kokkos_dependency {
+
+void print(
+    lib_with_private_kokkos_dependency::StructOfLibWithPrivateKokkosDependency
+        in) {
+  std::cout << "Hello from "
+               "lib_with_interface_dependency_on_lib_with_private_kokkos_"
+               "dependency\n";
+  std::cout << "Will call lib_with_private_kokkos_dependency now:\n";
+  lib_with_private_kokkos_dependency::print(in);
+  std::cout << "Done\n";
+}
+
+}  // namespace
+   // lib_with_interface_dependency_on_lib_with_private_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency/lib_with_interface_dependency_on_lib_with_public_kokkos_dependency.h
@@ -1,0 +1,38 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_INTERFACE_DEPENDENCY_ON_LIB_WITH_PUBLIC_KOKKOS_DEPENDENCY
+#define LIB_WITH_INTERFACE_DEPENDENCY_ON_LIB_WITH_PUBLIC_KOKKOS_DEPENDENCY
+
+#include <lib_with_public_kokkos_dependency.h>
+#include <iostream>
+
+namespace lib_with_interface_dependency_on_lib_with_public_kokkos_dependency {
+
+void print(
+    lib_with_public_kokkos_dependency::StructOfLibWithPublicKokkosDependency
+        in) {
+  std::cout << "Hello from "
+               "lib_with_interface_dependency_on_lib_with_interface_kokkos_"
+               "dependency\n";
+  std::cout << "Will call lib_with_interface_kokkos_dependency now:\n";
+  lib_with_public_kokkos_dependency::print(in.value);
+  std::cout << "Done\n";
+}
+
+}  // namespace
+   // lib_with_interface_dependency_on_lib_with_public_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_interface_kokkos_dependency/cuda_hip_header_without_kokkos_dependency.cuh
+++ b/cmake_test/test_source/lib_with_interface_kokkos_dependency/cuda_hip_header_without_kokkos_dependency.cuh
@@ -1,0 +1,32 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef CUDA_HIP_HEADER_WITHOUT_KOKKOS_DEPENDENCY
+#define CUDA_HIP_HEADER_WITHOUT_KOKKOS_DEPENDENCY
+
+#include <stdio.h>
+#ifdef __HIPCC__
+#include <hip/hip_runtime.h>
+#endif
+
+namespace cuda_hip_header_without_kokkos_dependency {
+
+template <typename T>
+__global__ void print_from_device([[maybe_unused]] T value) { printf("Hello, from a cuda function!\n"); }
+
+}  // namespace cuda_hip_header_without_kokkos_dependency
+
+#endif

--- a/cmake_test/test_source/lib_with_interface_kokkos_dependency/lib_with_interface_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_interface_kokkos_dependency/lib_with_interface_kokkos_dependency.h
@@ -1,0 +1,47 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_INTERFACE_KOKKOS_DEPENDENCY
+#define LIB_WITH_INTERFACE_KOKKOS_DEPENDENCY
+
+#include <Kokkos_Core.hpp>
+#if defined __CUDACC__ || defined __HIPCC__
+#include <cuda_hip_header_without_kokkos_dependency.cuh>
+#endif
+
+#include <iostream>
+
+namespace lib_with_interface_kokkos_dependency {
+
+template <typename ViewType>
+void print([[maybe_unused]] ViewType a) {
+  static_assert(std::is_same_v<Kokkos::View<int*>, ViewType>,
+                "ViewType must match Kokkos::View<int*>");
+  std::cout << "Hello from lib_with_interface_kokkos_dependency \n";
+#if defined __CUDACC__ || defined __HIPCC__
+  std::cout << "Calling additional device function without kokkos dependency\n";
+  cuda_hip_header_without_kokkos_dependency::print_from_device<<<1, 1>>>(1.0);
+#endif
+}
+
+template <typename ViewType>
+struct StructOfLibWithInterfaceKokkosDependency {
+  ViewType value;
+};
+
+}  // namespace lib_with_interface_kokkos_dependency
+
+#endif

--- a/cmake_test/test_source/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency.h
@@ -1,0 +1,30 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_PRIVATE_DEPENDENCY_ON_LIB_WITH_INTERFACE_KOKKOS_DEPENDENCY
+#define LIB_WITH_PRIVATE_DEPENDENCY_ON_LIB_WITH_INTERFACE_KOKKOS_DEPENDENCY
+
+namespace lib_with_private_dependency_on_lib_with_interface_kokkos_dependency {
+
+void initialize();
+
+void finalize();
+
+void print();
+
+}  // namespace
+   // lib_with_private_dependency_on_lib_with_interface_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/source_with_private_dependency_on_lib_with_interface_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_private_dependency_on_lib_with_interface_kokkos_dependency/source_with_private_dependency_on_lib_with_interface_kokkos_dependency.cpp
@@ -1,0 +1,48 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "lib_with_private_dependency_on_lib_with_interface_kokkos_dependency.h"
+#include <lib_with_interface_kokkos_dependency.h>
+#include <iostream>
+
+namespace lib_with_private_dependency_on_lib_with_interface_kokkos_dependency {
+
+static bool i_initialized_lib_with_interface_kokkos_dependency = false;
+
+void initialize() {
+  if (!Kokkos::is_initialized()) {
+    Kokkos::initialize();
+    i_initialized_lib_with_interface_kokkos_dependency = true;
+  }
+}
+
+void finalize() {
+  if (i_initialized_lib_with_interface_kokkos_dependency and
+      !Kokkos::is_finalized())
+    Kokkos::finalize();
+}
+
+void print() {
+  std::cout << "Hello from "
+               "lib_with_private_dependency_on_lib_with_interface_kokkos_"
+               "dependency\n";
+  std::cout << "Will call lib_with_interface_kokkos_dependency now:\n";
+  lib_with_interface_kokkos_dependency::print(Kokkos::View<int*>{"a", 10});
+  std::cout << "Done\n";
+}
+
+}  // namespace
+   // lib_with_private_dependency_on_lib_with_interface_kokkos_dependency

--- a/cmake_test/test_source/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/lib_with_private_dependency_on_lib_with_private_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/lib_with_private_dependency_on_lib_with_private_kokkos_dependency.h
@@ -1,0 +1,30 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_PRIVATE_DEPENDENCY_ON_LIB_WITH_PRIVATE_KOKKOS_DEPENDENCY
+#define LIB_WITH_PRIVATE_DEPENDENCY_ON_LIB_WITH_PRIVATE_KOKKOS_DEPENDENCY
+
+namespace lib_with_private_dependency_on_lib_with_private_kokkos_dependency {
+
+void initialize();
+
+void finalize();
+
+void print();
+
+}  // namespace
+   // lib_with_private_dependency_on_lib_with_private_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/source_with_private_dependency_on_lib_with_private_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_private_dependency_on_lib_with_private_kokkos_dependency/source_with_private_dependency_on_lib_with_private_kokkos_dependency.cpp
@@ -1,0 +1,50 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "lib_with_private_dependency_on_lib_with_private_kokkos_dependency.h"
+#include <lib_with_private_kokkos_dependency.h>
+#include <iostream>
+
+namespace lib_with_private_dependency_on_lib_with_private_kokkos_dependency {
+
+static bool i_initialized_lib_with_private_kokkos_dependency = false;
+
+void initialize() {
+  if (!lib_with_private_kokkos_dependency::is_initialized()) {
+    lib_with_private_kokkos_dependency::initialize();
+    i_initialized_lib_with_private_kokkos_dependency = true;
+  }
+}
+
+void finalize() {
+  if (i_initialized_lib_with_private_kokkos_dependency and
+      !lib_with_private_kokkos_dependency::is_finalized())
+    lib_with_private_kokkos_dependency::finalize();
+}
+
+void print() {
+  std::cout
+      << "Hello from "
+         "lib_with_private_dependency_on_lib_with_private_kokkos_dependency\n";
+  std::cout << "Will call lib_with_private_kokkos_dependency now:\n";
+  lib_with_private_kokkos_dependency::print(
+      lib_with_private_kokkos_dependency::
+          StructOfLibWithPrivateKokkosDependency{});
+  std::cout << "Done\n";
+}
+
+}  // namespace
+   // lib_with_private_dependency_on_lib_with_private_kokkos_dependency

--- a/cmake_test/test_source/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/lib_with_private_dependency_on_lib_with_public_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/lib_with_private_dependency_on_lib_with_public_kokkos_dependency.h
@@ -1,0 +1,29 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_PRIVATE_DEPENDENCY_ON_LIB_WITH_PUBLIC_KOKKOS_DEPENDENCY
+#define LIB_WITH_PRIVATE_DEPENDENCY_ON_LIB_WITH_PUBLIC_KOKKOS_DEPENDENCY
+
+namespace lib_with_private_dependency_on_lib_with_public_kokkos_dependency {
+
+void initialize();
+
+void finalize();
+
+void print();
+
+}  // namespace lib_with_private_dependency_on_lib_with_public_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/source_with_private_dependency_on_lib_with_public_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_private_dependency_on_lib_with_public_kokkos_dependency/source_with_private_dependency_on_lib_with_public_kokkos_dependency.cpp
@@ -1,0 +1,47 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "lib_with_private_dependency_on_lib_with_public_kokkos_dependency.h"
+#include <lib_with_public_kokkos_dependency.h>
+#include <iostream>
+
+namespace lib_with_private_dependency_on_lib_with_public_kokkos_dependency {
+
+static bool i_initialized_lib_with_public_kokkos_dependency = false;
+
+void initialize() {
+  if (!Kokkos::is_initialized()) {
+    Kokkos::initialize();
+    i_initialized_lib_with_public_kokkos_dependency = true;
+  }
+}
+
+void finalize() {
+  if (i_initialized_lib_with_public_kokkos_dependency and
+      !Kokkos::is_finalized())
+    Kokkos::finalize();
+}
+
+void print() {
+  std::cout
+      << "Hello from "
+         "lib_with_private_dependency_on_lib_with_public_kokkos_dependency\n";
+  std::cout << "Will call lib_with_public_kokkos_dependency now:\n";
+  lib_with_public_kokkos_dependency::print(Kokkos::View<int*>{"a", 10});
+  std::cout << "Done\n";
+}
+
+}  // namespace lib_with_private_dependency_on_lib_with_public_kokkos_dependency

--- a/cmake_test/test_source/lib_with_private_kokkos_dependency/cuda_hip_source_without_kokkos_dependency.cu
+++ b/cmake_test/test_source/lib_with_private_kokkos_dependency/cuda_hip_source_without_kokkos_dependency.cu
@@ -1,0 +1,26 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <cstdio>
+#ifdef __HIPCC__
+#include <hip/hip_runtime.h>
+#endif
+
+namespace cuda_hip_functions_without_kokkos_dependency {
+
+__global__ void print_from_device() { printf("Hello, from a cuda function!\n"); }
+
+}  // namespace cuda_hip_functions_without_kokkos_dependency

--- a/cmake_test/test_source/lib_with_private_kokkos_dependency/header_with_private_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_private_kokkos_dependency/header_with_private_kokkos_dependency.h
@@ -1,0 +1,33 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef HEADER_WITH_PRIVATE_KOKKOS_DEPENDENCY
+#define HEADER_WITH_PRIVATE_KOKKOS_DEPENDENCY
+
+namespace lib_with_private_kokkos_dependency {
+
+bool is_initialized();
+
+bool is_finalized();
+
+void initialize();
+
+void finalize();
+
+void print_kokkos();
+
+}  // namespace lib_with_private_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_private_kokkos_dependency/header_without_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_private_kokkos_dependency/header_without_kokkos_dependency.h
@@ -1,0 +1,27 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef HEADER_WITHOUT_KOKKOS_DEPENDENCY
+#define HEADER_WITHOUT_KOKKOS_DEPENDENCY
+
+namespace lib_with_private_kokkos_dependency {
+
+void print_non_kokkos();
+
+struct StructOfLibWithPrivateKokkosDependency {};
+
+}  // namespace lib_with_private_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_private_kokkos_dependency/lib_with_private_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_private_kokkos_dependency/lib_with_private_kokkos_dependency.h
@@ -1,0 +1,28 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_PRIVATE_KOKKOS_DEPENDENCY
+#define LIB_WITH_PRIVATE_KOKKOS_DEPENDENCY
+
+#include "header_with_private_kokkos_dependency.h"
+#include "header_without_kokkos_dependency.h"
+
+namespace lib_with_private_kokkos_dependency {
+
+void print([[maybe_unused]] StructOfLibWithPrivateKokkosDependency in);
+
+}  // namespace lib_with_private_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_private_kokkos_dependency/source_merging_prints.cpp
+++ b/cmake_test/test_source/lib_with_private_kokkos_dependency/source_merging_prints.cpp
@@ -1,0 +1,26 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "lib_with_private_kokkos_dependency.h"
+
+namespace lib_with_private_kokkos_dependency {
+
+void print([[maybe_unused]] StructOfLibWithPrivateKokkosDependency in) {
+  print_non_kokkos();
+  print_kokkos();
+}
+
+}  // namespace lib_with_private_kokkos_dependency

--- a/cmake_test/test_source/lib_with_private_kokkos_dependency/source_with_public_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_private_kokkos_dependency/source_with_public_kokkos_dependency.cpp
@@ -1,0 +1,48 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "header_with_private_kokkos_dependency.h"
+#include <Kokkos_Core.hpp>
+#include <iostream>
+
+namespace lib_with_private_kokkos_dependency {
+
+static bool i_initialized_kokkos = false;
+
+bool is_initialized() { return Kokkos::is_initialized(); }
+bool is_finalized() { return Kokkos::is_finalized(); }
+
+void initialize() {
+  // if I have to initialize kokkos, I assume I also have to finalize after I
+  // did what I needed Kokkos for
+  if (!Kokkos::is_initialized()) {
+    Kokkos::initialize();
+    i_initialized_kokkos = true;
+  }
+}
+
+void finalize() {
+  if (i_initialized_kokkos and !Kokkos::is_finalized()) {
+    Kokkos::finalize();
+  }
+}
+
+void print_kokkos() {
+  std::cout << "Hello from a kokkos function within "
+               "lib_with_private_kokkos_dependency\n";
+  Kokkos::print_configuration(std::cout);
+}
+}  // namespace lib_with_private_kokkos_dependency

--- a/cmake_test/test_source/lib_with_private_kokkos_dependency/source_without_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_private_kokkos_dependency/source_without_kokkos_dependency.cpp
@@ -1,0 +1,40 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "header_without_kokkos_dependency.h"
+#ifdef __HIPCC__
+#include <hip/hip_runtime.h>
+#endif
+#include <iostream>
+
+#if defined __CUDACC__ || defined __HIPCC__
+namespace cuda_hip_functions_without_kokkos_dependency {
+__global__ void print_from_device();
+}
+#endif
+
+namespace lib_with_private_kokkos_dependency {
+
+void print_non_kokkos() {
+  std::cout << "Hello from non-kokkos function inside "
+               "lib_with_private_kokkos_dependency\n";
+#if defined __CUDACC__ || defined __HIPCC__
+  std::cout << "Calling additional device function without kokkos dependency\n";
+  cuda_hip_functions_without_kokkos_dependency::print_from_device<<<1, 1>>>();
+#endif
+}
+
+}  // namespace lib_with_private_kokkos_dependency

--- a/cmake_test/test_source/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency.h
@@ -1,0 +1,30 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_PUBLIC_DEPENDENCY_ON_LIB_WITH_INTERFACE_KOKKOS_DEPENDENCY
+#define LIB_WITH_PUBLIC_DEPENDENCY_ON_LIB_WITH_INTERFACE_KOKKOS_DEPENDENCY
+
+#include <lib_with_interface_kokkos_dependency.h>
+
+namespace lib_with_public_dependency_on_lib_with_interface_kokkos_dependency {
+
+void print(lib_with_interface_kokkos_dependency::
+               StructOfLibWithInterfaceKokkosDependency<Kokkos::View<int*>>
+                   in);
+
+}  // namespace
+   // lib_with_public_dependency_on_lib_with_interface_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/source_with_public_dependency_on_lib_with_interface_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_public_dependency_on_lib_with_interface_kokkos_dependency/source_with_public_dependency_on_lib_with_interface_kokkos_dependency.cpp
@@ -1,0 +1,34 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "lib_with_public_dependency_on_lib_with_interface_kokkos_dependency.h"
+#include <iostream>
+
+namespace lib_with_public_dependency_on_lib_with_interface_kokkos_dependency {
+
+void print(lib_with_interface_kokkos_dependency::
+               StructOfLibWithInterfaceKokkosDependency<Kokkos::View<int*>>
+                   in) {
+  std::cout
+      << "Hello from "
+         "lib_with_public_dependency_on_lib_with_interface_kokkos_dependency\n";
+  std::cout << "Will call lib_with_interface_kokkos_dependency now:\n";
+  lib_with_interface_kokkos_dependency::print(in.value);
+  std::cout << "Done\n";
+}
+
+}  // namespace
+   // lib_with_public_dependency_on_lib_with_interface_kokkos_dependency

--- a/cmake_test/test_source/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/lib_with_public_dependency_on_lib_with_private_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/lib_with_public_dependency_on_lib_with_private_kokkos_dependency.h
@@ -1,0 +1,32 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_PUBLIC_DEPENDENCY_ON_LIB_WITH_PRIVATE_KOKKOS_DEPENDENCY
+#define LIB_WITH_PUBLIC_DEPENDENCY_ON_LIB_WITH_PRIVATE_KOKKOS_DEPENDENCY
+
+#include <lib_with_private_kokkos_dependency.h>
+
+namespace lib_with_public_dependency_on_lib_with_private_kokkos_dependency {
+
+void initialize();
+
+void finalize();
+
+void print(
+    lib_with_private_kokkos_dependency::StructOfLibWithPrivateKokkosDependency);
+
+}  // namespace lib_with_public_dependency_on_lib_with_private_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/source_with_public_dependency_on_lib_with_private_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_public_dependency_on_lib_with_private_kokkos_dependency/source_with_public_dependency_on_lib_with_private_kokkos_dependency.cpp
@@ -1,0 +1,48 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "lib_with_public_dependency_on_lib_with_private_kokkos_dependency.h"
+#include <iostream>
+
+namespace lib_with_public_dependency_on_lib_with_private_kokkos_dependency {
+
+static bool i_initialized_lib_with_private_kokkos_dependency = false;
+
+void initialize() {
+  if (!lib_with_private_kokkos_dependency::is_initialized()) {
+    lib_with_private_kokkos_dependency::initialize();
+    i_initialized_lib_with_private_kokkos_dependency = true;
+  }
+}
+
+void finalize() {
+  if (i_initialized_lib_with_private_kokkos_dependency and
+      !lib_with_private_kokkos_dependency::is_finalized())
+    lib_with_private_kokkos_dependency::finalize();
+}
+
+void print(
+    lib_with_private_kokkos_dependency::StructOfLibWithPrivateKokkosDependency
+        in) {
+  std::cout
+      << "Hello from "
+         "lib_with_public_dependency_on_lib_with_private_kokkos_dependency\n";
+  std::cout << "Will call lib_with_private_kokkos_dependency now:\n";
+  lib_with_private_kokkos_dependency::print(in);
+  std::cout << "Done\n";
+}
+
+}  // namespace lib_with_public_dependency_on_lib_with_private_kokkos_dependency

--- a/cmake_test/test_source/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/lib_with_public_dependency_on_lib_with_public_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/lib_with_public_dependency_on_lib_with_public_kokkos_dependency.h
@@ -1,0 +1,29 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_PUBLIC_DEPENDENCY_ON_LIB_WITH_PUBLIC_KOKKOS_DEPENDENCY
+#define LIB_WITH_PUBLIC_DEPENDENCY_ON_LIB_WITH_PUBLIC_KOKKOS_DEPENDENCY
+
+#include <lib_with_public_kokkos_dependency.h>
+
+namespace lib_with_public_dependency_on_lib_with_public_kokkos_dependency {
+
+void print(
+    lib_with_public_kokkos_dependency::StructOfLibWithPublicKokkosDependency
+        in);
+
+}  // namespace lib_with_public_dependency_on_lib_with_public_kokkos_dependency
+#endif

--- a/cmake_test/test_source/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/source_with_public_dependency_on_lib_with_public_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_public_dependency_on_lib_with_public_kokkos_dependency/source_with_public_dependency_on_lib_with_public_kokkos_dependency.cpp
@@ -1,0 +1,33 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "lib_with_public_dependency_on_lib_with_public_kokkos_dependency.h"
+#include <iostream>
+
+namespace lib_with_public_dependency_on_lib_with_public_kokkos_dependency {
+
+void print(
+    lib_with_public_kokkos_dependency::StructOfLibWithPublicKokkosDependency
+        in) {
+  std::cout
+      << "Hello from "
+         "lib_with_public_dependency_on_lib_with_public_kokkos_dependency\n";
+  std::cout << "Will call lib_with_public_kokkos_dependency now:\n";
+  lib_with_public_kokkos_dependency::print(in.value);
+  std::cout << "Done\n";
+}
+
+}  // namespace lib_with_public_dependency_on_lib_with_public_kokkos_dependency

--- a/cmake_test/test_source/lib_with_public_kokkos_dependency/cuda_hip_source_without_kokkos_dependency.cu
+++ b/cmake_test/test_source/lib_with_public_kokkos_dependency/cuda_hip_source_without_kokkos_dependency.cu
@@ -1,0 +1,26 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <cstdio>
+#ifdef __HIPCC__
+#include <hip/hip_runtime.h>
+#endif
+
+namespace cuda_hip_functions_without_kokkos_dependency {
+
+__global__ void print_from_device() { printf("Hello, from a cuda function!\n"); }
+
+}  // namespace cuda_hip_functions_without_kokkos_dependency

--- a/cmake_test/test_source/lib_with_public_kokkos_dependency/lib_with_public_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_with_public_kokkos_dependency/lib_with_public_kokkos_dependency.h
@@ -1,0 +1,32 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITH_PUBLIC_KOKKOS_DEPENDENCY
+#define LIB_WITH_PUBLIC_KOKKOS_DEPENDENCY
+
+#include <Kokkos_Core.hpp>
+
+namespace lib_with_public_kokkos_dependency {
+
+void print(Kokkos::View<int*> a);
+
+struct StructOfLibWithPublicKokkosDependency {
+  Kokkos::View<int*> value;
+};
+
+}  // namespace lib_with_public_kokkos_dependency
+
+#endif

--- a/cmake_test/test_source/lib_with_public_kokkos_dependency/source_with_public_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_with_public_kokkos_dependency/source_with_public_kokkos_dependency.cpp
@@ -1,0 +1,39 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "lib_with_public_kokkos_dependency.h"
+#ifdef __HIPCC__
+#include <hip/hip_runtime.h>
+#endif
+#include <iostream>
+
+#if defined __CUDACC__ || defined __HIPCC__
+namespace cuda_hip_functions_without_kokkos_dependency {
+__global__ void print_from_device();
+}
+#endif
+
+namespace lib_with_public_kokkos_dependency {
+
+void print([[maybe_unused]] Kokkos::View<int*> a) {
+  std::cout << "Hello from lib_with_public_kokkos_dependency \n";
+#if defined __CUDACC__ || defined __HIPCC__
+  std::cout << "Calling additional device function without kokkos dependency\n";
+  cuda_hip_functions_without_kokkos_dependency::print_from_device<<<1, 1>>>();
+#endif
+}
+
+}  // namespace lib_with_public_kokkos_dependency

--- a/cmake_test/test_source/lib_without_kokkos_dependency/lib_without_kokkos_dependency.h
+++ b/cmake_test/test_source/lib_without_kokkos_dependency/lib_without_kokkos_dependency.h
@@ -1,0 +1,25 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef LIB_WITHOUT_KOKKOS_DEPENDENCY
+#define LIB_WITHOUT_KOKKOS_DEPENDENCY
+
+namespace lib_without_kokkos_dependency {
+
+void print();
+
+}
+#endif

--- a/cmake_test/test_source/lib_without_kokkos_dependency/source_without_kokkos_dependency.cpp
+++ b/cmake_test/test_source/lib_without_kokkos_dependency/source_without_kokkos_dependency.cpp
@@ -1,0 +1,23 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <iostream>
+
+namespace lib_without_kokkos_dependency {
+
+void print() { std::cout << "Hello from lib_without_kokkos_dependency\n"; }
+
+}  // namespace lib_without_kokkos_dependency

--- a/cmake_test/test_source/source_plain_cxx.cpp
+++ b/cmake_test/test_source/source_plain_cxx.cpp
@@ -1,0 +1,19 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <iostream>
+
+void print_plain_cxx() { std::cout << "Hello From C++\n"; }

--- a/cmake_test/test_source/source_plain_fortran.f
+++ b/cmake_test/test_source/source_plain_fortran.f
@@ -1,0 +1,4 @@
+        FUNCTION print_fortran()
+          PRINT *, 'Hello World from Fortran'
+          RETURN
+        END

--- a/cmake_test/test_source/test_interface.cpp
+++ b/cmake_test/test_source/test_interface.cpp
@@ -1,0 +1,36 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_interface_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) {
+  lib_without_kokkos_dependency::print();
+  Kokkos::initialize(argc, argv);
+  {
+    print_fortran_();
+    print_plain_cxx();
+    lib_with_interface_kokkos_dependency::print(
+        Kokkos::View<int*>{"testview", 10});
+  }
+  Kokkos::finalize();
+}

--- a/cmake_test/test_source/test_interface_interface.cpp
+++ b/cmake_test/test_source/test_interface_interface.cpp
@@ -1,0 +1,38 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) {
+  lib_without_kokkos_dependency::print();
+  Kokkos::initialize(argc, argv);
+  {
+    print_fortran_();
+    print_plain_cxx();
+    lib_with_interface_dependency_on_lib_with_interface_kokkos_dependency::
+        print(
+            lib_with_interface_kokkos_dependency::
+                StructOfLibWithInterfaceKokkosDependency<Kokkos::View<int*>>{});
+  }
+  Kokkos::finalize();
+}

--- a/cmake_test/test_source/test_interface_private.cpp
+++ b/cmake_test/test_source/test_interface_private.cpp
@@ -1,0 +1,37 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_interface_dependency_on_lib_with_private_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) {
+  lib_without_kokkos_dependency::print();
+  lib_with_private_kokkos_dependency::initialize();
+  {
+    print_fortran_();
+    print_plain_cxx();
+    lib_with_interface_dependency_on_lib_with_private_kokkos_dependency::print(
+        lib_with_private_kokkos_dependency::
+            StructOfLibWithPrivateKokkosDependency{});
+  }
+  lib_with_private_kokkos_dependency::finalize();
+}

--- a/cmake_test/test_source/test_interface_public.cpp
+++ b/cmake_test/test_source/test_interface_public.cpp
@@ -1,0 +1,37 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_interface_dependency_on_lib_with_public_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) {
+  lib_without_kokkos_dependency::print();
+  Kokkos::initialize(argc, argv);
+  {
+    print_fortran_();
+    print_plain_cxx();
+    lib_with_interface_dependency_on_lib_with_public_kokkos_dependency::print(
+        lib_with_public_kokkos_dependency::
+            StructOfLibWithPublicKokkosDependency{});
+  }
+  Kokkos::finalize();
+}

--- a/cmake_test/test_source/test_private.cpp
+++ b/cmake_test/test_source/test_private.cpp
@@ -1,0 +1,39 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_private_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main() {
+  lib_without_kokkos_dependency::print();
+
+  lib_with_private_kokkos_dependency::initialize();
+  {
+    lib_with_private_kokkos_dependency::print(
+        lib_with_private_kokkos_dependency::
+            StructOfLibWithPrivateKokkosDependency{});
+  }
+  lib_with_private_kokkos_dependency::finalize();
+
+  print_fortran_();
+  print_plain_cxx();
+}

--- a/cmake_test/test_source/test_private_interface.cpp
+++ b/cmake_test/test_source/test_private_interface.cpp
@@ -1,0 +1,40 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_private_dependency_on_lib_with_interface_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main() {
+  lib_without_kokkos_dependency::print();
+
+  lib_with_private_dependency_on_lib_with_interface_kokkos_dependency::
+      initialize();
+  {
+    lib_with_private_dependency_on_lib_with_interface_kokkos_dependency::
+        print();
+  }
+  lib_with_private_dependency_on_lib_with_interface_kokkos_dependency::
+      finalize();
+
+  print_fortran_();
+  print_plain_cxx();
+}

--- a/cmake_test/test_source/test_private_private.cpp
+++ b/cmake_test/test_source/test_private_private.cpp
@@ -1,0 +1,38 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_private_dependency_on_lib_with_private_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main() {
+  lib_without_kokkos_dependency::print();
+
+  lib_with_private_dependency_on_lib_with_private_kokkos_dependency::
+      initialize();
+  {
+    lib_with_private_dependency_on_lib_with_private_kokkos_dependency::print();
+  }
+  lib_with_private_dependency_on_lib_with_private_kokkos_dependency::finalize();
+
+  print_fortran_();
+  print_plain_cxx();
+}

--- a/cmake_test/test_source/test_private_public.cpp
+++ b/cmake_test/test_source/test_private_public.cpp
@@ -1,0 +1,36 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_private_dependency_on_lib_with_public_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main() {
+  lib_without_kokkos_dependency::print();
+
+  lib_with_private_dependency_on_lib_with_public_kokkos_dependency::
+      initialize();
+  { lib_with_private_dependency_on_lib_with_public_kokkos_dependency::print(); }
+  lib_with_private_dependency_on_lib_with_public_kokkos_dependency::finalize();
+
+  print_fortran_();
+  print_plain_cxx();
+}

--- a/cmake_test/test_source/test_public.cpp
+++ b/cmake_test/test_source/test_public.cpp
@@ -1,0 +1,36 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_with_public_kokkos_dependency.h>
+
+#include <Kokkos_Core.hpp>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) {
+  Kokkos::initialize(argc, argv);
+  {
+    print_fortran_();
+    print_plain_cxx();
+    lib_with_public_kokkos_dependency::print(
+        Kokkos::View<int*>{"testview", 10});
+  }
+  Kokkos::finalize();
+}

--- a/cmake_test/test_source/test_public_interface.cpp
+++ b/cmake_test/test_source/test_public_interface.cpp
@@ -1,0 +1,37 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_public_dependency_on_lib_with_interface_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) {
+  lib_without_kokkos_dependency::print();
+  Kokkos::initialize(argc, argv);
+  {
+    print_fortran_();
+    print_plain_cxx();
+    lib_with_public_dependency_on_lib_with_interface_kokkos_dependency::print(
+        lib_with_interface_kokkos_dependency::
+            StructOfLibWithInterfaceKokkosDependency<Kokkos::View<int*>>{});
+  }
+  Kokkos::finalize();
+}

--- a/cmake_test/test_source/test_public_private.cpp
+++ b/cmake_test/test_source/test_public_private.cpp
@@ -1,0 +1,37 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_public_dependency_on_lib_with_private_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) {
+  lib_without_kokkos_dependency::print();
+  lib_with_private_kokkos_dependency::initialize();
+  {
+    print_fortran_();
+    print_plain_cxx();
+    lib_with_public_dependency_on_lib_with_private_kokkos_dependency::print(
+        lib_with_private_kokkos_dependency::
+            StructOfLibWithPrivateKokkosDependency{});
+  }
+  lib_with_private_kokkos_dependency::finalize();
+}

--- a/cmake_test/test_source/test_public_public.cpp
+++ b/cmake_test/test_source/test_public_public.cpp
@@ -1,0 +1,37 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+#include <lib_with_public_dependency_on_lib_with_public_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) {
+  lib_without_kokkos_dependency::print();
+  Kokkos::initialize(argc, argv);
+  {
+    print_fortran_();
+    print_plain_cxx();
+    lib_with_public_dependency_on_lib_with_public_kokkos_dependency::print(
+        lib_with_public_kokkos_dependency::
+            StructOfLibWithPublicKokkosDependency{});
+  }
+  Kokkos::finalize();
+}

--- a/cmake_test/test_source/test_without.cpp
+++ b/cmake_test/test_source/test_without.cpp
@@ -1,0 +1,25 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <lib_without_kokkos_dependency.h>
+
+#include <cstdio>
+#include <iostream>
+
+extern "C" void print_fortran_();
+void print_plain_cxx();
+
+int main(int argc, char* argv[]) { lib_without_kokkos_dependency::print(); }


### PR DESCRIPTION
This is a stripped-down version of https://github.com/kokkos/kokkos/pull/7582

As @bradking rightfully pointed out, changing the language of a cpp file breaks the generator expressions and affects the linker choice in CMake. In a discussion with Kitware, we agreed, that the best way forward for now is to use an external launcher to change what compiler compiles cpp files that contain Kokkos code using our `kokkos_launch_compiler`. Since at build time all information that CMake sets for the build is known, we can pick it up in our launcher and redefine what compiler will be used. This allows to mimic `CXX` to behave like `CUDA` for compilation with nvcc.

For now we have to traverse the targets and find which ones are using Kokkos to set `kokkos_launch_compiler` on these targets, but CMake is working on an internal solution to this which would allow us to use their dependency traversal to set the launcher in downstream libraries.

This PR will *not* allow users to compile downstream things with the language feature due to the raised concerns. This also means it is quite a big change and a lot of complexity for the functionality of setting `kokkos_lauch_compiler` only for targets that link to Kokkos (vs. setting it globally before). 

This PR is depending on https://github.com/kokkos/kokkos/pull/8138 and https://github.com/kokkos/kokkos/pull/8140