### PR TITLE
Correctly reduce with min/max over Views full of +inf/-inf

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
@@ -484,10 +484,10 @@ struct reduction_identity<Kokkos::Experimental::bhalf_t> {
     return 1.0F;
   }
   KOKKOS_FORCEINLINE_FUNCTION constexpr static float max() noexcept {
-    return -0x7f7f;
+    return -Kokkos::Experimental::infinity_v<float>;
   }
   KOKKOS_FORCEINLINE_FUNCTION constexpr static float min() noexcept {
-    return 0x7f7f;
+    return Kokkos::Experimental::infinity_v<float>;
   }
 };
 #endif  // CUDA_VERSION >= 11000
@@ -503,10 +503,10 @@ struct reduction_identity<Kokkos::Experimental::half_t> {
     return 1.0F;
   }
   KOKKOS_FORCEINLINE_FUNCTION constexpr static float max() noexcept {
-    return -65504.0F;
+    return -Kokkos::Experimental::infinity_v<float>;
   }
   KOKKOS_FORCEINLINE_FUNCTION constexpr static float min() noexcept {
-    return 65504.0F;
+    return Kokkos::Experimental::infinity_v<float>;
   }
 };
 

--- a/core/src/HIP/Kokkos_HIP_Half_Conversion.hpp
+++ b/core/src/HIP/Kokkos_HIP_Half_Conversion.hpp
@@ -206,10 +206,10 @@ struct reduction_identity<Kokkos::Experimental::half_t> {
     return 1.0F;
   }
   KOKKOS_FORCEINLINE_FUNCTION constexpr static float max() noexcept {
-    return -65504.0F;
+    return -Kokkos::Experimental::infinity_v<float>;
   }
   KOKKOS_FORCEINLINE_FUNCTION constexpr static float min() noexcept {
-    return 65504.0F;
+    return Kokkos::Experimental::infinity_v<float>;
   }
 };
 

--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -27,7 +27,6 @@
 #endif
 #include <type_traits>
 #include <limits>
