### PR TITLE
Address C++26 deprecation warnings from using std::is_trivial

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_View.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_View.hpp
@@ -76,7 +76,7 @@ class ViewDataHandle<
         (std::is_same_v<typename Traits::memory_space, Kokkos::CudaSpace> ||
          std::is_same_v<typename Traits::memory_space, Kokkos::CudaUVMSpace>)&&
         // Is a trivial const value of 4, 8, or 16 bytes
-        std::is_trivial_v<typename Traits::const_value_type> &&
+        std::is_trivially_copyable_v<typename Traits::const_value_type> &&
         std::is_same_v<typename Traits::const_value_type,
                        typename Traits::value_type> &&
         (sizeof(typename Traits::const_value_type) == 4 ||

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -835,7 +835,7 @@ struct ZeroMemset {
 // as an optimization.
 template <typename T>
 bool has_all_zero_bits(const T& value) {
-  static_assert(std::is_trivial_v<T>);
+  static_assert(std::is_trivially_copyable_v<T>);
 
   if constexpr (std::is_scalar_v<T>) {
     return value == T();
@@ -854,7 +854,7 @@ bool has_all_zero_bits(const T& value) {
 
 template <typename ExecutionSpace, class DT, class... DP>
 inline std::enable_if_t<
-    std::is_trivial_v<typename ViewTraits<DT, DP...>::value_type>>
+    std::is_trivially_copyable_v<typename ViewTraits<DT, DP...>::value_type>>
 contiguous_fill_or_memset(
     const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {
@@ -872,7 +872,7 @@ contiguous_fill_or_memset(
 
 template <typename ExecutionSpace, class DT, class... DP>
 inline std::enable_if_t<
-    !std::is_trivial_v<typename ViewTraits<DT, DP...>::value_type>>
+    !std::is_trivially_copyable_v<typename ViewTraits<DT, DP...>::value_type>>
 contiguous_fill_or_memset(
     const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -158,7 +158,7 @@ struct ViewValueFunctor {
 // On A64FX memset seems to do the wrong thing with regards to first touch
 // leading to the significant performance issues
 #ifndef KOKKOS_ARCH_A64FX
-    if constexpr (std::is_trivial_v<ValueType>) {
+    if constexpr (std::is_trivially_default_constructible_v<ValueType>) {
       // value-initialization is equivalent to filling with zeros
       zero_memset_implementation();
     } else
@@ -216,7 +216,7 @@ struct ViewValueFunctorSequentialHostInit {
       : ptr(arg_ptr), n(arg_n) {}
 
   void construct_shared_allocation() {
-    if constexpr (std::is_trivial_v<ValueType>) {
+    if constexpr (std::is_trivially_default_constructible_v<ValueType>) {
       // value-initialization is equivalent to filling with zeros
       std::memset(static_cast<void*>(ptr), 0, n * sizeof(ValueType));
     } else {

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -31,7 +31,7 @@ using ExecutionEnvironmentNonInitializedOrFinalized_DeathTest =
 struct NonTrivial {
   KOKKOS_FUNCTION NonTrivial() {}
 };
-static_assert(!std::is_trivial_v<NonTrivial>);
+static_assert(!std::is_trivially_default_constructible_v<NonTrivial>);
 
 TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,
        default_constructed_views) {


### PR DESCRIPTION
Fix #8154
Instead of just replacing `std::is_trivial_v<T>` with `std::is_trivially_default_constructible_v<T> && std::is_trivially_copyable_v<T>`, I clarified what property is actually needed.