### PR TITLE
Remove to edit CMakeCache.txt since this is bad practice

### DIFF
--- a/cmake/kokkos_enable_devices.cmake
+++ b/cmake/kokkos_enable_devices.cmake
@@ -47,7 +47,7 @@ else()
   if(NOT DEFINED Kokkos_ENABLE_SERIAL)
     message(
       STATUS
-        "SERIAL backend is being turned on to ensure there is at least one Host space. To change this, you must enable another host execution space and configure with -DKokkos_ENABLE_SERIAL=OFF or change CMakeCache.txt"
+        "SERIAL backend is being turned on to ensure there is at least one Host space. To change this, you must enable another host execution space and configure with -DKokkos_ENABLE_SERIAL=OFF."
     )
   endif()
 endif()


### PR DESCRIPTION
```bash
SERIAL backend is being turned on to ensure there is at least one Host space. To change this, you must enable another host execution space and configure with -DKokkos_ENABLE_SERIAL=OFF or change CMakeCache.txt
```

We recommend to edit `CMakeCache.txt` which is bad practice. This PR removes `or change CMakeCache.txt`.