### PR TITLE
HostMirror: make return types consistent and simplify HostSpace selection

### DIFF
--- a/containers/unit_tests/TestDynRankViewTypedefs.cpp
+++ b/containers/unit_tests/TestDynRankViewTypedefs.cpp
@@ -84,7 +84,7 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::memory_space, typename Space::memory_space>);
   static_assert(std::is_same_v<typename ViewType::device_type, Kokkos::Device<typename ViewType::execution_space, typename ViewType::memory_space>>);
   static_assert(std::is_same_v<typename ViewType::memory_traits, MemoryTraitsType>);
-  static_assert(std::is_same_v<typename ViewType::host_mirror_space, HostMirrorSpace>);
+  static_assert(std::is_same_v<typename ViewType::host_mirror_space::memory_space, typename HostMirrorSpace::memory_space>);
   static_assert(std::is_same_v<typename ViewType::size_type, typename ViewType::memory_space::size_type>);
 
   // FIXME: should be deprecated in favor of reference
@@ -120,7 +120,7 @@ KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
                                             typename ViewType::memory_traits>>);
   static_assert(std::is_same_v<typename ViewType::host_mirror_type,
                                Kokkos::DynRankView<typename ViewType::non_const_data_type, typename ViewType::array_layout,
-                                                   HostMirrorSpace
+                                                   typename HostMirrorSpace::memory_space
                                                    /*, typename ViewTraitsType::hooks_policy*/>>);
 
 /* FIXME: these don't exist in DynRankView, should they?
@@ -221,12 +221,12 @@ namespace TestInt {
   using layout_type = Kokkos::DefaultExecutionSpace::array_layout;
   using space = Kokkos::DefaultExecutionSpace;
   using memory_traits = Kokkos::MemoryTraits<>;
-  // Explicitly define host mirror: If the default exec is a host exec, that is it
+  // If the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is on, use DefaultExecutionSpace
-                               std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace>,
+                               std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace,
   // else it's HostSpace
-                                  Kokkos::HostSpace::execution_space>>;
+                                  Kokkos::HostSpace>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int, int&>(
                      ViewParams<int>{}));
 }
@@ -236,8 +236,8 @@ namespace TestIntDefaultExecutionSpace {
   using layout_type = Kokkos::DefaultExecutionSpace::array_layout;
   using space = Kokkos::DefaultExecutionSpace;
   using memory_traits = Kokkos::MemoryTraits<>;
-  // Explicitly define host mirror: If the default exec is a host exec, that is it
-  using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::HostSpace,
+  // If the default exec is a host exec, that is it
+  using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is on, use DefaultExecutionSpace
                                std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace,
   // else it's HostSpace
@@ -271,7 +271,7 @@ namespace TestIntAtomic {
   using layout_type = Kokkos::DefaultExecutionSpace::array_layout;
   using space = Kokkos::DefaultExecutionSpace;
   using memory_traits = Kokkos::MemoryTraits<Kokkos::Atomic>;
-  // Explicitly define host mirror: If the default exec is a host exec, that is it
+  // If the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is on, use DefaultExecutionSpace
                                std::conditional_t<has_unified_mem_space,Kokkos::DefaultExecutionSpace,

--- a/containers/unit_tests/TestDynRankViewTypedefs.cpp
+++ b/containers/unit_tests/TestDynRankViewTypedefs.cpp
@@ -221,12 +221,12 @@ namespace TestInt {
   using layout_type = Kokkos::DefaultExecutionSpace::array_layout;
   using space = Kokkos::DefaultExecutionSpace;
   using memory_traits = Kokkos::MemoryTraits<>;
-  // HostMirrorSpace is a mess so: if the default exec is a host exec, that is it
+  // Explicitly define host mirror: If the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
-  // otherwise if unified memory is not on its HostSpace
-                               std::conditional_t<!has_unified_mem_space, Kokkos::HostSpace,
-  // otherwise its the following Device type
-                               Kokkos::Device<Kokkos::DefaultHostExecutionSpace, typename Kokkos::DefaultExecutionSpace::memory_space>>>;
+  // otherwise if unified memory is on, use DefaultExecutionSpace
+                               std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace>,
+  // else it's HostSpace
+                                  Kokkos::HostSpace::execution_space>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int, int&>(
                      ViewParams<int>{}));
 }
@@ -236,12 +236,12 @@ namespace TestIntDefaultExecutionSpace {
   using layout_type = Kokkos::DefaultExecutionSpace::array_layout;
   using space = Kokkos::DefaultExecutionSpace;
   using memory_traits = Kokkos::MemoryTraits<>;
-  // HostMirrorSpace is a mess so: if the default exec is a host exec, it is HostSpace (note difference from View<int> ...)
+  // Explicitly define host mirror: If the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::HostSpace,
-  // otherwise if unified memory is not on its also HostSpace!
-                               std::conditional_t<!has_unified_mem_space, Kokkos::HostSpace,
-  // otherwise its the following memory space ...
-                               Kokkos::DefaultExecutionSpace::memory_space>>;
+  // otherwise if unified memory is on, use DefaultExecutionSpace
+                               std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace,
+  // else it's HostSpace
+                                Kokkos::HostSpace>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int, int&>(
                      ViewParams<int, Kokkos::DefaultExecutionSpace>{}));
 }
@@ -271,12 +271,12 @@ namespace TestIntAtomic {
   using layout_type = Kokkos::DefaultExecutionSpace::array_layout;
   using space = Kokkos::DefaultExecutionSpace;
   using memory_traits = Kokkos::MemoryTraits<Kokkos::Atomic>;
-  // HostMirrorSpace is a mess so: if the default exec is a host exec, that is it
+  // Explicitly define host mirror: If the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
-  // otherwise if unified memory is not on its HostSpace
-                               std::conditional_t<!has_unified_mem_space, Kokkos::HostSpace,
-  // otherwise its the following Device type
-                               Kokkos::Device<Kokkos::DefaultHostExecutionSpace, typename Kokkos::DefaultExecutionSpace::memory_space>>>;
+  // otherwise if unified memory is on, use DefaultExecutionSpace
+                               std::conditional_t<has_unified_mem_space,Kokkos::DefaultExecutionSpace,
+  // else it's HostSpace
+                                Kokkos::HostSpace>>;
 #ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
   using expected_ref_type = Kokkos::Impl::AtomicDataElement<Kokkos::ViewTraits<int*******, Kokkos::MemoryTraits<Kokkos::Atomic>>>;
 #else

--- a/containers/unit_tests/TestDynRankViewTypedefs.cpp
+++ b/containers/unit_tests/TestDynRankViewTypedefs.cpp
@@ -225,8 +225,8 @@ namespace TestInt {
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is on, use DefaultExecutionSpace
                                std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace,
-  // else it's HostSpace
-                                  Kokkos::HostSpace>>;
+  // else use host execution space
+                                  Kokkos::DefaultHostExecutionSpace>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int, int&>(
                      ViewParams<int>{}));
 }
@@ -240,8 +240,8 @@ namespace TestIntDefaultExecutionSpace {
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is on, use DefaultExecutionSpace
                                std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace,
-  // else it's HostSpace
-                                Kokkos::HostSpace>>;
+  // else use host execution space
+                                Kokkos::DefaultHostExecutionSpace>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int, int&>(
                      ViewParams<int, Kokkos::DefaultExecutionSpace>{}));
 }
@@ -251,7 +251,7 @@ namespace TestFloatPPHostSpace {
   using layout_type = Kokkos::LayoutRight;
   using space = Kokkos::HostSpace;
   using memory_traits = Kokkos::MemoryTraits<>;
-  using host_mirror_space = Kokkos::HostSpace;
+  using host_mirror_space = Kokkos::DefaultHostExecutionSpace;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, const float, const float&>(
                      ViewParams<const float, Kokkos::HostSpace>{}));
 }
@@ -261,7 +261,7 @@ namespace TestFloatPPDeviceDefaultHostExecHostSpace {
   using layout_type = Kokkos::LayoutRight;
   using space = Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>;
   using memory_traits = Kokkos::MemoryTraits<>;
-  using host_mirror_space = Kokkos::HostSpace;
+  using host_mirror_space = Kokkos::DefaultHostExecutionSpace;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, float, float&>(
                      ViewParams<float, Kokkos::LayoutRight, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>>{}));
 }
@@ -275,8 +275,8 @@ namespace TestIntAtomic {
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is on, use DefaultExecutionSpace
                                std::conditional_t<has_unified_mem_space,Kokkos::DefaultExecutionSpace,
-  // else it's HostSpace
-                                Kokkos::HostSpace>>;
+  // else use host execution space
+                                Kokkos::DefaultHostExecutionSpace>>;
 #ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
   using expected_ref_type = Kokkos::Impl::AtomicDataElement<Kokkos::ViewTraits<int*******, Kokkos::MemoryTraits<Kokkos::Atomic>>>;
 #else

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -283,6 +283,9 @@ struct is_space {
  public:
   static constexpr bool value = is_exe::value || is_mem::value || is_dev::value;
 
+  static constexpr bool is_exec_space() { return is_exe::value; }
+  static constexpr bool is_mem_space() { return is_mem::value; }
+
   constexpr operator bool() const noexcept { return value; }
 
   using execution_space = typename is_exe::space;

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -283,9 +283,6 @@ struct is_space {
  public:
   static constexpr bool value = is_exe::value || is_mem::value || is_dev::value;
 
-  static constexpr bool is_exec_space() { return is_exe::value; }
-  static constexpr bool is_mem_space() { return is_mem::value; }
-
   constexpr operator bool() const noexcept { return value; }
 
   using execution_space = typename is_exe::space;

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -101,24 +101,22 @@ namespace Impl {
 static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
                                               Kokkos::HostSpace>::assignable);
 
-template <typename S>
+template <typename MemSpace>
 struct HostMirror {
  private:
-  using is_space_ = typename Kokkos::is_space<S>;
-  static_assert(is_space_::value);
+  static_assert(is_memory_space_v<MemSpace>);
 
   // If input execution space can access HostSpace then keep it.
   // Example: Kokkos::OpenMP can access, Kokkos::Cuda cannot
   enum {
-    keep_exe = Kokkos::SpaceAccessibility<typename S::execution_space,
+    keep_exe = Kokkos::SpaceAccessibility<typename MemSpace::execution_space,
                                           Kokkos::HostSpace>::accessible
   };
   // If HostSpace can access memory space then keep it.
   // Example: Cannot access Kokkos::CudaSpace, can access Kokkos::CudaUVMSpace
   enum {
     keep_mem =
-        Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
-                                        typename S::memory_space>::accessible
+        Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace, MemSpace>::accessible
   };
 
  public:
@@ -129,26 +127,22 @@ struct HostMirror {
 
   // keep_exe | keep_mem | Result
   // ---------|----------|-------
-  //    T     |    T     | S::device_type
-  //    F     |    T     | Device<HostSpace::execution_space, S::memory_space>
+  //    T     |    T     | MemSpace::device_type
+  //    F     |    T     | Device<HostSpace::execution_space, MemSpace>
   //    T     |    F     | HostSpace::device_type
   //    F     |    F     | HostSpace::device_type
 
   using Device = std::conditional_t<
       keep_mem,
-      std::conditional_t<keep_exe, typename S::device_type,
-                         Kokkos::Device<Kokkos::HostSpace::execution_space,
-                                        typename S::memory_space>>,
+      std::conditional_t<
+          keep_exe, typename MemSpace::device_type,
+          Kokkos::Device<Kokkos::HostSpace::execution_space, MemSpace>>,
       Kokkos::HostSpace::device_type>;
 
   using execution_space = typename Device::execution_space;
   using memory_space    = typename Device::memory_space;
 
-  // Construct mirror type matching the template parameter type
-  using Space =
-      std::conditional_t<Kokkos::is_execution_space<S>::value, execution_space,
-                         std::conditional_t<Kokkos::is_memory_space<S>::value,
-                                            memory_space, Device>>;
+  using Space = memory_space;
 };
 
 }  // namespace Impl

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -101,7 +101,7 @@ namespace Impl {
 static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
                                               Kokkos::HostSpace>::assignable);
 
-template <class S>
+template <typename S>
 struct HostMirror {
  private:
   using is_space_ = typename Kokkos::is_space<S>;
@@ -133,9 +133,10 @@ struct HostMirror {
   using memory_space    = typename Device::memory_space;
 
   // Construct mirror type matching the template parameter type
-  using Space = std::conditional_t<
-      is_space_::is_exec_space(), execution_space,
-      std::conditional_t<is_space_::is_mem_space(), memory_space, Device>>;
+  using Space =
+      std::conditional_t<Kokkos::is_execution_space<S>::value, execution_space,
+                         std::conditional_t<Kokkos::is_memory_space<S>::value,
+                                            memory_space, Device>>;
 };
 
 }  // namespace Impl

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -110,7 +110,8 @@ struct HostMirror {
   // If input execution space can access HostSpace then keep it.
   // Example: Kokkos::OpenMP can access, Kokkos::Cuda cannot
   enum {
-    keep_exe = Kokkos::SpaceAccessibility<S, Kokkos::HostSpace>::accessible
+    keep_exe = Kokkos::SpaceAccessibility<typename S::execution_space,
+                                          Kokkos::HostSpace>::accessible
   };
   // If HostSpace can access memory space then keep it.
   // Example: Cannot access Kokkos::CudaSpace, can access Kokkos::CudaUVMSpace
@@ -122,12 +123,23 @@ struct HostMirror {
 
  public:
   // Construct a device mirror type
+  // Decision logic: First check if HostSpace can access the memory space.
+  // If yes, keep it and check execution space compatibility.
+  // If no, fall back to HostSpace::device_type.
+
+  // keep_exe | keep_mem | Result
+  // ---------|----------|-------
+  //    T     |    T     | S::device_type
+  //    F     |    T     | Device<HostSpace::execution_space, S::memory_space>
+  //    T     |    F     | HostSpace::device_type
+  //    F     |    F     | HostSpace::device_type
+
   using Device = std::conditional_t<
-      keep_exe && keep_mem, typename S::device_type,
-      std::conditional_t<keep_mem,
+      keep_mem,
+      std::conditional_t<keep_exe, typename S::device_type,
                          Kokkos::Device<Kokkos::HostSpace::execution_space,
-                                        typename S::memory_space>,
-                         Kokkos::HostSpace::device_type>>;
+                                        typename S::memory_space>>,
+      Kokkos::HostSpace::device_type>;
 
   using execution_space = typename Device::execution_space;
   using memory_space    = typename Device::memory_space;

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -101,19 +101,19 @@ namespace Impl {
 static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
                                               Kokkos::HostSpace>::assignable);
 
-template <typename S>
+template <class S>
 struct HostMirror {
  private:
+  using is_space_ = typename Kokkos::is_space<S>;
+  static_assert(is_space_::value);
+
   // If input execution space can access HostSpace then keep it.
   // Example: Kokkos::OpenMP can access, Kokkos::Cuda cannot
   enum {
-    keep_exe = Kokkos::Impl::MemorySpaceAccess<
-        typename S::execution_space::memory_space,
-        Kokkos::HostSpace>::accessible
+    keep_exe = Kokkos::SpaceAccessibility<S, Kokkos::HostSpace>::accessible
   };
-
   // If HostSpace can access memory space then keep it.
-  // Example:  Cannot access Kokkos::CudaSpace, can access Kokkos::CudaUVMSpace
+  // Example: Cannot access Kokkos::CudaSpace, can access Kokkos::CudaUVMSpace
   enum {
     keep_mem =
         Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
@@ -121,12 +121,21 @@ struct HostMirror {
   };
 
  public:
-  using Space = std::conditional_t<
-      keep_exe && keep_mem, S,
+  // Construct a device mirror type
+  using Device = std::conditional_t<
+      keep_exe && keep_mem, typename S::device_type,
       std::conditional_t<keep_mem,
                          Kokkos::Device<Kokkos::HostSpace::execution_space,
                                         typename S::memory_space>,
-                         Kokkos::HostSpace>>;
+                         Kokkos::HostSpace::device_type>>;
+
+  using execution_space = typename Device::execution_space;
+  using memory_space    = typename Device::memory_space;
+
+  // Construct mirror type matching the template parameter type
+  using Space = std::conditional_t<
+      is_space_::is_exec_space(), execution_space,
+      std::conditional_t<is_space_::is_mem_space(), memory_space, Device>>;
 };
 
 }  // namespace Impl

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -132,16 +132,17 @@ struct HostMirror {
   //    T     |    F     | HostSpace::device_type
   //    F     |    F     | HostSpace::device_type
 
-  using Device = std::conditional_t<
+  using device_type = std::conditional_t<
       keep_mem,
       std::conditional_t<
           keep_exe, typename MemSpace::device_type,
           Kokkos::Device<Kokkos::HostSpace::execution_space, MemSpace>>,
       Kokkos::HostSpace::device_type>;
 
-  using execution_space = typename Device::execution_space;
-  using memory_space    = typename Device::memory_space;
+  using execution_space = typename device_type::execution_space;
+  using memory_space    = typename device_type::memory_space;
 
+  // FIXME: should be deprecated eventually
   using Space = memory_space;
 };
 

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -395,7 +395,7 @@ struct ViewTraits<std::enable_if_t<Kokkos::is_space<Space>::value>, Space,
   using execution_space = typename Space::execution_space;
   using memory_space    = typename Space::memory_space;
   using host_mirror_space =
-      typename Kokkos::Impl::HostMirror<Space>::Space::memory_space;
+      typename Kokkos::Impl::HostMirror<memory_space>::Space;
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   using HostMirrorSpace KOKKOS_DEPRECATED_WITH_COMMENT(
       "Use host_mirror_space instead.") = host_mirror_space;
@@ -459,10 +459,10 @@ struct ViewTraits {
                          typename prop::array_layout,
                          typename ExecutionSpace::array_layout>;
 
-  using HostMirrorSpace = std::conditional_t<
-      !std::is_void_v<typename prop::host_mirror_space>,
-      typename prop::host_mirror_space,
-      typename Kokkos::Impl::HostMirror<ExecutionSpace>::Space>;
+  using HostMirrorSpace =
+      std::conditional_t<!std::is_void_v<typename prop::host_mirror_space>,
+                         typename prop::host_mirror_space,
+                         typename Kokkos::Impl::HostMirror<MemorySpace>::Space>;
 
   using MemoryTraits =
       std::conditional_t<!std::is_void_v<typename prop::memory_traits>,

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -1031,8 +1031,8 @@ void test_view_mapping() {
 // FIXME_NVCC For some reason, the use count is higher (but still constant) when
 // using nvcc. Replacing the lambda with a functor doesn't show this behavior.
 #if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC))
-    using host_exec_space =
-        typename Kokkos::Impl::HostMirror<Space>::execution_space;
+    using host_exec_space = typename Kokkos::Impl::HostMirror<
+        typename Space::memory_space>::execution_space;
 
     int errors = 0;
     Kokkos::parallel_reduce(

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -1032,7 +1032,7 @@ void test_view_mapping() {
 // using nvcc. Replacing the lambda with a functor doesn't show this behavior.
 #if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC))
     using host_exec_space =
-        typename Kokkos::Impl::HostMirror<Space>::Space::execution_space;
+        typename Kokkos::Impl::HostMirror<Space>::execution_space;
 
     int errors = 0;
     Kokkos::parallel_reduce(

--- a/core/unit_test/TestViewTypedefs.cpp
+++ b/core/unit_test/TestViewTypedefs.cpp
@@ -214,12 +214,12 @@ namespace TestInt {
   using layout_type = Kokkos::DefaultExecutionSpace::array_layout;
   using space = Kokkos::DefaultExecutionSpace;
   using memory_traits = Kokkos::MemoryTraits<>;
-  // HostMirrorSpace is a mess so: if the default exec is a host exec, that is it
+  // Explicitly define host mirror: If the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
-  // otherwise if unified memory is not on its HostSpace
-                               std::conditional_t<!has_unified_mem_space, Kokkos::HostSpace,
-  // otherwise its the following Device type
-                               Kokkos::Device<Kokkos::DefaultHostExecutionSpace, typename Kokkos::DefaultExecutionSpace::memory_space>>>;
+  // otherwise if unified memory is on, use DefaultExecutionSpace
+                               std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace::memory_space,
+  // else it's HostSpace
+                                Kokkos::HostSpace>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int, int&>(
                      ViewParams<int>{}));
 }
@@ -229,12 +229,12 @@ namespace TestIntDefaultExecutionSpace {
   using layout_type = Kokkos::DefaultExecutionSpace::array_layout;
   using space = Kokkos::DefaultExecutionSpace;
   using memory_traits = Kokkos::MemoryTraits<>;
-  // HostMirrorSpace is a mess so: if the default exec is a host exec, it is HostSpace (note difference from View<int> ...)
+  // Explicitly define host mirror: If the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::HostSpace,
-  // otherwise if unified memory is not on its also HostSpace!
-                               std::conditional_t<!has_unified_mem_space, Kokkos::HostSpace,
-  // otherwise its the following memory space ...
-                               Kokkos::DefaultExecutionSpace::memory_space>>;
+  // otherwise if unified memory is on, use DefaultExecutionSpace
+                               std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace::memory_space,
+  // else it's HostSpace
+                               Kokkos::HostSpace>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int, int&>(
                      ViewParams<int, Kokkos::DefaultExecutionSpace>{}));
 }
@@ -254,12 +254,12 @@ namespace TestFloatP3LayoutLeft {
   using layout_type = Kokkos::LayoutLeft;
   using space = Kokkos::DefaultExecutionSpace;
   using memory_traits = Kokkos::MemoryTraits<>;
-  // HostMirrorSpace is a mess so: if the default exec is a host exec, that is it
-  using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
-  // otherwise if unified memory is not on its HostSpace
-                               std::conditional_t<!has_unified_mem_space, Kokkos::HostSpace,
-  // otherwise its the following Device type
-                               Kokkos::Device<Kokkos::DefaultHostExecutionSpace, typename Kokkos::DefaultExecutionSpace::memory_space>>>;
+  // Explicitly define host mirror: If the default exec is a host exec, that is it
+  using host_mirror_space = std::conditional_t<is_host_exec, space,
+  // otherwise if unified memory is on, use DefaultExecutionSpace
+                               std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace::memory_space,
+  // else it's HostSpace
+                              Kokkos::HostSpace >>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, float, float&>(
                      ViewParams<float*[3], Kokkos::LayoutLeft>{}));
 }
@@ -279,12 +279,12 @@ namespace TestIntAtomic {
   using layout_type = Kokkos::DefaultExecutionSpace::array_layout;
   using space = Kokkos::DefaultExecutionSpace;
   using memory_traits = Kokkos::MemoryTraits<Kokkos::Atomic>;
-  // HostMirrorSpace is a mess so: if the default exec is a host exec, that is it
+  // Explicitly define host mirror: If the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
-  // otherwise if unified memory is not on its HostSpace
-                               std::conditional_t<!has_unified_mem_space, Kokkos::HostSpace,
-  // otherwise its the following Device type
-                               Kokkos::Device<Kokkos::DefaultHostExecutionSpace, typename Kokkos::DefaultExecutionSpace::memory_space>>>;
+  // otherwise if unified memory is on, use DefaultExecutionSpace
+                               std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace::memory_space,
+  // else it's HostSpace
+                               Kokkos::HostSpace>>;
 // clang-format on
 static_assert(test_view_typedefs<
               layout_type, space, memory_traits, host_mirror_space, int,

--- a/core/unit_test/TestViewTypedefs.cpp
+++ b/core/unit_test/TestViewTypedefs.cpp
@@ -222,8 +222,8 @@ namespace TestInt {
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is on, use DefaultExecutionSpace
                                std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace,
-  // else it's HostSpace
-                                Kokkos::HostSpace>>;
+  // else use host execution space
+                                Kokkos::DefaultHostExecutionSpace>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int, int&>(
                      ViewParams<int>{}));
 }
@@ -237,8 +237,8 @@ namespace TestIntDefaultExecutionSpace {
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is on, use DefaultExecutionSpace
                                std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace,
-  // else it's HostSpace
-                               Kokkos::HostSpace>>;
+  // else use host execution space
+                               Kokkos::DefaultHostExecutionSpace>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int, int&>(
                      ViewParams<int, Kokkos::DefaultExecutionSpace>{}));
 }
@@ -248,7 +248,7 @@ namespace TestFloatPPHostSpace {
   using layout_type = Kokkos::LayoutRight;
   using space = Kokkos::HostSpace;
   using memory_traits = Kokkos::MemoryTraits<>;
-  using host_mirror_space = Kokkos::HostSpace;
+  using host_mirror_space = Kokkos::DefaultHostExecutionSpace;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, const float, const float&>(
                      ViewParams<const float**, Kokkos::HostSpace>{}));
 }
@@ -262,8 +262,8 @@ namespace TestFloatP3LayoutLeft {
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is on, use DefaultExecutionSpace
                                std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace,
-  // else it's HostSpace
-                              Kokkos::HostSpace>>;
+  // else use host execution space
+                              Kokkos::DefaultHostExecutionSpace>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, float, float&>(
                      ViewParams<float*[3], Kokkos::LayoutLeft>{}));
 }
@@ -273,7 +273,7 @@ namespace TestFloatPPDeviceDefaultHostExecHostSpace {
   using layout_type = Kokkos::LayoutRight;
   using space = Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>;
   using memory_traits = Kokkos::MemoryTraits<>;
-  using host_mirror_space = Kokkos::HostSpace;
+  using host_mirror_space = Kokkos::DefaultHostExecutionSpace;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, float, float&>(
                      ViewParams<float[2][3], Kokkos::LayoutRight, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>>{}));
 }
@@ -287,8 +287,8 @@ namespace TestIntAtomic {
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is on, use DefaultExecutionSpace
                                std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace,
-  // else it's HostSpace
-                               Kokkos::HostSpace>>;
+  // else use host execution space
+                               Kokkos::DefaultHostExecutionSpace>>;
 // clang-format on
 static_assert(test_view_typedefs<
               layout_type, space, memory_traits, host_mirror_space, int,

--- a/core/unit_test/TestViewTypedefs.cpp
+++ b/core/unit_test/TestViewTypedefs.cpp
@@ -82,11 +82,15 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(!std::is_void_v<typename ViewType::dimension>);
 #endif
 
+  using device_type = Kokkos::Device<typename ViewType::execution_space, typename ViewType::memory_space>;
+  using host_mirror_device_type = Kokkos::Device<typename HostMirrorSpace::execution_space, typename HostMirrorSpace::memory_space>;
+
   static_assert(std::is_same_v<typename ViewType::execution_space, typename Space::execution_space>);
   static_assert(std::is_same_v<typename ViewType::memory_space, typename Space::memory_space>);
-  static_assert(std::is_same_v<typename ViewType::device_type, Kokkos::Device<typename ViewType::execution_space, typename ViewType::memory_space>>);
+  static_assert(std::is_same_v<typename ViewType::device_type, device_type>);
+  static_assert(std::is_same_v<typename ViewType::host_mirror_space::device_type, host_mirror_device_type>);
   static_assert(std::is_same_v<typename ViewType::memory_traits, MemoryTraitsType>);
-  static_assert(std::is_same_v<typename ViewType::host_mirror_space, HostMirrorSpace>);
+  static_assert(std::is_same_v<typename ViewType::host_mirror_space::memory_space, typename HostMirrorSpace::memory_space>);
   static_assert(std::is_same_v<typename ViewType::size_type, typename ViewType::memory_space::size_type>);
 
   // FIXME: should be deprecated in favor of reference
@@ -214,10 +218,10 @@ namespace TestInt {
   using layout_type = Kokkos::DefaultExecutionSpace::array_layout;
   using space = Kokkos::DefaultExecutionSpace;
   using memory_traits = Kokkos::MemoryTraits<>;
-  // Explicitly define host mirror: If the default exec is a host exec, that is it
+  // If the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is on, use DefaultExecutionSpace
-                               std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace::memory_space,
+                               std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace,
   // else it's HostSpace
                                 Kokkos::HostSpace>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int, int&>(
@@ -229,10 +233,10 @@ namespace TestIntDefaultExecutionSpace {
   using layout_type = Kokkos::DefaultExecutionSpace::array_layout;
   using space = Kokkos::DefaultExecutionSpace;
   using memory_traits = Kokkos::MemoryTraits<>;
-  // Explicitly define host mirror: If the default exec is a host exec, that is it
-  using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::HostSpace,
+  // If the default exec is a host exec, that is it
+  using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is on, use DefaultExecutionSpace
-                               std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace::memory_space,
+                               std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace,
   // else it's HostSpace
                                Kokkos::HostSpace>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, int, int&>(
@@ -254,12 +258,12 @@ namespace TestFloatP3LayoutLeft {
   using layout_type = Kokkos::LayoutLeft;
   using space = Kokkos::DefaultExecutionSpace;
   using memory_traits = Kokkos::MemoryTraits<>;
-  // Explicitly define host mirror: If the default exec is a host exec, that is it
-  using host_mirror_space = std::conditional_t<is_host_exec, space,
+  // If the default exec is a host exec, that is it
+  using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is on, use DefaultExecutionSpace
-                               std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace::memory_space,
+                               std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace,
   // else it's HostSpace
-                              Kokkos::HostSpace >>;
+                              Kokkos::HostSpace>>;
   static_assert(test_view_typedefs<layout_type, space, memory_traits, host_mirror_space, float, float&>(
                      ViewParams<float*[3], Kokkos::LayoutLeft>{}));
 }
@@ -279,10 +283,10 @@ namespace TestIntAtomic {
   using layout_type = Kokkos::DefaultExecutionSpace::array_layout;
   using space = Kokkos::DefaultExecutionSpace;
   using memory_traits = Kokkos::MemoryTraits<Kokkos::Atomic>;
-  // Explicitly define host mirror: If the default exec is a host exec, that is it
+  // If the default exec is a host exec, that is it
   using host_mirror_space = std::conditional_t<is_host_exec, Kokkos::DefaultExecutionSpace,
   // otherwise if unified memory is on, use DefaultExecutionSpace
-                               std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace::memory_space,
+                               std::conditional_t<has_unified_mem_space, Kokkos::DefaultExecutionSpace,
   // else it's HostSpace
                                Kokkos::HostSpace>>;
 // clang-format on

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -165,13 +165,18 @@ TEST(cuda, space_access) {
                      Kokkos::HostSpace>);
 #else
   static_assert(
-      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::Space,
+      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::Device,
                      Kokkos::Device<Kokkos::HostSpace::execution_space,
                                     Kokkos::CudaSpace>>);
 #endif
 
   static_assert(
-      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::Space,
+      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::Device,
+                     Kokkos::Device<Kokkos::HostSpace::execution_space,
+                                    Kokkos::CudaUVMSpace>>);
+
+  static_assert(
+      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::Device,
                      Kokkos::Device<Kokkos::HostSpace::execution_space,
                                     Kokkos::CudaUVMSpace>>);
 
@@ -195,7 +200,7 @@ TEST(cuda, space_access) {
 
   static_assert(Kokkos::SpaceAccessibility<
                 Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::Space,
-                Kokkos::HostSpace>::accessible);
+                Kokkos::CudaUVMSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<
                 Kokkos::Impl::HostMirror<Kokkos::CudaHostPinnedSpace>::Space,

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -166,20 +166,20 @@ TEST(cuda, space_access) {
 #else
   // Memory space stays the same as host can access CudaSpace
   static_assert(
-      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::Device,
+      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::device_type,
                      Kokkos::Device<Kokkos::HostSpace::execution_space,
                                     Kokkos::CudaSpace>>);
 #endif
 
-  static_assert(
-      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::Device,
-                     Kokkos::Device<Kokkos::HostSpace::execution_space,
-                                    Kokkos::CudaUVMSpace>>);
+  static_assert(std::is_same_v<
+                Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::device_type,
+                Kokkos::Device<Kokkos::HostSpace::execution_space,
+                               Kokkos::CudaUVMSpace>>);
 
-  static_assert(
-      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::Device,
-                     Kokkos::Device<Kokkos::HostSpace::execution_space,
-                                    Kokkos::CudaUVMSpace>>);
+  static_assert(std::is_same_v<
+                Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::device_type,
+                Kokkos::Device<Kokkos::HostSpace::execution_space,
+                               Kokkos::CudaUVMSpace>>);
 
   static_assert(std::is_same_v<
                 Kokkos::Impl::HostMirror<Kokkos::CudaHostPinnedSpace>::Space,

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -163,52 +163,50 @@ TEST(cuda, space_access) {
   static_assert(
       std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::Space,
                      Kokkos::HostSpace>);
+  static_assert(
+      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::device_type,
+                     Kokkos::Device<Kokkos::DefaultHostExecutionSpace,
+                                    Kokkos::HostSpace>>);
 #else
   // Memory space stays the same as host can access CudaSpace
   static_assert(
+      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::Space,
+                     Kokkos::CudaSpace>);
+  static_assert(
       std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::device_type,
-                     Kokkos::Device<Kokkos::HostSpace::execution_space,
+                     Kokkos::Device<Kokkos::DefaultHostExecutionSpace,
                                     Kokkos::CudaSpace>>);
 #endif
 
+  static_assert(
+      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::Space,
+                     Kokkos::CudaUVMSpace>);
   static_assert(std::is_same_v<
                 Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::device_type,
-                Kokkos::Device<Kokkos::HostSpace::execution_space,
-                               Kokkos::CudaUVMSpace>>);
-
-  static_assert(std::is_same_v<
-                Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::device_type,
-                Kokkos::Device<Kokkos::HostSpace::execution_space,
+                Kokkos::Device<Kokkos::DefaultHostExecutionSpace,
                                Kokkos::CudaUVMSpace>>);
 
   static_assert(std::is_same_v<
                 Kokkos::Impl::HostMirror<Kokkos::CudaHostPinnedSpace>::Space,
                 Kokkos::CudaHostPinnedSpace>);
+  static_assert(
+      std::is_same_v<
+          Kokkos::Impl::HostMirror<Kokkos::CudaHostPinnedSpace>::device_type,
+          Kokkos::Device<Kokkos::DefaultHostExecutionSpace,
+                         Kokkos::CudaHostPinnedSpace>>);
+
+  static_assert(Kokkos::SpaceAccessibility<
+                Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::device_type,
+                Kokkos::HostSpace>::accessible);
+
+  static_assert(Kokkos::SpaceAccessibility<
+                Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::device_type,
+                Kokkos::HostSpace>::accessible);
 
   static_assert(
-      std::is_same_v<Kokkos::Device<Kokkos::HostSpace::execution_space,
-                                    Kokkos::CudaUVMSpace>,
-                     Kokkos::Device<Kokkos::HostSpace::execution_space,
-                                    Kokkos::CudaUVMSpace>>);
-
-#ifndef KOKKOS_ENABLE_IMPL_CUDA_UNIFIED_MEMORY
-  static_assert(Kokkos::SpaceAccessibility<
-                Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::Space,
-                Kokkos::HostSpace>::accessible);
-#else
-  // Memory space stays the same as host can access CudaSpace
-  static_assert(Kokkos::SpaceAccessibility<
-                Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::Space,
-                Kokkos::CudaSpace>::accessible);
-#endif
-
-  static_assert(Kokkos::SpaceAccessibility<
-                Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::Space,
-                Kokkos::CudaUVMSpace>::accessible);
-
-  static_assert(Kokkos::SpaceAccessibility<
-                Kokkos::Impl::HostMirror<Kokkos::CudaHostPinnedSpace>::Space,
-                Kokkos::HostSpace>::accessible);
+      Kokkos::SpaceAccessibility<
+          Kokkos::Impl::HostMirror<Kokkos::CudaHostPinnedSpace>::device_type,
+          Kokkos::HostSpace>::accessible);
 }
 
 TEST(cuda, uvm) {

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -191,10 +191,6 @@ TEST(cuda, space_access) {
                      Kokkos::Device<Kokkos::HostSpace::execution_space,
                                     Kokkos::CudaUVMSpace>>);
 
-  static_assert(
-      Kokkos::SpaceAccessibility<Kokkos::Impl::HostMirror<Kokkos::Cuda>::Space,
-                                 Kokkos::HostSpace>::accessible);
-
 #ifndef KOKKOS_ENABLE_IMPL_CUDA_UNIFIED_MEMORY
   static_assert(Kokkos::SpaceAccessibility<
                 Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::Space,

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -164,6 +164,7 @@ TEST(cuda, space_access) {
       std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::Space,
                      Kokkos::HostSpace>);
 #else
+  // Memory space stays the same as host can access CudaSpace
   static_assert(
       std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::Device,
                      Kokkos::Device<Kokkos::HostSpace::execution_space,
@@ -194,9 +195,16 @@ TEST(cuda, space_access) {
       Kokkos::SpaceAccessibility<Kokkos::Impl::HostMirror<Kokkos::Cuda>::Space,
                                  Kokkos::HostSpace>::accessible);
 
+#ifndef KOKKOS_ENABLE_IMPL_CUDA_UNIFIED_MEMORY
   static_assert(Kokkos::SpaceAccessibility<
                 Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::Space,
                 Kokkos::HostSpace>::accessible);
+#else
+  // Memory space stays the same as host can access CudaSpace
+  static_assert(Kokkos::SpaceAccessibility<
+                Kokkos::Impl::HostMirror<Kokkos::CudaSpace>::Space,
+                Kokkos::CudaSpace>::accessible);
+#endif
 
   static_assert(Kokkos::SpaceAccessibility<
                 Kokkos::Impl::HostMirror<Kokkos::CudaUVMSpace>::Space,

--- a/core/unit_test/default/TestDefaultDeviceType.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType.cpp
@@ -21,8 +21,8 @@ namespace Test {
 TEST(TEST_CATEGORY, host_space_access) {
   using host_exec_space = Kokkos::HostSpace::execution_space;
   using device_space    = Kokkos::Device<host_exec_space, Kokkos::HostSpace>;
-  using mirror_space =
-      Kokkos::Impl::HostMirror<Kokkos::DefaultExecutionSpace>::Space;
+  using mirror_space    = Kokkos::Impl::HostMirror<
+      typename Kokkos::DefaultExecutionSpace::memory_space>::Space;
 
   static_assert(Kokkos::SpaceAccessibility<host_exec_space,
                                            Kokkos::HostSpace>::accessible);

--- a/core/unit_test/default/TestDefaultDeviceType.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType.cpp
@@ -19,19 +19,19 @@ import kokkos.core_impl;
 namespace Test {
 
 TEST(TEST_CATEGORY, host_space_access) {
-  using host_exec_space = Kokkos::HostSpace::execution_space;
-  using device_space    = Kokkos::Device<host_exec_space, Kokkos::HostSpace>;
-  using mirror_space    = Kokkos::Impl::HostMirror<
-      typename Kokkos::DefaultExecutionSpace::memory_space>::Space;
+  using host_exec_space    = Kokkos::HostSpace::execution_space;
+  using host_device        = Kokkos::Device<host_exec_space, Kokkos::HostSpace>;
+  using host_mirror_device = Kokkos::Impl::HostMirror<
+      typename Kokkos::DefaultExecutionSpace::memory_space>::device_type;
 
   static_assert(Kokkos::SpaceAccessibility<host_exec_space,
                                            Kokkos::HostSpace>::accessible);
 
   static_assert(
-      Kokkos::SpaceAccessibility<device_space, Kokkos::HostSpace>::accessible);
+      Kokkos::SpaceAccessibility<host_device, Kokkos::HostSpace>::accessible);
 
-  static_assert(
-      Kokkos::SpaceAccessibility<mirror_space, Kokkos::HostSpace>::accessible);
+  static_assert(Kokkos::SpaceAccessibility<host_mirror_device,
+                                           Kokkos::HostSpace>::accessible);
 }
 
 }  // namespace Test

--- a/core/unit_test/hip/TestHIP_Spaces.cpp
+++ b/core/unit_test/hip/TestHIP_Spaces.cpp
@@ -169,7 +169,7 @@ TEST(hip, space_access) {
 #else
   // Memory space stays the same as host can access HIPSpace
   static_assert(
-      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Device,
+      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::device_type,
                      Kokkos::Device<Kokkos::HostSpace::execution_space,
                                     Kokkos::HIPSpace>>);
 #endif
@@ -178,10 +178,10 @@ TEST(hip, space_access) {
                 Kokkos::Impl::HostMirror<Kokkos::HIPHostPinnedSpace>::Space,
                 Kokkos::HIPHostPinnedSpace>);
 
-  static_assert(
-      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::HIPManagedSpace>::Device,
-                     Kokkos::Device<Kokkos::HostSpace::execution_space,
-                                    Kokkos::HIPManagedSpace>>);
+  static_assert(std::is_same_v<
+                Kokkos::Impl::HostMirror<Kokkos::HIPManagedSpace>::device_type,
+                Kokkos::Device<Kokkos::HostSpace::execution_space,
+                               Kokkos::HIPManagedSpace>>);
 
 #ifndef KOKKOS_IMPL_HIP_UNIFIED_MEMORY
   static_assert(Kokkos::SpaceAccessibility<

--- a/core/unit_test/hip/TestHIP_Spaces.cpp
+++ b/core/unit_test/hip/TestHIP_Spaces.cpp
@@ -167,8 +167,9 @@ TEST(hip, space_access) {
       std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Space,
                      Kokkos::HostSpace>);
 #else
+  // Memory space stays the same as host can access HIPSpace
   static_assert(
-      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Space,
+      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Device,
                      Kokkos::Device<Kokkos::HostSpace::execution_space,
                                     Kokkos::HIPSpace>>);
 #endif
@@ -186,9 +187,16 @@ TEST(hip, space_access) {
       Kokkos::SpaceAccessibility<Kokkos::Impl::HostMirror<Kokkos::HIP>::Space,
                                  Kokkos::HostSpace>::accessible);
 
+#ifndef KOKKOS_IMPL_HIP_UNIFIED_MEMORY
   static_assert(Kokkos::SpaceAccessibility<
                 Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Space,
                 Kokkos::HostSpace>::accessible);
+#else
+  // Memory space stays the same as host can access HIPSpace
+  static_assert(Kokkos::SpaceAccessibility<
+                Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Space,
+                Kokkos::HIPSpace>::accessible);
+#endif
 
   static_assert(Kokkos::SpaceAccessibility<
                 Kokkos::Impl::HostMirror<Kokkos::HIPHostPinnedSpace>::Space,

--- a/core/unit_test/hip/TestHIP_Spaces.cpp
+++ b/core/unit_test/hip/TestHIP_Spaces.cpp
@@ -178,7 +178,7 @@ TEST(hip, space_access) {
                 Kokkos::HIPHostPinnedSpace>);
 
   static_assert(
-      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::HIPManagedSpace>::Space,
+      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::HIPManagedSpace>::Device,
                      Kokkos::Device<Kokkos::HostSpace::execution_space,
                                     Kokkos::HIPManagedSpace>>);
 
@@ -196,7 +196,7 @@ TEST(hip, space_access) {
 
   static_assert(Kokkos::SpaceAccessibility<
                 Kokkos::Impl::HostMirror<Kokkos::HIPManagedSpace>::Space,
-                Kokkos::HostSpace>::accessible);
+                Kokkos::HIPManagedSpace>::accessible);
 }
 
 template <class MemSpace, class ExecSpace>

--- a/core/unit_test/hip/TestHIP_Spaces.cpp
+++ b/core/unit_test/hip/TestHIP_Spaces.cpp
@@ -166,41 +166,50 @@ TEST(hip, space_access) {
   static_assert(
       std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Space,
                      Kokkos::HostSpace>);
+  static_assert(
+      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::device_type,
+                     Kokkos::Device<Kokkos::DefaultHostExecutionSpace,
+                                    Kokkos::HostSpace>>);
 #else
   // Memory space stays the same as host can access HIPSpace
   static_assert(
-      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::device_type,
-                     Kokkos::Device<Kokkos::HostSpace::execution_space,
-                                    Kokkos::HIPSpace>>);
+      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Space,
+                     Kokkos::HIPSpace>);
+  static_assert(
+      std::is_same_v<
+          Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::device_type,
+          Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HIPSpace>>);
 #endif
 
-  static_assert(std::is_same_v<
-                Kokkos::Impl::HostMirror<Kokkos::HIPHostPinnedSpace>::Space,
-                Kokkos::HIPHostPinnedSpace>);
-
+  static_assert(
+      std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::HIPManagedSpace>::Space,
+                     Kokkos::HIPManagedSpace>);
   static_assert(std::is_same_v<
                 Kokkos::Impl::HostMirror<Kokkos::HIPManagedSpace>::device_type,
                 Kokkos::Device<Kokkos::HostSpace::execution_space,
                                Kokkos::HIPManagedSpace>>);
 
-#ifndef KOKKOS_IMPL_HIP_UNIFIED_MEMORY
-  static_assert(Kokkos::SpaceAccessibility<
-                Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Space,
-                Kokkos::HostSpace>::accessible);
-#else
-  // Memory space stays the same as host can access HIPSpace
-  static_assert(Kokkos::SpaceAccessibility<
-                Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Space,
-                Kokkos::HIPSpace>::accessible);
-#endif
-
-  static_assert(Kokkos::SpaceAccessibility<
+  static_assert(std::is_same_v<
                 Kokkos::Impl::HostMirror<Kokkos::HIPHostPinnedSpace>::Space,
-                Kokkos::HostSpace>::accessible);
+                Kokkos::HIPHostPinnedSpace>);
+  static_assert(
+      std::is_same_v<
+          Kokkos::Impl::HostMirror<Kokkos::HIPHostPinnedSpace>::device_type,
+          Kokkos::Device<Kokkos::HostSpace::execution_space,
+                         Kokkos::HIPHostPinnedSpace>>);
 
   static_assert(Kokkos::SpaceAccessibility<
-                Kokkos::Impl::HostMirror<Kokkos::HIPManagedSpace>::Space,
-                Kokkos::HIPManagedSpace>::accessible);
+                Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::device_type,
+                Kokkos::HostSpace>::accessible);
+
+  static_assert(
+      Kokkos::SpaceAccessibility<
+          Kokkos::Impl::HostMirror<Kokkos::HIPHostPinnedSpace>::device_type,
+          Kokkos::HostSpace>::accessible);
+
+  static_assert(Kokkos::SpaceAccessibility<
+                Kokkos::Impl::HostMirror<Kokkos::HIPManagedSpace>::device_type,
+                Kokkos::HostSpace>::accessible);
 }
 
 template <class MemSpace, class ExecSpace>

--- a/core/unit_test/hip/TestHIP_Spaces.cpp
+++ b/core/unit_test/hip/TestHIP_Spaces.cpp
@@ -183,10 +183,6 @@ TEST(hip, space_access) {
                      Kokkos::Device<Kokkos::HostSpace::execution_space,
                                     Kokkos::HIPManagedSpace>>);
 
-  static_assert(
-      Kokkos::SpaceAccessibility<Kokkos::Impl::HostMirror<Kokkos::HIP>::Space,
-                                 Kokkos::HostSpace>::accessible);
-
 #ifndef KOKKOS_IMPL_HIP_UNIFIED_MEMORY
   static_assert(Kokkos::SpaceAccessibility<
                 Kokkos::Impl::HostMirror<Kokkos::HIPSpace>::Space,

--- a/core/unit_test/sycl/TestSYCL_Spaces.cpp
+++ b/core/unit_test/sycl/TestSYCL_Spaces.cpp
@@ -175,10 +175,6 @@ TEST(sycl, space_access) {
                      Kokkos::Device<Kokkos::HostSpace::execution_space,
                                     Kokkos::SYCLSharedUSMSpace>>);
 
-  static_assert(
-      Kokkos::SpaceAccessibility<Kokkos::Impl::HostMirror<Kokkos::SYCL>::Space,
-                                 Kokkos::HostSpace>::accessible);
-
   static_assert(Kokkos::SpaceAccessibility<
                 Kokkos::Impl::HostMirror<Kokkos::SYCLDeviceUSMSpace>::Space,
                 Kokkos::HostSpace>::accessible);

--- a/core/unit_test/sycl/TestSYCL_Spaces.cpp
+++ b/core/unit_test/sycl/TestSYCL_Spaces.cpp
@@ -153,10 +153,11 @@ TEST(sycl, space_access) {
                 Kokkos::Impl::HostMirror<Kokkos::SYCLDeviceUSMSpace>::Space,
                 Kokkos::HostSpace>);
 
-  static_assert(std::is_same_v<
-                Kokkos::Impl::HostMirror<Kokkos::SYCLSharedUSMSpace>::Device,
-                Kokkos::Device<Kokkos::HostSpace::execution_space,
-                               Kokkos::SYCLSharedUSMSpace>>);
+  static_assert(
+      std::is_same_v<
+          Kokkos::Impl::HostMirror<Kokkos::SYCLSharedUSMSpace>::device_type,
+          Kokkos::Device<Kokkos::HostSpace::execution_space,
+                         Kokkos::SYCLSharedUSMSpace>>);
 
   static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::SYCLHostUSMSpace,
                                                 Kokkos::HostSpace>::accessible);

--- a/core/unit_test/sycl/TestSYCL_Spaces.cpp
+++ b/core/unit_test/sycl/TestSYCL_Spaces.cpp
@@ -154,7 +154,7 @@ TEST(sycl, space_access) {
                 Kokkos::HostSpace>);
 
   static_assert(std::is_same_v<
-                Kokkos::Impl::HostMirror<Kokkos::SYCLSharedUSMSpace>::Space,
+                Kokkos::Impl::HostMirror<Kokkos::SYCLSharedUSMSpace>::Device,
                 Kokkos::Device<Kokkos::HostSpace::execution_space,
                                Kokkos::SYCLSharedUSMSpace>>);
 
@@ -185,11 +185,11 @@ TEST(sycl, space_access) {
 
   static_assert(Kokkos::SpaceAccessibility<
                 Kokkos::Impl::HostMirror<Kokkos::SYCLSharedUSMSpace>::Space,
-                Kokkos::HostSpace>::accessible);
+                Kokkos::SYCLSharedUSMSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<
                 Kokkos::Impl::HostMirror<Kokkos::SYCLHostUSMSpace>::Space,
-                Kokkos::HostSpace>::accessible);
+                Kokkos::SYCLHostUSMSpace>::accessible);
 }
 
 TEST(sycl, uvm) {

--- a/core/unit_test/sycl/TestSYCL_Spaces.cpp
+++ b/core/unit_test/sycl/TestSYCL_Spaces.cpp
@@ -149,16 +149,6 @@ TEST(sycl, space_access) {
       Kokkos::SpaceAccessibility<Kokkos::HostSpace,
                                  Kokkos::SYCLHostUSMSpace>::accessible);
 
-  static_assert(std::is_same_v<
-                Kokkos::Impl::HostMirror<Kokkos::SYCLDeviceUSMSpace>::Space,
-                Kokkos::HostSpace>);
-
-  static_assert(
-      std::is_same_v<
-          Kokkos::Impl::HostMirror<Kokkos::SYCLSharedUSMSpace>::device_type,
-          Kokkos::Device<Kokkos::HostSpace::execution_space,
-                         Kokkos::SYCLSharedUSMSpace>>);
-
   static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::SYCLHostUSMSpace,
                                                 Kokkos::HostSpace>::accessible);
 
@@ -166,27 +156,45 @@ TEST(sycl, space_access) {
       Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
                                       Kokkos::SYCLHostUSMSpace>::accessible);
 
+  static_assert(std::is_same_v<
+                Kokkos::Impl::HostMirror<Kokkos::SYCLDeviceUSMSpace>::Space,
+                Kokkos::HostSpace>);
+  static_assert(
+      std::is_same_v<
+          Kokkos::Impl::HostMirror<Kokkos::SYCLSharedUSMSpace>::device_type,
+          Kokkos::Device<Kokkos::DefaultHostExecutionSpace,
+                         Kokkos::SYCLSharedUSMSpace>>);
+
   static_assert(
       std::is_same_v<Kokkos::Impl::HostMirror<Kokkos::SYCLHostUSMSpace>::Space,
                      Kokkos::SYCLHostUSMSpace>);
+  static_assert(std::is_same_v<
+                Kokkos::Impl::HostMirror<Kokkos::SYCLHostUSMSpace>::device_type,
+                Kokkos::Device<Kokkos::DefaultHostExecutionSpace,
+                               Kokkos::SYCLHostUSMSpace>>);
+
+  static_assert(std::is_same_v<
+                Kokkos::Impl::HostMirror<Kokkos::SYCLSharedUSMSpace>::Space,
+                Kokkos::SYCLSharedUSMSpace>);
+  static_assert(
+      std::is_same_v<
+          Kokkos::Impl::HostMirror<Kokkos::SYCLSharedUSMSpace>::device_type,
+          Kokkos::Device<Kokkos::DefaultHostExecutionSpace,
+                         Kokkos::SYCLSharedUSMSpace>>);
 
   static_assert(
-      std::is_same_v<Kokkos::Device<Kokkos::HostSpace::execution_space,
-                                    Kokkos::SYCLSharedUSMSpace>,
-                     Kokkos::Device<Kokkos::HostSpace::execution_space,
-                                    Kokkos::SYCLSharedUSMSpace>>);
+      Kokkos::SpaceAccessibility<
+          Kokkos::Impl::HostMirror<Kokkos::SYCLDeviceUSMSpace>::device_type,
+          Kokkos::HostSpace>::accessible);
+
+  static_assert(
+      Kokkos::SpaceAccessibility<
+          Kokkos::Impl::HostMirror<Kokkos::SYCLSharedUSMSpace>::device_type,
+          Kokkos::HostSpace>::accessible);
 
   static_assert(Kokkos::SpaceAccessibility<
-                Kokkos::Impl::HostMirror<Kokkos::SYCLDeviceUSMSpace>::Space,
+                Kokkos::Impl::HostMirror<Kokkos::SYCLHostUSMSpace>::device_type,
                 Kokkos::HostSpace>::accessible);
-
-  static_assert(Kokkos::SpaceAccessibility<
-                Kokkos::Impl::HostMirror<Kokkos::SYCLSharedUSMSpace>::Space,
-                Kokkos::SYCLSharedUSMSpace>::accessible);
-
-  static_assert(Kokkos::SpaceAccessibility<
-                Kokkos::Impl::HostMirror<Kokkos::SYCLHostUSMSpace>::Space,
-                Kokkos::SYCLHostUSMSpace>::accessible);
 }
 
 TEST(sycl, uvm) {


### PR DESCRIPTION
This PR refines Kokkos::Impl::HostMirror to return a “host mirror” type that matches the category of the template argument (execution space vs memory space vs device), and updates ViewTraits and unit tests to use that behavior consistently. It also simplifies and documents the HostSpace decision logic.

Motivation: Several call sites effectively need “the host mirror space of this thing,” but HostMirror behavior was inconsistent depending on whether you passed an execution space, memory space, or device. This change makes the function predictable and reduces surprising type mismatches across backends.

Changes:

* HostMirror API refinement: Introduces/uses `HostMirror<S>::Device`, `execution_space`, `memory_space`, and `Space` so the returned type aligns with the kind of S.
* Clarifies and simplifies `HostSpace selection logic`
* ViewTraits consistency: `host_mirror_space` is now derived consistently via `HostMirror<MemorySpace>` (rather than mixing `Space`, `nested ::memory_space`, etc.).
* Tests updated