### PR TITLE
SIMD: Add C++20 module

### DIFF
--- a/simd/src/CMakeLists.txt
+++ b/simd/src/CMakeLists.txt
@@ -14,7 +14,7 @@ install(
   PATTERN "*.hpp"
 )
 
-file(GLOB SIMD_MODULES *.cppm)
+set(SIMD_MODULES Kokkos_SIMD.cppm)
 
 #-----------------------------------------------------------------------------
 

--- a/simd/src/CMakeLists.txt
+++ b/simd/src/CMakeLists.txt
@@ -14,14 +14,26 @@ install(
   PATTERN "*.hpp"
 )
 
+file(GLOB SIMD_MODULES *.cppm)
+
 #-----------------------------------------------------------------------------
 
 # We have to pass the sources in here for Tribits
 # These will get ignored for standalone CMake and a true interface library made
-kokkos_add_library(kokkossimd SOURCES ${SIMD_SOURCES} HEADERS ${SIMD_HEADERS})
+kokkos_add_library(
+  kokkossimd
+  SOURCES
+  ${SIMD_SOURCES}
+  HEADERS
+  ${SIMD_HEADERS}
+  MODULE_INTERFACE
+  ${SIMD_MODULES}
+)
 kokkos_lib_include_directories(
   kokkossimd ${KOKKOS_TOP_BUILD_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+kokkos_link_internal_library(kokkossimd kokkoscore)
 
 # If ARM-SVE, check and warn for available arm_neon_sve_bridge.h
 if(KOKKOS_ARCH_ARM_SVE)

--- a/simd/src/Kokkos_SIMD.cppm
+++ b/simd/src/Kokkos_SIMD.cppm
@@ -55,6 +55,9 @@ export {
   using ::Kokkos::tanh;
   using ::Kokkos::tgamma;
   using ::Kokkos::trunc;
+
+  using ::Kokkos::max;
+  using ::Kokkos::min;
   }  // namespace Kokkos
 
   namespace Kokkos::Experimental {
@@ -73,6 +76,17 @@ export {
   using ::Kokkos::Experimental::simd_flag_default;
   using ::Kokkos::Experimental::simd_mask;
   using ::Kokkos::Experimental::where;
+
+  using ::Kokkos::Experimental::operator+=;
+  using ::Kokkos::Experimental::operator*=;
+  using ::Kokkos::Experimental::operator-=;
+  using ::Kokkos::Experimental::operator/=;
+  using ::Kokkos::Experimental::operator+;
+  using ::Kokkos::Experimental::operator*;
+  using ::Kokkos::Experimental::operator-;
+  using ::Kokkos::Experimental::operator/;
+  using ::Kokkos::Experimental::operator>>=;
+  using ::Kokkos::Experimental::operator<<=;
 
   namespace simd_abi {
 #if defined(KOKKOS_ARCH_AVX2)

--- a/simd/src/Kokkos_SIMD.cppm
+++ b/simd/src/Kokkos_SIMD.cppm
@@ -74,14 +74,26 @@ export {
   using ::Kokkos::Experimental::simd_mask;
   using ::Kokkos::Experimental::where;
 
+  namespace simd_abi {
+#if defined(KOKKOS_ARCH_AVX2)
+  using ::Kokkos::Experimental::simd_abi::avx2_fixed_size;
+#endif
+#if defined(KOKKOS_ARCH_AVX512XEON)
+  using ::Kokkos::Experimental::simd_abi::avx512_fixed_size;
+#endif
+#if defined(KOKKOS_ARCH_ARM_NEON)
+  using ::Kokkos::Experimental::simd_abi::neon_fixed_size;
+#endif
+  using ::Kokkos::Experimental::simd_abi::scalar;
+#if defined(KOKKOS_ARCH_ARM_SVE)
+  using ::Kokkos::Experimental::simd_abi::sve_fixed_size;
+#endif
+  }  // namespace simd_abi
+
   namespace simd_abi::Impl {  // FIXME
   using ::Kokkos::Experimental::simd_abi::Impl::native_abi;
   using ::Kokkos::Experimental::simd_abi::Impl::native_fixed_abi;
   }  // namespace simd_abi::Impl
-
-  namespace simd_abi {
-  using ::Kokkos::Experimental::simd_abi::scalar;
-  }
 
   namespace Impl {  // FIXME
   using ::Kokkos::Experimental::Impl::abi_set;

--- a/simd/src/Kokkos_SIMD.cppm
+++ b/simd/src/Kokkos_SIMD.cppm
@@ -1,0 +1,95 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+module;
+
+#include <Kokkos_SIMD.hpp>
+
+export module kokkos.simd;
+
+export {
+  namespace Kokkos {
+  using ::Kokkos::abs;
+  using ::Kokkos::acos;
+  using ::Kokkos::acosh;
+  using ::Kokkos::asin;
+  using ::Kokkos::asinh;
+  using ::Kokkos::atan;
+  using ::Kokkos::atan2;
+  using ::Kokkos::atanh;
+  using ::Kokkos::cbrt;
+  using ::Kokkos::ceil;
+  using ::Kokkos::copysign;
+  using ::Kokkos::cos;
+  using ::Kokkos::cosh;
+  using ::Kokkos::erf;
+  using ::Kokkos::erfc;
+  using ::Kokkos::exp;
+  using ::Kokkos::exp2;
+  using ::Kokkos::floor;
+  using ::Kokkos::fma;
+  using ::Kokkos::hypot;
+  using ::Kokkos::lgamma;
+  using ::Kokkos::log;
+  using ::Kokkos::log10;
+  using ::Kokkos::log2;
+  using ::Kokkos::pow;
+  using ::Kokkos::round;
+  using ::Kokkos::sin;
+  using ::Kokkos::sinh;
+  using ::Kokkos::sqrt;
+  using ::Kokkos::tan;
+  using ::Kokkos::tanh;
+  using ::Kokkos::tgamma;
+  using ::Kokkos::trunc;
+  }  // namespace Kokkos
+
+  namespace Kokkos::Experimental {
+  using ::Kokkos::Experimental::all_of;
+  using ::Kokkos::Experimental::any_of;
+  using ::Kokkos::Experimental::basic_simd;
+  using ::Kokkos::Experimental::basic_simd_mask;
+  using ::Kokkos::Experimental::condition;
+  using ::Kokkos::Experimental::none_of;
+  using ::Kokkos::Experimental::reduce;
+  using ::Kokkos::Experimental::reduce_max;
+  using ::Kokkos::Experimental::reduce_min;
+  using ::Kokkos::Experimental::round_half_to_nearest_even;
+  using ::Kokkos::Experimental::simd;
+  using ::Kokkos::Experimental::simd_flag_aligned;
+  using ::Kokkos::Experimental::simd_flag_default;
+  using ::Kokkos::Experimental::simd_mask;
+  using ::Kokkos::Experimental::where;
+
+  namespace simd_abi::Impl {  // FIXME
+  using ::Kokkos::Experimental::simd_abi::Impl::native_abi;
+  using ::Kokkos::Experimental::simd_abi::Impl::native_fixed_abi;
+  }  // namespace simd_abi::Impl
+
+  namespace simd_abi {
+  using ::Kokkos::Experimental::simd_abi::scalar;
+  }
+
+  namespace Impl {  // FIXME
+  using ::Kokkos::Experimental::Impl::abi_set;
+  using ::Kokkos::Experimental::Impl::data_type_set;
+  using ::Kokkos::Experimental::Impl::data_types;
+  using ::Kokkos::Experimental::Impl::device_abi_set;
+  using ::Kokkos::Experimental::Impl::host_abi_set;
+  using ::Kokkos::Experimental::Impl::Identity;
+  }  // namespace Impl
+  }  // namespace Kokkos::Experimental
+}

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -17,7 +17,13 @@
 #ifndef KOKKOS_SIMD_TESTING_OPS_HPP
 #define KOKKOS_SIMD_TESTING_OPS_HPP
 
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.simd;
+#else
 #include <Kokkos_SIMD.hpp>
+#endif
+#include <Kokkos_Core.hpp>
 
 class plus {
  public:

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -18,7 +18,12 @@
 #define KOKKOS_SIMD_TESTING_UTILITIES_HPP
 
 #include <gtest/gtest.h>
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.simd;
+#else
 #include <Kokkos_SIMD.hpp>
+#endif
 #include <SIMDTesting_Ops.hpp>
 
 class gtest_checker {

--- a/simd/unit_tests/include/TestSIMD_Condition.hpp
+++ b/simd/unit_tests/include/TestSIMD_Condition.hpp
@@ -17,7 +17,12 @@
 #ifndef KOKKOS_TEST_SIMD_CONDITION_HPP
 #define KOKKOS_TEST_SIMD_CONDITION_HPP
 
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.simd;
+#else
 #include <Kokkos_SIMD.hpp>
+#endif
 #include <SIMDTesting_Utilities.hpp>
 
 template <typename Abi, typename DataType>

--- a/simd/unit_tests/include/TestSIMD_Construction.hpp
+++ b/simd/unit_tests/include/TestSIMD_Construction.hpp
@@ -17,7 +17,12 @@
 #ifndef KOKKOS_TEST_SIMD_CONSTRUCTION_HPP
 #define KOKKOS_TEST_SIMD_CONSTRUCTION_HPP
 
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.simd;
+#else
 #include <Kokkos_SIMD.hpp>
+#endif
 #include <SIMDTesting_Utilities.hpp>
 
 using Kokkos::Experimental::all_of;

--- a/simd/unit_tests/include/TestSIMD_Conversions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Conversions.hpp
@@ -17,7 +17,12 @@
 #ifndef KOKKOS_TEST_SIMD_CONVERSIONS_HPP
 #define KOKKOS_TEST_SIMD_CONVERSIONS_HPP
 
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.simd;
+#else
 #include <Kokkos_SIMD.hpp>
+#endif
 #include <SIMDTesting_Utilities.hpp>
 
 using Kokkos::Experimental::all_of;

--- a/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
+++ b/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
@@ -17,7 +17,12 @@
 #ifndef KOKKOS_TEST_SIMD_GENERATOR_CTORS_HPP
 #define KOKKOS_TEST_SIMD_GENERATOR_CTORS_HPP
 
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.simd;
+#else
 #include <Kokkos_SIMD.hpp>
+#endif
 #include <SIMDTesting_Utilities.hpp>
 
 template <typename Abi, typename DataType>

--- a/simd/unit_tests/include/TestSIMD_MaskOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MaskOps.hpp
@@ -17,7 +17,12 @@
 #ifndef KOKKOS_TEST_SIMD_MASK_OPS_HPP
 #define KOKKOS_TEST_SIMD_MASK_OPS_HPP
 
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.simd;
+#else
 #include <Kokkos_SIMD.hpp>
+#endif
 #include <SIMDTesting_Utilities.hpp>
 
 template <typename Abi, typename DataType>

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -17,7 +17,12 @@
 #ifndef KOKKOS_TEST_SIMD_MATH_OPS_HPP
 #define KOKKOS_TEST_SIMD_MATH_OPS_HPP
 
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.simd;
+#else
 #include <Kokkos_SIMD.hpp>
+#endif
 #include <SIMDTesting_Utilities.hpp>
 
 template <class Abi, class Loader, class TernaryOp, class T>

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -17,7 +17,12 @@
 #ifndef KOKKOS_TEST_SIMD_REDUCTIONS_HPP
 #define KOKKOS_TEST_SIMD_REDUCTIONS_HPP
 
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.simd;
+#else
 #include <Kokkos_SIMD.hpp>
+#endif
 #include <SIMDTesting_Utilities.hpp>
 
 template <typename T, typename ReductionOp>

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -17,7 +17,12 @@
 #ifndef KOKKOS_TEST_SIMD_SHIFT_OPS_HPP
 #define KOKKOS_TEST_SIMD_SHIFT_OPS_HPP
 
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.simd;
+#else
 #include <Kokkos_SIMD.hpp>
+#endif
 #include <SIMDTesting_Utilities.hpp>
 
 template <typename Abi, typename Loader, typename ShiftOp, typename DataType>

--- a/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
+++ b/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
@@ -17,7 +17,12 @@
 #ifndef KOKKOS_TEST_SIMD_WHERE_EXPRESSIONS_HPP
 #define KOKKOS_TEST_SIMD_WHERE_EXPRESSIONS_HPP
 
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.simd;
+#else
 #include <Kokkos_SIMD.hpp>
+#endif
 #include <SIMDTesting_Utilities.hpp>
 
 template <typename Abi, typename DataType>


### PR DESCRIPTION
Part of #8117. For now, I left some `Impl` symbols needed in the tests in the module file since they aren't in a separate Impl header that we could pull in without exposing other symbols.

We were missing
```
kokkos_link_internal_library(kokkossimd kokkoscore)
```