-#include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
 
 namespace Kokkos::Experimental {
 

--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -27,6 +27,7 @@
 #endif
 #include <type_traits>
 #include <limits>
+#include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
 
 namespace Kokkos::Experimental {
 

--- a/core/src/Kokkos_ReductionIdentity.hpp
+++ b/core/src/Kokkos_ReductionIdentity.hpp
@@ -24,6 +24,7 @@
 #include <Kokkos_Macros.hpp>
 #include <cfloat>
 #include <climits>
+#include <cmath>
 
 namespace Kokkos {
 

--- a/core/src/Kokkos_ReductionIdentity.hpp
+++ b/core/src/Kokkos_ReductionIdentity.hpp
@@ -22,9 +22,6 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
-#include <Kokkos_NumericTraits.hpp>
-#endif
 #include <cfloat>
 #include <climits>
 
@@ -366,17 +363,10 @@ struct reduction_identity<float> {
   KOKKOS_FORCEINLINE_FUNCTION constexpr static float prod() {
     return static_cast<float>(1.0f);
   }
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_FORCEINLINE_FUNCTION constexpr static float max() {
-    return -Kokkos::Experimental::infinity_v<float>;
+    return -HUGE_VALF;
   }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float min() {
-    return Kokkos::Experimental::infinity_v<float>;
-  }
-#else
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float max() { return -FLT_MAX; }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float min() { return FLT_MAX; }
-#endif
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static float min() { return HUGE_VALF; }
 };
 
 template <>
@@ -387,17 +377,10 @@ struct reduction_identity<double> {
   KOKKOS_FORCEINLINE_FUNCTION constexpr static double prod() {
     return static_cast<double>(1.0);
   }
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_FORCEINLINE_FUNCTION constexpr static double max() {
-    return -Kokkos::Experimental::infinity_v<double>;
+    return -HUGE_VAL;
   }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static double min() {
-    return Kokkos::Experimental::infinity_v<double>;
-  }
-#else
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static double max() { return -DBL_MAX; }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static double min() { return DBL_MAX; }
-#endif
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static double min() { return HUGE_VAL; }
 };
 
 // No __host__ __device__ annotation because long double treated as double in
@@ -406,17 +389,8 @@ template <>
 struct reduction_identity<long double> {
   constexpr static long double sum() { return static_cast<long double>(0.0); }
   constexpr static long double prod() { return static_cast<long double>(1.0); }
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  constexpr static long double max() {
-    return -Kokkos::Experimental::infinity_v<long double>;
-  }
-  constexpr static long double min() {
-    return Kokkos::Experimental::infinity_v<long double>;
-  }
-#else
-  constexpr static long double max() { return -LDBL_MAX; }
-  constexpr static long double min() { return LDBL_MAX; }
-#endif
+  constexpr static long double max() { return -HUGE_VALL; }
+  constexpr static long double min() { return HUGE_VALL; }
 };
 
 }  // namespace Kokkos

--- a/core/src/Kokkos_ReductionIdentity.hpp
+++ b/core/src/Kokkos_ReductionIdentity.hpp
@@ -22,6 +22,9 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#include <Kokkos_NumericTraits.hpp>
+#endif
 #include <cfloat>
 #include <climits>
 
@@ -363,8 +366,17 @@ struct reduction_identity<float> {
   KOKKOS_FORCEINLINE_FUNCTION constexpr static float prod() {
     return static_cast<float>(1.0f);
   }
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static float max() {
+    return -Kokkos::Experimental::infinity_v<float>;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static float min() {
+    return Kokkos::Experimental::infinity_v<float>;
+  }
+#else
   KOKKOS_FORCEINLINE_FUNCTION constexpr static float max() { return -FLT_MAX; }
   KOKKOS_FORCEINLINE_FUNCTION constexpr static float min() { return FLT_MAX; }
+#endif
 };
 
 template <>
@@ -375,8 +387,17 @@ struct reduction_identity<double> {
   KOKKOS_FORCEINLINE_FUNCTION constexpr static double prod() {
     return static_cast<double>(1.0);
   }
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static double max() {
+    return -Kokkos::Experimental::infinity_v<double>;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static double min() {
+    return Kokkos::Experimental::infinity_v<double>;
+  }
+#else
   KOKKOS_FORCEINLINE_FUNCTION constexpr static double max() { return -DBL_MAX; }
   KOKKOS_FORCEINLINE_FUNCTION constexpr static double min() { return DBL_MAX; }
+#endif
 };
 
 // No __host__ __device__ annotation because long double treated as double in
@@ -385,8 +406,17 @@ template <>
 struct reduction_identity<long double> {
   constexpr static long double sum() { return static_cast<long double>(0.0); }
   constexpr static long double prod() { return static_cast<long double>(1.0); }
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  constexpr static long double max() {
+    return -Kokkos::Experimental::infinity_v<long double>;
+  }
+  constexpr static long double min() {
+    return Kokkos::Experimental::infinity_v<long double>;
+  }
+#else
   constexpr static long double max() { return -LDBL_MAX; }
   constexpr static long double min() { return LDBL_MAX; }
+#endif
 };
 
 }  // namespace Kokkos

--- a/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
@@ -116,12 +116,11 @@ struct reduction_identity<Kokkos::Experimental::half_t> {
   }
   KOKKOS_FORCEINLINE_FUNCTION constexpr static Kokkos::Experimental::half_t
   max() noexcept {
-    return std::numeric_limits<
-        Kokkos::Experimental::half_t::impl_type>::lowest();
+    return -Kokkos::Experimental::infinity_v<Kokkos::Experimental::half_t>;
   }
   KOKKOS_FORCEINLINE_FUNCTION constexpr static Kokkos::Experimental::half_t
   min() noexcept {
-    return std::numeric_limits<Kokkos::Experimental::half_t::impl_type>::max();
+    return Kokkos::Experimental::infinity_v<Kokkos::Experimental::half_t>;
   }
 };
 
@@ -223,10 +222,10 @@ struct reduction_identity<Kokkos::Experimental::bhalf_t> {
     return 1.0f;
   }
   KOKKOS_FORCEINLINE_FUNCTION constexpr static float max() noexcept {
-    return -0x7f7f;
+    return -Kokkos::Experimental::infinity_v<float>;
   }
   KOKKOS_FORCEINLINE_FUNCTION constexpr static float min() noexcept {
-    return 0x7f7f;
+    return Kokkos::Experimental::infinity_v<float>;
   }
 };
 

--- a/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
@@ -22,6 +22,7 @@
 #include <SYCL/Kokkos_SYCL_Half_Impl_Type.hpp>
 #include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
 #include <Kokkos_ReductionIdentity.hpp>
+#include <impl/Kokkos_Half_NumericTraits.hpp>
 
 namespace Kokkos {
 namespace Experimental {
@@ -114,12 +115,16 @@ struct reduction_identity<Kokkos::Experimental::half_t> {
   prod() noexcept {
     return Kokkos::Experimental::half_t::impl_type(1.0F);
   }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static Kokkos::Experimental::half_t
-  max() noexcept {
-    return -Kokkos::Experimental::infinity_v<Kokkos::Experimental::half_t>;
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static auto max() noexcept {
+    // sycl::half doesn't have constexpr constructors so we return
+    // bit_comparison_type which doesn't have a unitary minus operator.
+    // -inf
+    return Kokkos::Experimental::half_t::bit_comparison_type{
+        0b1'11111'0000000000};
   }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static Kokkos::Experimental::half_t
-  min() noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static auto min() noexcept {
+    // sycl::half doesn't have constexpr constructors so we return
+    // bit_comparison_type
     return Kokkos::Experimental::infinity_v<Kokkos::Experimental::half_t>;
   }
 };

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -672,4 +672,65 @@ TEST(TEST_CATEGORY, reduction_with_large_iteration_count) {
 }
 #endif
 
+/* Test that searching the Max of a View containing only -inf returns -inf and
+   the Min of a View containing only +inf returns +inf. */
+template <typename ScalarType>
+class TestReductionOverInfiniteFloat {
+ public:
+  TestReductionOverInfiniteFloat() { runTest(); }
+
+  void runTest() {
+    const int N = 10;
+
+    ScalarType inf = std::numeric_limits<ScalarType>::infinity();
+    Kokkos::View<ScalarType*> view("view", N);
+
+    Kokkos::deep_copy(view, inf);
+    ScalarType min;
+    Kokkos::parallel_reduce(
+        N,
+        KOKKOS_LAMBDA(const int i, ScalarType& partial_min) {
+          if (view[i] < partial_min) {
+            partial_min = view[i];
+          }
+        },
+        Kokkos::Min<ScalarType>(min));
+    ASSERT_EQ(inf, min);
+
+    Kokkos::deep_copy(view, -inf);
+    ScalarType max;
+    Kokkos::parallel_reduce(
+        N,
+        KOKKOS_LAMBDA(const int i, ScalarType& partial_max) {
+          if (view[i] > partial_max) {
+            partial_max = view[i];
+          }
+        },
+        Kokkos::Max<ScalarType>(min));
+    ASSERT_EQ(-inf, min);
+  }
+};
+
+// We do not run the test if KOKKOS_ENABLE_DEPRECATED_CODE_4 is ON because the
+// fix is only available if it is OFF
+TEST(TEST_CATEGORY, float_reduction_over_infinite) {
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  TestReductionOverInfiniteFloat<float>();
+#endif
+}
+
+TEST(TEST_CATEGORY, double_reduction_over_infinite) {
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  TestReductionOverInfiniteFloat<double>();
+#endif
+}
+
+TEST(TEST_CATEGORY, longdouble_reduction_over_infinite) {
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  // This won't compile if TEST_EXECSPACE is not on host because long double =
+  // double on device.
+  // KOKKOS_IF_ON_HOST(TestReductionOverInfiniteFloat<long double>();)
+#endif
+}
+
 }  // namespace Test

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -695,7 +695,8 @@ class TestReductionOverInfiniteFloat {
           }
         },
         Kokkos::Min<ScalarType>(min));
-    ASSERT_EQ(inf, min);
+    ASSERT_EQ(inf, min) << "For type "
+                        << Kokkos::Impl::TypeInfo<ScalarType>::name() << '\n';
 
     Kokkos::deep_copy(view, -inf);
     ScalarType max;
@@ -707,30 +708,20 @@ class TestReductionOverInfiniteFloat {
           }
         },
         Kokkos::Max<ScalarType>(min));
