### PR TITLE
Deprecate ViewTraits::HostMirrorSpace in favor of host_mirror_space

### DIFF
--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -331,13 +331,17 @@ struct ViewTraits;
 
 template <>
 struct ViewTraits<void> {
-  using execution_space = void;
-  using memory_space    = void;
-  using HostMirrorSpace = void;
-  using array_layout    = void;
-  using memory_traits   = void;
-  using specialize      = void;
-  using hooks_policy    = void;
+  using execution_space   = void;
+  using memory_space      = void;
+  using host_mirror_space = void;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  using HostMirrorSpace KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use host_mirror_space instead.") = host_mirror_space;
+#endif
+  using array_layout  = void;
+  using memory_traits = void;
+  using specialize    = void;
+  using hooks_policy  = void;
 };
 
 template <class... Prop>
@@ -345,11 +349,16 @@ struct ViewTraits<void, void, Prop...> {
   // Ignore an extraneous 'void'
   using execution_space = typename ViewTraits<void, Prop...>::execution_space;
   using memory_space    = typename ViewTraits<void, Prop...>::memory_space;
-  using HostMirrorSpace = typename ViewTraits<void, Prop...>::HostMirrorSpace;
-  using array_layout    = typename ViewTraits<void, Prop...>::array_layout;
-  using memory_traits   = typename ViewTraits<void, Prop...>::memory_traits;
-  using specialize      = typename ViewTraits<void, Prop...>::specialize;
-  using hooks_policy    = typename ViewTraits<void, Prop...>::hooks_policy;
+  using host_mirror_space =
+      typename ViewTraits<void, Prop...>::host_mirror_space;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  using HostMirrorSpace KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use host_mirror_space instead.") = host_mirror_space;
+#endif
+  using array_layout  = typename ViewTraits<void, Prop...>::array_layout;
+  using memory_traits = typename ViewTraits<void, Prop...>::memory_traits;
+  using specialize    = typename ViewTraits<void, Prop...>::specialize;
+  using hooks_policy  = typename ViewTraits<void, Prop...>::hooks_policy;
 };
 
 template <class HooksPolicy, class... Prop>
@@ -358,11 +367,17 @@ struct ViewTraits<
     HooksPolicy, Prop...> {
   using execution_space = typename ViewTraits<void, Prop...>::execution_space;
   using memory_space    = typename ViewTraits<void, Prop...>::memory_space;
-  using HostMirrorSpace = typename ViewTraits<void, Prop...>::HostMirrorSpace;
-  using array_layout    = typename ViewTraits<void, Prop...>::array_layout;
-  using memory_traits   = typename ViewTraits<void, Prop...>::memory_traits;
-  using specialize      = typename ViewTraits<void, Prop...>::specialize;
-  using hooks_policy    = HooksPolicy;
+
+  using host_mirror_space =
+      typename ViewTraits<void, Prop...>::host_mirror_space;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  using HostMirrorSpace KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use host_mirror_space instead.") = host_mirror_space;
+#endif
+  using array_layout  = typename ViewTraits<void, Prop...>::array_layout;
+  using memory_traits = typename ViewTraits<void, Prop...>::memory_traits;
+  using specialize    = typename ViewTraits<void, Prop...>::specialize;
+  using hooks_policy  = HooksPolicy;
 };
 
 template <class ArrayLayout, class... Prop>
@@ -372,11 +387,16 @@ struct ViewTraits<std::enable_if_t<Kokkos::is_array_layout<ArrayLayout>::value>,
 
   using execution_space = typename ViewTraits<void, Prop...>::execution_space;
   using memory_space    = typename ViewTraits<void, Prop...>::memory_space;
