### PR TITLE
Report nightly jenkins to CDASH

### DIFF
--- a/.jenkins/nightly.groovy
+++ b/.jenkins/nightly.groovy
@@ -27,13 +27,18 @@ pipeline {
                           && \
                           apt-get clean && rm -rf /var/lib/apt/lists/*
 
+                          export SPACK_CDASH_ARGS="" && \
+                          export SPACK_CDASH_ARGS="${SPACK_CDASH_ARGS} --cdash-upload-url=https://my.cdash.org/submit.php?project=Kokkos" && \
+                          export SPACK_CDASH_ARGS="${SPACK_CDASH_ARGS} --cdash-track=Nightly" && \
+                          export SPACK_CDASH_ARGS="${SPACK_CDASH_ARGS} --cdash-site=ornl-jenkins" && \
+                          export SPACK_CDASH_ARGS="${SPACK_CDASH_ARGS} --cdash-build=spack-serial" && \
                           rm -rf spack && \
                           git clone https://github.com/spack/spack.git && \
                           . ./spack/share/spack/setup-env.sh && \
                           spack install --only=depencies kokkos@develop+tests && \
-                          spack install --only=package --cdash-upload-url="https://my.cdash.org/submit.php?project=Kokkos" --cdash-track=Nightly --cdash-site="ornl-jenkins" --cdash-build="spack-serial" kokkos@develop+tests && \
+                          spack install --only=package ${SPACK_CDASH_ARGS} kokkos@develop+tests && \
                           spack load cmake && \
-                          spack test run --cdash-upload-url="https://my.cdash.org/submit.php?project=Kokkos" --cdash-track=Nightly --cdash-site="ornl-jenkins" --cdash-build="spack-serial" kokkos && \
+                          spack test run ${SPACK_CDASH_ARGS} kokkos && \
                           spack test results -l
                           '''
                     }      
@@ -58,16 +63,21 @@ pipeline {
                           && \
                           apt-get clean && rm -rf /var/lib/apt/lists/*
 
+                          export SPACK_CDASH_ARGS="" && \
+                          export SPACK_CDASH_ARGS="${SPACK_CDASH_ARGS} --cdash-upload-url=https://my.cdash.org/submit.php?project=Kokkos" && \
+                          export SPACK_CDASH_ARGS="${SPACK_CDASH_ARGS} --cdash-track=Nightly" && \
+                          export SPACK_CDASH_ARGS="${SPACK_CDASH_ARGS} --cdash-site=ornl-jenkins" && \
+                          export SPACK_CDASH_ARGS="${SPACK_CDASH_ARGS} --cdash-build=spack-cuda" && \
                           rm -rf spack && \
                           git clone https://github.com/spack/spack.git && \
                           . ./spack/share/spack/setup-env.sh && \
                           spack install --only=dependencies kokkos@develop+cuda+wrapper+tests cuda_arch=80 ^cuda@12.1.0 && \
-                          spack install --only=package --cdash-upload-url="https://my.cdash.org/submit.php?project=Kokkos" --cdash-track=Nightly --cdash-site="ornl-jenkins" --cdash-build="spack-cuda" kokkos@develop+cuda+wrapper+tests cuda_arch=80 ^cuda@12.1.0 && \
+                          spack install --only=package ${SPACK_CDASH_ARGS} kokkos@develop+cuda+wrapper+tests cuda_arch=80 ^cuda@12.1.0 && \
                           spack load cmake  && \
                           spack load kokkos-nvcc-wrapper && \
                           spack load cuda && \
                           spack load kokkos && \
-                          spack test run --cdash-upload-url="https://my.cdash.org/submit.php?project=Kokkos" --cdash-track=Nightly --cdash-site="ornl-jenkins" --cdash-build="spack-cuda" kokkos && \
+                          spack test run ${SPACK_CDASH_ARGS} kokkos && \
                           spack test results -l
                           '''
                     }      

--- a/.jenkins/nightly.groovy
+++ b/.jenkins/nightly.groovy
@@ -1,6 +1,10 @@
 pipeline {
     agent none
 
+    environment {
+        SPACK_CDASH_ARGS="--cdash-upload-url=https://my.cdash.org/submit.php?project=Kokkos --cdash-track=Nightly --cdash-site=ornl-jenkins"
+    }
+
     options {
         timeout(time: 6, unit: 'HOURS')
     }
@@ -27,16 +31,11 @@ pipeline {
                           && \
                           apt-get clean && rm -rf /var/lib/apt/lists/*
 
-                          export SPACK_CDASH_ARGS="" && \
-                          export SPACK_CDASH_ARGS="${SPACK_CDASH_ARGS} --cdash-upload-url=https://my.cdash.org/submit.php?project=Kokkos" && \
-                          export SPACK_CDASH_ARGS="${SPACK_CDASH_ARGS} --cdash-track=Nightly" && \
-                          export SPACK_CDASH_ARGS="${SPACK_CDASH_ARGS} --cdash-site=ornl-jenkins" && \
-                          export SPACK_CDASH_ARGS="${SPACK_CDASH_ARGS} --cdash-build=spack-serial" && \
                           rm -rf spack && \
                           git clone https://github.com/spack/spack.git && \
                           . ./spack/share/spack/setup-env.sh && \
                           spack install --only=depencies kokkos@develop+tests && \
-                          spack install --only=package ${SPACK_CDASH_ARGS} kokkos@develop+tests && \
+                          spack install --only=package ${SPACK_CDASH_ARGS} --cdash-build=spack-serial kokkos@develop+tests && \
                           spack load cmake && \
                           spack test run ${SPACK_CDASH_ARGS} kokkos && \
                           spack test results -l
@@ -63,16 +62,11 @@ pipeline {
                           && \
                           apt-get clean && rm -rf /var/lib/apt/lists/*
 
-                          export SPACK_CDASH_ARGS="" && \
-                          export SPACK_CDASH_ARGS="${SPACK_CDASH_ARGS} --cdash-upload-url=https://my.cdash.org/submit.php?project=Kokkos" && \
-                          export SPACK_CDASH_ARGS="${SPACK_CDASH_ARGS} --cdash-track=Nightly" && \
-                          export SPACK_CDASH_ARGS="${SPACK_CDASH_ARGS} --cdash-site=ornl-jenkins" && \
-                          export SPACK_CDASH_ARGS="${SPACK_CDASH_ARGS} --cdash-build=spack-cuda" && \
                           rm -rf spack && \
                           git clone https://github.com/spack/spack.git && \
                           . ./spack/share/spack/setup-env.sh && \
                           spack install --only=dependencies kokkos@develop+cuda+wrapper+tests cuda_arch=80 ^cuda@12.1.0 && \
-                          spack install --only=package ${SPACK_CDASH_ARGS} kokkos@develop+cuda+wrapper+tests cuda_arch=80 ^cuda@12.1.0 && \
+                          spack install --only=package ${SPACK_CDASH_ARGS} --cdash-build=spack-cuda kokkos@develop+cuda+wrapper+tests cuda_arch=80 ^cuda@12.1.0 && \
                           spack load cmake  && \
                           spack load kokkos-nvcc-wrapper && \
                           spack load cuda && \


### PR DESCRIPTION
With this PR, all our nightlies will report the results to CDASH.  For spack, I have split the installation of Kokkos and its dependencies otherwise we get reports for all the dependencies. Right now we get one report for the build and one for the tests. We should be able to have everything in one report but I couldn't make it work. 