-    ASSERT_EQ(-inf, min);
+    ASSERT_EQ(-inf, min) << "For type "
+                         << Kokkos::Impl::TypeInfo<ScalarType>::name() << '\n';
   }
 };
 
-// We do not run the test if KOKKOS_ENABLE_DEPRECATED_CODE_4 is ON because the
-// fix is only available if it is OFF
-TEST(TEST_CATEGORY, float_reduction_over_infinite) {
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+TEST(TEST_CATEGORY, reduction_identity_min_max_floating_point_types) {
+  TestReductionOverInfiniteFloat<Kokkos::Experimental::half_t>();
+  TestReductionOverInfiniteFloat<Kokkos::Experimental::bhalf_t>();
   TestReductionOverInfiniteFloat<float>();
-#endif
-}
-
-TEST(TEST_CATEGORY, double_reduction_over_infinite) {
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
   TestReductionOverInfiniteFloat<double>();
-#endif
-}
-
-TEST(TEST_CATEGORY, longdouble_reduction_over_infinite) {
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  // This won't compile if TEST_EXECSPACE is not on host because long double =
-  // double on device.
-  // KOKKOS_IF_ON_HOST(TestReductionOverInfiniteFloat<long double>();)
-#endif
+  if constexpr (std::is_same_v<TEST_EXECSPACE::memory_space,
+                               Kokkos::HostSpace>) {
+    // TestReductionOverInfiniteFloat<long double>();
+  }
 }
 
 }  // namespace Test

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -18,8 +18,6 @@
 #include <iostream>
 #include <limits>
 
