### PR TITLE
core(graph): node properties and device handle

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -30,7 +30,9 @@ struct GraphImpl<Kokkos::Cuda> {
   using execution_space = Kokkos::Cuda;
 
  private:
-  execution_space m_execution_space;
+  using device_handle_t = Kokkos::Impl::DeviceHandle<execution_space>;
+
+  device_handle_t m_device_handle;
   cudaGraph_t m_graph          = nullptr;
   cudaGraphExec_t m_graph_exec = nullptr;
 
@@ -46,10 +48,9 @@ struct GraphImpl<Kokkos::Cuda> {
   void instantiate() {
     KOKKOS_EXPECTS(!m_graph_exec);
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (m_execution_space.impl_internal_space_instance()
+        (m_device_handle.m_exec.impl_internal_space_instance()
              ->cuda_graph_instantiate_wrapper(&m_graph_exec, m_graph)));
     KOKKOS_ENSURES(m_graph_exec);
-    // TODO @graphs print out errors
   }
 
   using root_node_impl_t =
@@ -71,29 +72,30 @@ struct GraphImpl<Kokkos::Cuda> {
     // TODO @graphs we need to somehow indicate the need for a fence in the
     //              destructor of the GraphImpl object (so that we don't have to
     //              just always do it)
-    m_execution_space.fence("Kokkos::GraphImpl::~GraphImpl: Graph Destruction");
+    m_device_handle.m_exec.fence(
+        "Kokkos::GraphImpl::~GraphImpl: Graph Destruction");
     KOKKOS_EXPECTS(bool(m_graph))
     if (bool(m_graph_exec)) {
       KOKKOS_IMPL_CUDA_SAFE_CALL(
-          (m_execution_space.impl_internal_space_instance()
+          (m_device_handle.m_exec.impl_internal_space_instance()
                ->cuda_graph_exec_destroy_wrapper(m_graph_exec)));
     }
     if (m_graph_owning) {
       KOKKOS_IMPL_CUDA_SAFE_CALL(
-          (m_execution_space.impl_internal_space_instance()
+          (m_device_handle.m_exec.impl_internal_space_instance()
                ->cuda_graph_destroy_wrapper(m_graph)));
     }
   }
 
-  explicit GraphImpl(Kokkos::Cuda arg_instance)
-      : m_execution_space(std::move(arg_instance)), m_graph_owning(true) {
+  explicit GraphImpl(device_handle_t device_handle)
+      : m_device_handle(std::move(device_handle)), m_graph_owning(true) {
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (m_execution_space.impl_internal_space_instance()
+        (m_device_handle.m_exec.impl_internal_space_instance()
              ->cuda_graph_create_wrapper(&m_graph, cuda_graph_flags_t{0})));
   }
 
-  explicit GraphImpl(Kokkos::Cuda arg_instance, cudaGraph_t graph)
-      : m_execution_space(std::move(arg_instance)),
+  explicit GraphImpl(device_handle_t device_handle, cudaGraph_t graph)
+      : m_device_handle(std::move(device_handle)),
         m_graph(graph),
         m_graph_owning(false) {
     KOKKOS_EXPECTS(graph != nullptr);
@@ -103,7 +105,7 @@ struct GraphImpl<Kokkos::Cuda> {
     // All of the predecessors are just added as normal, so all we need to
     // do here is add an empty node
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (m_execution_space.impl_internal_space_instance()
+        (m_device_handle.m_exec.impl_internal_space_instance()
              ->cuda_graph_add_empty_node_wrapper(
                  &(arg_node_ptr->node_details_t::node), m_graph,
                  /* dependencies = */ nullptr,
@@ -182,7 +184,7 @@ struct GraphImpl<Kokkos::Cuda> {
     KOKKOS_EXPECTS(bool(cuda_node))
 
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (m_execution_space.impl_internal_space_instance()
+        (m_device_handle.m_exec.impl_internal_space_instance()
              ->cuda_graph_add_dependencies_wrapper(m_graph, &pred_cuda_node,
                                                    &cuda_node, 1)));
   }
@@ -196,17 +198,17 @@ struct GraphImpl<Kokkos::Cuda> {
             m_graph_exec)));
   }
 
-  execution_space const& get_execution_space() const noexcept {
-    return m_execution_space;
+  device_handle_t const& get_device_handle() const noexcept {
+    return m_device_handle;
   }
 
   auto create_root_node_ptr() {
     KOKKOS_EXPECTS(bool(m_graph))
     KOKKOS_EXPECTS(!bool(m_graph_exec))
     auto rv = std::make_shared<root_node_impl_t>(
-        get_execution_space(), _graph_node_is_root_ctor_tag{});
+        m_device_handle, _graph_node_is_root_ctor_tag{});
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (m_execution_space.impl_internal_space_instance()
+        (m_device_handle.m_exec.impl_internal_space_instance()
              ->cuda_graph_add_empty_node_wrapper(&(rv->node_details_t::node),
                                                  m_graph,
                                                  /* dependencies = */ nullptr,
@@ -223,7 +225,7 @@ struct GraphImpl<Kokkos::Cuda> {
     // each predecessor ref, so all we need to do here is create the (trivial)
     // aggregate node.
     return std::make_shared<aggregate_node_impl_t>(
-        m_execution_space, _graph_node_kernel_ctor_tag{}, aggregate_impl_t{});
+        m_device_handle, _graph_node_kernel_ctor_tag{}, aggregate_impl_t{});
   }
 
   cudaGraph_t cuda_graph() { return m_graph; }

--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -87,17 +87,15 @@ struct GraphImpl<Kokkos::Cuda> {
     }
   }
 
-  explicit GraphImpl(device_handle_t device_handle)
-      : m_device_handle(std::move(device_handle)), m_graph_owning(true) {
+  explicit GraphImpl(const device_handle_t& device_handle)
+      : m_device_handle(device_handle), m_graph_owning(true) {
     KOKKOS_IMPL_CUDA_SAFE_CALL(
         (m_device_handle.m_exec.impl_internal_space_instance()
              ->cuda_graph_create_wrapper(&m_graph, cuda_graph_flags_t{0})));
   }
 
-  explicit GraphImpl(device_handle_t device_handle, cudaGraph_t graph)
-      : m_device_handle(std::move(device_handle)),
-        m_graph(graph),
-        m_graph_owning(false) {
+  explicit GraphImpl(const device_handle_t& device_handle, cudaGraph_t graph)
+      : m_device_handle(device_handle), m_graph(graph), m_graph_owning(false) {
     KOKKOS_EXPECTS(graph != nullptr);
   }
 

--- a/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
@@ -40,9 +40,9 @@ class GraphImpl<Kokkos::HIP> {
 
   ~GraphImpl();
 
-  explicit GraphImpl(device_handle_t device_handle);
+  explicit GraphImpl(const device_handle_t& device_handle);
 
-  GraphImpl(device_handle_t device_handle, hipGraph_t graph);
+  GraphImpl(const device_handle_t& device_handle, hipGraph_t graph);
 
   void add_node(std::shared_ptr<aggregate_node_impl_t> const& arg_node_ptr);
 
@@ -111,18 +111,16 @@ inline GraphImpl<Kokkos::HIP>::~GraphImpl() {
   }
 }
 
-inline GraphImpl<Kokkos::HIP>::GraphImpl(device_handle_t device_handle)
-    : m_device_handle(std::move(device_handle)), m_graph_owning(true) {
+inline GraphImpl<Kokkos::HIP>::GraphImpl(const device_handle_t& device_handle)
+    : m_device_handle(device_handle), m_graph_owning(true) {
   KOKKOS_IMPL_HIP_SAFE_CALL(
       m_device_handle.m_exec.impl_internal_space_instance()
           ->hip_graph_create_wrapper(&m_graph, 0));
 }
 
-inline GraphImpl<Kokkos::HIP>::GraphImpl(device_handle_t device_handle,
+inline GraphImpl<Kokkos::HIP>::GraphImpl(const device_handle_t& device_handle,
                                          hipGraph_t graph)
-    : m_device_handle(std::move(device_handle)),
-      m_graph(graph),
-      m_graph_owning(false) {
+    : m_device_handle(device_handle), m_graph(graph), m_graph_owning(false) {
   KOKKOS_EXPECTS(graph != nullptr);
 }
 

--- a/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
@@ -28,6 +28,8 @@ class GraphImpl<Kokkos::HIP> {
       GraphNodeImpl<Kokkos::HIP, aggregate_impl_t,
                     Kokkos::Experimental::TypeErasedTag>;
 
+  using device_handle_t = Kokkos::Impl::DeviceHandle<Kokkos::HIP>;
+
   // Not movable or copyable; it spends its whole life as a shared_ptr in the
   // Graph object.
   GraphImpl()                            = delete;
@@ -38,9 +40,9 @@ class GraphImpl<Kokkos::HIP> {
 
   ~GraphImpl();
 
-  explicit GraphImpl(Kokkos::HIP instance);
+  explicit GraphImpl(device_handle_t device_handle);
 
-  GraphImpl(Kokkos::HIP instance, hipGraph_t graph);
+  GraphImpl(device_handle_t device_handle, hipGraph_t graph);
 
   void add_node(std::shared_ptr<aggregate_node_impl_t> const& arg_node_ptr);
 
@@ -64,7 +66,7 @@ class GraphImpl<Kokkos::HIP> {
 
   void submit(const Kokkos::HIP& exec);
 
-  Kokkos::HIP const& get_execution_space() const noexcept;
+  auto get_device_handle() const noexcept -> device_handle_t const&;
 
   auto create_root_node_ptr();
 
@@ -74,7 +76,7 @@ class GraphImpl<Kokkos::HIP> {
   void instantiate() {
     KOKKOS_EXPECTS(!m_graph_exec);
     KOKKOS_IMPL_HIP_SAFE_CALL(
-        m_execution_space.impl_internal_space_instance()
+        m_device_handle.m_exec.impl_internal_space_instance()
             ->hip_graph_instantiate_wrapper(&m_graph_exec, m_graph, nullptr,
                                             nullptr, 0));
     KOKKOS_ENSURES(m_graph_exec);
@@ -84,7 +86,7 @@ class GraphImpl<Kokkos::HIP> {
   hipGraphExec_t hip_graph_exec() { return m_graph_exec; }
 
  private:
-  Kokkos::HIP m_execution_space;
+  device_handle_t m_device_handle;
   hipGraph_t m_graph          = nullptr;
   hipGraphExec_t m_graph_exec = nullptr;
 
@@ -94,27 +96,31 @@ class GraphImpl<Kokkos::HIP> {
 };
 
 inline GraphImpl<Kokkos::HIP>::~GraphImpl() {
-  m_execution_space.fence("Kokkos::GraphImpl::~GraphImpl: Graph Destruction");
+  m_device_handle.m_exec.fence(
+      "Kokkos::GraphImpl::~GraphImpl: Graph Destruction");
   KOKKOS_EXPECTS(m_graph);
   if (m_graph_exec) {
     KOKKOS_IMPL_HIP_SAFE_CALL(
-        m_execution_space.impl_internal_space_instance()
+        m_device_handle.m_exec.impl_internal_space_instance()
             ->hip_graph_exec_destroy_wrapper(m_graph_exec));
   }
   if (m_graph_owning) {
-    KOKKOS_IMPL_HIP_SAFE_CALL(m_execution_space.impl_internal_space_instance()
-                                  ->hip_graph_destroy_wrapper(m_graph));
+    KOKKOS_IMPL_HIP_SAFE_CALL(
+        m_device_handle.m_exec.impl_internal_space_instance()
+            ->hip_graph_destroy_wrapper(m_graph));
   }
 }
 
-inline GraphImpl<Kokkos::HIP>::GraphImpl(Kokkos::HIP instance)
-    : m_execution_space(std::move(instance)), m_graph_owning(true) {
-  KOKKOS_IMPL_HIP_SAFE_CALL(m_execution_space.impl_internal_space_instance()
-                                ->hip_graph_create_wrapper(&m_graph, 0));
+inline GraphImpl<Kokkos::HIP>::GraphImpl(device_handle_t device_handle)
+    : m_device_handle(std::move(device_handle)), m_graph_owning(true) {
+  KOKKOS_IMPL_HIP_SAFE_CALL(
+      m_device_handle.m_exec.impl_internal_space_instance()
+          ->hip_graph_create_wrapper(&m_graph, 0));
 }
 
-inline GraphImpl<Kokkos::HIP>::GraphImpl(Kokkos::HIP instance, hipGraph_t graph)
-    : m_execution_space(std::move(instance)),
+inline GraphImpl<Kokkos::HIP>::GraphImpl(device_handle_t device_handle,
+                                         hipGraph_t graph)
+    : m_device_handle(std::move(device_handle)),
       m_graph(graph),
       m_graph_owning(false) {
   KOKKOS_EXPECTS(graph != nullptr);
@@ -124,12 +130,12 @@ inline void GraphImpl<Kokkos::HIP>::add_node(
     std::shared_ptr<aggregate_node_impl_t> const& arg_node_ptr) {
   // All of the predecessors are just added as normal, so all we need to
   // do here is add an empty node
-  KOKKOS_IMPL_HIP_SAFE_CALL(m_execution_space.impl_internal_space_instance()
-                                ->hip_graph_add_empty_node_wrapper(
-                                    &(arg_node_ptr->node_details_t::node),
-                                    m_graph,
-                                    /* dependencies = */ nullptr,
-                                    /* numDependencies = */ 0));
+  KOKKOS_IMPL_HIP_SAFE_CALL(
+      m_device_handle.m_exec.impl_internal_space_instance()
+          ->hip_graph_add_empty_node_wrapper(
+              &(arg_node_ptr->node_details_t::node), m_graph,
+              /* dependencies = */ nullptr,
+              /* numDependencies = */ 0));
 }
 
 template <class NodeImpl>
@@ -196,7 +202,7 @@ inline void GraphImpl<Kokkos::HIP>::add_predecessor(
   KOKKOS_EXPECTS(node);
 
   KOKKOS_IMPL_HIP_SAFE_CALL(
-      m_execution_space.impl_internal_space_instance()
+      m_device_handle.m_exec.impl_internal_space_instance()
           ->hip_graph_add_dependencies_wrapper(m_graph, &pred_node, &node, 1));
 }
 
@@ -209,21 +215,22 @@ inline void GraphImpl<Kokkos::HIP>::submit(const Kokkos::HIP& exec) {
           m_graph_exec));
 }
 
-inline Kokkos::HIP const& GraphImpl<Kokkos::HIP>::get_execution_space()
-    const noexcept {
-  return m_execution_space;
+inline auto GraphImpl<Kokkos::HIP>::get_device_handle() const noexcept
+    -> device_handle_t const& {
+  return m_device_handle;
 }
 
 inline auto GraphImpl<Kokkos::HIP>::create_root_node_ptr() {
   KOKKOS_EXPECTS(m_graph);
   KOKKOS_EXPECTS(!m_graph_exec);
-  auto rv = std::make_shared<root_node_impl_t>(get_execution_space(),
+  auto rv = std::make_shared<root_node_impl_t>(m_device_handle,
                                                _graph_node_is_root_ctor_tag{});
-  KOKKOS_IMPL_HIP_SAFE_CALL(m_execution_space.impl_internal_space_instance()
-                                ->hip_graph_add_empty_node_wrapper(
-                                    &(rv->node_details_t::node), m_graph,
-                                    /* dependencies = */ nullptr,
-                                    /* numDependencies = */ 0));
+  KOKKOS_IMPL_HIP_SAFE_CALL(
+      m_device_handle.m_exec.impl_internal_space_instance()
+          ->hip_graph_add_empty_node_wrapper(&(rv->node_details_t::node),
+                                             m_graph,
+                                             /* dependencies = */ nullptr,
+                                             /* numDependencies = */ 0));
   KOKKOS_ENSURES(rv->node_details_t::node);
   return rv;
 }
@@ -235,7 +242,7 @@ inline auto GraphImpl<Kokkos::HIP>::create_aggregate_ptr(PredecessorRefs&&...) {
   // each predecessor ref, so all we need to do here is create the (trivial)
   // aggregate node.
   return std::make_shared<aggregate_node_impl_t>(
-      m_execution_space, _graph_node_kernel_ctor_tag{}, aggregate_impl_t{});
+      m_device_handle, _graph_node_kernel_ctor_tag{}, aggregate_impl_t{});
 }
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -67,8 +67,8 @@ struct [[nodiscard]] Graph {
 
  public:
   // Construct an empty graph with a root node.
-  Graph(device_handle_t device_handle = device_handle_t{})
-      : m_impl_ptr{std::make_shared<impl_t>(std::move(device_handle))},
+  Graph(const device_handle_t& device_handle = device_handle_t{})
+      : m_impl_ptr{std::make_shared<impl_t>(device_handle)},
         m_root{m_impl_ptr->create_root_node_ptr()} {}
 
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
@@ -78,8 +78,8 @@ struct [[nodiscard]] Graph {
 #if defined(KOKKOS_ENABLE_CXX20)
     requires std::same_as<ExecutionSpace, Kokkos::DefaultExecutionSpace>
 #endif
-  Graph(device_handle_t device_handle, T&& native_graph)
-      : m_impl_ptr{std::make_shared<impl_t>(std::move(device_handle),
+  Graph(const device_handle_t& device_handle, T&& native_graph)
+      : m_impl_ptr{std::make_shared<impl_t>(device_handle,
                                             std::forward<T>(native_graph))},
         m_root{m_impl_ptr->create_root_node_ptr()} {
   }
@@ -153,14 +153,14 @@ auto when_all(PredecessorRefs&&... arg_pred_refs) {
 
 template <class ExecutionSpace, class Closure>
 Graph<ExecutionSpace> create_graph(
-    Kokkos::Impl::DeviceHandle<ExecutionSpace> device_handle,
+    const Kokkos::Impl::DeviceHandle<ExecutionSpace>& device_handle,
     Closure&& arg_closure) {
   // Create a shared pointer to the graph:
   // We need an attorney class here so we have an implementation friend to
   // create a Graph class without graph having public constructors. We can't
   // just make `create_graph` itself a friend because of the way that friend
   // function template injection works.
-  Graph<ExecutionSpace> rv{std::move(device_handle)};
+  Graph<ExecutionSpace> rv{device_handle};
   // Invoke the user's graph construction closure
   ((Closure&&)arg_closure)(rv.root_node());
   // and given them back the graph

--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -16,6 +16,7 @@
 
 // GraphAccess needs to be defined, not just declared
 #include <impl/Kokkos_GraphImpl.hpp>
+#include <impl/Kokkos_GraphNodeCtorProps.hpp>
 
 #include <functional>
 #include <memory>
@@ -42,6 +43,8 @@ struct [[nodiscard]] Graph {
   //----------------------------------------------------------------------------
 
  private:
+  using device_handle_t = Kokkos::Impl::DeviceHandle<ExecutionSpace>;
+
   //----------------------------------------------------------------------------
   // <editor-fold desc="friends"> {{{2
 
@@ -64,8 +67,8 @@ struct [[nodiscard]] Graph {
 
  public:
   // Construct an empty graph with a root node.
-  Graph(ExecutionSpace exec = ExecutionSpace{})
-      : m_impl_ptr{std::make_shared<impl_t>(std::move(exec))},
+  Graph(device_handle_t device_handle = device_handle_t{})
+      : m_impl_ptr{std::make_shared<impl_t>(std::move(device_handle))},
         m_root{m_impl_ptr->create_root_node_ptr()} {}
 
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
@@ -75,15 +78,15 @@ struct [[nodiscard]] Graph {
 #if defined(KOKKOS_ENABLE_CXX20)
     requires std::same_as<ExecutionSpace, Kokkos::DefaultExecutionSpace>
 #endif
-  Graph(ExecutionSpace exec, T&& native_graph)
-      : m_impl_ptr{std::make_shared<impl_t>(std::move(exec),
+  Graph(device_handle_t device_handle, T&& native_graph)
+      : m_impl_ptr{std::make_shared<impl_t>(std::move(device_handle),
                                             std::forward<T>(native_graph))},
         m_root{m_impl_ptr->create_root_node_ptr()} {
   }
 #endif
 
-  ExecutionSpace const& get_execution_space() const {
-    return m_impl_ptr->get_execution_space();
+  const auto& get_device_handle() const {
+    return m_impl_ptr->get_device_handle();
   }
 
   // Once the graph is instantiated, it is undefined behavior to add nodes.
@@ -96,6 +99,14 @@ struct [[nodiscard]] Graph {
 
   auto root_node() const { return root_t{m_impl_ptr, m_root}; }
 
+  // The graph is started once previous work on the execution space has
+  // finished.
+  // TODO: The graph nodes are created with user-provided device handles.
+  //       However, preliminary work (e.g., copying the driver to the device for
+  //       global launch) is enqueued in the device handle execution space
+  //       instance. Currently, the user is responsible for adding proper
+  //       synchronization for node preliminary work. Ideally, the graph itself
+  //       should handle this synchronization on first submission.
   void submit(const execution_space& exec = execution_space{}) const {
     KOKKOS_EXPECTS(bool(m_impl_ptr))
     (*m_impl_ptr).submit(exec);
@@ -141,13 +152,15 @@ auto when_all(PredecessorRefs&&... arg_pred_refs) {
 // <editor-fold desc="create_graph"> {{{1
 
 template <class ExecutionSpace, class Closure>
-Graph<ExecutionSpace> create_graph(ExecutionSpace ex, Closure&& arg_closure) {
+Graph<ExecutionSpace> create_graph(
+    Kokkos::Impl::DeviceHandle<ExecutionSpace> device_handle,
+    Closure&& arg_closure) {
   // Create a shared pointer to the graph:
   // We need an attorney class here so we have an implementation friend to
   // create a Graph class without graph having public constructors. We can't
   // just make `create_graph` itself a friend because of the way that friend
   // function template injection works.
-  Graph<ExecutionSpace> rv{std::move(ex)};
+  Graph<ExecutionSpace> rv{std::move(device_handle)};
   // Invoke the user's graph construction closure
   ((Closure&&)arg_closure)(rv.root_node());
   // and given them back the graph
@@ -161,7 +174,8 @@ template <
 std::enable_if_t<!Kokkos::is_execution_space_v<std::remove_cvref_t<Closure>>,
                  Graph<ExecutionSpace>>
 create_graph(Closure&& arg_closure) {
-  return create_graph(ExecutionSpace{}, (Closure&&)arg_closure);
+  return create_graph(Kokkos::Impl::DeviceHandle<ExecutionSpace>{},
+                      (Closure&&)arg_closure);
 }
 
 // </editor-fold> end create_graph }}}1

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -20,13 +20,25 @@ static_assert(false,
 #include <impl/Kokkos_GraphImpl_Utilities.hpp>
 #include <impl/Kokkos_GraphImpl.hpp>  // GraphAccess
 #include <impl/Kokkos_GraphNodeThenPolicy.hpp>
+#include <impl/Kokkos_GraphNodeCtorProps.hpp>
 
 #include <memory>  // std::shared_ptr
 
 namespace Kokkos {
 namespace Experimental {
 
-template <class ExecutionSpace, class Kernel /*= TypeErasedTag*/,
+#define KOKKOS_IMPL_POLICY_ON_DEFAULT_EXEC(policy)                         \
+  if (policy.space() != std::remove_cvref_t<decltype(policy.space())>{})   \
+    Kokkos::abort(                                                         \
+        "The execution space instance of the execution policy of a graph " \
+        "node must be the default one.");
+
+template <typename T, typename Exec>
+concept ExecutionPolicyOn =
+    ExecutionPolicy<T> && std::same_as<typename T::execution_space, Exec>;
+
+template <Kokkos::ExecutionSpace ExecutionSpace,
+          class Kernel /*= TypeErasedTag*/,
           class Predecessor /*= TypeErasedTag*/>
 class GraphNodeRef {
   //----------------------------------------------------------------------------
@@ -39,10 +51,6 @@ class GraphNodeRef {
       std::is_same_v<Predecessor, TypeErasedTag> ||
           Kokkos::Impl::is_specialization_of<Predecessor, GraphNodeRef>::value,
       "Invalid predecessor template parameter given to GraphNodeRef");
-
-  static_assert(
-      Kokkos::is_execution_space<ExecutionSpace>::value,
-      "Invalid execution space template parameter given to GraphNodeRef");
 
   static_assert(std::is_same_v<Predecessor, TypeErasedTag> ||
                     Kokkos::Impl::is_graph_kernel<Kernel>::value ||
@@ -69,10 +77,12 @@ class GraphNodeRef {
   //----------------------------------------------------------------------------
 
  private:
+  using device_handle_t = Kokkos::Impl::DeviceHandle<ExecutionSpace>;
+
   //----------------------------------------------------------------------------
   // <editor-fold desc="Friends"> {{{2
 
-  template <class, class, class>
+  template <Kokkos::ExecutionSpace, class, class>
   friend class GraphNodeRef;
   friend struct Kokkos::Impl::GraphAccess;
   friend struct Graph<execution_space>;
@@ -136,7 +146,7 @@ class GraphNodeRef {
         m_graph_impl,
         Kokkos::Impl::GraphAccess::make_node_shared_ptr<
             typename return_t::node_impl_t>(
-            m_node_impl->execution_space_instance(),
+            m_node_impl->get_device_handle(),
             Kokkos::Impl::_graph_node_kernel_ctor_tag{},
             (NextKernelDeduced&&)arg_kernel,
             // *this is the predecessor
@@ -218,31 +228,39 @@ class GraphNodeRef {
   // TODO We should do better than a p-for (that uses registers, heavier).
   //      This should "just" launch the function on device with our driver.
   template <
-      typename Label, typename Policy, typename Functor,
+      Kokkos::Impl::NodeProperties Props, typename Policy, typename Functor,
       std::enable_if_t<
           std::is_invocable_r_v<void, const std::remove_cvref_t<Functor>> &&
-              Kokkos::Impl::is_view_label_v<std::remove_cvref_t<Label>> &&
               Kokkos::Impl::is_specialization_of_v<Policy, ThenPolicy>,
           int> = 0>
-  auto then(Label&& label, const ExecutionSpace& exec, Policy&& policy,
-            Functor&& functor) const {
+  auto then(Props&& props, Policy&& policy, Functor&& functor) const {
     using next_kernel_t =
         Kokkos::Impl::GraphNodeThenImpl<ExecutionSpace,
                                         std::remove_cvref_t<Policy>,
                                         std::remove_cvref_t<Functor>>;
-    return this->_then_kernel(next_kernel_t(std::forward<Label>(label), exec,
-                                            std::forward<Policy>(policy),
-                                            std::forward<Functor>(functor)));
+    auto graph_ptr = m_graph_impl.lock();
+    KOKKOS_EXPECTS(bool(graph_ptr))
+    auto full_props = Kokkos::Impl::with_properties_if_unset(
+        std::forward<Props>(props), graph_ptr->get_device_handle(),
+        "[unlabeled]");
+    return this->_then_kernel(next_kernel_t{
+        Kokkos::Impl::extract_property<std::string>(full_props),
+        Kokkos::Impl::extract_property<device_handle_t>(full_props).m_exec,
+        std::forward<Policy>(policy), std::forward<Functor>(functor)});
+  }
+
+  template <Kokkos::Impl::NodeProperties Props, typename Functor>
+  auto then(Props&& props, Functor&& functor) const {
+    return this->then(std::forward<Props>(props), ThenPolicy{},
+                      std::forward<Functor>(functor));
   }
 
   // Overload for a label.
-  template <
-      typename Label, typename Functor,
-      std::enable_if_t<
-          Kokkos::Impl::is_view_label_v<std::remove_cvref_t<Label>>, int> = 0>
+  template <typename Label, typename Functor>
+    requires Kokkos::Impl::ViewLabel<std::remove_cvref_t<Label>>
   auto then(Label&& label, Functor&& functor) const {
-    return this->then(std::forward<Label>(label), ExecutionSpace{},
-                      ThenPolicy{}, std::forward<Functor>(functor));
+    return this->then(node_props(std::forward<Label>(label)), ThenPolicy{},
+                      std::forward<Functor>(functor));
   }
 
   // Overload for a policy.
@@ -251,8 +269,7 @@ class GraphNodeRef {
                                  std::remove_cvref_t<Policy>, ThenPolicy>,
                              int> = 0>
   auto then(Policy&& policy, Functor&& functor) const {
-    return this->then(std::string{}, ExecutionSpace{},
-                      std::forward<Policy>(policy),
+    return this->then(node_props(), std::forward<Policy>(policy),
                       std::forward<Functor>(functor));
   }
 
@@ -264,16 +281,15 @@ class GraphNodeRef {
                     Kokkos::Impl::is_view_label_v<std::remove_cvref_t<Label>>,
                 int> = 0>
   auto then(Label&& label, Policy&& policy, Functor&& functor) const {
-    return this->then(std::forward<Label>(label), ExecutionSpace{},
+    return this->then(node_props(std::forward<Label>(label)),
                       std::forward<Policy>(policy),
                       std::forward<Functor>(functor));
   }
 
   // Overload without policy given.
-  template <typename Label, typename Functor>
-  auto then(Label&& label, const ExecutionSpace& exec,
-            Functor&& functor) const {
-    return this->then(std::forward<Label>(label), exec, ThenPolicy{},
+  template <typename Functor>
+  auto then(Functor&& functor) const {
+    return this->then(node_props(), ThenPolicy{},
                       std::forward<Functor>(functor));
   }
 
@@ -291,7 +307,7 @@ class GraphNodeRef {
         m_graph_impl,
         Kokkos::Impl::GraphAccess::make_node_shared_ptr<
             typename return_t::node_impl_t>(
-            m_node_impl->execution_space_instance(),
+            m_node_impl->get_device_handle(),
             Kokkos::Impl::_graph_node_host_ctor_tag{},
             std::forward<Functor>(functor),
             Kokkos::Impl::_graph_node_predecessor_ctor_tag{}, *this));
@@ -334,7 +350,7 @@ class GraphNodeRef {
           m_graph_impl,
           Kokkos::Impl::GraphAccess::make_node_shared_ptr<
               typename return_t::node_impl_t>(
-              m_node_impl->execution_space_instance(),
+              m_node_impl->get_device_handle(),
               Kokkos::Impl::_graph_node_capture_ctor_tag{},
               std::forward<Functor>(functor),
               Kokkos::Impl::_graph_node_predecessor_ctor_tag{}, *this));
@@ -351,63 +367,63 @@ class GraphNodeRef {
   }
 #endif
 
-  template <class Policy, class Functor,
-            std::enable_if_t<
-                // equivalent to:
-                //   requires Kokkos::ExecutionPolicy<remove_cvref_t<Policy>>
-                is_execution_policy<std::remove_cvref_t<Policy>>::value,
-                // --------------------
-                int> = 0>
-  auto then_parallel_for(std::string arg_name, Policy&& arg_policy,
+  template <Kokkos::Impl::NodeProperties Props, class Policy, class Functor>
+    requires ExecutionPolicyOn<std::remove_cvref_t<Policy>, ExecutionSpace>
+  auto then_parallel_for(Props&& props, Policy&& arg_policy,
                          Functor&& functor) const {
     //----------------------------------------
     KOKKOS_EXPECTS(!m_graph_impl.expired())
     KOKKOS_EXPECTS(bool(m_node_impl))
-    // TODO @graph restore this expectation once we add comparability to space
-    //      instances
-    // KOKKOS_EXPECTS(
-    //   arg_policy.space() == m_graph_impl->get_execution_space());
+
+    KOKKOS_IMPL_POLICY_ON_DEFAULT_EXEC(arg_policy)
 
     // needs to static assert constraint: DataParallelFunctor<Functor>
 
-    using policy_t = std::remove_cvref_t<Policy>;
-    // constraint check: same execution space type (or defaulted, maybe?)
-    static_assert(
-        std::is_same_v<typename policy_t::execution_space, execution_space>,
-        // TODO @graph make defaulted execution space work
-        //|| policy_t::execution_space_is_defaulted,
-        "Execution Space mismatch between execution policy and graph");
+    auto graph_ptr = m_graph_impl.lock();
+    KOKKOS_EXPECTS(bool(graph_ptr))
+    auto full_props =
+        with_properties_if_unset(std::forward<Props>(props),
+                                 graph_ptr->get_device_handle(), "[unlabeled]");
 
-    auto policy = Experimental::require((Policy&&)arg_policy,
-                                        Kokkos::Impl::KernelInGraphProperty{});
+    auto policy = Experimental::require(
+        Policy(Kokkos::Impl::PolicyUpdate{}, (Policy&&)arg_policy,
+               Kokkos::Impl::get_property<device_handle_t>(full_props).m_exec),
+        Kokkos::Impl::KernelInGraphProperty{});
 
     using next_policy_t = decltype(policy);
     using next_kernel_t =
         Kokkos::Impl::GraphNodeKernelImpl<ExecutionSpace, next_policy_t,
                                           std::decay_t<Functor>,
                                           Kokkos::ParallelForTag>;
-    return this->_then_kernel(next_kernel_t{std::move(arg_name), policy.space(),
-                                            (Functor&&)functor,
-                                            (Policy&&)policy});
+    return this->_then_kernel(next_kernel_t{
+        Kokkos::Impl::extract_property<std::string>(full_props),
+        Kokkos::Impl::extract_property<device_handle_t>(full_props).m_exec,
+        (Functor&&)functor, std::move(policy)});
   }
 
-  template <class Policy, class Functor,
-            std::enable_if_t<
-                // equivalent to:
-                //   requires Kokkos::ExecutionPolicy<remove_cvref_t<Policy>>
-                is_execution_policy<std::remove_cvref_t<Policy>>::value,
-                // --------------------
-                int> = 0>
+  template <class Policy, class Functor>
+    requires ExecutionPolicyOn<std::remove_cvref_t<Policy>, ExecutionSpace>
   auto then_parallel_for(Policy&& policy, Functor&& functor) const {
     // needs to static assert constraint: DataParallelFunctor<Functor>
-    return this->then_parallel_for("", (Policy&&)policy, (Functor&&)functor);
+    return this->then_parallel_for(node_props(), (Policy&&)policy,
+                                   (Functor&&)functor);
+  }
+
+  template <class Label, class Policy, class Functor>
+    requires(ExecutionPolicyOn<std::remove_cvref_t<Policy>, ExecutionSpace> &&
+             Kokkos::Impl::is_view_label_v<std::remove_cvref_t<Label>>)
+  auto then_parallel_for(Label&& label, Policy&& policy,
+                         Functor&& functor) const {
+    // needs to static assert constraint: DataParallelFunctor<Functor>
+    return this->then_parallel_for(node_props(std::forward<Label>(label)),
+                                   (Policy&&)policy, (Functor&&)functor);
   }
 
   template <class Functor>
   auto then_parallel_for(std::string name, std::size_t n,
                          Functor&& functor) const {
     // needs to static assert constraint: DataParallelFunctor<Functor>
-    return this->then_parallel_for(std::move(name),
+    return this->then_parallel_for(node_props(std::move(name)),
                                    Kokkos::RangePolicy<execution_space>(0, n),
                                    (Functor&&)functor);
   }
@@ -415,7 +431,9 @@ class GraphNodeRef {
   template <class Functor>
   auto then_parallel_for(std::size_t n, Functor&& functor) const {
     // needs to static assert constraint: DataParallelFunctor<Functor>
-    return this->then_parallel_for("", n, (Functor&&)functor);
+    return this->then_parallel_for(node_props(),
+                                   Kokkos::RangePolicy<execution_space>(0, n),
+                                   (Functor&&)functor);
   }
 
   // </editor-fold> end then_parallel_for }}}2
@@ -434,33 +452,24 @@ class GraphNodeRef {
       return static_cast<T2&&>(v2);
   }
 
-  template <class Policy, class Functor, class ReturnType,
-            std::enable_if_t<
-                // equivalent to:
-                //   requires Kokkos::ExecutionPolicy<remove_cvref_t<Policy>>
-                is_execution_policy<std::remove_cvref_t<Policy>>::value,
-                // --------------------
-                int> = 0>
-  auto then_parallel_reduce(std::string arg_name, Policy&& arg_policy,
+  template <Kokkos::Impl::NodeProperties Props, class Policy, class Functor,
+            class ReturnType>
+    requires ExecutionPolicyOn<std::remove_cvref_t<Policy>, ExecutionSpace>
+  auto then_parallel_reduce(Props&& props, Policy&& arg_policy,
                             Functor&& functor,
                             ReturnType&& return_value) const {
     auto graph_impl_ptr = m_graph_impl.lock();
     KOKKOS_EXPECTS(bool(graph_impl_ptr))
     KOKKOS_EXPECTS(bool(m_node_impl))
-    // TODO @graph restore this expectation once we add comparability to space
-    //      instances
-    // KOKKOS_EXPECTS(
-    //   arg_policy.space() == m_graph_impl->get_execution_space());
+
+    KOKKOS_IMPL_POLICY_ON_DEFAULT_EXEC(arg_policy)
 
     // needs static assertion of constraint:
     //   DataParallelReductionFunctor<Functor, ReturnType>
 
-    using policy_t = std::remove_cv_t<std::remove_reference_t<Policy>>;
-    static_assert(
-        std::is_same_v<typename policy_t::execution_space, execution_space>,
-        // TODO @graph make defaulted execution space work
-        // || policy_t::execution_space_is_defaulted,
-        "Execution Space mismatch between execution policy and graph");
+    auto full_props = with_properties_if_unset(
+        std::forward<Props>(props), graph_impl_ptr->get_device_handle(),
+        "[unlabeled]");
 
     // This is also just an expectation, but it's one that we expect the user
     // to interact with (even in release mode), so we should throw an exception
@@ -469,7 +478,8 @@ class GraphNodeRef {
     // whether or not they point to a View as a runtime boolean rather than part
     // of the type.
     if (Kokkos::Impl::parallel_reduce_needs_fence(
-            graph_impl_ptr->get_execution_space(), return_value)) {
+            Kokkos::Impl::get_property<device_handle_t>(full_props).m_exec,
+            return_value)) {
       Kokkos::Impl::throw_runtime_exception(
           "Parallel reductions in graphs can't operate on Reducers that "
           "reference a scalar because they can't complete synchronously. Use a "
@@ -517,8 +527,10 @@ class GraphNodeRef {
     // End of Kokkos reducer disaster
     //----------------------------------------
 
-    auto policy = Experimental::require((Policy&&)arg_policy,
-                                        Kokkos::Impl::KernelInGraphProperty{});
+    auto policy = Experimental::require(
+        Policy(Kokkos::Impl::PolicyUpdate{}, (Policy&&)arg_policy,
+               Kokkos::Impl::get_property<device_handle_t>(full_props).m_exec),
+        Kokkos::Impl::KernelInGraphProperty{});
 
     using passed_reducer_type = typename return_value_adapter::reducer_type;
 
@@ -545,21 +557,18 @@ class GraphNodeRef {
                                           Kokkos::ParallelReduceTag>;
 
     return this->_then_kernel(next_kernel_t{
-        std::move(arg_name), graph_impl_ptr->get_execution_space(),
-        functor_reducer, (Policy&&)policy,
-        return_value_adapter::return_value(return_value, functor)});
+        Kokkos::Impl::extract_property<std::string>(full_props),
+        Kokkos::Impl::extract_property<device_handle_t>(full_props).m_exec,
+        std::move(functor_reducer), std::move(policy),
+        return_value_adapter::return_value(return_value,
+                                           std::forward<Functor>(functor))});
   }
 
-  template <class Policy, class Functor, class ReturnType,
-            std::enable_if_t<
-                // equivalent to:
-                //   requires Kokkos::ExecutionPolicy<remove_cvref_t<Policy>>
-                is_execution_policy<std::remove_cvref_t<Policy>>::value,
-                // --------------------
-                int> = 0>
+  template <class Policy, class Functor, class ReturnType>
+    requires ExecutionPolicyOn<std::remove_cvref_t<Policy>, ExecutionSpace>
   auto then_parallel_reduce(Policy&& arg_policy, Functor&& functor,
                             ReturnType&& return_value) const {
-    return this->then_parallel_reduce("", (Policy&&)arg_policy,
+    return this->then_parallel_reduce(node_props(), (Policy&&)arg_policy,
                                       (Functor&&)functor,
                                       (ReturnType&&)return_value);
   }
@@ -570,16 +579,18 @@ class GraphNodeRef {
                             Functor&& functor,
                             ReturnType&& return_value) const {
     return this->then_parallel_reduce(
-        std::move(label), Kokkos::RangePolicy<execution_space>{0, idx_end},
-        (Functor&&)functor, (ReturnType&&)return_value);
+        node_props(std::move(label)),
+        Kokkos::RangePolicy<execution_space>{0, idx_end}, (Functor&&)functor,
+        (ReturnType&&)return_value);
   }
 
   template <class Functor, class ReturnType>
   auto then_parallel_reduce(typename execution_space::size_type idx_end,
                             Functor&& functor,
                             ReturnType&& return_value) const {
-    return this->then_parallel_reduce("", idx_end, (Functor&&)functor,
-                                      (ReturnType&&)return_value);
+    return this->then_parallel_reduce(
+        node_props(), Kokkos::RangePolicy<execution_space>{0, idx_end},
+        (Functor&&)functor, (ReturnType&&)return_value);
   }
 
   // </editor-fold> end then_parallel_reduce }}}2

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -227,12 +227,10 @@ class GraphNodeRef {
 
   // TODO We should do better than a p-for (that uses registers, heavier).
   //      This should "just" launch the function on device with our driver.
-  template <
-      Kokkos::Impl::NodeProperties Props, typename Policy, typename Functor,
-      std::enable_if_t<
-          std::is_invocable_r_v<void, const std::remove_cvref_t<Functor>> &&
-              Kokkos::Impl::is_specialization_of_v<Policy, ThenPolicy>,
-          int> = 0>
+  template <typename Props, typename Policy, typename Functor>
+    requires(Kokkos::Impl::NodeProperties<std::remove_cvref_t<Props>> &&
+             std::is_invocable_r_v<void, const std::remove_cvref_t<Functor>> &&
+             Kokkos::Impl::is_specialization_of_v<Policy, ThenPolicy>)
   auto then(Props&& props, Policy&& policy, Functor&& functor) const {
     using next_kernel_t =
         Kokkos::Impl::GraphNodeThenImpl<ExecutionSpace,
@@ -249,7 +247,8 @@ class GraphNodeRef {
         std::forward<Policy>(policy), std::forward<Functor>(functor)});
   }
 
-  template <Kokkos::Impl::NodeProperties Props, typename Functor>
+  template <typename Props, typename Functor>
+    requires Kokkos::Impl::NodeProperties<std::remove_cvref_t<Props>>
   auto then(Props&& props, Functor&& functor) const {
     return this->then(std::forward<Props>(props), ThenPolicy{},
                       std::forward<Functor>(functor));
@@ -367,8 +366,9 @@ class GraphNodeRef {
   }
 #endif
 
-  template <Kokkos::Impl::NodeProperties Props, class Policy, class Functor>
-    requires ExecutionPolicyOn<std::remove_cvref_t<Policy>, ExecutionSpace>
+  template <typename Props, class Policy, class Functor>
+    requires(Kokkos::Impl::NodeProperties<std::remove_cvref_t<Props>> &&
+             ExecutionPolicyOn<std::remove_cvref_t<Policy>, ExecutionSpace>)
   auto then_parallel_for(Props&& props, Policy&& arg_policy,
                          Functor&& functor) const {
     //----------------------------------------
@@ -452,9 +452,9 @@ class GraphNodeRef {
       return static_cast<T2&&>(v2);
   }
 
-  template <Kokkos::Impl::NodeProperties Props, class Policy, class Functor,
-            class ReturnType>
-    requires ExecutionPolicyOn<std::remove_cvref_t<Policy>, ExecutionSpace>
+  template <typename Props, class Policy, class Functor, class ReturnType>
+    requires(Kokkos::Impl::NodeProperties<std::remove_cvref_t<Props>> &&
+             ExecutionPolicyOn<std::remove_cvref_t<Policy>, ExecutionSpace>)
   auto then_parallel_reduce(Props&& props, Policy&& arg_policy,
                             Functor&& functor,
                             ReturnType&& return_value) const {

--- a/core/src/Kokkos_Graph_fwd.hpp
+++ b/core/src/Kokkos_Graph_fwd.hpp
@@ -8,7 +8,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_GRAPH_FWD
 #endif
 
-#include <Kokkos_Macros.hpp>
+#include <Kokkos_Concepts.hpp>
 
 namespace Kokkos {
 namespace Experimental {
@@ -18,7 +18,7 @@ struct TypeErasedTag {};
 template <class ExecutionSpace>
 struct Graph;
 
-template <class ExecutionSpace, class Kernel = TypeErasedTag,
+template <Kokkos::ExecutionSpace ExecutionSpace, class Kernel = TypeErasedTag,
           class Predecessor = TypeErasedTag>
 class GraphNodeRef;
 

--- a/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
@@ -45,9 +45,9 @@ class GraphImpl<Kokkos::SYCL> {
 
   ~GraphImpl();
 
-  explicit GraphImpl(device_handle_t device_handle);
+  explicit GraphImpl(const device_handle_t& device_handle);
 
-  GraphImpl(device_handle_t device_handle, native_graph_t native_graph);
+  GraphImpl(const device_handle_t& device_handle, native_graph_t native_graph);
 
   void add_node(std::shared_ptr<aggregate_node_impl_t> const& arg_node_ptr);
 
@@ -101,15 +101,14 @@ inline GraphImpl<Kokkos::SYCL>::~GraphImpl() {
       "Kokkos::GraphImpl::~GraphImpl: Graph Destruction");
 }
 
-inline GraphImpl<Kokkos::SYCL>::GraphImpl(device_handle_t device_handle)
-    : m_device_handle(std::move(device_handle)),
+inline GraphImpl<Kokkos::SYCL>::GraphImpl(const device_handle_t& device_handle)
+    : m_device_handle(device_handle),
       m_graph(m_device_handle.m_exec.sycl_queue().get_context(),
               m_device_handle.m_exec.sycl_queue().get_device()) {}
 
-inline GraphImpl<Kokkos::SYCL>::GraphImpl(device_handle_t device_handle,
+inline GraphImpl<Kokkos::SYCL>::GraphImpl(const device_handle_t& device_handle,
                                           native_graph_t native_graph)
-    : m_device_handle(std::move(device_handle)),
-      m_graph(std::move(native_graph)) {}
+    : m_device_handle(device_handle), m_graph(std::move(native_graph)) {}
 
 inline void GraphImpl<Kokkos::SYCL>::add_node(
     std::shared_ptr<aggregate_node_impl_t> const& arg_node_ptr) {

--- a/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
@@ -19,6 +19,9 @@ namespace Kokkos {
 namespace Impl {
 template <>
 class GraphImpl<Kokkos::SYCL> {
+ private:
+  using device_handle_t = Kokkos::Impl::DeviceHandle<Kokkos::SYCL>;
+
  public:
   using node_details_t = GraphNodeBackendSpecificDetails<Kokkos::SYCL>;
   using root_node_impl_t =
@@ -42,9 +45,9 @@ class GraphImpl<Kokkos::SYCL> {
 
   ~GraphImpl();
 
-  explicit GraphImpl(Kokkos::SYCL instance);
+  explicit GraphImpl(device_handle_t device_handle);
 
-  GraphImpl(Kokkos::SYCL instance, native_graph_t native_graph);
+  GraphImpl(device_handle_t device_handle, native_graph_t native_graph);
 
   void add_node(std::shared_ptr<aggregate_node_impl_t> const& arg_node_ptr);
 
@@ -68,7 +71,7 @@ class GraphImpl<Kokkos::SYCL> {
 
   void submit(const Kokkos::SYCL& exec);
 
-  Kokkos::SYCL const& get_execution_space() const noexcept;
+  auto get_device_handle() const noexcept -> device_handle_t const&;
 
   auto create_root_node_ptr();
 
@@ -84,7 +87,7 @@ class GraphImpl<Kokkos::SYCL> {
   auto& sycl_graph_exec() { return m_graph_exec; }
 
  private:
-  Kokkos::SYCL m_execution_space;
+  device_handle_t m_device_handle;
   native_graph_t m_graph;
   std::optional<sycl::ext::oneapi::experimental::command_graph<
       sycl::ext::oneapi::experimental::graph_state::executable>>
@@ -94,17 +97,18 @@ class GraphImpl<Kokkos::SYCL> {
 };
 
 inline GraphImpl<Kokkos::SYCL>::~GraphImpl() {
-  m_execution_space.fence("Kokkos::GraphImpl::~GraphImpl: Graph Destruction");
+  m_device_handle.m_exec.fence(
+      "Kokkos::GraphImpl::~GraphImpl: Graph Destruction");
 }
 
-inline GraphImpl<Kokkos::SYCL>::GraphImpl(Kokkos::SYCL instance)
-    : m_execution_space(std::move(instance)),
-      m_graph(m_execution_space.sycl_queue().get_context(),
-              m_execution_space.sycl_queue().get_device()) {}
+inline GraphImpl<Kokkos::SYCL>::GraphImpl(device_handle_t device_handle)
+    : m_device_handle(std::move(device_handle)),
+      m_graph(m_device_handle.m_exec.sycl_queue().get_context(),
+              m_device_handle.m_exec.sycl_queue().get_device()) {}
 
-inline GraphImpl<Kokkos::SYCL>::GraphImpl(Kokkos::SYCL instance,
+inline GraphImpl<Kokkos::SYCL>::GraphImpl(device_handle_t device_handle,
                                           native_graph_t native_graph)
-    : m_execution_space(std::move(instance)),
+    : m_device_handle(std::move(device_handle)),
       m_graph(std::move(native_graph)) {}
 
 inline void GraphImpl<Kokkos::SYCL>::add_node(
@@ -190,14 +194,14 @@ inline void GraphImpl<Kokkos::SYCL>::submit(const Kokkos::SYCL& exec) {
   exec.sycl_queue().ext_oneapi_graph(*m_graph_exec);
 }
 
-inline Kokkos::SYCL const& GraphImpl<Kokkos::SYCL>::get_execution_space()
-    const noexcept {
-  return m_execution_space;
+inline auto GraphImpl<Kokkos::SYCL>::get_device_handle() const noexcept
+    -> device_handle_t const& {
+  return m_device_handle;
 }
 
 inline auto GraphImpl<Kokkos::SYCL>::create_root_node_ptr() {
   KOKKOS_EXPECTS(!m_graph_exec);
-  auto rv = std::make_shared<root_node_impl_t>(get_execution_space(),
+  auto rv                  = std::make_shared<root_node_impl_t>(m_device_handle,
                                                _graph_node_is_root_ctor_tag{});
   rv->node_details_t::node = m_graph.add();
   return rv;
@@ -211,7 +215,7 @@ inline auto GraphImpl<Kokkos::SYCL>::create_aggregate_ptr(
   // each predecessor ref, so all we need to do here is create the (trivial)
   // aggregate node.
   return std::make_shared<aggregate_node_impl_t>(
-      m_execution_space, _graph_node_kernel_ctor_tag{}, aggregate_impl_t{});
+      m_device_handle, _graph_node_kernel_ctor_tag{}, aggregate_impl_t{});
 }
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/View/Kokkos_ViewCtor.hpp
+++ b/core/src/View/Kokkos_ViewCtor.hpp
@@ -4,6 +4,8 @@
 #ifndef KOKKOS_EXPERIMENTAL_IMPL_VIEW_CTOR_PROP_HPP
 #define KOKKOS_EXPERIMENTAL_IMPL_VIEW_CTOR_PROP_HPP
 
+#include "impl/Kokkos_Traits.hpp"
+
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
@@ -56,6 +58,9 @@ struct is_view_label<const char[N]> : public std::true_type {};
 
 template <typename T>
 constexpr bool is_view_label_v = is_view_label<T>::value;
+
+template <typename T>
+concept ViewLabel = is_view_label_v<T>;
 
 //----------------------------------------------------------------------------
 

--- a/core/src/impl/Kokkos_Default_Graph_Impl.hpp
+++ b/core/src/impl/Kokkos_Default_Graph_Impl.hpp
@@ -25,7 +25,8 @@ namespace Impl {
 // <editor-fold desc="GraphImpl default implementation"> {{{1
 
 template <class ExecutionSpace>
-struct GraphImpl : private InstanceStorage<ExecutionSpace> {
+struct GraphImpl
+    : private InstanceStorage<Kokkos::Impl::DeviceHandle<ExecutionSpace>> {
  public:
   using root_node_impl_t =
       GraphNodeImpl<ExecutionSpace, Kokkos::Experimental::TypeErasedTag,
@@ -34,8 +35,10 @@ struct GraphImpl : private InstanceStorage<ExecutionSpace> {
   using aggregate_impl_t = GraphNodeAggregateDefaultImpl<ExecutionSpace>;
 
  private:
-  using execution_space_instance_storage_base_t =
-      InstanceStorage<ExecutionSpace>;
+  using device_handle_t = Kokkos::Impl::DeviceHandle<ExecutionSpace>;
+
+  using device_handle_storage_base_t =
+      InstanceStorage<Kokkos::Impl::DeviceHandle<ExecutionSpace>>;
 
   using node_details_t = GraphNodeBackendSpecificDetails<ExecutionSpace>;
   std::set<std::shared_ptr<node_details_t>> m_sinks;
@@ -53,14 +56,14 @@ struct GraphImpl : private InstanceStorage<ExecutionSpace> {
   GraphImpl& operator=(GraphImpl&&)      = delete;
   ~GraphImpl()                           = default;
 
-  explicit GraphImpl(ExecutionSpace arg_space)
-      : execution_space_instance_storage_base_t(std::move(arg_space)) {}
+  explicit GraphImpl(device_handle_t device_handle)
+      : device_handle_storage_base_t(std::move(device_handle)) {}
 
   // </editor-fold> end Constructors, destructor, and assignment }}}2
   //----------------------------------------------------------------------------
 
-  ExecutionSpace const& get_execution_space() const {
-    return this->execution_space_instance_storage_base_t::instance();
+  device_handle_t const& get_device_handle() const {
+    return this->device_handle_storage_base_t::instance();
   }
 
   //----------------------------------------------------------------------------
@@ -110,13 +113,13 @@ struct GraphImpl : private InstanceStorage<ExecutionSpace> {
         GraphNodeImpl<ExecutionSpace, aggregate_impl_t,
                       Kokkos::Experimental::TypeErasedTag>;
     return GraphAccess::make_node_shared_ptr<aggregate_node_impl_t>(
-        this->get_execution_space(), _graph_node_kernel_ctor_tag{},
+        this->get_device_handle(), _graph_node_kernel_ctor_tag{},
         aggregate_impl_t{});
   }
 
   auto create_root_node_ptr() {
     auto rv = Kokkos::Impl::GraphAccess::make_node_shared_ptr<root_node_impl_t>(
-        get_execution_space(), _graph_node_is_root_ctor_tag{});
+        get_device_handle(), _graph_node_is_root_ctor_tag{});
     m_sinks.insert(rv);
     return rv;
   }

--- a/core/src/impl/Kokkos_Default_Graph_Impl.hpp
+++ b/core/src/impl/Kokkos_Default_Graph_Impl.hpp
@@ -56,8 +56,8 @@ struct GraphImpl
   GraphImpl& operator=(GraphImpl&&)      = delete;
   ~GraphImpl()                           = default;
 
-  explicit GraphImpl(device_handle_t device_handle)
-      : device_handle_storage_base_t(std::move(device_handle)) {}
+  explicit GraphImpl(const device_handle_t& device_handle)
+      : device_handle_storage_base_t(device_handle) {}
 
   // </editor-fold> end Constructors, destructor, and assignment }}}2
   //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_DeviceHandle.hpp
+++ b/core/src/impl/Kokkos_DeviceHandle.hpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_IMPL_KOKKOS_DEVICEHANDLE_HPP
+#define KOKKOS_IMPL_KOKKOS_DEVICEHANDLE_HPP
+
+#include "View/Kokkos_ViewCtor.hpp"
+
+namespace Kokkos::Impl {
+template <Kokkos::ExecutionSpace Exec>
+struct DeviceHandle {
+  // A device is implicitly contained in an execution space instance.
+  static DeviceHandle from(Exec exec) {
+    return DeviceHandle{.m_exec = std::move(exec)};
+  }
+
+  auto operator<=>(const DeviceHandle&) const = default;
+
+  // For now, let's store the execution space instance.
+  // It is the best portable way to ensure that the device handle has enough
+  // information. It is an implementation detail, let's keep this reference
+  // counted member extractible easily (no need to make it private yet).
+  // In the future, it could be treated as the default execution queue for the
+  // device.
+  Exec m_exec;
+};
+
+template <typename>
+struct is_device_handle : public std::false_type {};
+
+template <typename T>
+struct is_device_handle<DeviceHandle<T>> : public std::true_type {};
+
+template <typename T>
+constexpr bool is_device_handle_v = is_device_handle<T>::value;
+}  // namespace Kokkos::Impl
+
+namespace Kokkos::Experimental {
+// The user shall treat the return type as an opaque type.
+template <typename Exec>
+  requires Kokkos::ExecutionSpace<std::remove_cvref_t<Exec>>
+auto get_device_handle(Exec&& exec) {
+  return Kokkos::Impl::DeviceHandle<std::remove_cvref_t<Exec>>::from(
+      std::forward<Exec>(exec));
+}
+}  // namespace Kokkos::Experimental
+
+#endif  // KOKKOS_IMPL_KOKKOS_DEVICEHANDLE_HPP

--- a/core/src/impl/Kokkos_GraphNodeCtorProps.hpp
+++ b/core/src/impl/Kokkos_GraphNodeCtorProps.hpp
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_IMPL_KOKKOS_GRAPHNODECTORPROPS_HPP
+#define KOKKOS_IMPL_KOKKOS_GRAPHNODECTORPROPS_HPP
+
+#include "impl/Kokkos_DeviceHandle.hpp"
+#include "View/Kokkos_ViewCtor.hpp"
+
+namespace Kokkos::Impl {
+
+template <typename T>
+concept ValidNodeProperty = is_view_label_v<T> || is_device_handle_v<T>;
+
+// Transform a type into a valid property.
+template <typename T>
+struct NodeCtorPropTransform {
+  using type = T;
+};
+
+template <Kokkos::Impl::ViewLabel T>
+struct NodeCtorPropTransform<T> {
+  using type = std::string;
+};
+
+// A single property.
+template <ValidNodeProperty T>
+struct NodeCtorProp {
+  using value_type = typename NodeCtorPropTransform<T>::type;
+
+  explicit NodeCtorProp(value_type value) : m_value(std::move(value)) {}
+
+  value_type m_value;
+};
+
+// Aggregated properties.
+template <typename... Props>
+struct NodeCtorProps : public NodeCtorProp<Props>... {
+  using properties_value_type_list_t =
+      Kokkos::Impl::type_list<typename NodeCtorProp<Props>::value_type...>;
+
+  static_assert(Kokkos::Impl::type_list_size_v<Kokkos::Impl::filter_type_list_t<
+                        is_view_label, Kokkos::Impl::type_list<Props...>>> <= 1,
+                "Only one label allowed.");
+  static_assert(Kokkos::Impl::type_list_size_v<Kokkos::Impl::filter_type_list_t<
+                        is_device_handle, Kokkos::Impl::type_list<Props...>>> <=
+                    1,
+                "Only one device handle allowed.");
+
+  using uniform_type =
+      NodeCtorProps<typename NodeCtorProp<Props>::value_type...>;
+
+  template <typename T>
+  static constexpr bool has =
+      Kokkos::Impl::type_list_contains_v<T, properties_value_type_list_t>;
+
+  NodeCtorProps()                                = default;
+  NodeCtorProps(const NodeCtorProps&)            = default;
+  NodeCtorProps& operator=(const NodeCtorProps&) = default;
+  NodeCtorProps(NodeCtorProps&&)                 = default;
+  NodeCtorProps& operator=(NodeCtorProps&&)      = default;
+
+  // NOLINTBEGIN(modernize-type-traits)
+  template <typename... Args>
+    requires(std::constructible_from<NodeCtorProp<Props>, Args &&> && ...)
+  // NOLINTEND(modernize-type-traits)
+  explicit NodeCtorProps(Args&&... args)
+      : NodeCtorProp<Props>{std::forward<Args>(args)}... {}
+};
+
+template <typename T>
+struct is_node_props : public std::false_type {};
+
+template <typename... Args>
+struct is_node_props<NodeCtorProps<Args...>> : public std::true_type {};
+
+template <typename T>
+constexpr bool is_node_props_v = is_node_props<T>::value;
+
+template <typename T>
+concept NodeProperties = is_node_props_v<T>;
+
+template <typename Prop, NodeProperties Props>
+  requires Props::template
+has<Prop> [[nodiscard]] constexpr decltype(auto) get_property(
+    const Props& props) {
+  return static_cast<const NodeCtorProp<Prop>&>(props).m_value;
+}
+
+template <typename Prop, NodeProperties Props>
+  requires Props::template
+has<Prop> [[nodiscard]] constexpr decltype(auto) extract_property(
+    Props& props) {
+  return std::move(static_cast<NodeCtorProp<Prop>&>(props).m_value);
+}
+
+struct WithProperty {
+  template <typename... Props, typename Property>
+    requires(sizeof...(Props) > 0)
+  [[nodiscard]] static constexpr decltype(auto) set(
+      NodeCtorProps<Props...> props, Property&& property) {
+    using NewNodeCtorProps =
+        typename NodeCtorProps<Props...,
+                               std::remove_cvref_t<Property>>::uniform_type;
+    return NewNodeCtorProps{extract_property<Props>(props)...,
+                            std::forward<Property>(property)};
+  }
+
+  template <typename Property>
+  [[nodiscard]] static constexpr decltype(auto) set(NodeCtorProps<>,
+                                                    Property&& prop) {
+    return typename NodeCtorProps<std::remove_cvref_t<Property>>::uniform_type{
+        std::forward<Property>(prop)};
+  }
+};
+
+template <NodeProperties Props>
+[[nodiscard]] constexpr decltype(auto) with_properties_if_unset(
+    Props node_props) noexcept {
+  return node_props;
+}
+
+template <NodeProperties Props, typename Property, typename... Properties>
+[[nodiscard]] constexpr decltype(auto) with_properties_if_unset(
+    Props node_props, [[maybe_unused]] Property&& property,
+    Properties&&... properties) {
+  if constexpr (!Props::template has<typename Kokkos::Impl::NodeCtorProp<
+                    std::remove_cvref_t<Property>>::value_type>) {
+    return with_properties_if_unset(
+        WithProperty::set(std::move(node_props),
+                          std::forward<Property>(property)),
+        std::forward<Properties>(properties)...);
+  } else {
+    return with_properties_if_unset(std::move(node_props),
+                                    std::forward<Properties>(properties)...);
+  }
+}
+
+}  // namespace Kokkos::Impl
+
+namespace Kokkos::Experimental {
+template <typename... Args>
+[[nodiscard]] constexpr auto node_props(Args&&... args) {
+  using return_t = typename Kokkos::Impl::NodeCtorProps<
+      std::remove_cvref_t<Args>...>::uniform_type;
+  return return_t{std::forward<Args>(args)...};
+}
+
+}  // namespace Kokkos::Experimental
+
+#endif  // KOKKOS_IMPL_KOKKOS_GRAPHNODECTORPROPS_HPP

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -160,8 +160,9 @@ struct concat_type_list<type_list<T...>> {
 
 // combine consecutive type_lists
 template <typename... T, typename... U, typename... Tail>
-struct concat_type_list<type_list<T...>, type_list<U...>, Tail...>
-    : concat_type_list<type_list<T..., U...>, Tail...> {};
+struct concat_type_list<type_list<T...>, type_list<U...>, Tail...> {
+  using type = concat_type_list_t<type_list<T..., U...>, Tail...>;
+};
 // </editor-fold> end concat_type_list }}}2
 //------------------------------------------------------------------------------
 
@@ -175,10 +176,16 @@ template <template <typename> class PredicateT, typename TypeListT,
 struct filter_type_list;
 
 template <template <typename> class PredicateT, typename... T, bool ValueT>
+  requires(sizeof...(T) > 0)
 struct filter_type_list<PredicateT, type_list<T...>, ValueT> {
   using type =
       concat_type_list_t<std::conditional_t<PredicateT<T>::value == ValueT,
                                             type_list<T>, type_list<>>...>;
+};
+
+template <template <typename> class PredicateT, bool ValueT>
+struct filter_type_list<PredicateT, type_list<>, ValueT> {
+  using type = type_list<>;
 };
 
 template <template <typename> class PredicateT, typename T, bool ValueT = true>

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -130,6 +130,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL)
       ExecutionSpace
       FunctorAnalysis
       Graph
+      GraphNodeCtorProps
       HostSharedPtr
       HostSharedPtrAccessOnDevice
       JoinBackwardCompatibility

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -118,16 +118,19 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), submit_once) {
       Kokkos::Experimental::create_graph<TEST_EXECSPACE>([&](auto root) {
         root.then_parallel_for(1, count_functor{count, bugs, 0, 0});
       });
-  graph.submit();
+  graph.submit(TEST_EXECSPACE{});
 
   ASSERT_TRUE(contains(TEST_EXECSPACE{}, count, 1));
   ASSERT_TRUE(contains(TEST_EXECSPACE{}, bugs, 0));
 }
 
 TEST_F(TEST_CATEGORY_FIXTURE(graph), submit_once_rvalue) {
-  Kokkos::Experimental::create_graph(ex, [&](auto root) {
-    root.then_parallel_for(1, count_functor{count, bugs, 0, 0});
-  }).submit(ex);
+  Kokkos::Experimental::create_graph(
+      Kokkos::Experimental::get_device_handle(ex),
+      [&](auto root) {
+        root.then_parallel_for(1, count_functor{count, bugs, 0, 0});
+      })
+      .submit(ex);
 
   ASSERT_TRUE(contains(ex, count, 1));
   ASSERT_TRUE(contains(ex, bugs, 0));
@@ -137,9 +140,10 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), submit_once_rvalue) {
 // For now, Kokkos::Graph::submit will instantiate if needed,
 // so this test is not very strong.
 TEST_F(TEST_CATEGORY_FIXTURE(graph), instantiate_and_submit_once) {
-  auto graph = Kokkos::Experimental::create_graph(ex, [&](auto root) {
-    root.then_parallel_for(1, count_functor{count, bugs, 0, 0});
-  });
+  auto graph = Kokkos::Experimental::create_graph(
+      Kokkos::Experimental::get_device_handle(ex), [&](auto root) {
+        root.then_parallel_for(1, count_functor{count, bugs, 0, 0});
+      });
   graph.instantiate();
   graph.submit(ex);
 
@@ -174,17 +178,19 @@ TEST_F(TEST_CATEGORY_FIXTURE_DEATH(graph), can_instantiate_only_once) {
     }
   }
   {
-    auto graph = Kokkos::Experimental::create_graph(ex, [&](auto root) {
-      root.then_parallel_for(1, count_functor{count, bugs, 0, 0});
-    });
+    auto graph = Kokkos::Experimental::create_graph(
+        Kokkos::Experimental::get_device_handle(ex), [&](auto root) {
+          root.then_parallel_for(1, count_functor{count, bugs, 0, 0});
+        });
     graph.submit();
     ASSERT_DEATH(graph.instantiate(),
                  "Expected precondition `.*` evaluated false.");
   }
   {
-    auto graph = Kokkos::Experimental::create_graph(ex, [&](auto root) {
-      root.then_parallel_for(1, count_functor{count, bugs, 0, 0});
-    });
+    auto graph = Kokkos::Experimental::create_graph(
+        Kokkos::Experimental::get_device_handle(ex), [&](auto root) {
+          root.then_parallel_for(1, count_functor{count, bugs, 0, 0});
+        });
     graph.instantiate();
     ASSERT_DEATH(graph.instantiate(),
                  "Expected precondition `.*` evaluated false.");
@@ -195,29 +201,29 @@ TEST_F(TEST_CATEGORY_FIXTURE_DEATH(graph), can_instantiate_only_once) {
 // one passed to the Kokkos::Graph constructor.
 TEST_F(TEST_CATEGORY_FIXTURE(graph),
        submit_onto_another_execution_space_instance) {
-  const auto execution_space_instances =
-      Kokkos::Experimental::partition_space(ex, 1, 1);
+  const auto [exec_A, exec_B] = Kokkos::Experimental::partition_space(ex, 1, 1);
 
   auto graph = Kokkos::Experimental::create_graph(
-      execution_space_instances.at(0), [&](auto root) {
+      Kokkos::Experimental::get_device_handle(exec_A), [&](auto root) {
         root.then_parallel_for(1, count_functor{count, bugs, 0, 0});
       });
   graph.instantiate();
 
-  execution_space_instances.at(0).fence(
-      "The graph might make async copies to device.");
+  exec_A.fence("The graph might make async copies to device.");
 
-  graph.submit(execution_space_instances.at(1));
+  graph.submit(exec_B);
 
-  ASSERT_TRUE(contains(execution_space_instances.at(1), count, 1));
-  ASSERT_TRUE(contains(execution_space_instances.at(1), bugs, 0));
+  ASSERT_TRUE(contains(exec_B, count, 1));
+  ASSERT_TRUE(contains(exec_B, bugs, 0));
 }
 
 // This test ensures that it's possible to build a Kokkos::Graph using
-// Kokkos::Experimental::create_graph without providing a closure, but giving an
-// execution space instance.
-TEST_F(TEST_CATEGORY_FIXTURE(graph), create_graph_no_closure_with_exec) {
-  Kokkos::Experimental::Graph graph{ex};
+// Kokkos::Experimental::create_graph without providing a closure, but giving a
+// device handle.
+TEST_F(TEST_CATEGORY_FIXTURE(graph),
+       create_graph_no_closure_with_device_handle) {
+  Kokkos::Experimental::Graph graph{
+      Kokkos::Experimental::get_device_handle(ex)};
 
   graph.root_node().then_parallel_for(1, count_functor{count, bugs, 0, 0});
 
@@ -245,10 +251,12 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), create_graph_no_arg) {
 
   graph.root_node().then_parallel_for(1, count_functor{count, bugs, 0, 0});
 
-  graph.submit(graph.get_execution_space());
+  const Kokkos::DefaultExecutionSpace exec{};
 
-  ASSERT_TRUE(contains(graph.get_execution_space(), count, 1));
-  ASSERT_TRUE(contains(graph.get_execution_space(), bugs, 0));
+  graph.submit(exec);
+
+  ASSERT_TRUE(contains(exec, count, 1));
+  ASSERT_TRUE(contains(exec, bugs, 0));
 }
 
 TEST_F(TEST_CATEGORY_FIXTURE(graph), submit_six) {
@@ -259,29 +267,32 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), submit_six) {
     GTEST_SKIP() << "skipping since test case is known to fail with SYCL";
 #endif
 
-  auto graph = Kokkos::Experimental::create_graph(ex, [&](auto root) {
-    auto f_setup_count = root.then_parallel_for(1, set_functor{count, 0});
-    auto f_setup_bugs  = root.then_parallel_for(1, set_functor{bugs, 0});
+  auto graph = Kokkos::Experimental::create_graph(
+      Kokkos::Experimental::get_device_handle(ex), [&](auto root) {
+        auto f_setup_count = root.then_parallel_for(1, set_functor{count, 0});
+        auto f_setup_bugs  = root.then_parallel_for(1, set_functor{bugs, 0});
 
-    //----------------------------------------
-    auto ready = Kokkos::Experimental::when_all(f_setup_count, f_setup_bugs);
+        //----------------------------------------
+        auto ready =
+            Kokkos::Experimental::when_all(f_setup_count, f_setup_bugs);
 
-    //----------------------------------------
-    ready.then_parallel_for(1, count_functor{count, bugs, 0, 6});
-    //----------------------------------------
-    ready.then_parallel_for(Kokkos::RangePolicy<TEST_EXECSPACE>{0, 1},
-                            count_functor{count, bugs, 0, 6});
-    //----------------------------------------
-    ready.then_parallel_for(
-        Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>{{0, 0}, {1, 1}},
-        count_functor{count, bugs, 0, 6});
-    //----------------------------------------
-    ready.then_parallel_for(Kokkos::TeamPolicy<TEST_EXECSPACE>{1, 1},
-                            count_functor{count, bugs, 0, 6});
-    //----------------------------------------
-    ready.then_parallel_for(2, count_functor{count, bugs, 0, 6});
-    //----------------------------------------
-  });
+        //----------------------------------------
+        ready.then_parallel_for(1, count_functor{count, bugs, 0, 6});
+        //----------------------------------------
+        ready.then_parallel_for(Kokkos::RangePolicy<TEST_EXECSPACE>{0, 1},
+                                count_functor{count, bugs, 0, 6});
+        //----------------------------------------
+        ready.then_parallel_for(
+            Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>{{0, 0},
+                                                                   {1, 1}},
+            count_functor{count, bugs, 0, 6});
+        //----------------------------------------
+        ready.then_parallel_for(Kokkos::TeamPolicy<TEST_EXECSPACE>{1, 1},
+                                count_functor{count, bugs, 0, 6});
+        //----------------------------------------
+        ready.then_parallel_for(2, count_functor{count, bugs, 0, 6});
+        //----------------------------------------
+      });
   graph.submit(ex);
 
   ASSERT_TRUE(contains(ex, count, 6));
@@ -291,18 +302,21 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), submit_six) {
 TEST_F(TEST_CATEGORY_FIXTURE(graph), when_all_cycle) {
   view_type reduction_out{"reduction_out"};
   view_host reduction_host{"reduction_host"};
-  Kokkos::Experimental::create_graph(ex, [&](auto root) {
-    //----------------------------------------
-    // Test when_all when redundant dependencies are given
-    auto f1 = root.then_parallel_for(1, set_functor{count, 0});
-    auto f2 = f1.then_parallel_for(1, count_functor{count, bugs, 0, 0});
-    auto f3 = f2.then_parallel_for(5, count_functor{count, bugs, 1, 5});
-    auto f4 = Kokkos::Experimental::when_all(f2, f3).then_parallel_for(
-        1, count_functor{count, bugs, 6, 6});
-    Kokkos::Experimental::when_all(f1, f4, f3)
-        .then_parallel_reduce(6, set_result_functor{count}, reduction_out);
-    //----------------------------------------
-  }).submit(ex);
+  Kokkos::Experimental::create_graph(
+      Kokkos::Experimental::get_device_handle(ex),
+      [&](auto root) {
+        //----------------------------------------
+        // Test when_all when redundant dependencies are given
+        auto f1 = root.then_parallel_for(1, set_functor{count, 0});
+        auto f2 = f1.then_parallel_for(1, count_functor{count, bugs, 0, 0});
+        auto f3 = f2.then_parallel_for(5, count_functor{count, bugs, 1, 5});
+        auto f4 = Kokkos::Experimental::when_all(f2, f3).then_parallel_for(
+            1, count_functor{count, bugs, 6, 6});
+        Kokkos::Experimental::when_all(f1, f4, f3)
+            .then_parallel_reduce(6, set_result_functor{count}, reduction_out);
+        //----------------------------------------
+      })
+      .submit(ex);
 
   ASSERT_TRUE(contains(ex, bugs, 0));
   ASSERT_TRUE(contains(ex, count, 7));
@@ -321,26 +335,27 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), repeat_chain) {
     GTEST_SKIP() << "The graph requires the reduction targets like 'bugs_host' "
                     "to be accessible by the execution space.";
   } else {
-    auto graph = Kokkos::Experimental::create_graph(ex, [&, count_host =
-                                                                count_host](
-                                                            auto root) {
-      // FIXME_CLANG Recent clang versions would still trigger a similar
-      // static_assert without the additional if constexpr
-      constexpr bool result_not_accessible_by_exec_copy =
-          !Kokkos::SpaceAccessibility<
-              TEST_EXECSPACE, decltype(bugs_host)::memory_space>::accessible;
-      if constexpr (!result_not_accessible_by_exec_copy) {
-        //----------------------------------------
-        root.then_parallel_for(1, set_functor{count, 0})
-            .then_parallel_for(1, count_functor{count, bugs, 0, 0})
-            .then_parallel_for(1, count_functor{count, bugs, 1, 1})
-            .then_parallel_reduce(1, set_result_functor{count}, count_host)
-            .then_parallel_reduce(
-                1, set_result_functor{bugs},
-                Kokkos::Sum<int, Kokkos::HostSpace>{bugs_host});
-        //----------------------------------------
-      }
-    });
+    auto graph = Kokkos::Experimental::create_graph(
+        Kokkos::Experimental::get_device_handle(ex),
+        [&, count_host = count_host](auto root) {
+          // FIXME_CLANG Recent clang versions would still trigger a similar
+          // static_assert without the additional if constexpr
+          constexpr bool result_not_accessible_by_exec_copy =
+              !Kokkos::SpaceAccessibility<
+                  TEST_EXECSPACE,
+                  decltype(bugs_host)::memory_space>::accessible;
+          if constexpr (!result_not_accessible_by_exec_copy) {
+            //----------------------------------------
+            root.then_parallel_for(1, set_functor{count, 0})
+                .then_parallel_for(1, count_functor{count, bugs, 0, 0})
+                .then_parallel_for(1, count_functor{count, bugs, 1, 1})
+                .then_parallel_reduce(1, set_result_functor{count}, count_host)
+                .then_parallel_reduce(
+                    1, set_result_functor{bugs},
+                    Kokkos::Sum<int, Kokkos::HostSpace>{bugs_host});
+            //----------------------------------------
+          }
+        });
 
     //----------------------------------------
     constexpr int repeats = 10;
@@ -357,7 +372,8 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), repeat_chain) {
 
 TEST_F(TEST_CATEGORY_FIXTURE(graph), zero_work_reduce) {
   auto graph = Kokkos::Experimental::create_graph(
-      ex, [&](Kokkos::Experimental::GraphNodeRef<TEST_EXECSPACE> root) {
+      Kokkos::Experimental::get_device_handle(ex),
+      [&](Kokkos::Experimental::GraphNodeRef<TEST_EXECSPACE> root) {
         NoOpReduceFunctor<TEST_EXECSPACE, int> no_op_functor;
         root.then_parallel_reduce(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 0),
                                   no_op_functor, count)
@@ -393,7 +409,8 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), zero_work_reduce) {
 
 // Ensure that an empty graph can be submitted.
 TEST_F(TEST_CATEGORY_FIXTURE(graph), empty_graph) {
-  auto graph = Kokkos::Experimental::create_graph(ex, [](auto) {});
+  auto graph = Kokkos::Experimental::create_graph(
+      Kokkos::Experimental::get_device_handle(ex), [](auto) {});
   graph.instantiate();
   graph.submit(ex);
   ex.fence();
@@ -456,14 +473,15 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), force_global_launch) {
 
   ASSERT_TRUE(validate_existence(
       [&]() {
-        graph = Kokkos::Experimental::create_graph(ex, [&](const auto& root) {
-          auto node = root.then_parallel_for(
-              kernel_name,
-              Kokkos::Experimental::require(
-                  Kokkos::RangePolicy<TEST_EXECSPACE>(0, functor_t::count),
-                  Kokkos::Experimental::WorkItemProperty::HintHeavyWeight),
-              functor_t(data));
-        });
+        graph = Kokkos::Experimental::create_graph(
+            Kokkos::Experimental::get_device_handle(ex), [&](const auto& root) {
+              auto node = root.then_parallel_for(
+                  Kokkos::Experimental::node_props(kernel_name),
+                  Kokkos::Experimental::require(
+                      Kokkos::RangePolicy<TEST_EXECSPACE>(0, functor_t::count),
+                      Kokkos::Experimental::WorkItemProperty::HintHeavyWeight),
+                  functor_t(data));
+            });
       },
       [&](AllocateDataEvent alloc) {
         if (alloc.name != alloc_label)
@@ -482,12 +500,6 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), force_global_launch) {
 
   EXPECT_TRUE(static_cast<bool>(graph));
   graph->instantiate();  // NOLINT(bugprone-unchecked-optional-access)
-
-  // Fencing the default execution space instance, as the node policy
-  // was created without giving an instance (it used the default one).
-  TEST_EXECSPACE{}.fence(
-      "Ensure that kernel dispatch to global memory is finished "
-      "before submission.");
 
   graph->submit(ex);  // NOLINT(bugprone-unchecked-optional-access)
   ASSERT_TRUE(contains(ex, data, functor_t::count));
@@ -519,11 +531,14 @@ void test_sized_functor_launch(const ExecSpace& exec) {
 
   view_t data(Kokkos::view_alloc("witness", exec));
 
-  auto graph = Kokkos::Experimental::create_graph(exec, [&](const auto& root) {
-    auto node = root.then_parallel_for(
-        kernel_name, Kokkos::RangePolicy<ExecSpace>(exec, 0, range_end),
-        functor_t(data));
-  });
+  const auto dev_handle = Kokkos::Experimental::get_device_handle(exec);
+
+  auto graph =
+      Kokkos::Experimental::create_graph(dev_handle, [&](const auto& root) {
+        auto node = root.then_parallel_for(
+            Kokkos::Experimental::node_props(kernel_name, dev_handle),
+            Kokkos::RangePolicy<ExecSpace>(0, range_end), functor_t(data));
+      });
 
   graph.submit(exec);
   ASSERT_TRUE(contains(exec, data, range_end));
@@ -540,11 +555,12 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), sized_functor_launch) {
   test_sized_functor_launch<100000>(exec);
 }
 
-// Ensure that an empty graph on the default host execution space
+// Ensure that an empty graph on the default host device handle
 // can be submitted.
-TEST_F(TEST_CATEGORY_FIXTURE(graph), empty_graph_default_host_exec) {
+TEST_F(TEST_CATEGORY_FIXTURE(graph), empty_graph_default_host_device_handle) {
   const Kokkos::DefaultHostExecutionSpace exec{};
-  Kokkos::Experimental::Graph graph{exec};
+  Kokkos::Experimental::Graph graph{
+      Kokkos::Experimental::get_device_handle(exec)};
   graph.instantiate();
   graph.submit(exec);
   exec.fence();
@@ -573,13 +589,15 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), node_lifetime) {
   view_t data(Kokkos::view_alloc("data", ex));
 
   std::optional<Kokkos::Experimental::Graph<TEST_EXECSPACE>> graph =
-      Kokkos::Experimental::create_graph(ex, [&](const auto& root) {
-        // If the node lifetime is not bound to the graph's lifetime, the
-        // internal buffer view will get out of scope before graph submission.
-        const auto node = root.then_parallel_for(
-            size,
-            functor_t{data, view_t(Kokkos::view_alloc("internal buffer", ex))});
-      });
+      Kokkos::Experimental::create_graph(
+          Kokkos::Experimental::get_device_handle(ex), [&](const auto& root) {
+            // If the node lifetime is not bound to the graph's lifetime, the
+            // internal buffer view will get out of scope before graph
+            // submission.
+            const auto node = root.then_parallel_for(
+                size, functor_t{data, view_t(Kokkos::view_alloc(
+                                          "internal buffer", ex))});
+          });
 
   ASSERT_EQ(data.use_count(), 2) << "The node should be holding one count.";
 
@@ -656,21 +674,29 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), diamond) {
   std::integral_constant<size_t, 2> index_C;
   std::integral_constant<size_t, 3> index_D;
 
-  auto graph = Kokkos::Experimental::create_graph(exec_2, [&](auto root) {
+  auto dev_handle_0 = Kokkos::Experimental::get_device_handle(exec_0);
+  auto dev_handle_1 = Kokkos::Experimental::get_device_handle(exec_1);
+  auto dev_handle_2 = Kokkos::Experimental::get_device_handle(exec_2);
+
+  auto graph = Kokkos::Experimental::create_graph(dev_handle_2, [&](auto root) {
     auto node_A = root.then_parallel_for(
-        policy_t(exec_0, 0, 1),
-        FetchValuesAndContribute(data, index_A, value_A));
+        Kokkos::Experimental::node_props("node A", dev_handle_0),
+        policy_t(0, 1), FetchValuesAndContribute(data, index_A, value_A));
 
     auto node_B = node_A.then_parallel_for(
-        policy_t(exec_0, 0, 1),
+        Kokkos::Experimental::node_props("node B", dev_handle_0),
+        policy_t(0, 1),
         FetchValuesAndContribute(data, {index_A()}, index_B, value_B));
     auto node_C = node_A.then_parallel_for(
-        policy_t(exec_1, 0, 1),
+        Kokkos::Experimental::node_props("node C", std::move(dev_handle_1)),
+        policy_t(0, 1),
         FetchValuesAndContribute(data, {index_A()}, index_C, value_C));
 
     auto node_D = Kokkos::Experimental::when_all(node_B, node_C)
                       .then_parallel_for(
-                          policy_t(exec_0, 0, 1),
+                          Kokkos::Experimental::node_props(
+                              "node D", std::move(dev_handle_0)),
+                          policy_t(0, 1),
                           FetchValuesAndContribute(data, {index_B(), index_C()},
                                                    index_D, value_D));
   });
@@ -731,25 +757,32 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), end_of_submit_control_flow) {
   std::integral_constant<size_t, 4> index_E;
   std::integral_constant<size_t, 5> index_F;
 
-  auto graph = Kokkos::Experimental::create_graph(exec_2, [&](auto root) {
+  auto dev_handle_0 = Kokkos::Experimental::get_device_handle(exec_0);
+  auto dev_handle_1 = Kokkos::Experimental::get_device_handle(exec_1);
+  auto dev_handle_2 = Kokkos::Experimental::get_device_handle(exec_2);
+
+  auto graph = Kokkos::Experimental::create_graph(dev_handle_2, [&](auto root) {
     auto node_A = root.then_parallel_for(
-        policy_t(exec_0, 0, 1),
+        Kokkos::Experimental::node_props(dev_handle_0), policy_t(0, 1),
         FetchValuesAndContribute(data, index_A, value_A));
     auto node_B = root.then_parallel_for(
-        policy_t(exec_1, 0, 1),
+        Kokkos::Experimental::node_props(dev_handle_1), policy_t(0, 1),
         FetchValuesAndContribute(data, index_B, value_B));
 
-    auto node_C = Kokkos::Experimental::when_all(node_A, node_B)
-                      .then_parallel_for(
-                          policy_t(exec_0, 0, 1),
-                          FetchValuesAndContribute(data, {index_A(), index_B()},
-                                                   index_C, value_C));
+    auto node_C =
+        Kokkos::Experimental::when_all(node_A, node_B)
+            .then_parallel_for(
+                Kokkos::Experimental::node_props(dev_handle_0), policy_t(0, 1),
+                FetchValuesAndContribute(data, {index_A(), index_B()}, index_C,
+                                         value_C));
 
     auto node_D = node_C.then_parallel_for(
-        policy_t(exec_0, 0, 1),
+        Kokkos::Experimental::node_props(std::move(dev_handle_0)),
+        policy_t(0, 1),
         FetchValuesAndContribute(data, {index_C()}, index_D, value_D));
     auto node_E = node_B.then_parallel_for(
-        policy_t(exec_1, 0, 1),
+        Kokkos::Experimental::node_props(std::move(dev_handle_1)),
+        policy_t(0, 1),
         FetchValuesAndContribute(data, {index_B()}, index_E, value_E));
   });
   graph.instantiate();
@@ -909,7 +942,8 @@ TEST(TEST_CATEGORY, when_all_type) {
       Kokkos::Experimental::GraphNodeRef<TEST_EXECSPACE, node_kernel_impl_t,
                                          node_ref_agg_t>;
 
-  Kokkos::Experimental::Graph graph{TEST_EXECSPACE{}};
+  Kokkos::Experimental::Graph graph{
+      Kokkos::Experimental::get_device_handle(TEST_EXECSPACE{})};
 
   auto root   = graph.root_node();
   auto node_A = root.then_parallel_for(1, kernel_functor_t{});
@@ -1008,15 +1042,20 @@ void test_graph_capture() {
   const auto data_4(Kokkos::subview(data, 4));
 
   // FIXME nvcc 11.0 cannot use CTAD.
-  Kokkos::Experimental::Graph<Exec> graph{exec_graph};
+  Kokkos::Experimental::Graph<Exec> graph{
+      Kokkos::Experimental::get_device_handle(exec_graph)};
   auto root = graph.root_node();
 
   auto memset_left = root.then_parallel_for(
-      Kokkos::RangePolicy<Exec>(exec_left, 0, 1),
+      Kokkos::Experimental::node_props(
+          Kokkos::Experimental::get_device_handle(exec_left)),
+      Kokkos::RangePolicy<Exec>(0, 1),
       SetViewToValueFunctor<Exec, int>{data_0, offset_left});
 
   auto memset_right = root.then_parallel_for(
-      Kokkos::RangePolicy<Exec>(exec_right, 0, 1),
+      Kokkos::Experimental::node_props(
+          Kokkos::Experimental::get_device_handle(exec_right)),
+      Kokkos::RangePolicy<Exec>(0, 1),
       SetViewToValueFunctor<Exec, int>{data_4, offset_right});
 
   // Purposely use the 'left' exec for the 'right' node, and vice-versa.
@@ -1108,14 +1147,16 @@ TEST(TEST_CATEGORY, graph_then) {
 
   const view_t data(Kokkos::view_alloc(exec, "data used in 'then'"));
 
-  auto graph = Kokkos::Experimental::create_graph(exec, [&](const auto& root) {
-    const auto memset = root.then_parallel_for(
-        Kokkos::RangePolicy<TEST_EXECSPACE>(0, data.size()),
-        memset_t{data, value_memset});
-    const auto then =
-        memset.then("my nice node - with a 'then'", then_t{data, value_then});
-    static_assert(std::is_same_v<decltype(then), const node_ref_then_t>);
-  });
+  auto graph = Kokkos::Experimental::create_graph(
+      Kokkos::Experimental::get_device_handle(exec), [&](const auto& root) {
+        const auto memset = root.then_parallel_for(
+            Kokkos::RangePolicy<TEST_EXECSPACE>(0, data.size()),
+            memset_t{data, value_memset});
+        const auto then = memset.then(
+            Kokkos::Experimental::node_props("my nice node - with a 'then'"),
+            then_t{data, value_then});
+        static_assert(std::is_same_v<decltype(then), const node_ref_then_t>);
+      });
 
   // At this stage, no kernel was launched yet.
   ASSERT_TRUE(contains(exec, data, 0));
@@ -1170,7 +1211,7 @@ TEST(TEST_CATEGORY, then_host) {
 
   {
     // clang-format off
-    auto graph = Kokkos::Experimental::create_graph(exec, [&](const auto& root) {
+    auto graph = Kokkos::Experimental::create_graph(Kokkos::Experimental::get_device_handle(exec), [&](const auto& root) {
       root.then_host("lonely", functor_h_t{{counter, view_h_t(Kokkos::view_alloc("internal buffer - lonely - host"))}});
     });
     // clang-format on
@@ -1230,10 +1271,12 @@ void test_mixed_host_device_nodes();
 
     {
       // clang-format off
-      auto graph = Kokkos::Experimental::create_graph(exec, [&](const auto& root) {
-        root.then     ("node A", exec, functor_d_t{{counter, view_d_t(Kokkos::view_alloc("internal buffer - node A - device", exec))}})
+      using Kokkos::Experimental::node_props;
+      auto dev_handle = Kokkos::Experimental::get_device_handle(exec);
+      auto graph = Kokkos::Experimental::create_graph(dev_handle, [&](const auto& root) {
+        root.then     (node_props("node A", dev_handle), functor_d_t{{counter, view_d_t(Kokkos::view_alloc("internal buffer - node A - device", exec))}})
             .then_host("node B",       functor_h_t{{counter, view_h_t(Kokkos::view_alloc("internal buffer - node B - host"))}})
-            .then     ("node C", exec, functor_d_t{{counter, view_d_t(Kokkos::view_alloc("internal buffer - node C - device", exec))}});
+            .then     (node_props("node C", std::move(dev_handle)), functor_d_t{{counter, view_d_t(Kokkos::view_alloc("internal buffer - node C - device", exec))}});
       });
       // clang-format on
 
@@ -1255,6 +1298,27 @@ TEST(TEST_CATEGORY, mixed_then_host_device_nodes) {
     test_mixed_host_device_nodes<TEST_EXECSPACE>();
   } else {
     GTEST_SKIP() << "This test requires a shared space.";
+  }
+}
+
+struct NoOp {
+  template <typename... Args>
+  KOKKOS_FUNCTION void operator()(Args&&...) const {}
+};
+
+TEST(TEST_CATEGORY, execution_policy_with_default_execution_space_instance) {
+  Kokkos::Experimental::Graph<TEST_EXECSPACE> graph{};
+
+  const auto [exec] =
+      Kokkos::Experimental::partition_space(TEST_EXECSPACE{}, 1);
+
+  if (exec == TEST_EXECSPACE{}) {
+    GTEST_SKIP();
+  } else {
+    ASSERT_DEATH(graph.root_node().then_parallel_for(
+                     Kokkos::RangePolicy(exec, 0, 1), NoOp{}),
+                 "The execution space instance of the execution policy of a "
+                 "graph node must be the default one.");
   }
 }
 
@@ -1293,14 +1357,22 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), aggregate_is_awaitable) {
       Kokkos::View<int, TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic>>;
   const witness_t witness(Kokkos::view_alloc("witness", exec_default));
 
-  const Kokkos::Experimental::Graph graph{exec_default};
+  const auto dev_handle_default =
+      Kokkos::Experimental::get_device_handle(exec_default);
+  const auto dev_handle_other =
+      Kokkos::Experimental::get_device_handle(exec_other);
+
+  const Kokkos::Experimental::Graph graph{dev_handle_default};
   const auto root = graph.root_node();
-  auto node_left =
-      root.then("node left", exec_default, ThenFunctor<witness_t>{witness, 1});
-  auto node_right =
-      root.then("node right", exec_default, ThenFunctor<witness_t>{witness, 1});
+  auto node_left  = root.then(
+      Kokkos::Experimental::node_props("node left", dev_handle_default),
+      ThenFunctor<witness_t>{witness, 1});
+  auto node_right = root.then(
+      Kokkos::Experimental::node_props("node right", dev_handle_default),
+      ThenFunctor<witness_t>{witness, 1});
   Kokkos::Experimental::when_all(std::move(node_left), std::move(node_right))
-      .then("node final", exec_other, ThenFunctor<witness_t>{witness, 1});
+      .then(Kokkos::Experimental::node_props("node final", dev_handle_other),
+            ThenFunctor<witness_t>{witness, 1});
 
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableFences());
@@ -1345,16 +1417,17 @@ TEST(TEST_CATEGORY, graph_then_tag) {
 
   const view_t data(Kokkos::view_alloc(exec, "data used in 'then'"));
 
-  auto graph = Kokkos::Experimental::create_graph(exec, [&](const auto& root) {
-    const auto notag = root.then("no tag", functor_t{data, value_then});
-    const auto tagged_labelled =
-        notag.then("tag and label",
-                   Kokkos::Experimental::ThenPolicy<functor_t::TimesTwo>{},
-                   functor_t{data, value_then});
-    const auto tagged = tagged_labelled.then(
-        Kokkos::Experimental::ThenPolicy<functor_t::TimesTwo>{},
-        functor_t{data, value_then});
-  });
+  auto graph = Kokkos::Experimental::create_graph(
+      Kokkos::Experimental::get_device_handle(exec), [&](const auto& root) {
+        const auto notag = root.then("no tag", functor_t{data, value_then});
+        const auto tagged_labelled =
+            notag.then("tag and label",
+                       Kokkos::Experimental::ThenPolicy<functor_t::TimesTwo>{},
+                       functor_t{data, value_then});
+        const auto tagged = tagged_labelled.then(
+            Kokkos::Experimental::ThenPolicy<functor_t::TimesTwo>{},
+            functor_t{data, value_then});
+      });
 
   ASSERT_TRUE(contains(exec, data, 0));
 

--- a/core/unit_test/TestGraphNodeCtorProps.hpp
+++ b/core/unit_test/TestGraphNodeCtorProps.hpp
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <Kokkos_Core.hpp>
+#include <impl/Kokkos_GraphNodeCtorProps.hpp>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+constexpr bool test_node_ctor_prop_traits() {
+  static_assert(std::is_constructible_v<Kokkos::Impl::NodeCtorProp<std::string>,
+                                        const char(&)[6]>);
+  return true;
+}
+static_assert(test_node_ctor_prop_traits());
+
+TEST(TEST_CATEGORY, node_props_empty) {
+  using props_t = decltype(Kokkos::Experimental::node_props());
+
+  static_assert(std::same_as<props_t, Kokkos::Impl::NodeCtorProps<>>);
+
+  static_assert(Kokkos::Impl::is_node_props_v<props_t>);
+
+  static_assert(props_t::has<std::string> == false);
+  static_assert(props_t::has<TEST_EXECSPACE> == false);
+}
+
+TEST(TEST_CATEGORY, node_props_label) {
+  using props_t = decltype(Kokkos::Experimental::node_props("label"));
+
+  static_assert(
+      std::same_as<props_t, Kokkos::Impl::NodeCtorProps<std::string>>);
+
+  static_assert(Kokkos::Impl::is_node_props_v<props_t>);
+
+  static_assert(props_t::has<std::string> == true);
+  static_assert(props_t::has<TEST_EXECSPACE> == false);
+
+  const auto props = Kokkos::Experimental::node_props("label");
+
+  ASSERT_EQ(Kokkos::Impl::get_property<std::string>(props), "label");
+}
+
+TEST(TEST_CATEGORY, node_props_device_handle) {
+  using props_t = decltype(Kokkos::Experimental::node_props(
+      Kokkos::Experimental::get_device_handle(std::declval<TEST_EXECSPACE>())));
+
+  static_assert(
+      std::same_as<props_t, Kokkos::Impl::NodeCtorProps<
+                                Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>>);
+
+  static_assert(Kokkos::Impl::is_node_props_v<props_t>);
+
+  static_assert(props_t::has<std::string> == false);
+  static_assert(props_t::has<Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>> ==
+                true);
+
+  const auto props = Kokkos::Experimental::node_props(
+      Kokkos::Experimental::get_device_handle(TEST_EXECSPACE{}));
+
+  ASSERT_EQ(
+      Kokkos::Impl::get_property<Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>(
+          props),
+      Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>{});
+}
+
+TEST(TEST_CATEGORY, node_props_device_handle_label) {
+  using props_t = decltype(Kokkos::Experimental::node_props(
+      Kokkos::Experimental::get_device_handle(std::declval<TEST_EXECSPACE>()),
+      "label"));
+
+  static_assert(
+      std::same_as<props_t, Kokkos::Impl::NodeCtorProps<
+                                Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>,
+                                std::string>>);
+
+  static_assert(Kokkos::Impl::is_node_props_v<props_t>);
+
+  static_assert(props_t::has<std::string> == true);
+  static_assert(props_t::has<Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>> ==
+                true);
+
+  const auto props = Kokkos::Experimental::node_props(
+      Kokkos::Experimental::get_device_handle(TEST_EXECSPACE{}), "label");
+
+  ASSERT_EQ(
+      Kokkos::Impl::get_property<Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>(
+          props),
+      Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>{});
+  ASSERT_EQ(Kokkos::Impl::get_property<std::string>(props), "label");
+}
+
+TEST(TEST_CATEGORY, node_props_label_device_handle) {
+  using props_t = decltype(Kokkos::Experimental::node_props(
+      "label",
+      Kokkos::Experimental::get_device_handle(std::declval<TEST_EXECSPACE>())));
+
+  static_assert(
+      std::same_as<props_t, Kokkos::Impl::NodeCtorProps<
+                                std::string,
+                                Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>>);
+
+  static_assert(Kokkos::Impl::is_node_props_v<props_t>);
+
+  static_assert(props_t::has<std::string> == true);
+  static_assert(props_t::has<Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>> ==
+                true);
+
+  const auto props = Kokkos::Experimental::node_props(
+      "label", Kokkos::Experimental::get_device_handle(TEST_EXECSPACE{}));
+
+  ASSERT_EQ(Kokkos::Impl::get_property<std::string>(props), "label");
+  ASSERT_EQ(
+      Kokkos::Impl::get_property<Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>(
+          props),
+      Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>{});
+}
+
+TEST(TEST_CATEGORY, node_props_with_properties_if_unset) {
+  {
+    const auto props_label_device_handle_old = Kokkos::Experimental::node_props(
+        "label", Kokkos::Experimental::get_device_handle(TEST_EXECSPACE{}));
+    const auto props_label_device_handle_new =
+        Kokkos::Impl::with_properties_if_unset(props_label_device_handle_old,
+                                               "another label");
+
+    static_assert(
+        std::same_as<
+            decltype(props_label_device_handle_old),
+            const Kokkos::Impl::NodeCtorProps<
+                std::string, Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>>);
+    static_assert(
+        std::same_as<
+            decltype(props_label_device_handle_new),
+            const Kokkos::Impl::NodeCtorProps<
+                std::string, Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>>);
+
+    ASSERT_EQ(
+        Kokkos::Impl::get_property<std::string>(props_label_device_handle_old),
+        "label");
+    ASSERT_EQ(
+        Kokkos::Impl::get_property<std::string>(props_label_device_handle_new),
+        "label");
+  }
+
+  {
+    const auto props_empty = Kokkos::Experimental::node_props();
+    const auto props_label_device_handle =
+        Kokkos::Impl::with_properties_if_unset(
+            props_empty, "label", Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>{});
+
+    static_assert(
+        std::same_as<
+            decltype(props_label_device_handle),
+            const Kokkos::Impl::NodeCtorProps<
+                std::string, Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>>);
+
+    ASSERT_EQ(
+        Kokkos::Impl::get_property<std::string>(props_label_device_handle),
+        "label");
+    ASSERT_EQ(
+        Kokkos::Impl::get_property<Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>(
+            props_label_device_handle),
+        Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>{});
+  }
+}
+
+TEST(TEST_CATEGORY, node_props_get_property) {
+  auto props = Kokkos::Experimental::node_props(
+      "label", Kokkos::Experimental::get_device_handle(TEST_EXECSPACE{}));
+
+  ASSERT_EQ(Kokkos::Impl::get_property<std::string>(props), "label");
+  ASSERT_EQ(
+      Kokkos::Impl::get_property<Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>(
+          props),
+      Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>{});
+
+  const auto label = Kokkos::Impl::extract_property<std::string>(props);
+
+  ASSERT_EQ(label, "label");
+  ASSERT_TRUE(Kokkos::Impl::get_property<std::string>(props).empty());
+}
+
+}  // end namespace

--- a/core/unit_test/TestTypeList.cpp
+++ b/core/unit_test/TestTypeList.cpp
@@ -33,6 +33,44 @@ using FilterTypeList223NoVoid =
 static_assert(std::is_same_v<TypeList223NoVoid, FilterTypeList223NoVoid>,
               "filter_type_list with predicate value==false failed");
 
+constexpr bool test_concat_type_list() {
+  using Kokkos::Impl::concat_type_list_t;
+  using Kokkos::Impl::type_list;
+
+  static_assert(
+      std::same_as<concat_type_list_t<type_list_empty_t>, type_list_empty_t>);
+  static_assert(
+      std::same_as<concat_type_list_t<type_list_empty_t, type_list_empty_t>,
+                   type_list_empty_t>);
+
+  static_assert(std::same_as<
+                concat_type_list_t<type_list<int, int>, type_list<char, bool>>,
+                type_list<int, int, char, bool>>);
+
+  return true;
+}
+static_assert(test_concat_type_list());
+
+constexpr bool test_filter_type_list() {
+  using Kokkos::Impl::filter_type_list_t;
+  using Kokkos::Impl::type_list;
+
+  static_assert(
+      std::same_as<filter_type_list_t<std::is_integral, type_list_empty_t>,
+                   type_list_empty_t>);
+
+  static_assert(
+      std::same_as<filter_type_list_t<std::is_integral,
+                                      type_list<int, double, float, bool, int>>,
+                   type_list<int, bool, int>>);
+  static_assert(std::same_as<
+                filter_type_list_t<std::is_integral, type_list<double, float>>,
+                type_list_empty_t>);
+
+  return true;
+}
+static_assert(test_filter_type_list());
+
 constexpr bool test_type_list_any() {
   using Kokkos::Impl::type_list;
   using Kokkos::Impl::type_list_any_v;

--- a/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
@@ -38,9 +38,10 @@ class TEST_CATEGORY_FIXTURE(GraphInterOp) : public ::testing::Test {
   void SetUp() override {
     data = view_t(Kokkos::view_alloc(exec, "witness"));
 
-    graph = Kokkos::Experimental::create_graph(exec, [&](const auto& root) {
-      root.then_parallel_for(1, Increment<view_t>{data});
-    });
+    graph = Kokkos::Experimental::create_graph(
+        Kokkos::Experimental::get_device_handle(exec), [&](const auto& root) {
+          root.then_parallel_for(1, Increment<view_t>{data});
+        });
   }
 
  protected:
@@ -135,7 +136,8 @@ TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), construct_from_native) {
   cudaGraph_t native_graph = nullptr;
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGraphCreate(&native_graph, 0));
 
-  Kokkos::Experimental::Graph graph_from_native(this->exec, native_graph);
+  Kokkos::Experimental::Graph graph_from_native(
+      Kokkos::Experimental::get_device_handle(this->exec), native_graph);
 
   ASSERT_EQ(native_graph, graph_from_native.native_graph());
 

--- a/core/unit_test/cuda/TestCuda_InterOp_GraphMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_GraphMultiGPU.cpp
@@ -78,7 +78,9 @@ TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), then) {
   // when adding a node.
   for (int idevice = 0; idevice < num_devices; ++idevice) {
     pred = pred.then(
-        "then node device " + std::to_string(idevice), execs.at(idevice),
+        Kokkos::Experimental::node_props(
+            "then node device " + std::to_string(idevice),
+            Kokkos::Experimental::get_device_handle(execs.at(idevice))),
         ThenFunctor<view_t, shared_view_t>{views.at(idevice), shared});
   }
 

--- a/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
@@ -60,7 +60,8 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 
   view_t data(Kokkos::view_alloc(exec, "witness"));
 
-  Kokkos::Experimental::Graph graph{exec};
+  Kokkos::Experimental::Graph graph{
+      Kokkos::Experimental::get_device_handle(exec)};
 
   graph.root_node().then_parallel_for(1, Increment<view_t>{data});
 
@@ -104,7 +105,8 @@ TEST(TEST_CATEGORY, graph_construct_from_native) {
 
   const Kokkos::HIP exec{};
 
-  Kokkos::Experimental::Graph graph_from_native(exec, native_graph);
+  Kokkos::Experimental::Graph graph_from_native(
+      Kokkos::Experimental::get_device_handle(exec), native_graph);
 
   ASSERT_EQ(native_graph, graph_from_native.native_graph());
 

--- a/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
@@ -60,7 +60,8 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 
   view_t data(Kokkos::view_alloc(exec, "witness"));
 
-  Kokkos::Experimental::Graph graph{exec};
+  Kokkos::Experimental::Graph graph{
+      Kokkos::Experimental::get_device_handle(exec)};
 
   graph.root_node().then_parallel_for(1, Increment<view_t>{data});
 
@@ -101,7 +102,8 @@ TEST(TEST_CATEGORY, graph_construct_from_native) {
   native_graph_t native_graph(exec.sycl_queue().get_context(),
                               exec.sycl_queue().get_device());
 
-  Kokkos::Experimental::Graph graph_from_native(exec, std::move(native_graph));
+  Kokkos::Experimental::Graph graph_from_native(
+      Kokkos::Experimental::get_device_handle(exec), std::move(native_graph));
 
   const view_t data(Kokkos::view_alloc(exec, "witness"));
 


### PR DESCRIPTION
# API change

### Current API

```c++
Kokkos::Experimental::Graph graph{exec_create};

auto node = graph.root_node().then_parallel_for(
    label,
    Kokkos::RangePolicy(exec_node, 0, N),
    functor_t{data}
);

...

exec_node.fence();
graph.submit(exec_submit);
```

The main concern is that the user may intuitively expect that the work will execute on `exec_node`. However, it's only used for:
1. node placement (*i.e.* set device)
2. preliminary work (*e.g.* `Kokkos` global launch asynchronous copy)

The backend graph scheduler ensures the node placement and graph dependencies, but it may execute the work using its own execution resources (*e.g.* its own CUDA streams). 

### Solution

This PR introduces a **device handle** to allow programmers to express the device that the node should run on, without referring to a particular `exec` that the work should be enqueued in.
It also refactors the graph API to use node properties -  `node_props`  - for passing the label and device handle when adding a node. Note that `node_props` is consistent with the view constructor properties.

A device handle identifies where a node should be placed without carrying execution queue semantics:
```c++
const auto device_handle = Kokkos::Experimental::get_device_handle(exec_space);
```
This prevents users from conflating device placement with work submission queues.

Note that the device handle conveniently stores an execution space instance that can be used as a default submission queue for the device.

### New API

```c++
const auto device_0_handle = Kokkos::Experimental::get_device_handle(exec_dev_0);

Kokkos::Experimental::Graph graph{device_0_handle};

auto node = graph.root_node().then_parallel_for(
    Kokkos::Experimental::node_props(label, device_0_handle),
    Kokkos::RangePolicy(0, N),
    functor_t{data}
);

...

exec_dev_0.fence();
graph.submit(exec_submit);
```

# Behavior change

Proposed behavior when adding a node:
- If `policy.m_space != Exec{}`, abort (enforce not user-specified).
- Otherwise
    - If a device handle is passed to `node_props`, use it for device placement of the node and preliminary work.
    - Otherwise, use the graph’s one for this purpose.

:warning: The user still needs to explicitly *fence* the *exec* the preliminary work is enqueued in, before the first submission (aligned with view).

<details>
<summary>
Old PR description
</summary>

If no execution space instance is given for the `then` node, it should default to using the one of the graph.

For the `Cuda` specialization at least, it will place the node on the associated given device.

### Discussion

By default, the `Kokkos` behavior is that is you don't provide an execution space instance to the execution policy, it will use the default one.

I'm wondering if the same should hold true for graph nodes. Should a graph node use the graph's execution space instance by default, or the "global" default execution space instance ?

Consider the following:
```c++
Kokkos::Experimental::Graph mygraph(exec_device_x);

graph.root_node().then("my then no exec", Functor{});
```

Do you expect the *then* node to run on the default device or the device *x*?
</details>