### PR TITLE
OpenMPTarget: Remove guards for Intel GPUs

### DIFF
--- a/algorithms/unit_tests/CMakeLists.txt
+++ b/algorithms/unit_tests/CMakeLists.txt
@@ -325,26 +325,9 @@ if(KOKKOS_ENABLE_OPENMPTARGET)
   )
 endif()
 
-# FIXME_OPENMPTARGET This test causes internal compiler errors as of 09/01/22
-# when compiling for Intel's Xe-HP GPUs.
-# FRIZZI: 04/26/2023: not sure if the compilation error is still applicable
-# but we conservatively leave this guard on
-if(NOT (KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM))
-  kokkos_add_executable_and_test(
-    UnitTest_Sort SOURCES UnitTestMain.cpp TestStdAlgorithmsCommon.cpp ${ALGO_SORT_SOURCES}
-  )
+kokkos_add_executable_and_test(UnitTest_Sort SOURCES UnitTestMain.cpp TestStdAlgorithmsCommon.cpp ${ALGO_SORT_SOURCES})
 
-  kokkos_add_executable_and_test(UnitTest_Random SOURCES UnitTestMain.cpp ${ALGO_RANDOM_SOURCES})
-endif()
-
-# FIXME_OPENMPTARGET: These tests cause internal compiler errors as of 09/01/22
-# when compiling for Intel's Xe-HP GPUs.
-if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
-  list(REMOVE_ITEM STDALGO_SOURCES_D TestStdAlgorithmsCopyIf.cpp TestStdAlgorithmsRemoveCopy.cpp
-       TestStdAlgorithmsUnique.cpp TestStdAlgorithmsUniqueCopy.cpp
-  )
-  list(REMOVE_ITEM STDALGO_SOURCES_E TestStdAlgorithmsExclusiveScan.cpp TestStdAlgorithmsInclusiveScan.cpp)
-endif()
+kokkos_add_executable_and_test(UnitTest_Random SOURCES UnitTestMain.cpp ${ALGO_RANDOM_SOURCES})
 
 # FIXME_OPENMPTARGET remove tests for OpenMPTarget
 # causing failures for various reasons
@@ -374,8 +357,4 @@ foreach(ID A;B;C;D;E;F;G;H;I;L;M;P;Q)
   )
 endforeach()
 
-# FIXME_OPENMPTARGET This test causes internal compiler errors as of 09/01/22
-# when compiling for Intel's Xe-HP GPUs.
-if(NOT (KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM))
-  kokkos_add_executable(AlgorithmsUnitTest_StdAlgoCompileOnly SOURCES TestStdAlgorithmsCompileOnly.cpp)
-endif()
+kokkos_add_executable(AlgorithmsUnitTest_StdAlgoCompileOnly SOURCES TestStdAlgorithmsCompileOnly.cpp)

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamCopyIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamCopyIf.cpp
@@ -166,10 +166,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_copy_if_team_test, test) {
-// FIXME_OPENMPTARGET
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "the test is known to fail with OpenMPTarget on Intel GPUs";
-#endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();
   run_all_scenarios<StridedThreeRowsTag, unsigned>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamExclusiveScan.cpp
@@ -255,10 +255,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_exclusive_scan_team_test, test) {
-// FIXME_OPENMPTARGET
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "the test is known to fail with OpenMPTarget on Intel GPUs";
-#endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();
   run_all_scenarios<StridedThreeRowsTag, unsigned>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamInclusiveScan.cpp
@@ -280,10 +280,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_inclusive_scan_team_test, test) {
-// FIXME_OPENMPTARGET
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "the test is known to fail with OpenMPTarget on Intel GPUs";
-#endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();
   run_all_scenarios<StridedThreeRowsTag, unsigned>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamRemoveCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamRemoveCopy.cpp
@@ -212,10 +212,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_remove_copy_team_test, test) {
-// FIXME_OPENMPTARGET
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "the test is known to fail with OpenMPTarget on Intel GPUs";
-#endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();
   run_all_scenarios<StridedThreeRowsTag, unsigned>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamRemoveCopyIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamRemoveCopyIf.cpp
@@ -168,10 +168,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_remove_copy_if_team_test, test) {
-// FIXME_OPENMPTARGET
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "the test is known to fail with OpenMPTarget on Intel GPUs";
-#endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();
   run_all_scenarios<StridedThreeRowsTag, unsigned>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamUniqueCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamUniqueCopy.cpp
@@ -186,10 +186,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_unique_copy_team_test, test) {
-  // FIXME_OPENMPTARGET
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "the test is known to fail with OpenMPTarget on Intel GPUs";
-#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedTwoRowsTag, int>();
   run_all_scenarios<StridedThreeRowsTag, int>();

--- a/core/src/Kokkos_Printf.hpp
+++ b/core/src/Kokkos_Printf.hpp
@@ -30,9 +30,6 @@ namespace Kokkos {
 // In contrast to std::printf, return void to get a consistent behavior across
 // backends. The GPU backends always return 1 and NVHPC only compiles if we
 // don't ask for the return value.
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-using ::printf;
-#else
 template <typename... Args>
 KOKKOS_FORCEINLINE_FUNCTION void printf(const char* format, Args... args) {
 #ifdef KOKKOS_ENABLE_SYCL
@@ -48,7 +45,6 @@ KOKKOS_FORCEINLINE_FUNCTION void printf(const char* format, Args... args) {
     ::printf(format, args...);
 #endif
 }
-#endif
 
 }  // namespace Kokkos
 

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -55,17 +55,7 @@ using ALL_t KOKKOS_DEPRECATED_WITH_COMMENT("Use Kokkos::ALL_t instead!") =
 }  // namespace Impl
 #endif
 
-// FIXME_OPENMPTARGET - The `declare target` is needed for the Intel GPUs with
-// the OpenMPTarget backend
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_COMPILER_INTEL_LLVM)
-#pragma omp declare target
-#endif
-
 inline constexpr Kokkos::ALL_t ALL{};
