### PR TITLE
core(graph): fix `HIP` constant memory launch mechanism for graph node

### DIFF
--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -537,6 +537,25 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
     HIPInternal::constantMemReusable[hip_device].release(
         std::move(lock), hip_instance->m_stream);
   }
+
+  static void create_parallel_launch_graph_node(
+      DriverType const &driver, dim3 const &grid, dim3 const &block, int shmem,
+      HIPInternal const *hip_instance) {
+    // Just use global memory; coordinating through events to share constant
+    // memory with the non-graph interface is not really reasonable since
+    // events don't work with Graphs directly, and this would anyway require
+    // a much more complicated structure that finds previous nodes in the
+    // dependency structure of the graph and creates an implicit dependence
+    // based on the need for constant memory (which we would then have to
+    // somehow go and prove was not creating a dependency cycle, and I don't
+    // even know if there's an efficient way to do that, let alone in the
+    // structure we currenty have).
+    using global_launch_impl_t =
+        HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
+                                       HIPLaunchMechanism::GlobalMemory>;
+    global_launch_impl_t::create_parallel_launch_graph_node(
+        driver, grid, block, shmem, hip_instance);
+  }
 };
 
 //-----------------------------//

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -135,11 +135,12 @@ class SYCLInternal {
       fence();
       reserve(sizeof(T));
       if constexpr (sycl::usm::alloc::device == Kind) {
-        std::memcpy(static_cast<void*>(m_staging.get()), std::addressof(t),
-                    sizeof(T));
+        std::memcpy(static_cast<void*>(m_staging.get()),
+                    static_cast<const void*>(std::addressof(t)), sizeof(T));
         m_copy_event = m_q->memcpy(m_data, m_staging.get(), sizeof(T));
       } else
-        std::memcpy(m_data, std::addressof(t), sizeof(T));
+        std::memcpy(static_cast<void*>(m_data),
+                    static_cast<const void*>(std::addressof(t)), sizeof(T));
       return *reinterpret_cast<T*>(m_data);
     }
 


### PR DESCRIPTION
The `HIP` implementation of the graph  is currently missing the `create_parallel_launch_graph_node` function for the constant memory launch mechanism. Thus, we get a compilation error on HIP when the `then_parallel_for` ends up mapping to the constant memory launch mechanism.

This PR:
- adds to the `HIP` implementation  such a function similar to what's done in the `Cuda` implementation, i.e. a fallback that maps to the global memory launch mechanism
- extends the test of the global memory launch mechanism in `TestGraph.hpp` so that it now tests not only the global memory launch mechanism but also the local and constant memory launch mechanisms

Joint work with @romintomasetti.