### PR TITLE
Cuda+Clang+RDC: Skip test that yields internal compiler errors

### DIFF
--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1952,6 +1952,11 @@ struct TestNextAfterHalf {
 };
 
 TEST(TEST_CATEGORY, mathematical_functions_nextafter_fp16) {
+#if defined(KOKKOS_ENABLE_CUDA) &&                         \
+    defined(KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE) && \
+    defined(KOKKOS_COMPILER_CLANG)
+  GTEST_SKIP() << "FIXME internal compiler error for Clang+Cuda and RDC";
+#else
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC)
   GTEST_SKIP() << "FIXME MSVC nextafter for half precision "
                   "not implemented yet";
@@ -1966,6 +1971,7 @@ TEST(TEST_CATEGORY, mathematical_functions_nextafter_fp16) {
   TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t>();
 #endif
   if (skipped) GTEST_SKIP() << "no 16-bit floating-point precision support";
+#endif
 #endif
 }
 #endif


### PR DESCRIPTION
This fixes the CUDA-12.5.1-Clang-17-RDC jenkins CI. We merged the test in https://github.com/kokkos/kokkos/pull/8118.