-
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_COMPILER_INTEL_LLVM)
-#pragma omp end declare target
-#endif
 
 namespace Impl {
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -496,11 +496,6 @@ endif()
 if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang AND KOKKOS_AMDGPU_ARCH)
   list(REMOVE_ITEM OpenMPTarget_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_e.cpp)
 endif()
-# FIXME_OPENMPTARGET This test causes internal compiler errors as of 09/01/22
-# when compiling for Intel's Xe-HP GPUs.
-if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
-  list(REMOVE_ITEM OpenMPTarget_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamVectorRange.cpp)
-endif()
 
 # FIXME_OPENMPTARGET - Comment non-passing tests with the NVIDIA HPC compiler nvc++
 if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
@@ -973,12 +968,6 @@ endif()
 set(KOKKOSP_SOURCES UnitTestMainInit.cpp tools/TestEventCorrectness.cpp tools/TestKernelNames.cpp
                     tools/TestProfilingSection.cpp tools/TestScopedRegion.cpp tools/TestWithoutInitializing.cpp
 )
-
-# FIXME_OPENMPTARGET This test causes internal compiler errors as of 09/01/22
-# when compiling for Intel's Xe-HP GPUs.
-if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
-  list(REMOVE_ITEM KOKKOSP_SOURCES tools/TestEventCorrectness.cpp)
-endif()
 
 kokkos_add_executable_and_test(CoreUnitTest_KokkosP SOURCES ${KOKKOSP_SOURCES})
 if(KOKKOS_ENABLE_LIBDL)

