### PR TITLE
Avoid using KOKKOS_TEST_HALF_INTERNAL_IMPLEMENTATION

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Half_MathematicalFunctions.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_MathematicalFunctions.hpp
@@ -20,6 +20,23 @@
 #include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
 
 namespace Kokkos {
+#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+#ifdef KOKKOS_IMPL_CUDA_HALF_TYPE_DEFINED
+KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t impl_test_fallback_half(
+    Kokkos::Experimental::half_t) {
+  return Kokkos::Experimental::half_t(0.f);
+}
+#endif
+
+#if defined(KOKKOS_IMPL_BHALF_TYPE_DEFINED) && \
+    (KOKKOS_IMPL_ARCH_NVIDIA_GPU >= 80)
+KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(
+    Kokkos::Experimental::bhalf_t) {
+  return Kokkos::Experimental::bhalf_t(0.f);
+}
+#endif
+#endif
+
 namespace Impl {
 
 #ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
@@ -47,13 +64,6 @@ namespace Impl {
 #define KOKKOS_CUDA_HALF_UNARY_PREDICATE_IMPL(OP, CUDA_NAME) \
   KOKKOS_CUDA_HALF_UNARY_PREDICATE(OP, CUDA_NAME, Kokkos::Experimental::half_t)
 
-#ifdef KOKKOS_TEST_HALF_INTERNAL_IMPLEMENTATION
-KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t impl_test_fallback_half(
-    Kokkos::Experimental::half_t) {
-  return Kokkos::Experimental::half_t(0.f);
-}
-#endif
-
 #else
 #define KOKKOS_CUDA_HALF_UNARY_FUNCTION_IMPL(OP, CUDA_NAME)
 #define KOKKOS_CUDA_HALF_BINARY_FUNCTION_IMPL(OP, CUDA_NAME)
@@ -70,13 +80,6 @@ KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t impl_test_fallback_half(
   KOKKOS_CUDA_HALF_BINARY_FUNCTION(OP, CUDA_NAME, Kokkos::Experimental::bhalf_t)
 #define KOKKOS_CUDA_BHALF_UNARY_PREDICATE_IMPL(OP, CUDA_NAME) \
   KOKKOS_CUDA_HALF_UNARY_PREDICATE(OP, CUDA_NAME, Kokkos::Experimental::bhalf_t)
-
-#ifdef KOKKOS_TEST_HALF_INTERNAL_IMPLEMENTATION
-KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(
-    Kokkos::Experimental::bhalf_t) {
-  return Kokkos::Experimental::bhalf_t(0.f);
-}
-#endif
 
 #else
 #define KOKKOS_CUDA_BHALF_UNARY_FUNCTION_IMPL(OP, CUDA_NAME)

--- a/core/src/Cuda/Kokkos_Cuda_Half_MathematicalFunctions.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_MathematicalFunctions.hpp
@@ -20,23 +20,6 @@
 #include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
 
 namespace Kokkos {
-#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
-#ifdef KOKKOS_IMPL_CUDA_HALF_TYPE_DEFINED
-KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t impl_test_fallback_half(
-    Kokkos::Experimental::half_t) {
-  return Kokkos::Experimental::half_t(0.f);
-}
-#endif
-
-#if defined(KOKKOS_IMPL_BHALF_TYPE_DEFINED) && \
-    (KOKKOS_IMPL_ARCH_NVIDIA_GPU >= 80)
-KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(
-    Kokkos::Experimental::bhalf_t) {
-  return Kokkos::Experimental::bhalf_t(0.f);
-}
-#endif
-#endif
-
 namespace Impl {
 
 #ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
@@ -64,6 +47,11 @@ namespace Impl {
 #define KOKKOS_CUDA_HALF_UNARY_PREDICATE_IMPL(OP, CUDA_NAME) \
   KOKKOS_CUDA_HALF_UNARY_PREDICATE(OP, CUDA_NAME, Kokkos::Experimental::half_t)
 
+KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t impl_test_fallback_half(
+    Kokkos::Experimental::half_t) {
+  return Kokkos::Experimental::half_t(0.f);
+}
+
 #else
 #define KOKKOS_CUDA_HALF_UNARY_FUNCTION_IMPL(OP, CUDA_NAME)
 #define KOKKOS_CUDA_HALF_BINARY_FUNCTION_IMPL(OP, CUDA_NAME)
@@ -80,6 +68,11 @@ namespace Impl {
   KOKKOS_CUDA_HALF_BINARY_FUNCTION(OP, CUDA_NAME, Kokkos::Experimental::bhalf_t)
 #define KOKKOS_CUDA_BHALF_UNARY_PREDICATE_IMPL(OP, CUDA_NAME) \
   KOKKOS_CUDA_HALF_UNARY_PREDICATE(OP, CUDA_NAME, Kokkos::Experimental::bhalf_t)
+
+KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(
+    Kokkos::Experimental::bhalf_t) {
+  return Kokkos::Experimental::bhalf_t(0.f);
+}
 
 #else
 #define KOKKOS_CUDA_BHALF_UNARY_FUNCTION_IMPL(OP, CUDA_NAME)

--- a/core/src/SYCL/Kokkos_SYCL_Half_MathematicalFunctions.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_MathematicalFunctions.hpp
@@ -20,6 +20,19 @@
 #include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
 
 namespace Kokkos {
+#ifdef KOKKOS_IMPL_SYCL_HALF_TYPE_DEFINED
+KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t impl_test_fallback_half(
+    Kokkos::Experimental::half_t) {
+  return Kokkos::Experimental::half_t(0.f);
+}
+#endif
+#ifdef KOKKOS_IMPL_SYCL_BHALF_TYPE_DEFINED
+KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(
+    Kokkos::Experimental::bhalf_t) {
+  return Kokkos::Experimental::bhalf_t(0.f);
+}
+#endif
+
 namespace Impl {
 #ifdef KOKKOS_IMPL_SYCL_HALF_TYPE_DEFINED
 
@@ -41,13 +54,6 @@ namespace Impl {
   KOKKOS_INLINE_FUNCTION bool impl_##OP(Experimental::half_t x) { \
     return sycl::OP(Experimental::half_t::impl_type(x));          \
   }
-
-#ifdef KOKKOS_TEST_HALF_INTERNAL_IMPLEMENTATION
-KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t impl_test_fallback_half(
-    Kokkos::Experimental::half_t) {
-  return Kokkos::Experimental::half_t(0.f);
-}
-#endif
 
 // Basic operations
 // abs
@@ -133,13 +139,6 @@ KOKKOS_SYCL_HALF_UNARY_PREDICATE(signbit)
     return sycl::ext::oneapi::experimental::OP(                    \
         Experimental::bhalf_t::impl_type(x));                      \
   }
-
-#ifdef KOKKOS_TEST_HALF_INTERNAL_IMPLEMENTATION
-KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(
-    Kokkos::Experimental::bhalf_t) {
-  return Kokkos::Experimental::bhalf_t(0.f);
-}
-#endif
 
 // Basic operations
 // abs

--- a/core/src/SYCL/Kokkos_SYCL_Half_MathematicalFunctions.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_MathematicalFunctions.hpp
@@ -20,19 +20,6 @@
 #include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
 
 namespace Kokkos {
-#ifdef KOKKOS_IMPL_SYCL_HALF_TYPE_DEFINED
-KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t impl_test_fallback_half(
-    Kokkos::Experimental::half_t) {
-  return Kokkos::Experimental::half_t(0.f);
-}
-#endif
-#ifdef KOKKOS_IMPL_SYCL_BHALF_TYPE_DEFINED
-KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(
-    Kokkos::Experimental::bhalf_t) {
-  return Kokkos::Experimental::bhalf_t(0.f);
-}
-#endif
-
 namespace Impl {
 #ifdef KOKKOS_IMPL_SYCL_HALF_TYPE_DEFINED
 
@@ -54,6 +41,11 @@ namespace Impl {
   KOKKOS_INLINE_FUNCTION bool impl_##OP(Experimental::half_t x) { \
     return sycl::OP(Experimental::half_t::impl_type(x));          \
   }
+
+KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t impl_test_fallback_half(
+    Kokkos::Experimental::half_t) {
+  return Kokkos::Experimental::half_t(0.f);
+}
 
 // Basic operations
 // abs
@@ -139,6 +131,11 @@ KOKKOS_SYCL_HALF_UNARY_PREDICATE(signbit)
     return sycl::ext::oneapi::experimental::OP(                    \
         Experimental::bhalf_t::impl_type(x));                      \
   }
+
+KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(
+    Kokkos::Experimental::bhalf_t) {
+  return Kokkos::Experimental::bhalf_t(0.f);
+}
 
 // Basic operations
 // abs

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -325,6 +325,7 @@ KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_UNARY_PREDICATE_HALF, signbi
 // isunordered
 
 // Implementation test function: check if fallback for half and bhalf type are used
+namespace Impl {
 template <bool fallback = true>
 KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t impl_test_fallback_half(Kokkos::Experimental::half_t) {
   return Kokkos::Experimental::half_t(1.f);
@@ -332,6 +333,14 @@ KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t impl_test_fallback_half(Kokk
 template <bool fallback = true>
 KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(Kokkos::Experimental::bhalf_t) {
   return Kokkos::Experimental::bhalf_t(1.f);
+}
+}  // namespace Impl
+
+KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t test_fallback_half(Kokkos::Experimental::half_t x) {
+  return Impl::impl_test_fallback_half(x);
+}
+KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t test_fallback_bhalf(Kokkos::Experimental::bhalf_t x) {
+  return Impl::impl_test_fallback_bhalf(x);
 }
 
 // Complex number functions

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -325,8 +325,6 @@ KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_UNARY_PREDICATE_HALF, signbi
 // isunordered
 
 // Implementation test function: check if fallback for half and bhalf type are used
-#if defined(KOKKOS_TEST_HALF_INTERNAL_IMPLEMENTATION)
-namespace Impl {
 template <bool fallback = true>
 KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t impl_test_fallback_half(Kokkos::Experimental::half_t) {
   return Kokkos::Experimental::half_t(1.f);
@@ -335,15 +333,6 @@ template <bool fallback = true>
 KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(Kokkos::Experimental::bhalf_t) {
   return Kokkos::Experimental::bhalf_t(1.f);
 }
-}  // namespace Impl
-
-KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t test_fallback_half(Kokkos::Experimental::half_t x) {
-  return Impl::impl_test_fallback_half(x);
-}
-KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t test_fallback_bhalf(Kokkos::Experimental::bhalf_t x) {
-  return Impl::impl_test_fallback_bhalf(x);
-}
-#endif
 
 // Complex number functions
 #define KOKKOS_IMPL_MATH_COMPLEX_REAL_HALF(FUNC, HALF_TYPE) \

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1824,18 +1824,16 @@ KE::bhalf_t ref_test_fallback_bhalf(KE::bhalf_t) {
 #endif
 }
 
-DEFINE_UNARY_FUNCTION_EVAL_CUSTOM(impl_test_fallback_half, 0,
+DEFINE_UNARY_FUNCTION_EVAL_CUSTOM(test_fallback_half, 0,
                                   ref_test_fallback_half(x));
-DEFINE_UNARY_FUNCTION_EVAL_CUSTOM(impl_test_fallback_bhalf, 0,
+DEFINE_UNARY_FUNCTION_EVAL_CUSTOM(test_fallback_bhalf, 0,
                                   ref_test_fallback_bhalf(x));
 
 TEST(TEST_CATEGORY, mathematical_functions_impl_half_fallback) {
-  TestMathUnaryFunction<
-      TEST_EXECSPACE, MathUnaryFunction_impl_test_fallback_half, KE::half_t, 1>(
-      {KE::half_t(1.f)});
-  TestMathUnaryFunction<TEST_EXECSPACE,
-                        MathUnaryFunction_impl_test_fallback_bhalf, KE::bhalf_t,
-                        1>({KE::bhalf_t(1.f)});
+  TestMathUnaryFunction<TEST_EXECSPACE, MathUnaryFunction_test_fallback_half,
+                        KE::half_t, 1>({KE::half_t(1.f)});
+  TestMathUnaryFunction<TEST_EXECSPACE, MathUnaryFunction_test_fallback_bhalf,
+                        KE::bhalf_t, 1>({KE::bhalf_t(1.f)});
 }
 
 #endif

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -16,7 +16,6 @@
 
 #include <gtest/gtest.h>
 
-#define KOKKOS_TEST_HALF_INTERNAL_IMPLEMENTATION
 #include <Kokkos_Core.hpp>
 #include <algorithm>
 #include <initializer_list>
@@ -1825,16 +1824,18 @@ KE::bhalf_t ref_test_fallback_bhalf(KE::bhalf_t) {
 #endif
 }
 
-DEFINE_UNARY_FUNCTION_EVAL_CUSTOM(test_fallback_half, 0,
+DEFINE_UNARY_FUNCTION_EVAL_CUSTOM(impl_test_fallback_half, 0,
                                   ref_test_fallback_half(x));
-DEFINE_UNARY_FUNCTION_EVAL_CUSTOM(test_fallback_bhalf, 0,
+DEFINE_UNARY_FUNCTION_EVAL_CUSTOM(impl_test_fallback_bhalf, 0,
                                   ref_test_fallback_bhalf(x));
 
 TEST(TEST_CATEGORY, mathematical_functions_impl_half_fallback) {
-  TestMathUnaryFunction<TEST_EXECSPACE, MathUnaryFunction_test_fallback_half,
-                        KE::half_t, 1>({KE::half_t(1.f)});
-  TestMathUnaryFunction<TEST_EXECSPACE, MathUnaryFunction_test_fallback_bhalf,
-                        KE::bhalf_t, 1>({KE::bhalf_t(1.f)});
+  TestMathUnaryFunction<
+      TEST_EXECSPACE, MathUnaryFunction_impl_test_fallback_half, KE::half_t, 1>(
+      {KE::half_t(1.f)});
+  TestMathUnaryFunction<TEST_EXECSPACE,
+                        MathUnaryFunction_impl_test_fallback_bhalf, KE::bhalf_t,
+                        1>({KE::bhalf_t(1.f)});
 }
 
 #endif


### PR DESCRIPTION
Part of #8117. C++20 modules don't allow any modifications after a module is compiled and thus preprocessor macros don't have any effect. That means that the technique used in https://github.com/kokkos/kokkos/pull/7698 to only expose some symbols when testing doesn't work with modules. Thus, this pull request removes the `KOKKOS_TEST_HALF_INTERNAL_IMPLEMENTATION` macro and only uses the `impl_*` functons for testing (that are pulled out of the `Impl` namespace for compatibility with our testing setup).