### PR TITLE
Check subview extents in mdspan-based View implementation

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -565,75 +565,6 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     base_t::check_basic_view_constructibility(other.mapping());
   }
 
-#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
- private:
-  template <class Arg>
-  KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t extent,
-                                                  const Arg arg) {
-    return static_cast<std::size_t>(arg) < extent;
-  }
-
-  template <class T>
-  KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t extent,
-                                                  const std::pair<T, T> arg) {
-    return static_cast<std::size_t>(arg.second) <= extent && arg.first >= 0;
-  }
-
-  template <class T>
-  static bool is_in_bounds(size_t extent, const Kokkos::pair<T, T> arg) {
-    return static_cast<std::size_t>(arg.second) <= extent && arg.first >= 0 &&
-           arg.first <= arg.second;
-  }
-
-  KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t /*extent*/,
-                                                  const ALL_t) {
-    return true;
-  }
-
-  template <class RT, class... RP, size_t... Idx, class... Args>
-  KOKKOS_INLINE_FUNCTION static bool subview_extents_valid(
-      const View<RT, RP...>& src_view, std::index_sequence<Idx...>,
-      Args... args) {
-    return (is_in_bounds(src_view.extent(Idx), args) && ... && true);
-  }
-
-  template <class Arg>
-  static void append_error_message(std::stringstream& ss, size_t extent,
-                                   const Arg arg) {
-    ss << arg << " < " << extent;
-  }
-
-  template <class T>
-  static void append_error_message(std::stringstream& ss, size_t extent,
-                                   const std::pair<T, T> arg) {
-    ss << arg.first << " <= " << arg.second << " <= " << extent;
-  }
-
-  template <class T>
-  static void append_error_message(std::stringstream& ss, size_t extent,
-                                   const Kokkos::pair<T, T> arg) {
-    ss << arg.first << " <= " << arg.second << " <= " << extent;
-  }
-
-  static void append_error_message(std::stringstream& ss, size_t /*extent*/,
-                                   const ALL_t) {
-    ss << "Kokkos::ALL";
-  }
-
-  template <class RT, class... RP, size_t... Idx, class Arg0, class... Args>
-  static std::stringstream generate_error_message(
-      const View<RT, RP...>& src_view, std::index_sequence<Idx...>, Arg0 arg0,
-      Args... args) {
-    std::stringstream ss;
-    ss << "Kokkos::subview bounds error (";
-    append_error_message(ss, src_view.extent(0), arg0);
-    ((ss << ", ", append_error_message(ss, src_view.extent(Idx), args)), ...);
-    ss << ')';
-    return ss;
-  }
-#endif
-
- public:
   //----------------------------------------
   // Compatible subview constructor
   // may assign unmanaged from managed.
@@ -641,23 +572,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   template <class RT, class... RP, class Arg0, class... Args>
   KOKKOS_INLINE_FUNCTION View(const View<RT, RP...>& src_view, const Arg0 arg0,
                               Args... args)
-      : base_t(Impl::subview_ctor_tag, src_view, arg0, args...) {
-#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
-    bool valid = subview_extents_valid(
-        src_view, std::make_index_sequence<sizeof...(Args) + 1>{}, arg0,
-        args...);
-    if (!valid) {
-      KOKKOS_IF_ON_HOST(
-          Kokkos::abort(generate_error_message(
-                            src_view,
-                            std::make_index_sequence<sizeof...(Args)>{}, arg0,
-                            args...)
-                            .str()
-                            .c_str());)
-      KOKKOS_IF_ON_DEVICE(Kokkos::abort("Kokkos::subview bounds error");)
-    }
-#endif
-  }
+      : base_t(Impl::subview_ctor_tag, src_view, arg0, args...) {}
 
   //----------------------------------------
   // Allocation according to allocation properties and array layout

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -570,11 +570,13 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   // may assign unmanaged from managed.
 
  private:
-  template <class RT, class... RP, class Arg0, class... Args>
+  template <class RT, class... RP, class Arg, class... Args>
   KOKKOS_INLINE_FUNCTION static bool subview_extents_valid(
-      const View<RT, RP...>& src_view, const Arg0 arg0, Args... args) {
-    constexpr int rank = View<RT, RP...>::rank;
-    if (arg0 >= src_view.extent(rank - 1 - sizeof...(Args))) return false;
+      const View<RT, RP...>& src_view, const Arg arg, Args... args) {
+    constexpr int src_rank = View<RT, RP...>::rank;
+    if (static_cast<std::size_t>(arg) >=
+        src_view.extent(src_rank - 1 - sizeof...(Args)))
+      return false;
     if constexpr (sizeof...(Args) == 0)
       return true;
     else
@@ -585,8 +587,9 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   KOKKOS_INLINE_FUNCTION static bool subview_extents_valid(
       const View<RT, RP...>& src_view, const std::pair<T, T> arg,
       Args... args) {
-    constexpr int rank = View<RT, RP...>::rank;
-    if (arg.second > src_view.extent(rank - 1 - sizeof...(Args)) ||
+    constexpr int src_rank = View<RT, RP...>::rank;
+    if (static_cast<std::size_t>(arg.second) >
+            src_view.extent(src_rank - 1 - sizeof...(Args)) ||
         arg.first < 0)
       return false;
     if constexpr (sizeof...(Args) == 0)
@@ -599,8 +602,9 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   KOKKOS_INLINE_FUNCTION static bool subview_extents_valid(
       const View<RT, RP...>& src_view, const Kokkos::pair<T, T> arg,
       Args... args) {
-    constexpr int rank = View<RT, RP...>::rank;
-    if (arg.second > src_view.extent(rank - 1 - sizeof...(Args)) ||
+    constexpr int src_rank = View<RT, RP...>::rank;
+    if (static_cast<std::size_t>(arg.second) >
+            src_view.extent(src_rank - 1 - sizeof...(Args)) ||
         arg.first < 0)
       return false;
     if constexpr (sizeof...(Args) == 0)
@@ -618,12 +622,12 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
       return subview_extents_valid(src_view, args...);
   }
 
-  template <class RT, class... RP, class Arg0, class... Args>
+  template <class RT, class... RP, class Arg, class... Args>
   static void generate_error_message(std::stringstream& ss,
                                      const View<RT, RP...>& src_view,
-                                     const Arg0 arg0, Args... args) {
-    constexpr int rank = View<RT, RP...>::rank;
-    ss << arg0 << " < " << src_view.extent(rank - 1 - sizeof...(Args));
+                                     const Arg arg, Args... args) {
+    constexpr int src_rank = View<RT, RP...>::rank;
+    ss << arg << " < " << src_view.extent(src_rank - 1 - sizeof...(Args));
     if constexpr (sizeof...(Args) > 0) {
       ss << ", ";
       generate_error_message(ss, src_view, args...);
@@ -634,8 +638,8 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   static void generate_error_message(std::stringstream& ss,
                                      const View<RT, RP...>& src_view,
                                      const std::pair<T, T> arg, Args... args) {
-    constexpr int rank = View<RT, RP...>::rank;
-    ss << arg.first << " <= " << src_view.extent(rank - 1 - sizeof...(Args))
+    constexpr int src_rank = View<RT, RP...>::rank;
+    ss << arg.first << " <= " << src_view.extent(src_rank - 1 - sizeof...(Args))
        << " <= " << arg.second;
     if constexpr (sizeof...(Args) > 0)
       generate_error_message(ss, src_view, args...);
@@ -646,8 +650,8 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
                                      const View<RT, RP...>& src_view,
                                      const Kokkos::pair<T, T> arg,
                                      Args... args) {
-    constexpr int rank = View<RT, RP...>::rank;
-    ss << arg.first << " <= " << src_view.extent(rank - 1 - sizeof...(Args))
+    constexpr int src_rank = View<RT, RP...>::rank;
+    ss << arg.first << " <= " << src_view.extent(src_rank - 1 - sizeof...(Args))
        << " <= " << arg.second;
     if constexpr (sizeof...(Args) > 0) {
       ss << ", ";

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -569,10 +569,119 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   // Compatible subview constructor
   // may assign unmanaged from managed.
 
+ private:
+  template <class RT, class... RP, class Arg0, class... Args>
+  KOKKOS_INLINE_FUNCTION static bool subview_extents_valid(
+      const View<RT, RP...>& src_view, const Arg0 arg0, Args... args) {
+    constexpr int rank = View<RT, RP...>::rank;
+    if (arg0 >= src_view.extent(rank - 1 - sizeof...(Args))) return false;
+    if constexpr (sizeof...(Args) == 0)
+      return true;
+    else
+      return subview_extents_valid(src_view, args...);
+  }
+
+  template <class RT, class... RP, class T, class... Args>
+  KOKKOS_INLINE_FUNCTION static bool subview_extents_valid(
+      const View<RT, RP...>& src_view, const std::pair<T, T> arg,
+      Args... args) {
+    constexpr int rank = View<RT, RP...>::rank;
+    if (arg.second > src_view.extent(rank - 1 - sizeof...(Args)) ||
+        arg.first < 0)
+      return false;
+    if constexpr (sizeof...(Args) == 0)
+      return true;
+    else
+      return subview_extents_valid(src_view, args...);
+  }
+
+  template <class RT, class... RP, class T, class... Args>
+  KOKKOS_INLINE_FUNCTION static bool subview_extents_valid(
+      const View<RT, RP...>& src_view, const Kokkos::pair<T, T> arg,
+      Args... args) {
+    constexpr int rank = View<RT, RP...>::rank;
+    if (arg.second > src_view.extent(rank - 1 - sizeof...(Args)) ||
+        arg.first < 0)
+      return false;
+    if constexpr (sizeof...(Args) == 0)
+      return true;
+    else
+      return subview_extents_valid(src_view, args...);
+  }
+
+  template <class RT, class... RP, class... Args>
+  KOKKOS_INLINE_FUNCTION static bool subview_extents_valid(
+      const View<RT, RP...>& src_view, const ALL_t, Args... args) {
+    if constexpr (sizeof...(Args) == 0)
+      return true;
+    else
+      return subview_extents_valid(src_view, args...);
+  }
+
+  template <class RT, class... RP, class Arg0, class... Args>
+  static void generate_error_message(std::stringstream& ss,
+                                     const View<RT, RP...>& src_view,
+                                     const Arg0 arg0, Args... args) {
+    constexpr int rank = View<RT, RP...>::rank;
+    ss << arg0 << " < " << src_view.extent(rank - 1 - sizeof...(Args));
+    if constexpr (sizeof...(Args) > 0) {
+      ss << ", ";
+      generate_error_message(ss, src_view, args...);
+    }
+  }
+
+  template <class RT, class... RP, class T, class... Args>
+  static void generate_error_message(std::stringstream& ss,
+                                     const View<RT, RP...>& src_view,
+                                     const std::pair<T, T> arg, Args... args) {
+    constexpr int rank = View<RT, RP...>::rank;
+    ss << arg.first << " <= " << src_view.extent(rank - 1 - sizeof...(Args))
+       << " <= " << arg.second;
+    if constexpr (sizeof...(Args) > 0)
+      generate_error_message(ss, src_view, args...);
+  }
+
+  template <class RT, class... RP, class T, class... Args>
+  static void generate_error_message(std::stringstream& ss,
+                                     const View<RT, RP...>& src_view,
+                                     const Kokkos::pair<T, T> arg,
+                                     Args... args) {
+    constexpr int rank = View<RT, RP...>::rank;
+    ss << arg.first << " <= " << src_view.extent(rank - 1 - sizeof...(Args))
+       << " <= " << arg.second;
+    if constexpr (sizeof...(Args) > 0) {
+      ss << ", ";
+      generate_error_message(ss, src_view, args...);
+    }
+  }
+
+  template <class RT, class... RP, class... Args>
+  static void generate_error_message(std::stringstream& ss,
+                                     const View<RT, RP...>& src_view,
+                                     const ALL_t, Args... args) {
+    ss << "Kokkos::ALL";
+    if constexpr (sizeof...(Args) > 0) {
+      ss << ", ";
+      generate_error_message(ss, src_view, args...);
+    }
+  }
+
+ public:
   template <class RT, class... RP, class Arg0, class... Args>
   KOKKOS_INLINE_FUNCTION View(const View<RT, RP...>& src_view, const Arg0 arg0,
                               Args... args)
-      : base_t(Impl::subview_ctor_tag, src_view, arg0, args...) {}
+      : base_t(Impl::subview_ctor_tag, src_view, arg0, args...) {
+#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
+    bool valid = subview_extents_valid(src_view, arg0, args...);
+    if (!valid) {
+      KOKKOS_IF_ON_HOST(std::stringstream ss;
+                        ss << "Kokkos::subview bounds error: (";
+                        generate_error_message(ss, src_view, arg0, args...);
+                        ss << ")"; Kokkos::abort(ss.str().c_str());)
+      KOKKOS_IF_ON_DEVICE(Kokkos::abort("Kokkos::subview bounds error");)
+    }
+#endif
+  }
 
   //----------------------------------------
   // Allocation according to allocation properties and array layout

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -565,123 +565,95 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     base_t::check_basic_view_constructibility(other.mapping());
   }
 
+#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
+ private:
+  template <class Arg>
+  KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t extent,
+                                                  const Arg arg) {
+    return static_cast<std::size_t>(arg) < extent;
+  }
+
+  template <class T>
+  KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t extent,
+                                                  const std::pair<T, T> arg) {
+    return static_cast<std::size_t>(arg.second) <= extent && arg.first >= 0;
+  }
+
+  template <class T>
+  static bool is_in_bounds(size_t extent, const Kokkos::pair<T, T> arg) {
+    return static_cast<std::size_t>(arg.second) <= extent && arg.first >= 0 &&
+           arg.first <= arg.second;
+  }
+
+  KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t /*extent*/,
+                                                  const ALL_t) {
+    return true;
+  }
+
+  template <class RT, class... RP, size_t... Idx, class... Args>
+  KOKKOS_INLINE_FUNCTION static bool subview_extents_valid(
+      const View<RT, RP...>& src_view, std::index_sequence<Idx...>,
+      Args... args) {
+    return (is_in_bounds(src_view.extent(Idx), args) && ... && true);
+  }
+
+  template <class Arg>
+  static void append_error_message(std::stringstream& ss, size_t extent,
+                                   const Arg arg) {
+    ss << arg << " < " << extent;
+  }
+
+  template <class T>
+  static void append_error_message(std::stringstream& ss, size_t extent,
+                                   const std::pair<T, T> arg) {
+    ss << arg.first << " <= " << arg.second << " <= " << extent;
+  }
+
+  template <class T>
+  static void append_error_message(std::stringstream& ss, size_t extent,
+                                   const Kokkos::pair<T, T> arg) {
+    ss << arg.first << " <= " << arg.second << " <= " << extent;
+  }
+
+  static void append_error_message(std::stringstream& ss, size_t /*extent*/,
+                                   const ALL_t) {
+    ss << "Kokkos::ALL";
+  }
+
+  template <class RT, class... RP, size_t... Idx, class Arg0, class... Args>
+  static std::stringstream generate_error_message(
+      const View<RT, RP...>& src_view, std::index_sequence<Idx...>, Arg0 arg0,
+      Args... args) {
+    std::stringstream ss;
+    ss << "Kokkos::subview bounds error (";
+    append_error_message(ss, src_view.extent(0), arg0);
+    ((ss << ", ", append_error_message(ss, src_view.extent(Idx), args)), ...);
+    ss << ')';
+    return ss;
+  }
+#endif
+
+ public:
   //----------------------------------------
   // Compatible subview constructor
   // may assign unmanaged from managed.
 
- private:
-  template <class RT, class... RP, class Arg, class... Args>
-  KOKKOS_INLINE_FUNCTION static bool subview_extents_valid(
-      const View<RT, RP...>& src_view, const Arg arg, Args... args) {
-    constexpr int src_rank = View<RT, RP...>::rank;
-    if (static_cast<std::size_t>(arg) >=
-        src_view.extent(src_rank - 1 - sizeof...(Args)))
-      return false;
-    if constexpr (sizeof...(Args) == 0)
-      return true;
-    else
-      return subview_extents_valid(src_view, args...);
-  }
-
-  template <class RT, class... RP, class T, class... Args>
-  KOKKOS_INLINE_FUNCTION static bool subview_extents_valid(
-      const View<RT, RP...>& src_view, const std::pair<T, T> arg,
-      Args... args) {
-    constexpr int src_rank = View<RT, RP...>::rank;
-    if (static_cast<std::size_t>(arg.second) >
-            src_view.extent(src_rank - 1 - sizeof...(Args)) ||
-        arg.first < 0)
-      return false;
-    if constexpr (sizeof...(Args) == 0)
-      return true;
-    else
-      return subview_extents_valid(src_view, args...);
-  }
-
-  template <class RT, class... RP, class T, class... Args>
-  KOKKOS_INLINE_FUNCTION static bool subview_extents_valid(
-      const View<RT, RP...>& src_view, const Kokkos::pair<T, T> arg,
-      Args... args) {
-    constexpr int src_rank = View<RT, RP...>::rank;
-    if (static_cast<std::size_t>(arg.second) >
-            src_view.extent(src_rank - 1 - sizeof...(Args)) ||
-        arg.first < 0)
-      return false;
-    if constexpr (sizeof...(Args) == 0)
-      return true;
-    else
-      return subview_extents_valid(src_view, args...);
-  }
-
-  template <class RT, class... RP, class... Args>
-  KOKKOS_INLINE_FUNCTION static bool subview_extents_valid(
-      const View<RT, RP...>& src_view, const ALL_t, Args... args) {
-    if constexpr (sizeof...(Args) == 0)
-      return true;
-    else
-      return subview_extents_valid(src_view, args...);
-  }
-
-  template <class RT, class... RP, class Arg, class... Args>
-  static void generate_error_message(std::stringstream& ss,
-                                     const View<RT, RP...>& src_view,
-                                     const Arg arg, Args... args) {
-    constexpr int src_rank = View<RT, RP...>::rank;
-    ss << arg << " < " << src_view.extent(src_rank - 1 - sizeof...(Args));
-    if constexpr (sizeof...(Args) > 0) {
-      ss << ", ";
-      generate_error_message(ss, src_view, args...);
-    }
-  }
-
-  template <class RT, class... RP, class T, class... Args>
-  static void generate_error_message(std::stringstream& ss,
-                                     const View<RT, RP...>& src_view,
-                                     const std::pair<T, T> arg, Args... args) {
-    constexpr int src_rank = View<RT, RP...>::rank;
-    ss << arg.first << " <= " << src_view.extent(src_rank - 1 - sizeof...(Args))
-       << " <= " << arg.second;
-    if constexpr (sizeof...(Args) > 0)
-      generate_error_message(ss, src_view, args...);
-  }
-
-  template <class RT, class... RP, class T, class... Args>
-  static void generate_error_message(std::stringstream& ss,
-                                     const View<RT, RP...>& src_view,
-                                     const Kokkos::pair<T, T> arg,
-                                     Args... args) {
-    constexpr int src_rank = View<RT, RP...>::rank;
-    ss << arg.first << " <= " << src_view.extent(src_rank - 1 - sizeof...(Args))
-       << " <= " << arg.second;
-    if constexpr (sizeof...(Args) > 0) {
-      ss << ", ";
-      generate_error_message(ss, src_view, args...);
-    }
-  }
-
-  template <class RT, class... RP, class... Args>
-  static void generate_error_message(std::stringstream& ss,
-                                     const View<RT, RP...>& src_view,
-                                     const ALL_t, Args... args) {
-    ss << "Kokkos::ALL";
-    if constexpr (sizeof...(Args) > 0) {
-      ss << ", ";
-      generate_error_message(ss, src_view, args...);
-    }
-  }
-
- public:
   template <class RT, class... RP, class Arg0, class... Args>
   KOKKOS_INLINE_FUNCTION View(const View<RT, RP...>& src_view, const Arg0 arg0,
                               Args... args)
       : base_t(Impl::subview_ctor_tag, src_view, arg0, args...) {
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
-    bool valid = subview_extents_valid(src_view, arg0, args...);
+    bool valid = subview_extents_valid(
+        src_view, std::make_index_sequence<sizeof...(Args) + 1>{}, arg0,
+        args...);
     if (!valid) {
-      KOKKOS_IF_ON_HOST(std::stringstream ss;
-                        ss << "Kokkos::subview bounds error: (";
-                        generate_error_message(ss, src_view, arg0, args...);
-                        ss << ")"; Kokkos::abort(ss.str().c_str());)
+      KOKKOS_IF_ON_HOST(
+          Kokkos::abort(generate_error_message(
+                            src_view,
+                            std::make_index_sequence<sizeof...(Args)>{}, arg0,
+                            args...)
+                            .str()
+                            .c_str());)
       KOKKOS_IF_ON_DEVICE(Kokkos::abort("Kokkos::subview bounds error");)
     }
 #endif

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -524,7 +524,8 @@ class BasicView {
   template <class T>
   KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t extent,
                                                   const std::pair<T, T> arg) {
-    return static_cast<std::size_t>(arg.second) <= extent && arg.first >= 0;
+    return static_cast<std::size_t>(arg.second) <= extent && arg.first >= 0 &&
+           arg.first <= arg.second;
   }
 
   template <class T>

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -576,7 +576,8 @@ class BasicView {
     std::stringstream ss;
     ss << "Kokkos::subview bounds error (";
     append_error_message(ss, src_view.extent(0), arg0);
-    ((ss << ", ", append_error_message(ss, src_view.extent(Idx), args)), ...);
+    ((ss << ", ", append_error_message(ss, src_view.extent(Idx + 1), args)),
+     ...);
     ss << ')';
     return ss;
   }

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -513,6 +513,74 @@ class BasicView {
             data_handle_type{Impl::get_property<Impl::PointerTag>(arg_prop)},
             arg_mapping) {}
 
+#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
+ private:
+  template <class Arg>
+  KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t extent,
+                                                  const Arg arg) {
+    return static_cast<std::size_t>(arg) < extent;
+  }
+
+  template <class T>
+  KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t extent,
+                                                  const std::pair<T, T> arg) {
+    return static_cast<std::size_t>(arg.second) <= extent && arg.first >= 0;
+  }
+
+  template <class T>
+  static bool is_in_bounds(size_t extent, const Kokkos::pair<T, T> arg) {
+    return static_cast<std::size_t>(arg.second) <= extent && arg.first >= 0 &&
+           arg.first <= arg.second;
+  }
+
+  KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t /*extent*/,
+                                                  const Kokkos::ALL_t) {
+    return true;
+  }
+
+  template <class RT, class... RP, size_t... Idx, class... Args>
+  KOKKOS_INLINE_FUNCTION static bool subview_extents_valid(
+      const BasicView<RT, RP...> &src_view, std::index_sequence<Idx...>,
+      Args... args) {
+    return (is_in_bounds(src_view.extent(Idx), args) && ... && true);
+  }
+
+  template <class Arg>
+  static void append_error_message(std::stringstream &ss, size_t extent,
+                                   const Arg arg) {
+    ss << arg << " < " << extent;
+  }
+
+  template <class T>
+  static void append_error_message(std::stringstream &ss, size_t extent,
+                                   const std::pair<T, T> arg) {
+    ss << arg.first << " <= " << arg.second << " <= " << extent;
+  }
+
+  template <class T>
+  static void append_error_message(std::stringstream &ss, size_t extent,
+                                   const Kokkos::pair<T, T> arg) {
+    ss << arg.first << " <= " << arg.second << " <= " << extent;
+  }
+
+  static void append_error_message(std::stringstream &ss, size_t /*extent*/,
+                                   const Kokkos::ALL_t) {
+    ss << "Kokkos::ALL";
+  }
+
+  template <class RT, class... RP, size_t... Idx, class Arg0, class... Args>
+  static std::stringstream generate_error_message(
+      const BasicView<RT, RP...> &src_view, std::index_sequence<Idx...>,
+      Arg0 arg0, Args... args) {
+    std::stringstream ss;
+    ss << "Kokkos::subview bounds error (";
+    append_error_message(ss, src_view.extent(0), arg0);
+    ((ss << ", ", append_error_message(ss, src_view.extent(Idx), args)), ...);
+    ss << ')';
+    return ss;
+  }
+#endif
+
  protected:
   template <class OtherElementType, class OtherExtents, class OtherLayoutPolicy,
             class OtherAccessorPolicy, class... SliceSpecifiers>
@@ -523,7 +591,24 @@ class BasicView {
       SliceSpecifiers... slices)
       : BasicView(submdspan(
             src_view.to_mdspan(),
-            Impl::transform_kokkos_slice_to_mdspan_slice(slices)...)) {}
+            Impl::transform_kokkos_slice_to_mdspan_slice(slices)...)) {
+#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
+    bool valid = subview_extents_valid(
+        src_view, std::make_index_sequence<sizeof...(SliceSpecifiers)>{},
+        slices...);
+    if (!valid) {
+      KOKKOS_IF_ON_HOST(
+          Kokkos::abort(
+              generate_error_message(
+                  src_view,
+                  std::make_index_sequence<sizeof...(SliceSpecifiers) - 1>{},
+                  slices...)
+                  .str()
+                  .c_str());)
+      KOKKOS_IF_ON_DEVICE(Kokkos::abort("Kokkos::subview bounds error");)
+    }
+#endif
+  }
 
  public:
   //----------------------------------------

