### PR TITLE
Fix scripts/apply-clang-format

### DIFF
--- a/scripts/apply-clang-format
+++ b/scripts/apply-clang-format
@@ -30,7 +30,8 @@ TRACKED_FILES="$(git ls-files)"
 
 echo "***   Running clang-format"
 find ${TRACKED_FILES} \
-  -type f -name '*.cpp' -o -name '*.hpp' -o -name '*.cc' -o -name '*.h' -exec ${CLANG_FORMAT_EXECUTABLE} -i {} \;
+  -type f -name '*.cpp' -o -name '*.hpp' -o -name '*.cc' -o -name '*.h' |
+  ${CLANG_FORMAT_EXECUTABLE} -i --files=/dev/stdin
 echo "***   Running clang-format - done"
 
 # Now also check for trailing whitspace. Mac OSX creates backup files

--- a/scripts/apply-clang-format
+++ b/scripts/apply-clang-format
@@ -39,7 +39,7 @@ echo "***   Running clang-format - done"
 echo "***   Running whitespace check"
 TRACKED_FILES="$(git ls-tree HEAD --name-only)"
 find ${TRACKED_FILES} \
-  -type f \( -name "*.md" -o -name "*.cc" -o -name "*.h" -o -name "*.txt" -o -name "*.cmake" \) -exec bash -c "sed -i -e 's/\s\+$//g' {} && rm -f '{}-e'" \;
+  -type f \( -name "*.md" -o -name "*.cc" -o -name "*.h" -o -name "*.txt" -o -name "*.cmake" \) -exec bash -c "sed -i -e 's/[[:space:]]*$//g' {} && rm -f '{}-e'" \;
 echo "***   Running whitespace check - done"
 
 # Check that we do not introduce any file with the old copyright


### PR DESCRIPTION
#8203 broke `apply-clang-format` in that it returns immediately and doesn't fix any formatting. This pull request proposes a different solution that just hands all the files to `clang-format`.