### PR TITLE
Complex operators improved

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -258,7 +258,7 @@ class
       this->im_ /= s;
     } else {
       const complex x_scaled(this->re_ / s, this->im_ / s);
-      const complex y_conj_scaled(y.re_ / s, -(y.im_) / s);
+      const complex y_conj_scaled(y.real() / s, -(y.imag()) / s);
       const RealType y_scaled_abs =
           y_conj_scaled.re_ * y_conj_scaled.re_ +
           y_conj_scaled.im_ * y_conj_scaled.im_;  // abs(y) == abs(conj(y))

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -451,6 +451,16 @@ class
     return complex(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
                    lhs.real() * rhs.imag() + lhs.imag() * rhs.real());
   }
+
+  KOKKOS_FUNCTION friend constexpr complex operator/(
+      const complex& lhs, const std::complex<RealType>& rhs) {
+    return lhs / complex(rhs);
+  }
+
+  KOKKOS_FUNCTION friend constexpr complex operator/(
+      const std::complex<RealType>& lhs, const complex& rhs) {
+    return complex(lhs) / rhs;
+  }
 };
 
 }  // namespace Kokkos
@@ -1082,21 +1092,70 @@ inline complex<RealType> exp(const std::complex<RealType>& c) {
                            std::exp(c.real()) * std::sin(c.imag()));
 }
 
