### PR TITLE
Move KOKKOS_NONTEMPORAL_PREFETCH_[LOAD|STORE] to IMPL in Kokkos_UnorderedMap.hpp

### DIFF
--- a/core/src/Kokkos_Atomics_Desul_Wrapper.hpp
+++ b/core/src/Kokkos_Atomics_Desul_Wrapper.hpp
@@ -35,6 +35,7 @@ KOKKOS_DEPRECATED inline const char* atomic_query_version() {
 }
 #endif
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 #if defined(KOKKOS_COMPILER_GNU) && !defined(__PGIC__) && \
     !defined(__CUDA_ARCH__)
 
@@ -46,6 +47,7 @@ KOKKOS_DEPRECATED inline const char* atomic_query_version() {
 #define KOKKOS_NONTEMPORAL_PREFETCH_LOAD(addr) ((void)0)
 #define KOKKOS_NONTEMPORAL_PREFETCH_STORE(addr) ((void)0)
 
+#endif
 #endif
 // ============================================================
 


### PR DESCRIPTION
Part of https://github.com/kokkos/kokkos/pull/8117.
We define the macros `KOKKOS_NONTEMPORAL_PREFETCH_LOAD` and `KOKKOS_NONTEMPORAL_PREFETCH_STORE` in `core/src/Kokkos_Atomics_Desul_Wrapper.hpp` but only use them in `containers/src/Kokkos_UnorderedMap.hpp`.
This is problematic when defining separate modules for Kokkos Core and Kokkos Containers since macros are not exported (and those macros aren't defined in `Kokkos_Macros.hpp` which we would still expect to `#include` when using modules).

I couldn't find any other use case for these macros. Hence, this pull request is proposing to just move them to `containers/src/Kokkos_UnorderedMap.hpp` and give them a `KOKKOS_IMPL` prefix when deprecated code is disabled.

If we deem these macros to be useful in user code, we should move them to `Kokkos_Macros.hpp` instead.