### PR TITLE
core(tests): using `static` for free functions in `ToolTestingUtilities` that refer to `static` variables defined in the same header

### DIFF
--- a/core/unit_test/tools/include/ToolTestingUtilities.hpp
+++ b/core/unit_test/tools/include/ToolTestingUtilities.hpp
@@ -1217,7 +1217,7 @@ void listen_tool_events_impl(std::integral_constant<int, priority> prio,
   listen_tool_events_impl(prio, in, configs...);
 }
 template <class... Configs>
-void listen_tool_events(Configs... confs) {
+static void listen_tool_events(Configs... confs) {
   ToolValidatorConfiguration conf;
   listen_tool_events_impl(std::integral_constant<int, 0>{}, conf, confs...);
   listen_tool_events_impl(std::integral_constant<int, 1>{}, conf, confs...);
@@ -1240,7 +1240,7 @@ void listen_tool_events(Configs... confs) {
  * matchers success, false otherwise
  */
 template <class Lambda, class... Matchers>
-bool validate_event_set(const Lambda& lam, Matchers&&... matchers) {
+static bool validate_event_set(const Lambda& lam, Matchers&&... matchers) {
   // First, erase events from previous invocations
   found_events.clear();
   // Invoke the lambda (this will populate found_events, via tooling)
@@ -1265,7 +1265,7 @@ bool validate_event_set(const Lambda& lam, Matchers&&... matchers) {
  * @return auto
  */
 template <class Lambda>
-auto get_event_set(const Lambda& lam) {
+static auto get_event_set(const Lambda& lam) {
   found_events.clear();
   lam();
   // return compare_event_vectors(expected, found_events);
@@ -1293,7 +1293,7 @@ MatchDiagnostic check_presence_of(const EventBasePtr& event, const Matcher& m,
 }
 
 template <class Lambda, class... Matchers>
-bool validate_absence(const Lambda& lam, const Matchers... matchers) {
+static bool validate_absence(const Lambda& lam, const Matchers... matchers) {
   // First, erase events from previous invocations
   found_events.clear();
   // Invoke the lambda (this will populate found_events, via tooling)
@@ -1318,7 +1318,7 @@ bool validate_absence(const Lambda& lam, const Matchers... matchers) {
 }
 
 template <class Lambda, class Matcher>
-bool validate_existence(const Lambda& lam, const Matcher matcher) {
+static bool validate_existence(const Lambda& lam, const Matcher matcher) {
   // First, erase events from previous invocations
   found_events.clear();
   // Invoke the lambda (this will populate found_events, via tooling)


### PR DESCRIPTION
This PR is extracted from:
- #8075

In this PR, I observed that tests unrelated to the introduced changes in #8075 started to fail because some events could not be found (https://github.com/kokkos/kokkos/actions/runs/15927827409/job/44929350004?pr=8075):
```bash
[ RUN      ] openmp.view_alloc
Test failure: Didn't encounter wanted events
/__w/kokkos/kokkos/core/unit_test/TestWithoutInitializing.hpp:139: Failure
Value of: success
  Actual: false
Expected: true
```

The scenario seemed to be triggered by the fact that the variable `found_events` seems to be defined in each compilation unit in which we use `listen_tool_events`. In #8075,, it would be in the compilation units related to `TestGraph.hpp` and `TestWithoutInitializing.hpp` that are later merged into `Kokkos_CoreUnitTest_OpenMP` executable.

This issue would only be observed for the `DEBUG` jobs (mostly `gcc`/`clang` with `OpenMP` backend).

Switching to a `inline` makes it work (https://pabloariasal.github.io/2019/02/28/cpp-inlining/).

Note that I couldn't reproduce the scenario in this PR.