-#include <Kokkos_Macros.hpp>
-
 #include <Kokkos_Core.hpp>
 
 namespace Test {
@@ -685,6 +683,9 @@ class TestReductionOverInfiniteFloat {
     const unsigned int N = 10;
 
     ScalarType inf = Kokkos::Experimental::infinity_v<ScalarType>;
+    // Ensure that inf correctly correspond to infinity for type `ScalarType`
+    EXPECT_EQ(inf, inf * inf);
+
     Kokkos::View<ScalarType*> view("view", N);
 
     Kokkos::deep_copy(view, inf);
@@ -729,4 +730,3 @@ TEST(TEST_CATEGORY, reduction_identity_min_max_floating_point_types) {
 }
 
 }  // namespace Test
-

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -694,7 +694,7 @@ class TestReductionOverInfiniteFloat {
   TestReductionOverInfiniteFloat() { runTest(); }
 
   void runTest() {
-    const int N = 10;
+    const unsigned int N = 10;
 
     ScalarType inf = std::numeric_limits<ScalarType>::infinity();
     Kokkos::View<ScalarType*> view("view", N);

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -20,18 +20,6 @@
 
 #include <Kokkos_Macros.hpp>
 
-#ifdef KOKKOS_COMPILER_NVCC
-#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
-#pragma nv_diagnostic push
-#pragma nv_diag_suppress 20208
-#else
-#ifdef __CUDA_ARCH__
-#pragma diagnostic push
-#pragma diag_suppress 3245
-#endif
-#endif
-#endif
-
 #include <Kokkos_Core.hpp>
 
 namespace Test {
@@ -742,12 +730,3 @@ TEST(TEST_CATEGORY, reduction_identity_min_max_floating_point_types) {
 
 }  // namespace Test
 
-#ifdef KOKKOS_COMPILER_NVCC
-#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
-#pragma nv_diagnostic pop
-#else
-#ifdef __CUDA_ARCH__
-#pragma diagnostic pop
-#endif
-#endif
-#endif

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -18,6 +18,20 @@
 #include <iostream>
 #include <limits>
 
+#include <Kokkos_Macros.hpp>
+
+#ifdef KOKKOS_COMPILER_NVCC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress 20208
+#else
+#ifdef __CUDA_ARCH__
+#pragma diagnostic push
+#pragma diag_suppress 3245
+#endif
+#endif
+#endif
+
 #include <Kokkos_Core.hpp>
 
 namespace Test {
@@ -718,10 +732,22 @@ TEST(TEST_CATEGORY, reduction_identity_min_max_floating_point_types) {
   TestReductionOverInfiniteFloat<Kokkos::Experimental::bhalf_t>();
   TestReductionOverInfiniteFloat<float>();
   TestReductionOverInfiniteFloat<double>();
-  if constexpr (std::is_same_v<TEST_EXECSPACE::memory_space,
-                               Kokkos::HostSpace>) {
-    // TestReductionOverInfiniteFloat<long double>();
-  }
+
+#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) &&          \
+    !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_OPENMPTARGET) && \
+    !defined(KOKKOS_ENABLE_OPENACC)
+  TestReductionOverInfiniteFloat<long double>();
+#endif
 }
 
 }  // namespace Test
+
+#ifdef KOKKOS_COMPILER_NVCC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic pop
+#else
+#ifdef __CUDA_ARCH__
+#pragma diagnostic pop
+#endif
+#endif
+#endif

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -684,7 +684,7 @@ class TestReductionOverInfiniteFloat {
   void runTest() {
     const unsigned int N = 10;
 
-    ScalarType inf = std::numeric_limits<ScalarType>::infinity();
+    ScalarType inf = Kokkos::Experimental::infinity_v<ScalarType>;
     Kokkos::View<ScalarType*> view("view", N);
 
     Kokkos::deep_copy(view, inf);
@@ -697,7 +697,7 @@ class TestReductionOverInfiniteFloat {
           }
         },
         Kokkos::Min<ScalarType>(min));
-    ASSERT_EQ(inf, min) << "For type "
+    EXPECT_EQ(inf, min) << "For type "
                         << Kokkos::Impl::TypeInfo<ScalarType>::name() << '\n';
 
     Kokkos::deep_copy(view, -inf);
@@ -710,7 +710,7 @@ class TestReductionOverInfiniteFloat {
           }
         },
         Kokkos::Max<ScalarType>(max));
-    ASSERT_EQ(-inf, max) << "For type "
+    EXPECT_EQ(-inf, max) << "For type "
                          << Kokkos::Impl::TypeInfo<ScalarType>::name() << '\n';
   }
 };

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -717,6 +717,9 @@ class TestReductionOverInfiniteFloat {
 };
 
 TEST(TEST_CATEGORY, reduction_identity_min_max_floating_point_types) {
+  // nvhpc on device doesn't use the correct neutral value for the min and max
+  // reducers
+#if !(defined(KOKKOS_COMPILER_NVHPC) && defined(KOKKOS_ENABLE_OPENACC))
   TestReductionOverInfiniteFloat<Kokkos::Experimental::half_t>();
   TestReductionOverInfiniteFloat<Kokkos::Experimental::bhalf_t>();
   TestReductionOverInfiniteFloat<float>();
@@ -726,6 +729,7 @@ TEST(TEST_CATEGORY, reduction_identity_min_max_floating_point_types) {
     !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_OPENMPTARGET) && \
     !defined(KOKKOS_ENABLE_OPENACC)
   TestReductionOverInfiniteFloat<long double>();
+#endif
 #endif
 }
 

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -707,8 +707,8 @@ class TestReductionOverInfiniteFloat {
             partial_max = view[i];
           }
         },