+//! Binary operator / for complex.
+//      Returns: complex<T>(lhs) /= rhs
+//
+//  Note: not constexpr until C++23 (because fabs is not constexpr until C++23)
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator/(const complex<T>& lhs,
+                                               const complex<T>& rhs) {
+  // Scale (by the "1-norm" of rhs) to avoid unwarranted overflow.
+  // If the real part is +/-Inf and the imaginary part is -/+Inf,
+  // this won't change the result.
+  const T s = fabs(real(rhs)) + fabs(imag(rhs));
+
+  // If s is 0, then rhs is zero, so lhs/rhs == real(lhs)/0 + i*imag(lhs)/0.
+  // In that case, the relation lhs/rhs == (lhs/s) / (rhs/s) doesn't hold,
+  // because rhs/s is NaN.
+  if (s == 0.0) {
+    return complex<T>(real(lhs) / s, imag(lhs) / s);
+  } else {
+    const complex<T> lhs_scaled(real(lhs) / s, imag(lhs) / s);
+    const complex<T> rhs_conj_scaled(real(rhs) / s, -imag(rhs) / s);
+    const T rhs_scaled_abs =
+        real(rhs_conj_scaled) * real(rhs_conj_scaled) +
+        imag(rhs_conj_scaled) *
+            imag(rhs_conj_scaled);  // abs(rhs) == abs(conj(rhs))
+    complex<T> result = lhs_scaled * rhs_conj_scaled;
+    result /= rhs_scaled_abs;
+    return result;
+  }
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator/(const complex<T>& lhs,
+                                               const T& rhs) {
+  return complex<T>(real(lhs) / rhs, imag(lhs) / rhs);
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator/(const T& lhs,
+                                               const complex<T>& rhs) {
+  return complex<T>(lhs) / rhs;
+}
+
 //! Binary operator / for complex and real numbers
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator/(const complex<RealType1>& x,
-          const RealType2& y) noexcept(noexcept(RealType1{} / RealType2{})) {
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator/(const complex<RealType1>& x,
+              const RealType2& y) noexcept(noexcept(RealType1{} /
+                                                    RealType2{})) {
   return complex<std::common_type_t<RealType1, RealType2>>(real(x) / y,
                                                            imag(x) / y);
 }
 
 //! Binary operator / for complex.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator/(const complex<RealType1>& x,
-          const complex<RealType2>& y) noexcept(noexcept(RealType1{} /
-                                                         RealType2{})) {
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator/(const complex<RealType1>& x,
+              const complex<RealType2>& y) noexcept(noexcept(RealType1{} /
+                                                             RealType2{})) {
   // Scale (by the "1-norm" of y) to avoid unwarranted overflow.
   // If the real part is +/-Inf and the imaginary part is -/+Inf,
   // this won't change the result.
@@ -1121,11 +1180,14 @@ operator/(const complex<RealType1>& x,
 }
 
 //! Binary operator / for complex and real numbers
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator/(const RealType1& x,
-          const complex<RealType2>& y) noexcept(noexcept(RealType1{} /
-                                                         RealType2{})) {
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator/(const RealType1& x,
+              const complex<RealType2>& y) noexcept(noexcept(RealType1{} /
+                                                             RealType2{})) {
   return complex<std::common_type_t<RealType1, RealType2>>(x) / y;
 }
 

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -12,6 +12,7 @@
 #include <Kokkos_NumericTraits.hpp>
 #include <Kokkos_ReductionIdentity.hpp>
 #include <impl/Kokkos_Error.hpp>
+#include <impl/Kokkos_Utilities.hpp>
 #include <complex>
 #include <type_traits>
 #include <iosfwd>

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -430,6 +430,16 @@ class
     return complex(lhs.real() + rhs.real(), lhs.imag() + rhs.imag());
   }
 
+  KOKKOS_FUNCTION friend constexpr complex operator-(
+      const complex& lhs, const std::complex<RealType>& rhs) {
+    return complex(lhs.real() - rhs.real(), lhs.imag() - rhs.imag());
+  }
+
+  KOKKOS_FUNCTION friend constexpr complex operator-(
+      const std::complex<RealType>& lhs, const complex& rhs) {
+    return complex(lhs.real() - rhs.real(), lhs.imag() - rhs.imag());
+  }
+
   KOKKOS_FUNCTION friend constexpr complex operator*(
       const complex& lhs, const std::complex<RealType>& rhs) {
     return complex(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
@@ -677,25 +687,55 @@ KOKKOS_INLINE_FUNCTION complex<RealType> operator+(
 }
 
 //! Binary - operator for complex.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator-(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
+//      Returns: complex<T>(lhs) -= rhs
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator-(const complex<T>& lhs,
+                                               const complex<T>& rhs) {
+  return complex<T>(lhs.real() - rhs.real(), lhs.imag() - rhs.imag());
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator-(const complex<T>& lhs,
+                                               const T& rhs) {
+  return complex<T>(lhs.real() - rhs, lhs.imag());
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator-(const T& lhs,
+                                               const complex<T>& rhs) {
+  return complex<T>(lhs - rhs.real(), -rhs.imag());
+}
+
+//! Binary - operator for complex.
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator-(const complex<RealType1>& x,
+              const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x.real() - y.real(),
                                                            x.imag() - y.imag());
 }
 
 //! Binary - operator for complex scalar.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator-(const complex<RealType1>& x, const RealType2& y) noexcept {
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator-(const complex<RealType1>& x, const RealType2& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x.real() - y,
                                                            x.imag());
 }
 
 //! Binary - operator for scalar complex.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator-(const RealType1& x, const complex<RealType2>& y) noexcept {
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator-(const RealType1& x, const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x - y.real(),
                                                            -y.imag());
 }

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -414,6 +414,18 @@ class
     im_ *= src;
   }
 #endif  // KOKKOS_ENABLE_DEPRECATED_CODE_4
+
+  KOKKOS_FUNCTION friend constexpr complex operator*(
+      const complex& lhs, const std::complex<RealType>& rhs) {
+    return complex(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
+                   lhs.real() * rhs.imag() + lhs.imag() * rhs.real());
+  }
+
+  KOKKOS_FUNCTION friend constexpr complex operator*(
+      const std::complex<RealType>& lhs, const complex& rhs) {
+    return complex(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
+                   lhs.real() * rhs.imag() + lhs.imag() * rhs.real());
+  }
 };
 
 }  // namespace Kokkos
@@ -652,35 +664,21 @@ KOKKOS_INLINE_FUNCTION complex<RealType> operator-(
 //! Binary * operator for complex.
 //      Returns: complex<T>(lhs) *= rhs.
 template <class T>
-KOKKOS_INLINE_FUNCTION constexpr complex<T> operator*(
-    const complex<T>& lhs, const std::complex<T>& rhs) {
+KOKKOS_FUNCTION constexpr complex<T> operator*(const complex<T>& lhs,
+                                               const complex<T>& rhs) {
   return complex<T>(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
                     lhs.real() * rhs.imag() + lhs.imag() * rhs.real());
 }
 
 template <class T>
-KOKKOS_INLINE_FUNCTION constexpr complex<T> operator*(
-    const std::complex<T>& lhs, const complex<T>& rhs) {
-  return complex<T>(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
-                    lhs.real() * rhs.imag() + lhs.imag() * rhs.real());
-}
-
-template <class T>
-KOKKOS_INLINE_FUNCTION constexpr complex<T> operator*(const complex<T>& lhs,
-                                                      const complex<T>& rhs) {
-  return complex<T>(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
-                    lhs.real() * rhs.imag() + lhs.imag() * rhs.real());
-}
-
-template <class T>
-KOKKOS_INLINE_FUNCTION constexpr complex<T> operator*(const complex<T>& lhs,
-                                                      const T& rhs) {
+KOKKOS_FUNCTION constexpr complex<T> operator*(const complex<T>& lhs,
+                                               const T& rhs) {
   return complex<T>(lhs.real() * rhs, lhs.imag() * rhs);
 }
 
 template <class T>
-KOKKOS_INLINE_FUNCTION constexpr complex<T> operator*(const T& lhs,
-                                                      const complex<T>& rhs) {
+KOKKOS_FUNCTION constexpr complex<T> operator*(const T& lhs,
+                                               const complex<T>& rhs) {
   return complex<T>(lhs * rhs.real(), lhs * rhs.imag());
 }
 

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -415,6 +415,21 @@ class
   }
 #endif  // KOKKOS_ENABLE_DEPRECATED_CODE_4
 
+  // Operators for mixed operations involving std::complex and Kokkos::complex
+  //
+  // These can be hidden friends because they are not specified by the C++
+  // standard.
+
+  KOKKOS_FUNCTION friend constexpr complex operator+(
+      const complex& lhs, const std::complex<RealType>& rhs) {
+    return complex(lhs.real() + rhs.real(), lhs.imag() + rhs.imag());
+  }
+
+  KOKKOS_FUNCTION friend constexpr complex operator+(
+      const std::complex<RealType>& lhs, const complex& rhs) {
+    return complex(lhs.real() + rhs.real(), lhs.imag() + rhs.imag());
+  }
+
   KOKKOS_FUNCTION friend constexpr complex operator*(
       const complex& lhs, const std::complex<RealType>& rhs) {
     return complex(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
@@ -600,25 +615,56 @@ KOKKOS_INLINE_FUNCTION constexpr bool operator!=(
 //==============================================================================
 
 //! Binary + operator for complex complex.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator+(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
+//      Returns: complex<T>(lhs) == rhs
+
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator+(const complex<T>& lhs,
+                                               const complex<T>& rhs) {
+  return complex<T>(lhs.real() + rhs.real(), lhs.imag() + rhs.imag());
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator+(const complex<T>& lhs,
+                                               const T& rhs) {
+  return complex<T>(lhs.real() + rhs, lhs.imag());
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator+(const T& lhs,
+                                               const complex<T>& rhs) {
+  return complex<T>(lhs + rhs.real(), rhs.imag());
+}
+
+//! Binary + operator for complex complex.
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator+(const complex<RealType1>& x,
+              const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x.real() + y.real(),
                                                            x.imag() + y.imag());
 }
 
 //! Binary + operator for complex scalar.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator+(const complex<RealType1>& x, const RealType2& y) noexcept {
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator+(const complex<RealType1>& x, const RealType2& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x.real() + y,
                                                            x.imag());
 }
 
 //! Binary + operator for scalar complex.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator+(const RealType1& x, const complex<RealType2>& y) noexcept {
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator+(const RealType1& x, const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x + y.real(),
                                                            y.imag());
 }
@@ -685,7 +731,7 @@ KOKKOS_FUNCTION constexpr complex<T> operator*(const T& lhs,
 template <class RealType1, class RealType2,
           class = std::enable_if_t<Impl::is_noncv_floating_point_v<
               std::common_type_t<RealType1, RealType2>>>>
-KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
     complex<std::common_type_t<RealType1, RealType2>>
     operator*(const complex<RealType1>& x,
               const complex<RealType2>& y) noexcept {
@@ -719,7 +765,7 @@ KOKKOS_DEPRECATED complex<std::common_type_t<RealType1, RealType2>> operator*(
 template <class RealType1, class RealType2,
           class = std::enable_if_t<Impl::is_noncv_floating_point_v<
               std::common_type_t<RealType1, RealType2>>>>
-KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
     complex<std::common_type_t<RealType1, RealType2>>
     operator*(const RealType1& x, const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x * y.real(),
@@ -733,7 +779,7 @@ KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION
 template <class RealType1, class RealType2,
           class = std::enable_if_t<Impl::is_noncv_floating_point_v<
               std::common_type_t<RealType1, RealType2>>>>
-KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
     complex<std::common_type_t<RealType1, RealType2>>
     operator*(const complex<RealType1>& y, const RealType2& x) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x * y.real(),

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -155,6 +155,16 @@ class
     return *this;
   }
 
+  KOKKOS_FUNCTION friend constexpr complex& operator+=(
+      complex& lhs, const std::complex<RealType>& rhs) {
+    return lhs = lhs + rhs;
+  }
+
+  KOKKOS_FUNCTION friend constexpr std::complex<RealType>& operator+=(
+      std::complex<RealType>& lhs, const complex& rhs) {
+    return lhs = lhs + rhs;
+  }
+
   constexpr KOKKOS_INLINE_FUNCTION complex& operator-=(
       const complex<RealType>& src) noexcept {
     re_ -= src.re_;
@@ -166,6 +176,16 @@ class
       const RealType& src) noexcept {
     re_ -= src;
     return *this;
+  }
+
+  KOKKOS_FUNCTION friend constexpr complex& operator-=(
+      complex& lhs, const std::complex<RealType>& rhs) {
+    return lhs = lhs - rhs;
+  }
+
+  KOKKOS_FUNCTION friend constexpr std::complex<RealType>& operator-=(
+      std::complex<RealType>& lhs, const complex& rhs) {
+    return lhs = lhs - rhs;
   }
 
   constexpr KOKKOS_INLINE_FUNCTION complex& operator*=(
@@ -182,6 +202,16 @@ class
     re_ *= src;
     im_ *= src;
     return *this;
+  }
+
+  KOKKOS_FUNCTION friend constexpr complex& operator*=(
+      complex& lhs, const std::complex<RealType>& rhs) {
+    return lhs = lhs * rhs;
+  }
+
+  KOKKOS_FUNCTION friend constexpr std::complex<RealType>& operator*=(
+      std::complex<RealType>& lhs, const complex& rhs) {
+    return lhs = lhs * rhs;
   }
 
   // Conditional noexcept, just in case RType throws on divide-by-zero
@@ -235,6 +265,11 @@ class
       *this /= y_scaled_abs;
     }
     return *this;
+  }
+
+  KOKKOS_FUNCTION friend constexpr std::complex<RealType>& operator/=(
+      std::complex<RealType>& lhs, const complex& rhs) {
+    return lhs = lhs / rhs;
   }
 
   constexpr KOKKOS_INLINE_FUNCTION complex& operator/=(

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -727,7 +727,7 @@ KOKKOS_DEPRECATED KOKKOS_FUNCTION bool operator!=(
 //==============================================================================
 
 //! Binary + operator for complex complex.
-//      Returns: complex<T>(lhs) == rhs
+//      Returns: complex<T>(lhs) += rhs
 
 template <class T>
 KOKKOS_FUNCTION constexpr complex<T> operator+(const complex<T>& lhs,
@@ -750,7 +750,7 @@ KOKKOS_FUNCTION constexpr complex<T> operator+(const T& lhs,
 //! Binary + operator for complex complex.
 template <class RealType1, class RealType2,
           class = std::enable_if_t<Impl::is_noncv_floating_point_v<
-              std::common_type<RealType1, RealType2>>>>
+              std::common_type_t<RealType1, RealType2>>>>
 KOKKOS_DEPRECATED KOKKOS_FUNCTION
     complex<std::common_type_t<RealType1, RealType2>>
     operator+(const complex<RealType1>& x,
@@ -762,7 +762,7 @@ KOKKOS_DEPRECATED KOKKOS_FUNCTION
 //! Binary + operator for complex scalar.
 template <class RealType1, class RealType2,
           class = std::enable_if_t<Impl::is_noncv_floating_point_v<
-              std::common_type<RealType1, RealType2>>>>
+              std::common_type_t<RealType1, RealType2>>>>
 KOKKOS_DEPRECATED KOKKOS_FUNCTION
     complex<std::common_type_t<RealType1, RealType2>>
     operator+(const complex<RealType1>& x, const RealType2& y) noexcept {
@@ -773,7 +773,7 @@ KOKKOS_DEPRECATED KOKKOS_FUNCTION
 //! Binary + operator for scalar complex.
 template <class RealType1, class RealType2,
           class = std::enable_if_t<Impl::is_noncv_floating_point_v<
-              std::common_type<RealType1, RealType2>>>>
+              std::common_type_t<RealType1, RealType2>>>>
 KOKKOS_DEPRECATED KOKKOS_FUNCTION
     complex<std::common_type_t<RealType1, RealType2>>
     operator+(const RealType1& x, const complex<RealType2>& y) noexcept {
@@ -811,7 +811,7 @@ KOKKOS_FUNCTION constexpr complex<T> operator-(const T& lhs,
 //! Binary - operator for complex.
 template <class RealType1, class RealType2,
           class = std::enable_if_t<Impl::is_noncv_floating_point_v<
-              std::common_type<RealType1, RealType2>>>>
+              std::common_type_t<RealType1, RealType2>>>>
 KOKKOS_DEPRECATED KOKKOS_FUNCTION
     complex<std::common_type_t<RealType1, RealType2>>
     operator-(const complex<RealType1>& x,
@@ -823,7 +823,7 @@ KOKKOS_DEPRECATED KOKKOS_FUNCTION
 //! Binary - operator for complex scalar.
 template <class RealType1, class RealType2,
           class = std::enable_if_t<Impl::is_noncv_floating_point_v<
-              std::common_type<RealType1, RealType2>>>>
+              std::common_type_t<RealType1, RealType2>>>>
 KOKKOS_DEPRECATED KOKKOS_FUNCTION
     complex<std::common_type_t<RealType1, RealType2>>
     operator-(const complex<RealType1>& x, const RealType2& y) noexcept {
@@ -834,7 +834,7 @@ KOKKOS_DEPRECATED KOKKOS_FUNCTION
 //! Binary - operator for scalar complex.
 template <class RealType1, class RealType2,
           class = std::enable_if_t<Impl::is_noncv_floating_point_v<
-              std::common_type<RealType1, RealType2>>>>
+              std::common_type_t<RealType1, RealType2>>>>
 KOKKOS_DEPRECATED KOKKOS_FUNCTION
     complex<std::common_type_t<RealType1, RealType2>>
     operator-(const RealType1& x, const complex<RealType2>& y) noexcept {
@@ -1229,7 +1229,7 @@ KOKKOS_FUNCTION constexpr complex<T> operator/(const T& lhs,
 //! Binary operator / for complex and real numbers
 template <class RealType1, class RealType2,
           class = std::enable_if_t<Impl::is_noncv_floating_point_v<
-              std::common_type<RealType1, RealType2>>>>
+              std::common_type_t<RealType1, RealType2>>>>
 KOKKOS_DEPRECATED KOKKOS_FUNCTION
     complex<std::common_type_t<RealType1, RealType2>>
     operator/(const complex<RealType1>& x,
@@ -1242,7 +1242,7 @@ KOKKOS_DEPRECATED KOKKOS_FUNCTION
 //! Binary operator / for complex.
 template <class RealType1, class RealType2,
           class = std::enable_if_t<Impl::is_noncv_floating_point_v<
-              std::common_type<RealType1, RealType2>>>>
+              std::common_type_t<RealType1, RealType2>>>>
 KOKKOS_DEPRECATED KOKKOS_FUNCTION
     complex<std::common_type_t<RealType1, RealType2>>
     operator/(const complex<RealType1>& x,
@@ -1274,7 +1274,7 @@ KOKKOS_DEPRECATED KOKKOS_FUNCTION
 //! Binary operator / for complex and real numbers
 template <class RealType1, class RealType2,
           class = std::enable_if_t<Impl::is_noncv_floating_point_v<
-              std::common_type<RealType1, RealType2>>>>
+              std::common_type_t<RealType1, RealType2>>>>
 KOKKOS_DEPRECATED KOKKOS_FUNCTION
     complex<std::common_type_t<RealType1, RealType2>>
     operator/(const RealType1& x,

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -461,6 +461,26 @@ class
       const std::complex<RealType>& lhs, const complex& rhs) {
     return complex(lhs) / rhs;
   }
+
+  KOKKOS_FUNCTION friend constexpr bool operator==(
+      const complex& lhs, const std::complex<RealType>& rhs) {
+    return lhs.real() == rhs.real() && lhs.imag() == rhs.imag();
+  }
+
+  KOKKOS_FUNCTION friend constexpr bool operator==(
+      const std::complex<RealType>& lhs, const complex& rhs) {
+    return lhs.real() == rhs.real() && lhs.imag() == rhs.imag();
+  }
+
+  KOKKOS_FUNCTION friend constexpr bool operator!=(
+      const complex& lhs, const std::complex<RealType>& rhs) {
+    return !(lhs == rhs);
+  }
+
+  KOKKOS_FUNCTION friend constexpr bool operator!=(
+      const std::complex<RealType>& lhs, const complex& rhs) {
+    return !(lhs == rhs);
+  }
 };
 
 }  // namespace Kokkos
@@ -528,8 +548,27 @@ KOKKOS_FUNCTION constexpr const RealType&& get(
 // to do it this way now.
 
 //! Binary == operator for complex complex.
+//      Returns: complex(lhs).real() == complex(rhs).real() &&
+//      complex(lhs).imag() == complex(rhs).imag()
+template <class T>
+KOKKOS_FUNCTION constexpr bool operator==(const complex<T>& lhs,
+                                          const complex<T>& rhs) {
+  return lhs.real() == rhs.real() && lhs.imag() == rhs.imag();
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr bool operator==(const complex<T>& lhs, const T& rhs) {
+  return lhs.real() == rhs && lhs.imag() == T();
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr bool operator==(const T& lhs, const complex<T>& rhs) {
+  return lhs == rhs.real() && T() == rhs.imag();
+}
+
+//! Binary == operator for complex complex.
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION constexpr bool operator==(
+KOKKOS_DEPRECATED KOKKOS_FUNCTION bool operator==(
     complex<RealType1> const& x, complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) == common_type(y.real()) &&
@@ -540,8 +579,8 @@ KOKKOS_INLINE_FUNCTION constexpr bool operator==(
 //      and do the comparison in a device-marked function
 //! Binary == operator for std::complex complex.
 template <class RealType1, class RealType2>
-inline bool operator==(std::complex<RealType1> const& x,
-                       complex<RealType2> const& y) noexcept {
+KOKKOS_DEPRECATED bool operator==(std::complex<RealType1> const& x,
+                                  complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) == common_type(y.real()) &&
          common_type(x.imag()) == common_type(y.imag());
@@ -549,8 +588,8 @@ inline bool operator==(std::complex<RealType1> const& x,
 
 //! Binary == operator for complex std::complex.
 template <class RealType1, class RealType2>
-inline bool operator==(complex<RealType1> const& x,
-                       std::complex<RealType2> const& y) noexcept {
+KOKKOS_DEPRECATED bool operator==(complex<RealType1> const& x,
+                                  std::complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) == common_type(y.real()) &&
          common_type(x.imag()) == common_type(y.imag());
@@ -561,8 +600,8 @@ template <
     class RealType1, class RealType2,
     // Constraints to avoid participation in oparator==() for every possible RHS
     std::enable_if_t<std::is_convertible_v<RealType2, RealType1>, int> = 0>
-KOKKOS_INLINE_FUNCTION constexpr bool operator==(complex<RealType1> const& x,
-                                                 RealType2 const& y) noexcept {
+KOKKOS_DEPRECATED KOKKOS_FUNCTION bool operator==(complex<RealType1> const& x,
+                                                  RealType2 const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) == common_type(y) &&
          common_type(x.imag()) == common_type(0);
@@ -573,7 +612,7 @@ template <
     class RealType1, class RealType2,
     // Constraints to avoid participation in oparator==() for every possible RHS
     std::enable_if_t<std::is_convertible_v<RealType1, RealType2>, int> = 0>
-KOKKOS_INLINE_FUNCTION constexpr bool operator==(
+KOKKOS_DEPRECATED KOKKOS_FUNCTION bool operator==(
     RealType1 const& x, complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x) == common_type(y.real()) &&
@@ -581,8 +620,26 @@ KOKKOS_INLINE_FUNCTION constexpr bool operator==(
 }
 
 //! Binary != operator for complex complex.
+//      Returns: !(lhs == rhs)
+template <class T>
+KOKKOS_FUNCTION constexpr bool operator!=(const complex<T>& lhs,
+                                          const complex<T>& rhs) {
+  return !(lhs == rhs);
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr bool operator!=(const complex<T>& lhs, const T& rhs) {
+  return !(lhs == rhs);
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr bool operator!=(const T& lhs, const complex<T>& rhs) {
+  return !(lhs == rhs);
+}
+
+//! Binary != operator for complex complex.
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION constexpr bool operator!=(
+KOKKOS_DEPRECATED KOKKOS_FUNCTION bool operator!=(
     complex<RealType1> const& x, complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) != common_type(y.real()) ||
@@ -591,8 +648,8 @@ KOKKOS_INLINE_FUNCTION constexpr bool operator!=(
 
 //! Binary != operator for std::complex complex.
 template <class RealType1, class RealType2>
-inline bool operator!=(std::complex<RealType1> const& x,
-                       complex<RealType2> const& y) noexcept {
+KOKKOS_DEPRECATED bool operator!=(std::complex<RealType1> const& x,
+                                  complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) != common_type(y.real()) ||
          common_type(x.imag()) != common_type(y.imag());
@@ -600,8 +657,8 @@ inline bool operator!=(std::complex<RealType1> const& x,
 
 //! Binary != operator for complex std::complex.
 template <class RealType1, class RealType2>
-inline bool operator!=(complex<RealType1> const& x,
-                       std::complex<RealType2> const& y) noexcept {
+KOKKOS_DEPRECATED bool operator!=(complex<RealType1> const& x,
+                                  std::complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) != common_type(y.real()) ||
          common_type(x.imag()) != common_type(y.imag());
@@ -612,8 +669,8 @@ template <
     class RealType1, class RealType2,
     // Constraints to avoid participation in oparator==() for every possible RHS
     std::enable_if_t<std::is_convertible_v<RealType2, RealType1>, int> = 0>
-KOKKOS_INLINE_FUNCTION constexpr bool operator!=(complex<RealType1> const& x,
-                                                 RealType2 const& y) noexcept {
+KOKKOS_DEPRECATED KOKKOS_FUNCTION bool operator!=(complex<RealType1> const& x,
+                                                  RealType2 const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) != common_type(y) ||
          common_type(x.imag()) != common_type(0);
@@ -624,7 +681,7 @@ template <
     class RealType1, class RealType2,
     // Constraints to avoid participation in oparator==() for every possible RHS
     std::enable_if_t<std::is_convertible_v<RealType1, RealType2>, int> = 0>
-KOKKOS_INLINE_FUNCTION constexpr bool operator!=(
+KOKKOS_DEPRECATED KOKKOS_FUNCTION bool operator!=(
     RealType1 const& x, complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x) != common_type(y.real()) ||

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -32,8 +32,7 @@ class
     alignas(2 * sizeof(RealType))
 #endif
         complex {
-  static_assert(std::is_floating_point_v<RealType> &&
-                    std::is_same_v<RealType, std::remove_cv_t<RealType>>,
+  static_assert(Impl::is_noncv_floating_point_v<RealType>,
                 "Kokkos::complex can only be instantiated for a cv-unqualified "
                 "floating point type");
 
@@ -651,9 +650,47 @@ KOKKOS_INLINE_FUNCTION complex<RealType> operator-(
 }
 
 //! Binary * operator for complex.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator*(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
+//      Returns: complex<T>(lhs) *= rhs.
+template <class T>
+KOKKOS_INLINE_FUNCTION constexpr complex<T> operator*(
+    const complex<T>& lhs, const std::complex<T>& rhs) {
+  return complex<T>(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
+                    lhs.real() * rhs.imag() + lhs.imag() * rhs.real());
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION constexpr complex<T> operator*(
+    const std::complex<T>& lhs, const complex<T>& rhs) {
+  return complex<T>(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
+                    lhs.real() * rhs.imag() + lhs.imag() * rhs.real());
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION constexpr complex<T> operator*(const complex<T>& lhs,
+                                                      const complex<T>& rhs) {
+  return complex<T>(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
+                    lhs.real() * rhs.imag() + lhs.imag() * rhs.real());
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION constexpr complex<T> operator*(const complex<T>& lhs,
+                                                      const T& rhs) {
+  return complex<T>(lhs.real() * rhs, lhs.imag() * rhs);
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION constexpr complex<T> operator*(const T& lhs,
+                                                      const complex<T>& rhs) {
+  return complex<T>(lhs * rhs.real(), lhs * rhs.imag());
+}
+
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator*(const complex<RealType1>& x,
+              const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(
       x.real() * y.real() - x.imag() * y.imag(),
       x.real() * y.imag() + x.imag() * y.real());
@@ -667,8 +704,10 @@ operator*(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
 /// This function cannot be called in a CUDA device function, because
 /// std::complex's methods and nonmember functions are not marked as
 /// CUDA device functions.
-template <class RealType1, class RealType2>
-inline complex<std::common_type_t<RealType1, RealType2>> operator*(
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED complex<std::common_type_t<RealType1, RealType2>> operator*(
     const std::complex<RealType1>& x, const complex<RealType2>& y) {
   return complex<std::common_type_t<RealType1, RealType2>>(
       x.real() * y.real() - x.imag() * y.imag(),
@@ -679,9 +718,12 @@ inline complex<std::common_type_t<RealType1, RealType2>> operator*(
 ///
 /// This function exists because the compiler doesn't know that
 /// RealType and complex<RealType> commute with respect to operator*.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator*(const RealType1& x, const complex<RealType2>& y) noexcept {
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator*(const RealType1& x, const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x * y.real(),
                                                            x * y.imag());
 }
@@ -690,9 +732,12 @@ operator*(const RealType1& x, const complex<RealType2>& y) noexcept {
 ///
 /// This function exists because the compiler doesn't know that
 /// RealType and complex<RealType> commute with respect to operator*.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator*(const complex<RealType1>& y, const RealType2& x) noexcept {
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator*(const complex<RealType1>& y, const RealType2& x) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x * y.real(),
                                                            x * y.imag());
 }

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -70,6 +70,15 @@ template <typename E>
 inline constexpr bool is_scoped_enum_v = is_scoped_enum<E>::value;
 #endif
 
+template <typename F>
+struct is_noncv_floating_point
+    : std::bool_constant<std::is_floating_point_v<F> &&
+                         std::is_same_v<F, std::remove_cv_t<F>>> {};
+
+template <typename F>
+inline constexpr bool is_noncv_floating_point_v =
+    is_noncv_floating_point<F>::value;
+
 //==============================================================================
 // <editor-fold desc="is_specialization_of"> {{{1
 

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -957,7 +957,7 @@ struct TestComplexOperators {
   }
 
   void testit() {
-    d_results = device_view_type("TestComplexOperators", 99);
+    d_results = device_view_type("TestComplexOperators", 24);
     h_results = Kokkos::create_mirror_view(d_results);
 
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0, 1), *this);

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -734,11 +734,17 @@ static_assert(comparison_in_constant_expression());
 
 struct TestStdComplexOperators {
   static void testit() {
-    using kcomplex_t = Kokkos::complex<double>;
-    using scomplex_t = std::complex<kcomplex_t::value_type>;
+    using fp_t       = double;
+    using kcomplex_t = Kokkos::complex<fp_t>;
+    using scomplex_t = std::complex<fp_t>;
 
-    const kcomplex_t k(.5, .25);
-    const scomplex_t s(.125, .0625);
+    constexpr kcomplex_t k(.5, .25);
+    constexpr scomplex_t s(.125, .0625);
+
+    // Division involving Kokkos::complex numbers with exact
+    // floating point representations is inexact because of the way we perform
+    // it, so we need to check results against an epsilon.
+    constexpr fp_t epsilon = std::numeric_limits<fp_t>::epsilon();
 
     // operator +=
     kcomplex_t k0 = k;
@@ -771,23 +777,15 @@ struct TestStdComplexOperators {
     ASSERT_FLOAT_EQ(s5.real(), .046875);
     ASSERT_FLOAT_EQ(s5.imag(), .0625);
 
-// FIXME
-// Does not compile (old code)
-#if 0
     kcomplex_t k6 = k;
     k6 /= s;
     ASSERT_FLOAT_EQ(k6.real(), 4.);
-    ASSERT_FLOAT_EQ(k6.imag(), 0.);
-#endif
+    ASSERT_NEAR(k6.imag(), 0., epsilon);
 
-// FIXME
-#if 0
     scomplex_t s7 = s;
     s7 /= k;
     ASSERT_FLOAT_EQ(s7.real(), .25);
-    ASSERT_FLOAT_EQ(s7.imag(), 0.); // assert fails; s7.imag() == 5.5511152e-18
-  }
-#endif
+    ASSERT_NEAR(s7.imag(), 0., epsilon);
 
     kcomplex_t k8 = k + s;
     ASSERT_FLOAT_EQ(k8.real(), .625);
@@ -813,20 +811,13 @@ struct TestStdComplexOperators {
     ASSERT_FLOAT_EQ(k13.real(), .046875);
     ASSERT_FLOAT_EQ(k13.imag(), .0625);
 
-// FIXME
-#if 0
     kcomplex_t k14 = k / s;
     ASSERT_FLOAT_EQ(k14.real(), 4.);
-    ASSERT_FLOAT_EQ(k14.imag(), 0.);  // assert fails; k14.imag() == 8.8817843e-17
-#endif
+    ASSERT_NEAR(k14.imag(), 0., epsilon);
 
-// FIXME
-#if 0
     kcomplex_t k15 = s / k;
     ASSERT_FLOAT_EQ(k15.real(), .25);
-    ASSERT_FLOAT_EQ(k15.imag(), 0.); // assert fails; s7.imag() == 5.5511152e-18
-#endif
-
+    ASSERT_NEAR(k15.imag(), 0., epsilon);
   }
 };
 

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -738,6 +738,9 @@ struct TestStdComplexOperators {
     using kcomplex_t = Kokkos::complex<fp_t>;
     using scomplex_t = std::complex<fp_t>;
 
+    // These values have exact floating point representations
+    // For addition, subtraction and multiplication, the result
+    // also has an exact floating point representation.
     constexpr kcomplex_t k(.5, .25);
     constexpr scomplex_t s(.125, .0625);
 
@@ -855,6 +858,221 @@ TEST(TEST_CATEGORY, std_complex_operators) {
   TestStdComplexOperators test;
   test.testit();
 }
+
+template <class ExecSpace>
+struct TestComplexOperators {
+  using exec_space          = ExecSpace;
+  using floating_point_type = double;
+  using complex_type        = Kokkos::complex<double>;
+  using device_view_type    = Kokkos::View<complex_type *, exec_space>;
+  using host_view_type      = typename device_view_type::host_mirror_type;
+
+  device_view_type d_results;
+  host_view_type h_results;
+
+  KOKKOS_FUNCTION
+  void operator()(int) const {
+    {
+      // These values have exact floating point representations.
+      // For addition, subtraction and multiplication, the result
+      // also has an exact floating point representation.
+      constexpr complex_type zl{.5, .25};
+      constexpr complex_type zr{.125, .0625};
+
+      constexpr floating_point_type f{.03125};
+      constexpr complex_type zf{f};
+
+      bool b0      = (zl == zl);
+      d_results[0] = complex_type(b0);
+
+      bool b1      = (zl == zr);
+      d_results[1] = complex_type(b1);
+
+      bool b2      = (zf == f);
+      d_results[2] = complex_type(b2);
+
+      bool b3      = (zl == f);
+      d_results[3] = complex_type(b3);
+
+      bool b4      = (f == zf);
+      d_results[4] = complex_type(b4);
+
+      bool b5      = (f == zr);
+      d_results[5] = complex_type(b5);
+
+      bool b6      = (zl != zl);
+      d_results[6] = complex_type(b6);
+
+      bool b7      = (zl != zr);
+      d_results[7] = complex_type(b7);
+
+      bool b8      = (zf != f);
+      d_results[8] = complex_type(b8);
+
+      bool b9      = (zl != f);
+      d_results[9] = complex_type(b9);
+
+      bool b10      = (f != zf);
+      d_results[10] = complex_type(b10);
+
+      bool b11      = (f != zr);
+      d_results[11] = complex_type(b11);
+
+      complex_type z12 = zl + zr;
+      d_results[12]    = z12;
+
+      complex_type z13 = zl + f;
+      d_results[13]    = z13;
+
+      complex_type z14 = f + zr;
+      d_results[14]    = z14;
+
+      complex_type z15 = zl - zr;
+      d_results[15]    = z15;
+
+      complex_type z16 = zl - f;
+      d_results[16]    = z16;
+
+      complex_type z17 = f - zr;
+      d_results[17]    = z17;
+
+      complex_type z18 = zl * zr;
+      d_results[18]    = z18;
+
+      complex_type z19 = zl * f;
+      d_results[19]    = z19;
+
+      complex_type z20 = f * zr;
+      d_results[20]    = z20;
+
+      complex_type z21 = zl / zr;
+      d_results[21]    = z21;
+
+      complex_type z22 = zl / f;
+      d_results[22]    = z22;
+
+      complex_type z23 = f / zr;
+      d_results[23]    = z23;
+    }
+  }
+
+  void testit() {
+    d_results = device_view_type("TestComplexOperators", 99);
+    h_results = Kokkos::create_mirror_view(d_results);
+
+    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0, 1), *this);
+    Kokkos::fence();
+    Kokkos::deep_copy(h_results, d_results);
+
+    // l == l
+    ASSERT_FLOAT_EQ(h_results[0].real(), 1.);
+    ASSERT_FLOAT_EQ(h_results[0].imag(), 0.);
+
+    // l == r
+    ASSERT_FLOAT_EQ(h_results[1].real(), 0.);
+    ASSERT_FLOAT_EQ(h_results[1].imag(), 0.);
+
+    // zf == f
+    ASSERT_FLOAT_EQ(h_results[2].real(), 1.);
+    ASSERT_FLOAT_EQ(h_results[2].imag(), 0.);
+
+    // zl == f
+    ASSERT_FLOAT_EQ(h_results[3].real(), 0.);
+    ASSERT_FLOAT_EQ(h_results[3].imag(), 0.);
+
+    // f == zf
+    ASSERT_FLOAT_EQ(h_results[4].real(), 1.);
+    ASSERT_FLOAT_EQ(h_results[4].imag(), 0.);
+
+    // f == zr
+    ASSERT_FLOAT_EQ(h_results[5].real(), 0.);
+    ASSERT_FLOAT_EQ(h_results[5].imag(), 0.);
+
+    // l != l
+    ASSERT_FLOAT_EQ(h_results[6].real(), 0.);
+    ASSERT_FLOAT_EQ(h_results[6].imag(), 0.);
+
+    // l != r
+    ASSERT_FLOAT_EQ(h_results[7].real(), 1.);
+    ASSERT_FLOAT_EQ(h_results[7].imag(), 0.);
+
+    // zf != f
+    ASSERT_FLOAT_EQ(h_results[8].real(), 0.);
+    ASSERT_FLOAT_EQ(h_results[8].imag(), 0.);
+
+    // zl != f
+    ASSERT_FLOAT_EQ(h_results[9].real(), 1.);
+    ASSERT_FLOAT_EQ(h_results[9].imag(), 0.);
+
+    // f != zf
+    ASSERT_FLOAT_EQ(h_results[10].real(), 0.);
+    ASSERT_FLOAT_EQ(h_results[10].imag(), 0.);
+
+    // f != zr
+    ASSERT_FLOAT_EQ(h_results[11].real(), 1.);
+    ASSERT_FLOAT_EQ(h_results[11].imag(), 0.);
+
+    // zl + zr
+    ASSERT_FLOAT_EQ(h_results[12].real(), .625);
+    ASSERT_FLOAT_EQ(h_results[12].imag(), .3125);
+
+    // zl + f
+    ASSERT_FLOAT_EQ(h_results[13].real(), .53125);
+    ASSERT_FLOAT_EQ(h_results[13].imag(), .25);
+
+    // f + zr
+    ASSERT_FLOAT_EQ(h_results[14].real(), .15625);
+    ASSERT_FLOAT_EQ(h_results[14].imag(), .0625);
+
+    // zl - zr
+    ASSERT_FLOAT_EQ(h_results[15].real(), .375);
+    ASSERT_FLOAT_EQ(h_results[15].imag(), .1875);
+
+    // zl - f
+    ASSERT_FLOAT_EQ(h_results[16].real(), .46875);
+    ASSERT_FLOAT_EQ(h_results[16].imag(), .25);
+
+    // f - zr
+    ASSERT_FLOAT_EQ(h_results[17].real(), -.09375);
+    ASSERT_FLOAT_EQ(h_results[17].imag(), -.0625);
+
+    // zl * zr
+    ASSERT_FLOAT_EQ(h_results[18].real(), .046875);
+    ASSERT_FLOAT_EQ(h_results[18].imag(), .0625);
+
+    // zl * f
+    ASSERT_FLOAT_EQ(h_results[19].real(), .015625);
+    ASSERT_FLOAT_EQ(h_results[19].imag(), .0078125);
+
+    // f * zr
+    ASSERT_FLOAT_EQ(h_results[20].real(), .00390625);
+    ASSERT_FLOAT_EQ(h_results[20].imag(), .001953125);
+
+    // Division involving Kokkos::complex numbers with exact
+    // floating point representations is inexact because of the way we perform
+    // it, so we need to check results against an epsilon.
+    constexpr floating_point_type epsilon{
+        std::numeric_limits<floating_point_type>::epsilon()};
+
+    // z1 / zr
+    ASSERT_FLOAT_EQ(h_results[21].real(), 4.);
+    ASSERT_NEAR(h_results[21].imag(), 0., epsilon);
+
+    // zl / f
+    ASSERT_FLOAT_EQ(h_results[22].real(), 16.);
+    ASSERT_FLOAT_EQ(h_results[22].imag(), 8.);
+
+    // f / zr
+    ASSERT_FLOAT_EQ(h_results[23].real(), .2);
+    ASSERT_FLOAT_EQ(h_results[23].imag(), -.1);
+  }
+};
+
+TEST(TEST_CATEGORY, complex_operators) {
+  TestComplexOperators<TEST_EXECSPACE> test;
+  test.testit();
+}
+
 }  // namespace Test
 
 #ifdef KOKKOS_COMPILER_NVCC

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -732,6 +732,108 @@ constexpr bool comparison_in_constant_expression() {
 
 static_assert(comparison_in_constant_expression());
 
+struct TestStdComplexOperators {
+  static void testit() {
+    using kcomplex_t = Kokkos::complex<double>;
+    using scomplex_t = std::complex<kcomplex_t::value_type>;
+
+    const kcomplex_t k(.5, .25);
+    const scomplex_t s(.125, .0625);
+
+    // operator +=
+    kcomplex_t k0 = k;
+    k0 += s;
+    ASSERT_FLOAT_EQ(k0.real(), .625);
+    ASSERT_FLOAT_EQ(k0.imag(), .3125);
+
+    scomplex_t s1 = s;
+    s1 += k;
+    ASSERT_FLOAT_EQ(s1.real(), .625);
+    ASSERT_FLOAT_EQ(s1.imag(), .3125);
+
+    kcomplex_t k2 = k;
+    k2 -= s;
+    ASSERT_FLOAT_EQ(k2.real(), .375);
+    ASSERT_FLOAT_EQ(k2.imag(), .1875);
+
+    scomplex_t s3 = s;
+    s3 -= k;
+    ASSERT_FLOAT_EQ(s3.real(), -.375);
+    ASSERT_FLOAT_EQ(s3.imag(), -.1875);
+
+    kcomplex_t k4 = k;
+    k4 *= s;
+    ASSERT_FLOAT_EQ(k4.real(), .046875);
+    ASSERT_FLOAT_EQ(k4.imag(), .0625);
+
+    scomplex_t s5 = s;
+    s5 *= k;
+    ASSERT_FLOAT_EQ(s5.real(), .046875);
+    ASSERT_FLOAT_EQ(s5.imag(), .0625);
+
+// FIXME
+// Does not compile (old code)
+#if 0
+    kcomplex_t k6 = k;
+    k6 /= s;
+    ASSERT_FLOAT_EQ(k6.real(), 4.);
+    ASSERT_FLOAT_EQ(k6.imag(), 0.);
+#endif
+
+// FIXME
+#if 0
+    scomplex_t s7 = s;
+    s7 /= k;
+    ASSERT_FLOAT_EQ(s7.real(), .25);
+    ASSERT_FLOAT_EQ(s7.imag(), 0.); // assert fails; s7.imag() == 5.5511152e-18
+  }
+#endif
+
+    kcomplex_t k8 = k + s;
+    ASSERT_FLOAT_EQ(k8.real(), .625);
+    ASSERT_FLOAT_EQ(k8.imag(), .3125);
+
+    kcomplex_t s9 = s + k;
+    ASSERT_FLOAT_EQ(s9.real(), .625);
+    ASSERT_FLOAT_EQ(s9.imag(), .3125);
+
+    kcomplex_t k10 = k - s;
+    ASSERT_FLOAT_EQ(k10.real(), .375);
+    ASSERT_FLOAT_EQ(k10.imag(), .1875);
+
+    kcomplex_t k11 = s - k;
+    ASSERT_FLOAT_EQ(k11.real(), -.375);
+    ASSERT_FLOAT_EQ(k11.imag(), -.1875);
+
+    kcomplex_t k12 = k * s;
+    ASSERT_FLOAT_EQ(k12.real(), .046875);
+    ASSERT_FLOAT_EQ(k12.imag(), .0625);
+
+    kcomplex_t k13 = s * k;
+    ASSERT_FLOAT_EQ(k13.real(), .046875);
+    ASSERT_FLOAT_EQ(k13.imag(), .0625);
+
+// FIXME
+#if 0
+    kcomplex_t k14 = k / s;
+    ASSERT_FLOAT_EQ(k14.real(), 4.);
+    ASSERT_FLOAT_EQ(k14.imag(), 0.);  // assert fails; k14.imag() == 8.8817843e-17
+#endif
+
+// FIXME
+#if 0
+    kcomplex_t k15 = s / k;
+    ASSERT_FLOAT_EQ(k15.real(), .25);
+    ASSERT_FLOAT_EQ(k15.imag(), 0.); // assert fails; s7.imag() == 5.5511152e-18
+#endif
+
+  }
+};
+
+TEST(TEST_CATEGORY, std_complex_operators) {
+  TestStdComplexOperators test;
+  test.testit();
+}
 }  // namespace Test
 
 #ifdef KOKKOS_COMPILER_NVCC

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -818,6 +818,36 @@ struct TestStdComplexOperators {
     kcomplex_t k15 = s / k;
     ASSERT_FLOAT_EQ(k15.real(), .25);
     ASSERT_NEAR(k15.imag(), 0., epsilon);
+
+    bool b16 = (k == s);
+    ASSERT_FALSE(b16);
+
+    bool b17 = (s == k);
+    ASSERT_FALSE(b17);
+
+    bool b18 = (k != s);
+    ASSERT_TRUE(b18);
+
+    bool b19 = (s != k);
+    ASSERT_TRUE(b19);
+
+    bool b20 = (k == k);
+    ASSERT_TRUE(b20);
+
+    bool b21 = (k == epsilon);
+    ASSERT_FALSE(b21);
+
+    bool b22 = (epsilon == k);
+    ASSERT_FALSE(b22);
+
+    bool b23 = (k != k);
+    ASSERT_FALSE(b23);
+
+    bool b24 = (k != epsilon);
+    ASSERT_TRUE(b24);
+
+    bool b25 = (epsilon != k);
+    ASSERT_TRUE(b25);
   }
 };
 


### PR DESCRIPTION
This is an alternate approach for the issues brought up in #8137.

This approach:

1. We constrain the current free function templated operators.
2. We deprecate the current free function templated operators.
3. We introduce the free function templated operators that are in the standard.
4. We introduce forms of the operators that take a `std::complex<T>` on one side and a `Kokkos::complex<T>` on the other side.

1 directly addresses the problem brought up in #8137.  2+3 gets us closer to the `std::complex` interface.  4 is a pure addition to make interaction between `Kokkos::complex` and `std::complex` as seamless as possible.