### PR TITLE
Make HipSpace assignable to HostSpace in APU mode

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Space.hpp
+++ b/core/src/HIP/Kokkos_HIP_Space.hpp
@@ -305,11 +305,12 @@ static_assert(Kokkos::Impl::MemorySpaceAccess<HIPSpace, HIPSpace>::assignable);
 
 template <>
 struct MemorySpaceAccess<HostSpace, HIPSpace> {
-  enum : bool { assignable = false };
 #if !defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
   enum : bool{accessible = false};
+  enum : bool{assignable = false};
 #else
   enum : bool { accessible = true };
+  enum : bool { assignable = true };
 #endif
   enum : bool { deepcopy = true };
 };

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -267,6 +267,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         ViewCopy_a
         ViewCopy_b
         ViewCopy_c
+        ViewCreateMirror
         ViewCtorDimMatch
         ViewCtorProp
         ViewEmptyRuntimeUnmanaged
@@ -391,6 +392,7 @@ foreach(PairDeviceSpace HIP-HostPinned;HIP-Managed;Cuda-HostPinned;Cuda-UVM;SYCL
     foreach(
       Name
       SharedAlloc
+      ViewCreateMirror
       ViewAPI_a
       ViewAPI_b
       ViewAPI_c

--- a/core/unit_test/TestViewCreateMirror.hpp
+++ b/core/unit_test/TestViewCreateMirror.hpp
@@ -1,0 +1,35 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+#include <gtest/gtest.h>
+
+// Test that the result of create_mirror is assignable to host views
+TEST(TEST_CATEGORY, create_mirror_assign_to_host) {
+  Kokkos::View<float*, TEST_EXECSPACE> a("A", 10);
+  Kokkos::View<float*, Kokkos::HostSpace> h_a1 = Kokkos::create_mirror(a);
+  Kokkos::View<float*, Kokkos::HostSpace> h_a2 =
+      Kokkos::create_mirror(Kokkos::HostSpace(), a);
+}
+
+// Test that the result of create_mirror_view is assignable to host views
+TEST(TEST_CATEGORY, create_mirror_view_assign_to_host) {
+  Kokkos::View<float*, TEST_EXECSPACE> a("A", 10);
+  Kokkos::View<float*, Kokkos::HostSpace> h_a1 = Kokkos::create_mirror_view(a);
+  Kokkos::View<float*, Kokkos::HostSpace> h_a2 =
+      Kokkos::create_mirror_view(Kokkos::HostSpace(), a);
+}

--- a/core/unit_test/hip/TestHIP_Spaces.cpp
+++ b/core/unit_test/hip/TestHIP_Spaces.cpp
@@ -35,13 +35,14 @@ TEST(hip, space_access) {
       Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
                                       Kokkos::HIPHostPinnedSpace>::assignable);
 
+#if !defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
   static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
                                                  Kokkos::HIPSpace>::assignable);
-
-#if !defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
   static_assert(!Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
                                                  Kokkos::HIPSpace>::accessible);
 #else
+  static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
+                                                Kokkos::HIPSpace>::assignable);
   static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
                                                 Kokkos::HIPSpace>::accessible);
 #endif


### PR DESCRIPTION
This addresses issue #8048 and adds testing for that situation. Specifically it checks that we can assign the result of a create_mirror to a HostSpace View (if you create the mirror in something host accessible).

I opted for adding a new test file instead of stuffing the new test for create_mirror into one of the existing view test header files. Eventually we should move other tests of `create_mirror[_view]` over into this header. 