### PR TITLE
GitHub CI: Update to Jimver/cuda-toolkit v0.2.24

### DIFF
--- a/.github/workflows/continuous-integration-windows.yml
+++ b/.github/workflows/continuous-integration-windows.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-2022
 
     steps:
-    - uses: Jimver/cuda-toolkit@9b993a72d35b5634a69ca7e34b39a002a87c367c # v0.2.23
+    - uses: Jimver/cuda-toolkit@c35baa1a18fd1fc9dcf47c5bd839bf30559c0bc3 # v0.2.24
       id: cuda-toolkit
       with:
         cuda: '12.4.1'


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/pull/8158#issuecomment-2955788168. We know that v0.2.25 is broken but we can at least go from v.0.2.23 to v0.2.24.