### PR TITLE
Ensure appropriate checks on subview specific View constructor

### DIFF
--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -950,18 +950,9 @@ class View : public ViewTraits<DataType, Properties...> {
                               Args... args)
       : m_track(src_view), m_map() {
     using SrcType = View<RT, RP...>;
-
     using Mapping = Kokkos::Impl::ViewMapping<void, typename SrcType::traits,
                                               Arg0, Args...>;
-
-    using DstType = typename Mapping::type;
-
-    static_assert(
-        Kokkos::Impl::ViewMapping<traits, typename DstType::traits,
-                                  typename traits::specialize>::is_assignable,
-        "Subview construction requires compatible view and subview arguments");
-
-    Mapping::assign(m_map, src_view.m_map, arg0, args...);
+    Mapping::assign(m_map, src_view.m_map, m_track.m_tracker, arg0, args...);
   }
 
   //----------------------------------------

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -952,7 +952,7 @@ class View : public ViewTraits<DataType, Properties...> {
     using SrcType = View<RT, RP...>;
     using Mapping = Kokkos::Impl::ViewMapping<void, typename SrcType::traits,
                                               Arg0, Args...>;
-    Mapping::assign(m_map, src_view.m_map, m_track.m_tracker, arg0, args...);
+    Mapping::assign(m_map, src_view.m_map, arg0, args...);
   }
 
   //----------------------------------------

--- a/core/src/View/Kokkos_ViewMapping.hpp
+++ b/core/src/View/Kokkos_ViewMapping.hpp
@@ -3312,13 +3312,15 @@ class ViewMapping<
   template <class DstTraits>
   KOKKOS_INLINE_FUNCTION static void assign(
       ViewMapping<DstTraits, void>& dst,
-      ViewMapping<SrcTraits, void> const& src,
-      Args... args) {
-    // Create ViewMapping based on traits_type, which was determined by this class.
-    // We cannot assume that aligned src memory implies the subview will be aligned,
-    // so remove aligned memory trait before mapping.
-    using traits_type_wo_align = typename apply<typename Impl::RemoveAlignedMemoryTrait<typename traits_type::memory_traits>::type::memory_traits>::traits_type;
-    using base_dst_type = ViewMapping<traits_type_wo_align, void>;
+      ViewMapping<SrcTraits, void> const& src, Args... args) {
+    // Create ViewMapping based on traits_type, which was determined by this
+    // class. We cannot assume that aligned src memory implies the subview will
+    // be aligned, so remove aligned memory trait before mapping.
+    using traits_type_wo_align =
+        typename apply<typename Impl::RemoveAlignedMemoryTrait<
+            typename traits_type::memory_traits>::type::memory_traits>::
+            traits_type;
+    using base_dst_type        = ViewMapping<traits_type_wo_align, void>;
     using base_dst_offset_type = typename base_dst_type::offset_type;
 
     base_dst_type base_dst;
@@ -3334,7 +3336,9 @@ class ViewMapping<
 
     // Map from base dst to dst requested.
     Kokkos::Impl::SharedAllocationTracker dummy_track;
-    ViewMapping<DstTraits, traits_type_wo_align, typename DstTraits::specialize>::assign(dst, base_dst, dummy_track);
+    ViewMapping<DstTraits, traits_type_wo_align,
+                typename DstTraits::specialize>::assign(dst, base_dst,
+                                                        dummy_track);
   }
 };
 

