### PR TITLE
Avoid forward references in Core to Containers

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -28,6 +28,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
+#include <KokkosExp_InterOp.hpp>
 #include <impl/Kokkos_Error.hpp>
 #include <type_traits>
 
@@ -1846,6 +1847,14 @@ inline std::enable_if_t<Impl::is_view_ctor_property<I>::value> realloc(
     const size_t n7 = KOKKOS_INVALID_INDEX) {
   impl_realloc(v, n0, n1, n2, n3, n4, n5, n6, n7, Kokkos::view_alloc(arg_prop));
 }
+
+namespace Experimental {
+template <class T, class... P>
+struct python_view_type<DynRankView<T, P...>> {
+  using type = Kokkos::Impl::python_view_type_impl_t<
+      typename DynRankView<T, P...>::array_type>;
+};
+}  // namespace Experimental
 
 }  // namespace Kokkos
 

--- a/core/src/KokkosExp_InterOp.hpp
+++ b/core/src/KokkosExp_InterOp.hpp
@@ -75,23 +75,6 @@ using python_view_type_impl_t = typename python_view_type_impl<T...>::type;
 }  // namespace Kokkos
 
 namespace Kokkos {
-
-template <typename DataType, class... Properties>
-class DynRankView;
-
-namespace Impl {
-
-// Duplicate from the header file for DynRankView to avoid core depending on
-// containers.
-template <class>
-struct is_dyn_rank_view_dup : public std::false_type {};
-
-template <class D, class... P>
-struct is_dyn_rank_view_dup<Kokkos::DynRankView<D, P...>>
-    : public std::true_type {};
-
-}  // namespace Impl
-
 namespace Experimental {
 
 // ------------------------------------------------------------------ //
@@ -99,11 +82,7 @@ namespace Experimental {
 //
 template <typename ViewT>
 struct python_view_type {
-  static_assert(
-      Kokkos::is_view<std::decay_t<ViewT>>::value ||
-          Kokkos::Impl::is_dyn_rank_view_dup<std::decay_t<ViewT>>::value,
-      "Error! python_view_type only supports Kokkos::View and "
-      "Kokkos::DynRankView");
+  static_assert(Kokkos::is_view<std::decay_t<ViewT>>::value);
 
   using type =
       Kokkos::Impl::python_view_type_impl_t<typename ViewT::array_type>;


### PR DESCRIPTION
Related to #8117. C++20 modules don't work well with forward references to symbols in different modules since a forward reference is interpreted as that symbol belonging to that module.
`python_view_type` used a forward reference for `DynRankViews` which this pull request avoids by placing a specialization of `python_view_type` in the `DynRankView` implementation.