--- a/core/unit_test/TestSubView_a.hpp
+++ b/core/unit_test/TestSubView_a.hpp
@@ -84,14 +84,14 @@ TEST(TEST_CATEGORY_DEATH, view_subview_wrong_extents) {
 #endif
 #endif
 
-  TestViewSubview::test_subview_extents<1>();
-  TestViewSubview::test_subview_extents<2>();
-  TestViewSubview::test_subview_extents<3>();
-  TestViewSubview::test_subview_extents<4>();
-  TestViewSubview::test_subview_extents<5>();
-  TestViewSubview::test_subview_extents<6>();
-  TestViewSubview::test_subview_extents<7>();
-  TestViewSubview::test_subview_extents<8>();
+  TestViewSubview::test_subview_extents<1, TEST_EXECSPACE>();
+  TestViewSubview::test_subview_extents<2, TEST_EXECSPACE>();
+  TestViewSubview::test_subview_extents<3, TEST_EXECSPACE>();
+  TestViewSubview::test_subview_extents<4, TEST_EXECSPACE>();
+  TestViewSubview::test_subview_extents<5, TEST_EXECSPACE>();
+  TestViewSubview::test_subview_extents<6, TEST_EXECSPACE>();
+  TestViewSubview::test_subview_extents<7, TEST_EXECSPACE>();
+  TestViewSubview::test_subview_extents<8, TEST_EXECSPACE>();
 }
 
 }  // namespace Test

