### PR TITLE
`DualView` Guard modification flag increment against `impl_is_single_device`

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -1009,7 +1009,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
         resync_host(properties);
 
         /* Mark Device copy as modified */
-        ++modified_flags(1);
+        if constexpr (!impl_dualview_is_single_device) ++modified_flags(1);
       }
     };
 
@@ -1023,7 +1023,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
         resync_device(properties);
 
         /* Mark Host copy as modified */
-        ++modified_flags(0);
+        if constexpr (!impl_dualview_is_single_device) ++modified_flags(0);
       }
     };
 

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -775,6 +775,24 @@ TEST(TEST_CATEGORY, dualview_default_constructed) {
   ASSERT_FALSE(dv.need_sync_device());
   dv.sync_device();
 }
+
+TEST(TEST_CATEGORY, dualview_resize_single_device) {
+  using dv_t = Kokkos::DualView<double*, TEST_EXECSPACE>;
+  dv_t dv("DV", 10);
+  bool is_same_device = std::is_same_v<typename dv_t::t_host::device_type,
+                                       typename dv_t::t_dev::device_type>;
+
+  dv.resize(20);
+  ASSERT_EQ(!is_same_device, dv.need_sync_host());
+  ASSERT_FALSE(dv.need_sync_device());
+
+  dv.sync_host();
+  dv.modify_host();
+  dv.resize(30);
+  ASSERT_FALSE(dv.need_sync_host());
+  ASSERT_EQ(!is_same_device, dv.need_sync_device());
+}
+
 }  // anonymous namespace
 }  // namespace Test
 


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/8277
Reported by @stanmoore1 on Slack https://kokkosteam.slack.com/archives/C5BGU5NDQ/p1753401051183099

Alternative to https://github.com/kokkos/kokkos/pull/7993 since we are close to the release it might be a good idea to minimize risk.


**TODO** I don't know a good way to test this -> Christian added a minimal test
Feel free to push to this branch