### PR TITLE
Deprecate Kokkos::Experimental::subview for OffsetView and correct behavior of Kokkos::subview

### DIFF
--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1115,6 +1115,7 @@ KOKKOS_INLINE_FUNCTION
   return offsetView;
 }
 }  // namespace Impl
+}  // namespace Experimental
 
 template <class D, class... P, class... Args>
 KOKKOS_INLINE_FUNCTION
@@ -1123,15 +1124,32 @@ KOKKOS_INLINE_FUNCTION
             void /* deduce subview type from source view traits */
             ,
             ViewTraits<D, P...>, Args...>::type>::type
-    subview(const OffsetView<D, P...>& src, Args... args) {
+    subview(const Kokkos::Experimental::OffsetView<D, P...>& src,
+            Args... args) {
   static_assert(
-      OffsetView<D, P...>::rank() == sizeof...(Args),
+      Kokkos::Experimental::OffsetView<D, P...>::rank() == sizeof...(Args),
       "subview requires one argument for each source OffsetView rank");
 
   return Kokkos::Experimental::Impl::subview_offset(src, args...);
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+namespace Experimental {
+template <class D, class... P, class... Args>
+KOKKOS_DEPRECATED_WITH_COMMENT("Use Kokkos::subview instead")
+KOKKOS_INLINE_FUNCTION
+    typename Kokkos::Experimental::Impl::GetOffsetViewTypeFromViewType<
+        typename Kokkos::Impl::ViewMapping<
+            void /* deduce subview type from source view traits */
+            ,
+            ViewTraits<D, P...>, Args...>::type>::type
+    subview(const Kokkos::Experimental::OffsetView<D, P...>& src,
+            Args... args) {
+  return Kokkos::subview(src, args...);
+}
 }  // namespace Experimental
+#endif
+
 }  // namespace Kokkos
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -468,7 +468,7 @@ void test_offsetview_subview() {
     Kokkos::Experimental::OffsetView<Scalar*, Device> sliceMe("offsetToSlice",
                                                               {-10, 20});
     {
-      auto offsetSubview = Kokkos::Experimental::subview(sliceMe, 0);
+      auto offsetSubview = Kokkos::subview(sliceMe, 0);
       ASSERT_EQ(offsetSubview.rank(), 0u) << "subview of offset is broken.";
     }
   }
@@ -476,14 +476,12 @@ void test_offsetview_subview() {
     Kokkos::Experimental::OffsetView<Scalar**, Device> sliceMe(
         "offsetToSlice", {-10, 20}, {-20, 30});
     {
-      auto offsetSubview =
-          Kokkos::Experimental::subview(sliceMe, Kokkos::ALL(), -2);
+      auto offsetSubview = Kokkos::subview(sliceMe, Kokkos::ALL(), -2);
       ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
 
     {
-      auto offsetSubview =
-          Kokkos::Experimental::subview(sliceMe, 0, Kokkos::ALL());
+      auto offsetSubview = Kokkos::subview(sliceMe, 0, Kokkos::ALL());
       ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
   }
@@ -495,24 +493,24 @@ void test_offsetview_subview() {
 
     // slice 1
     {
-      auto offsetSubview = Kokkos::Experimental::subview(sliceMe, Kokkos::ALL(),
-                                                         Kokkos::ALL(), 0);
+      auto offsetSubview =
+          Kokkos::subview(sliceMe, Kokkos::ALL(), Kokkos::ALL(), 0);
       ASSERT_EQ(offsetSubview.rank(), 2u) << "subview of offset is broken.";
     }
     {
-      auto offsetSubview = Kokkos::Experimental::subview(sliceMe, Kokkos::ALL(),
-                                                         0, Kokkos::ALL());
+      auto offsetSubview =
+          Kokkos::subview(sliceMe, Kokkos::ALL(), 0, Kokkos::ALL());
       ASSERT_EQ(offsetSubview.rank(), 2u) << "subview of offset is broken.";
     }
 
     {
-      auto offsetSubview = Kokkos::Experimental::subview(
-          sliceMe, 0, Kokkos::ALL(), Kokkos::ALL());
+      auto offsetSubview =
+          Kokkos::subview(sliceMe, 0, Kokkos::ALL(), Kokkos::ALL());
       ASSERT_EQ(offsetSubview.rank(), 2u) << "subview of offset is broken.";
     }
     {
-      auto offsetSubview = Kokkos::Experimental::subview(
-          sliceMe, 0, Kokkos::ALL(), Kokkos::make_pair(-30, -21));
+      auto offsetSubview = Kokkos::subview(sliceMe, 0, Kokkos::ALL(),
+                                           Kokkos::make_pair(-30, -21));
       ASSERT_EQ(offsetSubview.rank(), 2u) << "subview of offset is broken.";
 
       ASSERT_EQ(offsetSubview.begin(0), -20);
@@ -549,19 +547,16 @@ void test_offsetview_subview() {
 
     // slice 2
     {
-      auto offsetSubview =
-          Kokkos::Experimental::subview(sliceMe, Kokkos::ALL(), 0, 0);
+      auto offsetSubview = Kokkos::subview(sliceMe, Kokkos::ALL(), 0, 0);
       ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
     {
-      auto offsetSubview =
-          Kokkos::Experimental::subview(sliceMe, 0, 0, Kokkos::ALL());
+      auto offsetSubview = Kokkos::subview(sliceMe, 0, 0, Kokkos::ALL());
       ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
 
     {
-      auto offsetSubview =
-          Kokkos::Experimental::subview(sliceMe, 0, Kokkos::ALL(), 0);
+      auto offsetSubview = Kokkos::subview(sliceMe, 0, Kokkos::ALL(), 0);
       ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
   }
@@ -573,69 +568,65 @@ void test_offsetview_subview() {
 
     // slice 1
     {
-      auto offsetSubview = Kokkos::Experimental::subview(
-          sliceMe, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), 0);
+      auto offsetSubview = Kokkos::subview(sliceMe, Kokkos::ALL(),
+                                           Kokkos::ALL(), Kokkos::ALL(), 0);
       ASSERT_EQ(offsetSubview.rank(), 3u) << "subview of offset is broken.";
     }
     {
-      auto offsetSubview = Kokkos::Experimental::subview(
-          sliceMe, Kokkos::ALL(), Kokkos::ALL(), 0, Kokkos::ALL());
+      auto offsetSubview = Kokkos::subview(sliceMe, Kokkos::ALL(),
+                                           Kokkos::ALL(), 0, Kokkos::ALL());
       ASSERT_EQ(offsetSubview.rank(), 3u) << "subview of offset is broken.";
     }
     {
-      auto offsetSubview = Kokkos::Experimental::subview(
-          sliceMe, Kokkos::ALL(), 0, Kokkos::ALL(), Kokkos::ALL());
+      auto offsetSubview = Kokkos::subview(sliceMe, Kokkos::ALL(), 0,
+                                           Kokkos::ALL(), Kokkos::ALL());
       ASSERT_EQ(offsetSubview.rank(), 3u) << "subview of offset is broken.";
     }
     {
-      auto offsetSubview = Kokkos::Experimental::subview(
-          sliceMe, 0, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+      auto offsetSubview = Kokkos::subview(sliceMe, 0, Kokkos::ALL(),
+                                           Kokkos::ALL(), Kokkos::ALL());
       ASSERT_EQ(offsetSubview.rank(), 3u) << "subview of offset is broken.";
     }
 
     // slice 2
-    auto offsetSubview2a = Kokkos::Experimental::subview(sliceMe, Kokkos::ALL(),
-                                                         Kokkos::ALL(), 0, 0);
+    auto offsetSubview2a =
+        Kokkos::subview(sliceMe, Kokkos::ALL(), Kokkos::ALL(), 0, 0);
     ASSERT_EQ(offsetSubview2a.rank(), 2u) << "subview of offset is broken.";
     {
-      auto offsetSubview2b = Kokkos::Experimental::subview(
-          sliceMe, Kokkos::ALL(), 0, Kokkos::ALL(), 0);
+      auto offsetSubview2b =
+          Kokkos::subview(sliceMe, Kokkos::ALL(), 0, Kokkos::ALL(), 0);
       ASSERT_EQ(offsetSubview2b.rank(), 2u) << "subview of offset is broken.";
     }
     {
-      auto offsetSubview2b = Kokkos::Experimental::subview(
-          sliceMe, Kokkos::ALL(), 0, 0, Kokkos::ALL());
+      auto offsetSubview2b =
+          Kokkos::subview(sliceMe, Kokkos::ALL(), 0, 0, Kokkos::ALL());
       ASSERT_EQ(offsetSubview2b.rank(), 2u) << "subview of offset is broken.";
     }
     {
-      auto offsetSubview2b = Kokkos::Experimental::subview(
-          sliceMe, 0, Kokkos::ALL(), 0, Kokkos::ALL());
+      auto offsetSubview2b =
+          Kokkos::subview(sliceMe, 0, Kokkos::ALL(), 0, Kokkos::ALL());
       ASSERT_EQ(offsetSubview2b.rank(), 2u) << "subview of offset is broken.";
     }
     {
-      auto offsetSubview2b = Kokkos::Experimental::subview(
-          sliceMe, 0, 0, Kokkos::ALL(), Kokkos::ALL());
+      auto offsetSubview2b =
+          Kokkos::subview(sliceMe, 0, 0, Kokkos::ALL(), Kokkos::ALL());
       ASSERT_EQ(offsetSubview2b.rank(), 2u) << "subview of offset is broken.";
     }
     // slice 3
     {
-      auto offsetSubview =
-          Kokkos::Experimental::subview(sliceMe, Kokkos::ALL(), 0, 0, 0);
+      auto offsetSubview = Kokkos::subview(sliceMe, Kokkos::ALL(), 0, 0, 0);
       ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
     {
-      auto offsetSubview =
-          Kokkos::Experimental::subview(sliceMe, 0, Kokkos::ALL(), 0, 0);
+      auto offsetSubview = Kokkos::subview(sliceMe, 0, Kokkos::ALL(), 0, 0);
       ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
     {
-      auto offsetSubview =
-          Kokkos::Experimental::subview(sliceMe, 0, 0, Kokkos::ALL(), 0);
+      auto offsetSubview = Kokkos::subview(sliceMe, 0, 0, Kokkos::ALL(), 0);
       ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
     {
-      auto offsetSubview =
-          Kokkos::Experimental::subview(sliceMe, 0, 0, 0, Kokkos::ALL());
+      auto offsetSubview = Kokkos::subview(sliceMe, 0, 0, 0, Kokkos::ALL());
       ASSERT_EQ(offsetSubview.rank(), 1u) << "subview of offset is broken.";
     }
   }


### PR DESCRIPTION
`Kokkos::subview` with an `OffsetView` argument was using the implicit conversion to `Kokkos::View` while `Kokkos::Experimental::subview` respects the offsets as intended. This is confusing (and the former is likely a bug and not intended). Also see https://kokkosteam.slack.com/archives/C5BGU5NDQ/p1753897842407869.
This pull request deprecates `Kokkos::Experimental::subview` and moves its definition to the `Kokkos` namespace.