### PR TITLE
Aurora CI: Don't use -fsycl-device-code-split

### DIFF
--- a/.gitlab/alcf-gitlab-ci.yml
+++ b/.gitlab/alcf-gitlab-ci.yml
@@ -57,7 +57,7 @@ Aurora:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_INTEL_PVC=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_NATIVE=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_TESTS=ON"
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Wno-pass-failed -fsycl-device-code-split=per_kernel -fp-model=precise'"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Wno-pass-failed -fp-model=precise'"
     - ctest -VV
         -D CDASH_MODEL=Nightly
         -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}"


### PR DESCRIPTION
Fixes https://my.cdash.org/viewTest.php?onlyfailed&buildid=2955625. The flag isn't as important for build time anymore after we are using `-fno-sycl-rdc` to disable relocatable device code by default. We reported the issue to Intel.
With this change, we should see all tests pass.