### PR TITLE
SYCL: MDRangePolicy parallel_reduce avoid storing reference to execution space instance

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
@@ -370,7 +370,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
  private:
   const CombinedFunctorReducerType m_functor_reducer;
   const BarePolicy m_policy;
-  const Kokkos::SYCL& m_space;
+  const Kokkos::SYCL m_space;
   const pointer_type m_result_ptr;
   const bool m_result_ptr_device_accessible;
 };

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -378,8 +378,6 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), zero_work_reduce) {
         NoOpReduceFunctor<TEST_EXECSPACE, int> no_op_functor;
         root.then_parallel_reduce(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 0),
                                   no_op_functor, count)
-#if !defined(KOKKOS_ENABLE_SYCL) || \
-    defined(KOKKOS_IMPL_SYCL_GRAPH_SUPPORT)  // FIXME_SYCL
 #if !defined(KOKKOS_ENABLE_CUDA) && \
     !defined(KOKKOS_ENABLE_HIP)  // FIXME_CUDA FIXME_HIP
             .then_parallel_reduce(
@@ -389,9 +387,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), zero_work_reduce) {
 #endif
             .then_parallel_reduce(
                 Kokkos::TeamPolicy<TEST_EXECSPACE>{0, Kokkos::AUTO},
-                no_op_functor, count)
-#endif
-            ;
+                no_op_functor, count);
       });
 // These fences are only necessary because of the weirdness of how CUDA
 // UVM works on pre pascal cards.


### PR DESCRIPTION
Superseeds #8194. It turns out that the test failures were ultimately caused by a dangling reference. Of course, reductions in the Graph interface are still very brittle even when there are no work items but it's reasomable for the test to work in its current form (when there is no other kernel called between creaing the graph and executing it).