### PR TITLE
C++20 modules: Avoid static functions at namespace scope

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -185,7 +185,7 @@ struct DynRankDimTraits {
 
 // Non-strided Layout
 template <typename Layout, typename iType>
-KOKKOS_INLINE_FUNCTION static std::enable_if_t<
+KOKKOS_INLINE_FUNCTION std::enable_if_t<
     (std::is_same_v<Layout, Kokkos::LayoutRight> ||
      std::is_same_v<Layout, Kokkos::LayoutLeft>)&&std::is_integral_v<iType>,
     Layout>
@@ -202,7 +202,7 @@ reconstructLayout(const Layout& layout, iType dynrank) {
 
 // LayoutStride
 template <typename Layout, typename iType>
-KOKKOS_INLINE_FUNCTION static std::enable_if_t<
+KOKKOS_INLINE_FUNCTION std::enable_if_t<
     (std::is_same_v<Layout, Kokkos::LayoutStride>)&&std::is_integral_v<iType>,
     Layout>
 reconstructLayout(const Layout& layout, iType dynrank) {


### PR DESCRIPTION
Part of #8117. We can't export `static` functions at namespace scope with C++20 modules. There was only one more occurence I came across in the `DynRankView` implementation. 