### PR TITLE
hpx: TeamPolicy routine updates for large number of hw threads

### DIFF
--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -277,5 +277,5 @@ jobs:
 
       - name: test_kokkos
         working-directory: kokkos/build
-        run: KOKKOS_NUM_THREADS=32 ctest --output-on-failure --timeout 3600
+        run: ctest --output-on-failure --timeout 3600
 

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -1622,7 +1622,10 @@ class ParallelReduce<CombinedFunctorReducerType,
     const int num_worker_threads = m_policy.space().concurrency();
 
     hpx_thread_buffer &buffer = m_policy.space().impl_get_buffer();
-    buffer.resize(num_worker_threads, value_size + m_shared);
+    auto nchunks =
+        get_num_chunks(0, m_policy.chunk_size(), m_policy.league_size());
+    const auto buffer_size = std::min(nchunks, num_worker_threads);
+    buffer.resize(buffer_size, value_size + m_shared);
 
     for (int t = 0; t < num_worker_threads; ++t) {
       reducer.init(reinterpret_cast<pointer_type>(buffer.get(t)));
@@ -1634,11 +1637,19 @@ class ParallelReduce<CombinedFunctorReducerType,
     const std::size_t value_size = reducer.value_size();
     std::size_t t = Kokkos::Experimental::HPX::impl_hardware_thread_id();
     hpx_thread_buffer &buffer = m_policy.space().impl_get_buffer();
-    reference_type update =
-        ReducerType::reference(reinterpret_cast<pointer_type>(buffer.get(t)));
+
+    const int num_chunks =
+        get_num_chunks(0, m_policy.chunk_size(), m_policy.league_size());
+    const int num_worker_threads = m_policy.space().concurrency();
+    // if num_chunks > num hw threads, use hw threadid t; else use chunkid i
+    const std::size_t buffer_t = num_chunks > num_worker_threads ? t : i;
+
+    reference_type update = ReducerType::reference(
+        reinterpret_cast<pointer_type>(buffer.get(buffer_t)));
     const auto r =
         get_chunk_range(i, 0, m_policy.chunk_size(), m_policy.league_size());
-    char *local_buffer = static_cast<char *>(buffer.get(t)) + value_size;
+
+    char *local_buffer = static_cast<char *>(buffer.get(buffer_t)) + value_size;
     for (int league_rank = r.begin; league_rank < r.end; ++league_rank) {
       if constexpr (std::is_same_v<WorkTag, void>) {
         m_functor_reducer.get_functor()(

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -1545,8 +1545,9 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
  public:
   void setup() const {
     const int num_worker_threads = m_policy.space().concurrency();
-    hpx_thread_buffer &buffer = m_policy.space().impl_get_buffer();
-    auto nchunks = get_num_chunks(0, m_policy.chunk_size(), m_policy.league_size());
+    hpx_thread_buffer &buffer    = m_policy.space().impl_get_buffer();
+    auto nchunks =
+        get_num_chunks(0, m_policy.chunk_size(), m_policy.league_size());
     const auto buffer_size = std::min(nchunks, num_worker_threads);
     buffer.resize(buffer_size, m_shared);
   }
@@ -1563,10 +1564,11 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     const int buffer_t = num_chunks > num_worker_threads ? t : i;
     for (int league_rank = r.begin; league_rank < r.end; ++league_rank) {
       if constexpr (std::is_same_v<WorkTag, void>) {
-        m_functor(Member(m_policy, 0, league_rank, buffer.get(buffer_t), m_shared));
+        m_functor(
+            Member(m_policy, 0, league_rank, buffer.get(buffer_t), m_shared));
       } else {
-        m_functor(WorkTag{},
-                  Member(m_policy, 0, league_rank, buffer.get(buffer_t), m_shared));
+        m_functor(WorkTag{}, Member(m_policy, 0, league_rank,
+                                    buffer.get(buffer_t), m_shared));
       }
     }
   }


### PR DESCRIPTION
This PR updates the setup() and execute_range() member routines of the ParallelFor specialization for HPX TeamPolicy to constrain hpx_thread_buffer size when running on hardware with large numbers of threads

These changes were made after observing std::bad_alloc failures in the `hpx.large_team_scratch_size` when testing on Intel SPX arch (192 hw threads) due to request for too much memory

Changes to resolve the failure were suggested by @crtrott