### PR TITLE
Update NERSC gitlab-ci file.

### DIFF
--- a/.gitlab/nersc-gitlab-ci.yml
+++ b/.gitlab/nersc-gitlab-ci.yml
@@ -13,10 +13,9 @@ default:
     - fi
     - cd ${SOURCE_DIR} && pwd && git pull && git branch
     - export CMAKE_BUILD_PARALLEL_LEVEL=32
-    - export ENV_CMAKE_OPTIONS=""
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_TESTS=ON"
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Werror=all-warnings -Werror'"
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_COMPILER_WARNINGS=ON"
+    - export ENV_KOKKOS_OPTIONS=""
+    - export ENV_KOKKOS_OPTIONS="${ENV_KOKKOS_OPTIONS};-DKokkos_ENABLE_TESTS=ON"
+    - export ENV_KOKKOS_OPTIONS="${ENV_KOKKOS_OPTIONS};-DKokkos_ENABLE_COMPILER_WARNINGS=ON"
     - export SCRIPT_FILE=${SOURCE_DIR}/scripts/CTestRun.cmake
     - export OMP_NUM_THREADS=4
     - export OMP_PROC_BIND=spread
@@ -28,6 +27,8 @@ EPYC-OMP-gcc:
     - echo "Kokkos-OpenMP tests by $GITLAB_USER_LOGIN using gcc."
     - module load PrgEnv-gnu gcc/12.2.0
     - export BUILD_DIR=${SOURCE_DIR}/build_omp_gcc
+    - export ENV_CMAKE_OPTIONS="${ENV_KOKKOS_OPTIONS}"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='--all-warnings -Werror'"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DCMAKE_CXX_COMPILER=g++"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ARCH_ZEN3=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_OPENMP=ON"
@@ -39,6 +40,7 @@ A100-CUDA-nvcc:
     - echo "Kokkos-CUDA tests by $GITLAB_USER_LOGIN using nvcc."
     - module load PrgEnv-gnu gcc/12.2.0
     - export BUILD_DIR=${SOURCE_DIR}/build_cuda_nvcc
+    - export ENV_CMAKE_OPTIONS="${ENV_KOKKOS_OPTIONS}"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DCMAKE_CXX_COMPILER=${SOURCE_DIR}/bin/nvcc_wrapper"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ARCH_AMPERE80=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_CUDA=ON"
@@ -50,6 +52,7 @@ A100-CUDA-clang:
     - echo "Kokkos-CUDA tests by $GITLAB_USER_LOGIN using clang."
     - module load PrgEnv-llvm/1.0
     - export BUILD_DIR=${SOURCE_DIR}/build_cuda_clang
+    - export ENV_CMAKE_OPTIONS="${ENV_KOKKOS_OPTIONS}"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DCMAKE_CXX_COMPILER=clang++"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ARCH_AMPERE80=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_CUDA=ON"
@@ -59,24 +62,26 @@ EPYC-OMP-clang:
   stage: test
   script:
     - echo "Kokkos-OpenMP tests by $GITLAB_USER_LOGIN using clang."
-    - module load PrgEnv-llvm/1.0
+    - module load llvm/20.1.3
     - export BUILD_DIR=${SOURCE_DIR}/build_omp_clang
+    - export ENV_CMAKE_OPTIONS="${ENV_KOKKOS_OPTIONS}"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DCMAKE_CXX_COMPILER=clang++"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ARCH_ZEN3=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_OPENMP=ON"
-    - ctest -VV -D CDASH_MODEL="Nightly" -D CTEST_SITE="nersc" -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}" -S ${SCRIPT_FILE} -D CTEST_BUILD_NAME="AMD-EPYC-OpenMP-gcc/12.2"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Wno-unknown-cuda-version'"
+    - ctest -VV -D CDASH_MODEL="Nightly" -D CTEST_SITE="nersc" -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}" -S ${SCRIPT_FILE} -D CTEST_BUILD_NAME="AMD-EPYC-OpenMP-clang/20.1.3"
 
 A100-OpenMPTarget-clang:
   stage: test
   script:
     - echo "Kokkos-OpenMPTarget tests by $GITLAB_USER_LOGIN using clang."
-    - module load PrgEnv-llvm/1.0
+    - module load llvm/20.1.3
     - export BUILD_DIR=${SOURCE_DIR}/build_ompt_clang
+    - export ENV_CMAKE_OPTIONS="${ENV_KOKKOS_OPTIONS}"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DCMAKE_CXX_COMPILER=clang++"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ARCH_AMPERE80=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_OPENMPTARGET=ON"
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DCMAKE_CXX_FLAGS='-Wno-unknown-cuda-version -Wno-pass-failed'"
-    - ctest -VV -D CDASH_MODEL="Nightly" -D CTEST_SITE="nersc" -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}" -S ${SCRIPT_FILE} -D CTEST_BUILD_NAME="NVIDIA-A100-OpenMPTarget-clang/18"
+    - ctest -VV -D CDASH_MODEL="Nightly" -D CTEST_SITE="nersc" -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}" -S ${SCRIPT_FILE} -D CTEST_BUILD_NAME="NVIDIA-A100-OpenMPTarget-clang/20.1.3"
 
 clear-ci-builds:
   stage: clean_up

--- a/.gitlab/nersc-gitlab-ci.yml
+++ b/.gitlab/nersc-gitlab-ci.yml
@@ -28,7 +28,7 @@ EPYC-OMP-gcc:
     - module load PrgEnv-gnu gcc/12.2.0
     - export BUILD_DIR=${SOURCE_DIR}/build_omp_gcc
     - export ENV_CMAKE_OPTIONS="${ENV_KOKKOS_OPTIONS}"
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='--all-warnings -Werror'"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Werror'"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DCMAKE_CXX_COMPILER=g++"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ARCH_ZEN3=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_OPENMP=ON"


### PR DESCRIPTION
The PR updates NERSC's nightly gitlab-ci file. 
It does the following:
* Fix flags and separate gcc flags from clang flags
* Clear flags before each build
* Update llvm compiler version being used to the latest available on Perlmutter 