### PR TITLE
Fix builds with Kokkos_ENABLE_DEBUG_BOUND_CHECKS

### DIFF
--- a/cmake/kokkos_enable_options.cmake
+++ b/cmake/kokkos_enable_options.cmake
@@ -80,7 +80,7 @@ endif()
 
 unset(_UPPERCASE_CMAKE_BUILD_TYPE)
 kokkos_enable_option(LARGE_MEM_TESTS OFF "Whether to perform extra large memory tests")
-kokkos_enable_option(DEBUG_BOUNDS_CHECK OFF "Whether to use bounds checking - will increase runtime")
+kokkos_enable_option(DEBUG_BOUNDS_CHECK ${DEBUG_DEFAULT} "Whether to use bounds checking - will increase runtime")
 kokkos_enable_option(COMPILER_WARNINGS OFF "Whether to print all compiler warnings")
 kokkos_enable_option(TUNING OFF "Whether to create bindings for tuning tools")
 kokkos_enable_option(AGGRESSIVE_VECTORIZATION OFF "Whether to aggressively vectorize loops")

--- a/cmake/kokkos_enable_options.cmake
+++ b/cmake/kokkos_enable_options.cmake
@@ -80,7 +80,7 @@ endif()
 
 unset(_UPPERCASE_CMAKE_BUILD_TYPE)
 kokkos_enable_option(LARGE_MEM_TESTS OFF "Whether to perform extra large memory tests")
-kokkos_enable_option(DEBUG_BOUNDS_CHECK ${DEBUG_DEFAULT} "Whether to use bounds checking - will increase runtime")
+kokkos_enable_option(DEBUG_BOUNDS_CHECK OFF "Whether to use bounds checking - will increase runtime")
 kokkos_enable_option(COMPILER_WARNINGS OFF "Whether to print all compiler warnings")
 kokkos_enable_option(TUNING OFF "Whether to create bindings for tuning tools")
 kokkos_enable_option(AGGRESSIVE_VECTORIZATION OFF "Whether to aggressively vectorize loops")

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -644,7 +644,9 @@ class DynRankView : private View<DataType*******, Properties...> {
       return view_type::data()[0];
     } else
 #endif
+    {
       return view_type::operator()(0, 0, 0, 0, 0, 0, 0);
+    }
   }
 
   KOKKOS_FUNCTION reference_type operator()(index_type i0) const {
@@ -665,7 +667,9 @@ class DynRankView : private View<DataType*******, Properties...> {
       }
     } else
 #endif
+    {
       return view_type::operator()(i0, 0, 0, 0, 0, 0, 0);
+    }
 #if defined(KOKKOS_COMPILER_NVCC) && KOKKOS_COMPILER_NVCC >= 1130 && \
     !defined(KOKKOS_COMPILER_MSVC)
     __builtin_unreachable();
@@ -694,7 +698,9 @@ class DynRankView : private View<DataType*******, Properties...> {
       }
     } else
 #endif
+    {
       return view_type::operator()(i0, i1, 0, 0, 0, 0, 0);
+    }
 #if defined(KOKKOS_COMPILER_NVCC) && KOKKOS_COMPILER_NVCC >= 1130 && \
     !defined(KOKKOS_COMPILER_MSVC)
     __builtin_unreachable();
@@ -727,7 +733,9 @@ class DynRankView : private View<DataType*******, Properties...> {
       }
     } else
 #endif
