### PR TITLE
Fix a warning on nvhpc

### DIFF
--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -56,14 +56,7 @@ struct extrema {
 
   DEFINE_EXTREMA(float, -FLT_MAX, FLT_MAX)
   DEFINE_EXTREMA(double, -DBL_MAX, DBL_MAX)
-
-#if !defined(KOKKOS_ENABLE_CUDA) || \
-    !defined(KOKKOS_COMPILER_NVHPC)  // 23.7 long double
   DEFINE_EXTREMA(long double, -LDBL_MAX, LDBL_MAX)
-#else
-  static long double min(long double) { return -LDBL_MAX; }
-  static long double max(long double) { return LDBL_MAX; }
-#endif
 
 #undef DEFINE_EXTREMA
 };


### PR DESCRIPTION
This PR removes a guard that caused the following warning when compiling with nvhpc:
```
/var/jenkins/workspace/Kokkos_PR-8292/core/unit_test/TestNumericTraits.hpp(142): warning #20014-D: calling a __host__ function from a __host__ __device__ function is not allowed

      auto const min = finite_min<T>::value;

                       ^

          detected during:

            instantiation of "void TestNumericTraits<Space, T, Tag>::operator()(FiniteMin, int, int &) const [with Space=Kokkos::OpenMP, T=long double, Tag=FiniteMin]" at line 64 of /var/jenkins/workspace/Kokkos_PR-8292/core/src/OpenMP/Kokkos_OpenMP_Parallel_Reduce.hpp
```

Note that this will generate a "'long double' is treated as 'double' in device code" warning, but we are already suppressing those warnings in this file:
https://github.com/kokkos/kokkos/blob/b06886a3700f14c493df4ddbe3076501fd910be4/core/unit_test/TestNumericTraits.hpp#L19-L32

This fixes the warning observed in https://github.com/kokkos/kokkos/pull/8295