### PR TITLE
Fix view_subview_constructor_layout_compatibility

### DIFF
--- a/core/unit_test/TestSubView_c15.hpp
+++ b/core/unit_test/TestSubView_c15.hpp
@@ -48,8 +48,7 @@ TEST(TEST_CATEGORY_DEATH, view_subview_constructor_layout_compatibility) {
 
   Kokkos::View<int**, LL> a2("A2", 1, N);
   {
-    // Using subview dims (1, ALL), but the first dimension is stride 1. Any
-    // subview layout should be appropriate.
+    // Using subview dims (0, ALL). Any subview layout should be appropriate.
     (void)Kokkos::View<int*, LL>(a2, 0, Kokkos::ALL);
     (void)Kokkos::View<int*, LS>(a2, 0, Kokkos::ALL);
     (void)Kokkos::View<int*, LR>(a2, 0, Kokkos::ALL);

--- a/core/unit_test/TestSubView_c15.hpp
+++ b/core/unit_test/TestSubView_c15.hpp
@@ -50,9 +50,9 @@ TEST(TEST_CATEGORY_DEATH, view_subview_constructor_layout_compatibility) {
   {
     // Using subview dims (1, ALL), but the first dimension is stride 1. Any
     // subview layout should be appropriate.
-    (void)Kokkos::View<int*, LL>(a2, 1, Kokkos::ALL);
-    (void)Kokkos::View<int*, LS>(a2, 1, Kokkos::ALL);
-    (void)Kokkos::View<int*, LR>(a2, 1, Kokkos::ALL);
+    (void)Kokkos::View<int*, LL>(a2, 0, Kokkos::ALL);
+    (void)Kokkos::View<int*, LS>(a2, 0, Kokkos::ALL);
+    (void)Kokkos::View<int*, LR>(a2, 0, Kokkos::ALL);
   }
 }
 }  // namespace


### PR DESCRIPTION
Fixes #8245. The first extent is 1 so we can only request index 0 when creating a subview.