### PR TITLE
Cleanup zero memset in view alloc and view copy with omp

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -859,12 +859,7 @@ inline std::enable_if_t<
 contiguous_fill_or_memset(
     const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {
-  // With OpenMP, using memset has significant performance issues.
-  if (has_all_zero_bits(value)
-#ifdef KOKKOS_ENABLE_OPENMP
-      && !std::is_same_v<ExecutionSpace, Kokkos::OpenMP>
-#endif
-  )
+  if (has_all_zero_bits(value))
     ZeroMemset(exec_space, dst.data(),
                dst.size() * sizeof(typename ViewTraits<DT, DP...>::value_type));
   else

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -155,15 +155,12 @@ struct ViewValueFunctor {
   }
 
   void construct_shared_allocation() {
-// On A64FX memset seems to do the wrong thing with regards to first touch
-// leading to the significant performance issues
-#ifndef KOKKOS_ARCH_A64FX
     if constexpr (std::is_trivially_default_constructible_v<ValueType>) {
       // value-initialization is equivalent to filling with zeros
       zero_memset_implementation();
-    } else
-#endif
+    } else {
       parallel_for_implementation<ConstructTag>();
+    }
   }
 
   void destroy_shared_allocation() {


### PR DESCRIPTION
Following up on #8178
We do not need these extra levels of guarding, the strategy is selected in the OpenMP specialization of ZeroMemset.