--- a/core/src/View/Kokkos_ViewMapping.hpp
+++ b/core/src/View/Kokkos_ViewMapping.hpp
@@ -3312,26 +3312,29 @@ class ViewMapping<
   template <class DstTraits>
   KOKKOS_INLINE_FUNCTION static void assign(
       ViewMapping<DstTraits, void>& dst,
-      ViewMapping<SrcTraits, void> const& src, Args... args) {
-    static_assert(ViewMapping<DstTraits, traits_type, void>::is_assignable,
-                  "Subview destination type must be compatible with subview "
-                  "derived type");
+      ViewMapping<SrcTraits, void> const& src,
+      const Kokkos::Impl::SharedAllocationTracker& src_track,
+      Args... args) {
+    // Create ViewMapping based on traits_type, which was determined by this class.
+    // We cannot assume that aligned src memory implies the subview will be aligned,
+    // so remove aligned memory trait before mapping.
+    using traits_type_wo_align = typename apply<typename Impl::RemoveAlignedMemoryTrait<typename traits_type::memory_traits>::type::memory_traits>::traits_type;
+    using base_dst_type = ViewMapping<traits_type_wo_align, void>;
+    using base_dst_offset_type = typename base_dst_type::offset_type;
 
-    using DstType = ViewMapping<DstTraits, void>;
-
-    using dst_offset_type = typename DstType::offset_type;
-
+    base_dst_type base_dst;
     const SubviewExtents<SrcTraits::rank, rank> extents(src.m_impl_offset.m_dim,
                                                         args...);
-
-    dst.m_impl_offset = dst_offset_type(src.m_impl_offset, extents);
-
-    dst.m_impl_handle = ViewDataHandle<DstTraits>::assign(
+    base_dst.m_impl_offset = base_dst_offset_type(src.m_impl_offset, extents);
+    base_dst.m_impl_handle = ViewDataHandle<traits_type_wo_align>::assign(
         src.m_impl_handle,
         src.m_impl_offset(extents.domain_offset(0), extents.domain_offset(1),
                           extents.domain_offset(2), extents.domain_offset(3),
                           extents.domain_offset(4), extents.domain_offset(5),
                           extents.domain_offset(6), extents.domain_offset(7)));
+
+    // Map from base dst to dst requested.
+    ViewMapping<DstTraits, traits_type_wo_align, typename DstTraits::specialize>::assign(dst, base_dst, src_track);
   }
 };
 

--- a/core/src/View/Kokkos_ViewMapping.hpp
+++ b/core/src/View/Kokkos_ViewMapping.hpp
@@ -3313,7 +3313,6 @@ class ViewMapping<
   KOKKOS_INLINE_FUNCTION static void assign(
       ViewMapping<DstTraits, void>& dst,
       ViewMapping<SrcTraits, void> const& src,
-      const Kokkos::Impl::SharedAllocationTracker& src_track,
       Args... args) {
     // Create ViewMapping based on traits_type, which was determined by this class.
     // We cannot assume that aligned src memory implies the subview will be aligned,
@@ -3334,7 +3333,8 @@ class ViewMapping<
                           extents.domain_offset(6), extents.domain_offset(7)));
 
     // Map from base dst to dst requested.
-    ViewMapping<DstTraits, traits_type_wo_align, typename DstTraits::specialize>::assign(dst, base_dst, src_track);
+    Kokkos::Impl::SharedAllocationTracker dummy_track;
+    ViewMapping<DstTraits, traits_type_wo_align, typename DstTraits::specialize>::assign(dst, base_dst, dummy_track);
   }
 };
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -342,7 +342,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
     endforeach()
 
     set(${Tag}_SOURCES2D)
-    foreach(Name SubView_c10 SubView_c11 SubView_c12 SubView_c13 SubView_c14)
+    foreach(Name SubView_c10 SubView_c11 SubView_c12 SubView_c13 SubView_c14 SubView_c15)
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.

--- a/core/unit_test/TestSubView_c15.hpp
+++ b/core/unit_test/TestSubView_c15.hpp
@@ -14,13 +14,10 @@
 //
 //@HEADER
 
-#ifndef KOKKOS_TEST_SUBVIEW_C15_HPP
-#define KOKKOS_TEST_SUBVIEW_C15_HPP
-
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
 
-namespace Test {
+namespace {
 
 TEST(TEST_CATEGORY_DEATH, subview_constructor_types) {
   int N    = 10;
@@ -47,5 +44,4 @@ TEST(TEST_CATEGORY_DEATH, subview_constructor_types) {
     ASSERT_DEATH(((void)Kokkos::View<int*, LR>(a, 1, Kokkos::ALL)), msg);
   }
 }
-}  // namespace Test
-#endif
+}  // namespace

--- a/core/unit_test/TestSubView_c15.hpp
+++ b/core/unit_test/TestSubView_c15.hpp
@@ -16,13 +16,34 @@
 
 #ifndef KOKKOS_TEST_SUBVIEW_C15_HPP
 #define KOKKOS_TEST_SUBVIEW_C15_HPP