--- a/core/unit_test/TestSubView_a.hpp
+++ b/core/unit_test/TestSubView_a.hpp
@@ -79,6 +79,9 @@ TEST(TEST_CATEGORY_DEATH, view_subview_wrong_extents) {
 
 #ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
+#ifdef KOKKOS_COMPILER_NVHPC
+  __builtin_unreachable();
+#endif
 #endif
 
   TestViewSubview::test_subview_extents<1>();

--- a/core/unit_test/TestSubView_a.hpp
+++ b/core/unit_test/TestSubView_a.hpp
@@ -74,5 +74,22 @@ TEST(TEST_CATEGORY, view_static_tests) {
   TestViewSubview::TestExtentsStaticTests<TEST_EXECSPACE>();
 }
 
+TEST(TEST_CATEGORY_DEATH, view_subview_wrong_extents) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+#ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
+  GTEST_SKIP() << "only enforced when debug bound checks is enabled";
+#endif
+
+  TestViewSubview::test_subview_extents<1>();
+  TestViewSubview::test_subview_extents<2>();
+  TestViewSubview::test_subview_extents<3>();
+  TestViewSubview::test_subview_extents<4>();
+  TestViewSubview::test_subview_extents<5>();
+  TestViewSubview::test_subview_extents<6>();
+  TestViewSubview::test_subview_extents<7>();
+  TestViewSubview::test_subview_extents<8>();
+}
+
 }  // namespace Test
 #endif

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -2320,9 +2320,10 @@ struct TestExtentsStaticTests {
       typename Kokkos::Impl::ParseViewExtents<double>::type>::type;
 };
 
