### PR TITLE
simd: change [native_]simd to use max available simd size

### DIFF
--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -85,32 +85,39 @@ namespace Impl {
 #if defined(KOKKOS_ARCH_AVX512XEON)
 template <class T>
 using host_fixed_native = avx512_fixed_size<8>;
-template <int N>
-using host_native_abi = avx512_fixed_size<N>;
+template <typename T, int N>
+using host_native_abi =
+    std::conditional_t<N == 0, avx512_fixed_size<512 / sizeof(T)>,
+                       avx512_fixed_size<N>>;
 
 #elif defined(KOKKOS_ARCH_AVX2)
 template <class T>
 using host_fixed_native = avx2_fixed_size<4>;
-template <int N>
-using host_native_abi = avx2_fixed_size<N>;
+template <typename T, int N>
+using host_native_abi =
+    std::conditional_t<N == 0, avx2_fixed_size<256 / sizeof(T)>,
+                       avx2_fixed_size<N>>;
 
 #elif defined(KOKKOS_ARCH_ARM_SVE)
 template <class T>
 using host_fixed_native =
     sve_fixed_size<(__ARM_FEATURE_SVE_BITS / (8 * sizeof(T)))>;
-template <int N>
-using host_native_abi = sve_fixed_size<N>;
+template <typename T, int N>
+using host_native_abi =
+    std::conditional_t<N == 0, host_fixed_native<T>, sve_fixed_size<N>>;
 
 #elif defined(KOKKOS_ARCH_ARM_NEON)
 template <class T>
 using host_fixed_native = neon_fixed_size<2>;
-template <int N>
-using host_native_abi = neon_fixed_size<N>;
+template <typename T, int N>
+using host_native_abi =
+    std::conditional_t<N == 0, avx512_fixed_size<128 / sizeof(T)>,
+                       neon_fixed_size<N>>;
 
 #else
 template <class T>
 using host_fixed_native = scalar;
-template <int N>
+template <typename T, int N>
 using host_native_abi = scalar;
 #endif
 
@@ -123,8 +130,8 @@ struct ForSpace<Kokkos::Serial> {
   template <class T>
   using type = host_fixed_native<T>;
 
-  template <int N>
-  using simd_abi = host_native_abi<N>;
+  template <typename T, int N>
+  using simd_abi = host_native_abi<T, N>;
 };
 #endif
 
@@ -134,7 +141,7 @@ struct ForSpace<Kokkos::Cuda> {
   template <class T>
   using type = scalar;
 
-  template <int N>
+  template <typename T, int N>
   using simd_abi = scalar;
 };
 #endif
@@ -145,8 +152,8 @@ struct ForSpace<Kokkos::Threads> {
   template <class T>
   using type = host_fixed_native<T>;
 
-  template <int N>
-  using simd_abi = host_native_abi<N>;
+  template <typename T, int N>
+  using simd_abi = host_native_abi<T, N>;
 };
 #endif
 
@@ -156,7 +163,7 @@ struct ForSpace<Kokkos::Experimental::HPX> {
   template <class T>
   using type = scalar;
 
-  template <int N>
+  template <typename T, int N>
   using simd_abi = scalar;
 };
 #endif
@@ -167,8 +174,8 @@ struct ForSpace<Kokkos::OpenMP> {
   template <class T>
   using type = host_fixed_native<T>;
 
-  template <int N>
-  using simd_abi = host_native_abi<N>;
+  template <typename T, int N>
+  using simd_abi = host_native_abi<T, N>;
 };
 #endif
 
@@ -178,7 +185,7 @@ struct ForSpace<Kokkos::Experimental::OpenMPTarget> {
   template <class T>
   using type = scalar;
 
-  template <int N>
+  template <typename T, int N>
   using simd_abi = scalar;
 };
 #endif
@@ -189,7 +196,7 @@ struct ForSpace<Kokkos::Experimental::OpenACC> {
   template <class T>
   using type = scalar;
 
-  template <int N>
+  template <typename T, int N>
   using simd_abi = scalar;
 };
 #endif
@@ -200,7 +207,7 @@ struct ForSpace<Kokkos::HIP> {
   template <class T>
   using type = scalar;
 
-  template <int N>
+  template <typename T, int N>
   using simd_abi = scalar;
 };
 #endif
@@ -211,7 +218,7 @@ struct ForSpace<Kokkos::SYCL> {
   template <class T>
   using type = scalar;
 
-  template <int N>
+  template <typename T, int N>
   using simd_abi = scalar;
 };
 #endif
@@ -219,8 +226,8 @@ struct ForSpace<Kokkos::SYCL> {
 template <class T, class Space = Kokkos::DefaultExecutionSpace>
 using native_fixed_abi = typename ForSpace<Space>::template type<T>;
 
-template <int N, class Space = Kokkos::DefaultExecutionSpace>
-using native_abi = typename ForSpace<Space>::template simd_abi<N>;
+template <typename T, int N, class Space = Kokkos::DefaultExecutionSpace>
+using native_abi = typename ForSpace<Space>::template simd_abi<T, N>;
 
 }  // namespace Impl
 
@@ -245,15 +252,10 @@ using native_simd_mask KOKKOS_DEPRECATED_WITH_COMMENT(
 #endif
 
 template <class T, int N = 0>
-using simd =
-    basic_simd<T,
-               std::conditional_t<(N == 0), simd_abi::Impl::native_fixed_abi<T>,
-                                  simd_abi::Impl::native_abi<N>>>;
+using simd = basic_simd<T, simd_abi::Impl::native_abi<T, N>>;
 
 template <class T, int N = 0>
-using simd_mask = basic_simd_mask<
-    T, std::conditional_t<(N == 0), simd_abi::Impl::native_fixed_abi<T>,
-                          simd_abi::Impl::native_abi<N>>>;
+using simd_mask = basic_simd_mask<T, simd_abi::Impl::native_abi<T, N>>;
 
 namespace Impl {
 
@@ -269,7 +271,7 @@ using host_abi_set  = abi_set<simd_abi::scalar, simd_abi::avx512_fixed_size<8>,
 using data_type_set = data_types<std::int32_t, std::uint32_t, std::int64_t,
                                  std::uint64_t, double, float>;
 #elif defined(KOKKOS_ARCH_AVX2)
-using host_abi_set    = abi_set<simd_abi::scalar, simd_abi::avx2_fixed_size<4>,
+using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx2_fixed_size<4>,
                              simd_abi::avx2_fixed_size<8>>;
 using data_type_set =
     data_types<std::int32_t, std::int64_t, std::uint64_t, double, float>;
@@ -281,7 +283,7 @@ using host_abi_set =
 using data_type_set = data_types<std::int32_t, std::uint32_t, std::int64_t,
                                  std::uint64_t, double, float>;
 #elif defined(KOKKOS_ARCH_ARM_NEON)
-using host_abi_set    = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>,
+using host_abi_set = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>,
                              simd_abi::neon_fixed_size<4>>;
 using data_type_set =
     data_types<std::int32_t, std::int64_t, std::uint64_t, double, float>;

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -111,7 +111,7 @@ template <class T>
 using host_fixed_native = neon_fixed_size<2>;
 template <typename T, int N>
 using host_native_abi =
-    std::conditional_t<N == 0, avx512_fixed_size<128 / sizeof(T)>,
+    std::conditional_t<N == 0, neon_fixed_size<128 / sizeof(T)>,
                        neon_fixed_size<N>>;
 
 #else

--- a/simd/unit_tests/include/TestSIMD_Construction.hpp
+++ b/simd/unit_tests/include/TestSIMD_Construction.hpp
@@ -67,11 +67,14 @@ inline void host_test_simd_alias() {
   using native_fixed_abi =
       Kokkos::Experimental::simd_abi::Impl::native_fixed_abi<DataType>;
   using native_abi =
-      Kokkos::Experimental::simd_abi::Impl::native_abi<basic_simd_type::size()>;
+      Kokkos::Experimental::simd_abi::Impl::native_abi<DataType,
+                                                       basic_simd_type::size()>;
 
   if constexpr (std::is_same_v<Abi, native_fixed_abi>) {
-    using simd_type      = Kokkos::Experimental::simd<DataType>;
-    using simd_mask_type = Kokkos::Experimental::simd_mask<DataType>;
+    using simd_type =
+        Kokkos::Experimental::simd<DataType, basic_simd_type::size()>;
+    using simd_mask_type =
+        Kokkos::Experimental::simd_mask<DataType, basic_simd_type::size()>;
     static_assert(std::is_same_v<basic_simd_type, simd_type>);
     static_assert(
         std::is_same_v<typename basic_simd_type::mask_type, simd_mask_type>);


### PR DESCRIPTION
Related to #6802 

Changed `[native_]simd` to set the `native_abi` to an abi with max available simd vector width based on specified data type.

- This is to follow the detail from the C++26 simd `native-abi`, which advocates using the most efficient supported data-parallel type per data type.
- This also resolves tangential inconsistencies in determining sizes of `native_abi` between other backends and recently merged in SVE backend, which adapts its simd size based on the vector length supported by the hardware.