### PR TITLE
[WIP] Initial version of self similar interface for range loops

### DIFF
--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -61,6 +61,7 @@
 #include <Kokkos_Vectorization.hpp>
 #include <Kokkos_Atomic.hpp>
 #include <Kokkos_hwloc.hpp>
+#include <Kokkos_ParallelRange.hpp>
 #include <Kokkos_Timer.hpp>
 #include <Kokkos_Tuners.hpp>
 #include <Kokkos_Complex.hpp>

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -148,13 +148,6 @@ inline void parallel_for(const std::string& str, const ExecPolicy& policy,
   Kokkos::Tools::Impl::end_parallel_for(inner_policy, functor, str, kpID);
 }
 
-template <class ExecPolicy, class FunctorType>
-inline void parallel_for(
-    const ExecPolicy& policy, const FunctorType& functor,
-    std::enable_if_t<is_execution_policy<ExecPolicy>::value>* = nullptr) {
-  Kokkos::parallel_for("", policy, functor);
-}
-
 template <class FunctorType>
 inline void parallel_for(const std::string& str, const size_t work_count,
                          const FunctorType& functor) {
@@ -170,6 +163,23 @@ inline void parallel_for(const std::string& str, const size_t work_count,
 template <class FunctorType>
 inline void parallel_for(const size_t work_count, const FunctorType& functor) {
   ::Kokkos::parallel_for("", work_count, functor);
+}
+
+// This overload is used in any self-similar parallel_for(exec_type, ...) call
+// as it takes only a execution type and a functor (like with nested p-fors).
+// So, we must mark it __host__ __device__ and supress warnings for this being
+// a purely host function. Additionally, we assert that this version is only
+// called from host, ensuring no negative impacts from ignoring warnings.
+template <class ExecPolicy, class FunctorType>
+KOKKOS_INLINE_FUNCTION void parallel_for(
+    const ExecPolicy& policy, const FunctorType& functor,
+    std::enable_if_t<is_execution_policy<ExecPolicy>::value>* = nullptr) {
+  KOKKOS_IF_ON_DEVICE(
+      Kokkos::abort("Kokkos::parallel_for(ExecutionPolicy, functor) cannot be "
+                    "called from device.\n");)
+#pragma nv_diag_suppress 20011, 20013, 20014, 20015
+  Kokkos::parallel_for("", policy, functor);
+#pragma nv_diag_default 20011, 20013, 20014, 20015
 }
 
 }  // namespace Kokkos

--- a/core/src/Kokkos_ParallelRange.hpp
+++ b/core/src/Kokkos_ParallelRange.hpp
@@ -1,0 +1,88 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+#include <Kokkos_Macros.hpp>
+static_assert(false,
+              "Including non-public Kokkos header files is not allowed.");
+#endif
+#ifndef KOKKOS_PARALLEL_RANGE_HPP
+#define KOKKOS_PARALLEL_RANGE_HPP
+
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+
+namespace Kokkos {
+
+/** \brief  Self-similar interface for work over a range of an integral type.
+ *
+ * If called with an ExecutionSpace, this returns a RangePolicy over work range.
+ * If called with a TeamHandle, this returns a TeamVectorRange over work range.
+ *
+ * Allows for writing code like
+ *
+ * template <class Exec, class X, class Y>
+ * KOKKOS_INLINE_FUNCTION void sum_views(const Exec& exec, const X& x, const Y&
+ * y) { Kokkos::parallel_for( Kokkos::parallel_range(exec, 0, x.extent(0)),
+ *     KOKKOS_LAMBDA(const int& i) { x(i) += y(i); });
+ * }
+ *
+ * which can be called from host:
+ *
+ *   sum_views(exec_space, x, y);
+ *
+ * or inside a TeamPolicy loop
+ *
+ *   Kokkos::parallel_for(TeamPolicy, KOKKOS_LAMBDA(team) {
+ *     sum_views(team, x, y);
+ *   });
+ * }
+ */
+
+template <class ExecType, class IndexType1, class IndexType2, class... Args>
+KOKKOS_INLINE_FUNCTION auto parallel_range(const ExecType& exec,
+                                           const IndexType1& begin,
+                                           const IndexType2& end,
+                                           const Args&... args) {
+  if constexpr (Kokkos::is_execution_space_v<ExecType>) {
+    KOKKOS_IF_ON_DEVICE(
+        Kokkos::abort("Kokkos::parallel_range() called with an execution space "
+                      "should only be called from host.");)
+
+    // Get the RangePolicy. Supress warnings about host/device
+    // function calling constructor which is __host__ only since
+    // we are asserting above that we are on host.
+#pragma nv_diag_suppress 20011, 20013, 20014, 20015
+    auto policy = Kokkos::RangePolicy(exec, begin, end, args...);
+#pragma nv_diag_default 20011, 20013, 20014, 20015
+
+    return policy;
+  } else if constexpr (Kokkos::is_team_handle_v<ExecType>) {
+    return Kokkos::TeamVectorRange(exec, begin, end);
+  } else {
+    static_assert(
+        Kokkos::is_execution_space_v<ExecType> ||
+            Kokkos::is_team_handle_v<ExecType>,
+        "Kokkos::parallel_range() must take execution space or team handle.\n");
+  }
+}
+
+}  // namespace Kokkos
+
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+
+#endif  // KOKKOS_PARALLEL_RANGE_HPP

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -206,6 +206,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         NumericTraits
         OccupancyControlTrait
         Other
+        ParallelRangeInterface
         ParallelScanRangePolicy
         Printf
         QuadPrecisionMath

--- a/core/unit_test/TestParallelRangeInterface.hpp
+++ b/core/unit_test/TestParallelRangeInterface.hpp
@@ -1,0 +1,69 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+namespace {
+
+template <class Exec, class X, class Y>
+KOKKOS_INLINE_FUNCTION void axpy(const Exec& exec, const X& x, const Y& y) {
+  Kokkos::parallel_for(
+      Kokkos::parallel_range(exec, 0, x.extent(0)),
+      KOKKOS_LAMBDA(const int& i) { x(i) += y(i); });
+}
+
+void test_parallel_range_interface() {
+  int N = 10000;
+  int M = 100;
+
+  Kokkos::View<float*> VA("VA", N), VB("VB", N);
+  Kokkos::View<float**> MA("MA", N / M, M), MB("MB", N / M, M);
+  Kokkos::deep_copy(VA, 1);
+  Kokkos::deep_copy(VB, 2);
+  Kokkos::deep_copy(MA, 1);
+  Kokkos::deep_copy(MB, 2);
+
+  // Call axpy from host
+  axpy(Kokkos::DefaultExecutionSpace(), VA, VB);
+
+  // call axpy from device with team handle
+  using team_t = typename Kokkos::TeamPolicy<>::member_type;
+  Kokkos::parallel_for(
+      "apxyFromTeam", Kokkos::TeamPolicy(N / M, Kokkos::AUTO()),
+      KOKKOS_LAMBDA(const team_t& team) {
+        axpy(team, Kokkos::subview(MA, team.league_rank(), Kokkos::ALL()),
+             Kokkos::subview(MB, team.league_rank(), Kokkos::ALL()));
+      });
+
+  // check
+  size_t result = 0;
+  Kokkos::parallel_reduce(
+      "Check1", VA.extent(0),
+      KOKKOS_LAMBDA(int i, size_t& val) { val += VA(i); }, result);
+  ASSERT_EQ(result, size_t(3) * VA.extent(0));
+  Kokkos::parallel_reduce(
+      "Check2", MA.extent(0),
+      KOKKOS_LAMBDA(int i, size_t& val) {
+        for (int j = 0; j < MA.extent(1); j++) val += MA(i, j);
+      },
+      result);
+  ASSERT_EQ(result, size_t(3) * MA.extent(0) * MA.extent(1));
+}
+
+TEST(TEST_CATEGORY, parallel_range_interface) {
+  test_parallel_range_interface();
+}
+}  // namespace


### PR DESCRIPTION
Add an interface for requesting a range policy based on an ExecutionType. For ExecutionType=ExecutionSpace, return a `RangePolicy<ExecutionSpace>`, and for ExecutionType=TeamHandle, return a `TeamVectorRange(team)`.

This allows for writing code like

```c++
template <class Exec, class X, class Y>
KOKKOS_INLINE_FUNCTION void sum_views(const Exec& exec, const X& x, const Y& y) { 
  Kokkos::parallel_for( Kokkos::parallel_range(exec, 0, x.extent(0)),
    KOKKOS_LAMBDA(const int& i) { x(i) += y(i); });
}

// Can be called from host:
sum_views(exec_space, x, y);

// Can be called in team policy loop
Kokkos::parallel_for(TeamPolicy, KOKKOS_LAMBDA(team) {
  sum_views(team, x, y);
});
```

I wanted to put `Kokkos::range_policy()` in `Kokkos_ExecPolicy.hpp`, but annoyingly I could not get `Kokkos::TeamVectorRange` to call the backend specific versions (instead of the deleted versions in that file). I added to a new `Kokkos_SelfSimilarInterface.hpp` to get something out there, and can worry about cleaning it up later if we go this route.