### PR TITLE
Deprecate is_hostspace, is_managed, is_random_access from ViewTraits

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -394,7 +394,8 @@ class ViewMapping<
         src.layout());  // Check this for integer input1 for padding, etc
     dst.m_map.m_impl_handle = Kokkos::Impl::ViewDataHandle<DstTraits>::assign(
         src.m_map.m_impl_handle, src.m_track.m_tracker);
-    dst.m_track.m_tracker.assign(src.m_track.m_tracker, DstTraits::is_managed);
+    dst.m_track.m_tracker.assign(src.m_track.m_tracker,
+                                 !DstTraits::memory_traits::is_unmanaged);
     dst.m_rank = Kokkos::View<ST, SP...>::rank();
   }
 };
@@ -1835,7 +1836,7 @@ inline void impl_resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
   using drview_type      = DynRankView<T, P...>;
   using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
 
-  static_assert(Kokkos::ViewTraits<T, P...>::is_managed,
+  static_assert(!Kokkos::ViewTraits<T, P...>::memory_traits::is_unmanaged,
                 "Can only resize managed views");
   static_assert(!alloc_prop_input::has_label,
                 "The view constructor arguments passed to Kokkos::resize "
@@ -1915,7 +1916,7 @@ inline void impl_realloc(DynRankView<T, P...>& v, const size_t n0,
   using drview_type      = DynRankView<T, P...>;
   using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
 
-  static_assert(Kokkos::ViewTraits<T, P...>::is_managed,
+  static_assert(!Kokkos::ViewTraits<T, P...>::memory_traits::is_unmanaged,
                 "Can only realloc managed views");
   static_assert(!alloc_prop_input::has_label,
                 "The view constructor arguments passed to Kokkos::realloc must "

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -2535,7 +2535,7 @@ impl_resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
   using view_type        = Kokkos::View<T, P...>;
   using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
 
-  static_assert(Kokkos::ViewTraits<T, P...>::is_managed,
+  static_assert(!Kokkos::ViewTraits<T, P...>::memory_traits::is_unmanaged,
                 "Can only resize managed views");
   static_assert(!alloc_prop_input::has_label,
                 "The view constructor arguments passed to Kokkos::resize "
@@ -2681,7 +2681,7 @@ impl_resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
   using view_type        = Kokkos::View<T, P...>;
   using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
 
-  static_assert(Kokkos::ViewTraits<T, P...>::is_managed,
+  static_assert(!Kokkos::ViewTraits<T, P...>::memory_traits::is_unmanaged,
                 "Can only resize managed views");
   static_assert(!alloc_prop_input::has_label,
                 "The view constructor arguments passed to Kokkos::resize "
@@ -2727,7 +2727,7 @@ impl_resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
   using view_type        = Kokkos::View<T, P...>;
   using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
 
-  static_assert(Kokkos::ViewTraits<T, P...>::is_managed,
+  static_assert(!Kokkos::ViewTraits<T, P...>::memory_traits::is_unmanaged,
                 "Can only resize managed views");
   static_assert(!alloc_prop_input::has_label,
                 "The view constructor arguments passed to Kokkos::resize "
@@ -2795,7 +2795,7 @@ impl_realloc(Kokkos::View<T, P...>& v, const size_t n0, const size_t n1,
   using view_type        = Kokkos::View<T, P...>;
   using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
 
-  static_assert(Kokkos::ViewTraits<T, P...>::is_managed,
+  static_assert(!Kokkos::ViewTraits<T, P...>::memory_traits::is_unmanaged,
                 "Can only realloc managed views");
   static_assert(!alloc_prop_input::has_label,
                 "The view constructor arguments passed to Kokkos::realloc must "
@@ -2898,7 +2898,7 @@ impl_realloc(Kokkos::View<T, P...>& v,
   using view_type        = Kokkos::View<T, P...>;
   using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
 
-  static_assert(Kokkos::ViewTraits<T, P...>::is_managed,
+  static_assert(!Kokkos::ViewTraits<T, P...>::memory_traits::is_unmanaged,
                 "Can only realloc managed views");
   static_assert(!alloc_prop_input::has_label,
                 "The view constructor arguments passed to Kokkos::realloc must "
@@ -2943,7 +2943,7 @@ impl_realloc(Kokkos::View<T, P...>& v,
   using view_type        = Kokkos::View<T, P...>;
   using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
 
-  static_assert(Kokkos::ViewTraits<T, P...>::is_managed,
+  static_assert(!Kokkos::ViewTraits<T, P...>::memory_traits::is_unmanaged,
                 "Can only realloc managed views");
   static_assert(!alloc_prop_input::has_label,
                 "The view constructor arguments passed to Kokkos::realloc must "

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -361,7 +361,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 
   KOKKOS_INLINE_FUNCTION
   const Kokkos::Impl::SharedAllocationTracker& impl_track() const {
-    if constexpr (traits::is_managed) {
+    if constexpr (!traits::memory_traits::is_unmanaged) {
       return base_t::data_handle().tracker();
     } else {
       static const Kokkos::Impl::SharedAllocationTracker empty_tracker = {};
@@ -586,7 +586,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
             arg_prop,
             Impl::mapping_from_array_layout<typename mdspan_type::mapping_type>(
                 arg_layout)) {
-    static_assert(traits::is_managed,
+    static_assert(!traits::memory_traits::is_unmanaged,
                   "Can't construct managed View with unmanaged memory trait!");
   }
 
@@ -772,7 +772,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     static_assert(traits::array_layout::is_extent_constructible,
                   "Layout is not constructible from extent arguments. Use "
                   "overload taking a layout object instead.");
-    static_assert(traits::is_managed,
+    static_assert(!traits::memory_traits::is_unmanaged,
                   "Can't construct managed View with unmanaged memory trait!");
   }
 
@@ -1074,7 +1074,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   //----------------------------------------
   // Allocation tracking properties
   std::string label() const {
-    if constexpr (traits::is_managed) {
+    if constexpr (!traits::memory_traits::is_unmanaged) {
       return this->data_handle().get_label();
     } else {
       return "";
@@ -1082,7 +1082,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   }
 
   int use_count() const {
-    if constexpr (traits::is_managed) {
+    if constexpr (!traits::memory_traits::is_unmanaged) {
       return this->data_handle().use_count();
     } else {
       return 0;

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -361,11 +361,11 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 
   KOKKOS_INLINE_FUNCTION
   const Kokkos::Impl::SharedAllocationTracker& impl_track() const {
-    if constexpr (!traits::memory_traits::is_unmanaged) {
-      return base_t::data_handle().tracker();
-    } else {
+    if constexpr (traits::memory_traits::is_unmanaged) {
       static const Kokkos::Impl::SharedAllocationTracker empty_tracker = {};
       return empty_tracker;
+    } else {
+      return base_t::data_handle().tracker();
     }
   }
   //----------------------------------------
@@ -1074,18 +1074,18 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   //----------------------------------------
   // Allocation tracking properties
   std::string label() const {
-    if constexpr (!traits::memory_traits::is_unmanaged) {
-      return this->data_handle().get_label();
-    } else {
+    if constexpr (traits::memory_traits::is_unmanaged) {
       return "";
+    } else {
+      return this->data_handle().get_label();
     }
   }
 
   int use_count() const {
-    if constexpr (!traits::memory_traits::is_unmanaged) {
-      return this->data_handle().use_count();
-    } else {
+    if constexpr (traits::memory_traits::is_unmanaged) {
       return 0;
+    } else {
+      return this->data_handle().use_count();
     }
   }
 

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -998,7 +998,7 @@ class View : public ViewTraits<DataType, Properties...> {
         typename traits::device_type::execution_space{});
     using alloc_prop = decltype(prop_copy);
 
-    static_assert(traits::is_managed,
+    static_assert(!traits::memory_traits::is_unmanaged,
                   "View allocation constructor requires managed memory");
 
     if (alloc_prop::initialize &&
@@ -1304,7 +1304,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename U = typename Impl::MDSpanViewTraits<traits>::mdspan_type>
   KOKKOS_INLINE_FUNCTION
 #ifndef KOKKOS_ENABLE_CXX17
-      explicit(traits::is_managed)
+      explicit(!traits::memory_traits::is_unmanaged)
 #endif
           View(const typename Impl::MDSpanViewTraits<traits>::mdspan_type& mds,
                std::enable_if_t<

--- a/core/src/View/Kokkos_ViewMapping.hpp
+++ b/core/src/View/Kokkos_ViewMapping.hpp
@@ -2531,7 +2531,7 @@ class ViewMapping<
 
  public:
   using printable_label_typedef = void;
-  enum { is_managed = Traits::is_managed };
+  enum { is_managed = !Traits::memory_traits::is_unmanaged };
 
   //----------------------------------------
   // Domain dimensions

--- a/core/src/View/Kokkos_ViewTracker.hpp
+++ b/core/src/View/Kokkos_ViewTracker.hpp
@@ -47,7 +47,7 @@ struct ViewTracker {
 
   KOKKOS_INLINE_FUNCTION
   ViewTracker(const ViewTracker& vt) noexcept
-      : m_tracker(vt.m_tracker, view_traits::is_managed) {}
+      : m_tracker(vt.m_tracker, !view_traits::memory_traits::is_unmanaged) {}
 
   KOKKOS_INLINE_FUNCTION
   explicit ViewTracker(const ParentView& vt) noexcept : m_tracker() {
@@ -65,8 +65,9 @@ struct ViewTracker {
   KOKKOS_INLINE_FUNCTION void assign(const View<RT, RP...>& vt) noexcept {
     if (this == reinterpret_cast<const ViewTracker*>(&vt.m_track)) return;
     KOKKOS_IF_ON_HOST((
-        if (view_traits::is_managed && Kokkos::Impl::SharedAllocationRecord<
-                                           void, void>::tracking_enabled()) {
+        if (!view_traits::memory_traits::is_unmanaged &&
+            Kokkos::Impl::SharedAllocationRecord<void,
+                                                 void>::tracking_enabled()) {
           m_tracker.assign_direct(vt.m_track.m_tracker);
         } else { m_tracker.assign_force_disable(vt.m_track.m_tracker); }))
 
@@ -77,8 +78,9 @@ struct ViewTracker {
       const ViewTracker& rhs) noexcept {
     if (this == &rhs) return *this;
     KOKKOS_IF_ON_HOST((
-        if (view_traits::is_managed && Kokkos::Impl::SharedAllocationRecord<
-                                           void, void>::tracking_enabled()) {
+        if (!view_traits::memory_traits::is_unmanaged &&
+            Kokkos::Impl::SharedAllocationRecord<void,
+                                                 void>::tracking_enabled()) {
           m_tracker.assign_direct(rhs.m_tracker);
         } else { m_tracker.assign_force_disable(rhs.m_tracker); }))
 
@@ -88,7 +90,7 @@ struct ViewTracker {
 
   KOKKOS_INLINE_FUNCTION
   explicit ViewTracker(const track_type& tt) noexcept
-      : m_tracker(tt, view_traits::is_managed) {}
+      : m_tracker(tt, !view_traits::memory_traits::is_unmanaged) {}
 };
 
 }  // namespace Impl

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -557,19 +557,12 @@ struct ViewTraits {
                           Impl::ViewArguments<value_type, array_layout,
                                               device_type, memory_traits>()))>;
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  enum {
-    is_hostspace KOKKOS_DEPRECATED = std::is_same_v<MemorySpace, HostSpace>
-  };
-  enum {
-    is_managed KOKKOS_DEPRECATED_WITH_COMMENT(
-        "Use !MemoryTraits::is_unmanaged instead.") =
-        MemoryTraits::is_unmanaged == 0
-  };
-  enum {
-    is_random_access KOKKOS_DEPRECATED_WITH_COMMENT(
-        "Use MemoryTraits::is_random_access instead.") =
-        MemoryTraits::is_random_access == 1
-  };
+  KOKKOS_DEPRECATED static constexpr bool is_hostspace =
+      std::is_same_v<MemorySpace, HostSpace>;
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use !MemoryTraits::is_unmanaged instead.")
+  static constexpr bool is_managed = !MemoryTraits::is_unmanaged;
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use MemoryTraits::is_random_access instead.")
+  static constexpr bool is_random_access = MemoryTraits::is_random_access;
 #endif
   //------------------------------------
 };

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -218,8 +218,8 @@ struct AccessorFromViewTraits {
 #ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
 template <class Traits>
 struct AccessorFromViewTraits<
-    Traits,
-    std::enable_if_t<Traits::is_managed && !Traits::memory_traits::is_atomic>> {
+    Traits, std::enable_if_t<!Traits::memory_traits::is_unmanaged &&
+                             !Traits::memory_traits::is_atomic>> {
   using type =
       SpaceAwareAccessor<typename Traits::memory_space,
                          default_accessor<typename Traits::value_type>>;
@@ -227,24 +227,24 @@ struct AccessorFromViewTraits<
 
 template <class Traits>
 struct AccessorFromViewTraits<
-    Traits,
-    std::enable_if_t<Traits::is_managed && Traits::memory_traits::is_atomic>> {
+    Traits, std::enable_if_t<!Traits::memory_traits::is_unmanaged &&
+                             Traits::memory_traits::is_atomic>> {
   using type = CheckedRelaxedAtomicAccessor<typename Traits::value_type,
                                             typename Traits::memory_space>;
 };
 #else
 template <class Traits>
 struct AccessorFromViewTraits<
-    Traits,
-    std::enable_if_t<Traits::is_managed && !Traits::memory_traits::is_atomic>> {
+    Traits, std::enable_if_t<!Traits::memory_traits::is_unmanaged &&
+                             !Traits::memory_traits::is_atomic>> {
   using type = CheckedReferenceCountedAccessor<typename Traits::value_type,
                                                typename Traits::memory_space>;
 };
 
 template <class Traits>
 struct AccessorFromViewTraits<
-    Traits,
-    std::enable_if_t<Traits::is_managed && Traits::memory_traits::is_atomic>> {
+    Traits, std::enable_if_t<!Traits::memory_traits::is_unmanaged &&
+                             Traits::memory_traits::is_atomic>> {
   using type = CheckedReferenceCountedRelaxedAtomicAccessor<
       typename Traits::value_type, typename Traits::memory_space>;
 };
@@ -252,8 +252,8 @@ struct AccessorFromViewTraits<
 
 template <class Traits>
 struct AccessorFromViewTraits<
-    Traits,
-    std::enable_if_t<!Traits::is_managed && Traits::memory_traits::is_atomic>> {
+    Traits, std::enable_if_t<Traits::memory_traits::is_unmanaged &&
+                             Traits::memory_traits::is_atomic>> {
   using type = CheckedRelaxedAtomicAccessor<typename Traits::value_type,
                                             typename Traits::memory_space>;
 };
@@ -556,11 +556,21 @@ struct ViewTraits {
                       decltype(customize_view_arguments(
                           Impl::ViewArguments<value_type, array_layout,
                                               device_type, memory_traits>()))>;
-
-  enum { is_hostspace = std::is_same_v<MemorySpace, HostSpace> };
-  enum { is_managed = MemoryTraits::is_unmanaged == 0 };
-  enum { is_random_access = MemoryTraits::is_random_access == 1 };
-
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  enum {
+    is_hostspace KOKKOS_DEPRECATED = std::is_same_v<MemorySpace, HostSpace>
+  };
+  enum {
+    is_managed KOKKOS_DEPRECATED_WITH_COMMENT(
+        "Use !MemoryTraits::is_unmanaged instead.") =
+        MemoryTraits::is_unmanaged == 0
+  };
+  enum {
+    is_random_access KOKKOS_DEPRECATED_WITH_COMMENT(
+        "Use MemoryTraits::is_random_access instead.") =
+        MemoryTraits::is_random_access == 1
+  };
+#endif
   //------------------------------------
 };
 


### PR DESCRIPTION
We should be able to deprecate these three enums. 
Const expr values for `is_managed` and `is_random_access` should be obtainable via `ViewTraits::memory_traits`.
From what I can tell, Trilinos` Sacado and kokkos-kernels would show deprecation warnings on two instances in total. 

EDIT - Adding deprecation info matching out core-wiki formatting

* ``Kokkos::ViewTraits::is_hostspace``
   * Replacement: none
   * Unused, can be achieved via ``std::is_same_v`` standard template

* ``Kokkos::ViewTraits::is_random_access``
  * Replacement: ``MemoryTraits::is_random_access``

* ``Kokkos::ViewTraits::is_managed``
   * Replacement: ``!MemoryTraits::is_unmanaged``
   * Unused and less suitable given View's default memory behavior
