### PR TITLE
OpenMPTarget: Skip unit tests failing with clang 17

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsTeamIsSortedUntil.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamIsSortedUntil.cpp
@@ -255,6 +255,10 @@ TEST(std_algorithms_is_sorted_until_team_test, test_trivialB) {
 }
 
 TEST(std_algorithms_is_sorted_until_team_test, test_nontrivialA) {
+#ifdef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET Failing with clang 17
+  GTEST_SKIP() << "Known to fail with OpenMPTarget and clang 17";
+#endif
+
   const std::string name      = "nontrivialUntilLast";
   const std::vector<int> cols = {13, 101, 1444, 5153};
   run_all_scenarios<DynamicTag, double>(name, cols);
@@ -263,6 +267,10 @@ TEST(std_algorithms_is_sorted_until_team_test, test_nontrivialA) {
 }
 
 TEST(std_algorithms_is_sorted_until_team_test, test_nontrivialB) {
+#ifdef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET Failing with clang 17
+  GTEST_SKIP() << "Known to fail with OpenMPTarget and clang 17";
+#endif
+
   const std::string name      = "nontrivialRandom";
   const std::vector<int> cols = {13, 101, 1444, 5153};
   run_all_scenarios<DynamicTag, double>(name, cols);

--- a/core/unit_test/TestReducers_a.hpp
+++ b/core/unit_test/TestReducers_a.hpp
@@ -18,6 +18,10 @@
 
 namespace Test {
 TEST(TEST_CATEGORY, reducers_int) {
+#ifdef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET Failing with clang 17
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>)
+    GTEST_SKIP() << "Known to fail with OpenMPTarget and clang 17";
+#endif
   TestReducers<int, TEST_EXECSPACE>::execute_integer();
 }
 


### PR DESCRIPTION
The OpenMPTarget CI is consistently failing. This pull request skips the tests failing for clang 17.
I expect that @rgayatri23 wants to raise the minimum compiler version some time soon ad reevaluate all skipped unit tests.