### PR TITLE
core(graph): allow work tag for `then` node

### DIFF
--- a/core/src/Kokkos_Graph_fwd.hpp
+++ b/core/src/Kokkos_Graph_fwd.hpp
@@ -35,6 +35,9 @@ template <class ExecutionSpace, class Kernel = TypeErasedTag,
           class Predecessor = TypeErasedTag>
 class GraphNodeRef;
 
+template <class Worktag = void>
+struct ThenPolicy;
+
 }  // end namespace Experimental
 }  // end namespace Kokkos
 

--- a/core/src/View/Kokkos_ViewCtor.hpp
+++ b/core/src/View/Kokkos_ViewCtor.hpp
@@ -67,6 +67,9 @@ struct is_view_label<char[N]> : public std::true_type {};
 template <unsigned N>
 struct is_view_label<const char[N]> : public std::true_type {};
 
+template <typename T>
+constexpr bool is_view_label_v = is_view_label<T>::value;
+
 //----------------------------------------------------------------------------
 
 template <typename... P>

--- a/core/src/impl/Kokkos_GraphImpl_fwd.hpp
+++ b/core/src/impl/Kokkos_GraphImpl_fwd.hpp
@@ -32,7 +32,7 @@ template <class ExecutionSpace, class Policy, class Functor,
           class KernelTypeTag, class... Args>
 class GraphNodeKernelImpl;
 
-template <class ExecutionSpace, class Functor>
+template <class ExecutionSpace, class Policy, class Functor>
 struct GraphNodeThenImpl;
 
 template <typename ExecutionSpace, typename Functor>

--- a/core/src/impl/Kokkos_GraphNodeThenImpl.hpp
+++ b/core/src/impl/Kokkos_GraphNodeThenImpl.hpp
@@ -19,37 +19,52 @@
 
 #include <Kokkos_ExecPolicy.hpp>
 #include <impl/Kokkos_GraphImpl_fwd.hpp>
+#include <impl/Kokkos_GraphNodeThenPolicy.hpp>
 
 namespace Kokkos::Impl {
 
 // Helper for the 'then', such that the user can indeed pass a callable that
-// takes no argument.
+// takes no index.
 template <typename Functor>
 struct ThenWrapper {
   Functor m_functor;
-  template <typename T>
-  KOKKOS_FUNCTION void operator()(const T) const {
-    m_functor();
+
+  template <typename WorkTagOrIndex, typename... MaybeIndex>
+  KOKKOS_FUNCTION void operator()(WorkTagOrIndex, MaybeIndex...) const {
+    static_assert(sizeof...(MaybeIndex) <= 1);
+    if constexpr (sizeof...(MaybeIndex) == 0) {
+      m_functor();
+    } else {
+      static_assert(std::is_empty_v<WorkTagOrIndex>);
+      m_functor(WorkTagOrIndex{});
+    }
   }
 };
 
-template <typename ExecutionSpace, typename Functor>
+// MSVC needs the 'policy' template argument to have a distinct name from the
+// 'policy' template argument of the base class GraphNodeKernelImpl, see
+// https://github.com/kokkos/kokkos/pull/8190#issuecomment-3083682368.
+template <typename ExecutionSpace, typename ThenPolicyType, typename Functor>
 struct GraphNodeThenImpl
     : public GraphNodeKernelImpl<
           ExecutionSpace,
           Kokkos::RangePolicy<ExecutionSpace, IsGraphKernelTag,
-                              Kokkos::LaunchBounds<1>>,
+                              Kokkos::LaunchBounds<1>,
+                              typename ThenPolicyType::work_tag>,
           ThenWrapper<Functor>, ParallelForTag> {
-  using policy_t  = Kokkos::RangePolicy<ExecutionSpace, IsGraphKernelTag,
-                                       Kokkos::LaunchBounds<1>>;
-  using base_t    = GraphNodeKernelImpl<ExecutionSpace, policy_t,
-                                     ThenWrapper<Functor>, ParallelForTag>;
-  using wrapper_t = ThenWrapper<Functor>;
+  using inner_policy_t = Kokkos::RangePolicy<ExecutionSpace, IsGraphKernelTag,
+                                             Kokkos::LaunchBounds<1>,
+                                             typename ThenPolicyType::work_tag>;
+  using wrapper_t      = ThenWrapper<Functor>;
+  using base_t = GraphNodeKernelImpl<ExecutionSpace, inner_policy_t, wrapper_t,
+                                     ParallelForTag>;
 
   template <typename Label, typename T>
-  GraphNodeThenImpl(Label&& label_, const ExecutionSpace& exec, T&& functor)
+  GraphNodeThenImpl(Label&& label_, const ExecutionSpace& exec, ThenPolicyType,
+                    T&& functor)
       : base_t(std::forward<Label>(label_), exec,
-               wrapper_t{std::forward<T>(functor)}, policy_t(exec, 0, 1)) {}
+               wrapper_t{std::forward<T>(functor)},
+               inner_policy_t(exec, 0, 1)) {}
 };
 
 }  // namespace Kokkos::Impl

