### PR TITLE
Store sequential host init in unordered map

### DIFF
--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -62,6 +62,29 @@
 
 namespace Kokkos {
 
+namespace Impl {
+
+template <typename ViewType, typename... P, typename Property, typename... Args>
+auto allocate_with_property_if_compatible(
+    const Impl::ViewCtorProp<P...> &alloc_prop,
+    [[maybe_unused]] const Property &property, Args &&...args) {
+  using alloc_prop_t = Impl::remove_cvref_t<decltype(alloc_prop)>;
+
+  // if incompatible we don't add the property
+  if constexpr ((std::is_same_v<Property, Impl::WithoutInitializing_t> &&
+                 alloc_prop_t::sequential_host_init) ||
+                (std::is_same_v<Property, Impl::SequentialHostInit_t> &&
+                 !SpaceAccessibility<
+                     typename ViewType::execution_space::memory_space,
+                     HostSpace>::accessible))
+    return ViewType(alloc_prop, std::forward<Args>(args)...);
+  // otherwise we add it if unset
+  else
+    return ViewType(Impl::with_properties_if_unset(alloc_prop, property),
+                    std::forward<Args>(args)...);
+}
+}  // namespace Impl
+
 enum : unsigned { UnorderedMapInvalidIndex = ~0u };
 
 /// \brief First element of the return value of UnorderedMap::insert().
@@ -331,7 +354,11 @@ class UnorderedMap {
   UnorderedMap(const Impl::ViewCtorProp<P...> &arg_prop,
                size_type capacity_hint = 0, hasher_type hasher = hasher_type(),
                equal_to_type equal_to = equal_to_type())
-      : m_bounded_insert(true), m_hasher(hasher), m_equal_to(equal_to) {
+      : m_bounded_insert(true),
+        m_hasher(hasher),
+        m_equal_to(equal_to),
+        m_sequential_host_init(
+            Impl::remove_cvref_t<decltype(arg_prop)>::sequential_host_init) {
     if (!is_insertable_map) {
       Kokkos::Impl::throw_runtime_exception(
           "Cannot construct a non-insertable (i.e. const key_type) "
@@ -350,8 +377,6 @@ class UnorderedMap {
     /// properties.
     const auto prop_copy =
         Impl::with_properties_if_unset(arg_prop, std::string("UnorderedMap"));
-    const auto prop_copy_noinit =
-        Impl::with_properties_if_unset(prop_copy, Kokkos::WithoutInitializing);
 
     //! Initialize member views.
     m_size = shared_size_t(Kokkos::view_alloc(
@@ -362,14 +387,15 @@ class UnorderedMap {
         bitset_type(Kokkos::Impl::append_to_label(prop_copy, " - bitset"),
                     calculate_capacity(capacity_hint));
 
-    m_hash_lists = size_type_view(
-        Kokkos::Impl::append_to_label(prop_copy_noinit, " - hash list"),
-        Impl::find_hash_size(capacity()));
+    m_hash_lists = Impl::allocate_with_property_if_compatible<size_type_view>(
+        Kokkos::Impl::append_to_label(prop_copy, " - hash list"),
+        WithoutInitializing, Impl::find_hash_size(capacity()));
 
-    m_next_index = size_type_view(
-        Kokkos::Impl::append_to_label(prop_copy_noinit, " - next index"),
-        capacity() + 1);  // +1 so that the *_at functions can always return a
-                          // valid reference
+    m_next_index = Impl::allocate_with_property_if_compatible<size_type_view>(
+        Kokkos::Impl::append_to_label(prop_copy, " - next index"),
+        WithoutInitializing,
+        capacity() + 1);  // +1 so that the *_at functions can always return
+                          // a valid reference
 
     m_keys = key_type_view(Kokkos::Impl::append_to_label(prop_copy, " - keys"),
                            capacity());
@@ -446,7 +472,12 @@ class UnorderedMap {
     requested_capacity =
         (requested_capacity < curr_size) ? curr_size : requested_capacity;
 
-    insertable_map_type tmp(requested_capacity, m_hasher, m_equal_to);
+    auto tmp =
+        m_sequential_host_init
+            ? Impl::allocate_with_property_if_compatible<insertable_map_type>(
+                  view_alloc(), SequentialHostInit, requested_capacity,
+                  m_hasher, m_equal_to)
+            : insertable_map_type(requested_capacity, m_hasher, m_equal_to);
 
     if (curr_size) {
       tmp.m_bounded_insert = false;
@@ -807,7 +838,8 @@ class UnorderedMap {
         m_next_index(src.m_next_index),
         m_keys(src.m_keys),
         m_values(src.m_values),
-        m_scalars(src.m_scalars) {}
+        m_scalars(src.m_scalars),
+        m_sequential_host_init(src.m_sequential_host_init) {}
 
   template <typename SKey, typename SValue>
   std::enable_if_t<
@@ -815,16 +847,17 @@ class UnorderedMap {
                                   SValue>::value,
       declared_map_type &>
   operator=(UnorderedMap<SKey, SValue, Device, Hasher, EqualTo> const &src) {
-    m_bounded_insert    = src.m_bounded_insert;
-    m_hasher            = src.m_hasher;
-    m_equal_to          = src.m_equal_to;
-    m_size              = src.m_size;
-    m_available_indexes = src.m_available_indexes;
-    m_hash_lists        = src.m_hash_lists;
-    m_next_index        = src.m_next_index;
-    m_keys              = src.m_keys;
-    m_values            = src.m_values;
-    m_scalars           = src.m_scalars;
+    m_bounded_insert       = src.m_bounded_insert;
+    m_hasher               = src.m_hasher;
+    m_equal_to             = src.m_equal_to;
+    m_size                 = src.m_size;
+    m_available_indexes    = src.m_available_indexes;
+    m_hash_lists           = src.m_hash_lists;
+    m_next_index           = src.m_next_index;
+    m_keys                 = src.m_keys;
+    m_values               = src.m_values;
+    m_scalars              = src.m_scalars;
+    m_sequential_host_init = src.m_sequential_host_init;
     return *this;
   }
 
@@ -850,12 +883,14 @@ class UnorderedMap {
       UnorderedMap<SKey, SValue, SDevice, Hasher, EqualTo> const &src) {
     insertable_map_type tmp;
 
-    tmp.m_bounded_insert    = src.m_bounded_insert;
-    tmp.m_hasher            = src.m_hasher;
-    tmp.m_equal_to          = src.m_equal_to;
-    tmp.m_size()            = src.m_size();
-    tmp.m_available_indexes = bitset_type(src.capacity());
-    tmp.m_hash_lists        = size_type_view(
+    tmp.m_bounded_insert       = src.m_bounded_insert;
+    tmp.m_hasher               = src.m_hasher;
+    tmp.m_equal_to             = src.m_equal_to;
+    tmp.m_size()               = src.m_size();
+    tmp.m_sequential_host_init = src.m_sequential_host_init;
+    tmp.m_available_indexes    = bitset_type(src.capacity());
+
+    tmp.m_hash_lists = size_type_view(
         view_alloc(WithoutInitializing, "UnorderedMap hash list"),
         src.m_hash_lists.extent(0));
     tmp.m_next_index = size_type_view(
@@ -865,8 +900,14 @@ class UnorderedMap {
         key_type_view(view_alloc(WithoutInitializing, "UnorderedMap keys"),
                       src.m_keys.extent(0));
     tmp.m_values =
-        value_type_view(view_alloc(WithoutInitializing, "UnorderedMap values"),
-                        src.m_values.extent(0));
+        src.m_sequential_host_init
+            ? Impl::allocate_with_property_if_compatible<value_type_view>(
+                  view_alloc("UnorderedMap values"), SequentialHostInit,
+                  src.m_values.extent(0))
+            : Impl::allocate_with_property_if_compatible<value_type_view>(
+                  view_alloc("UnorderedMap values"), WithoutInitializing,
+                  src.m_values.extent(0));
+
     tmp.m_scalars = scalars_view("UnorderedMap scalars");
 
     *this = tmp;
@@ -966,6 +1007,7 @@ class UnorderedMap {
   key_type_view m_keys;
   value_type_view m_values;
   scalars_view m_scalars;
+  bool m_sequential_host_init = false;
 
   template <typename KKey, typename VValue, typename DDevice, typename HHash,
             typename EEqualTo>

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -82,8 +82,6 @@ auto allocate_without_initializing_if_possible(
 template <typename ViewType, typename... P, typename... Args>
 auto allocate_with_sequential_host_init_if_possible(
     const Impl::ViewCtorProp<P...> &alloc_prop, Args &&...args) {
-  using alloc_prop_t = Impl::remove_cvref_t<decltype(alloc_prop)>;
-
   // if incompatible we don't add the property
   if constexpr (!SpaceAccessibility<
                     typename ViewType::execution_space::memory_space,

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -366,7 +366,7 @@ class UnorderedMap {
     }
 
     //! Ensure that allocation properties are consistent.
-    using alloc_prop_t = std::decay_t<decltype(arg_prop)>;
+    using alloc_prop_t = Impl::remove_cvref_t<decltype(arg_prop)>;
     static_assert(alloc_prop_t::initialize,
                   "Allocation property 'initialize' should be true.");
     static_assert(

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -560,6 +560,48 @@ TEST(TEST_CATEGORY, UnorderedMap_constructor_view_alloc) {
   ASSERT_TRUE(map.is_allocated());
 }
 
+//////////////////////////Tests for UnorderedMap with View as value_type
+
+/**
+ * @test This test ensures that an @ref UnorderedMap with View as value_type can
+ * be built with SequentialHostInit instance (using @ref view_alloc).
+ */
+TEST(TEST_CATEGORY, UnorderedMap_View_as_value) {
+  using value_type = Kokkos::View<size_t *, TEST_EXECSPACE>;
+  using map_type   = Kokkos::UnorderedMap<int, value_type, Kokkos::HostSpace>;
+  map_type map(Kokkos::view_alloc(Kokkos::SequentialHostInit, "test view umap"),
+               150);
+  // creation
+  ASSERT_EQ(map.size(), 0u);
+  ASSERT_GE(map.capacity(), 150u);
+  ASSERT_TRUE(map.is_allocated());
+
+  // insert
+  ASSERT_TRUE(map.insert(1, Kokkos::View<size_t *, TEST_EXECSPACE>(
+                                "UnorderedMap inserted View one", 10))
+                  .success());
+  ASSERT_TRUE(map.insert(2, Kokkos::View<size_t *, TEST_EXECSPACE>(
+                                "UnorderedMap inserted View two", 20))
+                  .success());
+  ASSERT_EQ(map.size(), 2u);
+
+  // copy
+  map_type map_copy(map);
+  ASSERT_EQ(map_copy.size(), 2u);
+  ASSERT_GE(map_copy.capacity(), 150u);
+  ASSERT_TRUE(map_copy.is_allocated());
+
+  // rehash
+  ASSERT_TRUE(map.rehash(200u));
+  ASSERT_GE(map.capacity(), 200u);
+  ASSERT_TRUE(map.is_allocated());
+
+  // assign
+  map_copy = map;
+  ASSERT_EQ(map_copy.size(), 2u);
+  ASSERT_GE(map_copy.capacity(), 200u);
+  ASSERT_TRUE(map_copy.is_allocated());
+}
 }  // namespace Test
 
 #endif  // KOKKOS_TEST_UNORDERED_MAP_HPP


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/8110

This is an attempt to fix the `UnorderedMap` with `value_type=View_like_type` by storing if it was constructed with `SequentialHostInit` and using it for all functions that reallocate.

Another solution (which I found quite hard to implement) would be to add a functionality to remove `SequentialHostInit` (or any property) from `ViewCtorProp` ... the best thing I could think of for this is a meta template typelist and rewriting `ViewCtorProp`...I don't think that is worth it

- [x] needs testing