### PR TITLE
Add new microbench to measure the overhead of launching parallel_for

### DIFF
--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -114,6 +114,7 @@ set(BENCHMARK_SOURCES
     PerfTest_ViewResize_7.cpp
     PerfTest_ViewResize_8.cpp
     PerfTest_ViewResize_Raw.cpp
+    MicroBench_ParallelForOverheads.cpp
 )
 
 if(Kokkos_ENABLE_OPENMPTARGET)

--- a/core/perf_test/MicroBench_ParallelForOverheads.cpp
+++ b/core/perf_test/MicroBench_ParallelForOverheads.cpp
@@ -1,0 +1,253 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#include <Kokkos_Core.hpp>
+#include <benchmark/benchmark.h>
+
+/*
+ * Set of micro benchmarks measuring the cost of initializing the different
+ * parts surrounding a parallel_for
+ */
+
+// Minimal overhead, reuse the name, the policy and the lambda and only measure
+// the time it takes to call Kokkos::parallel_for
+static void ParallelFor_NoOverhead(benchmark::State& state) {
+  std::string name = "kernel";
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  const auto lambda = KOKKOS_LAMBDA(int){};
+
+  for (auto _ : state) {
+    Kokkos::parallel_for(name, policy, lambda);
+  }
+}
+BENCHMARK(ParallelFor_NoOverhead)->Unit(benchmark::kNanosecond);
+
+// Cost of creating the default name for the kernel
+static void ParallelFor_Overhead_DefaultedName(benchmark::State& state) {
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  const auto lambda = KOKKOS_LAMBDA(int){};
+
+  for (auto _ : state) {
+    Kokkos::parallel_for(policy, lambda);
+  }
+}
+BENCHMARK(ParallelFor_Overhead_DefaultedName)->Unit(benchmark::kNanosecond);
+
+// Cost of constructing a small string (it should fit in the small string
+// optimisation) to use as the kernel name.
+static void ParallelFor_Overhead_EmptyName(benchmark::State& state) {
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  const auto lambda = KOKKOS_LAMBDA(int){};
+
+  for (auto _ : state) {
+    Kokkos::parallel_for("", policy, lambda);
+  }
+}
+BENCHMARK(ParallelFor_Overhead_EmptyName)->Unit(benchmark::kNanosecond);
+
+// Is there a cost for using a very long name as kernel name?
+// (checks that we don't uselessly copy the string around)
+static void ParallelFor_Overhead_UsingLongKernelName(benchmark::State& state) {
+  std::string name =
+      "A very long string that should not be able to fit in the short string "
+      "optimization of std::string";
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  const auto lambda = KOKKOS_LAMBDA(int){};
+
+  for (auto _ : state) {
+    Kokkos::parallel_for(name, policy, lambda);
+  }
+}
+BENCHMARK(ParallelFor_Overhead_UsingLongKernelName)
+    ->Unit(benchmark::kNanosecond);
+
+// Cost for constructing a name that will not fit inside short string
+// optimization
+static void ParallelFor_Overhead_LongNameConstruction(benchmark::State& state) {
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  const auto lambda = KOKKOS_LAMBDA(int){};
+
+  for (auto _ : state) {
+    Kokkos::parallel_for("Name not fitting in the short string optimisation",
+                         policy, lambda);
+  }
+}
+BENCHMARK(ParallelFor_Overhead_LongNameConstruction)
+    ->Unit(benchmark::kNanosecond);
+
+// Is there a cost for creating the lambda?
+static void ParallelFor_Overhead_LambdaCreation(benchmark::State& state) {
+  std::string name = "kernel";
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+
+  for (auto _ : state) {
+    Kokkos::parallel_for(name, policy, KOKKOS_LAMBDA(int){});
+  }
+}
+BENCHMARK(ParallelFor_Overhead_LambdaCreation)->Unit(benchmark::kNanosecond);
+
+// Is there a cost for using a functor instead of a lambda?
+struct Func {
+  KOKKOS_FUNCTION void operator()(int) const {}
+};
+static void ParallelFor_Overhead_Functor(benchmark::State& state) {
+  std::string name = "kernel";
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  Func func;
+
+  for (auto _ : state) {
+    Kokkos::parallel_for(name, policy, func);
+  }
+}
+BENCHMARK(ParallelFor_Overhead_Functor)->Unit(benchmark::kNanosecond);
+
+// Is there a cost for using a functor with a very long name?
+struct
+    FunctorWithAVeryLongNameAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA {
+  KOKKOS_FUNCTION void operator()(int) const {}
+};
+static void ParallelFor_Overhead_FunctorLongName(benchmark::State& state) {
+  std::string name = "kernel";
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  FunctorWithAVeryLongNameAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+      func;
+
+  for (auto _ : state) {
+    Kokkos::parallel_for(name, policy, func);
+  }
+}
+BENCHMARK(ParallelFor_Overhead_FunctorLongName)->Unit(benchmark::kNanosecond);
+
+// Is there a cost for using a very long name for the range policy tag?
+struct
+    TagWithALongNameAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA {
+};
+
+static void ParallelFor_Overhead_LongTag(benchmark::State& state) {
+  std::string name = "kernel";
+  Kokkos::RangePolicy<
+      Kokkos::DefaultExecutionSpace,
+      TagWithALongNameAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA>
+      policy(0, 0);
+  const auto lambda = KOKKOS_LAMBDA(
+      TagWithALongNameAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+      int){};
+
+  for (auto _ : state) {
+    Kokkos::parallel_for(name, policy, lambda);
+  }
+}
+BENCHMARK(ParallelFor_Overhead_LongTag)->Unit(benchmark::kNanosecond);
+
+// Cost of using the default range policy (and thus incur the cost of creating
+// it)
+static void ParallelFor_Overhead_PolicyCreation(benchmark::State& state) {
+  std::string name  = "kernel";
+  const auto lambda = KOKKOS_LAMBDA(int){};
+
+  for (auto _ : state) {
+    Kokkos::parallel_for(name, 0, lambda);
+  }
+}
+BENCHMARK(ParallelFor_Overhead_PolicyCreation)->Unit(benchmark::kNanosecond);
+
+// Fences cost
+
+// Cost of calling a space specific fence in-between kernel
+static void ParallelFor_Overhead_SpaceSpecificFence(benchmark::State& state) {
+  std::string name = "kernel";
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  const auto lambda = KOKKOS_LAMBDA(int){};
+  Kokkos::DefaultExecutionSpace space;
+
+  for (auto _ : state) {
+    Kokkos::parallel_for(name, policy, lambda);
+    space.fence();
+  }
+}
+BENCHMARK(ParallelFor_Overhead_SpaceSpecificFence)
+    ->Unit(benchmark::kNanosecond);
+
+// Cost of calling a space specific fence with a non defaulted name in-between
+// kernel
+static void ParallelFor_Overhead_NamedSpaceSpecificFence(
+    benchmark::State& state) {
+  std::string kernel_name = "kernel";
+  const auto lambda       = KOKKOS_LAMBDA(int){};
+  Kokkos::DefaultExecutionSpace space;
+  Kokkos::RangePolicy policy(space, 0, 0);
+  std::string fence_name = "fence";
+
+  for (auto _ : state) {
+    Kokkos::parallel_for(kernel_name, policy, lambda);
+    space.fence(fence_name);
+  }
+}
+BENCHMARK(ParallelFor_Overhead_NamedSpaceSpecificFence)
+    ->Unit(benchmark::kNanosecond);
+
+// Cost of calling a fence over a specific space in-between kernel,
+// when this space needs to be created.
+static void ParallelFor_Overhead_FenceWithSpaceCreation(
+    benchmark::State& state) {
+  std::string name = "kernel";
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  const auto lambda = KOKKOS_LAMBDA(int){};
+
+  for (auto _ : state) {
+    Kokkos::parallel_for(name, policy, lambda);
+    Kokkos::DefaultExecutionSpace{}.fence();
+  }
+}
+BENCHMARK(ParallelFor_Overhead_FenceWithSpaceCreation)
+    ->Unit(benchmark::kNanosecond);
+
+// Cost of calling a global fence with a non defaulted name in-between kernels
+static void ParallelFor_Overhead_NamedGlobalFence(benchmark::State& state) {
+  std::string kernel_name = "kernel";
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  const auto lambda      = KOKKOS_LAMBDA(int){};
+  std::string fence_name = "fence";
+
+  for (auto _ : state) {
+    Kokkos::parallel_for(kernel_name, policy, lambda);
+    Kokkos::fence(fence_name);
+  }
+}
+BENCHMARK(ParallelFor_Overhead_NamedGlobalFence)->Unit(benchmark::kNanosecond);
+
+// Cost of calling a global fence in-between kernel (including fence name
+// creation cost)
+static void ParallelFor_Overhead_GlobalFence(benchmark::State& state) {
+  std::string name = "kernel";
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  const auto lambda = KOKKOS_LAMBDA(int){};
+
+  for (auto _ : state) {
+    Kokkos::parallel_for(name, policy, lambda);
+    Kokkos::fence();
+  }
+}
+BENCHMARK(ParallelFor_Overhead_GlobalFence)->Unit(benchmark::kNanosecond);
+
+// Full overhead for a classic call to parallel_for
+static void ParallelFor_Overhead_Full(benchmark::State& state) {
+  for (auto _ : state) {
+    Kokkos::parallel_for("Name not fitting in the short string optimisation", 0,
+                         KOKKOS_LAMBDA(int){});
+    Kokkos::fence();
+  }
+}
+BENCHMARK(ParallelFor_Overhead_Full)->Unit(benchmark::kNanosecond);

