### PR TITLE
Enable CopyViews to deal with customized view

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3004,8 +3004,9 @@ inline auto create_mirror(const Kokkos::View<T, P...>& src,
     // We don't construct from the src accessor generally because our accessors
     // aren't generally constructible from each other.
     // We could change that, but all our internal accessors are stateless anyway
-    // right now. So for now if you have custom accessors that need to carry forward
-    // information you just have to make the conversion constructors work.
+    // right now. So for now if you have custom accessors that need to carry
+    // forward information you just have to make the conversion constructors
+    // work.
     if constexpr (std::is_constructible_v<
                       typename dst_type::accessor_type,
                       typename Kokkos::View<T, P...>::accessor_type>)

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3001,6 +3001,11 @@ inline auto create_mirror(const Kokkos::View<T, P...>& src,
 #ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
     // This is necessary because constructing non-const element type from
     // const element type accessors is not generally supported
+    // We don't construct from the src accessor generally because our accessors
+    // aren't generally constructible from each other.
+    // We could change that, but all our internal accessors are stateless anyway
+    // right now. So for now if you have custom accessors that need to carry forward
+    // information you just have to make the conversion constructors work.
     if constexpr (std::is_constructible_v<
                       typename dst_type::accessor_type,
                       typename Kokkos::View<T, P...>::accessor_type>)

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1692,6 +1692,8 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
   const size_t N = dst.extent(0) * dst.extent(1);
 
   if (dst.span_is_contiguous()) {
+    // FIXME We might want to check the traits for customization here but we
+    // aren't aware of a use case where that is necessary.
     if constexpr (std::is_same_v<decltype(dst.data()),
                                  typename View<DT, DP...>::element_type*>) {
       team.team_barrier();
@@ -1721,6 +1723,8 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
   const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2);
 
   if (dst.span_is_contiguous()) {
+    // FIXME We might want to check the traits for customization here but we
+    // aren't aware of a use case where that is necessary.
     if constexpr (std::is_same_v<decltype(dst.data()),
                                  typename View<DT, DP...>::element_type*>) {
       team.team_barrier();
@@ -1753,6 +1757,8 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
       dst.extent(0) * dst.extent(1) * dst.extent(2) * dst.extent(3);
 
   if (dst.span_is_contiguous()) {
+    // FIXME We might want to check the traits for customization here but we
+    // aren't aware of a use case where that is necessary.
     if constexpr (std::is_same_v<decltype(dst.data()),
                                  typename View<DT, DP...>::element_type*>) {
       team.team_barrier();
@@ -1787,6 +1793,8 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
                    dst.extent(3) * dst.extent(4);
 
   if (dst.span_is_contiguous()) {
+    // FIXME We might want to check the traits for customization here but we
+    // aren't aware of a use case where that is necessary.
     if constexpr (std::is_same_v<decltype(dst.data()),
                                  typename View<DT, DP...>::element_type*>) {
       team.team_barrier();
@@ -1823,6 +1831,8 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
                    dst.extent(3) * dst.extent(4) * dst.extent(5);
 
   if (dst.span_is_contiguous()) {
+    // FIXME We might want to check the traits for customization here but we
+    // aren't aware of a use case where that is necessary.
     if constexpr (std::is_same_v<decltype(dst.data()),
                                  typename View<DT, DP...>::element_type*>) {
       team.team_barrier();
@@ -1862,6 +1872,8 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
                    dst.extent(6);
 
   if (dst.span_is_contiguous()) {
+    // FIXME We might want to check the traits for customization here but we
+    // aren't aware of a use case where that is necessary.
     if constexpr (std::is_same_v<decltype(dst.data()),
                                  typename View<DT, DP...>::element_type*>) {
       team.team_barrier();
@@ -1915,6 +1927,8 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
   }
 
   if (dst.span_is_contiguous()) {
+    // FIXME We might want to check the traits for customization here but we
+    // aren't aware of a use case where that is necessary.
     if constexpr (std::is_same_v<decltype(dst.data()),
                                  typename View<DT, DP...>::element_type*>) {
       local_deep_copy_contiguous(dst, value);
@@ -1935,6 +1949,8 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
   }
 
   if (dst.span_is_contiguous()) {
+    // FIXME We might want to check the traits for customization here but we
+    // aren't aware of a use case where that is necessary.
     if constexpr (std::is_same_v<decltype(dst.data()),
                                  typename View<DT, DP...>::element_type*>) {
       local_deep_copy_contiguous(dst, value);
@@ -1956,6 +1972,8 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
   }
 
   if (dst.span_is_contiguous()) {
+    // FIXME We might want to check the traits for customization here but we
+    // aren't aware of a use case where that is necessary.
     if constexpr (std::is_same_v<decltype(dst.data()),
                                  typename View<DT, DP...>::element_type*>) {
       local_deep_copy_contiguous(dst, value);
@@ -1979,6 +1997,8 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
   }
 
   if (dst.span_is_contiguous()) {
+    // FIXME We might want to check the traits for customization here but we
+    // aren't aware of a use case where that is necessary.
     if constexpr (std::is_same_v<decltype(dst.data()),
                                  typename View<DT, DP...>::element_type*>) {
       local_deep_copy_contiguous(dst, value);
@@ -2003,6 +2023,8 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
   }
 
   if (dst.span_is_contiguous()) {
+    // FIXME We might want to check the traits for customization here but we
+    // aren't aware of a use case where that is necessary.
     if constexpr (std::is_same_v<decltype(dst.data()),
                                  typename View<DT, DP...>::element_type*>) {
       local_deep_copy_contiguous(dst, value);
@@ -2028,6 +2050,8 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
   }
 
   if (dst.span_is_contiguous()) {
+    // FIXME We might want to check the traits for customization here but we
+    // aren't aware of a use case where that is necessary.
     if constexpr (std::is_same_v<decltype(dst.data()),
                                  typename View<DT, DP...>::element_type*>) {
       local_deep_copy_contiguous(dst, value);

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -474,6 +474,27 @@ class BasicView {
   // Ctors taking CtorProp that don't have AccessorArg_t in it
  public:
   template <class... P>
+  explicit BasicView(
+      const Impl::ViewCtorProp<P...> &arg_prop,
+      std::enable_if_t<!Impl::ViewCtorProp<P...>::has_pointer &&
+                           !Impl::ViewCtorProp<P...>::has_accessor_arg,
+                       typename mdspan_type::mapping_type> const &arg_mapping,
+      const accessor_type &arg_accessor)
+      : BasicView(create_data_handle(arg_prop, arg_mapping, arg_accessor),
+                  arg_mapping, arg_accessor) {}
+
+  template <class... P>
+  KOKKOS_FUNCTION explicit BasicView(
+      const Impl::ViewCtorProp<P...> &arg_prop,
+      std::enable_if_t<ViewCtorProp<P...>::has_pointer &&
+                           !Impl::ViewCtorProp<P...>::has_accessor_arg,
+                       typename mdspan_type::mapping_type> const &arg_mapping,
+      const accessor_type &arg_accessor)
+      : BasicView(
+            data_handle_type{Impl::get_property<Impl::PointerTag>(arg_prop)},
+            arg_mapping, arg_accessor) {}
+
+  template <class... P>
   explicit inline BasicView(
       const Impl::ViewCtorProp<P...> &arg_prop,
       std::enable_if_t<!Impl::ViewCtorProp<P...>::has_pointer &&

--- a/core/src/View/Kokkos_ViewUniformType.hpp
+++ b/core/src/View/Kokkos_ViewUniformType.hpp
@@ -34,18 +34,18 @@ struct ViewScalarToDataType<ScalarType, 0> {
   using const_type = const ScalarType;
 };
 
-template <class LayoutType, int Rank>
+template <class LayoutType, int Rank, bool is_customized>
 struct ViewUniformLayout {
   using array_layout = LayoutType;
 };
 
 template <class LayoutType>
-struct ViewUniformLayout<LayoutType, 0> {
+struct ViewUniformLayout<LayoutType, 0, false> {
   using array_layout = Kokkos::LayoutLeft;
 };
 
 template <>
-struct ViewUniformLayout<Kokkos::LayoutRight, 1> {
+struct ViewUniformLayout<Kokkos::LayoutRight, 1, false> {
   using array_layout = Kokkos::LayoutLeft;
 };
 
@@ -65,9 +65,9 @@ struct ViewUniformType {
   using runtime_const_data_type = typename ViewScalarToDataType<
       std::add_const_t<typename ViewType::value_type>, rank>::type;
 
-  using array_layout =
-      typename ViewUniformLayout<typename ViewType::array_layout,
-                                 rank>::array_layout;
+  using array_layout = typename ViewUniformLayout<
+      typename ViewType::array_layout, rank,
+      ViewType::traits::impl_is_customized>::array_layout;
 
   using device_type = typename ViewType::device_type;
   using anonymous_device_type =

--- a/core/unit_test/view/TestViewCustomizationAllocationType.hpp
+++ b/core/unit_test/view/TestViewCustomizationAllocationType.hpp
@@ -38,8 +38,6 @@ struct BarRef {
   KOKKOS_FUNCTION
   T& operator[](size_t idx) const { return ptr[idx]; }
 
-  // assignment from value type should work for deep_copy from scalar!
-  // Just will some defined values so we know we did it.
   KOKKOS_FUNCTION
   operator Bar() const {
     Bar val;
@@ -48,8 +46,8 @@ struct BarRef {
   }
 
   KOKKOS_FUNCTION
-  auto operator=(const Bar&) {
-    for (size_t i = 0; i < size; i++) ptr[i] = i;
+  auto operator=(const Bar& val) {
+    for (size_t i = 0; i < size; i++) ptr[i] = val[i];
   }
 };
 

--- a/core/unit_test/view/TestViewCustomizationAllocationType.hpp
+++ b/core/unit_test/view/TestViewCustomizationAllocationType.hpp
@@ -259,7 +259,9 @@ void test_deep_copy() {
       "view_customization_deep_copy_a", policy2d,
       KOKKOS_LAMBDA(int i, int j, int& error) {
         for (size_t k = 0; k < size; k++) {
-          if (a(i, j)[k] != i * 100 + j + 0.1 * k) error++;
+          if (Kokkos::abs(a(i, j)[k] - (i * 100 + j + 0.1 * k)) >
+              Kokkos::Experimental::epsilon_v<float>)
+            error++;
           a(i, j)[k] = i * 200 + j + 0.1 * k;
         }
       },
@@ -271,7 +273,7 @@ void test_deep_copy() {
   for (size_t i = 0; i < ext0; i++)
     for (size_t j = 0; j < ext1; j++)
       for (size_t k = 0; k < size; k++)
-        ASSERT_EQ(host_a(i, j)[k], i * 200 + j + 0.1 * k);
+        ASSERT_FLOAT_EQ(host_a(i, j)[k], i * 200 + j + 0.1 * k);
   auto b = Kokkos::create_mirror(TEST_EXECSPACE::memory_space(), a);
 
   num_errors = 0;
@@ -297,7 +299,9 @@ void test_deep_copy() {
       "view_customization_check_pre_deep_copy_b", policy2d,
       KOKKOS_LAMBDA(int i, int j, int& error) {
         for (size_t k = 0; k < size; k++) {
-          if (b(i, j)[k] != i * 200 + j + 0.1 * k) error++;
+          if (Kokkos::abs(b(i, j)[k] - (i * 200 + j + 0.1 * k)) >
+              Kokkos::Experimental::epsilon_v<float>)
+            error++;
         }
       },
       num_errors);


### PR DESCRIPTION
This fixes up CopyViews to enable deep_copies and create_mirror with the customized views where the allocation type is not element type*. 

I needed to fix my test cases a bit, because it turns out a bunch of functions expect that reference and element types are assignable to each other - I guess not a all that stupid expectation for View ...

