### PR TITLE
fix(graph): lock arrays must be on device when defining (instead of submitting) graph 

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -201,8 +201,6 @@ struct GraphImpl<Kokkos::Cuda> {
   }
 
   void submit(const execution_space& exec) {
-    desul::ensure_cuda_lock_arrays_on_device();
-
     if (!bool(m_graph_exec)) {
       instantiate();
     }

--- a/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
@@ -214,8 +214,6 @@ inline void GraphImpl<Kokkos::HIP>::add_predecessor(
 }
 
 inline void GraphImpl<Kokkos::HIP>::submit(const Kokkos::HIP& exec) {
-  desul::ensure_hip_lock_arrays_on_device();
-
   if (!m_graph_exec) {
     instantiate();
   }

--- a/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
@@ -194,17 +194,13 @@ inline void GraphImpl<Kokkos::SYCL>::add_predecessor(
 }
 
 inline void GraphImpl<Kokkos::SYCL>::submit(const Kokkos::SYCL& exec) {
-  auto q = exec.sycl_queue();
-
-  desul::ensure_sycl_lock_arrays_on_device(q);
-
   if (!m_graph_exec) {
     instantiate();
   }
   KOKKOS_ASSERT(m_graph_exec);
 
   // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-  q.ext_oneapi_graph(*m_graph_exec);
+  exec.sycl_queue().ext_oneapi_graph(*m_graph_exec);
 }
 
 inline Kokkos::SYCL const& GraphImpl<Kokkos::SYCL>::get_execution_space()


### PR DESCRIPTION
This PR "fixes the fix" that we had proposed in
- https://github.com/kokkos/kokkos/pull/7685

In that earlier PR, we had meant to fix memory access faults that we had seen when using lock-based atomics in graphs. As a fix, we had added a call to `ensure_cuda/hip/sycl_lock_arrays_on_device` in the graph submit function on the cuda/hip/sycl backends.

However, graphs follow a three step approach: (i) definition, (ii) instantiation, (iii) submission. And, rather than in the submission step, it is in the definition step that we're in the compile unit in which we're compiling the kernel and the lock arrays must hence be on device.

And so this PR moves the call to `ensure_cuda/hip/sycl_lock_arrays_on_device` from the `submit` functions to the launch functions that define the graph nodes.

In the earlier PR, we had added a new test `core/unit_test/TestGraphAtomicLocks.hpp`. Without the fix from the earlier PR, and likewise without the revised fix from this PR, this test fails on Cuda and HIP. With either the fix from the earlier PR or the revised fix from this PR, this test passes on Cuda, HIP and SYCL. The reason is that the definition, instantiation and submission are all in the same compile unit in this test.

Joint work with @romintomasetti.