### PR TITLE
SYCL: Don't define FALLBACK_ASSERT

### DIFF
--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -212,7 +212,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=icpx \
             -DCMAKE_CXX_STANDARD=20 \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_CXX_FLAGS='-Werror -fp-model=precise -fsycl-device-code-split=per_kernel' \
+            -DCMAKE_CXX_FLAGS='-Werror -fp-model=precise -fsycl-device-code-split=per_kernel -Wno-zero-length-array' \
             -DKokkos_ENABLE_SYCL=ON \
             -DKokkos_ARCH_INTEL_PVC=ON \
             -DKokkos_ENABLE_COMPILER_WARNINGS=ON \

--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -127,7 +127,7 @@ INTEL-DATA-CENTER-MAX-1100:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_TESTS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_COMPILER_WARNINGS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_VERBOSE_MAKEFILE=ON"
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Werror -fsycl-device-code-split=per_kernel -fp-model=precise'"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Wno-zero-length-array -Werror -fsycl-device-code-split=per_kernel -fp-model=precise'"
     - export CTEST_BUILD_NAME="INTEL-DATA-CENTER-MAX-1100"
     - ctest -VV
         -D CDASH_MODEL=${CDASH_MODEL}
@@ -164,7 +164,7 @@ INTEL-DATA-CENTER-MAX-1100-OUT-OF-ORDER:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_TESTS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_COMPILER_WARNINGS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_VERBOSE_MAKEFILE=ON"
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Werror -fsycl-device-code-split=per_kernel -fp-model=precise'"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Wno-zero-length-array -Werror -fsycl-device-code-split=per_kernel -fp-model=precise'"
     - export CTEST_BUILD_NAME="INTEL-DATA-CENTER-MAX-1100-OUT-ORDER"
     - ctest -VV
         -D CDASH_MODEL=${CDASH_MODEL}

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -111,10 +111,6 @@ if(NOT desul_FOUND)
     append_glob(KOKKOS_CORE_SRCS ${KOKKOS_SOURCE_DIR}/tpls/desul/src/Lock_Array_HIP.cpp)
   elseif(KOKKOS_ENABLE_SYCL)
     append_glob(KOKKOS_CORE_SRCS ${KOKKOS_SOURCE_DIR}/tpls/desul/src/Lock_Array_SYCL.cpp)
-    # The compiler implicitly generates a file that uses a zero size array for device global variables
-    set_source_files_properties(
-      ${KOKKOS_SOURCE_DIR}/tpls/desul/src/Lock_Array_SYCL.cpp PROPERTIES COMPILE_FLAGS "-Wno-zero-length-array"
-    )
   endif()
   append_glob(KOKKOS_CORE_HEADERS ${KOKKOS_SOURCE_DIR}/tpls/desul/include/desul/*.hpp)
   append_glob(KOKKOS_CORE_HEADERS ${KOKKOS_SOURCE_DIR}/tpls/desul/include/desul/*/*.hpp)

--- a/core/src/setup/Kokkos_Setup_SYCL.hpp
+++ b/core/src/setup/Kokkos_Setup_SYCL.hpp
@@ -17,15 +17,6 @@
 #ifndef KOKKOS_SETUP_SYCL_HPP_
 #define KOKKOS_SETUP_SYCL_HPP_
 
-// FIXME_SYCL the fallback assert is temporarily disabled by default in the
-// compiler so we need to force it
-#ifndef SYCL_ENABLE_FALLBACK_ASSERT
-#define SYCL_ENABLE_FALLBACK_ASSERT
-#endif
-#ifndef SYCL_FALLBACK_ASSERT
-#define SYCL_FALLBACK_ASSERT 1
-#endif
-
 // FIXME_SYCL
 #if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
All Intel, Nvidia, and AMD devices we care about, should support device asserts without expliciting requesting to have a fallback in place. Removing the macros fixes lauch issues on AMD GPUs.