--- a/core/src/impl/Kokkos_GraphNodeThenPolicy.hpp
+++ b/core/src/impl/Kokkos_GraphNodeThenPolicy.hpp
@@ -1,0 +1,33 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_IMPL_KOKKOS_GRAPHNODETHENPOLICY_HPP
+#define KOKKOS_IMPL_KOKKOS_GRAPHNODETHENPOLICY_HPP
+
+#include <type_traits>
+
+namespace Kokkos::Experimental {
+
+template <typename WorkTag>
+struct ThenPolicy {
+  static_assert(std::is_empty_v<WorkTag> || std::is_void_v<WorkTag>);
+
+  using work_tag = WorkTag;
+};
+
+}  // namespace Kokkos::Experimental
+
+#endif  // KOKKOS_IMPL_KOKKOS_GRAPHNODETHENPOLICY_HPP

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -816,10 +816,14 @@ template <typename ViewType>
 struct ThenFunctor {
   static_assert(ViewType::rank() == 0);
 
+  struct TimesTwo {};
+
   ViewType data;
   typename ViewType::value_type value;
 
   KOKKOS_FUNCTION void operator()() const { data() += value; }
+
+  KOKKOS_FUNCTION void operator()(const TimesTwo) const { data() += 2 * value; }
 };
 
 // Supported graph node types.
@@ -865,7 +869,8 @@ struct GraphNodeTypes {
 
   // Type of a then node.
   using then_t =
-      Kokkos::Impl::GraphNodeThenImpl<Exec, ThenFunctor<Kokkos::View<int>>>;
+      Kokkos::Impl::GraphNodeThenImpl<Exec, Kokkos::Experimental::ThenPolicy<>,
+                                      ThenFunctor<Kokkos::View<int>>>;
 
   // Type of a host node.
   using host_t =
@@ -1124,7 +1129,8 @@ TEST(TEST_CATEGORY, graph_then) {
   using node_ref_memset_t =
       Kokkos::Experimental::GraphNodeRef<TEST_EXECSPACE, node_memset_t,
                                          typename types::node_ref_root_t>;
-  using node_then_t = Kokkos::Impl::GraphNodeThenImpl<TEST_EXECSPACE, then_t>;
+  using node_then_t = Kokkos::Impl::GraphNodeThenImpl<
+      TEST_EXECSPACE, Kokkos::Experimental::ThenPolicy<>, then_t>;
   using node_ref_then_t =
       Kokkos::Experimental::GraphNodeRef<TEST_EXECSPACE, node_then_t,
                                          node_ref_memset_t>;
@@ -1281,6 +1287,35 @@ TEST(TEST_CATEGORY, mixed_then_host_device_nodes) {
   } else {
     GTEST_SKIP() << "This test requires a shared space.";
   }
+}
+
+// Ensure that a then can be given a work tag.
+TEST(TEST_CATEGORY, graph_then_tag) {
+  using view_t    = Kokkos::View<int, TEST_EXECSPACE>;
+  using functor_t = ThenFunctor<view_t>;
+
+  constexpr int value_then = 456;
+
+  const TEST_EXECSPACE exec{};
+
+  const view_t data(Kokkos::view_alloc(exec, "data used in 'then'"));
+
+  auto graph = Kokkos::Experimental::create_graph(exec, [&](const auto& root) {
+    const auto notag = root.then("no tag", functor_t{data, value_then});
+    const auto tagged_labelled =
+        notag.then("tag and label",
+                   Kokkos::Experimental::ThenPolicy<functor_t::TimesTwo>{},
+                   functor_t{data, value_then});
+    const auto tagged = tagged_labelled.then(
+        Kokkos::Experimental::ThenPolicy<functor_t::TimesTwo>{},
+        functor_t{data, value_then});
+  });
+
+  ASSERT_TRUE(contains(exec, data, 0));
+
+  graph.submit(exec);
+
+  ASSERT_TRUE(contains(exec, data, 5 * value_then));
 }
 
 }  // end namespace Test


### PR DESCRIPTION
This is the only missing execution policy argument that we are allowed to pass to the node.