### PR TITLE
SYCL: Return out-of-order queues if internal out-of-order queues are requested

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -58,13 +58,10 @@ SYCL::SYCL(const sycl::queue& stream)
         ptr->finalize();
         delete ptr;
       }) {
-  // In principle could be guarded with
-  // #ifdef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
-  // but we chose to require user-provided queues to be in-order
-  // unconditionally so that code downstream does not break
-  // when the backend setting changes.
+#ifdef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
   if (!stream.is_in_order())
     Kokkos::abort("User provided sycl::queues must be in-order!");
+#endif
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
   m_space_instance->initialize(stream);

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -154,11 +154,15 @@ std::vector<SYCL> impl_partition_space(const SYCL& base_instance,
 
   std::vector<SYCL> instances;
   instances.reserve(weights.size());
-  std::generate_n(
-      std::back_inserter(instances), weights.size(), [&context, &device]() {
-        return SYCL(
-            sycl::queue(context, device, sycl::property::queue::in_order()));
-      });
+  std::generate_n(std::back_inserter(instances), weights.size(),
+                  [&context, &device]() {
+                    return SYCL(sycl::queue(context, device
+#ifdef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
+                                            ,
+                                            sycl::property::queue::in_order()
+#endif
+                                                ));
+                  });
 
   return instances;
 }


### PR DESCRIPTION
In reponse to https://github.com/kokkos/kokkos/pull/8114#discussion_r2128775754.
Also allow external queues to be out-of-order if internal queues are requested to be out-of-order.