### PR TITLE
Avoid more TU-local symbols

### DIFF
--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -149,7 +149,7 @@ namespace Kokkos {
 
 namespace Impl {
 
-static inline void check_init_final([[maybe_unused]] char const* func_name) {
+inline void check_init_final([[maybe_unused]] char const* func_name) {
 // FIXME_THREADS: Checking for calls to kokkos_malloc, kokkos_realloc,
 // kokkos_free before initialize or after finalize is currently disabled
 // for the Threads backend. Refer issue #7944.

--- a/core/src/Kokkos_MemoryTraits.hpp
+++ b/core/src/Kokkos_MemoryTraits.hpp
@@ -91,12 +91,12 @@ namespace Impl {
  *  Use compiler flag to enable overwrites.
  */
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-static constexpr unsigned MEMORY_ALIGNMENT = KOKKOS_IMPL_MEMORY_ALIGNMENT;
-static constexpr unsigned MEMORY_ALIGNMENT_THRESHOLD =
+inline constexpr unsigned MEMORY_ALIGNMENT = KOKKOS_IMPL_MEMORY_ALIGNMENT;
+inline constexpr unsigned MEMORY_ALIGNMENT_THRESHOLD =
     KOKKOS_IMPL_MEMORY_ALIGNMENT_THRESHOLD;
 #else
-static constexpr unsigned MEMORY_ALIGNMENT           = 64;
-static constexpr unsigned MEMORY_ALIGNMENT_THRESHOLD = 1;
+inline constexpr unsigned MEMORY_ALIGNMENT           = 64;
+inline constexpr unsigned MEMORY_ALIGNMENT_THRESHOLD = 1;
 #endif
 static_assert(has_single_bit(MEMORY_ALIGNMENT),
               "MEMORY_ALIGNMENT must be a power of 2");

--- a/core/src/impl/Kokkos_ExecSpaceManager.hpp
+++ b/core/src/impl/Kokkos_ExecSpaceManager.hpp
@@ -106,11 +106,6 @@ constexpr bool check_valid_execution_space() {
   return true;
 }
 
-}  // namespace Kokkos::Impl
-
-namespace Kokkos {
-namespace Impl {
-
 struct ExecSpaceBase {
   virtual void initialize(InitializationSettings const&)           = 0;
   virtual void finalize()                                          = 0;
@@ -162,7 +157,6 @@ int initialize_space_factory(std::string name) {
   return 1;
 }
 
-}  // namespace Impl
-}  // namespace Kokkos
+}  // namespace Kokkos::Impl
 
 #endif

--- a/core/src/impl/Kokkos_ExecSpaceManager.hpp
+++ b/core/src/impl/Kokkos_ExecSpaceManager.hpp
@@ -26,7 +26,7 @@
 #include <string>
 #include <utility>
 
-namespace {
+namespace Kokkos::Impl {
 
 template <class T>
 using public_member_types_t = std::enable_if_t<
@@ -106,7 +106,7 @@ constexpr bool check_valid_execution_space() {
   return true;
 }
 
-}  // namespace
+}  // namespace Kokkos::Impl
 
 namespace Kokkos {
 namespace Impl {


### PR DESCRIPTION
Related to #8117 (g++ in particular). This pull request avoids more TU-local symbols in headers that are problematic when creating C++20 modules.
In particular,
- avoid unnamed namespaces in headers. I ignored the ones used in `core/src/Cuda/Kokkos_Cuda_Task.hpp`, `containers/src/Kokkos_StaticCrsGraph.hpp` and `containers/src/Kokkos_Vector.hpp` since I intend to only care about modules when deprecated code is disabled and we thus won't include them in any module anyway.
- avoid (explicit) static global symbols.
