### PR TITLE
Remove hard coded compiler in spack tests

### DIFF
--- a/scripts/spack_test/CMakeLists.txt.in
+++ b/scripts/spack_test/CMakeLists.txt.in
@@ -9,8 +9,6 @@ enable_testing()
 list(LENGTH SRC_NAME_LIST LEN) 
 math(EXPR LEN "${LEN}-1")
 
-set(CMAKE_CXX_COMPILER ${Kokkos_CXX_COMPILER})
-
 foreach (it RANGE ${LEN}) 
   list(GET SRC_NAME_LIST ${it} src) 
   list(GET BIN_NAME_LIST ${it} bin)


### PR DESCRIPTION
Fixes #8037.

Spack compiler wrappers cannot be called outside a spack context, so the `spack test run` command was failing.

Kokkos recipe in Spack should be updated for the tests to support any kind of backend.