### PR TITLE
Fix a segfault with GCC 12

### DIFF
--- a/.github/workflows/continuous-integration-linux.yml
+++ b/.github/workflows/continuous-integration-linux.yml
@@ -96,6 +96,12 @@ jobs:
             backend: 'HPX'
             stdcxx: '17'
             cmake_extra_opts: '-DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*"'
+          - arch: 'x64'
+            distro: 'ubuntu:latest'
+            cxx: 'g++-12'
+            cmake_build_type: 'RelWithDebInfo'
+            backend: 'OPENMP'
+            stdcxx: '17'
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     container:
       image: ghcr.io/kokkos/ci-containers/${{ matrix.distro }}
@@ -136,6 +142,9 @@ jobs:
       - name: maybe_set_hpx_vars
         if: ${{ matrix.backend == 'HPX' }}
         run: echo "HPX_HANDLE_FAILED_NEW=0" >> $GITHUB_ENV
+      - name: maybe_install_gcc_12
+        if: ${{ matrix.cxx == 'g++-12' }}
+        run: sudo apt-get install -y g++-12
       - name: Configure Kokkos
         run: |
           cmake -B builddir \

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -609,6 +609,11 @@ union SharedAllocationTracker {
   KOKKOS_FORCEINLINE_FUNCTION
 #if !defined(KOKKOS_COMPILER_GNU) || (KOKKOS_COMPILER_GNU < 1220) || \
     (KOKKOS_COMPILER_GNU > 1240)
+      // FIXME_GCC: The ViewSupport test fails with gcc 12.2, 12.3 and 12.4
+      // because this constructor is optimized out, which leads to a nullptr
+      // dereference. Removing the constexpr fixes the issue but nvcc complains,
+      // so we keep the constexpr but only when using anything other than those
+      // three faulty gcc versions.
       constexpr
 #endif
       SharedAllocationTracker()

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -607,8 +607,8 @@ union SharedAllocationTracker {
   ~SharedAllocationTracker(){KOKKOS_IMPL_SHARED_ALLOCATION_TRACKER_DECREMENT}
 
   KOKKOS_FORCEINLINE_FUNCTION
-#if !defined(KOKKOS_COMPILER_GNU) || (KOKKOS_COMPILER_GNU < 1220) || \
-    (KOKKOS_COMPILER_GNU > 1240)
+#if defined(KOKKOS_COMPILER_NVCC) || !defined(KOKKOS_COMPILER_GNU) || \
+    (KOKKOS_COMPILER_GNU < 1220) || (KOKKOS_COMPILER_GNU > 1240)
       // FIXME_GCC: The ViewSupport test fails with gcc 12.2, 12.3 and 12.4
       // because this constructor is optimized out, which leads to a nullptr
       // dereference. Removing the constexpr fixes the issue but nvcc complains,

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -606,7 +606,7 @@ union SharedAllocationTracker {
   KOKKOS_FORCEINLINE_FUNCTION
   ~SharedAllocationTracker(){KOKKOS_IMPL_SHARED_ALLOCATION_TRACKER_DECREMENT}
 
-  KOKKOS_FORCEINLINE_FUNCTION constexpr SharedAllocationTracker()
+  KOKKOS_FORCEINLINE_FUNCTION SharedAllocationTracker()
       : m_record_bits(DO_NOT_DEREF_FLAG) {}
 
   // Move:

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -606,8 +606,14 @@ union SharedAllocationTracker {
   KOKKOS_FORCEINLINE_FUNCTION
   ~SharedAllocationTracker(){KOKKOS_IMPL_SHARED_ALLOCATION_TRACKER_DECREMENT}
 
-  KOKKOS_FORCEINLINE_FUNCTION SharedAllocationTracker()
-      : m_record_bits(DO_NOT_DEREF_FLAG) {}
+  KOKKOS_FORCEINLINE_FUNCTION
+#if !defined(KOKKOS_COMPILER_GNU) || (KOKKOS_COMPILER_GNU < 1220) || \
+    (KOKKOS_COMPILER_GNU > 1240)
+      constexpr
+#endif
+      SharedAllocationTracker()
+      : m_record_bits(DO_NOT_DEREF_FLAG) {
+  }
 
   // Move:
 


### PR DESCRIPTION
This PR is intended to fix #8187 ~~(for the moment there is a single commit adding a gcc12.3 ci run to make sure it is detected)~~

Several tests are failing when using GCC 12.{2,3,4}. It looks like a compiler bug, as it doesn't happen with clang or with gcc versions <=12.1 or >=13.1, the constructor of `SharedAllocTracker` (shown below) is not called, which later causes a dereference of a null pointer when trying to call its `get_label()` method
https://github.com/kokkos/kokkos/blob/3e7dfc68cc1fb371c345ef42cb0f0d97caee8b81/core/src/impl/Kokkos_SharedAlloc.hpp#L609-L610

Making the `SharedAllocTracker` constructor non-constexpr seems to fix the issue, ~~afaict none of the classes using `SharedAllocTracker` have a constexpr constructor, so I guess it would be safe to make it non-constexpr~~ nvcc needs it to be constexpr, making it constexpr only when `KOKKOS_COMPILER_GCC` is off or corresponds to the non-faulty versions seems to work

The first failing commit is d77422167c2ef09e6f26fb90cebe5b3f3dc91575 (which introduced the basic view tests)