### PR TITLE
Add `-Werror=all-warnings` to the NVHPC-AS-HOST-COMPILER jenkins ci job

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -348,7 +348,7 @@ pipeline {
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                                 -DCMAKE_CXX_COMPILER=nvc++ \
                                 -DCMAKE_CXX_STANDARD=20 \
-                                -DCMAKE_CXX_FLAGS="-Werror --diag_suppress=implicit_return_from_non_void_function" \
+                                -DCMAKE_CXX_FLAGS="-Werror -Werror=all-warnings --diag_suppress=implicit_return_from_non_void_function" \
                                 -DKokkos_ARCH_NATIVE=ON \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF \


### PR DESCRIPTION
There are currently two warnings generated by the `CUDA-12.2-NVHPC-AS-HOST-COMPILER` job in the jenkins CI which are not treated as errors with `-Werror` (for example [here](https://cloud1.cees.ornl.gov/jenkins-ci/job/Kokkos/job/PR-8292/2/pipeline-overview/?start-byte=0&selected-node=375#log-353)), this PR adds the flag `-Werror=all-warnings` to fix this (see [here](https://cloud1.cees.ornl.gov/jenkins-ci/job/Kokkos/job/PR-8295/1/pipeline-overview/?start-byte=0&selected-node=276#log-322))