### PR TITLE
`check_format_cpp.sh`: favor -exec instead of xargs

### DIFF
--- a/scripts/apply-clang-format
+++ b/scripts/apply-clang-format
@@ -28,16 +28,20 @@ fi
 
 TRACKED_FILES="$(git ls-files)"
 
+echo "***   Running clang-format"
 find ${TRACKED_FILES} \
-  -type f -name '*.cpp' -o -name '*.hpp' -o -name '*.cc' -o -name '*.h' |
-  xargs -n 1 -P 10 ${CLANG_FORMAT_EXECUTABLE} -i
+  -type f -name '*.cpp' -o -name '*.hpp' -o -name '*.cc' -o -name '*.h' -exec ${CLANG_FORMAT_EXECUTABLE} -i {} \;
+echo "***   Running clang-format - done"
 
 # Now also check for trailing whitspace. Mac OSX creates backup files
 # that we need to delete manually.
+echo "***   Running whitespace check"
 TRACKED_FILES="$(git ls-tree HEAD --name-only)"
 find ${TRACKED_FILES} \
-  -type f \( -name "*.md" -o -name "*.cc" -o -name "*.h" -o -name "*.txt" -o -name "*.cmake" \) |
-  xargs -n 1 -P 10 -I {} bash -c "sed -i -e 's/\s\+$//g' {} && rm -f '{}-e'"
+  -type f \( -name "*.md" -o -name "*.cc" -o -name "*.h" -o -name "*.txt" -o -name "*.cmake" \) -exec bash -c "sed -i -e 's/\s\+$//g' {} && rm -f '{}-e'" \;
+echo "***   Running whitespace check - done"
 
 # Check that we do not introduce any file with the old copyright
+echo "***   Running copyright"
 ./scripts/check-copyright
+echo "***   Running copyright - done"


### PR DESCRIPTION
This allows to run it on my laptop which is pretty helpful finding trailing whitespaces or missing copyrights.

xargs errors out with `xargs: argument line too long`.