-#include <TestViewSubview.hpp>
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
 
 namespace Test {
 
 TEST(TEST_CATEGORY_DEATH, subview_constructor_types) {
-  TestViewSubview::test_subview_constructor_types();
-}
+  int N=10;
+  using LR = Kokkos::LayoutRight;
+  using LL = Kokkos::LayoutLeft;
+  using LS = Kokkos::LayoutStride;
 
+  Kokkos::View<int**, LL> a("A",N,N);
+  {
+    // Using subview dims (ALL, 1). For a LayoutLeft,
+    // any view layout is appropriate.
+    (void)Kokkos::View<int*, LL>(a, Kokkos::ALL, 1);
+    (void)Kokkos::View<int*, LS>(a, Kokkos::ALL, 1);
+    //(void)Kokkos::View<int*, LR>(a, Kokkos::ALL, 1); // FIXME: This doesn't compile for BasicView?
+  }
+  {
+    // Using subview dims (1, ALL). For a LayoutLeft,
+    // resutling subview must be strided.
+    const std::string msg = "View assignment must have compatible layouts";
+    ASSERT_DEATH(((void)Kokkos::View<int*, LL>(a, 1, Kokkos::ALL)), msg);
+    (void)Kokkos::View<int*, LS>(a, 1, Kokkos::ALL);
+    ASSERT_DEATH(((void)Kokkos::View<int*, LR>(a, 1, Kokkos::ALL)), msg);
+  }
+}
 }  // namespace Test
 #endif

--- a/core/unit_test/TestSubView_c15.hpp
+++ b/core/unit_test/TestSubView_c15.hpp
@@ -19,29 +19,40 @@
 
 namespace {
 
-TEST(TEST_CATEGORY_DEATH, subview_constructor_types) {
+TEST(TEST_CATEGORY_DEATH, view_subview_constructor_layout_compatibility) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
   int N    = 10;
   using LR = Kokkos::LayoutRight;
   using LL = Kokkos::LayoutLeft;
   using LS = Kokkos::LayoutStride;
 
-  Kokkos::View<int**, LL> a("A", N, N);
+  Kokkos::View<int**, LL> a1("A1", N, N);
   {
     // Using subview dims (ALL, 1). For a LayoutLeft,
-    // any view layout is appropriate.
-    (void)Kokkos::View<int*, LL>(a, Kokkos::ALL, 1);
-    (void)Kokkos::View<int*, LS>(a, Kokkos::ALL, 1);
+    // any subview layout should be appropriate.
+    (void)Kokkos::View<int*, LL>(a1, Kokkos::ALL, 1);
+    (void)Kokkos::View<int*, LS>(a1, Kokkos::ALL, 1);
 
-    // FIXME: This doesn't compile for BasicView?
+    // FIXME: This doesn't compile for BasicView, but should
     //(void)Kokkos::View<int*, LR>(a, Kokkos::ALL, 1);
   }
   {
     // Using subview dims (1, ALL). For a LayoutLeft,
     // resutling subview must be strided.
     const std::string msg = "View assignment must have compatible layouts";
-    ASSERT_DEATH(((void)Kokkos::View<int*, LL>(a, 1, Kokkos::ALL)), msg);
-    (void)Kokkos::View<int*, LS>(a, 1, Kokkos::ALL);
-    ASSERT_DEATH(((void)Kokkos::View<int*, LR>(a, 1, Kokkos::ALL)), msg);
+    ASSERT_DEATH(((void)Kokkos::View<int*, LL>(a1, 1, Kokkos::ALL)), msg);
+    (void)Kokkos::View<int*, LS>(a1, 1, Kokkos::ALL);
+    ASSERT_DEATH(((void)Kokkos::View<int*, LR>(a1, 1, Kokkos::ALL)), msg);
+  }
+
+  Kokkos::View<int**, LL> a2("A2", 1, N);
+  {
+    // Using subview dims (1, ALL), but first dimension is stride 1. Any subview
+    // layout should be appropriate.
+    (void)Kokkos::View<int*, LL>(a2, 1, Kokkos::ALL);
+    (void)Kokkos::View<int*, LS>(a2, 1, Kokkos::ALL);
+    (void)Kokkos::View<int*, LR>(a2, 1, Kokkos::ALL);
   }
 }
 }  // namespace