--- a/core/unit_test/TestMathematicalSpecialFunctions.hpp
+++ b/core/unit_test/TestMathematicalSpecialFunctions.hpp
@@ -1962,21 +1962,11 @@ TEST(TEST_CATEGORY, mathspecialfunc_errorfunc) {
 #endif
 
 TEST(TEST_CATEGORY, mathspecialfunc_cbesselj0y0) {
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
-    GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
-                    "Intel GPUs";  // FIXME_OPENMPTARGET
-#endif
   TestComplexBesselJ0Y0Function<TEST_EXECSPACE> test;
   test.testit();
 }
 
 TEST(TEST_CATEGORY, mathspecialfunc_cbesselj1y1) {
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
-    GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
-                    "Intel GPUs";  // FIXME_OPENMPTARGET
-#endif
 #if defined(KOKKOS_ENABLE_HIP) &&                         \
     (HIP_VERSION_MAJOR == 5 && HIP_VERSION_MINOR == 3) && \
     defined(KOKKOS_ARCH_AMD_GFX908)
@@ -1989,33 +1979,18 @@ TEST(TEST_CATEGORY, mathspecialfunc_cbesselj1y1) {
 }
 
 TEST(TEST_CATEGORY, mathspecialfunc_cbesseli0k0) {
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
-    GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
-                    "Intel GPUs";  // FIXME_OPENMPTARGET
-#endif
   TestComplexBesselI0K0Function<TEST_EXECSPACE> test;
   test.testit();
 }
 
 TEST(TEST_CATEGORY, mathspecialfunc_cbesseli1k1) {
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
-    GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
-                    "Intel GPUs";  // FIXME_OPENMPTARGET
-#endif
   TestComplexBesselI1K1Function<TEST_EXECSPACE> test;
   test.testit();
 }
 
 TEST(TEST_CATEGORY, mathspecialfunc_cbesselh1stkind) {
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
-    GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
-                    "Intel GPUs";  // FIXME_OPENMPTARGET
-#endif
-    // Disable the test when using ROCm 5.5, 5.6, and 6.2 due to a
-    // known compiler bug. The test always fails on MI100.
+  // Disable the test when using ROCm 5.5, 5.6, and 6.2 due to a
+  // known compiler bug. The test always fails on MI100.
 #if defined(KOKKOS_ENABLE_HIP) &&                            \
     (((HIP_VERSION_MAJOR == 5 && HIP_VERSION_MINOR == 5) ||  \
       (HIP_VERSION_MAJOR == 5 && HIP_VERSION_MINOR == 6) ||  \
@@ -2030,11 +2005,6 @@ TEST(TEST_CATEGORY, mathspecialfunc_cbesselh1stkind) {
 }
 
 TEST(TEST_CATEGORY, mathspecialfunc_cbesselh2ndkind) {
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU)
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
-    GTEST_SKIP() << "skipping since test is known to fail with OpenMPTarget on "
-                    "Intel GPUs";  // FIXME_OPENMPTARGET
-#endif
   TestComplexBesselH2Function<TEST_EXECSPACE> test;
   test.testit();
 }

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -217,10 +217,7 @@ TEST(TEST_CATEGORY, numeric_traits_infinity) {
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Infinity>();
   TestNumericTraits<TEST_EXECSPACE, float, Infinity>();
   TestNumericTraits<TEST_EXECSPACE, double, Infinity>();
-  // FIXME_OPENMPTARGET long double on Intel GPUs
-#if (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, Infinity>();
-#endif
 }
 
 TEST(TEST_CATEGORY, numeric_traits_epsilon) {
@@ -228,10 +225,7 @@ TEST(TEST_CATEGORY, numeric_traits_epsilon) {
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Epsilon>();
   TestNumericTraits<TEST_EXECSPACE, float, Epsilon>();
   TestNumericTraits<TEST_EXECSPACE, double, Epsilon>();
-  // FIXME_OPENMPTARGET long double on Intel GPUs
-#if (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, Epsilon>();
-#endif
 }
 
 TEST(TEST_CATEGORY, numeric_traits_round_error) {
@@ -240,10 +234,7 @@ TEST(TEST_CATEGORY, numeric_traits_round_error) {
                     RoundError>();
   TestNumericTraits<TEST_EXECSPACE, float, RoundError>();
   TestNumericTraits<TEST_EXECSPACE, double, RoundError>();
-  // FIXME_OPENMPTARGET long double on Intel GPUs
-#if (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, RoundError>();
-#endif
 }
 
 TEST(TEST_CATEGORY, numeric_traits_norm_min) {
@@ -251,19 +242,13 @@ TEST(TEST_CATEGORY, numeric_traits_norm_min) {
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, NormMin>();
   TestNumericTraits<TEST_EXECSPACE, float, NormMin>();
   TestNumericTraits<TEST_EXECSPACE, double, NormMin>();
-  // FIXME_OPENMPTARGET long double on Intel GPUs
-#if (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, NormMin>();
-#endif
 }
 
 TEST(TEST_CATEGORY, numeric_traits_denorm_min) {
   TestNumericTraits<TEST_EXECSPACE, float, DenormMin>();
   TestNumericTraits<TEST_EXECSPACE, double, DenormMin>();
-  // FIXME_OPENMPTARGET long double on Intel GPUs
-#if (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, DenormMin>();
-#endif
 }
 
 TEST(TEST_CATEGORY, numeric_traits_finite_min_max) {
@@ -298,11 +283,8 @@ TEST(TEST_CATEGORY, numeric_traits_finite_min_max) {
   TestNumericTraits<TEST_EXECSPACE, float, FiniteMax>();
   TestNumericTraits<TEST_EXECSPACE, double, FiniteMin>();
   TestNumericTraits<TEST_EXECSPACE, double, FiniteMax>();
-  // FIXME_OPENMPTARGET long double on Intel GPUs
-#if (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, FiniteMin>();
   TestNumericTraits<TEST_EXECSPACE, long double, FiniteMax>();
-#endif
 }
 
 TEST(TEST_CATEGORY, numeric_traits_digits) {
@@ -322,10 +304,7 @@ TEST(TEST_CATEGORY, numeric_traits_digits) {
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Digits>();
   TestNumericTraits<TEST_EXECSPACE, float, Digits>();
   TestNumericTraits<TEST_EXECSPACE, double, Digits>();
-  // FIXME_OPENMPTARGET long double on Intel GPUs
-#if (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, Digits>();
-#endif
 }
 
 TEST(TEST_CATEGORY, numeric_traits_digits10) {
@@ -345,19 +324,13 @@ TEST(TEST_CATEGORY, numeric_traits_digits10) {
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Digits10>();
   TestNumericTraits<TEST_EXECSPACE, float, Digits10>();
   TestNumericTraits<TEST_EXECSPACE, double, Digits10>();
-  // FIXME_OPENMPTARGET long double on Intel GPUs
-#if (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, Digits10>();
-#endif
 }
 
 TEST(TEST_CATEGORY, numeric_traits_max_digits10) {
   TestNumericTraits<TEST_EXECSPACE, float, MaxDigits10>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxDigits10>();
-  // FIXME_OPENMPTARGET long double on Intel GPUs
-#if (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, MaxDigits10>();
-#endif
 }
 TEST(TEST_CATEGORY, numeric_traits_radix) {
   TestNumericTraits<TEST_EXECSPACE, bool, Radix>();
@@ -376,10 +349,7 @@ TEST(TEST_CATEGORY, numeric_traits_radix) {
   TestNumericTraits<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t, Radix>();
   TestNumericTraits<TEST_EXECSPACE, float, Radix>();
   TestNumericTraits<TEST_EXECSPACE, double, Radix>();
-  // FIXME_OPENMPTARGET long double on Intel GPUs
-#if (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, Radix>();
-#endif
 }
 
 TEST(TEST_CATEGORY, numeric_traits_min_max_exponent) {
@@ -391,11 +361,8 @@ TEST(TEST_CATEGORY, numeric_traits_min_max_exponent) {
   TestNumericTraits<TEST_EXECSPACE, float, MaxExponent>();
   TestNumericTraits<TEST_EXECSPACE, double, MinExponent>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxExponent>();
-  // FIXME_OPENMPTARGET long double on Intel GPUs
-#if (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, MinExponent>();
   TestNumericTraits<TEST_EXECSPACE, long double, MaxExponent>();
-#endif
 }
 
 TEST(TEST_CATEGORY, numeric_traits_min_max_exponent10) {
@@ -403,11 +370,8 @@ TEST(TEST_CATEGORY, numeric_traits_min_max_exponent10) {
   TestNumericTraits<TEST_EXECSPACE, float, MaxExponent10>();
   TestNumericTraits<TEST_EXECSPACE, double, MinExponent10>();
   TestNumericTraits<TEST_EXECSPACE, double, MaxExponent10>();
-  // FIXME_OPENMPTARGET long double on Intel GPUs
-#if (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, MinExponent10>();
   TestNumericTraits<TEST_EXECSPACE, long double, MaxExponent10>();
-#endif
 }
 
 KOKKOS_IMPL_DISABLE_UNREACHABLE_WARNINGS_PUSH()
@@ -426,11 +390,8 @@ TEST(TEST_CATEGORY, numeric_traits_quiet_and_signaling_nan) {
   TestNumericTraits<TEST_EXECSPACE, float, SignalingNaN>();
   TestNumericTraits<TEST_EXECSPACE, double, QuietNaN>();
   TestNumericTraits<TEST_EXECSPACE, double, SignalingNaN>();
-  // FIXME_OPENMPTARGET long double on Intel GPUs
-#if (!defined(KOKKOS_ENABLE_OPENMPTARGET) || !defined(KOKKOS_ARCH_INTEL_GPU))
   TestNumericTraits<TEST_EXECSPACE, long double, QuietNaN>();
   TestNumericTraits<TEST_EXECSPACE, long double, SignalingNaN>();
-#endif
 }
 // NOLINTEND(bugprone-unused-raii)
 KOKKOS_IMPL_DISABLE_UNREACHABLE_WARNINGS_POP()
@@ -517,13 +478,7 @@ CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(double, round_error);
 CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(long double, round_error);
 CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(float, denorm_min);
 CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(double, denorm_min);
-
-// FIXME_OPENMPTARGET - The static_assert causes issues on Intel GPUs with the
-// OpenMPTarget backend.
-#if !(defined(KOKKOS_ENABLE_OPENMPTARGET) && \
-      defined(KOKKOS_COMPILER_INTEL_LLVM))
 CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(long double, denorm_min);
-#endif
 
 // clang-format off
 static_assert(Kokkos::Experimental::norm_min<float      >::value == std::numeric_limits<      float>::min());

--- a/core/unit_test/TestPrintf.hpp
+++ b/core/unit_test/TestPrintf.hpp
@@ -30,8 +30,4 @@ void test_kokkos_printf() {
   ASSERT_EQ(captured, expected_string);
 }
 
-// FIXME_OPENMPTARGET non-string-literal argument used in printf is not
-// supported for spir64
-#if !(defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_GPU))
 TEST(TEST_CATEGORY, kokkos_printf) { test_kokkos_printf<TEST_EXECSPACE>(); }
-#endif


### PR DESCRIPTION
Follow-up to https://github.com/kokkos/kokkos/pull/7973. That pull request removed support for Intel GPUs with OpenMPTarget but there were still a bunch of related guards that this pull request removes.