-  using HostMirrorSpace = typename ViewTraits<void, Prop...>::HostMirrorSpace;
-  using array_layout    = ArrayLayout;
-  using memory_traits   = typename ViewTraits<void, Prop...>::memory_traits;
-  using specialize      = typename ViewTraits<void, Prop...>::specialize;
-  using hooks_policy    = typename ViewTraits<void, Prop...>::hooks_policy;
+  using host_mirror_space =
+      typename ViewTraits<void, Prop...>::host_mirror_space;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  using HostMirrorSpace KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use host_mirror_space instead.") = host_mirror_space;
+#endif
+  using array_layout  = ArrayLayout;
+  using memory_traits = typename ViewTraits<void, Prop...>::memory_traits;
+  using specialize    = typename ViewTraits<void, Prop...>::specialize;
+  using hooks_policy  = typename ViewTraits<void, Prop...>::hooks_policy;
 };
 
 template <class Space, class... Prop>
@@ -389,7 +409,11 @@ struct ViewTraits<std::enable_if_t<Kokkos::is_space<Space>::value>, Space,
                      void> &&
           std::is_same_v<typename ViewTraits<void, Prop...>::memory_space,
                          void> &&
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
           std::is_same_v<typename ViewTraits<void, Prop...>::HostMirrorSpace,
+                         void> &&
+#endif
+          std::is_same_v<typename ViewTraits<void, Prop...>::host_mirror_space,
                          void> &&
           std::is_same_v<typename ViewTraits<void, Prop...>::array_layout,
                          void>,
@@ -397,8 +421,12 @@ struct ViewTraits<std::enable_if_t<Kokkos::is_space<Space>::value>, Space,
 
   using execution_space = typename Space::execution_space;
   using memory_space    = typename Space::memory_space;
-  using HostMirrorSpace =
+  using host_mirror_space =
       typename Kokkos::Impl::HostMirror<Space>::Space::memory_space;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  using HostMirrorSpace KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use host_mirror_space instead.") = host_mirror_space;
+#endif
   using array_layout  = typename execution_space::array_layout;
   using memory_traits = typename ViewTraits<void, Prop...>::memory_traits;
   using specialize    = typename ViewTraits<void, Prop...>::specialize;
@@ -424,13 +452,17 @@ struct ViewTraits<
                          void>,
       "MemoryTrait is the final optional template argument for a View");
 
-  using execution_space = void;
-  using memory_space    = void;
-  using HostMirrorSpace = void;
-  using array_layout    = void;
-  using memory_traits   = MemoryTraits;
-  using specialize      = void;
-  using hooks_policy    = void;
+  using execution_space   = void;
+  using memory_space      = void;
+  using host_mirror_space = void;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  using HostMirrorSpace KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Use host_mirror_space instead.") = host_mirror_space;
+#endif
+  using array_layout  = void;
+  using memory_traits = MemoryTraits;
+  using specialize    = void;
+  using hooks_policy  = void;
 };
 
 template <class DataType, class... Properties>
@@ -455,8 +487,8 @@ struct ViewTraits {
                          typename ExecutionSpace::array_layout>;
 
   using HostMirrorSpace = std::conditional_t<
-      !std::is_void_v<typename prop::HostMirrorSpace>,
-      typename prop::HostMirrorSpace,
+      !std::is_void_v<typename prop::host_mirror_space>,
+      typename prop::host_mirror_space,
       typename Kokkos::Impl::HostMirror<ExecutionSpace>::Space>;
 
   using MemoryTraits =

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -409,10 +409,6 @@ struct ViewTraits<std::enable_if_t<Kokkos::is_space<Space>::value>, Space,
                      void> &&
           std::is_same_v<typename ViewTraits<void, Prop...>::memory_space,
                          void> &&
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-          std::is_same_v<typename ViewTraits<void, Prop...>::HostMirrorSpace,
-                         void> &&
-#endif
           std::is_same_v<typename ViewTraits<void, Prop...>::host_mirror_space,
                          void> &&
           std::is_same_v<typename ViewTraits<void, Prop...>::array_layout,


### PR DESCRIPTION
Splits further https://github.com/kokkos/kokkos/pull/7490.

Changes:
- ViewTraits::HostMirrorSpace -> deprecated in favor of ViewTraits::host_mirror_space