-template <class RankType, std::size_t... Is>
+template <class ExecutionSpace, class RankType, std::size_t... Is>
 void test_subview_extents_helper_index(std::index_sequence<Is...>) {
-  using view_type = Kokkos::View<RankType>;
+  using view_type =
+      Kokkos::View<RankType, typename ExecutionSpace::memory_space>;
   view_type v("v", ((Is * 0) + 1)...);
 
   auto sv = Kokkos::subview(v, (Is * 0)...);
@@ -2330,9 +2331,10 @@ void test_subview_extents_helper_index(std::index_sequence<Is...>) {
                "Kokkos::subview bounds error");
 }
 
-template <class RankType, std::size_t... Is>
+template <class ExecutionSpace, class RankType, std::size_t... Is>
 void test_subview_extents_helper_range(std::index_sequence<Is...>) {
-  using view_type = Kokkos::View<RankType>;
+  using view_type =
+      Kokkos::View<RankType, typename ExecutionSpace::memory_space>;
   view_type v("v", 1, ((Is * 0) + 1)...);
 
   auto sv = Kokkos::subview(v, std::pair{0, 1}, (Is * 0)...);
@@ -2358,11 +2360,13 @@ struct DynamicRank<0> {
   using type = int;
 };
 
-template <int rank>
+template <int rank, class ExecutionSpace>
 void test_subview_extents() {
-  test_subview_extents_helper_index<typename DynamicRank<rank>::type>(
+  test_subview_extents_helper_index<ExecutionSpace,
+                                    typename DynamicRank<rank>::type>(
       std::make_index_sequence<rank>());
-  test_subview_extents_helper_range<typename DynamicRank<rank>::type>(
+  test_subview_extents_helper_range<ExecutionSpace,
+                                    typename DynamicRank<rank>::type>(
       std::make_index_sequence<rank - 1>());
 }
 

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -2320,6 +2320,52 @@ struct TestExtentsStaticTests {
       typename Kokkos::Impl::ParseViewExtents<double>::type>::type;
 };
 
+template <class RankType, std::size_t... Is>
+void test_subview_extents_helper_index(std::index_sequence<Is...>) {
+  using view_type = Kokkos::View<RankType>;
+  view_type v("v", ((Is * 0) + 1)...);
+
+  auto sv = Kokkos::subview(v, (Is * 0)...);
+  ASSERT_DEATH({ auto sv_fail = Kokkos::subview(v, ((Is * 0) + 1)...); },
+               "Kokkos::subview bounds error");
+}
+
+template <class RankType, std::size_t... Is>
+void test_subview_extents_helper_range(std::index_sequence<Is...>) {
+  using view_type = Kokkos::View<RankType>;
+  view_type v("v", 1, ((Is * 0) + 1)...);
+
+  auto sv = Kokkos::subview(v, std::pair{0, 1}, (Is * 0)...);
+  ASSERT_DEATH(
+      {
+        auto sv_fail = Kokkos::subview(v, std::pair{0, 2}, (Is * 0)...);
+      },
+      "Kokkos::subview bounds error");
+  ASSERT_DEATH(
+      {
+        auto sv_fail = Kokkos::subview(v, Kokkos::pair{0, 2}, (Is * 0)...);
+      },
+      "Kokkos::subview bounds error");
+}
+
+template <int rank>
+struct DynamicRank {
+  using type = typename DynamicRank<rank - 1>::type*;
+};
+
+template <>
+struct DynamicRank<0> {
+  using type = int;
+};
+
+template <int rank>
+void test_subview_extents() {
+  test_subview_extents_helper_index<typename DynamicRank<rank>::type>(
+      std::make_index_sequence<rank>());
+  test_subview_extents_helper_range<typename DynamicRank<rank>::type>(
+      std::make_index_sequence<rank - 1>());
+}
+
 }  // namespace TestViewSubview
 
 #endif


### PR DESCRIPTION
The mdspan-based View implementation didn't check the extents when constructing a subview. This pull request creates a corresponding check and adds a test.