### PR TITLE
Disable graph_capture test for cuda/11.4+gcc/10.3.0

### DIFF
--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -839,7 +839,13 @@ struct GraphNodeTypes {
                                          Kokkos::Experimental::TypeErasedTag>;
 
 #if defined(KOKKOS_ENABLE_CUDA)
+// TODO check range of problematic nvcc/11.4 and gcc/10.x combos
+#if (defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU == 1030)) && \
+    (defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC == 1140))
+  static constexpr bool support_capture = false;
+#else
   static constexpr bool support_capture = std::is_same_v<Exec, Kokkos::Cuda>;
+#endif
 #elif defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
     static constexpr bool support_capture = std::is_same_v<Exec, Kokkos::HIP>;
 #elif defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_SYCL_GRAPH_SUPPORT)


### PR DESCRIPTION
Workaround to compilation errors of the type:
```
/root/kokkos/core/unit_test/TestGraph.hpp:1027:24: error: '__T4' was not declared in this scope; did you mean '__T9'?
 1027 |   const auto data_0(Kokkos::subview(data, 0));
```