### PR TITLE
SYCL: Skip zero_work_reduce test

### DIFF
--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -373,7 +373,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), repeat_chain) {
 }
 
 TEST_F(TEST_CATEGORY_FIXTURE(graph), zero_work_reduce) {
-#ifdef KOKKOS_ENABLE_SYCL  // FIXME_SYCL
+#ifdef KOKKOS_IMPL_SYCL_GRAPH_SUPPORT  // FIXME_SYCL
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::SYCL>)
     GTEST_SKIP() << "The SYCL implementation always tries to allocate memory "
                     "for parallel-reduce which doesn't work reliably with the "


### PR DESCRIPTION
The SYCL implementation will always use a (global) scratch allocation for parallel_reduce to execute `init` and `final` on the device. Since the `Graph` interface only captures the execution of the kernel but not the allocation, testing even with no work items is very brittle. Thus, this pull request suggests to just skip the `Graph` `zero_work_reduce` test.
Fixes the failure in https://my.cdash.org/tests/280081944. We can revisit when we have a proper strategy for dealing with allocations in the Graph interface.