### PR TITLE
core(graph): enforce unit launch bound

### DIFF
--- a/core/src/impl/Kokkos_GraphNodeThenImpl.hpp
+++ b/core/src/impl/Kokkos_GraphNodeThenImpl.hpp
@@ -36,21 +36,20 @@ struct ThenWrapper {
 template <typename ExecutionSpace, typename Functor>
 struct GraphNodeThenImpl
     : public GraphNodeKernelImpl<
-          ExecutionSpace, Kokkos::RangePolicy<ExecutionSpace, IsGraphKernelTag>,
+          ExecutionSpace,
+          Kokkos::RangePolicy<ExecutionSpace, IsGraphKernelTag,
+                              Kokkos::LaunchBounds<1>>,
           ThenWrapper<Functor>, ParallelForTag> {
-  using base_t =
-      GraphNodeKernelImpl<ExecutionSpace,
-                          Kokkos::RangePolicy<ExecutionSpace, IsGraphKernelTag>,
-                          ThenWrapper<Functor>, ParallelForTag>;
+  using policy_t  = Kokkos::RangePolicy<ExecutionSpace, IsGraphKernelTag,
+                                       Kokkos::LaunchBounds<1>>;
+  using base_t    = GraphNodeKernelImpl<ExecutionSpace, policy_t,
+                                     ThenWrapper<Functor>, ParallelForTag>;
   using wrapper_t = ThenWrapper<Functor>;
 
   template <typename Label, typename T>
   GraphNodeThenImpl(Label&& label_, const ExecutionSpace& exec, T&& functor)
-      : base_t(
-            std::forward<Label>(label_), exec,
-            wrapper_t{std::forward<T>(functor)},
-            Kokkos::RangePolicy<ExecutionSpace, IsGraphKernelTag>(exec, 0, 1)) {
-  }
+      : base_t(std::forward<Label>(label_), exec,
+               wrapper_t{std::forward<T>(functor)}, policy_t(exec, 0, 1)) {}
 };
 
 }  // namespace Kokkos::Impl


### PR DESCRIPTION
Otherwise `Kokkos` might schedule *e.g.* a block of 128 threads, though only one is needed.

I was hoping that `nvcc` would then be smart enough to remove the code related to the grid stride, but it didn't.

Yet, this is improving the way we show the `then` kernel to the drivers/compilers.