--- a/core/perf_test/MicroBench_ParallelForOverheads.cpp
+++ b/core/perf_test/MicroBench_ParallelForOverheads.cpp
@@ -25,7 +25,7 @@
 // the time it takes to call Kokkos::parallel_for
 static void ParallelFor_NoOverhead(benchmark::State& state) {
   std::string name = "kernel";
-  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 1);
   const auto lambda = KOKKOS_LAMBDA(int){};
 
   for (auto _ : state) {
@@ -36,7 +36,7 @@ BENCHMARK(ParallelFor_NoOverhead)->Unit(benchmark::kNanosecond);
 
 // Cost of creating the default name for the kernel
 static void ParallelFor_Overhead_DefaultedName(benchmark::State& state) {
-  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 1);
   const auto lambda = KOKKOS_LAMBDA(int){};
 
   for (auto _ : state) {
@@ -48,7 +48,7 @@ BENCHMARK(ParallelFor_Overhead_DefaultedName)->Unit(benchmark::kNanosecond);
 // Cost of constructing a small string (it should fit in the small string
 // optimisation) to use as the kernel name.
 static void ParallelFor_Overhead_EmptyName(benchmark::State& state) {
-  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 1);
   const auto lambda = KOKKOS_LAMBDA(int){};
 
   for (auto _ : state) {
@@ -63,7 +63,7 @@ static void ParallelFor_Overhead_UsingLongKernelName(benchmark::State& state) {
   std::string name =
       "A very long string that should not be able to fit in the short string "
       "optimization of std::string";
-  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 1);
   const auto lambda = KOKKOS_LAMBDA(int){};
 
   for (auto _ : state) {
@@ -76,7 +76,7 @@ BENCHMARK(ParallelFor_Overhead_UsingLongKernelName)
 // Cost for constructing a name that will not fit inside short string
 // optimization
 static void ParallelFor_Overhead_LongNameConstruction(benchmark::State& state) {
-  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 1);
   const auto lambda = KOKKOS_LAMBDA(int){};
 
   for (auto _ : state) {
@@ -90,7 +90,7 @@ BENCHMARK(ParallelFor_Overhead_LongNameConstruction)
 // Is there a cost for creating the lambda?
 static void ParallelFor_Overhead_LambdaCreation(benchmark::State& state) {
   std::string name = "kernel";
-  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 1);
 
   for (auto _ : state) {
     Kokkos::parallel_for(name, policy, KOKKOS_LAMBDA(int){});
@@ -104,7 +104,7 @@ struct Func {
 };
 static void ParallelFor_Overhead_Functor(benchmark::State& state) {
   std::string name = "kernel";
-  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 1);
   Func func;
 
   for (auto _ : state) {
@@ -120,7 +120,7 @@ struct
 };
 static void ParallelFor_Overhead_FunctorLongName(benchmark::State& state) {
   std::string name = "kernel";
-  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 1);
   FunctorWithAVeryLongNameAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
       func;
 
@@ -140,7 +140,7 @@ static void ParallelFor_Overhead_LongTag(benchmark::State& state) {
   Kokkos::RangePolicy<
       Kokkos::DefaultExecutionSpace,
       TagWithALongNameAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA>
-      policy(0, 0);
+      policy(0, 1);
   const auto lambda = KOKKOS_LAMBDA(
       TagWithALongNameAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
       int){};
@@ -168,7 +168,7 @@ BENCHMARK(ParallelFor_Overhead_PolicyCreation)->Unit(benchmark::kNanosecond);
 // Cost of calling a space specific fence in-between kernel
 static void ParallelFor_Overhead_SpaceSpecificFence(benchmark::State& state) {
   std::string name = "kernel";
-  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 1);
   const auto lambda = KOKKOS_LAMBDA(int){};
   Kokkos::DefaultExecutionSpace space;
 
@@ -187,7 +187,7 @@ static void ParallelFor_Overhead_NamedSpaceSpecificFence(
   std::string kernel_name = "kernel";
   const auto lambda       = KOKKOS_LAMBDA(int){};
   Kokkos::DefaultExecutionSpace space;
-  Kokkos::RangePolicy policy(space, 0, 0);
+  Kokkos::RangePolicy policy(space, 0, 1);
   std::string fence_name = "fence";
 
   for (auto _ : state) {
@@ -203,7 +203,7 @@ BENCHMARK(ParallelFor_Overhead_NamedSpaceSpecificFence)
 static void ParallelFor_Overhead_FenceWithSpaceCreation(
     benchmark::State& state) {
   std::string name = "kernel";
-  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 1);
   const auto lambda = KOKKOS_LAMBDA(int){};
 
   for (auto _ : state) {
@@ -217,7 +217,7 @@ BENCHMARK(ParallelFor_Overhead_FenceWithSpaceCreation)
 // Cost of calling a global fence with a non defaulted name in-between kernels
 static void ParallelFor_Overhead_NamedGlobalFence(benchmark::State& state) {
   std::string kernel_name = "kernel";
-  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 1);
   const auto lambda      = KOKKOS_LAMBDA(int){};
   std::string fence_name = "fence";
 
@@ -232,7 +232,7 @@ BENCHMARK(ParallelFor_Overhead_NamedGlobalFence)->Unit(benchmark::kNanosecond);
 // creation cost)
 static void ParallelFor_Overhead_GlobalFence(benchmark::State& state) {
   std::string name = "kernel";
-  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 0);
+  Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace> policy(0, 1);
   const auto lambda = KOKKOS_LAMBDA(int){};
 
   for (auto _ : state) {
@@ -245,7 +245,7 @@ BENCHMARK(ParallelFor_Overhead_GlobalFence)->Unit(benchmark::kNanosecond);
 // Full overhead for a classic call to parallel_for
 static void ParallelFor_Overhead_Full(benchmark::State& state) {
   for (auto _ : state) {
-    Kokkos::parallel_for("Name not fitting in the short string optimisation", 0,
+    Kokkos::parallel_for("Name not fitting in the short string optimisation", 1,
                          KOKKOS_LAMBDA(int){});
     Kokkos::fence();
   }


### PR DESCRIPTION
The main goal of this benchs is to check that there is no regression regarding performances of launching a parallel_for.

Results with
g++-13.3.0
```
---------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations
---------------------------------------------------------------------------------------
ParallelFor_NoOverhead                             2.59 ns         2.59 ns    269110461
ParallelFor_Overhead_DefaultedName                 3.11 ns         3.09 ns    226658030
ParallelFor_Overhead_EmptyName                     3.05 ns         3.05 ns    228475132
ParallelFor_Overhead_UsingLongKernelName           2.58 ns         2.58 ns    268179298
ParallelFor_Overhead_LongNameConstruction          11.5 ns         11.5 ns     61961611
ParallelFor_Overhead_LambdaCreation                2.60 ns         2.60 ns    268560541
ParallelFor_Overhead_Functor                       2.62 ns         2.60 ns    271374758
ParallelFor_Overhead_FunctorLongName               2.60 ns         2.60 ns    269581961
ParallelFor_Overhead_LongTag                       2.60 ns         2.59 ns    267894999
ParallelFor_Overhead_PolicyCreation                18.5 ns         18.5 ns     38202743
ParallelFor_Overhead_SpaceSpecificFence            11.9 ns         11.8 ns     59162593
ParallelFor_Overhead_NamedSpaceSpecificFence       3.30 ns         3.30 ns    211451781
ParallelFor_Overhead_FenceWithSpaceCreation        23.1 ns         23.1 ns     30599635
ParallelFor_Overhead_NamedGlobalFence              6.13 ns         6.13 ns    115246285
ParallelFor_Overhead_GlobalFence                   14.7 ns         14.7 ns     47815999
ParallelFor_Overhead_Full                          39.6 ns         39.6 ns     17733538
```
clang-18.1.3
```
---------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations
---------------------------------------------------------------------------------------
ParallelFor_NoOverhead                             5.62 ns         5.61 ns    126245523
ParallelFor_Overhead_DefaultedName                 6.20 ns         6.20 ns    110768303
ParallelFor_Overhead_EmptyName                     6.11 ns         6.11 ns    113816719
ParallelFor_Overhead_UsingLongKernelName           5.74 ns         5.74 ns    121895956
ParallelFor_Overhead_LongNameConstruction          14.8 ns         14.8 ns     47555313
ParallelFor_Overhead_LambdaCreation                5.58 ns         5.54 ns    127408276
ParallelFor_Overhead_Functor                       6.56 ns         6.51 ns    107710501
ParallelFor_Overhead_FunctorLongName               6.58 ns         6.58 ns    107382264
ParallelFor_Overhead_LongTag                       5.78 ns         5.77 ns    121389773
ParallelFor_Overhead_PolicyCreation                25.8 ns         25.8 ns     27147682
ParallelFor_Overhead_SpaceSpecificFence            16.2 ns         16.1 ns     43708072
ParallelFor_Overhead_NamedSpaceSpecificFence       6.90 ns         6.90 ns     99273526
ParallelFor_Overhead_FenceWithSpaceCreation        27.3 ns         27.3 ns     25896422
ParallelFor_Overhead_NamedGlobalFence              11.0 ns         11.0 ns     63143577
ParallelFor_Overhead_GlobalFence                   19.2 ns         19.2 ns     36141798
ParallelFor_Overhead_Full                          46.4 ns         46.4 ns     15314474
```
icpx-2025.0.0
```
---------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations
---------------------------------------------------------------------------------------
ParallelFor_NoOverhead                             3.30 ns         3.30 ns    211165135
ParallelFor_Overhead_DefaultedName                 3.79 ns         3.76 ns    185467307
ParallelFor_Overhead_EmptyName                     3.78 ns         3.78 ns    186205621
ParallelFor_Overhead_UsingLongKernelName           3.10 ns         3.07 ns    225774326
ParallelFor_Overhead_LongNameConstruction          12.3 ns         12.3 ns     56928325
ParallelFor_Overhead_LambdaCreation                3.30 ns         3.30 ns    212274119
ParallelFor_Overhead_Functor                       3.80 ns         3.77 ns    185102571
ParallelFor_Overhead_FunctorLongName               3.80 ns         3.77 ns    184796886
ParallelFor_Overhead_LongTag                       3.30 ns         3.30 ns    212321319
ParallelFor_Overhead_PolicyCreation                22.5 ns         22.4 ns     31245232
ParallelFor_Overhead_SpaceSpecificFence            13.5 ns         13.5 ns     51210749
ParallelFor_Overhead_NamedSpaceSpecificFence       3.60 ns         3.54 ns    196377530
ParallelFor_Overhead_FenceWithSpaceCreation        24.7 ns         24.7 ns     28381451
ParallelFor_Overhead_NamedGlobalFence              6.93 ns         6.93 ns    100968924
ParallelFor_Overhead_GlobalFence                   16.4 ns         16.4 ns     42376065
ParallelFor_Overhead_Full                          39.3 ns         39.3 ns     17786570
```