### PR TITLE
Switch to `find_last_of` to parse key value pairs in benchmarks

### DIFF
--- a/core/perf_test/Benchmark_Context.cpp
+++ b/core/perf_test/Benchmark_Context.cpp
@@ -45,7 +45,7 @@ void add_kokkos_configuration(bool verbose) {
   // Iterate over lines returned from kokkos and extract key:value pairs
   std::stringstream ss{msg.str()};
   for (std::string line; std::getline(ss, line, '\n');) {
-    auto found = line.find_first_of(':');
+    auto found = line.find_last_of(':');
     if (found != std::string::npos) {
       auto val = remove_unwanted_characters(line.substr(found + 1));
       // Ignore line without value, for example a category name

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -210,7 +210,10 @@ void CudaInternal::print_configuration(std::ostream &s) const {
     cudaDeviceProp prop;
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceProperties(&prop, i));
     s << "Kokkos::Cuda[ " << i << " ] " << prop.name;
-    if (m_cudaDev == i) s << " : Selected";
+    if (m_cudaDev == i)
+      s << " : Selected";
+    else
+      s << " : Not Selected";
     s << '\n'
       << "  Capability: " << prop.major << "." << prop.minor << '\n'
       << "  Total Global Memory: " << human_memory_size(prop.totalGlobalMem)

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -202,7 +202,7 @@ void CudaInternal::print_configuration(std::ostream &s) const {
   s << "macro  KOKKOS_ENABLE_CUDA      : defined\n";
 #endif
 #if defined(CUDA_VERSION)
-  s << "macro  CUDA_VERSION          = " << CUDA_VERSION << " = version "
+  s << "macro  CUDA_VERSION          : " << CUDA_VERSION << " = version "
     << CUDA_VERSION / 1000 << "." << (CUDA_VERSION % 1000) / 10 << '\n';
 #endif
 

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -113,7 +113,10 @@ void HIPInternal::print_configuration(std::ostream &s) const {
 
     s << "Kokkos::HIP[ " << i << " ] "
       << "gcnArch " << hipProp.gcnArchName;
-    if (m_hipDev == i) s << " : Selected";
+    if (m_hipDev == i)
+      s << " : Selected";
+    else
+      s << " : Not Selected";
     s << '\n'
       << "  Total Global Memory: "
       << ::Kokkos::Impl::human_memory_size(hipProp.totalGlobalMem) << '\n'

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -87,7 +87,7 @@ int HIPInternal::concurrency() {
 void HIPInternal::print_configuration(std::ostream &s) const {
   s << "macro  KOKKOS_ENABLE_HIP : defined" << '\n';
 #if defined(HIP_VERSION)
-  s << "macro  HIP_VERSION = " << HIP_VERSION << " = version "
+  s << "macro  HIP_VERSION : " << HIP_VERSION << " = version "
     << HIP_VERSION_MAJOR << '.' << HIP_VERSION_MINOR << '.' << HIP_VERSION_PATCH
     << '\n';
 #endif

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -167,7 +167,10 @@ void SYCL::print_configuration(std::ostream& os, bool verbose) const {
     }
     os << "[" << device.get_backend() << "]:" << device_type << ':' << counter
        << "] " << device.get_info<sycl::info::device::name>();
-    if (counter == active_device) os << " : Selected";
+    if (counter == active_device)
+      os << " : Selected";
+    else
+      os << " : Not Selected";
     os << '\n';
     ++counter;
   }


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/8241.
This is the quickest attempt of a fix by splitting the parsed line at the last `:` instead of the first. This only requires that the last `:` is the one delimiting key and value.

Currently we do not promise a parsable output in our `print_configuration`. We can discuss if we want to do that.
Sine `benchmark::AddCustomContext` does not error out for invalid arguments, but just prints a message our CI did not catch it. So to catch errors in the context we would need our own error detection for which we would want a parsable output of `print_configuration`