### PR TITLE
core(complex): `constexpr` comparison

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -496,8 +496,8 @@ KOKKOS_FUNCTION constexpr const RealType&& get(
 
 //! Binary == operator for complex complex.
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION bool operator==(complex<RealType1> const& x,
-                                       complex<RealType2> const& y) noexcept {
+KOKKOS_INLINE_FUNCTION constexpr bool operator==(
+    complex<RealType1> const& x, complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) == common_type(y.real()) &&
          common_type(x.imag()) == common_type(y.imag());
@@ -528,8 +528,8 @@ template <
     class RealType1, class RealType2,
     // Constraints to avoid participation in oparator==() for every possible RHS
     std::enable_if_t<std::is_convertible_v<RealType2, RealType1>, int> = 0>
-KOKKOS_INLINE_FUNCTION bool operator==(complex<RealType1> const& x,
-                                       RealType2 const& y) noexcept {
+KOKKOS_INLINE_FUNCTION constexpr bool operator==(complex<RealType1> const& x,
+                                                 RealType2 const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) == common_type(y) &&
          common_type(x.imag()) == common_type(0);
@@ -540,8 +540,8 @@ template <
     class RealType1, class RealType2,
     // Constraints to avoid participation in oparator==() for every possible RHS
     std::enable_if_t<std::is_convertible_v<RealType1, RealType2>, int> = 0>
-KOKKOS_INLINE_FUNCTION bool operator==(RealType1 const& x,
-                                       complex<RealType2> const& y) noexcept {
+KOKKOS_INLINE_FUNCTION constexpr bool operator==(
+    RealType1 const& x, complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x) == common_type(y.real()) &&
          common_type(0) == common_type(y.imag());
@@ -549,8 +549,8 @@ KOKKOS_INLINE_FUNCTION bool operator==(RealType1 const& x,
 
 //! Binary != operator for complex complex.
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION bool operator!=(complex<RealType1> const& x,
-                                       complex<RealType2> const& y) noexcept {
+KOKKOS_INLINE_FUNCTION constexpr bool operator!=(
+    complex<RealType1> const& x, complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) != common_type(y.real()) ||
          common_type(x.imag()) != common_type(y.imag());
@@ -579,8 +579,8 @@ template <
     class RealType1, class RealType2,
     // Constraints to avoid participation in oparator==() for every possible RHS
     std::enable_if_t<std::is_convertible_v<RealType2, RealType1>, int> = 0>
-KOKKOS_INLINE_FUNCTION bool operator!=(complex<RealType1> const& x,
-                                       RealType2 const& y) noexcept {
+KOKKOS_INLINE_FUNCTION constexpr bool operator!=(complex<RealType1> const& x,
+                                                 RealType2 const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) != common_type(y) ||
          common_type(x.imag()) != common_type(0);
@@ -591,8 +591,8 @@ template <
     class RealType1, class RealType2,
     // Constraints to avoid participation in oparator==() for every possible RHS
     std::enable_if_t<std::is_convertible_v<RealType1, RealType2>, int> = 0>
-KOKKOS_INLINE_FUNCTION bool operator!=(RealType1 const& x,
-                                       complex<RealType2> const& y) noexcept {
+KOKKOS_INLINE_FUNCTION constexpr bool operator!=(
+    RealType1 const& x, complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x) != common_type(y.real()) ||
          common_type(0) != common_type(y.imag());

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -727,6 +727,23 @@ constexpr bool can_appear_in_constant_expressions() {
 
 static_assert(can_appear_in_constant_expressions());
 
+constexpr bool comparison_in_constant_expression() {
+  static_assert(Kokkos::complex<double>{42., 43.} ==
+                Kokkos::complex<double>{42., 43.});
+  static_assert(Kokkos::complex<double>{42., 43.} !=
+                Kokkos::complex<double>{42., 42.});
+
+  static_assert(Kokkos::complex<double>{42., 0.} == double{42.});
+  static_assert(Kokkos::complex<double>{42., 43.} != double{42.});
+
+  static_assert(double{42.} == Kokkos::complex<double>{42., 0.});
+  static_assert(double{43.} != Kokkos::complex<double>{42., 0.});
+
+  return true;
+}
+
+static_assert(comparison_in_constant_expression());
+
 }  // namespace Test
 
 #ifdef KOKKOS_COMPILER_NVCC


### PR DESCRIPTION
This PR marks comparison operators for `Kokkos::complex` as `constexpr`, as per the standard.

Note that I have avoided the overloads that mix `std` and `Kokkos` explicitly.