### PR TITLE
A few more fixes to deal with Sacado stuff and special accessors

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -499,6 +499,11 @@ class DynRankView : private View<DataType*******, Properties...> {
   using reference        = reference_type;
   using data_handle_type = pointer_type;
 
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+  using accessor_type = typename view_type::accessor_type;
+  using mapping_type  = typename view_type::mapping_type;
+#endif
+
   KOKKOS_FUNCTION
   view_type& DownCast() const { return (view_type&)(*this); }
 
@@ -905,7 +910,8 @@ class DynRankView : private View<DataType*******, Properties...> {
       std::enable_if_t<((!std::is_same_v<P, std::string>)&&...),
                        const typename traits::array_layout&>
           layout) {
-    if constexpr (traits::impl_is_customized) {
+    if constexpr (traits::impl_is_customized &&
+                  !Impl::ViewCtorProp<P...>::has_accessor_arg) {
       int r = 0;
       while (r < 7 && layout.dimension[r] != KOKKOS_INVALID_INDEX) r++;
 
@@ -1602,23 +1608,16 @@ namespace Impl {
 template <class T, class... P, class... ViewCtorArgs>
 inline auto create_mirror(const DynRankView<T, P...>& src,
                           const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
-  check_view_ctor_args_create_mirror<ViewCtorArgs...>();
-
-  auto prop_copy = Impl::with_properties_if_unset(
-      arg_prop, std::string(src.label()).append("_mirror"));
-
   if constexpr (Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space) {
     using dst_type = typename Impl::MirrorDRViewType<
         typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
         P...>::dest_view_type;
-    return dst_type(prop_copy,
-                    Impl::reconstructLayout(src.layout(), src.rank()));
+    return dst_type(create_mirror(arg_prop, src.DownCast()), src.rank());
   } else {
     using src_type = DynRankView<T, P...>;
     using dst_type = typename src_type::HostMirror;
 
-    return dst_type(prop_copy,
-                    Impl::reconstructLayout(src.layout(), src.rank()));
+    return dst_type(create_mirror(arg_prop, src.DownCast()), src.rank());
   }
 #if defined(KOKKOS_COMPILER_NVCC) && KOKKOS_COMPILER_NVCC >= 1130 && \
     !defined(KOKKOS_COMPILER_MSVC)

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -513,8 +513,8 @@ class DynRankView : private View<DataType*******, Properties...> {
   const view_type& ConstDownCast() const { return (const view_type&)(*this); }
 
   // FIXME: deprecate DownCast in favor of to_view
-  KOKKOS_FUNCTION
-  view_type to_view() const { return *this; }
+  // KOKKOS_FUNCTION
+  // view_type to_view() const { return *this; }
 
   // Types below - at least the HostMirror requires the value_type, NOT the rank
   // 7 data_type of the traits
@@ -1612,12 +1612,12 @@ inline auto create_mirror(const DynRankView<T, P...>& src,
     using dst_type = typename Impl::MirrorDRViewType<
         typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
         P...>::dest_view_type;
-    return dst_type(create_mirror(arg_prop, src.to_view()), src.rank());
+    return dst_type(create_mirror(arg_prop, src.DownCast()), src.rank());
   } else {
     using src_type = DynRankView<T, P...>;
     using dst_type = typename src_type::HostMirror;
 
-    return dst_type(create_mirror(arg_prop, src.to_view()), src.rank());
+    return dst_type(create_mirror(arg_prop, src.DownCast()), src.rank());
   }
 #if defined(KOKKOS_COMPILER_NVCC) && KOKKOS_COMPILER_NVCC >= 1130 && \
     !defined(KOKKOS_COMPILER_MSVC)

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -513,8 +513,8 @@ class DynRankView : private View<DataType*******, Properties...> {
   const view_type& ConstDownCast() const { return (const view_type&)(*this); }
 
   // FIXME: deprecate DownCast in favor of to_view
-  // KOKKOS_FUNCTION
-  // view_type to_view() const { return *this; }
+  KOKKOS_FUNCTION
+  view_type to_view() const { return *this; }
 
   // Types below - at least the HostMirror requires the value_type, NOT the rank
   // 7 data_type of the traits
@@ -1612,12 +1612,12 @@ inline auto create_mirror(const DynRankView<T, P...>& src,
     using dst_type = typename Impl::MirrorDRViewType<
         typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
         P...>::dest_view_type;
-    return dst_type(create_mirror(arg_prop, src.DownCast()), src.rank());
+    return dst_type(create_mirror(arg_prop, src.to_view()), src.rank());
   } else {
     using src_type = DynRankView<T, P...>;
     using dst_type = typename src_type::HostMirror;
 
-    return dst_type(create_mirror(arg_prop, src.DownCast()), src.rank());
+    return dst_type(create_mirror(arg_prop, src.to_view()), src.rank());
   }
 #if defined(KOKKOS_COMPILER_NVCC) && KOKKOS_COMPILER_NVCC >= 1130 && \
     !defined(KOKKOS_COMPILER_MSVC)

--- a/containers/unit_tests/TestDynRankViewTypedefs.cpp
+++ b/containers/unit_tests/TestDynRankViewTypedefs.cpp
@@ -56,7 +56,7 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::data_type, DataType>);
   static_assert(std::is_same_v<typename ViewType::const_data_type, typename data_analysis<DataType>::const_data_type>);
   static_assert(std::is_same_v<typename ViewType::non_const_data_type, typename data_analysis<DataType>::non_const_data_type>);
-  
+
   // FIXME: these should be deprecated and for proper testing (I.e. where this is different from data_type)
   // we would need ensemble types which use the hidden View dimension facility of View (i.e. which make
   // "specialize" not void)
@@ -84,12 +84,12 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::memory_traits, MemoryTraitsType>);
   static_assert(std::is_same_v<typename ViewType::host_mirror_space, HostMirrorSpace>);
   static_assert(std::is_same_v<typename ViewType::size_type, typename ViewType::memory_space::size_type>);
- 
+
   // FIXME: should be deprecated in favor of reference
   static_assert(std::is_same_v<typename ViewType::reference_type, ReferenceType>);
   // FIXME: should be deprecated in favor of data_handle_type
   static_assert(std::is_same_v<typename ViewType::pointer_type, ValueType*>);
- 
+
   // =========================================
   // in Legacy View: some helper View variants
   // =========================================
@@ -173,6 +173,14 @@ constexpr bool test_view_typedefs_impl() {
   // FIXME: should come from accessor_type
   static_assert(std::is_same_v<typename ViewType::data_handle_type, typename ViewType::pointer_type>);
   static_assert(std::is_same_v<typename ViewType::reference, typename ViewType::reference_type>);
+
+  #ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+  using base_view_type = typename ViewType::view_type;
+  static_assert(
+      std::is_same_v<typename ViewType::accessor_type, typename base_view_type::accessor_type>);
+  static_assert(
+      std::is_same_v<typename ViewType::mapping_type, typename base_view_type::mapping_type>);
+  #endif
   return true;
 }
 

--- a/containers/unit_tests/TestDynRankView_ViewCustomization.hpp
+++ b/containers/unit_tests/TestDynRankView_ViewCustomization.hpp
@@ -221,7 +221,8 @@ TEST(TEST_CATEGORY, view_customization_extra_int_arg) {
     // This shouldn't take the last argument given and make it the accessor arg
     // as we provided it explicitly
     // Note that with and without labels are two separate cases
-    view_t a(Kokkos::view_alloc("A", Kokkos::Impl::AccessorArg_t{5ul}), 3, 7, 11);
+    view_t a(Kokkos::view_alloc("A", Kokkos::Impl::AccessorArg_t{5ul}), 3, 7,
+             11);
     ASSERT_EQ(a.rank(), 3lu);
     ASSERT_EQ(a.extent(0), 3lu);
     ASSERT_EQ(a.extent(1), 7lu);
@@ -240,6 +241,5 @@ TEST(TEST_CATEGORY, view_customization_extra_int_arg) {
     ASSERT_EQ(b.extent(2), 11lu);
     ASSERT_EQ(b.accessor().size, 5lu);
     ASSERT_EQ(b.accessor().stride, size_t(3 * 7 * 11));
-
   }
 }

--- a/containers/unit_tests/TestDynRankView_ViewCustomization.hpp
+++ b/containers/unit_tests/TestDynRankView_ViewCustomization.hpp
@@ -203,4 +203,43 @@ TEST(TEST_CATEGORY, view_customization_extra_int_arg) {
         sizeof(double);
     ASSERT_EQ(shmem, expected_shmem_size);
   }
+  // With accessor arg and no label
+  {
+    // This shouldn't take the last argument given and make it the accessor arg
+    // as we provided it explicitly
+    // Note that with and without labels are two separate cases
+    view_t a(Kokkos::view_alloc(Kokkos::Impl::AccessorArg_t{5ul}), 3, 7, 11);
+    ASSERT_EQ(a.rank(), 3lu);
+    ASSERT_EQ(a.extent(0), 3lu);
+    ASSERT_EQ(a.extent(1), 7lu);
+    ASSERT_EQ(a.extent(2), 11lu);
+    ASSERT_EQ(a.accessor().size, 5lu);
+    ASSERT_EQ(a.accessor().stride, size_t(3 * 7 * 11));
+  }
+  // With accessor arg and label
+  {
+    // This shouldn't take the last argument given and make it the accessor arg
+    // as we provided it explicitly
+    // Note that with and without labels are two separate cases
+    view_t a(Kokkos::view_alloc("A", Kokkos::Impl::AccessorArg_t{5ul}), 3, 7, 11);
+    ASSERT_EQ(a.rank(), 3lu);
+    ASSERT_EQ(a.extent(0), 3lu);
+    ASSERT_EQ(a.extent(1), 7lu);
+    ASSERT_EQ(a.extent(2), 11lu);
+    ASSERT_EQ(a.accessor().size, 5lu);
+    ASSERT_EQ(a.accessor().stride, size_t(3 * 7 * 11));
+  }
+  // Create mirror
+  {
+    view_t a("A", 3, 7, 11, 5);
+
+    auto b = Kokkos::create_mirror(a);
+    ASSERT_EQ(b.rank(), 3lu);
+    ASSERT_EQ(b.extent(0), 3lu);
+    ASSERT_EQ(b.extent(1), 7lu);
+    ASSERT_EQ(b.extent(2), 11lu);
+    ASSERT_EQ(b.accessor().size, 5lu);
+    ASSERT_EQ(b.accessor().stride, size_t(3 * 7 * 11));
+
+  }
 }

--- a/containers/unit_tests/TestDynRankView_ViewCustomization.hpp
+++ b/containers/unit_tests/TestDynRankView_ViewCustomization.hpp
@@ -206,9 +206,10 @@ TEST(TEST_CATEGORY, view_customization_extra_int_arg) {
   }
   // With accessor arg and no label
   {
-    // This shouldn't take the last argument given and make it the accessor arg
-    // as we provided it explicitly
-    // Note that with and without labels are two separate cases
+    // This should not interpret the last argument (11) as an accessor arg since
+    // we are providing AccessorArg_t explicitly
+    // Note that with and without
+    // labels are two separate cases
     view_t a(Kokkos::view_alloc(Kokkos::Impl::AccessorArg_t{5ul}), 3, 7, 11);
     ASSERT_EQ(a.rank(), 3lu);
     ASSERT_EQ(a.extent(0), 3lu);
@@ -219,9 +220,10 @@ TEST(TEST_CATEGORY, view_customization_extra_int_arg) {
   }
   // With accessor arg and label
   {
-    // This shouldn't take the last argument given and make it the accessor arg
-    // as we provided it explicitly
-    // Note that with and without labels are two separate cases
+    // This should not interpret the last argument (11) as an accessor arg since
+    // we are providing AccessorArg_t explicitly
+    // Note that with and without
+    // labels are two separate cases
     view_t a(Kokkos::view_alloc("A", Kokkos::Impl::AccessorArg_t{5ul}), 3, 7,
              11);
     ASSERT_EQ(a.rank(), 3lu);

--- a/containers/unit_tests/TestDynRankView_ViewCustomization.hpp
+++ b/containers/unit_tests/TestDynRankView_ViewCustomization.hpp
@@ -56,12 +56,13 @@ struct TestAccessorStrided {
   constexpr TestAccessorStrided() = default;
 
   template <class OtherElementType,
+            class OtherMemorySpace,
             std::enable_if_t<std::is_constructible_v<
                                  Kokkos::default_accessor<element_type>,
                                  Kokkos::default_accessor<OtherElementType>>,
                              int> = 0>
   KOKKOS_FUNCTION constexpr TestAccessorStrided(
-      const TestAccessorStrided<OtherElementType, MemorySpace>& other) noexcept
+      const TestAccessorStrided<OtherElementType, OtherMemorySpace>& other) noexcept
       : size(other.size), stride(other.stride) {}
 
   KOKKOS_FUNCTION

--- a/containers/unit_tests/TestDynRankView_ViewCustomization.hpp
+++ b/containers/unit_tests/TestDynRankView_ViewCustomization.hpp
@@ -55,14 +55,14 @@ struct TestAccessorStrided {
   KOKKOS_DEFAULTED_FUNCTION
   constexpr TestAccessorStrided() = default;
 
-  template <class OtherElementType,
-            class OtherMemorySpace,
+  template <class OtherElementType, class OtherMemorySpace,
             std::enable_if_t<std::is_constructible_v<
                                  Kokkos::default_accessor<element_type>,
                                  Kokkos::default_accessor<OtherElementType>>,
                              int> = 0>
   KOKKOS_FUNCTION constexpr TestAccessorStrided(
-      const TestAccessorStrided<OtherElementType, OtherMemorySpace>& other) noexcept
+      const TestAccessorStrided<OtherElementType, OtherMemorySpace>&
+          other) noexcept
       : size(other.size), stride(other.stride) {}
 
   KOKKOS_FUNCTION

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1054,7 +1054,7 @@ inline void deep_copy(
   using dst_memory_space = typename dst_type::memory_space;
   using src_memory_space = typename src_type::memory_space;
 
-  static_assert(std::is_same_v<typename dst_type::value_type,
+  static_assert(std::is_same_v<value_type,
                                typename src_type::non_const_value_type>,
                 "deep_copy requires matching non-const destination type");
 

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -56,11 +56,27 @@ namespace Impl {
 
 template <class ViewType, class Layout, class ExecSpace, typename iType>
 struct ViewFill<ViewType, Layout, ExecSpace, 0, iType> {
+  ViewType a;
+  typename ViewType::const_value_type val;
   using ST = typename ViewType::non_const_value_type;
-  ViewFill(const ViewType& a, const ST& val, const ExecSpace& space) {
-    Kokkos::Impl::DeepCopy<typename ViewType::memory_space, Kokkos::HostSpace,
-                           ExecSpace>(space, a.data(), &val, sizeof(ST));
+  ViewFill(const ViewType& a_, const ST& val_, const ExecSpace& space)
+      : a(a_), val(val_) {
+    // If the View is not customized and uses one of the trivial accessors
+    // we can deep_copy, otherwise we need to run a kernel so the accessor
+    // side effects take place.
+    if constexpr (!ViewType::traits::impl_is_customized) {
+      Kokkos::Impl::DeepCopy<typename ViewType::memory_space, Kokkos::HostSpace,
+                             ExecSpace>(space, a.data(), &val, sizeof(ST));
+    } else {
+      using policy_type =
+          Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<iType>>;
+      Kokkos::parallel_for("Kokkos::ViewFill-1D", policy_type(space, 0, 1),
+                           *this);
+    }
   }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType&) const { a() = val; }
 };
 
 template <class ViewType, class Layout, class ExecSpace, typename iType>
@@ -1062,8 +1078,16 @@ inline void deep_copy(
 
   Kokkos::fence("Kokkos::deep_copy: scalar to scalar copy, pre copy fence");
   if (dst.data() != src.data()) {
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+    using dst_ptr_type  = decltype(dst.data());
+    const size_t nbytes = allocation_size_from_mapping_and_accessor(
+                              src.mapping(), src.accessor()) *
+                          sizeof(std::remove_pointer_t<dst_ptr_type>);
+#else
+    const size_t nbytes = sizeof(value_type);
+#endif
     Kokkos::Impl::DeepCopy<dst_memory_space, src_memory_space>(
-        dst.data(), src.data(), sizeof(value_type));
+        dst.data(), src.data(), nbytes);
     Kokkos::fence("Kokkos::deep_copy: scalar to scalar copy, post copy fence");
   }
   if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1054,9 +1054,9 @@ inline void deep_copy(
   using dst_memory_space = typename dst_type::memory_space;
   using src_memory_space = typename src_type::memory_space;
 
-  static_assert(std::is_same_v<value_type,
-                               typename src_type::non_const_value_type>,
-                "deep_copy requires matching non-const destination type");
+  static_assert(
+      std::is_same_v<value_type, typename src_type::non_const_value_type>,
+      "deep_copy requires matching non-const destination type");
 
   if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
     Kokkos::Profiling::beginDeepCopy(

--- a/core/unit_test/view/TestViewCustomizationAllocationType.hpp
+++ b/core/unit_test/view/TestViewCustomizationAllocationType.hpp
@@ -324,6 +324,10 @@ void test_deep_copy_single_element_view() {
 
   Kokkos::RangePolicy<TEST_EXECSPACE> policy{0, 1};
 
+  // Verify that all "size" subelements in the single view
+  // are correctly copied. This verifies that views with
+  // custom allocated size (e.g. Sacado derivatives embedded in the view)
+  // work with single views.
   int num_errors = 0;
   Kokkos::parallel_reduce(
       "view_customization_deep_copy_a", policy,

--- a/core/unit_test/view/TestViewCustomizationAllocationType.hpp
+++ b/core/unit_test/view/TestViewCustomizationAllocationType.hpp
@@ -307,3 +307,70 @@ void test_deep_copy() {
 }
 
 TEST(TEST_CATEGORY, view_customization_deep_copy) { test_deep_copy(); }
+
+TEST(TEST_CATEGORY, view_customization_deep_copy_single_element_view) {
+  size_t size = 5;
+
+  using view_t = Kokkos::View<Foo::Bar, TEST_EXECSPACE>;
+
+  view_t a(Kokkos::view_alloc("A", Kokkos::Impl::AccessorArg_t{size}));
+
+  auto host_a = Kokkos::create_mirror_view(a);
+
+  for (size_t k = 0; k < size; ++k)
+    host_a()[k] = 0.1 * k;
+
+  // Contiguous deep_copy, potentially host to device
+  Kokkos::deep_copy(a, host_a);
+
+  int num_errors = 0;
+  Kokkos::parallel_reduce(
+      "view_customization_deep_copy_a", 1,
+      KOKKOS_LAMBDA(int, int& error) {
+        for (size_t k = 0; k < size; ++k) {
+          if (Kokkos::abs(a()[k] - 0.1 * k) >
+              Kokkos::Experimental::epsilon_v<float>)
+            ++error;
+          a()[k] = k;
+        }
+      },
+      num_errors);
+  ASSERT_EQ(num_errors, 0);
+
+  // Contiguous deep_copy, potentially device to host
+  Kokkos::deep_copy(host_a, a);
+  for (size_t k = 0; k < size; k++)
+    ASSERT_FLOAT_EQ(host_a()[k], k);
+  auto b = Kokkos::create_mirror(TEST_EXECSPACE::memory_space(), a);
+
+  num_errors = 0;
+  Kokkos::parallel_reduce(
+      "view_customization_check_pre_deep_copy_b", 1,
+      KOKKOS_LAMBDA(int, int& error) {
+        for (size_t k = 0; k < size; ++k) {
+          // Note b is value initalized for the scalar value type for the
+          // allocation
+          if (b()[k] != 0) {
+            ++error;
+          }
+        }
+      },
+      num_errors);
+  ASSERT_EQ(num_errors, 0);
+
+  // Contiguous deep_copy, same execspace
+  Kokkos::deep_copy(b, a);
+
+  num_errors = 0;
+  Kokkos::parallel_reduce(
+      "view_customization_check_pre_deep_copy_b", 1,
+      KOKKOS_LAMBDA(int, int& error) {
+        for (size_t k = 0; k < size; ++k) {
+          if (Kokkos::abs(b()[k] - k) >
+              Kokkos::Experimental::epsilon_v<float>)
+            ++error;
+        }
+      },
+      num_errors);
+  ASSERT_EQ(num_errors, 0);
+}

--- a/core/unit_test/view/TestViewCustomizationAllocationType.hpp
+++ b/core/unit_test/view/TestViewCustomizationAllocationType.hpp
@@ -308,7 +308,7 @@ void test_deep_copy() {
 
 TEST(TEST_CATEGORY, view_customization_deep_copy) { test_deep_copy(); }
 
-TEST(TEST_CATEGORY, view_customization_deep_copy_single_element_view) {
+void test_deep_copy_single_element_view() {
   size_t size = 5;
 
   using view_t = Kokkos::View<Foo::Bar, TEST_EXECSPACE>;
@@ -322,9 +322,11 @@ TEST(TEST_CATEGORY, view_customization_deep_copy_single_element_view) {
   // Contiguous deep_copy, potentially host to device
   Kokkos::deep_copy(a, host_a);
 
+  Kokkos::RangePolicy<TEST_EXECSPACE> policy{0, 1};
+
   int num_errors = 0;
   Kokkos::parallel_reduce(
-      "view_customization_deep_copy_a", 1,
+      "view_customization_deep_copy_a", policy,
       KOKKOS_LAMBDA(int, int& error) {
         for (size_t k = 0; k < size; ++k) {
           if (Kokkos::abs(a()[k] - 0.1 * k) >
@@ -343,7 +345,7 @@ TEST(TEST_CATEGORY, view_customization_deep_copy_single_element_view) {
 
   num_errors = 0;
   Kokkos::parallel_reduce(
-      "view_customization_check_pre_deep_copy_b", 1,
+      "view_customization_check_pre_deep_copy_b", policy,
       KOKKOS_LAMBDA(int, int& error) {
         for (size_t k = 0; k < size; ++k) {
           // Note b is value initalized for the scalar value type for the
@@ -361,7 +363,7 @@ TEST(TEST_CATEGORY, view_customization_deep_copy_single_element_view) {
 
   num_errors = 0;
   Kokkos::parallel_reduce(
-      "view_customization_check_pre_deep_copy_b", 1,
+      "view_customization_check_pre_deep_copy_b", policy,
       KOKKOS_LAMBDA(int, int& error) {
         for (size_t k = 0; k < size; ++k) {
           if (Kokkos::abs(b()[k] - k) > Kokkos::Experimental::epsilon_v<float>)
@@ -370,4 +372,8 @@ TEST(TEST_CATEGORY, view_customization_deep_copy_single_element_view) {
       },
       num_errors);
   ASSERT_EQ(num_errors, 0);
+}
+
+TEST(TEST_CATEGORY, view_customization_deep_copy_single_element_view) {
+  test_deep_copy_single_element_view();
 }

--- a/core/unit_test/view/TestViewCustomizationAllocationType.hpp
+++ b/core/unit_test/view/TestViewCustomizationAllocationType.hpp
@@ -317,8 +317,7 @@ TEST(TEST_CATEGORY, view_customization_deep_copy_single_element_view) {
 
   auto host_a = Kokkos::create_mirror_view(a);
 
-  for (size_t k = 0; k < size; ++k)
-    host_a()[k] = 0.1 * k;
+  for (size_t k = 0; k < size; ++k) host_a()[k] = 0.1 * k;
 
   // Contiguous deep_copy, potentially host to device
   Kokkos::deep_copy(a, host_a);
@@ -339,8 +338,7 @@ TEST(TEST_CATEGORY, view_customization_deep_copy_single_element_view) {
 
   // Contiguous deep_copy, potentially device to host
   Kokkos::deep_copy(host_a, a);
-  for (size_t k = 0; k < size; k++)
-    ASSERT_FLOAT_EQ(host_a()[k], k);
+  for (size_t k = 0; k < size; k++) ASSERT_FLOAT_EQ(host_a()[k], k);
   auto b = Kokkos::create_mirror(TEST_EXECSPACE::memory_space(), a);
 
   num_errors = 0;
@@ -366,8 +364,7 @@ TEST(TEST_CATEGORY, view_customization_deep_copy_single_element_view) {
       "view_customization_check_pre_deep_copy_b", 1,
       KOKKOS_LAMBDA(int, int& error) {
         for (size_t k = 0; k < size; ++k) {
-          if (Kokkos::abs(b()[k] - k) >
-              Kokkos::Experimental::epsilon_v<float>)
+          if (Kokkos::abs(b()[k] - k) > Kokkos::Experimental::epsilon_v<float>)
             ++error;
         }
       },


### PR DESCRIPTION
This fixes some oversights in CUDA builds for dealing with customized accessors.

Specifically deep_copies of rank 0 weren't doing the right thing yet, and create_mirror for DynRankView had issues when an actually mirror needed to be created.

This needs to get some standalone tests added.