### PR TITLE
Deprecate View::HostMirror

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -980,9 +980,9 @@ class Random_XorShift64_Pool {
         state_data_type(view_alloc(exec, "Kokkos::Random_XorShift64::state"),
                         num_states_, padding_);
 
-    typename state_data_type::HostMirror h_state =
+    typename state_data_type::host_mirror_type h_state =
         Kokkos::create_mirror_view(Kokkos::WithoutInitializing, state_);
-    typename locks_type::HostMirror h_lock =
+    typename locks_type::host_mirror_type h_lock =
         Kokkos::create_mirror_view(Kokkos::WithoutInitializing, locks_);
 
     // if the host mirror is the device view, need to fence here
@@ -990,8 +990,9 @@ class Random_XorShift64_Pool {
     if (state_.data() == h_state.data())
       exec.fence("Random_XorShift64_Pool::init UnifiedMemory");
 
-    // Execute on the HostMirror's default execution space.
-    Random_XorShift64<typename state_data_type::HostMirror::execution_space>
+    // Execute on the host_mirror_type's default execution space.
+    Random_XorShift64<
+        typename state_data_type::host_mirror_type::execution_space>
         gen(seed, 0);
     for (int i = 0; i < 17; i++) gen.rand();
     for (int i = 0; i < num_states_; i++) {
@@ -1256,11 +1257,11 @@ class Random_XorShift1024_Pool {
     p_ = int_view_type(view_alloc(exec, "Kokkos::Random_XorShift1024::p"),
                        num_states_, padding_);
 
-    typename state_data_type::HostMirror h_state =
+    typename state_data_type::host_mirror_type h_state =
         Kokkos::create_mirror_view(Kokkos::WithoutInitializing, state_);
-    typename locks_type::HostMirror h_lock =
+    typename locks_type::host_mirror_type h_lock =
         Kokkos::create_mirror_view(Kokkos::WithoutInitializing, locks_);
-    typename int_view_type::HostMirror h_p =
+    typename int_view_type::host_mirror_type h_p =
         Kokkos::create_mirror_view(Kokkos::WithoutInitializing, p_);
 
     // if the host mirror is the device view, need to fence here
@@ -1268,8 +1269,9 @@ class Random_XorShift1024_Pool {
     if (state_.data() == h_state.data())
       exec.fence("Random_XorShift1024_Pool::init UnifiedMemory");
 
-    // Execute on the HostMirror's default execution space.
-    Random_XorShift64<typename state_data_type::HostMirror::execution_space>
+    // Execute on the host_mirror_type's default execution space.
+    Random_XorShift64<
+        typename state_data_type::host_mirror_type::execution_space>
         gen(seed, 0);
     for (int i = 0; i < 17; i++) gen.rand();
     for (int i = 0; i < num_states_; i++) {

--- a/benchmarks/stream/stream-kokkos.cpp
+++ b/benchmarks/stream/stream-kokkos.cpp
@@ -28,7 +28,7 @@
 
 using StreamDeviceArray =
     Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Restrict>>;
-using StreamHostArray = typename StreamDeviceArray::HostMirror;
+using StreamHostArray = typename StreamDeviceArray::host_mirror_type;
 
 using StreamIndex = int;
 using Policy      = Kokkos::RangePolicy<Kokkos::IndexType<StreamIndex>>;

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -140,7 +140,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
   /// \typedef t_host
   /// \brief The type of a Kokkos::View host mirror of \c t_dev.
-  using t_host = typename t_dev::HostMirror;
+  using t_host = typename t_dev::host_mirror_type;
 
   //! The type of a const View on the device.
   //! The type of a Kokkos::View on the device.
@@ -153,7 +153,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
   /// \typedef t_host_const
   /// \brief The type of a const View host mirror of \c t_dev_const.
-  using t_host_const = typename t_dev_const::HostMirror;
+  using t_host_const = typename t_dev_const::host_mirror_type;
 
   //! The type of a const, random-access View on the device.
   using t_dev_const_randomread =
@@ -164,7 +164,8 @@ class DualView : public ViewTraits<DataType, Properties...> {
   /// \typedef t_host_const_randomread
   /// \brief The type of a const, random-access View host mirror of
   ///   \c t_dev_const_randomread.
-  using t_host_const_randomread = typename t_dev_const_randomread::HostMirror;
+  using t_host_const_randomread =
+      typename t_dev_const_randomread::host_mirror_type;
 
   //! The type of an unmanaged View on the device.
   using t_dev_um =
@@ -196,7 +197,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
   /// \brief The type of a const, random-access View host mirror of
   ///   \c t_dev_const_randomread.
   using t_host_const_randomread_um =
-      typename t_dev_const_randomread_um::HostMirror;
+      typename t_dev_const_randomread_um::host_mirror_type;
 
   //@}
   //! \name Counters to keep track of changes ("modified" flags)
@@ -332,7 +333,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
   /// modify() methods to ensure synchronization of the View objects.
   ///
   /// \param d_view_ Device View
-  /// \param h_view_ Host View (must have type t_host = t_dev::HostMirror)
+  /// \param h_view_ Host View (must have type t_host = t_dev::host_mirror_type)
   DualView(const t_dev& d_view_, const t_host& h_view_)
       : modified_flags(t_modified_flags("DualView::modified_flags")),
         d_view(d_view_),

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -485,8 +485,8 @@ class DynRankView : private View<DataType*******, Properties...> {
   // KOKKOS_FUNCTION
   // view_type to_view() const { return *this; }
 
-  // Types below - at least the HostMirror requires the value_type, NOT the rank
-  // 7 data_type of the traits
+  // Types below - at least host_mirror_type requires the value_type, NOT the
+  // rank 7 data_type of the traits
 
   /** \brief  Compatible view of array of scalar types */
   using array_type = DynRankView<
@@ -503,12 +503,16 @@ class DynRankView : private View<DataType*******, Properties...> {
       typename drvtraits::non_const_data_type, typename drvtraits::array_layout,
       typename drvtraits::device_type, typename drvtraits::memory_traits>;
 
-  /** \brief  Compatible HostMirror view */
-  using HostMirror = DynRankView<typename drvtraits::non_const_data_type,
-                                 typename drvtraits::array_layout,
-                                 typename drvtraits::host_mirror_space>;
+  /** \brief  Compatible host mirror view */
+  using host_mirror_type = DynRankView<typename drvtraits::non_const_data_type,
+                                       typename drvtraits::array_layout,
+                                       typename drvtraits::host_mirror_space>;
 
-  using host_mirror_type = HostMirror;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  /** \brief  Compatible HostMirror view */
+  using HostMirror KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use host_mirror_type instead.") = host_mirror_type;
+#endif
   //----------------------------------------
   // Domain rank and extents
 
@@ -1497,7 +1501,7 @@ inline auto create_mirror(const DynRankView<T, P...>& src,
                     Impl::reconstructLayout(src.layout(), src.rank()));
   } else {
     using src_type = DynRankView<T, P...>;
-    using dst_type = typename src_type::HostMirror;
+    using dst_type = typename src_type::host_mirror_type;
 
     return dst_type(prop_copy,
                     Impl::reconstructLayout(src.layout(), src.rank()));
@@ -1571,12 +1575,12 @@ inline auto create_mirror_view(
         arg_prop) {
   if constexpr (!Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space) {
     if constexpr (std::is_same_v<typename DynRankView<T, P...>::memory_space,
+                                 typename DynRankView<T, P...>::
+                                     host_mirror_type::memory_space> &&
+                  std::is_same_v<typename DynRankView<T, P...>::data_type,
                                  typename DynRankView<
-                                     T, P...>::HostMirror::memory_space> &&
-                  std::is_same_v<
-                      typename DynRankView<T, P...>::data_type,
-                      typename DynRankView<T, P...>::HostMirror::data_type>) {
-      return typename DynRankView<T, P...>::HostMirror(src);
+                                     T, P...>::host_mirror_type::data_type>) {
+      return typename DynRankView<T, P...>::host_mirror_type(src);
     } else {
       return Kokkos::Impl::choose_create_mirror(src, arg_prop);
     }

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -281,7 +281,7 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
                                      typename traits::device_type>;
 
   /** \brief  Must be accessible everywhere */
-  using HostMirror = DynamicView;
+  using host_mirror_type = DynamicView;
 
   /** \brief Unified types */
   using uniform_device =
@@ -617,8 +617,9 @@ inline auto create_mirror(const Kokkos::Experimental::DynamicView<T, P...>& src,
 
     return ret;
   } else {
-    auto ret = typename Kokkos::Experimental::DynamicView<T, P...>::HostMirror(
-        prop_copy, src.chunk_size(), src.chunk_max() * src.chunk_size());
+    auto ret =
+        typename Kokkos::Experimental::DynamicView<T, P...>::host_mirror_type(
+            prop_copy, src.chunk_size(), src.chunk_max() * src.chunk_size());
 
     ret.resize_serial(src.extent(0));
 
@@ -695,16 +696,18 @@ inline auto create_mirror_view(
     const Kokkos::Experimental::DynamicView<T, P...>& src,
     [[maybe_unused]] const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
   if constexpr (!Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space) {
-    if constexpr (std::is_same_v<typename Kokkos::Experimental::DynamicView<
-                                     T, P...>::memory_space,
-                                 typename Kokkos::Experimental::DynamicView<
-                                     T, P...>::HostMirror::memory_space> &&
+    if constexpr (std::is_same_v<
+                      typename Kokkos::Experimental::DynamicView<
+                          T, P...>::memory_space,
+                      typename Kokkos::Experimental::DynamicView<
+                          T, P...>::host_mirror_type::memory_space> &&
                   std::is_same_v<typename Kokkos::Experimental::DynamicView<
                                      T, P...>::data_type,
                                  typename Kokkos::Experimental::DynamicView<
-                                     T, P...>::HostMirror::data_type>) {
+                                     T, P...>::host_mirror_type::data_type>) {
       return
-          typename Kokkos::Experimental::DynamicView<T, P...>::HostMirror(src);
+          typename Kokkos::Experimental::DynamicView<T, P...>::host_mirror_type(
+              src);
     } else {
       return Kokkos::Impl::choose_create_mirror(src, arg_prop);
     }

--- a/containers/src/Kokkos_ErrorReporter.hpp
+++ b/containers/src/Kokkos_ErrorReporter.hpp
@@ -52,11 +52,10 @@ class ErrorReporter {
   void getReports(std::vector<int> &reporters_out,
                   std::vector<report_type> &reports_out);
   void getReports(
-      typename Kokkos::View<int *,
-                            typename DeviceType::execution_space>::HostMirror
-          &reporters_out,
-      typename Kokkos::View<report_type *,
-                            typename DeviceType::execution_space>::HostMirror
+      typename Kokkos::View<int *, typename DeviceType::execution_space>::
+          host_mirror_type &reporters_out,
+      typename Kokkos::View<
+          report_type *, typename DeviceType::execution_space>::host_mirror_type
           &reports_out);
 
   void clear();
@@ -128,16 +127,16 @@ void ErrorReporter<ReportType, DeviceType>::getReports(
 
 template <typename ReportType, typename DeviceType>
 void ErrorReporter<ReportType, DeviceType>::getReports(
-    typename Kokkos::View<
-        int *, typename DeviceType::execution_space>::HostMirror &reporters_out,
-    typename Kokkos::View<report_type *,
-                          typename DeviceType::execution_space>::HostMirror
-        &reports_out) {
+    typename Kokkos::View<int *, typename DeviceType::execution_space>::
+        host_mirror_type &reporters_out,
+    typename Kokkos::View<report_type *, typename DeviceType::execution_space>::
+        host_mirror_type &reports_out) {
   int num_reports = getNumReports();
-  reporters_out   = typename Kokkos::View<int *, DeviceType>::HostMirror(
+  reporters_out   = typename Kokkos::View<int *, DeviceType>::host_mirror_type(
       "ErrorReport::reporters_out", num_reports);
-  reports_out = typename Kokkos::View<report_type *, DeviceType>::HostMirror(
-      "ErrorReport::reports_out", num_reports);
+  reports_out =
+      typename Kokkos::View<report_type *, DeviceType>::host_mirror_type(
+          "ErrorReport::reports_out", num_reports);
 
   if (num_reports > 0) {
     m_reports.template sync<host_mirror_space>();

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -236,10 +236,16 @@ class OffsetView : public View<DataType, Properties...> {
                  typename traits::array_layout, typename traits::device_type,
                  typename traits::memory_traits>;
 
-  /** \brief  Compatible HostMirror view */
-  using HostMirror = OffsetView<typename traits::non_const_data_type,
-                                typename traits::array_layout,
-                                typename traits::host_mirror_space>;
+  /** \brief  Compatible host mirror view */
+  using host_mirror_type = OffsetView<typename traits::non_const_data_type,
+                                      typename traits::array_layout,
+                                      typename traits::host_mirror_space>;
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  /** \brief  Compatible HistMirror view */
+  using HostMirror KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use host_mirror_type instead.") = host_mirror_type;
+#endif
 
   template <size_t... I, class... OtherIndexTypes>
   KOKKOS_FUNCTION typename base_t::reference_type offset_operator(
@@ -1309,7 +1315,7 @@ inline auto create_mirror(const Kokkos::Experimental::OffsetView<T, P...>& src,
                                          src.begin(4), src.begin(5),
                                          src.begin(6), src.begin(7)});
   } else {
-    return typename Kokkos::Experimental::OffsetView<T, P...>::HostMirror(
+    return typename Kokkos::Experimental::OffsetView<T, P...>::host_mirror_type(
         Kokkos::create_mirror(arg_prop, src.view()), src.begins());
   }
 #if defined(KOKKOS_COMPILER_NVCC) && KOKKOS_COMPILER_NVCC >= 1130 && \
@@ -1383,16 +1389,18 @@ inline auto create_mirror_view(
     const Kokkos::Experimental::OffsetView<T, P...>& src,
     [[maybe_unused]] const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
   if constexpr (!Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space) {
-    if constexpr (std::is_same_v<typename Kokkos::Experimental::OffsetView<
-                                     T, P...>::memory_space,
-                                 typename Kokkos::Experimental::OffsetView<
-                                     T, P...>::HostMirror::memory_space> &&
+    if constexpr (std::is_same_v<
+                      typename Kokkos::Experimental::OffsetView<
+                          T, P...>::memory_space,
+                      typename Kokkos::Experimental::OffsetView<
+                          T, P...>::host_mirror_type::memory_space> &&
                   std::is_same_v<typename Kokkos::Experimental::OffsetView<
                                      T, P...>::data_type,
                                  typename Kokkos::Experimental::OffsetView<
-                                     T, P...>::HostMirror::data_type>) {
+                                     T, P...>::host_mirror_type::data_type>) {
       return
-          typename Kokkos::Experimental::OffsetView<T, P...>::HostMirror(src);
+          typename Kokkos::Experimental::OffsetView<T, P...>::host_mirror_type(
+              src);
     } else {
       return Kokkos::Impl::choose_create_mirror(src, arg_prop);
     }

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -242,7 +242,7 @@ class OffsetView : public View<DataType, Properties...> {
                                       typename traits::host_mirror_space>;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  /** \brief  Compatible HistMirror view */
+  /** \brief  Compatible HostMirror view */
   using HostMirror KOKKOS_DEPRECATED_WITH_COMMENT(
       "Use host_mirror_type instead.") = host_mirror_type;
 #endif

--- a/containers/src/Kokkos_StaticCrsGraph.hpp
+++ b/containers/src/Kokkos_StaticCrsGraph.hpp
@@ -288,9 +288,15 @@ class StaticCrsGraph {
 
   using staticcrsgraph_type =
       StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type, SizeType>;
-  using HostMirror = StaticCrsGraph<data_type, array_layout,
-                                    typename traits::host_mirror_space,
-                                    memory_traits, size_type>;
+
+  using host_mirror_type = StaticCrsGraph<data_type, array_layout,
+                                          typename traits::host_mirror_space,
+                                          memory_traits, size_type>;
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  using HostMirror KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use host_mirror_type instead.") = host_mirror_type;
+#endif
 
   using row_map_type =
       View<const size_type*, array_layout, device_type, memory_traits>;
@@ -401,14 +407,14 @@ typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
 typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                        SizeType>::HostMirror
+                        SizeType>::host_mirror_type
 create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
                                         SizeType>& input);
 
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
 typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                        SizeType>::HostMirror
+                        SizeType>::host_mirror_type
 create_mirror(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
                                    SizeType>& input);
 

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -278,8 +278,13 @@ class UnorderedMap {
 
   using insert_result = UnorderedMapInsertResult;
 
-  using HostMirror =
+  using host_mirror_type =
       UnorderedMap<Key, Value, host_mirror_space, Hasher, EqualTo>;
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  using HostMirror KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use host_mirror_type instead.") = host_mirror_type;
+#endif
 
   using histogram_type = Impl::UnorderedMapHistogram<const_map_type>;
   //@}
@@ -993,11 +998,11 @@ inline void deep_copy(
 // Specialization of create_mirror() for an UnorderedMap object.
 template <typename Key, typename ValueType, typename Device, typename Hasher,
           typename EqualTo>
-typename UnorderedMap<Key, ValueType, Device, Hasher, EqualTo>::HostMirror
+typename UnorderedMap<Key, ValueType, Device, Hasher, EqualTo>::host_mirror_type
 create_mirror(
     const UnorderedMap<Key, ValueType, Device, Hasher, EqualTo> &src) {
-  typename UnorderedMap<Key, ValueType, Device, Hasher, EqualTo>::HostMirror
-      dst;
+  typename UnorderedMap<Key, ValueType, Device, Hasher,
+                        EqualTo>::host_mirror_type dst;
   dst.allocate_view(src);
   return dst;
 }

--- a/containers/src/impl/Kokkos_StaticCrsGraph_factory.hpp
+++ b/containers/src/impl/Kokkos_StaticCrsGraph_factory.hpp
@@ -27,7 +27,7 @@ namespace Kokkos {
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
 inline typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                               SizeType>::HostMirror
+                               SizeType>::host_mirror_type
 create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
                                         SizeType>& view,
                    std::enable_if_t<ViewTraits<DataType, Arg1Type, Arg2Type,
@@ -38,7 +38,7 @@ create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
 inline typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                               SizeType>::HostMirror
+                               SizeType>::host_mirror_type
 create_mirror(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
                                    SizeType>& view) {
   // Force copy:
@@ -46,10 +46,10 @@ create_mirror(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
   using staticcrsgraph_type =
       StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type, SizeType>;
 
-  typename staticcrsgraph_type::HostMirror tmp;
-  typename staticcrsgraph_type::row_map_type::HostMirror tmp_row_map =
+  typename staticcrsgraph_type::host_mirror_type tmp;
+  typename staticcrsgraph_type::row_map_type::host_mirror_type tmp_row_map =
       create_mirror(view.row_map);
-  typename staticcrsgraph_type::row_block_type::HostMirror
+  typename staticcrsgraph_type::row_block_type::host_mirror_type
       tmp_row_block_offsets = create_mirror(view.row_block_offsets);
 
   // Allocation to match:
@@ -69,7 +69,7 @@ create_mirror(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
 inline typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
-                               SizeType>::HostMirror
+                               SizeType>::host_mirror_type
 create_mirror_view(const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
                                         SizeType>& view,
                    std::enable_if_t<!ViewTraits<DataType, Arg1Type, Arg2Type,
@@ -101,7 +101,8 @@ inline typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
   {
     work_type row_work("tmp", length + 1);
 
-    typename work_type::HostMirror row_work_host = create_mirror_view(row_work);
+    typename work_type::host_mirror_type row_work_host =
+        create_mirror_view(row_work);
 
     size_t sum       = 0;
     row_work_host[0] = 0;
@@ -142,7 +143,8 @@ inline typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
   {
     work_type row_work("tmp", length + 1);
 
-    typename work_type::HostMirror row_work_host = create_mirror_view(row_work);
+    typename work_type::host_mirror_type row_work_host =
+        create_mirror_view(row_work);
 
     size_t sum       = 0;
     row_work_host[0] = 0;
@@ -158,7 +160,7 @@ inline typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
 
   // Fill in the entries:
   {
-    typename entries_type::HostMirror host_entries =
+    typename entries_type::host_mirror_type host_entries =
         create_mirror_view(output.entries);
 
     size_t sum = 0;

--- a/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
+++ b/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
@@ -132,7 +132,7 @@ struct UnorderedMapHistogram {
   using size_type       = typename map_type::size_type;
 
   using histogram_view      = View<int[100], typename map_type::device_type>;
-  using host_histogram_view = typename histogram_view::HostMirror;
+  using host_histogram_view = typename histogram_view::host_mirror_type;
 
   map_type m_map;
   histogram_view m_length;

--- a/containers/unit_tests/TestCreateMirror.cpp
+++ b/containers/unit_tests/TestCreateMirror.cpp
@@ -40,7 +40,7 @@ void test_create_mirror_properties(const View& view) {
   // clang-format off
   
   // create_mirror
-  // FIXME DynamicView: HostMirror is the same type
+  // FIXME DynamicView: host_mirror_type is the same type
   if constexpr (!is_dynamic_view<View>::value) {
     check_memory_space(create_mirror(WithoutInitializing,                        view), host_mirror_test_space(view));
     check_memory_space(create_mirror(                                            view), host_mirror_test_space(view));
@@ -49,7 +49,7 @@ void test_create_mirror_properties(const View& view) {
   check_memory_space(create_mirror(                     DefaultExecutionSpace{}, view), DeviceMemorySpace{});
 
   // create_mirror_view
-  // FIXME DynamicView: HostMirror is the same type
+  // FIXME DynamicView: host_mirror_type is the same type
   if constexpr (!is_dynamic_view<View>::value) {
     check_memory_space(create_mirror_view(WithoutInitializing,                        view), host_mirror_test_space(view));
     check_memory_space(create_mirror_view(                                            view), host_mirror_test_space(view));
@@ -58,7 +58,7 @@ void test_create_mirror_properties(const View& view) {
   check_memory_space(create_mirror_view(                     DefaultExecutionSpace{}, view), DeviceMemorySpace{});
 
   // create_mirror view_alloc
-  // FIXME DynamicView: HostMirror is the same type
+  // FIXME DynamicView: host_mirror_type is the same type
   if constexpr (!is_dynamic_view<View>::value) {
     check_memory_space(create_mirror(view_alloc(WithoutInitializing),                    view), host_mirror_test_space(view));
     check_memory_space(create_mirror(view_alloc(),                                       view), host_mirror_test_space(view));
@@ -67,7 +67,7 @@ void test_create_mirror_properties(const View& view) {
   check_memory_space(create_mirror(view_alloc(                     DeviceMemorySpace{}), view), DeviceMemorySpace{});
 
   // create_mirror_view view_alloc
-  // FIXME DynamicView: HostMirror is the same type
+  // FIXME DynamicView: host_mirror_type is the same type
   if constexpr (!is_dynamic_view<View>::value) {
     check_memory_space(create_mirror_view(view_alloc(WithoutInitializing),                    view), host_mirror_test_space(view));
     check_memory_space(create_mirror_view(view_alloc(),                                       view), host_mirror_test_space(view));
@@ -76,7 +76,7 @@ void test_create_mirror_properties(const View& view) {
   check_memory_space(create_mirror_view(view_alloc(                     DeviceMemorySpace{}), view), DeviceMemorySpace{});
 
   // create_mirror view_alloc + execution space
-  // FIXME DynamicView: HostMirror is the same type
+  // FIXME DynamicView: host_mirror_type is the same type
   if constexpr (!is_dynamic_view<View>::value) {
     check_memory_space(create_mirror(view_alloc(DefaultHostExecutionSpace{}, WithoutInitializing),                      view), host_mirror_test_space(view));
     check_memory_space(create_mirror(view_alloc(DefaultHostExecutionSpace{}),                                           view), host_mirror_test_space(view));
@@ -85,7 +85,7 @@ void test_create_mirror_properties(const View& view) {
   check_memory_space(create_mirror(view_alloc(DefaultExecutionSpace{},                            DeviceMemorySpace{}), view), DeviceMemorySpace{});
 
   // create_mirror_view view_alloc + execution space
-  // FIXME DynamicView: HostMirror is the same type
+  // FIXME DynamicView: host_mirror_type is the same type
   if constexpr (!is_dynamic_view<View>::value) {
     check_memory_space(create_mirror_view(view_alloc(DefaultHostExecutionSpace{}, WithoutInitializing),                      view), host_mirror_test_space(view));
     check_memory_space(create_mirror_view(view_alloc(DefaultHostExecutionSpace{}),                                           view), host_mirror_test_space(view));

--- a/containers/unit_tests/TestDynRankViewTypedefs.cpp
+++ b/containers/unit_tests/TestDynRankViewTypedefs.cpp
@@ -108,7 +108,7 @@ constexpr bool test_view_typedefs_impl() {
                                Kokkos::DynRankView<typename ViewType::non_const_data_type, typename ViewType::array_layout,
                                             typename ViewType::device_type, //typename ViewTraitsType::hooks_policy,
                                             typename ViewType::memory_traits>>);
-  static_assert(std::is_same_v<typename ViewType::HostMirror,
+  static_assert(std::is_same_v<typename ViewType::host_mirror_type,
                                Kokkos::DynRankView<typename ViewType::non_const_data_type, typename ViewType::array_layout,
                                                    HostMirrorSpace
                                                    /*, typename ViewTraitsType::hooks_policy*/>>);

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -731,7 +731,7 @@ class TestDynViewAPI {
 
   static void run_test_mirror() {
     using view_type   = Kokkos::DynRankView<int, host_drv_space>;
-    using mirror_type = typename view_type::HostMirror;
+    using mirror_type = typename view_type::host_mirror_type;
     view_type a("a");
     mirror_type am = Kokkos::create_mirror_view(a);
     mirror_type ax = Kokkos::create_mirror(a);
@@ -1117,8 +1117,9 @@ class TestDynViewAPI {
   }
 
   static void run_test_scalar() {
-    using hView0 = typename dView0::HostMirror;  // HostMirror of DynRankView is
-                                                 // a DynRankView
+    using hView0 =
+        typename dView0::host_mirror_type;  // host_mirror_type of DynRankView
+                                            // is a DynRankView
 
     dView0 dx, dy;
     hView0 hx, hy;
@@ -1216,7 +1217,7 @@ class TestDynViewAPI {
     // usual "(void)" marker to avoid compiler warnings for unused
     // variables.
 
-    using hView0 = typename dView0::HostMirror;
+    using hView0 = typename dView0::host_mirror_type;
 
     {
       hView0 thing;

--- a/containers/unit_tests/TestDynamicView.hpp
+++ b/containers/unit_tests/TestDynamicView.hpp
@@ -220,7 +220,8 @@ struct TestDynamicView {
     //   Case 4:
     {
       using device_view_type = Kokkos::View<Scalar*, Space>;
-      using host_view_type = typename Kokkos::View<Scalar*, Space>::HostMirror;
+      using host_view_type =
+          typename Kokkos::View<Scalar*, Space>::host_mirror_type;
 
       view_type device_dynamic_view("on-device DynamicView", 1024,
                                     arg_total_size);

--- a/containers/unit_tests/TestErrorReporter.hpp
+++ b/containers/unit_tests/TestErrorReporter.hpp
@@ -93,12 +93,12 @@ void TestErrorReporter() {
   test2.m_errorReporter.getReports(reporters, reports);
   checkReportersAndReportsAgree(reporters, reports);
 
-  typename Kokkos::View<
-      int *, typename ErrorReporterDriverType::execution_space>::HostMirror
-      view_reporters;
+  typename Kokkos::View<int *,
+                        typename ErrorReporterDriverType::execution_space>::
+      host_mirror_type view_reporters;
   typename Kokkos::View<typename tester_type::report_type *,
                         typename ErrorReporterDriverType::execution_space>::
-      HostMirror view_reports;
+      host_mirror_type view_reports;
   test2.m_errorReporter.getReports(view_reporters, view_reports);
 
   int num_reports = view_reporters.extent(0);

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -100,7 +100,7 @@ void test_offsetview_construction() {
   }
   {  // test deep copy of scalar const value into mirro
     const int constVal = 6;
-    typename offset_view_type::HostMirror hostOffsetView =
+    typename offset_view_type::host_mirror_type hostOffsetView =
         Kokkos::create_mirror_view(ov);
 
     Kokkos::deep_copy(hostOffsetView, constVal);
@@ -131,7 +131,7 @@ void test_offsetview_construction() {
       KOKKOS_LAMBDA(const int i, const int j) { ov(i, j) = constValue; });
 
   // test offsetview to offsetviewmirror deep copy
-  typename offset_view_type::HostMirror hostOffsetView =
+  typename offset_view_type::host_mirror_type hostOffsetView =
       Kokkos::create_mirror_view(ov);
 
   Kokkos::deep_copy(hostOffsetView, ov);

--- a/containers/unit_tests/TestStaticCrsGraph.hpp
+++ b/containers/unit_tests/TestStaticCrsGraph.hpp
@@ -30,7 +30,7 @@ namespace TestStaticCrsGraph {
 template <class Space>
 void run_test_graph() {
   using dView = Kokkos::StaticCrsGraph<unsigned, Space>;
-  using hView = typename dView::HostMirror;
+  using hView = typename dView::host_mirror_type;
 
   const unsigned LENGTH = 1000;
 
@@ -88,7 +88,7 @@ void run_test_graph() {
 template <class Space>
 void run_test_graph2() {
   using dView = Kokkos::StaticCrsGraph<unsigned[3], Space>;
-  using hView = typename dView::HostMirror;
+  using hView = typename dView::host_mirror_type;
 
   const unsigned LENGTH = 10;
 
@@ -148,7 +148,7 @@ void run_test_graph3(size_t B, size_t N) {
   srand(10310);
 
   using dView = Kokkos::StaticCrsGraph<int, Space>;
-  using hView = typename dView::HostMirror;
+  using hView = typename dView::host_mirror_type;
 
   const unsigned LENGTH = 2000;
 
@@ -185,7 +185,7 @@ void run_test_graph4() {
   using memory_traits_type = Kokkos::MemoryUnmanaged;
   using dView = Kokkos::StaticCrsGraph<ordinal_type, layout_type, space_type,
                                        memory_traits_type>;
-  using hView = typename dView::HostMirror;
+  using hView = typename dView::host_mirror_type;
 
   dView dx;
 

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -75,7 +75,7 @@ struct TestInsert {
     ASSERT_EQ(map_h.size(), map.size());
 
     if (!rehash_on_fail && CheckValues) {
-      typename expected_values_type::HostMirror expected_values_h =
+      typename expected_values_type::host_mirror_type expected_values_h =
           create_mirror_view(expected_values);
       Kokkos::deep_copy(expected_values_h, expected_values);
       for (unsigned i = 0; i < map_h.size(); i++) {
@@ -349,7 +349,7 @@ void test_deep_copy(uint32_t num_nodes) {
   using const_map_type =
       Kokkos::UnorderedMap<const uint32_t, const uint32_t, Device>;
 
-  using host_map_type = typename map_type::HostMirror;
+  using host_map_type = typename map_type::host_mirror_type;
 
   map_type map;
   map.rehash(num_nodes, false);

--- a/containers/unit_tests/TestViewCtorPropEmbeddedDim.hpp
+++ b/containers/unit_tests/TestViewCtorPropEmbeddedDim.hpp
@@ -66,7 +66,7 @@ struct TestViewCtorProp_EmbeddedDim {
         using CommonViewValueType =
             typename decltype(view_alloc_arg)::value_type;
         using CVT     = typename Kokkos::View<CommonViewValueType*, ExecSpace>;
-        using HostCVT = typename CVT::HostMirror;
+        using HostCVT = typename CVT::host_mirror_type;
 
         // Construct View using the common type; for case of specialization, an
         // 'embedded_dim' would be stored by view_alloc_arg
@@ -103,7 +103,7 @@ struct TestViewCtorProp_EmbeddedDim {
         using CommonViewValueType =
             typename decltype(view_alloc_arg)::value_type;
         using CVT     = typename Kokkos::View<CommonViewValueType*, ExecSpace>;
-        using HostCVT = typename CVT::HostMirror;
+        using HostCVT = typename CVT::host_mirror_type;
 
         // Construct View using the common type; for case of specialization, an
         // 'embedded_dim' would be stored by view_alloc_arg
@@ -136,7 +136,7 @@ struct TestViewCtorProp_EmbeddedDim {
         using CommonViewValueType =
             typename decltype(view_alloc_arg)::value_type;
         using CVT     = typename Kokkos::View<CommonViewValueType*, ExecSpace>;
-        using HostCVT = typename CVT::HostMirror;
+        using HostCVT = typename CVT::host_mirror_type;
 
         // Construct View using the common type; for case of specialization, an
         // 'embedded_dim' would be stored by view_alloc_arg
@@ -157,7 +157,7 @@ struct TestViewCtorProp_EmbeddedDim {
         using CommonViewValueType =
             typename decltype(view_alloc_arg)::value_type;
         using CVT     = typename Kokkos::View<CommonViewValueType*, ExecSpace>;
-        using HostCVT = typename CVT::HostMirror;
+        using HostCVT = typename CVT::host_mirror_type;
 
         // Construct View using the common type; for case of specialization, an
         // 'embedded_dim' would be stored by view_alloc_arg

--- a/core/perf_test/PerfTestGramSchmidt.cpp
+++ b/core/perf_test/PerfTestGramSchmidt.cpp
@@ -141,7 +141,7 @@ struct ModifiedGramSchmidt {
     multivector_type Q_("Q", length, count);
     multivector_type R_("R", count, count);
 
-    typename multivector_type::HostMirror A = Kokkos::create_mirror(Q_);
+    typename multivector_type::host_mirror_type A = Kokkos::create_mirror(Q_);
 
     // Create and fill A on the host
     for (size_type j = 0; j < count; ++j) {

--- a/core/perf_test/PerfTestMDRange.hpp
+++ b/core/perf_test/PerfTestMDRange.hpp
@@ -24,7 +24,7 @@ struct MultiDimRangePerf3D {
   using iterate_type = Kokkos::Iterate;
 
   using view_type      = Kokkos::View<ScalarType ***, TestLayout, DeviceType>;
-  using host_view_type = typename view_type::HostMirror;
+  using host_view_type = typename view_type::host_mirror_type;
 
   view_type A;
   view_type B;
@@ -285,7 +285,7 @@ struct RangePolicyCollapseTwo {
   using iterate_type = Kokkos::Iterate;
 
   using view_type      = Kokkos::View<ScalarType ***, TestLayout, DeviceType>;
-  using host_view_type = typename view_type::HostMirror;
+  using host_view_type = typename view_type::host_mirror_type;
 
   view_type A;
   view_type B;
@@ -457,7 +457,7 @@ struct RangePolicyCollapseAll {
   using layout          = TestLayout;
 
   using view_type      = Kokkos::View<ScalarType ***, TestLayout, DeviceType>;
-  using host_view_type = typename view_type::HostMirror;
+  using host_view_type = typename view_type::host_mirror_type;
 
   view_type A;
   view_type B;

--- a/core/perf_test/test_atomic.cpp
+++ b/core/perf_test/test_atomic.cpp
@@ -30,7 +30,7 @@ template <class T, class DEVICE_TYPE>
 struct ZeroFunctor {
   using execution_space = DEVICE_TYPE;
   using type            = typename Kokkos::View<T, execution_space>;
-  using h_type          = typename Kokkos::View<T, execution_space>::HostMirror;
+  using h_type = typename Kokkos::View<T, execution_space>::host_mirror_type;
   type data;
   KOKKOS_INLINE_FUNCTION
   void operator()(int) const { data() = 0; }

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3041,7 +3041,7 @@ inline auto create_mirror(const Kokkos::View<T, P...>& src,
     return dst_type(prop_copy, src.layout());
 #endif
   } else {
-    using dst_type = typename View<T, P...>::HostMirror;
+    using dst_type = typename View<T, P...>::host_mirror_type;
 #ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
     // This is necessary because constructing non-const element type from
     // const element type accessors is not generally supported
@@ -3181,13 +3181,13 @@ inline auto create_mirror_view(
     [[maybe_unused]] const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
   if constexpr (!Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space) {
     if constexpr (std::is_same_v<typename Kokkos::View<T, P...>::memory_space,
+                                 typename Kokkos::View<T, P...>::
+                                     host_mirror_type::memory_space> &&
+                  std::is_same_v<typename Kokkos::View<T, P...>::data_type,
                                  typename Kokkos::View<
-                                     T, P...>::HostMirror::memory_space> &&
-                  std::is_same_v<
-                      typename Kokkos::View<T, P...>::data_type,
-                      typename Kokkos::View<T, P...>::HostMirror::data_type>) {
+                                     T, P...>::host_mirror_type::data_type>) {
       check_view_ctor_args_create_mirror<ViewCtorArgs...>();
-      return typename Kokkos::View<T, P...>::HostMirror(src);
+      return typename Kokkos::View<T, P...>::host_mirror_type(src);
     } else {
       return Kokkos::Impl::choose_create_mirror(src, arg_prop);
     }

--- a/core/src/Kokkos_Crs.hpp
+++ b/core/src/Kokkos_Crs.hpp
@@ -73,8 +73,16 @@ class Crs {
   using size_type       = SizeType;
 
   using staticcrsgraph_type = Crs<DataType, Arg1Type, Arg2Type, SizeType>;
-  using HostMirror =
+
+  using host_mirror_type =
       Crs<DataType, array_layout, typename traits::host_mirror_space, SizeType>;
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  /** \brief  Compatible host mirror view */
+  using HostMirror KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use host_mirror_type instead.") = host_mirror_type;
+#endif
+
   using row_map_type = View<size_type*, array_layout, device_type>;
   using entries_type = View<DataType*, array_layout, device_type>;
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -224,15 +224,18 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
            typename traits::device_type, typename traits::hooks_policy,
            typename traits::memory_traits>;
 
-  // Compatible HostMirror view
+  // Compatible host mirror view
   using host_mirror_type =
       View<typename traits::non_const_data_type, typename traits::array_layout,
            Device<DefaultHostExecutionSpace,
                   typename traits::host_mirror_space::memory_space>,
            typename traits::hooks_policy>;
 
-  // Compatible HostMirror view
-  using HostMirror = host_mirror_type;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  /** \brief  Compatible HostMirror view */
+  using HostMirror KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use host_mirror_type instead.") = host_mirror_type;
+#endif
 
   // Unified types
   using uniform_type = typename Impl::ViewUniformType<View, 0>::type;

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -271,8 +271,11 @@ class View : public ViewTraits<DataType, Properties...> {
                   typename traits::host_mirror_space::memory_space>,
            typename traits::hooks_policy>;
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   /** \brief  Compatible host mirror view */
-  using HostMirror = host_mirror_type;
+  using HostMirror KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use host_mirror_type instead.") = host_mirror_type;
+#endif
 
   /** \brief Unified types */
   using uniform_type = typename Impl::ViewUniformType<View, 0>::type;

--- a/core/unit_test/TestAtomicViews.hpp
+++ b/core/unit_test/TestAtomicViews.hpp
@@ -377,7 +377,7 @@ struct PlusEqualAtomicViewFunctor {
 template <class T, class execution_space>
 T PlusEqualAtomicView(const int64_t input_length) {
   using view_type      = Kokkos::View<T*, execution_space>;
-  using host_view_type = typename view_type::HostMirror;
+  using host_view_type = typename view_type::host_mirror_type;
 
   const int64_t length = input_length;
 
@@ -466,7 +466,7 @@ struct MinusEqualAtomicViewFunctor {
 template <class T, class execution_space>
 T MinusEqualAtomicView(const int64_t input_length) {
   using view_type      = Kokkos::View<T*, execution_space>;
-  using host_view_type = typename view_type::HostMirror;
+  using host_view_type = typename view_type::host_mirror_type;
 
   const int64_t length = input_length;
 
@@ -550,7 +550,7 @@ struct TimesEqualAtomicViewFunctor {
 template <class T, class execution_space>
 T TimesEqualAtomicView(const int64_t input_length, const int64_t remainder) {
   using view_type      = Kokkos::View<T*, execution_space>;
-  using host_view_type = typename view_type::HostMirror;
+  using host_view_type = typename view_type::host_mirror_type;
 
   const int64_t length = input_length;
 
@@ -634,7 +634,7 @@ template <class T, class execution_space>
 T DivEqualAtomicView(const int64_t input_length, const int64_t remainder) {
   using view_type             = Kokkos::View<T*, execution_space>;
   using scalar_view_type      = Kokkos::View<T, execution_space>;
-  using host_scalar_view_type = typename scalar_view_type::HostMirror;
+  using host_scalar_view_type = typename scalar_view_type::host_mirror_type;
 
   const int64_t length = input_length;
 
@@ -716,7 +716,7 @@ template <class T, class execution_space>
 T ModEqualAtomicView(const int64_t input_length, const int64_t remainder) {
   using view_type             = Kokkos::View<T*, execution_space>;
   using scalar_view_type      = Kokkos::View<T, execution_space>;
-  using host_scalar_view_type = typename scalar_view_type::HostMirror;
+  using host_scalar_view_type = typename scalar_view_type::host_mirror_type;
 
   const int64_t length = input_length;
 
@@ -812,7 +812,7 @@ T RSEqualAtomicView(const int64_t input_length, const int64_t value,
                     const int64_t remainder) {
   using view_type             = Kokkos::View<T*, execution_space>;
   using result_view_type      = Kokkos::View<T****, execution_space>;
-  using host_scalar_view_type = typename result_view_type::HostMirror;
+  using host_scalar_view_type = typename result_view_type::host_mirror_type;
 
   const int64_t length = input_length;
 
@@ -932,7 +932,7 @@ T LSEqualAtomicView(const int64_t input_length, const int64_t value,
                     const int64_t remainder) {
   using view_type             = Kokkos::View<T*, execution_space>;
   using result_view_type      = Kokkos::View<T****, execution_space>;
-  using host_scalar_view_type = typename result_view_type::HostMirror;
+  using host_scalar_view_type = typename result_view_type::host_mirror_type;
 
   const int64_t length = input_length;
 
@@ -1044,7 +1044,7 @@ struct AndEqualAtomicViewFunctor {
 template <class T, class execution_space>
 T AndEqualAtomicView(const int64_t input_length) {
   using view_type      = Kokkos::View<T*, execution_space>;
-  using host_view_type = typename view_type::HostMirror;
+  using host_view_type = typename view_type::host_mirror_type;
 
   const int64_t length = input_length;
 
@@ -1125,7 +1125,7 @@ struct OrEqualAtomicViewFunctor {
 template <class T, class execution_space>
 T OrEqualAtomicView(const int64_t input_length) {
   using view_type      = Kokkos::View<T*, execution_space>;
-  using host_view_type = typename view_type::HostMirror;
+  using host_view_type = typename view_type::host_mirror_type;
 
   const int64_t length = input_length;
 
@@ -1209,7 +1209,7 @@ struct XOrEqualAtomicViewFunctor {
 template <class T, class execution_space>
 T XOrEqualAtomicView(const int64_t input_length) {
   using view_type      = Kokkos::View<T*, execution_space>;
-  using host_view_type = typename view_type::HostMirror;
+  using host_view_type = typename view_type::host_mirror_type;
 
   const int64_t length = input_length;
 

--- a/core/unit_test/TestAtomics.hpp
+++ b/core/unit_test/TestAtomics.hpp
@@ -137,7 +137,7 @@ template <class T, class DEVICE_TYPE>
 struct ZeroFunctor {
   using execution_space = DEVICE_TYPE;
   using type            = typename Kokkos::View<T, execution_space>;
-  using h_type          = typename Kokkos::View<T, execution_space>::HostMirror;
+  using h_type = typename Kokkos::View<T, execution_space>::host_mirror_type;
 
   type data;
 

--- a/core/unit_test/TestCXX11.hpp
+++ b/core/unit_test/TestCXX11.hpp
@@ -57,9 +57,9 @@ double AddTestFunctor() {
 
   Kokkos::View<double**, DeviceType> a("A", 100, 5);
   Kokkos::View<double**, DeviceType> b("B", 100, 5);
-  typename Kokkos::View<double**, DeviceType>::HostMirror h_a =
+  typename Kokkos::View<double**, DeviceType>::host_mirror_type h_a =
       Kokkos::create_mirror_view(a);
-  typename Kokkos::View<double**, DeviceType>::HostMirror h_b =
+  typename Kokkos::View<double**, DeviceType>::host_mirror_type h_b =
       Kokkos::create_mirror_view(b);
 
   for (int i = 0; i < 100; i++) {
@@ -91,9 +91,9 @@ template <class DeviceType, bool PWRTest>
 double AddTestLambda() {
   Kokkos::View<double**, DeviceType> a("A", 100, 5);
   Kokkos::View<double**, DeviceType> b("B", 100, 5);
-  typename Kokkos::View<double**, DeviceType>::HostMirror h_a =
+  typename Kokkos::View<double**, DeviceType>::host_mirror_type h_a =
       Kokkos::create_mirror_view(a);
-  typename Kokkos::View<double**, DeviceType>::HostMirror h_b =
+  typename Kokkos::View<double**, DeviceType>::host_mirror_type h_b =
       Kokkos::create_mirror_view(b);
 
   for (int i = 0; i < 100; i++) {
@@ -194,7 +194,7 @@ double ReduceTestFunctor() {
       Kokkos::View<double, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>;
 
   view_type a("A", 100, 5);
-  typename view_type::HostMirror h_a = Kokkos::create_mirror_view(a);
+  typename view_type::host_mirror_type h_a = Kokkos::create_mirror_view(a);
 
   for (int i = 0; i < 100; i++) {
     for (int j = 0; j < 5; j++) {
@@ -225,7 +225,7 @@ double ReduceTestLambda() {
       Kokkos::View<double, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>;
 
   view_type a("A", 100, 5);
-  typename view_type::HostMirror h_a = Kokkos::create_mirror_view(a);
+  typename view_type::host_mirror_type h_a = Kokkos::create_mirror_view(a);
 
   for (int i = 0; i < 100; i++) {
     for (int j = 0; j < 5; j++) {

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -46,7 +46,7 @@ namespace Test {
 template <class ExecSpace>
 struct TestComplexConstruction {
   Kokkos::View<Kokkos::complex<double> *, ExecSpace> d_results;
-  typename Kokkos::View<Kokkos::complex<double> *, ExecSpace>::HostMirror
+  typename Kokkos::View<Kokkos::complex<double> *, ExecSpace>::host_mirror_type
       h_results;
 
   void testit() {
@@ -127,7 +127,7 @@ TEST(TEST_CATEGORY, complex_construction) {
 template <class ExecSpace>
 struct TestComplexBasicMath {
   Kokkos::View<Kokkos::complex<double> *, ExecSpace> d_results;
-  typename Kokkos::View<Kokkos::complex<double> *, ExecSpace>::HostMirror
+  typename Kokkos::View<Kokkos::complex<double> *, ExecSpace>::host_mirror_type
       h_results;
 
   void testit() {
@@ -279,7 +279,7 @@ TEST(TEST_CATEGORY, complex_basic_math) {
 template <class ExecSpace>
 struct TestComplexSpecialFunctions {
   Kokkos::View<Kokkos::complex<double> *, ExecSpace> d_results;
-  typename Kokkos::View<Kokkos::complex<double> *, ExecSpace>::HostMirror
+  typename Kokkos::View<Kokkos::complex<double> *, ExecSpace>::host_mirror_type
       h_results;
 
   void testit() {
@@ -556,7 +556,7 @@ struct TestComplexStructuredBindings {
   using value_type       = double;
   using complex_type     = Kokkos::complex<double>;
   using device_view_type = Kokkos::View<complex_type *, exec_space>;
-  using host_view_type   = typename device_view_type::HostMirror;
+  using host_view_type   = typename device_view_type::host_mirror_type;
 
   device_view_type d_results;
   host_view_type h_results;

--- a/core/unit_test/TestConcurrentBitset.hpp
+++ b/core/unit_test/TestConcurrentBitset.hpp
@@ -109,7 +109,7 @@ void test_concurrent_bitset(int bit_count) {
 
   view_int_type acquired("acquired", n);
 
-  typename view_unsigned_type::HostMirror bitset_host =
+  typename view_unsigned_type::host_mirror_type bitset_host =
       Kokkos::create_mirror_view(bitset);
 
   Kokkos::deep_copy(bitset, 0u);

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -970,9 +970,9 @@ void _test_half_operators(half_type h_lhs, half_type h_rhs) {
 
   Functor_TestHalfOperators<ViewType, half_type> f_device(h_lhs, h_rhs);
   Functor_TestHalfOperators<ViewTypeHost, half_type> f_host(h_lhs, h_rhs);
-  typename ViewType::HostMirror f_device_actual_lhs =
+  typename ViewType::host_mirror_type f_device_actual_lhs =
       Kokkos::create_mirror_view(f_device.actual_lhs);
-  typename ViewType::HostMirror f_device_expected_lhs =
+  typename ViewType::host_mirror_type f_device_expected_lhs =
       Kokkos::create_mirror_view(f_device.expected_lhs);
 
   ExecutionSpace().fence();

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -31,8 +31,8 @@ void impl_test_local_deepcopy_teampolicy_rank_1(const int N) {
   ViewType B("B", N, N, N, N, N, N, N, N);
 
   // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
+  typename ViewType::host_mirror_type h_A = Kokkos::create_mirror_view(A);
+  typename ViewType::host_mirror_type h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   auto subA =
@@ -93,8 +93,8 @@ void impl_test_local_deepcopy_teampolicy_rank_2(const int N) {
   ViewType B("B", N, N, N, N, N, N, N, N);
 
   // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
+  typename ViewType::host_mirror_type h_A = Kokkos::create_mirror_view(A);
+  typename ViewType::host_mirror_type h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   auto subA = Kokkos::subview(A, 1, 1, 1, 1, 1, Kokkos::ALL(), Kokkos::ALL(),
@@ -158,8 +158,8 @@ void impl_test_local_deepcopy_teampolicy_rank_3(const int N) {
   ViewType B("B", N, N, N, N, N, N, N, N);
 
   // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
+  typename ViewType::host_mirror_type h_A = Kokkos::create_mirror_view(A);
+  typename ViewType::host_mirror_type h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   auto subA = Kokkos::subview(A, 1, 1, 1, 1, Kokkos::ALL(), Kokkos::ALL(),
@@ -223,8 +223,8 @@ void impl_test_local_deepcopy_teampolicy_rank_4(const int N) {
   ViewType B("B", N, N, N, N, N, N, N, N);
 
   // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
+  typename ViewType::host_mirror_type h_A = Kokkos::create_mirror_view(A);
+  typename ViewType::host_mirror_type h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   auto subA = Kokkos::subview(A, 1, 1, 1, Kokkos::ALL(), Kokkos::ALL(),
@@ -291,8 +291,8 @@ void impl_test_local_deepcopy_teampolicy_rank_5(const int N) {
   ViewType B("B", N, N, N, N, N, N, N, N);
 
   // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
+  typename ViewType::host_mirror_type h_A = Kokkos::create_mirror_view(A);
+  typename ViewType::host_mirror_type h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   auto subA =
@@ -360,8 +360,8 @@ void impl_test_local_deepcopy_teampolicy_rank_6(const int N) {
   ViewType B("B", N, N, N, N, N, N, N, N);
 
   // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
+  typename ViewType::host_mirror_type h_A = Kokkos::create_mirror_view(A);
+  typename ViewType::host_mirror_type h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   auto subA = Kokkos::subview(A, 1, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(),
@@ -429,8 +429,8 @@ void impl_test_local_deepcopy_teampolicy_rank_7(const int N) {
   ViewType B("B", N, N, N, N, N, N, N, N);
 
   // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
+  typename ViewType::host_mirror_type h_A = Kokkos::create_mirror_view(A);
+  typename ViewType::host_mirror_type h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   Kokkos::deep_copy(A, 10.0);
@@ -495,8 +495,8 @@ void impl_test_local_deepcopy_rangepolicy_rank_1(const int N) {
   ViewType B("B", N, N, N, N, N, N, N, N);
 
   // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
+  typename ViewType::host_mirror_type h_A = Kokkos::create_mirror_view(A);
+  typename ViewType::host_mirror_type h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   auto subA =
@@ -550,8 +550,8 @@ void impl_test_local_deepcopy_rangepolicy_rank_2(const int N) {
   ViewType B("B", N, N, N, N, N, N, N, N);
 
   // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
+  typename ViewType::host_mirror_type h_A = Kokkos::create_mirror_view(A);
+  typename ViewType::host_mirror_type h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   auto subA = Kokkos::subview(A, 1, 1, 1, 1, 1, Kokkos::ALL(), Kokkos::ALL(),
@@ -608,8 +608,8 @@ void impl_test_local_deepcopy_rangepolicy_rank_3(const int N) {
   ViewType B("B", N, N, N, N, N, N, N, N);
 
   // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
+  typename ViewType::host_mirror_type h_A = Kokkos::create_mirror_view(A);
+  typename ViewType::host_mirror_type h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   auto subA = Kokkos::subview(A, 1, 1, 1, 1, Kokkos::ALL(), Kokkos::ALL(),
@@ -666,8 +666,8 @@ void impl_test_local_deepcopy_rangepolicy_rank_4(const int N) {
   ViewType B("B", N, N, N, N, N, N, N, N);
 
   // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
+  typename ViewType::host_mirror_type h_A = Kokkos::create_mirror_view(A);
+  typename ViewType::host_mirror_type h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   auto subA = Kokkos::subview(A, 1, 1, 1, Kokkos::ALL(), Kokkos::ALL(),
@@ -727,8 +727,8 @@ void impl_test_local_deepcopy_rangepolicy_rank_5(const int N) {
   ViewType B("B", N, N, N, N, N, N, N, N);
 
   // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
+  typename ViewType::host_mirror_type h_A = Kokkos::create_mirror_view(A);
+  typename ViewType::host_mirror_type h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   auto subA =
@@ -789,8 +789,8 @@ void impl_test_local_deepcopy_rangepolicy_rank_6(const int N) {
   ViewType B("B", N, N, N, N, N, N, N, N);
 
   // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
+  typename ViewType::host_mirror_type h_A = Kokkos::create_mirror_view(A);
+  typename ViewType::host_mirror_type h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   auto subA = Kokkos::subview(A, 1, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(),
@@ -851,8 +851,8 @@ void impl_test_local_deepcopy_rangepolicy_rank_7(const int N) {
   ViewType B("B", N, N, N, N, N, N, N, N);
 
   // Create host mirrors of device views.
-  typename ViewType::HostMirror h_A = Kokkos::create_mirror_view(A);
-  typename ViewType::HostMirror h_B = Kokkos::create_mirror_view(B);
+  typename ViewType::host_mirror_type h_A = Kokkos::create_mirror_view(A);
+  typename ViewType::host_mirror_type h_B = Kokkos::create_mirror_view(B);
 
   // Initialize A matrix.
   Kokkos::deep_copy(A, 10.0);

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -31,7 +31,7 @@ template <typename ExecSpace>
 struct TestMDRange_ReduceArray_2D {
   using DataType       = int;
   using ViewType_2     = typename Kokkos::View<DataType **, ExecSpace>;
-  using HostViewType_2 = typename ViewType_2::HostMirror;
+  using HostViewType_2 = typename ViewType_2::host_mirror_type;
 
   ViewType_2 input_view;
 
@@ -99,7 +99,7 @@ template <typename ExecSpace>
 struct TestMDRange_ReduceArray_3D {
   using DataType       = int;
   using ViewType_3     = typename Kokkos::View<DataType ***, ExecSpace>;
-  using HostViewType_3 = typename ViewType_3::HostMirror;
+  using HostViewType_3 = typename ViewType_3::host_mirror_type;
 
   ViewType_3 input_view;
 
@@ -182,7 +182,7 @@ template <typename ExecSpace>
 struct TestMDRange_2D {
   using DataType     = int;
   using ViewType     = typename Kokkos::View<DataType **, ExecSpace>;
-  using HostViewType = typename ViewType::HostMirror;
+  using HostViewType = typename ViewType::host_mirror_type;
 
   ViewType input_view;
   using value_type = double;
@@ -808,7 +808,7 @@ template <typename ExecSpace>
 struct TestMDRange_3D {
   using DataType     = int;
   using ViewType     = typename Kokkos::View<DataType ***, ExecSpace>;
-  using HostViewType = typename ViewType::HostMirror;
+  using HostViewType = typename ViewType::host_mirror_type;
 
   ViewType input_view;
   using value_type = double;
@@ -1426,7 +1426,7 @@ template <typename ExecSpace>
 struct TestMDRange_4D {
   using DataType     = int;
   using ViewType     = typename Kokkos::View<DataType ****, ExecSpace>;
-  using HostViewType = typename ViewType::HostMirror;
+  using HostViewType = typename ViewType::host_mirror_type;
 
   ViewType input_view;
   using value_type = double;
@@ -2124,7 +2124,7 @@ template <typename ExecSpace>
 struct TestMDRange_5D {
   using DataType     = int;
   using ViewType     = typename Kokkos::View<DataType *****, ExecSpace>;
-  using HostViewType = typename ViewType::HostMirror;
+  using HostViewType = typename ViewType::host_mirror_type;
 
   ViewType input_view;
   using value_type = double;
@@ -2768,7 +2768,7 @@ template <typename ExecSpace>
 struct TestMDRange_6D {
   using DataType     = int;
   using ViewType     = typename Kokkos::View<DataType ******, ExecSpace>;
-  using HostViewType = typename ViewType::HostMirror;
+  using HostViewType = typename ViewType::host_mirror_type;
 
   ViewType input_view;
   using value_type = double;
@@ -3537,7 +3537,7 @@ struct TestMDRange_2D_NegIdx {
 
   using DataType     = int;
   using ViewType     = typename Kokkos::View<DataType **, ExecSpace>;
-  using HostViewType = typename ViewType::HostMirror;
+  using HostViewType = typename ViewType::host_mirror_type;
 
   ViewType input_view;
   DataType lower_offset[2];
@@ -3594,7 +3594,7 @@ struct TestMDRange_3D_NegIdx {
 
   using DataType     = int;
   using ViewType     = typename Kokkos::View<DataType ***, ExecSpace>;
-  using HostViewType = typename ViewType::HostMirror;
+  using HostViewType = typename ViewType::host_mirror_type;
 
   ViewType input_view;
   DataType lower_offset[3];
@@ -3658,7 +3658,7 @@ struct TestMDRange_4D_NegIdx {
 
   using DataType     = int;
   using ViewType     = typename Kokkos::View<DataType ****, ExecSpace>;
-  using HostViewType = typename ViewType::HostMirror;
+  using HostViewType = typename ViewType::host_mirror_type;
 
   ViewType input_view;
   DataType lower_offset[4];
@@ -3725,7 +3725,7 @@ struct TestMDRange_5D_NegIdx {
 
   using DataType     = int;
   using ViewType     = typename Kokkos::View<DataType *****, ExecSpace>;
-  using HostViewType = typename ViewType::HostMirror;
+  using HostViewType = typename ViewType::host_mirror_type;
 
   ViewType input_view;
   DataType lower_offset[5];
@@ -3799,7 +3799,7 @@ struct TestMDRange_6D_NegIdx {
 
   using DataType     = int;
   using ViewType     = typename Kokkos::View<DataType ******, ExecSpace>;
-  using HostViewType = typename ViewType::HostMirror;
+  using HostViewType = typename ViewType::host_mirror_type;
 
   ViewType input_view;
   DataType lower_offset[6];

--- a/core/unit_test/TestMathematicalSpecialFunctions.hpp
+++ b/core/unit_test/TestMathematicalSpecialFunctions.hpp
@@ -29,7 +29,7 @@ struct TestExponentialIntergral1Function {
   using HostViewType = Kokkos::View<double*, Kokkos::HostSpace>;
 
   ViewType d_x, d_expint;
-  typename ViewType::HostMirror h_x, h_expint;
+  typename ViewType::host_mirror_type h_x, h_expint;
   HostViewType h_ref;
 
   void testit() {
@@ -105,11 +105,11 @@ struct TestComplexErrorFunction {
   using DblHostViewType = Kokkos::View<double*, Kokkos::HostSpace>;
 
   ViewType d_z, d_erf, d_erfcx;
-  typename ViewType::HostMirror h_z, h_erf, h_erfcx;
+  typename ViewType::host_mirror_type h_z, h_erf, h_erfcx;
   HostViewType h_ref_erf, h_ref_erfcx;
 
   DblViewType d_x, d_erfcx_dbl;
-  typename DblViewType::HostMirror h_x, h_erfcx_dbl;
+  typename DblViewType::host_mirror_type h_x, h_erfcx_dbl;
   DblHostViewType h_ref_erfcx_dbl;
 
   void testit() {
@@ -453,11 +453,11 @@ struct TestComplexBesselJ0Y0Function {
       Kokkos::View<Kokkos::complex<double>*, Kokkos::HostSpace>;
 
   ViewType d_z, d_cbj0, d_cby0;
-  typename ViewType::HostMirror h_z, h_cbj0, h_cby0;
+  typename ViewType::host_mirror_type h_z, h_cbj0, h_cby0;
   HostViewType h_ref_cbj0, h_ref_cby0;
 
   ViewType d_z_large, d_cbj0_large, d_cby0_large;
-  typename ViewType::HostMirror h_z_large, h_cbj0_large, h_cby0_large;
+  typename ViewType::host_mirror_type h_z_large, h_cbj0_large, h_cby0_large;
   HostViewType h_ref_cbj0_large, h_ref_cby0_large;
 
   void testit() {
@@ -749,11 +749,11 @@ struct TestComplexBesselJ1Y1Function {
       Kokkos::View<Kokkos::complex<double>*, Kokkos::HostSpace>;
 
   ViewType d_z, d_cbj1, d_cby1;
-  typename ViewType::HostMirror h_z, h_cbj1, h_cby1;
+  typename ViewType::host_mirror_type h_z, h_cbj1, h_cby1;
   HostViewType h_ref_cbj1, h_ref_cby1;
 
   ViewType d_z_large, d_cbj1_large, d_cby1_large;
-  typename ViewType::HostMirror h_z_large, h_cbj1_large, h_cby1_large;
+  typename ViewType::host_mirror_type h_z_large, h_cbj1_large, h_cby1_large;
   HostViewType h_ref_cbj1_large, h_ref_cby1_large;
 
   void testit() {
@@ -1050,11 +1050,11 @@ struct TestComplexBesselI0K0Function {
       Kokkos::View<Kokkos::complex<double>*, Kokkos::HostSpace>;
 
   ViewType d_z, d_cbi0, d_cbk0;
-  typename ViewType::HostMirror h_z, h_cbi0, h_cbk0;
+  typename ViewType::host_mirror_type h_z, h_cbi0, h_cbk0;
   HostViewType h_ref_cbi0, h_ref_cbk0;
 
   ViewType d_z_large, d_cbi0_large, d_cbk0_large;
-  typename ViewType::HostMirror h_z_large, h_cbi0_large, h_cbk0_large;
+  typename ViewType::host_mirror_type h_z_large, h_cbi0_large, h_cbk0_large;
   HostViewType h_ref_cbi0_large, h_ref_cbk0_large;
 
   void testit() {
@@ -1306,11 +1306,11 @@ struct TestComplexBesselI1K1Function {
       Kokkos::View<Kokkos::complex<double>*, Kokkos::HostSpace>;
 
   ViewType d_z, d_cbi1, d_cbk1;
-  typename ViewType::HostMirror h_z, h_cbi1, h_cbk1;
+  typename ViewType::host_mirror_type h_z, h_cbi1, h_cbk1;
   HostViewType h_ref_cbi1, h_ref_cbk1;
 
   ViewType d_z_large, d_cbi1_large, d_cbk1_large;
-  typename ViewType::HostMirror h_z_large, h_cbi1_large, h_cbk1_large;
+  typename ViewType::host_mirror_type h_z_large, h_cbi1_large, h_cbk1_large;
   HostViewType h_ref_cbi1_large, h_ref_cbk1_large;
 
   void testit() {
@@ -1557,7 +1557,7 @@ struct TestComplexBesselH1Function {
       Kokkos::View<Kokkos::complex<double>*, Kokkos::HostSpace>;
 
   ViewType d_z, d_ch10, d_ch11;
-  typename ViewType::HostMirror h_z, h_ch10, h_ch11;
+  typename ViewType::host_mirror_type h_z, h_ch10, h_ch11;
   HostViewType h_ref_ch10, h_ref_ch11;
 
   void testit() {
@@ -1755,7 +1755,7 @@ struct TestComplexBesselH2Function {
       Kokkos::View<Kokkos::complex<double>*, Kokkos::HostSpace>;
 
   ViewType d_z, d_ch20, d_ch21;
-  typename ViewType::HostMirror h_z, h_ch20, h_ch21;
+  typename ViewType::host_mirror_type h_z, h_ch20, h_ch21;
   HostViewType h_ref_ch20, h_ref_ch21;
 
   void testit() {

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -54,7 +54,7 @@ struct TestRange {
   }
 
   void test_for() {
-    typename view_type::HostMirror host_flags =
+    typename view_type::host_mirror_type host_flags =
         Kokkos::create_mirror_view(m_flags);
 
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, ScheduleType>(0, N),

--- a/core/unit_test/TestRangePolicyRequire.hpp
+++ b/core/unit_test/TestRangePolicyRequire.hpp
@@ -47,7 +47,7 @@ struct TestRangeRequire {
         N(N_) {}
 
   void test_for() {
-    typename view_type::HostMirror host_flags =
+    typename view_type::host_mirror_type host_flags =
         Kokkos::create_mirror_view(m_flags);
 
     Kokkos::parallel_for(

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -479,7 +479,7 @@ class TestReduceDynamicView {
         Test::RuntimeReduceFunctor<ScalarType, execution_space>;
 
     using result_type      = Kokkos::View<ScalarType*, DeviceType>;
-    using result_host_type = typename result_type::HostMirror;
+    using result_host_type = typename result_type::host_mirror_type;
 
     const unsigned CountLimit = 23;
 

--- a/core/unit_test/TestResize.hpp
+++ b/core/unit_test/TestResize.hpp
@@ -123,13 +123,13 @@ void impl_testResize() {
   {
     using view_type = Kokkos::View<int*, DeviceType>;
     view_type view_1d("view_1d", sizes[0]);
-    typename view_type::HostMirror h_view_1d_old =
+    typename view_type::host_mirror_type h_view_1d_old =
         Kokkos::create_mirror(view_1d);
     Kokkos::deep_copy(view_1d, 111);
     Kokkos::deep_copy(h_view_1d_old, view_1d);
     resize_dispatch(Tag{}, view_1d, 2 * sizes[0]);
     EXPECT_EQ(view_1d.extent(0), 2 * sizes[0]);
-    typename view_type::HostMirror h_view_1d =
+    typename view_type::host_mirror_type h_view_1d =
         Kokkos::create_mirror_view(view_1d);
     Kokkos::deep_copy(h_view_1d, view_1d);
     bool test = true;
@@ -144,13 +144,13 @@ void impl_testResize() {
   {
     using view_type = Kokkos::View<int**, DeviceType>;
     view_type view_2d("view_2d", sizes[0], sizes[1]);
-    typename view_type::HostMirror h_view_2d_old =
+    typename view_type::host_mirror_type h_view_2d_old =
         Kokkos::create_mirror(view_2d);
     Kokkos::deep_copy(view_2d, 222);
     Kokkos::deep_copy(h_view_2d_old, view_2d);
     resize_dispatch(Tag{}, view_2d, 2 * sizes[0], sizes[1]);
     EXPECT_EQ(view_2d.extent(0), 2 * sizes[0]);
-    typename view_type::HostMirror h_view_2d =
+    typename view_type::host_mirror_type h_view_2d =
         Kokkos::create_mirror_view(view_2d);
     Kokkos::deep_copy(h_view_2d, view_2d);
     bool test = true;
@@ -167,13 +167,13 @@ void impl_testResize() {
   {
     using view_type = Kokkos::View<int***, DeviceType>;
     view_type view_3d("view_3d", sizes[0], sizes[1], sizes[2]);
-    typename view_type::HostMirror h_view_3d_old =
+    typename view_type::host_mirror_type h_view_3d_old =
         Kokkos::create_mirror(view_3d);
     Kokkos::deep_copy(view_3d, 333);
     Kokkos::deep_copy(h_view_3d_old, view_3d);
     resize_dispatch(Tag{}, view_3d, 2 * sizes[0], sizes[1], sizes[2]);
     EXPECT_EQ(view_3d.extent(0), 2 * sizes[0]);
-    typename view_type::HostMirror h_view_3d =
+    typename view_type::host_mirror_type h_view_3d =
         Kokkos::create_mirror_view(view_3d);
     Kokkos::deep_copy(h_view_3d, view_3d);
     bool test = true;
@@ -192,13 +192,13 @@ void impl_testResize() {
   {
     using view_type = Kokkos::View<int****, DeviceType>;
     view_type view_4d("view_4d", sizes[0], sizes[1], sizes[2], sizes[3]);
-    typename view_type::HostMirror h_view_4d_old =
+    typename view_type::host_mirror_type h_view_4d_old =
         Kokkos::create_mirror(view_4d);
     Kokkos::deep_copy(view_4d, 444);
     Kokkos::deep_copy(h_view_4d_old, view_4d);
     resize_dispatch(Tag{}, view_4d, 2 * sizes[0], sizes[1], sizes[2], sizes[3]);
     EXPECT_EQ(view_4d.extent(0), 2 * sizes[0]);
-    typename view_type::HostMirror h_view_4d =
+    typename view_type::host_mirror_type h_view_4d =
         Kokkos::create_mirror_view(view_4d);
     Kokkos::deep_copy(h_view_4d, view_4d);
     bool test = true;
@@ -220,14 +220,14 @@ void impl_testResize() {
     using view_type = Kokkos::View<int*****, DeviceType>;
     view_type view_5d("view_5d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4]);
-    typename view_type::HostMirror h_view_5d_old =
+    typename view_type::host_mirror_type h_view_5d_old =
         Kokkos::create_mirror(view_5d);
     Kokkos::deep_copy(view_5d, 555);
     Kokkos::deep_copy(h_view_5d_old, view_5d);
     resize_dispatch(Tag{}, view_5d, 2 * sizes[0], sizes[1], sizes[2], sizes[3],
                     sizes[4]);
     EXPECT_EQ(view_5d.extent(0), 2 * sizes[0]);
-    typename view_type::HostMirror h_view_5d =
+    typename view_type::host_mirror_type h_view_5d =
         Kokkos::create_mirror_view(view_5d);
     Kokkos::deep_copy(h_view_5d, view_5d);
     bool test = true;
@@ -252,14 +252,14 @@ void impl_testResize() {
     using view_type = Kokkos::View<int******, DeviceType>;
     view_type view_6d("view_6d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4], sizes[5]);
-    typename view_type::HostMirror h_view_6d_old =
+    typename view_type::host_mirror_type h_view_6d_old =
         Kokkos::create_mirror(view_6d);
     Kokkos::deep_copy(view_6d, 666);
     Kokkos::deep_copy(h_view_6d_old, view_6d);
     resize_dispatch(Tag{}, view_6d, 2 * sizes[0], sizes[1], sizes[2], sizes[3],
                     sizes[4], sizes[5]);
     EXPECT_EQ(view_6d.extent(0), 2 * sizes[0]);
-    typename view_type::HostMirror h_view_6d =
+    typename view_type::host_mirror_type h_view_6d =
         Kokkos::create_mirror_view(view_6d);
     Kokkos::deep_copy(h_view_6d, view_6d);
     bool test = true;
@@ -286,14 +286,14 @@ void impl_testResize() {
     using view_type = Kokkos::View<int*******, DeviceType>;
     view_type view_7d("view_7d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4], sizes[5], sizes[6]);
-    typename view_type::HostMirror h_view_7d_old =
+    typename view_type::host_mirror_type h_view_7d_old =
         Kokkos::create_mirror(view_7d);
     Kokkos::deep_copy(view_7d, 777);
     Kokkos::deep_copy(h_view_7d_old, view_7d);
     resize_dispatch(Tag{}, view_7d, 2 * sizes[0], sizes[1], sizes[2], sizes[3],
                     sizes[4], sizes[5], sizes[6]);
     EXPECT_EQ(view_7d.extent(0), 2 * sizes[0]);
-    typename view_type::HostMirror h_view_7d =
+    typename view_type::host_mirror_type h_view_7d =
         Kokkos::create_mirror_view(view_7d);
     Kokkos::deep_copy(h_view_7d, view_7d);
     bool test = true;
@@ -322,14 +322,14 @@ void impl_testResize() {
     using view_type = Kokkos::View<int********, DeviceType>;
     view_type view_8d("view_8d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4], sizes[5], sizes[6], sizes[7]);
-    typename view_type::HostMirror h_view_8d_old =
+    typename view_type::host_mirror_type h_view_8d_old =
         Kokkos::create_mirror(view_8d);
     Kokkos::deep_copy(view_8d, 888);
     Kokkos::deep_copy(h_view_8d_old, view_8d);
     resize_dispatch(Tag{}, view_8d, 2 * sizes[0], sizes[1], sizes[2], sizes[3],
                     sizes[4], sizes[5], sizes[6], sizes[7]);
     EXPECT_EQ(view_8d.extent(0), 2 * sizes[0]);
-    typename view_type::HostMirror h_view_8d =
+    typename view_type::host_mirror_type h_view_8d =
         Kokkos::create_mirror_view(view_8d);
     Kokkos::deep_copy(h_view_8d, view_8d);
     bool test = true;

--- a/core/unit_test/TestTaskScheduler.hpp
+++ b/core/unit_test/TestTaskScheduler.hpp
@@ -212,7 +212,7 @@ struct TestTaskDependence {
 
     accum_type accum("accum");
 
-    typename accum_type::HostMirror host_accum =
+    typename accum_type::host_mirror_type host_accum =
         Kokkos::create_mirror_view(accum);
 
     Kokkos::host_spawn(Kokkos::TaskSingle(sched), TestTaskDependence(n, accum));
@@ -402,13 +402,13 @@ struct TestTaskTeam {
     view_type root_parscan_result("parscan_result", n + 1);
     view_type root_parscan_check("parscan_check", n + 1);
 
-    typename view_type::HostMirror host_parfor_result =
+    typename view_type::host_mirror_type host_parfor_result =
         Kokkos::create_mirror_view(root_parfor_result);
-    typename view_type::HostMirror host_parreduce_check =
+    typename view_type::host_mirror_type host_parreduce_check =
         Kokkos::create_mirror_view(root_parreduce_check);
-    typename view_type::HostMirror host_parscan_result =
+    typename view_type::host_mirror_type host_parscan_result =
         Kokkos::create_mirror_view(root_parscan_result);
-    typename view_type::HostMirror host_parscan_check =
+    typename view_type::host_mirror_type host_parscan_check =
         Kokkos::create_mirror_view(root_parscan_check);
 
     future_type f = Kokkos::host_spawn(
@@ -516,7 +516,7 @@ struct TestTaskTeamValue {
 
     view_type root_result("result", n + 1);
 
-    typename view_type::HostMirror host_result =
+    typename view_type::host_mirror_type host_result =
         Kokkos::create_mirror_view(root_result);
 
     future_type fv = root_sched.host_spawn(TestTaskTeamValue(root_result, n),

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -1096,7 +1096,7 @@ struct ClassNoShmemSizeFunction {
           *this);
       Kokkos::fence();
 
-      typename Kokkos::View<int, ExecSpace>::HostMirror h_errors =
+      typename Kokkos::View<int, ExecSpace>::host_mirror_type h_errors =
           Kokkos::create_mirror_view(d_errors);
       Kokkos::deep_copy(h_errors, d_errors);
       ASSERT_EQ(h_errors(), 0);
@@ -1168,7 +1168,7 @@ struct ClassWithShmemSizeFunction {
           *this);
       Kokkos::fence();
 
-      typename Kokkos::View<int, ExecSpace>::HostMirror h_errors =
+      typename Kokkos::View<int, ExecSpace>::host_mirror_type h_errors =
           Kokkos::create_mirror_view(d_errors);
       Kokkos::deep_copy(h_errors, d_errors);
       ASSERT_EQ(h_errors(), 0);
@@ -1247,7 +1247,7 @@ void test_team_mulit_level_scratch_test_lambda() {
       });
   Kokkos::fence();
 
-  typename Kokkos::View<int, ExecSpace>::HostMirror h_errors =
+  typename Kokkos::View<int, ExecSpace>::host_mirror_type h_errors =
       Kokkos::create_mirror_view(errors);
   Kokkos::deep_copy(h_errors, d_errors);
   ASSERT_EQ(h_errors(), 0);

--- a/core/unit_test/TestTeamMDRange.hpp
+++ b/core/unit_test/TestTeamMDRange.hpp
@@ -155,7 +155,7 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_3D_TeamThreadMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -194,7 +194,7 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_4D_TeamThreadMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -234,7 +234,7 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_5D_TeamThreadMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -276,7 +276,7 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_6D_TeamThreadMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -320,7 +320,7 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_7D_TeamThreadMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -365,7 +365,7 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_8D_TeamThreadMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -412,7 +412,7 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_single_direction_test(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int n0 = dims[0];
     int n1 = dims[1];
@@ -447,7 +447,7 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_4D_ThreadVectorMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -490,7 +490,7 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_5D_ThreadVectorMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -535,7 +535,7 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_6D_ThreadVectorMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -581,7 +581,7 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_7D_ThreadVectorMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -629,7 +629,7 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_8D_ThreadVectorMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -683,7 +683,7 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_3D_TeamVectorMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -722,7 +722,7 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_4D_TeamVectorMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -762,7 +762,7 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_5D_TeamVectorMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -804,7 +804,7 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_6D_TeamVectorMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -848,7 +848,7 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_7D_TeamVectorMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -893,7 +893,7 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_8D_TeamVectorMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -940,7 +940,7 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_double_direction_test(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
+    using HostViewType = typename ViewType::host_mirror_type;
 
     int n0 = dims[0];
     int n1 = dims[1];

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -682,8 +682,8 @@ struct functor_reduce {
 template <typename Scalar, class ExecutionSpace>
 bool test_scalar(int nteams, int team_size, int test) {
   Kokkos::View<int, Kokkos::LayoutLeft, ExecutionSpace> d_flag("flag");
-  typename Kokkos::View<int, Kokkos::LayoutLeft, ExecutionSpace>::HostMirror
-      h_flag("h_flag");
+  typename Kokkos::View<int, Kokkos::LayoutLeft,
+                        ExecutionSpace>::host_mirror_type h_flag("h_flag");
   h_flag() = 0;
   Kokkos::deep_copy(d_flag, h_flag);
 

--- a/core/unit_test/TestTeamVectorRange.hpp
+++ b/core/unit_test/TestTeamVectorRange.hpp
@@ -356,8 +356,8 @@ struct functor_teamvector_reduce_reducer {
 template <typename Scalar, class ExecutionSpace>
 bool test_scalar(int nteams, int team_size, int test) {
   Kokkos::View<int, Kokkos::LayoutLeft, ExecutionSpace> d_flag("flag");
-  typename Kokkos::View<int, Kokkos::LayoutLeft, ExecutionSpace>::HostMirror
-      h_flag("h_flag");
+  typename Kokkos::View<int, Kokkos::LayoutLeft,
+                        ExecutionSpace>::host_mirror_type h_flag("h_flag");
   h_flag() = 0;
   Kokkos::deep_copy(d_flag, h_flag);
 

--- a/core/unit_test/TestUniqueToken.hpp
+++ b/core/unit_test/TestUniqueToken.hpp
@@ -90,7 +90,7 @@ class TestUniqueToken {
       Kokkos::fence();
     }
 
-    typename view_type::HostMirror host_counts =
+    typename view_type::host_mirror_type host_counts =
         Kokkos::create_mirror_view(self.counts);
 
     Kokkos::deep_copy(host_counts, self.counts);
@@ -124,7 +124,7 @@ class TestUniqueToken {
     }
 #endif
 
-    typename view_type::HostMirror host_errors =
+    typename view_type::host_mirror_type host_errors =
         Kokkos::create_mirror_view(self.errors);
 
     Kokkos::deep_copy(host_errors, self.errors);
@@ -224,7 +224,7 @@ class TestAcquireTeamUniqueToken {
       Kokkos::fence();
     }
 
-    typename view_type::HostMirror host_counts =
+    typename view_type::host_mirror_type host_counts =
         Kokkos::create_mirror_view(self.counts);
 
     Kokkos::deep_copy(host_counts, self.counts);
@@ -238,7 +238,7 @@ class TestAcquireTeamUniqueToken {
       }
     }
 
-    typename view_type::HostMirror host_errors =
+    typename view_type::host_mirror_type host_errors =
         Kokkos::create_mirror_view(self.errors);
 
     Kokkos::deep_copy(host_errors, self.errors);

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -952,8 +952,16 @@ class TestViewAPI {
     using view_type   = Kokkos::View<int, host>;
     using mirror_type = typename view_type::host_mirror_type;
 
-    static_assert(std::is_same_v<typename view_type::host_mirror_type,
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
+#endif
+    static_assert(std::is_same_v<typename view_type::HostMirror,
                                  typename view_type::host_mirror_type>);
+#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+#endif
+#endif
 
     static_assert(std::is_same_v<typename view_type::memory_space,
                                  typename mirror_type::memory_space>);

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -950,9 +950,9 @@ class TestViewAPI {
 
   static void run_test_mirror() {
     using view_type   = Kokkos::View<int, host>;
-    using mirror_type = typename view_type::HostMirror;
+    using mirror_type = typename view_type::host_mirror_type;
 
-    static_assert(std::is_same_v<typename view_type::HostMirror,
+    static_assert(std::is_same_v<typename view_type::host_mirror_type,
                                  typename view_type::host_mirror_type>);
 
     static_assert(std::is_same_v<typename view_type::memory_space,
@@ -968,7 +968,7 @@ class TestViewAPI {
   }
 
   static void run_test_scalar() {
-    using hView0 = typename dView0::HostMirror;
+    using hView0 = typename dView0::host_mirror_type;
 
     dView0 dx, dy;
     hView0 hx, hy;
@@ -990,17 +990,17 @@ class TestViewAPI {
   }
 
   static void run_test_contruction_from_layout() {
-    using hView0 = typename dView0::HostMirror;
-    using hView1 = typename dView1::HostMirror;
-    using hView2 = typename dView2::HostMirror;
-    using hView3 = typename dView3::HostMirror;
-    using hView4 = typename dView4::HostMirror;
+    using hView0 = typename dView0::host_mirror_type;
+    using hView1 = typename dView1::host_mirror_type;
+    using hView2 = typename dView2::host_mirror_type;
+    using hView3 = typename dView3::host_mirror_type;
+    using hView4 = typename dView4::host_mirror_type;
 
-    hView0 hv_0("dView0::HostMirror");
-    hView1 hv_1("dView1::HostMirror", N0);
-    hView2 hv_2("dView2::HostMirror", N0);
-    hView3 hv_3("dView3::HostMirror", N0);
-    hView4 hv_4("dView4::HostMirror", N0);
+    hView0 hv_0("dView0::host_mirror_type");
+    hView1 hv_1("dView1::host_mirror_type", N0);
+    hView2 hv_2("dView2::host_mirror_type", N0);
+    hView3 hv_3("dView3::host_mirror_type", N0);
+    hView4 hv_4("dView4::host_mirror_type", N0);
 
     dView0 dummy("dummy");
     dView0 dv_0_1(dummy.data());
@@ -1082,11 +1082,11 @@ class TestViewAPI {
     // usual "(void)" marker to avoid compiler warnings for unused
     // variables.
 
-    using hView0 = typename dView0::HostMirror;
-    using hView1 = typename dView1::HostMirror;
-    using hView2 = typename dView2::HostMirror;
-    using hView3 = typename dView3::HostMirror;
-    using hView4 = typename dView4::HostMirror;
+    using hView0 = typename dView0::host_mirror_type;
+    using hView1 = typename dView1::host_mirror_type;
+    using hView2 = typename dView2::host_mirror_type;
+    using hView3 = typename dView3::host_mirror_type;
+    using hView4 = typename dView4::host_mirror_type;
 
     {
       hView0 thing;

--- a/core/unit_test/TestViewCtorPropEmbeddedDim.hpp
+++ b/core/unit_test/TestViewCtorPropEmbeddedDim.hpp
@@ -62,7 +62,7 @@ struct TestViewCtorProp_EmbeddedDim {
         using CommonViewValueType =
             typename decltype(view_alloc_arg)::value_type;
         using CVT     = typename Kokkos::View<CommonViewValueType*, ExecSpace>;
-        using HostCVT = typename CVT::HostMirror;
+        using HostCVT = typename CVT::host_mirror_type;
 
         // Construct View using the common type; for case of specialization, an
         // 'embedded_dim' would be stored by view_alloc_arg
@@ -103,7 +103,7 @@ struct TestViewCtorProp_EmbeddedDim {
         using CommonViewValueType =
             typename decltype(view_alloc_arg)::value_type;
         using CVT     = typename Kokkos::View<CommonViewValueType*, ExecSpace>;
-        using HostCVT = typename CVT::HostMirror;
+        using HostCVT = typename CVT::host_mirror_type;
 
         // Construct View using the common type; for case of specialization, an
         // 'embedded_dim' would be stored by view_alloc_arg

--- a/core/unit_test/TestViewLayoutStrideAssignment.hpp
+++ b/core/unit_test/TestViewLayoutStrideAssignment.hpp
@@ -38,8 +38,8 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
     Kokkos::View<double*, Kokkos::LayoutStride, exec_space> src("LayoutStride",
                                                                 layout);
 
-    Kokkos::View<double*, Kokkos::LayoutStride, exec_space>::HostMirror h_src =
-        Kokkos::create_mirror_view(src);
+    Kokkos::View<double*, Kokkos::LayoutStride, exec_space>::host_mirror_type
+        h_src = Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
       h_src.data()[i] = (double)rand() / RAND_MAX * (100);
@@ -48,8 +48,8 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
 
     Kokkos::View<double*, Kokkos::LayoutLeft, exec_space> dst = src;
 
-    Kokkos::View<double*, Kokkos::LayoutLeft, exec_space>::HostMirror h_dst =
-        Kokkos::create_mirror_view(dst);
+    Kokkos::View<double*, Kokkos::LayoutLeft, exec_space>::host_mirror_type
+        h_dst = Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
 
@@ -72,8 +72,8 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
     Kokkos::View<double**, Kokkos::LayoutStride, exec_space> src("LayoutStride",
                                                                  layout);
 
-    Kokkos::View<double**, Kokkos::LayoutStride, exec_space>::HostMirror h_src =
-        Kokkos::create_mirror_view(src);
+    Kokkos::View<double**, Kokkos::LayoutStride, exec_space>::host_mirror_type
+        h_src = Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
       h_src.data()[i] = (double)rand() / RAND_MAX * (100);
@@ -82,8 +82,8 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
 
     Kokkos::View<double**, Kokkos::LayoutLeft, exec_space> dst = src;
 
-    Kokkos::View<double**, Kokkos::LayoutLeft, exec_space>::HostMirror h_dst =
-        Kokkos::create_mirror_view(dst);
+    Kokkos::View<double**, Kokkos::LayoutLeft, exec_space>::host_mirror_type
+        h_dst = Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
 
@@ -106,7 +106,7 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
     Kokkos::View<double***, Kokkos::LayoutStride, exec_space> src(
         "LayoutStride", layout);
 
-    Kokkos::View<double***, Kokkos::LayoutStride, exec_space>::HostMirror
+    Kokkos::View<double***, Kokkos::LayoutStride, exec_space>::host_mirror_type
         h_src = Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
@@ -116,8 +116,8 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
 
     Kokkos::View<double***, Kokkos::LayoutLeft, exec_space> dst = src;
 
-    Kokkos::View<double***, Kokkos::LayoutLeft, exec_space>::HostMirror h_dst =
-        Kokkos::create_mirror_view(dst);
+    Kokkos::View<double***, Kokkos::LayoutLeft, exec_space>::host_mirror_type
+        h_dst = Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
 
@@ -140,7 +140,7 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
     Kokkos::View<double****, Kokkos::LayoutStride, exec_space> src(
         "LayoutStride", layout);
 
-    Kokkos::View<double****, Kokkos::LayoutStride, exec_space>::HostMirror
+    Kokkos::View<double****, Kokkos::LayoutStride, exec_space>::host_mirror_type
         h_src = Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
@@ -150,8 +150,8 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
 
     Kokkos::View<double****, Kokkos::LayoutLeft, exec_space> dst = src;
 
-    Kokkos::View<double****, Kokkos::LayoutLeft, exec_space>::HostMirror h_dst =
-        Kokkos::create_mirror_view(dst);
+    Kokkos::View<double****, Kokkos::LayoutLeft, exec_space>::host_mirror_type
+        h_dst = Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
 
@@ -174,8 +174,9 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
     Kokkos::View<double*****, Kokkos::LayoutStride, exec_space> src(
         "LayoutStride", layout);
 
-    Kokkos::View<double*****, Kokkos::LayoutStride, exec_space>::HostMirror
-        h_src = Kokkos::create_mirror_view(src);
+    Kokkos::View<double*****, Kokkos::LayoutStride,
+                 exec_space>::host_mirror_type h_src =
+        Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
       h_src.data()[i] = (double)rand() / RAND_MAX * (100);
@@ -184,7 +185,7 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
 
     Kokkos::View<double*****, Kokkos::LayoutLeft, exec_space> dst = src;
 
-    Kokkos::View<double*****, Kokkos::LayoutLeft, exec_space>::HostMirror
+    Kokkos::View<double*****, Kokkos::LayoutLeft, exec_space>::host_mirror_type
         h_dst = Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
@@ -208,8 +209,9 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
     Kokkos::View<double******, Kokkos::LayoutStride, exec_space> src(
         "LayoutStride", layout);
 
-    Kokkos::View<double******, Kokkos::LayoutStride, exec_space>::HostMirror
-        h_src = Kokkos::create_mirror_view(src);
+    Kokkos::View<double******, Kokkos::LayoutStride,
+                 exec_space>::host_mirror_type h_src =
+        Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
       h_src.data()[i] = (double)rand() / RAND_MAX * (100);
@@ -218,7 +220,7 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
 
     Kokkos::View<double******, Kokkos::LayoutLeft, exec_space> dst = src;
 
-    Kokkos::View<double******, Kokkos::LayoutLeft, exec_space>::HostMirror
+    Kokkos::View<double******, Kokkos::LayoutLeft, exec_space>::host_mirror_type
         h_dst = Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
@@ -242,8 +244,9 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
     Kokkos::View<double*******, Kokkos::LayoutStride, exec_space> src(
         "LayoutStride", layout);
 
-    Kokkos::View<double*******, Kokkos::LayoutStride, exec_space>::HostMirror
-        h_src = Kokkos::create_mirror_view(src);
+    Kokkos::View<double*******, Kokkos::LayoutStride,
+                 exec_space>::host_mirror_type h_src =
+        Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
       h_src.data()[i] = (double)rand() / RAND_MAX * (100);
@@ -252,8 +255,9 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
 
     Kokkos::View<double*******, Kokkos::LayoutLeft, exec_space> dst = src;
 
-    Kokkos::View<double*******, Kokkos::LayoutLeft, exec_space>::HostMirror
-        h_dst = Kokkos::create_mirror_view(dst);
+    Kokkos::View<double*******, Kokkos::LayoutLeft,
+                 exec_space>::host_mirror_type h_dst =
+        Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
 
@@ -276,8 +280,9 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
     Kokkos::View<double********, Kokkos::LayoutStride, exec_space> src(
         "LayoutStride", layout);
 
-    Kokkos::View<double********, Kokkos::LayoutStride, exec_space>::HostMirror
-        h_src = Kokkos::create_mirror_view(src);
+    Kokkos::View<double********, Kokkos::LayoutStride,
+                 exec_space>::host_mirror_type h_src =
+        Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
       h_src.data()[i] = (double)rand() / RAND_MAX * (100);
@@ -286,8 +291,9 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
 
     Kokkos::View<double********, Kokkos::LayoutLeft, exec_space> dst = src;
 
-    Kokkos::View<double********, Kokkos::LayoutLeft, exec_space>::HostMirror
-        h_dst = Kokkos::create_mirror_view(dst);
+    Kokkos::View<double********, Kokkos::LayoutLeft,
+                 exec_space>::host_mirror_type h_dst =
+        Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
 
@@ -317,8 +323,8 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
     Kokkos::View<double*, Kokkos::LayoutStride, exec_space> src("LayoutStride",
                                                                 layout);
 
-    Kokkos::View<double*, Kokkos::LayoutStride, exec_space>::HostMirror h_src =
-        Kokkos::create_mirror_view(src);
+    Kokkos::View<double*, Kokkos::LayoutStride, exec_space>::host_mirror_type
+        h_src = Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
       h_src.data()[i] = (double)rand() / RAND_MAX * (100);
@@ -327,8 +333,8 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
 
     Kokkos::View<double*, Kokkos::LayoutRight, exec_space> dst = src;
 
-    Kokkos::View<double*, Kokkos::LayoutRight, exec_space>::HostMirror h_dst =
-        Kokkos::create_mirror_view(dst);
+    Kokkos::View<double*, Kokkos::LayoutRight, exec_space>::host_mirror_type
+        h_dst = Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
 
@@ -351,8 +357,8 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
     Kokkos::View<double**, Kokkos::LayoutStride, exec_space> src("LayoutStride",
                                                                  layout);
 
-    Kokkos::View<double**, Kokkos::LayoutStride, exec_space>::HostMirror h_src =
-        Kokkos::create_mirror_view(src);
+    Kokkos::View<double**, Kokkos::LayoutStride, exec_space>::host_mirror_type
+        h_src = Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
       h_src.data()[i] = (double)rand() / RAND_MAX * (100);
@@ -361,8 +367,8 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
 
     Kokkos::View<double**, Kokkos::LayoutRight, exec_space> dst = src;
 
-    Kokkos::View<double**, Kokkos::LayoutRight, exec_space>::HostMirror h_dst =
-        Kokkos::create_mirror_view(dst);
+    Kokkos::View<double**, Kokkos::LayoutRight, exec_space>::host_mirror_type
+        h_dst = Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
 
@@ -385,7 +391,7 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
     Kokkos::View<double***, Kokkos::LayoutStride, exec_space> src(
         "LayoutStride", layout);
 
-    Kokkos::View<double***, Kokkos::LayoutStride, exec_space>::HostMirror
+    Kokkos::View<double***, Kokkos::LayoutStride, exec_space>::host_mirror_type
         h_src = Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
@@ -395,8 +401,8 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
 
     Kokkos::View<double***, Kokkos::LayoutRight, exec_space> dst = src;
 
-    Kokkos::View<double***, Kokkos::LayoutRight, exec_space>::HostMirror h_dst =
-        Kokkos::create_mirror_view(dst);
+    Kokkos::View<double***, Kokkos::LayoutRight, exec_space>::host_mirror_type
+        h_dst = Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
 
@@ -419,7 +425,7 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
     Kokkos::View<double****, Kokkos::LayoutStride, exec_space> src(
         "LayoutStride", layout);
 
-    Kokkos::View<double****, Kokkos::LayoutStride, exec_space>::HostMirror
+    Kokkos::View<double****, Kokkos::LayoutStride, exec_space>::host_mirror_type
         h_src = Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
@@ -429,7 +435,7 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
 
     Kokkos::View<double****, Kokkos::LayoutRight, exec_space> dst = src;
 
-    Kokkos::View<double****, Kokkos::LayoutRight, exec_space>::HostMirror
+    Kokkos::View<double****, Kokkos::LayoutRight, exec_space>::host_mirror_type
         h_dst = Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
@@ -453,8 +459,9 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
     Kokkos::View<double*****, Kokkos::LayoutStride, exec_space> src(
         "LayoutStride", layout);
 
-    Kokkos::View<double*****, Kokkos::LayoutStride, exec_space>::HostMirror
-        h_src = Kokkos::create_mirror_view(src);
+    Kokkos::View<double*****, Kokkos::LayoutStride,
+                 exec_space>::host_mirror_type h_src =
+        Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
       h_src.data()[i] = (double)rand() / RAND_MAX * (100);
@@ -463,7 +470,7 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
 
     Kokkos::View<double*****, Kokkos::LayoutRight, exec_space> dst = src;
 
-    Kokkos::View<double*****, Kokkos::LayoutRight, exec_space>::HostMirror
+    Kokkos::View<double*****, Kokkos::LayoutRight, exec_space>::host_mirror_type
         h_dst = Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
@@ -487,8 +494,9 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
     Kokkos::View<double******, Kokkos::LayoutStride, exec_space> src(
         "LayoutStride", layout);
 
-    Kokkos::View<double******, Kokkos::LayoutStride, exec_space>::HostMirror
-        h_src = Kokkos::create_mirror_view(src);
+    Kokkos::View<double******, Kokkos::LayoutStride,
+                 exec_space>::host_mirror_type h_src =
+        Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
       h_src.data()[i] = (double)rand() / RAND_MAX * (100);
@@ -497,8 +505,9 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
 
     Kokkos::View<double******, Kokkos::LayoutRight, exec_space> dst = src;
 
-    Kokkos::View<double******, Kokkos::LayoutRight, exec_space>::HostMirror
-        h_dst = Kokkos::create_mirror_view(dst);
+    Kokkos::View<double******, Kokkos::LayoutRight,
+                 exec_space>::host_mirror_type h_dst =
+        Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
 
@@ -521,8 +530,9 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
     Kokkos::View<double*******, Kokkos::LayoutStride, exec_space> src(
         "LayoutStride", layout);
 
-    Kokkos::View<double*******, Kokkos::LayoutStride, exec_space>::HostMirror
-        h_src = Kokkos::create_mirror_view(src);
+    Kokkos::View<double*******, Kokkos::LayoutStride,
+                 exec_space>::host_mirror_type h_src =
+        Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
       h_src.data()[i] = (double)rand() / RAND_MAX * (100);
@@ -531,8 +541,9 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
 
     Kokkos::View<double*******, Kokkos::LayoutRight, exec_space> dst = src;
 
-    Kokkos::View<double*******, Kokkos::LayoutRight, exec_space>::HostMirror
-        h_dst = Kokkos::create_mirror_view(dst);
+    Kokkos::View<double*******, Kokkos::LayoutRight,
+                 exec_space>::host_mirror_type h_dst =
+        Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
 
@@ -555,8 +566,9 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
     Kokkos::View<double********, Kokkos::LayoutStride, exec_space> src(
         "LayoutStride", layout);
 
-    Kokkos::View<double********, Kokkos::LayoutStride, exec_space>::HostMirror
-        h_src = Kokkos::create_mirror_view(src);
+    Kokkos::View<double********, Kokkos::LayoutStride,
+                 exec_space>::host_mirror_type h_src =
+        Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
       h_src.data()[i] = (double)rand() / RAND_MAX * (100);
@@ -565,8 +577,9 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
 
     Kokkos::View<double********, Kokkos::LayoutRight, exec_space> dst = src;
 
-    Kokkos::View<double********, Kokkos::LayoutRight, exec_space>::HostMirror
-        h_dst = Kokkos::create_mirror_view(dst);
+    Kokkos::View<double********, Kokkos::LayoutRight,
+                 exec_space>::host_mirror_type h_dst =
+        Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
 
@@ -596,8 +609,8 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_right_to_layoutleft_assignment) {
     Kokkos::View<double*, Kokkos::LayoutStride, exec_space> src("LayoutStride",
                                                                 layout);
 
-    Kokkos::View<double*, Kokkos::LayoutStride, exec_space>::HostMirror h_src =
-        Kokkos::create_mirror_view(src);
+    Kokkos::View<double*, Kokkos::LayoutStride, exec_space>::host_mirror_type
+        h_src = Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
       h_src.data()[i] = (double)rand() / RAND_MAX * (100);
@@ -608,8 +621,8 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_right_to_layoutleft_assignment) {
 
     dst = src;
 
-    Kokkos::View<double*, Kokkos::LayoutLeft, exec_space>::HostMirror h_dst =
-        Kokkos::create_mirror_view(dst);
+    Kokkos::View<double*, Kokkos::LayoutLeft, exec_space>::host_mirror_type
+        h_dst = Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
 
@@ -748,8 +761,8 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_left_to_layoutright_assignment) {
     Kokkos::View<double*, Kokkos::LayoutStride, exec_space> src("LayoutStride",
                                                                 layout);
 
-    Kokkos::View<double*, Kokkos::LayoutStride, exec_space>::HostMirror h_src =
-        Kokkos::create_mirror_view(src);
+    Kokkos::View<double*, Kokkos::LayoutStride, exec_space>::host_mirror_type
+        h_src = Kokkos::create_mirror_view(src);
 
     for (size_t i = 0; i < src.span(); i++)
       h_src.data()[i] = (double)rand() / RAND_MAX * (100);
@@ -760,8 +773,8 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_left_to_layoutright_assignment) {
 
     dst = src;
 
-    Kokkos::View<double*, Kokkos::LayoutRight, exec_space>::HostMirror h_dst =
-        Kokkos::create_mirror_view(dst);
+    Kokkos::View<double*, Kokkos::LayoutRight, exec_space>::host_mirror_type
+        h_dst = Kokkos::create_mirror_view(dst);
 
     Kokkos::deep_copy(h_dst, dst);
 

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -850,7 +850,7 @@ void test_view_mapping() {
 
   {
     using V           = Kokkos::View<int**, Space>;
-    using M           = typename V::HostMirror;
+    using M           = typename V::host_mirror_type;
     using layout_type = typename Kokkos::View<int**, Space>::array_layout;
 
     constexpr size_t N0 = 10;
@@ -924,7 +924,7 @@ void test_view_mapping() {
 
   {
     using V = Kokkos::View<int**, Kokkos::LayoutStride, Space>;
-    using M = typename V::HostMirror;
+    using M = typename V::host_mirror_type;
     using layout_type =
         typename Kokkos::View<int**, Kokkos::LayoutStride, Space>::array_layout;
 

--- a/core/unit_test/TestViewMapping_b.hpp
+++ b/core/unit_test/TestViewMapping_b.hpp
@@ -76,7 +76,7 @@ struct TestViewMappingAtomic {
 
     ASSERT_EQ(0, error_count);
 
-    typename T_atom::HostMirror x_host = Kokkos::create_mirror_view(x);
+    typename T_atom::host_mirror_type x_host = Kokkos::create_mirror_view(x);
     Kokkos::deep_copy(x_host, x);
 
     error_count = -1;

--- a/core/unit_test/TestViewOfClass.hpp
+++ b/core/unit_test/TestViewOfClass.hpp
@@ -62,7 +62,7 @@ template <class Space>
 void view_nested_view() {
   Kokkos::View<int *, Space> tracking("tracking", 1);
 
-  typename Kokkos::View<int *, Space>::HostMirror host_tracking =
+  typename Kokkos::View<int *, Space>::host_mirror_type host_tracking =
       Kokkos::create_mirror(tracking);
 
   {

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -150,7 +150,7 @@ void test_auto_1d() {
   const size_type numCols = 3;
 
   mv_type X = getView<Layout, Space>::get(numRows, numCols);
-  typename mv_type::HostMirror X_h = Kokkos::create_mirror_view(X);
+  typename mv_type::host_mirror_type X_h = Kokkos::create_mirror_view(X);
 
   fill_2D<mv_type, Space> f1(X, ONE);
 #if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 3)

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -210,7 +210,7 @@ TEST(cuda, space_access) {
                 Kokkos::HostSpace>::accessible);
 #ifdef KOKKOS_ENABLE_CUDA_UVM
   using uvm_view = Kokkos::View<double *, Kokkos::CudaUVMSpace>;
-  static_assert(std::is_same_v<uvm_view::HostMirror::execution_space,
+  static_assert(std::is_same_v<uvm_view::host_mirror_type::execution_space,
                                Kokkos::DefaultHostExecutionSpace>,
                 "Verify HostMirror execution space is really a host space");
 #endif

--- a/core/unit_test/default/TestDefaultDeviceTypeViewAPI.cpp
+++ b/core/unit_test/default/TestDefaultDeviceTypeViewAPI.cpp
@@ -40,7 +40,7 @@ struct TestViewAPI<
                          Kokkos::LayoutLeft, layout_type>;
   using d_alloc_type = Kokkos::View<data_type, alloc_layout_type, space_type>;
   using h_alloc_type = typename Kokkos::View<data_type, alloc_layout_type,
-                                             space_type>::HostMirror;
+                                             space_type>::host_mirror_type;
 
   // add a +1 to avoid zero length static array
   size_t dyn_sizes[sizeof...(DynamicSizes) + 1] = {DynamicSizes..., 1};

--- a/core/unit_test/incremental/Test08_deep_copy.hpp
+++ b/core/unit_test/incremental/Test08_deep_copy.hpp
@@ -34,17 +34,17 @@ template <class ExecSpace>
 struct TestMDRangePolicy {
   // 2D View
   using View_2D      = Kokkos::View<value_type **, ExecSpace>;
-  using Host_View_2D = typename View_2D::HostMirror;
+  using Host_View_2D = typename View_2D::host_mirror_type;
   Host_View_2D hostDataView_2D;
 
   // 3D View
   using View_3D      = Kokkos::View<value_type ***, ExecSpace>;
-  using Host_View_3D = typename View_3D::HostMirror;
+  using Host_View_3D = typename View_3D::host_mirror_type;
   Host_View_3D hostDataView_3D;
 
   // 4D View
   using View_4D      = Kokkos::View<value_type ****, ExecSpace>;
-  using Host_View_4D = typename View_4D::HostMirror;
+  using Host_View_4D = typename View_4D::host_mirror_type;
   Host_View_4D hostDataView_4D;
 
   // Memory space type for Device and Host data

--- a/example/tutorial/04_simple_memoryspaces/simple_memoryspaces.cpp
+++ b/example/tutorial/04_simple_memoryspaces/simple_memoryspaces.cpp
@@ -21,7 +21,7 @@
 // It lives in Kokkos' default memory space.
 using view_type = Kokkos::View<double *[3]>;
 
-// The "HostMirror" type corresponding to view_type above is also a
+// The "host_mirror_type" type corresponding to view_type above is also a
 // two-dimensional N x 3 array of double.  However, it lives in the
 // host memory space corresponding to view_type's memory space.  For
 // example, if view_type lives in CUDA device memory, host_view_type
@@ -33,7 +33,7 @@ using view_type = Kokkos::View<double *[3]>;
 // performance penalties then it is its own host_mirror_space. This is
 // the case for HostSpace, CudaUVMSpace and CudaHostPinnedSpace.
 
-using host_view_type = view_type::HostMirror;
+using host_view_type = view_type::host_mirror_type;
 
 struct ReduceFunctor {
   view_type a;

--- a/example/tutorial/05_simple_atomics/simple_atomics.cpp
+++ b/example/tutorial/05_simple_atomics/simple_atomics.cpp
@@ -21,7 +21,7 @@
 
 // Type of a one-dimensional length-N array of int.
 using view_type      = Kokkos::View<int*>;
-using host_view_type = view_type::HostMirror;
+using host_view_type = view_type::host_mirror_type;
 // This is a "zero-dimensional" View, that is, a View of a single
 // value (an int, in this case).  Access the value using operator()
 // with no arguments: e.g., 'count()'.
@@ -30,7 +30,7 @@ using host_view_type = view_type::HostMirror;
 // resident in device memory, as well as for irregularly updated
 // shared state.  We use it for the latter in this example.
 using count_type      = Kokkos::View<int>;
-using host_count_type = count_type::HostMirror;
+using host_count_type = count_type::host_mirror_type;
 
 // Functor for finding a list of primes in a given set of numbers.  If
 // run in parallel, the order of results is nondeterministic, because

--- a/example/tutorial/Advanced_Views/02_memory_traits/memory_traits.cpp
+++ b/example/tutorial/Advanced_Views/02_memory_traits/memory_traits.cpp
@@ -46,7 +46,7 @@ using view_type = Kokkos::View<double*>;
 using view_type_rnd =
     Kokkos::View<const double*, Kokkos::MemoryTraits<Kokkos::RandomAccess> >;
 using idx_type      = Kokkos::View<int**>;
-using idx_type_host = idx_type::HostMirror;
+using idx_type_host = idx_type::host_mirror_type;
 
 // We template this functor on the ViewTypes to show the effect of the
 // RandomAccess trait.


### PR DESCRIPTION
Splits https://github.com/kokkos/kokkos/pull/7490.

Changes:
- `View::HostMirror` -> deprecated in favor of `View::host_mirror_type`

Note: In this PR we are still keeping `Kokkos::Impl::HostMirror`.