-        Kokkos::Max<ScalarType>(min));
-    ASSERT_EQ(-inf, min) << "For type "
+        Kokkos::Max<ScalarType>(max));
+    ASSERT_EQ(-inf, max) << "For type "
                          << Kokkos::Impl::TypeInfo<ScalarType>::name() << '\n';
   }
 };

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -684,7 +684,7 @@ class TestReductionOverInfiniteFloat {
 
     ScalarType inf = Kokkos::Experimental::infinity_v<ScalarType>;
     // Ensure that inf correctly correspond to infinity for type `ScalarType`
-    EXPECT_EQ(inf, inf * inf);
+    EXPECT_TRUE((inf == inf * inf) && (inf == inf + 1));
 
     Kokkos::View<ScalarType*> view("view", N);
 


### PR DESCRIPTION
Currently, when reducing using the `Min` reducer over a View containing only +inf, we get FLOAT_MAX as a result ([reproducer](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,selection:(endColumn:2,endLineNumber:30,positionColumn:2,positionLineNumber:30,selectionStartColumn:2,selectionStartLineNumber:30,startColumn:2,startLineNumber:30),source:'%23include+%3Ciostream%3E%0A%23include+%3Climits%3E%0A%0A%23include+%3CKokkos_Core.hpp%3E%0A%0Aint+main(int+argc,+char*+argv%5B%5D)+%7B%0A++++Kokkos::ScopeGuard+guard(argc,+argv)%3B%0A++++%7B%0A++++++++const+int+N+%3D+10%3B%0A++++++++%0A++++++++Kokkos::View%3Cfloat*%3E+f(%22view%22,+N)%3B%0A++++++++Kokkos::parallel_for(N,+KOKKOS_LAMBDA(const+int+i)%7B%0A++++++++++++f(i)+%3D+std::numeric_limits%3Cfloat%3E::infinity()%3B%0A++++++++%7D)%3B%0A++++++++%0A++++++++float+min%3B%0A++++++++Kokkos::parallel_reduce(N,+KOKKOS_LAMBDA+(const+int%26+i,+float%26+res)+%7B%0A++++++++++++res+%3D+res+%3C+f(i)+%3F+res+:+f(i)%3B%0A++++++++%7D,+Kokkos::Min%3Cfloat%3E(min))%3B%0A++++++++%0A++++++++std::cout+%3C%3C+min+%3C%3C+std::endl%3B%0A%0A++++++++min+%3D+std::numeric_limits%3Cfloat%3E::infinity()%3B%0A++++++++for+(int+i+%3D+0%3B+i%3CN%3B+%2B%2Bi)+%7B%0A++++++++++++min+%3D+min+%3C+f(i)+%3F+min+:+f(i)%3B%0A++++++++%7D%0A++++++++std::cout+%3C%3C+min+%3C%3C+std::endl%3B%0A%0A++++%7D%0A%7D'),l:'5',n:'0',o:'C%2B%2B+source+%231',t:'0')),k:53.43450479233227,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((g:!((h:compiler,i:(compiler:g121,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'0',intel:'0',libraryCode:'0',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,libs:!((name:kokkos,ver:'4500')),options:'-std%3Dc%2B%2B23+-Wall+-Wextra+-Werror',overrides:!(),selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+x86-64+gcc+12.1+(Editor+%231)',t:'0')),k:50,l:'4',m:50.32010243277849,n:'0',o:'',s:0,t:'0'),(g:!((h:output,i:(editorid:1,fontScale:14,fontUsePx:'0',j:1,wrap:'1'),l:'5',n:'0',o:'Output+of+x86-64+gcc+12.1+(Compiler+%231)',t:'0')),header:(),l:'4',m:49.67989756722151,n:'0',o:'',s:0,t:'0')),k:46.56549520766773,l:'3',n:'0',o:'',t:'0')),l:'2',n:'0',o:'',t:'0')),version:4)).
With this PR, we should correctly return +inf/-inf.