--- a/core/unit_test/TestSubView_c15.hpp
+++ b/core/unit_test/TestSubView_c15.hpp
@@ -39,7 +39,7 @@ TEST(TEST_CATEGORY_DEATH, view_subview_constructor_layout_compatibility) {
   }
   {
     // Using subview dims (1, ALL). For a LayoutLeft,
-    // resutling subview must be strided.
+    // resulting subview must be strided.
     const std::string msg = "View assignment must have compatible layouts";
     ASSERT_DEATH(((void)Kokkos::View<int*, LL>(a1, 1, Kokkos::ALL)), msg);
     (void)Kokkos::View<int*, LS>(a1, 1, Kokkos::ALL);

--- a/core/unit_test/TestSubView_c15.hpp
+++ b/core/unit_test/TestSubView_c15.hpp
@@ -48,7 +48,7 @@ TEST(TEST_CATEGORY_DEATH, view_subview_constructor_layout_compatibility) {
 
   Kokkos::View<int**, LL> a2("A2", 1, N);
   {
-    // Using subview dims (1, ALL), but first dimension is stride 1. Any subview
+    // Using subview dims (1, ALL), but the first dimension is stride 1. Any subview
     // layout should be appropriate.
     (void)Kokkos::View<int*, LL>(a2, 1, Kokkos::ALL);
     (void)Kokkos::View<int*, LS>(a2, 1, Kokkos::ALL);

--- a/core/unit_test/TestSubView_c15.hpp
+++ b/core/unit_test/TestSubView_c15.hpp
@@ -48,8 +48,8 @@ TEST(TEST_CATEGORY_DEATH, view_subview_constructor_layout_compatibility) {
 
   Kokkos::View<int**, LL> a2("A2", 1, N);
   {
-    // Using subview dims (1, ALL), but the first dimension is stride 1. Any subview
-    // layout should be appropriate.
+    // Using subview dims (1, ALL), but the first dimension is stride 1. Any
+    // subview layout should be appropriate.
     (void)Kokkos::View<int*, LL>(a2, 1, Kokkos::ALL);
     (void)Kokkos::View<int*, LS>(a2, 1, Kokkos::ALL);
     (void)Kokkos::View<int*, LR>(a2, 1, Kokkos::ALL);

--- a/core/unit_test/TestSubView_c15.hpp
+++ b/core/unit_test/TestSubView_c15.hpp
@@ -1,0 +1,28 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_TEST_SUBVIEW_C15_HPP
+#define KOKKOS_TEST_SUBVIEW_C15_HPP
+#include <TestViewSubview.hpp>
+
+namespace Test {
+
+TEST(TEST_CATEGORY_DEATH, subview_constructor_types) {
+  TestViewSubview::test_subview_constructor_types();
+}
+
+}  // namespace Test
+#endif

--- a/core/unit_test/TestSubView_c15.hpp
+++ b/core/unit_test/TestSubView_c15.hpp
@@ -23,18 +23,20 @@
 namespace Test {
 
 TEST(TEST_CATEGORY_DEATH, subview_constructor_types) {
-  int N=10;
+  int N    = 10;
   using LR = Kokkos::LayoutRight;
   using LL = Kokkos::LayoutLeft;
   using LS = Kokkos::LayoutStride;
 
-  Kokkos::View<int**, LL> a("A",N,N);
+  Kokkos::View<int**, LL> a("A", N, N);
   {
     // Using subview dims (ALL, 1). For a LayoutLeft,
     // any view layout is appropriate.
     (void)Kokkos::View<int*, LL>(a, Kokkos::ALL, 1);
     (void)Kokkos::View<int*, LS>(a, Kokkos::ALL, 1);
-    //(void)Kokkos::View<int*, LR>(a, Kokkos::ALL, 1); // FIXME: This doesn't compile for BasicView?
+
+    // FIXME: This doesn't compile for BasicView?
+    //(void)Kokkos::View<int*, LR>(a, Kokkos::ALL, 1);
   }
   {
     // Using subview dims (1, ALL). For a LayoutLeft,

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -2332,7 +2332,7 @@ inline void test_subview_constructor_types() {
     // any view layout is appropriate.
     (void)Kokkos::View<int*, LL>(a, Kokkos::ALL, 1);
     (void)Kokkos::View<int*, LS>(a, Kokkos::ALL, 1);
-    (void)Kokkos::View<int*, LR>(a, Kokkos::ALL, 1);
+    //(void)Kokkos::View<int*, LR>(a, Kokkos::ALL, 1); // FIXME: This doesn't compile for BasicView?
   }
   {
     // Using subview dims (1, ALL). For a LayoutLeft,

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -2320,30 +2320,6 @@ struct TestExtentsStaticTests {
       typename Kokkos::Impl::ParseViewExtents<double>::type>::type;
 };
 
-inline void test_subview_constructor_types() {
-  int N=10;
-  using LR = Kokkos::LayoutRight;
-  using LL = Kokkos::LayoutLeft;
-  using LS = Kokkos::LayoutStride;
-
-  Kokkos::View<int**, LL> a("A",N,N);
-  {
-    // Using subview dims (ALL, 1). For a LayoutLeft,
-    // any view layout is appropriate.
-    (void)Kokkos::View<int*, LL>(a, Kokkos::ALL, 1);
-    (void)Kokkos::View<int*, LS>(a, Kokkos::ALL, 1);
-    //(void)Kokkos::View<int*, LR>(a, Kokkos::ALL, 1); // FIXME: This doesn't compile for BasicView?
-  }
-  {
-    // Using subview dims (1, ALL). For a LayoutLeft,
-    // resutling subview must be strided.
-    const std::string msg = "View assignment must have compatible layouts";
-    ASSERT_DEATH(((void)Kokkos::View<int*, LL>(a, 1, Kokkos::ALL)), msg);
-    (void)Kokkos::View<int*, LS>(a, 1, Kokkos::ALL);
-    ASSERT_DEATH(((void)Kokkos::View<int*, LR>(a, 1, Kokkos::ALL)), msg);
-  }
-}
-
 }  // namespace TestViewSubview
 
 #endif

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -2320,6 +2320,30 @@ struct TestExtentsStaticTests {
       typename Kokkos::Impl::ParseViewExtents<double>::type>::type;
 };
 
+inline void test_subview_constructor_types() {
+  int N=10;
+  using LR = Kokkos::LayoutRight;
+  using LL = Kokkos::LayoutLeft;
+  using LS = Kokkos::LayoutStride;
+
+  Kokkos::View<int**, LL> a("A",N,N);
+  {
+    // Using subview dims (ALL, 1). For a LayoutLeft,
+    // any view layout is appropriate.
+    (void)Kokkos::View<int*, LL>(a, Kokkos::ALL, 1);
+    (void)Kokkos::View<int*, LS>(a, Kokkos::ALL, 1);
+    (void)Kokkos::View<int*, LR>(a, Kokkos::ALL, 1);
+  }
+  {
+    // Using subview dims (1, ALL). For a LayoutLeft,
+    // resutling subview must be strided.
+    const std::string msg = "View assignment must have compatible layouts";
+    ASSERT_DEATH(((void)Kokkos::View<int*, LL>(a, 1, Kokkos::ALL)), msg);
+    (void)Kokkos::View<int*, LS>(a, 1, Kokkos::ALL);
+    ASSERT_DEATH(((void)Kokkos::View<int*, LR>(a, 1, Kokkos::ALL)), msg);
+  }
+}
+
 }  // namespace TestViewSubview
 
 #endif


### PR DESCRIPTION
Addresses https://github.com/kokkos/kokkos/issues/7735 for `Kokkos_ENABLE_IMPL_VIEW_LEGACY=ON`. For MDSpan impl, we still get an erroneous build error.

Internally in the subview specification for `ViewMapping`, map subview to `traits_type` (subview type presumed by `ViewMapping`), then map that to the `DstTraits` requested by the `View` constructor. This allows for all proper checks to be run on the `DstTraits` type to ensure no illegal subview types are being requested by the user.

Previously, we blindly mapped to `DstTraits` with no layout checking, which resulted in strided subviews being assigned to non-stided layouts. Also, there were cases where subviews were not strided, but internal build errors stopped appropriate types from being assigned (e.g., LayoutLeft 2d view, subviewed along dim0 (contig.), did not allow assignment to LayoutRight 1d view).

Added a test for the situations above.

Note: We cannot simply deprecate the subview constructor as suggested in the issue, since this is what `Kokkos::subview()` uses to return the subview.