+    {
       return view_type::operator()(i0, i1, i2, 0, 0, 0, 0);
+    }
 #if defined(KOKKOS_COMPILER_NVCC) && KOKKOS_COMPILER_NVCC >= 1130 && \
     !defined(KOKKOS_COMPILER_MSVC)
     __builtin_unreachable();

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -746,6 +746,23 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
                    typename mdspan_type::mapping_type, sizeof(value_type)>(
                    arg_prop, arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5,
                    arg_N6, arg_N7)) {
+#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
+    if constexpr (std::is_same_v<typename traits::array_layout,
+                                 Kokkos::LayoutLeft> ||
+                  std::is_same_v<typename traits::array_layout,
+                                 Kokkos::LayoutRight> ||
+                  std::is_same_v<typename traits::array_layout,
+                                 Kokkos::LayoutStride>) {
+      auto prop_copy = Impl::with_properties_if_unset(arg_prop, std::string{});
+      const std::string& alloc_name =
+          Impl::get_property<Impl::LabelTag>(prop_copy);
+
+      Impl::runtime_check_rank(
+          *this, std::is_same_v<typename traits::specialize, void>, arg_N0,
+          arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7,
+          alloc_name.c_str());
+    }
+#endif
     static_assert(traits::array_layout::is_extent_constructible,
                   "Layout is not constructible from extent arguments. Use "
                   "overload taking a layout object instead.");
@@ -770,6 +787,18 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
                    typename mdspan_type::mapping_type, sizeof(value_type)>(
                    arg_prop, arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5,
                    arg_N6, arg_N7)) {
+#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
+    if constexpr (std::is_same_v<typename traits::array_layout,
+                                 Kokkos::LayoutLeft> ||
+                  std::is_same_v<typename traits::array_layout,
+                                 Kokkos::LayoutRight> ||
+                  std::is_same_v<typename traits::array_layout,
+                                 Kokkos::LayoutStride>) {
+      Impl::runtime_check_rank(
+          *this, std::is_same_v<typename traits::specialize, void>, arg_N0,
+          arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7, "UNMANAGED");
+    }
+#endif
     static_assert(traits::array_layout::is_extent_constructible,
                   "Layout is not constructible from extent arguments. Use "
                   "overload taking a layout object instead.");

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -757,10 +757,9 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
       const std::string& alloc_name =
           Impl::get_property<Impl::LabelTag>(prop_copy);
 
-      Impl::runtime_check_rank(
-          *this, std::is_same_v<typename traits::specialize, void>, arg_N0,
-          arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7,
-          alloc_name.c_str());
+      Impl::runtime_check_rank(*this, !traits::impl_is_customized, arg_N0,
+                               arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6,
+                               arg_N7, alloc_name.c_str());
     }
 #endif
     static_assert(traits::array_layout::is_extent_constructible,
@@ -794,9 +793,9 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
                                  Kokkos::LayoutRight> ||
                   std::is_same_v<typename traits::array_layout,
                                  Kokkos::LayoutStride>) {
-      Impl::runtime_check_rank(
-          *this, std::is_same_v<typename traits::specialize, void>, arg_N0,
-          arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7, "UNMANAGED");
+      Impl::runtime_check_rank(*this, !traits::impl_is_customized, arg_N0,
+                               arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6,
+                               arg_N7, "UNMANAGED");
     }
 #endif
     static_assert(traits::array_layout::is_extent_constructible,

--- a/core/src/View/Kokkos_ViewAccessPreconditionsCheck.hpp
+++ b/core/src/View/Kokkos_ViewAccessPreconditionsCheck.hpp
@@ -95,7 +95,9 @@ KOKKOS_FUNCTION bool within_range(
     return true;
   };
 
-  return ((indices < exts.extent(Enumerate)) && ...) &&
+  return ((static_cast<size_t>(indices) <
+           static_cast<size_t>(exts.extent(Enumerate))) &&
+          ...) &&
          (check_index_min(indices) && ...);
 }
 

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -163,7 +163,7 @@ KOKKOS_FUNCTION constexpr to_chars_result to_chars_i(char *first, char *last,
                                                      Integral value) {
   using Unsigned = std::conditional_t<sizeof(Integral) <= sizeof(unsigned int),
                                       unsigned int, unsigned long long>;
-  Unsigned unsigned_val = value;
+  Unsigned unsigned_val = value;  // NOLINT(bugprone-signed-char-misuse)
   if (value == 0) {
     *first = '0';
     return {first + 1, {}};


### PR DESCRIPTION
- Reenable runtime check rank for mdspan-based View implementation
- Fix compiler warnings and clang-tidy complaints

To discuss:
- Should we enable Kokkos_ENABLE_DEBUG_BOUND_CHECKS when requesting a `Debug` build?