### PR TITLE
Added support for kokkos to be built as a shared lib on Windows

### DIFF
--- a/.github/workflows/continuous-integration-windows.yml
+++ b/.github/workflows/continuous-integration-windows.yml
@@ -24,7 +24,7 @@ jobs:
     - name: configure
       shell: bash
       run: |
-        cmake -B build -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_TESTS=ON -DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON
+        cmake -B build -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_TESTS=ON -DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON -DBUILD_SHARED_LIBS=ON
     - name: build library
       shell: bash
       run: |

--- a/.github/workflows/continuous-integration-windows.yml
+++ b/.github/workflows/continuous-integration-windows.yml
@@ -39,7 +39,7 @@ jobs:
     - name: configure
       shell: bash
       run: |
-        cmake -B build -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_TESTS=ON -DKokkos_ENABLE_DEPRECATED_CODE_4=ON
+        cmake -B build -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_TESTS=ON -DKokkos_ENABLE_DEPRECATED_CODE_4=ON -DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON -DBUILD_SHARED_LIBS=ON
     - name: build library
       shell: bash
       run: |

--- a/.github/workflows/continuous-integration-windows.yml
+++ b/.github/workflows/continuous-integration-windows.yml
@@ -28,7 +28,7 @@ jobs:
     - name: build library
       shell: bash
       run: |
-        export PATH="$(pwd)/core/src:$(pwd)/containers/src:$PATH"
+        export PATH="$(pwd)/build/core/src/Release:$(pwd)/build/containers/src/Release:$PATH"
         cmake --build build --parallel 4 --config Release
   windows-serial:
     # Serial build on Windows
@@ -48,5 +48,5 @@ jobs:
     - name: run tests
       shell: bash
       run: |
-        export PATH="$(pwd)/core/src:$(pwd)/containers/src:$PATH"
+        export PATH="$(pwd)/build/core/src/Release:$(pwd)/build/containers/src/Release:$PATH"
         ctest --test-dir build -C Release -j 4 --output-on-failure

--- a/.github/workflows/continuous-integration-windows.yml
+++ b/.github/workflows/continuous-integration-windows.yml
@@ -28,6 +28,7 @@ jobs:
     - name: build library
       shell: bash
       run: |
+        export PATH="$(pwd)/core/src:$(pwd)/containers/src:$PATH"
         cmake --build build --parallel 4 --config Release
   windows-serial:
     # Serial build on Windows
@@ -47,4 +48,5 @@ jobs:
     - name: run tests
       shell: bash
       run: |
+        export PATH="$(pwd)/core/src:$(pwd)/containers/src:$PATH"
         ctest --test-dir build -C Release -j 4 --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/kokkos_configure_trilinos.cmake)
 
 if(Kokkos_ENABLE_TESTS)
   find_package(GTest QUIET)
-  if (WIN32)
+  if(WIN32)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/bigobj>)
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=/bigobj")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,10 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/kokkos_configure_trilinos.cmake)
 
 if(Kokkos_ENABLE_TESTS)
   find_package(GTest QUIET)
+  if (WIN32)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/bigobj>)
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=/bigobj")
+  endif()
 endif()
 
 # Include a set of Kokkos-specific wrapper functions that

--- a/algorithms/src/CMakeLists.txt
+++ b/algorithms/src/CMakeLists.txt
@@ -22,6 +22,7 @@ install(
 
 kokkos_add_library(
   kokkosalgorithms
+  STATIC
   HEADERS
   ${ALGO_HEADERS}
   MODULE_INTERFACE

--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -339,7 +339,7 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
 endfunction()
 
 function(KOKKOS_ADD_LIBRARY LIBRARY_NAME)
-  cmake_parse_arguments(PARSE "ADD_BUILD_OPTIONS;STATIC;SHARED" "" "HEADERS;SOURCES;MODULE_INTERFACE" ${ARGN})
+  cmake_parse_arguments(PARSE "ADD_BUILD_OPTIONS;STATIC;SHARED;INTERFACE" "" "HEADERS;SOURCES;MODULE_INTERFACE" ${ARGN})
 
   if(PARSE_HEADERS)
     list(REMOVE_DUPLICATES PARSE_HEADERS)
@@ -360,6 +360,10 @@ function(KOKKOS_ADD_LIBRARY LIBRARY_NAME)
 
   if(PARSE_SHARED)
     set(LINK_TYPE SHARED)
+  endif()
+
+  if(PARSE_INTERFACE)
+    set(LINK_TYPE INTERFACE)
   endif()
 
   # MSVC and other platforms want to have the headers included as source files for better dependency detection

--- a/containers/src/CMakeLists.txt
+++ b/containers/src/CMakeLists.txt
@@ -23,10 +23,8 @@ if(NOT BUILD_SHARED_LIBS OR UNIX)
   target_compile_definitions(kokkoscontainers PRIVATE KOKKOSCONTAINERS_STATIC_DEFINE)
 endif()
 
-include(GenerateExportHeader) 
-  generate_export_header(kokkoscontainers
-  EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Containers_Export.h"
-)
+include(GenerateExportHeader)
+generate_export_header(kokkoscontainers EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Containers_Export.h")
 
 kokkos_lib_include_directories(
   kokkoscontainers ${KOKKOS_TOP_BUILD_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}

--- a/containers/src/CMakeLists.txt
+++ b/containers/src/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 
 include(GenerateExportHeader) 
   generate_export_header(kokkoscontainers
-  EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/kokkoscontainers_export.h"
+  EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Containers_Export.h"
 )
 
 kokkos_lib_include_directories(

--- a/containers/src/CMakeLists.txt
+++ b/containers/src/CMakeLists.txt
@@ -19,6 +19,15 @@ install(
 
 kokkos_add_library(kokkoscontainers SOURCES ${KOKKOS_CONTAINERS_SRCS} HEADERS ${KOKKOS_CONTAINERS_HEADERS})
 
+if(NOT BUILD_SHARED_LIBS OR UNIX)
+  target_compile_definitions(kokkoscontainers PRIVATE KOKKOSCONTAINERS_STATIC_DEFINE)
+endif()
+
+include(GenerateExportHeader) 
+  generate_export_header(kokkoscontainers
+  EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/kokkoscontainers_export.h"
+)
+
 kokkos_lib_include_directories(
   kokkoscontainers ${KOKKOS_TOP_BUILD_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/containers/src/CMakeLists.txt
+++ b/containers/src/CMakeLists.txt
@@ -26,10 +26,7 @@ endif()
 include(GenerateExportHeader)
 generate_export_header(kokkoscontainers EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Containers_Export.h")
 
-install(
-  FILES "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Containers_Export.h"
-  DESTINATION ${KOKKOS_HEADER_DIR}
-)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Containers_Export.h" DESTINATION ${KOKKOS_HEADER_DIR})
 
 kokkos_lib_include_directories(
   kokkoscontainers ${KOKKOS_TOP_BUILD_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}

--- a/containers/src/CMakeLists.txt
+++ b/containers/src/CMakeLists.txt
@@ -26,6 +26,11 @@ endif()
 include(GenerateExportHeader)
 generate_export_header(kokkoscontainers EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Containers_Export.h")
 
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Containers_Export.h"
+  DESTINATION ${KOKKOS_HEADER_DIR}
+)
+
 kokkos_lib_include_directories(
   kokkoscontainers ${KOKKOS_TOP_BUILD_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/containers/src/CMakeLists.txt
+++ b/containers/src/CMakeLists.txt
@@ -19,9 +19,8 @@ install(
 
 kokkos_add_library(kokkoscontainers SOURCES ${KOKKOS_CONTAINERS_SRCS} HEADERS ${KOKKOS_CONTAINERS_HEADERS})
 
-if(NOT BUILD_SHARED_LIBS OR UNIX)
-  target_compile_definitions(kokkoscontainers PRIVATE KOKKOSCONTAINERS_STATIC_DEFINE)
-endif()
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
 
 include(GenerateExportHeader)
 generate_export_header(kokkoscontainers EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Containers_Export.h")

--- a/containers/src/impl/Kokkos_UnorderedMap_impl.cpp
+++ b/containers/src/impl/Kokkos_UnorderedMap_impl.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <Kokkos_UnorderedMap.hpp>
-#include "kokkoscontainers_export.h"
+#include "Kokkos_Containers_Export.h"
 
 namespace Kokkos {
 namespace Impl {

--- a/containers/src/impl/Kokkos_UnorderedMap_impl.cpp
+++ b/containers/src/impl/Kokkos_UnorderedMap_impl.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <Kokkos_UnorderedMap.hpp>
-#include "Kokkos_Containers_Export.h"
+#include <Kokkos_Containers_Export.h>
 
 namespace Kokkos {
 namespace Impl {

--- a/containers/src/impl/Kokkos_UnorderedMap_impl.cpp
+++ b/containers/src/impl/Kokkos_UnorderedMap_impl.cpp
@@ -19,11 +19,12 @@
 #endif
 
 #include <Kokkos_UnorderedMap.hpp>
+#include "kokkoscontainers_export.h"
 
 namespace Kokkos {
 namespace Impl {
 
-uint32_t find_hash_size(uint32_t size) {
+KOKKOSCONTAINERS_EXPORT uint32_t find_hash_size(uint32_t size) {
   if (size == 0u) return 0u;
 
   // these primes try to preserve randomness of hash

--- a/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
+++ b/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
@@ -18,7 +18,7 @@
 #define KOKKOS_UNORDERED_MAP_IMPL_HPP
 
 #include <Kokkos_Core.hpp>
-#include "Kokkos_Containers_Export.h"
+#include <Kokkos_Containers_Export.h>
 #include <cstdint>
 
 #include <cstdio>

--- a/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
+++ b/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_UNORDERED_MAP_IMPL_HPP
 
 #include <Kokkos_Core.hpp>
+#include "kokkoscontainers_export.h"
 #include <cstdint>
 
 #include <cstdio>
@@ -39,7 +40,7 @@ auto append_to_label(const ViewCtorProp<P...>& view_ctor_prop,
   return new_ctor_props;
 }
 
-uint32_t find_hash_size(uint32_t size);
+KOKKOSCONTAINERS_EXPORT uint32_t find_hash_size(uint32_t size);
 
 template <typename Map>
 struct UnorderedMapRehash {

--- a/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
+++ b/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
@@ -18,7 +18,7 @@
 #define KOKKOS_UNORDERED_MAP_IMPL_HPP
 
 #include <Kokkos_Core.hpp>
-#include "kokkoscontainers_export.h"
+#include "Kokkos_Containers_Export.h"
 #include <cstdint>
 
 #include <cstdio>

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -145,6 +145,11 @@ endif()
 include(GenerateExportHeader)
 generate_export_header(kokkoscore EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Core_Export.h")
 
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Core_Export.h"
+  DESTINATION ${KOKKOS_HEADER_DIR}
+)
+
 kokkos_lib_include_directories(
   kokkoscore ${KOKKOS_TOP_BUILD_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -138,6 +138,15 @@ kokkos_add_library(
   ADD_BUILD_OPTIONS # core should be given all the necessary compiler/linker flags
 )
 
+if(NOT BUILD_SHARED_LIBS OR UNIX)
+  target_compile_definitions(kokkoscore PRIVATE KOKKOSCORE_STATIC_DEFINE)
+endif()
+
+include(GenerateExportHeader) 
+  generate_export_header(kokkoscore
+  EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/kokkoscore_export.h"
+)
+
 kokkos_lib_include_directories(
   kokkoscore ${KOKKOS_TOP_BUILD_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -145,10 +145,7 @@ endif()
 include(GenerateExportHeader)
 generate_export_header(kokkoscore EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Core_Export.h")
 
-install(
-  FILES "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Core_Export.h"
-  DESTINATION ${KOKKOS_HEADER_DIR}
-)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Core_Export.h" DESTINATION ${KOKKOS_HEADER_DIR})
 
 kokkos_lib_include_directories(
   kokkoscore ${KOKKOS_TOP_BUILD_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -144,7 +144,7 @@ endif()
 
 include(GenerateExportHeader) 
   generate_export_header(kokkoscore
-  EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/kokkoscore_export.h"
+  EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Core_Export.h"
 )
 
 kokkos_lib_include_directories(

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -142,10 +142,8 @@ if(NOT BUILD_SHARED_LIBS OR UNIX)
   target_compile_definitions(kokkoscore PRIVATE KOKKOSCORE_STATIC_DEFINE)
 endif()
 
-include(GenerateExportHeader) 
-  generate_export_header(kokkoscore
-  EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Core_Export.h"
-)
+include(GenerateExportHeader)
+generate_export_header(kokkoscore EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Core_Export.h")
 
 kokkos_lib_include_directories(
   kokkoscore ${KOKKOS_TOP_BUILD_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -138,9 +138,8 @@ kokkos_add_library(
   ADD_BUILD_OPTIONS # core should be given all the necessary compiler/linker flags
 )
 
-if(NOT BUILD_SHARED_LIBS OR UNIX)
-  target_compile_definitions(kokkoscore PRIVATE KOKKOSCORE_STATIC_DEFINE)
-endif()
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
 
 include(GenerateExportHeader)
 generate_export_header(kokkoscore EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/Kokkos_Core_Export.h")

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -27,6 +27,9 @@ if(NOT desul_FOUND)
       set(DESUL_ATOMICS_ENABLE_OPENACC ON)
     endif()
   endif()
+  if(BUILD_SHARED_LIBS)
+    set(DESUL_BUILD_SHARED_LIBS ON)
+  endif()
   configure_file(
     ${KOKKOS_SOURCE_DIR}/tpls/desul/Config.hpp.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/desul/atomics/Config.hpp
   )
@@ -151,6 +154,9 @@ kokkos_lib_include_directories(
 )
 if(NOT desul_FOUND)
   target_include_directories(kokkoscore SYSTEM PUBLIC $<BUILD_INTERFACE:${KOKKOS_SOURCE_DIR}/tpls/desul/include>)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(kokkoscore PRIVATE DESUL_EXPORT_SYMBOLS)
+  endif()
 endif()
 
 if(Kokkos_ENABLE_IMPL_MDSPAN)

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -140,8 +140,9 @@ class Cuda {
   /// device have completed.
   static void impl_static_fence(const std::string& name);
 
-  KOKKOSCORE_EXPORT void fence(const std::string& name =
-                 "Kokkos::Cuda::fence(): Unnamed Instance Fence") const;
+  KOKKOSCORE_EXPORT void fence(
+      const std::string& name =
+          "Kokkos::Cuda::fence(): Unnamed Instance Fence") const;
 
   /** \brief  Return the maximum amount of concurrency.  */
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -151,7 +152,8 @@ class Cuda {
 #endif
 
   //! Print configuration information to the given output stream.
-  KOKKOSCORE_EXPORT void print_configuration(std::ostream& os, bool verbose = false) const;
+  KOKKOSCORE_EXPORT void print_configuration(std::ostream& os,
+                                             bool verbose = false) const;
 
   //@}
   //--------------------------------------------------

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -38,7 +38,7 @@ static_assert(false,
 #include <Kokkos_Layout.hpp>
 #include <Kokkos_ScratchSpace.hpp>
 #include <Kokkos_MemoryTraits.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <impl/Kokkos_HostSharedPtr.hpp>
 #include <impl/Kokkos_InitializationSettings.hpp>
 

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -23,6 +23,7 @@ static_assert(false,
 #define KOKKOS_CUDA_HPP
 
 #include <Kokkos_Macros.hpp>
+#include "kokkoscore_export.h"
 #if defined(KOKKOS_ENABLE_CUDA)
 
 #include <Kokkos_Core_fwd.hpp>
@@ -139,24 +140,24 @@ class Cuda {
   /// device have completed.
   static void impl_static_fence(const std::string& name);
 
-  void fence(const std::string& name =
+  KOKKOSCORE_EXPORT void fence(const std::string& name =
                  "Kokkos::Cuda::fence(): Unnamed Instance Fence") const;
 
   /** \brief  Return the maximum amount of concurrency.  */
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  static int concurrency();
+  KOKKOSCORE_EXPORT static int concurrency();
 #else
-  int concurrency() const;
+  KOKKOSCORE_EXPORT int concurrency() const;
 #endif
 
   //! Print configuration information to the given output stream.
-  void print_configuration(std::ostream& os, bool verbose = false) const;
+  KOKKOSCORE_EXPORT void print_configuration(std::ostream& os, bool verbose = false) const;
 
   //@}
   //--------------------------------------------------
   //! \name  Cuda space instances
 
-  Cuda();
+  KOKKOSCORE_EXPORT Cuda();
 
   explicit Cuda(cudaStream_t stream) : Cuda(stream, Impl::ManageStream::no) {}
 
@@ -168,19 +169,19 @@ class Cuda {
       : Cuda(stream) {}
 #endif
 
-  Cuda(cudaStream_t stream, Impl::ManageStream manage_stream);
+  KOKKOSCORE_EXPORT Cuda(cudaStream_t stream, Impl::ManageStream manage_stream);
 
   KOKKOS_DEPRECATED Cuda(cudaStream_t stream, bool manage_stream);
 
   //--------------------------------------------------------------------------
   //! Free any resources being consumed by the device.
-  static void impl_finalize();
+  KOKKOSCORE_EXPORT static void impl_finalize();
 
   //! Has been initialized
-  static int impl_is_initialized();
+  KOKKOSCORE_EXPORT static int impl_is_initialized();
 
   //! Initialize, telling the CUDA run-time library which device to use.
-  static void impl_initialize(InitializationSettings const&);
+  KOKKOSCORE_EXPORT static void impl_initialize(InitializationSettings const&);
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   /// \brief Cuda device architecture of the selected device.
@@ -214,19 +215,19 @@ class Cuda {
   }
 #endif
 
-  cudaStream_t cuda_stream() const;
-  int cuda_device() const;
-  const cudaDeviceProp& cuda_device_prop() const;
+  KOKKOSCORE_EXPORT cudaStream_t cuda_stream() const;
+  KOKKOSCORE_EXPORT int cuda_device() const;
+  KOKKOSCORE_EXPORT const cudaDeviceProp& cuda_device_prop() const;
 
   //@}
   //--------------------------------------------------------------------------
 
-  static const char* name();
+  KOKKOSCORE_EXPORT static const char* name();
 
   inline Impl::CudaInternal* impl_internal_space_instance() const {
     return m_space_instance.get();
   }
-  uint32_t impl_instance_id() const noexcept;
+  KOKKOSCORE_EXPORT uint32_t impl_instance_id() const noexcept;
 
  private:
   friend bool operator==(Cuda const& lhs, Cuda const& rhs) {

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -23,7 +23,6 @@ static_assert(false,
 #define KOKKOS_CUDA_HPP
 
 #include <Kokkos_Macros.hpp>
-#include "kokkoscore_export.h"
 #if defined(KOKKOS_ENABLE_CUDA)
 
 #include <Kokkos_Core_fwd.hpp>
@@ -39,6 +38,7 @@ static_assert(false,
 #include <Kokkos_Layout.hpp>
 #include <Kokkos_ScratchSpace.hpp>
 #include <Kokkos_MemoryTraits.hpp>
+#include "kokkoscore_export.h"
 #include <impl/Kokkos_HostSharedPtr.hpp>
 #include <impl/Kokkos_InitializationSettings.hpp>
 

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -38,7 +38,7 @@ static_assert(false,
 #include <Kokkos_Layout.hpp>
 #include <Kokkos_ScratchSpace.hpp>
 #include <Kokkos_MemoryTraits.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <impl/Kokkos_HostSharedPtr.hpp>
 #include <impl/Kokkos_InitializationSettings.hpp>
 

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -22,6 +22,7 @@
 #ifdef KOKKOS_ENABLE_CUDA
 
 #include <Kokkos_Core.hpp>
+#include "kokkoscore_export.h"
 #include <Cuda/Kokkos_Cuda.hpp>
 #include <Cuda/Kokkos_CudaSpace.hpp>
 
@@ -47,7 +48,7 @@ cudaStream_t Kokkos::Impl::cuda_get_deep_copy_stream() {
   return s;
 }
 
-const std::unique_ptr<Kokkos::Cuda> &Kokkos::Impl::cuda_get_deep_copy_space(
+KOKKOSCORE_EXPORT const std::unique_ptr<Kokkos::Cuda> &Kokkos::Impl::cuda_get_deep_copy_space(
     bool initialize) {
   static std::unique_ptr<Cuda> space = nullptr;
   if (!space && initialize)
@@ -58,19 +59,19 @@ const std::unique_ptr<Kokkos::Cuda> &Kokkos::Impl::cuda_get_deep_copy_space(
 namespace Kokkos {
 namespace Impl {
 
-void DeepCopyCuda(void *dst, const void *src, size_t n) {
+KOKKOSCORE_EXPORT void DeepCopyCuda(void *dst, const void *src, size_t n) {
   KOKKOS_IMPL_CUDA_SAFE_CALL((CudaInternal::singleton().cuda_memcpy_wrapper(
       dst, src, n, cudaMemcpyDefault)));
 }
 
-void DeepCopyAsyncCuda(const Cuda &instance, void *dst, const void *src,
+KOKKOSCORE_EXPORT void DeepCopyAsyncCuda(const Cuda &instance, void *dst, const void *src,
                        size_t n) {
   KOKKOS_IMPL_CUDA_SAFE_CALL(
       (instance.impl_internal_space_instance()->cuda_memcpy_async_wrapper(
           dst, src, n, cudaMemcpyDefault)));
 }
 
-void DeepCopyAsyncCuda(void *dst, const void *src, size_t n) {
+KOKKOSCORE_EXPORT void DeepCopyAsyncCuda(void *dst, const void *src, size_t n) {
   cudaStream_t s = cuda_get_deep_copy_stream();
   KOKKOS_IMPL_CUDA_SAFE_CALL(
       cudaMemcpyAsync(dst, src, n, cudaMemcpyDefault, s));
@@ -126,19 +127,19 @@ void kokkos_impl_cuda_set_pin_uvm_to_host(bool val) {
 
 namespace Kokkos {
 
-CudaSpace::CudaSpace()
+KOKKOSCORE_EXPORT CudaSpace::CudaSpace()
     : m_device(Kokkos::Cuda().cuda_device()),
       m_stream(Kokkos::Cuda().cuda_stream()) {}
-CudaSpace::CudaSpace(int device_id, cudaStream_t stream)
+KOKKOSCORE_EXPORT CudaSpace::CudaSpace(int device_id, cudaStream_t stream)
     : m_device(device_id), m_stream(stream) {}
 
-CudaUVMSpace::CudaUVMSpace()
+KOKKOSCORE_EXPORT CudaUVMSpace::CudaUVMSpace()
     : m_device(Kokkos::Cuda().cuda_device()),
       m_stream(Kokkos::Cuda().cuda_stream()) {}
 CudaUVMSpace::CudaUVMSpace(int device_id, cudaStream_t stream)
     : m_device(device_id), m_stream(stream) {}
 
-CudaHostPinnedSpace::CudaHostPinnedSpace()
+KOKKOSCORE_EXPORT CudaHostPinnedSpace::CudaHostPinnedSpace()
     : m_device(Kokkos::Cuda().cuda_device()),
       m_stream(Kokkos::Cuda().cuda_stream()) {}
 CudaHostPinnedSpace::CudaHostPinnedSpace(int device_id, cudaStream_t stream)
@@ -153,12 +154,12 @@ void *CudaSpace::allocate(const size_t arg_alloc_size) const {
   return allocate("[unlabeled]", arg_alloc_size);
 }
 
-void *CudaSpace::allocate(const Cuda &exec_space, const char *arg_label,
+KOKKOSCORE_EXPORT void *CudaSpace::allocate(const Cuda &exec_space, const char *arg_label,
                           const size_t arg_alloc_size,
                           const size_t arg_logical_size) const {
   return impl_allocate(exec_space, arg_label, arg_alloc_size, arg_logical_size);
 }
-void *CudaSpace::allocate(const char *arg_label, const size_t arg_alloc_size,
+KOKKOSCORE_EXPORT void *CudaSpace::allocate(const char *arg_label, const size_t arg_alloc_size,
                           const size_t arg_logical_size) const {
   return impl_allocate(arg_label, arg_alloc_size, arg_logical_size);
 }
@@ -262,7 +263,7 @@ void *CudaSpace::impl_allocate(
 void *CudaUVMSpace::allocate(const size_t arg_alloc_size) const {
   return allocate("[unlabeled]", arg_alloc_size);
 }
-void *CudaUVMSpace::allocate(const char *arg_label, const size_t arg_alloc_size,
+KOKKOSCORE_EXPORT void *CudaUVMSpace::allocate(const char *arg_label, const size_t arg_alloc_size,
                              const size_t arg_logical_size) const {
   return impl_allocate(arg_label, arg_alloc_size, arg_logical_size);
 }
@@ -306,7 +307,7 @@ void *CudaUVMSpace::impl_allocate(
 void *CudaHostPinnedSpace::allocate(const size_t arg_alloc_size) const {
   return allocate("[unlabeled]", arg_alloc_size);
 }
-void *CudaHostPinnedSpace::allocate(const char *arg_label,
+KOKKOSCORE_EXPORT void *CudaHostPinnedSpace::allocate(const char *arg_label,
                                     const size_t arg_alloc_size,
                                     const size_t arg_logical_size) const {
   return impl_allocate(arg_label, arg_alloc_size, arg_logical_size);
@@ -341,7 +342,7 @@ void CudaSpace::deallocate(void *const arg_alloc_ptr,
                            const size_t arg_alloc_size) const {
   deallocate("[unlabeled]", arg_alloc_ptr, arg_alloc_size);
 }
-void CudaSpace::deallocate(const char *arg_label, void *const arg_alloc_ptr,
+KOKKOSCORE_EXPORT void CudaSpace::deallocate(const char *arg_label, void *const arg_alloc_ptr,
                            const size_t arg_alloc_size,
                            const size_t arg_logical_size) const {
   impl_deallocate(arg_label, arg_alloc_ptr, arg_alloc_size, arg_logical_size);
@@ -443,7 +444,7 @@ void CudaHostPinnedSpace::impl_deallocate(
 namespace Kokkos {
 namespace Impl {
 
-void cuda_prefetch_pointer(const Cuda &space, const void *ptr, size_t bytes,
+KOKKOSCORE_EXPORT void cuda_prefetch_pointer(const Cuda &space, const void *ptr, size_t bytes,
                            bool to_device) {
   if ((ptr == nullptr) || (bytes == 0)) return;
   cudaPointerAttributes attr;

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -22,7 +22,7 @@
 #ifdef KOKKOS_ENABLE_CUDA
 
 #include <Kokkos_Core.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <Cuda/Kokkos_Cuda.hpp>
 #include <Cuda/Kokkos_CudaSpace.hpp>
 

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -48,8 +48,8 @@ cudaStream_t Kokkos::Impl::cuda_get_deep_copy_stream() {
   return s;
 }
 
-KOKKOSCORE_EXPORT const std::unique_ptr<Kokkos::Cuda> &Kokkos::Impl::cuda_get_deep_copy_space(
-    bool initialize) {
+KOKKOSCORE_EXPORT const std::unique_ptr<Kokkos::Cuda> &
+Kokkos::Impl::cuda_get_deep_copy_space(bool initialize) {
   static std::unique_ptr<Cuda> space = nullptr;
   if (!space && initialize)
     space = std::make_unique<Cuda>(Kokkos::Impl::cuda_get_deep_copy_stream());
@@ -64,8 +64,8 @@ KOKKOSCORE_EXPORT void DeepCopyCuda(void *dst, const void *src, size_t n) {
       dst, src, n, cudaMemcpyDefault)));
 }
 
-KOKKOSCORE_EXPORT void DeepCopyAsyncCuda(const Cuda &instance, void *dst, const void *src,
-                       size_t n) {
+KOKKOSCORE_EXPORT void DeepCopyAsyncCuda(const Cuda &instance, void *dst,
+                                         const void *src, size_t n) {
   KOKKOS_IMPL_CUDA_SAFE_CALL(
       (instance.impl_internal_space_instance()->cuda_memcpy_async_wrapper(
           dst, src, n, cudaMemcpyDefault)));
@@ -154,13 +154,14 @@ void *CudaSpace::allocate(const size_t arg_alloc_size) const {
   return allocate("[unlabeled]", arg_alloc_size);
 }
 
-KOKKOSCORE_EXPORT void *CudaSpace::allocate(const Cuda &exec_space, const char *arg_label,
-                          const size_t arg_alloc_size,
-                          const size_t arg_logical_size) const {
+KOKKOSCORE_EXPORT void *CudaSpace::allocate(
+    const Cuda &exec_space, const char *arg_label, const size_t arg_alloc_size,
+    const size_t arg_logical_size) const {
   return impl_allocate(exec_space, arg_label, arg_alloc_size, arg_logical_size);
 }
-KOKKOSCORE_EXPORT void *CudaSpace::allocate(const char *arg_label, const size_t arg_alloc_size,
-                          const size_t arg_logical_size) const {
+KOKKOSCORE_EXPORT void *CudaSpace::allocate(
+    const char *arg_label, const size_t arg_alloc_size,
+    const size_t arg_logical_size) const {
   return impl_allocate(arg_label, arg_alloc_size, arg_logical_size);
 }
 
@@ -263,8 +264,9 @@ void *CudaSpace::impl_allocate(
 void *CudaUVMSpace::allocate(const size_t arg_alloc_size) const {
   return allocate("[unlabeled]", arg_alloc_size);
 }
-KOKKOSCORE_EXPORT void *CudaUVMSpace::allocate(const char *arg_label, const size_t arg_alloc_size,
-                             const size_t arg_logical_size) const {
+KOKKOSCORE_EXPORT void *CudaUVMSpace::allocate(
+    const char *arg_label, const size_t arg_alloc_size,
+    const size_t arg_logical_size) const {
   return impl_allocate(arg_label, arg_alloc_size, arg_logical_size);
 }
 void *CudaUVMSpace::impl_allocate(
@@ -307,9 +309,9 @@ void *CudaUVMSpace::impl_allocate(
 void *CudaHostPinnedSpace::allocate(const size_t arg_alloc_size) const {
   return allocate("[unlabeled]", arg_alloc_size);
 }
-KOKKOSCORE_EXPORT void *CudaHostPinnedSpace::allocate(const char *arg_label,
-                                    const size_t arg_alloc_size,
-                                    const size_t arg_logical_size) const {
+KOKKOSCORE_EXPORT void *CudaHostPinnedSpace::allocate(
+    const char *arg_label, const size_t arg_alloc_size,
+    const size_t arg_logical_size) const {
   return impl_allocate(arg_label, arg_alloc_size, arg_logical_size);
 }
 void *CudaHostPinnedSpace::impl_allocate(
@@ -342,9 +344,9 @@ void CudaSpace::deallocate(void *const arg_alloc_ptr,
                            const size_t arg_alloc_size) const {
   deallocate("[unlabeled]", arg_alloc_ptr, arg_alloc_size);
 }
-KOKKOSCORE_EXPORT void CudaSpace::deallocate(const char *arg_label, void *const arg_alloc_ptr,
-                           const size_t arg_alloc_size,
-                           const size_t arg_logical_size) const {
+KOKKOSCORE_EXPORT void CudaSpace::deallocate(
+    const char *arg_label, void *const arg_alloc_ptr,
+    const size_t arg_alloc_size, const size_t arg_logical_size) const {
   impl_deallocate(arg_label, arg_alloc_ptr, arg_alloc_size, arg_logical_size);
 }
 void CudaSpace::impl_deallocate(
@@ -444,8 +446,8 @@ void CudaHostPinnedSpace::impl_deallocate(
 namespace Kokkos {
 namespace Impl {
 
-KOKKOSCORE_EXPORT void cuda_prefetch_pointer(const Cuda &space, const void *ptr, size_t bytes,
-                           bool to_device) {
+KOKKOSCORE_EXPORT void cuda_prefetch_pointer(const Cuda &space, const void *ptr,
+                                             size_t bytes, bool to_device) {
   if ((ptr == nullptr) || (bytes == 0)) return;
   cudaPointerAttributes attr;
   KOKKOS_IMPL_CUDA_SAFE_CALL((

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -22,7 +22,7 @@
 #ifdef KOKKOS_ENABLE_CUDA
 
 #include <Kokkos_Core.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <Cuda/Kokkos_Cuda.hpp>
 #include <Cuda/Kokkos_CudaSpace.hpp>
 

--- a/core/src/Cuda/Kokkos_CudaSpace.hpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.hpp
@@ -26,7 +26,7 @@ static_assert(false,
 #if defined(KOKKOS_ENABLE_CUDA)
 
 #include <Kokkos_Core_fwd.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #include <iosfwd>
 #include <typeinfo>

--- a/core/src/Cuda/Kokkos_CudaSpace.hpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.hpp
@@ -82,12 +82,14 @@ class CudaSpace {
 
   /**\brief  Allocate untracked memory in the cuda space */
   void* allocate(const Cuda& exec_space, const size_t arg_alloc_size) const;
-  KOKKOSCORE_EXPORT void* allocate(const Cuda& exec_space, const char* arg_label,
-                 const size_t arg_alloc_size,
-                 const size_t arg_logical_size = 0) const;
+  KOKKOSCORE_EXPORT void* allocate(const Cuda& exec_space,
+                                   const char* arg_label,
+                                   const size_t arg_alloc_size,
+                                   const size_t arg_logical_size = 0) const;
   void* allocate(const size_t arg_alloc_size) const;
-  KOKKOSCORE_EXPORT void* allocate(const char* arg_label, const size_t arg_alloc_size,
-                 const size_t arg_logical_size = 0) const;
+  KOKKOSCORE_EXPORT void* allocate(const char* arg_label,
+                                   const size_t arg_alloc_size,
+                                   const size_t arg_logical_size = 0) const;
 
 #if defined(KOKKOS_ENABLE_IMPL_CUDA_UNIFIED_MEMORY)
   template <typename ExecutionSpace>
@@ -104,9 +106,10 @@ class CudaSpace {
 
   /**\brief  Deallocate untracked memory in the cuda space */
   void deallocate(void* const arg_alloc_ptr, const size_t arg_alloc_size) const;
-  KOKKOSCORE_EXPORT void deallocate(const char* arg_label, void* const arg_alloc_ptr,
-                  const size_t arg_alloc_size,
-                  const size_t arg_logical_size = 0) const;
+  KOKKOSCORE_EXPORT void deallocate(const char* arg_label,
+                                    void* const arg_alloc_ptr,
+                                    const size_t arg_alloc_size,
+                                    const size_t arg_logical_size = 0) const;
 
   static CudaSpace impl_create(int device_id, cudaStream_t stream) {
     return CudaSpace(device_id, stream);
@@ -193,8 +196,9 @@ class CudaUVMSpace {
     return allocate(arg_label, arg_alloc_size, arg_logical_size);
   }
   void* allocate(const size_t arg_alloc_size) const;
-  KOKKOSCORE_EXPORT void* allocate(const char* arg_label, const size_t arg_alloc_size,
-                 const size_t arg_logical_size = 0) const;
+  KOKKOSCORE_EXPORT void* allocate(const char* arg_label,
+                                   const size_t arg_alloc_size,
+                                   const size_t arg_logical_size = 0) const;
 
   /**\brief  Deallocate untracked memory in the cuda space */
   void deallocate(void* const arg_alloc_ptr, const size_t arg_alloc_size) const;
@@ -285,8 +289,9 @@ class CudaHostPinnedSpace {
     return allocate(arg_label, arg_alloc_size, arg_logical_size);
   }
   void* allocate(const size_t arg_alloc_size) const;
-  KOKKOSCORE_EXPORT void* allocate(const char* arg_label, const size_t arg_alloc_size,
-                 const size_t arg_logical_size = 0) const;
+  KOKKOSCORE_EXPORT void* allocate(const char* arg_label,
+                                   const size_t arg_alloc_size,
+                                   const size_t arg_logical_size = 0) const;
 
   /**\brief  Deallocate untracked memory in the space */
   void deallocate(void* const arg_alloc_ptr, const size_t arg_alloc_size) const;
@@ -467,8 +472,8 @@ namespace Kokkos {
 namespace Impl {
 
 KOKKOSCORE_EXPORT void DeepCopyCuda(void* dst, const void* src, size_t n);
-KOKKOSCORE_EXPORT void DeepCopyAsyncCuda(const Cuda& instance, void* dst, const void* src,
-                       size_t n);
+KOKKOSCORE_EXPORT void DeepCopyAsyncCuda(const Cuda& instance, void* dst,
+                                         const void* src, size_t n);
 KOKKOSCORE_EXPORT void DeepCopyAsyncCuda(void* dst, const void* src, size_t n);
 
 template <class MemSpace>

--- a/core/src/Cuda/Kokkos_CudaSpace.hpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.hpp
@@ -23,10 +23,10 @@ static_assert(false,
 #define KOKKOS_CUDASPACE_HPP
 
 #include <Kokkos_Macros.hpp>
-#include "kokkoscore_export.h"
 #if defined(KOKKOS_ENABLE_CUDA)
 
 #include <Kokkos_Core_fwd.hpp>
+#include "kokkoscore_export.h"
 
 #include <iosfwd>
 #include <typeinfo>

--- a/core/src/Cuda/Kokkos_CudaSpace.hpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.hpp
@@ -26,7 +26,7 @@ static_assert(false,
 #if defined(KOKKOS_ENABLE_CUDA)
 
 #include <Kokkos_Core_fwd.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #include <iosfwd>
 #include <typeinfo>

--- a/core/src/Cuda/Kokkos_CudaSpace.hpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.hpp
@@ -23,6 +23,7 @@ static_assert(false,
 #define KOKKOS_CUDASPACE_HPP
 
 #include <Kokkos_Macros.hpp>
+#include "kokkoscore_export.h"
 #if defined(KOKKOS_ENABLE_CUDA)
 
 #include <Kokkos_Core_fwd.hpp>
@@ -67,10 +68,10 @@ class CudaSpace {
 
   /*--------------------------------*/
 
-  CudaSpace();
+  KOKKOSCORE_EXPORT CudaSpace();
 
  private:
-  CudaSpace(int device_id, cudaStream_t stream);
+  KOKKOSCORE_EXPORT CudaSpace(int device_id, cudaStream_t stream);
 
  public:
   CudaSpace(CudaSpace&& rhs)                 = default;
@@ -81,11 +82,11 @@ class CudaSpace {
 
   /**\brief  Allocate untracked memory in the cuda space */
   void* allocate(const Cuda& exec_space, const size_t arg_alloc_size) const;
-  void* allocate(const Cuda& exec_space, const char* arg_label,
+  KOKKOSCORE_EXPORT void* allocate(const Cuda& exec_space, const char* arg_label,
                  const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;
   void* allocate(const size_t arg_alloc_size) const;
-  void* allocate(const char* arg_label, const size_t arg_alloc_size,
+  KOKKOSCORE_EXPORT void* allocate(const char* arg_label, const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;
 
 #if defined(KOKKOS_ENABLE_IMPL_CUDA_UNIFIED_MEMORY)
@@ -103,7 +104,7 @@ class CudaSpace {
 
   /**\brief  Deallocate untracked memory in the cuda space */
   void deallocate(void* const arg_alloc_ptr, const size_t arg_alloc_size) const;
-  void deallocate(const char* arg_label, void* const arg_alloc_ptr,
+  KOKKOSCORE_EXPORT void deallocate(const char* arg_label, void* const arg_alloc_ptr,
                   const size_t arg_alloc_size,
                   const size_t arg_logical_size = 0) const;
 
@@ -168,7 +169,7 @@ class CudaUVMSpace {
 
   /*--------------------------------*/
 
-  CudaUVMSpace();
+  KOKKOSCORE_EXPORT CudaUVMSpace();
 
  private:
   CudaUVMSpace(int device_id, cudaStream_t stream);
@@ -192,7 +193,7 @@ class CudaUVMSpace {
     return allocate(arg_label, arg_alloc_size, arg_logical_size);
   }
   void* allocate(const size_t arg_alloc_size) const;
-  void* allocate(const char* arg_label, const size_t arg_alloc_size,
+  KOKKOSCORE_EXPORT void* allocate(const char* arg_label, const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;
 
   /**\brief  Deallocate untracked memory in the cuda space */
@@ -260,7 +261,7 @@ class CudaHostPinnedSpace {
 
   /*--------------------------------*/
 
-  CudaHostPinnedSpace();
+  KOKKOSCORE_EXPORT CudaHostPinnedSpace();
 
  private:
   CudaHostPinnedSpace(int device_id, cudaStream_t stream);
@@ -284,7 +285,7 @@ class CudaHostPinnedSpace {
     return allocate(arg_label, arg_alloc_size, arg_logical_size);
   }
   void* allocate(const size_t arg_alloc_size) const;
-  void* allocate(const char* arg_label, const size_t arg_alloc_size,
+  KOKKOSCORE_EXPORT void* allocate(const char* arg_label, const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;
 
   /**\brief  Deallocate untracked memory in the space */
@@ -334,7 +335,7 @@ namespace Impl {
 
 cudaStream_t cuda_get_deep_copy_stream();
 
-const std::unique_ptr<Kokkos::Cuda>& cuda_get_deep_copy_space(
+KOKKOSCORE_EXPORT const std::unique_ptr<Kokkos::Cuda>& cuda_get_deep_copy_space(
     bool initialize = true);
 
 static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaSpace,
@@ -465,10 +466,10 @@ struct MemorySpaceAccess<Kokkos::CudaHostPinnedSpace, Kokkos::CudaUVMSpace> {
 namespace Kokkos {
 namespace Impl {
 
-void DeepCopyCuda(void* dst, const void* src, size_t n);
-void DeepCopyAsyncCuda(const Cuda& instance, void* dst, const void* src,
+KOKKOSCORE_EXPORT void DeepCopyCuda(void* dst, const void* src, size_t n);
+KOKKOSCORE_EXPORT void DeepCopyAsyncCuda(const Cuda& instance, void* dst, const void* src,
                        size_t n);
-void DeepCopyAsyncCuda(void* dst, const void* src, size_t n);
+KOKKOSCORE_EXPORT void DeepCopyAsyncCuda(void* dst, const void* src, size_t n);
 
 template <class MemSpace>
 struct DeepCopy<MemSpace, HostSpace, Cuda,

--- a/core/src/Cuda/Kokkos_Cuda_Error.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Error.hpp
@@ -18,9 +18,9 @@
 #define KOKKOS_CUDA_ERROR_HPP
 
 #include <Kokkos_Macros.hpp>
-#include "kokkoscore_export.h"
 #ifdef KOKKOS_ENABLE_CUDA
 
+#include "kokkoscore_export.h"
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Profiling.hpp>
 

--- a/core/src/Cuda/Kokkos_Cuda_Error.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Error.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_CUDA_ERROR_HPP
 
 #include <Kokkos_Macros.hpp>
+#include "kokkoscore_export.h"
 #ifdef KOKKOS_ENABLE_CUDA
 
 #include <impl/Kokkos_Error.hpp>
@@ -30,14 +31,14 @@ void cuda_device_synchronize(const std::string& name);
 void cuda_stream_synchronize(const cudaStream_t stream,
                              const std::string& name);
 
-[[noreturn]] void cuda_internal_error_throw(cudaError e, const char* name,
+[[noreturn]] KOKKOSCORE_EXPORT void cuda_internal_error_throw(cudaError e, const char* name,
                                             const char* file = nullptr,
                                             const int line   = 0);
 
 #ifndef KOKKOS_COMPILER_NVHPC
 [[noreturn]]
 #endif
-             void cuda_internal_error_abort(cudaError e, const char* name,
+             KOKKOSCORE_EXPORT void cuda_internal_error_abort(cudaError e, const char* name,
                                             const char* file = nullptr,
                                             const int line   = 0);
 

--- a/core/src/Cuda/Kokkos_Cuda_Error.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Error.hpp
@@ -31,16 +31,16 @@ void cuda_device_synchronize(const std::string& name);
 void cuda_stream_synchronize(const cudaStream_t stream,
                              const std::string& name);
 
-[[noreturn]] KOKKOSCORE_EXPORT void cuda_internal_error_throw(cudaError e, const char* name,
-                                            const char* file = nullptr,
-                                            const int line   = 0);
+[[noreturn]] KOKKOSCORE_EXPORT void cuda_internal_error_throw(
+    cudaError e, const char* name, const char* file = nullptr,
+    const int line = 0);
 
 #ifndef KOKKOS_COMPILER_NVHPC
 [[noreturn]]
 #endif
-             KOKKOSCORE_EXPORT void cuda_internal_error_abort(cudaError e, const char* name,
-                                            const char* file = nullptr,
-                                            const int line   = 0);
+KOKKOSCORE_EXPORT void
+cuda_internal_error_abort(cudaError e, const char* name,
+                          const char* file = nullptr, const int line = 0);
 
 inline void cuda_internal_safe_call(cudaError e, const char* name,
                                     const char* file = nullptr,

--- a/core/src/Cuda/Kokkos_Cuda_Error.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Error.hpp
@@ -20,7 +20,7 @@
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_CUDA
 
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Profiling.hpp>
 

--- a/core/src/Cuda/Kokkos_Cuda_Error.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Error.hpp
@@ -20,7 +20,7 @@
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_CUDA
 
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Profiling.hpp>
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -25,7 +25,7 @@
 #ifdef KOKKOS_ENABLE_CUDA
 
 #include <Kokkos_Core.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 // #include <Cuda/Kokkos_Cuda_Error.hpp>
 // #include <Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp>

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
+#include "kokkoscore_export.h"
 #ifdef KOKKOS_ENABLE_CUDA
 
 #include <Kokkos_Core.hpp>
@@ -125,7 +126,7 @@ std::size_t scratch_count(const std::size_t size) {
 
 }  // namespace
 
-Kokkos::View<uint32_t *, Kokkos::CudaSpace> cuda_global_unique_token_locks(
+KOKKOSCORE_EXPORT Kokkos::View<uint32_t *, Kokkos::CudaSpace> cuda_global_unique_token_locks(
     bool deallocate) {
   static Kokkos::View<uint32_t *, Kokkos::CudaSpace> locks =
       Kokkos::View<uint32_t *, Kokkos::CudaSpace>();
@@ -165,7 +166,7 @@ void cuda_stream_synchronize(const cudaStream_t stream, const CudaInternal *ptr,
       [stream] { KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamSynchronize(stream)); });
 }
 
-void cuda_internal_error_throw(cudaError e, const char *name, const char *file,
+KOKKOSCORE_EXPORT void cuda_internal_error_throw(cudaError e, const char *name, const char *file,
                                const int line) {
   std::ostringstream out;
   out << name << " error( " << cudaGetErrorName(e)
@@ -176,7 +177,7 @@ void cuda_internal_error_throw(cudaError e, const char *name, const char *file,
   throw_runtime_exception(out.str());
 }
 
-void cuda_internal_error_abort(cudaError e, const char *name, const char *file,
+KOKKOSCORE_EXPORT void cuda_internal_error_abort(cudaError e, const char *name, const char *file,
                                const int line) {
   std::ostringstream out;
   out << name << " error( " << cudaGetErrorName(e)
@@ -248,7 +249,7 @@ CudaInternal::~CudaInternal() {
   }
 }
 
-int CudaInternal::verify_is_initialized(const char *const label) const {
+KOKKOSCORE_EXPORT int CudaInternal::verify_is_initialized(const char *const label) const {
   if (m_cudaDev < 0) {
     Kokkos::abort((std::string("Kokkos::Cuda::") + label +
                    " : ERROR device not initialized\n")
@@ -420,7 +421,7 @@ Cuda::size_type *CudaInternal::scratch_functor(const std::size_t size) const {
   return m_scratchFunctor;
 }
 
-int CudaInternal::acquire_team_scratch_space() {
+KOKKOSCORE_EXPORT int CudaInternal::acquire_team_scratch_space() {
   int current_team_scratch = 0;
   int zero                 = 0;
   while (!m_team_scratch_pool[current_team_scratch].compare_exchange_weak(
@@ -431,7 +432,7 @@ int CudaInternal::acquire_team_scratch_space() {
   return current_team_scratch;
 }
 
-void *CudaInternal::resize_team_scratch_space(int scratch_pool_id,
+KOKKOSCORE_EXPORT void *CudaInternal::resize_team_scratch_space(int scratch_pool_id,
                                               std::int64_t bytes,
                                               bool force_shrink) {
   // Multiple ParallelFor/Reduce Teams can call this function at the same time
@@ -456,7 +457,7 @@ void *CudaInternal::resize_team_scratch_space(int scratch_pool_id,
   return m_team_scratch_ptr[scratch_pool_id];
 }
 
-void CudaInternal::release_team_scratch_space(int scratch_pool_id) {
+KOKKOSCORE_EXPORT void CudaInternal::release_team_scratch_space(int scratch_pool_id) {
   m_team_scratch_pool[scratch_pool_id] = 0;
 }
 
@@ -508,17 +509,17 @@ void CudaInternal::finalize() {
 
 //----------------------------------------------------------------------------
 
-Cuda::size_type *cuda_internal_scratch_space(const Cuda &instance,
+KOKKOSCORE_EXPORT Cuda::size_type *cuda_internal_scratch_space(const Cuda &instance,
                                              const std::size_t size) {
   return instance.impl_internal_space_instance()->scratch_space(size);
 }
 
-Cuda::size_type *cuda_internal_scratch_flags(const Cuda &instance,
+KOKKOSCORE_EXPORT Cuda::size_type *cuda_internal_scratch_flags(const Cuda &instance,
                                              const std::size_t size) {
   return instance.impl_internal_space_instance()->scratch_flags(size);
 }
 
-Cuda::size_type *cuda_internal_scratch_unified(const Cuda &instance,
+KOKKOSCORE_EXPORT Cuda::size_type *cuda_internal_scratch_unified(const Cuda &instance,
                                                const std::size_t size) {
   return instance.impl_internal_space_instance()->scratch_unified(size);
 }
@@ -538,11 +539,11 @@ int Cuda::concurrency() const {
   return Impl::CudaInternal::concurrency();
 }
 
-int Cuda::impl_is_initialized() {
+KOKKOSCORE_EXPORT int Cuda::impl_is_initialized() {
   return Impl::CudaInternal::singleton().is_initialized();
 }
 
-void Cuda::impl_initialize(InitializationSettings const &settings) {
+KOKKOSCORE_EXPORT void Cuda::impl_initialize(InitializationSettings const &settings) {
   const std::vector<int> &visible_devices = Impl::get_visible_devices();
   const int cuda_device_id =
       Impl::get_gpu(settings).value_or(visible_devices[0]);
@@ -643,7 +644,7 @@ Kokkos::Cuda::initialize WARNING: Cuda is allocating into UVMSpace by default
   Impl::CudaInternal::singleton().initialize(singleton_stream);
 }
 
-void Cuda::impl_finalize() {
+KOKKOSCORE_EXPORT void Cuda::impl_finalize() {
   (void)Impl::cuda_global_unique_token_locks(true);
   desul::Impl::finalize_lock_arrays();  // FIXME
 
@@ -667,7 +668,7 @@ void Cuda::impl_finalize() {
       cudaStreamDestroy(Impl::CudaInternal::singleton().m_stream));
 }
 
-Cuda::Cuda()
+KOKKOSCORE_EXPORT Cuda::Cuda()
     : m_space_instance(&Impl::CudaInternal::singleton(),
                        [](Impl::CudaInternal *) {}) {
   Impl::CudaInternal::singleton().verify_is_initialized(
@@ -678,7 +679,7 @@ KOKKOS_DEPRECATED Cuda::Cuda(cudaStream_t stream, bool manage_stream)
     : Cuda(stream,
            manage_stream ? Impl::ManageStream::yes : Impl::ManageStream::no) {}
 
-Cuda::Cuda(cudaStream_t stream, Impl::ManageStream manage_stream)
+KOKKOSCORE_EXPORT Cuda::Cuda(cudaStream_t stream, Impl::ManageStream manage_stream)
     : m_space_instance(
           new Impl::CudaInternal, [manage_stream](Impl::CudaInternal *ptr) {
             ptr->finalize();
@@ -692,7 +693,7 @@ Cuda::Cuda(cudaStream_t stream, Impl::ManageStream manage_stream)
   m_space_instance->initialize(stream);
 }
 
-void Cuda::print_configuration(std::ostream &os, bool /*verbose*/) const {
+KOKKOSCORE_EXPORT void Cuda::print_configuration(std::ostream &os, bool /*verbose*/) const {
   os << "Device Execution Space:\n";
   os << "  KOKKOS_ENABLE_CUDA: yes\n";
 
@@ -729,18 +730,18 @@ void Cuda::impl_static_fence(const std::string &name) {
   Kokkos::Impl::cuda_device_synchronize(name);
 }
 
-void Cuda::fence(const std::string &name) const {
+KOKKOSCORE_EXPORT void Cuda::fence(const std::string &name) const {
   m_space_instance->fence(name);
 }
 
-const char *Cuda::name() { return "Cuda"; }
-uint32_t Cuda::impl_instance_id() const noexcept {
+KOKKOSCORE_EXPORT const char *Cuda::name() { return "Cuda"; }
+KOKKOSCORE_EXPORT uint32_t Cuda::impl_instance_id() const noexcept {
   return m_space_instance->impl_get_instance_id();
 }
 
-cudaStream_t Cuda::cuda_stream() const { return m_space_instance->m_stream; }
-int Cuda::cuda_device() const { return m_space_instance->m_cudaDev; }
-const cudaDeviceProp &Cuda::cuda_device_prop() const {
+KOKKOSCORE_EXPORT cudaStream_t Cuda::cuda_stream() const { return m_space_instance->m_stream; }
+KOKKOSCORE_EXPORT int Cuda::cuda_device() const { return m_space_instance->m_cudaDev; }
+KOKKOSCORE_EXPORT const cudaDeviceProp &Cuda::cuda_device_prop() const {
   return m_space_instance->m_deviceProp;
 }
 
@@ -750,12 +751,12 @@ int g_cuda_space_factory_initialized =
     initialize_space_factory<Cuda>("150_Cuda");
 
 int CudaInternal::m_cudaArch = -1;
-cudaDeviceProp CudaInternal::m_deviceProp;
+KOKKOSCORE_EXPORT cudaDeviceProp CudaInternal::m_deviceProp;
 std::set<int> CudaInternal::cuda_devices = {};
-std::map<int, unsigned long *> CudaInternal::constantMemHostStagingPerDevice =
+KOKKOSCORE_EXPORT std::map<int, unsigned long *> CudaInternal::constantMemHostStagingPerDevice =
     {};
-std::map<int, cudaEvent_t> CudaInternal::constantMemReusablePerDevice = {};
-std::map<int, std::mutex> CudaInternal::constantMemMutexPerDevice     = {};
+KOKKOSCORE_EXPORT std::map<int, cudaEvent_t> CudaInternal::constantMemReusablePerDevice = {};
+KOKKOSCORE_EXPORT std::map<int, std::mutex> CudaInternal::constantMemMutexPerDevice     = {};
 
 }  // namespace Impl
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -22,10 +22,10 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#include "kokkoscore_export.h"
 #ifdef KOKKOS_ENABLE_CUDA
 
 #include <Kokkos_Core.hpp>
+#include "kokkoscore_export.h"
 
 // #include <Cuda/Kokkos_Cuda_Error.hpp>
 // #include <Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp>

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -25,7 +25,7 @@
 #ifdef KOKKOS_ENABLE_CUDA
 
 #include <Kokkos_Core.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 // #include <Cuda/Kokkos_Cuda_Error.hpp>
 // #include <Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp>

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -126,8 +126,8 @@ std::size_t scratch_count(const std::size_t size) {
 
 }  // namespace
 
-KOKKOSCORE_EXPORT Kokkos::View<uint32_t *, Kokkos::CudaSpace> cuda_global_unique_token_locks(
-    bool deallocate) {
+KOKKOSCORE_EXPORT Kokkos::View<uint32_t *, Kokkos::CudaSpace>
+cuda_global_unique_token_locks(bool deallocate) {
   static Kokkos::View<uint32_t *, Kokkos::CudaSpace> locks =
       Kokkos::View<uint32_t *, Kokkos::CudaSpace>();
   if (!deallocate && locks.extent(0) == 0)
@@ -166,8 +166,9 @@ void cuda_stream_synchronize(const cudaStream_t stream, const CudaInternal *ptr,
       [stream] { KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamSynchronize(stream)); });
 }
 
-KOKKOSCORE_EXPORT void cuda_internal_error_throw(cudaError e, const char *name, const char *file,
-                               const int line) {
+KOKKOSCORE_EXPORT void cuda_internal_error_throw(cudaError e, const char *name,
+                                                 const char *file,
+                                                 const int line) {
   std::ostringstream out;
   out << name << " error( " << cudaGetErrorName(e)
       << "): " << cudaGetErrorString(e);
@@ -177,8 +178,9 @@ KOKKOSCORE_EXPORT void cuda_internal_error_throw(cudaError e, const char *name, 
   throw_runtime_exception(out.str());
 }
 
-KOKKOSCORE_EXPORT void cuda_internal_error_abort(cudaError e, const char *name, const char *file,
-                               const int line) {
+KOKKOSCORE_EXPORT void cuda_internal_error_abort(cudaError e, const char *name,
+                                                 const char *file,
+                                                 const int line) {
   std::ostringstream out;
   out << name << " error( " << cudaGetErrorName(e)
       << "): " << cudaGetErrorString(e);
@@ -249,7 +251,8 @@ CudaInternal::~CudaInternal() {
   }
 }
 
-KOKKOSCORE_EXPORT int CudaInternal::verify_is_initialized(const char *const label) const {
+KOKKOSCORE_EXPORT int CudaInternal::verify_is_initialized(
+    const char *const label) const {
   if (m_cudaDev < 0) {
     Kokkos::abort((std::string("Kokkos::Cuda::") + label +
                    " : ERROR device not initialized\n")
@@ -432,9 +435,8 @@ KOKKOSCORE_EXPORT int CudaInternal::acquire_team_scratch_space() {
   return current_team_scratch;
 }
 
-KOKKOSCORE_EXPORT void *CudaInternal::resize_team_scratch_space(int scratch_pool_id,
-                                              std::int64_t bytes,
-                                              bool force_shrink) {
+KOKKOSCORE_EXPORT void *CudaInternal::resize_team_scratch_space(
+    int scratch_pool_id, std::int64_t bytes, bool force_shrink) {
   // Multiple ParallelFor/Reduce Teams can call this function at the same time
   // and invalidate the m_team_scratch_ptr. We use a pool to avoid any race
   // condition.
@@ -457,7 +459,8 @@ KOKKOSCORE_EXPORT void *CudaInternal::resize_team_scratch_space(int scratch_pool
   return m_team_scratch_ptr[scratch_pool_id];
 }
 
-KOKKOSCORE_EXPORT void CudaInternal::release_team_scratch_space(int scratch_pool_id) {
+KOKKOSCORE_EXPORT void CudaInternal::release_team_scratch_space(
+    int scratch_pool_id) {
   m_team_scratch_pool[scratch_pool_id] = 0;
 }
 
@@ -509,18 +512,18 @@ void CudaInternal::finalize() {
 
 //----------------------------------------------------------------------------
 
-KOKKOSCORE_EXPORT Cuda::size_type *cuda_internal_scratch_space(const Cuda &instance,
-                                             const std::size_t size) {
+KOKKOSCORE_EXPORT Cuda::size_type *cuda_internal_scratch_space(
+    const Cuda &instance, const std::size_t size) {
   return instance.impl_internal_space_instance()->scratch_space(size);
 }
 
-KOKKOSCORE_EXPORT Cuda::size_type *cuda_internal_scratch_flags(const Cuda &instance,
-                                             const std::size_t size) {
+KOKKOSCORE_EXPORT Cuda::size_type *cuda_internal_scratch_flags(
+    const Cuda &instance, const std::size_t size) {
   return instance.impl_internal_space_instance()->scratch_flags(size);
 }
 
-KOKKOSCORE_EXPORT Cuda::size_type *cuda_internal_scratch_unified(const Cuda &instance,
-                                               const std::size_t size) {
+KOKKOSCORE_EXPORT Cuda::size_type *cuda_internal_scratch_unified(
+    const Cuda &instance, const std::size_t size) {
   return instance.impl_internal_space_instance()->scratch_unified(size);
 }
 
@@ -543,7 +546,8 @@ KOKKOSCORE_EXPORT int Cuda::impl_is_initialized() {
   return Impl::CudaInternal::singleton().is_initialized();
 }
 
-KOKKOSCORE_EXPORT void Cuda::impl_initialize(InitializationSettings const &settings) {
+KOKKOSCORE_EXPORT void Cuda::impl_initialize(
+    InitializationSettings const &settings) {
   const std::vector<int> &visible_devices = Impl::get_visible_devices();
   const int cuda_device_id =
       Impl::get_gpu(settings).value_or(visible_devices[0]);
@@ -679,7 +683,8 @@ KOKKOS_DEPRECATED Cuda::Cuda(cudaStream_t stream, bool manage_stream)
     : Cuda(stream,
            manage_stream ? Impl::ManageStream::yes : Impl::ManageStream::no) {}
 
-KOKKOSCORE_EXPORT Cuda::Cuda(cudaStream_t stream, Impl::ManageStream manage_stream)
+KOKKOSCORE_EXPORT Cuda::Cuda(cudaStream_t stream,
+                             Impl::ManageStream manage_stream)
     : m_space_instance(
           new Impl::CudaInternal, [manage_stream](Impl::CudaInternal *ptr) {
             ptr->finalize();
@@ -693,7 +698,8 @@ KOKKOSCORE_EXPORT Cuda::Cuda(cudaStream_t stream, Impl::ManageStream manage_stre
   m_space_instance->initialize(stream);
 }
 
-KOKKOSCORE_EXPORT void Cuda::print_configuration(std::ostream &os, bool /*verbose*/) const {
+KOKKOSCORE_EXPORT void Cuda::print_configuration(std::ostream &os,
+                                                 bool /*verbose*/) const {
   os << "Device Execution Space:\n";
   os << "  KOKKOS_ENABLE_CUDA: yes\n";
 
@@ -739,8 +745,12 @@ KOKKOSCORE_EXPORT uint32_t Cuda::impl_instance_id() const noexcept {
   return m_space_instance->impl_get_instance_id();
 }
 
-KOKKOSCORE_EXPORT cudaStream_t Cuda::cuda_stream() const { return m_space_instance->m_stream; }
-KOKKOSCORE_EXPORT int Cuda::cuda_device() const { return m_space_instance->m_cudaDev; }
+KOKKOSCORE_EXPORT cudaStream_t Cuda::cuda_stream() const {
+  return m_space_instance->m_stream;
+}
+KOKKOSCORE_EXPORT int Cuda::cuda_device() const {
+  return m_space_instance->m_cudaDev;
+}
 KOKKOSCORE_EXPORT const cudaDeviceProp &Cuda::cuda_device_prop() const {
   return m_space_instance->m_deviceProp;
 }
@@ -753,10 +763,12 @@ int g_cuda_space_factory_initialized =
 int CudaInternal::m_cudaArch = -1;
 KOKKOSCORE_EXPORT cudaDeviceProp CudaInternal::m_deviceProp;
 std::set<int> CudaInternal::cuda_devices = {};
-KOKKOSCORE_EXPORT std::map<int, unsigned long *> CudaInternal::constantMemHostStagingPerDevice =
-    {};
-KOKKOSCORE_EXPORT std::map<int, cudaEvent_t> CudaInternal::constantMemReusablePerDevice = {};
-KOKKOSCORE_EXPORT std::map<int, std::mutex> CudaInternal::constantMemMutexPerDevice     = {};
+KOKKOSCORE_EXPORT std::map<int, unsigned long *>
+    CudaInternal::constantMemHostStagingPerDevice = {};
+KOKKOSCORE_EXPORT std::map<int, cudaEvent_t>
+    CudaInternal::constantMemReusablePerDevice = {};
+KOKKOSCORE_EXPORT std::map<int, std::mutex>
+    CudaInternal::constantMemMutexPerDevice = {};
 
 }  // namespace Impl
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -23,7 +23,7 @@
 #include <Cuda/Kokkos_Cuda_Error.hpp>
 #include <cuda_runtime_api.h>
 #include "Kokkos_CudaSpace.hpp"
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #include <set>
 #include <map>

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -23,6 +23,7 @@
 #include <Cuda/Kokkos_Cuda_Error.hpp>
 #include <cuda_runtime_api.h>
 #include "Kokkos_CudaSpace.hpp"
+#include "kokkoscore_export.h"
 
 #include <set>
 #include <map>
@@ -63,11 +64,11 @@ struct CudaTraits {
 
 //----------------------------------------------------------------------------
 
-CudaSpace::size_type* cuda_internal_scratch_flags(const Cuda&,
+KOKKOSCORE_EXPORT CudaSpace::size_type* cuda_internal_scratch_flags(const Cuda&,
                                                   const std::size_t size);
-CudaSpace::size_type* cuda_internal_scratch_space(const Cuda&,
+KOKKOSCORE_EXPORT CudaSpace::size_type* cuda_internal_scratch_space(const Cuda&,
                                                   const std::size_t size);
-CudaSpace::size_type* cuda_internal_scratch_unified(const Cuda&,
+KOKKOSCORE_EXPORT CudaSpace::size_type* cuda_internal_scratch_unified(const Cuda&,
                                                     const std::size_t size);
 
 }  // namespace Impl
@@ -94,7 +95,7 @@ class CudaInternal {
   static int m_cudaArch;
   static int concurrency();
 
-  static cudaDeviceProp m_deviceProp;
+  KOKKOSCORE_EXPORT static cudaDeviceProp m_deviceProp;
 
   // Scratch Spaces for Reductions
   mutable std::size_t m_scratchSpaceCount;
@@ -121,13 +122,13 @@ class CudaInternal {
   bool was_finalized   = false;
 
   static std::set<int> cuda_devices;
-  static std::map<int, unsigned long*> constantMemHostStagingPerDevice;
-  static std::map<int, cudaEvent_t> constantMemReusablePerDevice;
-  static std::map<int, std::mutex> constantMemMutexPerDevice;
+  KOKKOSCORE_EXPORT static std::map<int, unsigned long*> constantMemHostStagingPerDevice;
+  KOKKOSCORE_EXPORT static std::map<int, cudaEvent_t> constantMemReusablePerDevice;
+  KOKKOSCORE_EXPORT static std::map<int, std::mutex> constantMemMutexPerDevice;
 
   static CudaInternal& singleton();
 
-  int verify_is_initialized(const char* const label) const;
+  KOKKOSCORE_EXPORT int verify_is_initialized(const char* const label) const;
 
   int is_initialized() const {
     return nullptr != m_scratchSpace && nullptr != m_scratchFlags;
@@ -357,11 +358,11 @@ class CudaInternal {
   size_type* scratch_unified(const std::size_t size) const;
   size_type* scratch_functor(const std::size_t size) const;
   uint32_t impl_get_instance_id() const;
-  int acquire_team_scratch_space();
+  KOKKOSCORE_EXPORT int acquire_team_scratch_space();
   // Resizing of team level 1 scratch
-  void* resize_team_scratch_space(int scratch_pool_id, std::int64_t bytes,
+  KOKKOSCORE_EXPORT void* resize_team_scratch_space(int scratch_pool_id, std::int64_t bytes,
                                   bool force_shrink = false);
-  void release_team_scratch_space(int scratch_pool_id);
+  KOKKOSCORE_EXPORT void release_team_scratch_space(int scratch_pool_id);
 };
 }  // Namespace Impl
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -64,12 +64,12 @@ struct CudaTraits {
 
 //----------------------------------------------------------------------------
 
-KOKKOSCORE_EXPORT CudaSpace::size_type* cuda_internal_scratch_flags(const Cuda&,
-                                                  const std::size_t size);
-KOKKOSCORE_EXPORT CudaSpace::size_type* cuda_internal_scratch_space(const Cuda&,
-                                                  const std::size_t size);
-KOKKOSCORE_EXPORT CudaSpace::size_type* cuda_internal_scratch_unified(const Cuda&,
-                                                    const std::size_t size);
+KOKKOSCORE_EXPORT CudaSpace::size_type* cuda_internal_scratch_flags(
+    const Cuda&, const std::size_t size);
+KOKKOSCORE_EXPORT CudaSpace::size_type* cuda_internal_scratch_space(
+    const Cuda&, const std::size_t size);
+KOKKOSCORE_EXPORT CudaSpace::size_type* cuda_internal_scratch_unified(
+    const Cuda&, const std::size_t size);
 
 }  // namespace Impl
 }  // namespace Kokkos
@@ -122,8 +122,10 @@ class CudaInternal {
   bool was_finalized   = false;
 
   static std::set<int> cuda_devices;
-  KOKKOSCORE_EXPORT static std::map<int, unsigned long*> constantMemHostStagingPerDevice;
-  KOKKOSCORE_EXPORT static std::map<int, cudaEvent_t> constantMemReusablePerDevice;
+  KOKKOSCORE_EXPORT static std::map<int, unsigned long*>
+      constantMemHostStagingPerDevice;
+  KOKKOSCORE_EXPORT static std::map<int, cudaEvent_t>
+      constantMemReusablePerDevice;
   KOKKOSCORE_EXPORT static std::map<int, std::mutex> constantMemMutexPerDevice;
 
   static CudaInternal& singleton();
@@ -360,8 +362,9 @@ class CudaInternal {
   uint32_t impl_get_instance_id() const;
   KOKKOSCORE_EXPORT int acquire_team_scratch_space();
   // Resizing of team level 1 scratch
-  KOKKOSCORE_EXPORT void* resize_team_scratch_space(int scratch_pool_id, std::int64_t bytes,
-                                  bool force_shrink = false);
+  KOKKOSCORE_EXPORT void* resize_team_scratch_space(int scratch_pool_id,
+                                                    std::int64_t bytes,
+                                                    bool force_shrink = false);
   KOKKOSCORE_EXPORT void release_team_scratch_space(int scratch_pool_id);
 };
 }  // Namespace Impl

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -23,7 +23,7 @@
 #include <Cuda/Kokkos_Cuda_Error.hpp>
 #include <cuda_runtime_api.h>
 #include "Kokkos_CudaSpace.hpp"
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #include <set>
 #include <map>

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -35,7 +35,7 @@
 #include <Kokkos_BitManipulation.hpp>
 #include <Kokkos_MinMax.hpp>
 #include <Kokkos_Vectorization.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #include <impl/Kokkos_Tools.hpp>
 #include <typeinfo>

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -35,7 +35,7 @@
 #include <Kokkos_BitManipulation.hpp>
 #include <Kokkos_MinMax.hpp>
 #include <Kokkos_Vectorization.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #include <impl/Kokkos_Tools.hpp>
 #include <typeinfo>

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -35,6 +35,7 @@
 #include <Kokkos_BitManipulation.hpp>
 #include <Kokkos_MinMax.hpp>
 #include <Kokkos_Vectorization.hpp>
+#include "kokkoscore_export.h"
 
 #include <impl/Kokkos_Tools.hpp>
 #include <typeinfo>

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -43,7 +43,7 @@
 
 namespace Kokkos {
 
-extern bool show_warnings() noexcept;
+KOKKOSCORE_EXPORT extern bool show_warnings() noexcept;
 
 namespace Impl {
 

--- a/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
@@ -27,8 +27,8 @@
 namespace Kokkos {
 
 namespace Impl {
-KOKKOSCORE_EXPORT Kokkos::View<uint32_t*, Kokkos::CudaSpace> cuda_global_unique_token_locks(
-    bool deallocate = false);
+KOKKOSCORE_EXPORT Kokkos::View<uint32_t*, Kokkos::CudaSpace>
+cuda_global_unique_token_locks(bool deallocate = false);
 }
 
 namespace Experimental {

--- a/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
@@ -26,7 +26,7 @@
 namespace Kokkos {
 
 namespace Impl {
-Kokkos::View<uint32_t*, Kokkos::CudaSpace> cuda_global_unique_token_locks(
+KOKKOSCORE_EXPORT Kokkos::View<uint32_t*, Kokkos::CudaSpace> cuda_global_unique_token_locks(
     bool deallocate = false);
 }
 

--- a/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
@@ -22,7 +22,7 @@
 
 #include <Cuda/Kokkos_CudaSpace.hpp>
 #include <Kokkos_UniqueToken.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 namespace Kokkos {
 

--- a/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
@@ -22,6 +22,7 @@
 
 #include <Cuda/Kokkos_CudaSpace.hpp>
 #include <Kokkos_UniqueToken.hpp>
+#include "kokkoscore_export.h"
 
 namespace Kokkos {
 

--- a/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
@@ -22,7 +22,7 @@
 
 #include <Cuda/Kokkos_CudaSpace.hpp>
 #include <Kokkos_UniqueToken.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 namespace Kokkos {
 

--- a/core/src/Kokkos_Abort.hpp
+++ b/core/src/Kokkos_Abort.hpp
@@ -19,7 +19,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Printf.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #ifdef KOKKOS_ENABLE_CUDA
 #include <Cuda/Kokkos_Cuda_abort.hpp>
 #endif

--- a/core/src/Kokkos_Abort.hpp
+++ b/core/src/Kokkos_Abort.hpp
@@ -19,6 +19,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Printf.hpp>
+#include "kokkoscore_export.h"
 #ifdef KOKKOS_ENABLE_CUDA
 #include <Cuda/Kokkos_Cuda_abort.hpp>
 #endif
@@ -32,7 +33,7 @@
 namespace Kokkos {
 namespace Impl {
 
-[[noreturn]] void host_abort(const char *const);
+[[noreturn]] KOKKOSCORE_EXPORT void host_abort(const char *const);
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
 

--- a/core/src/Kokkos_Abort.hpp
+++ b/core/src/Kokkos_Abort.hpp
@@ -19,7 +19,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Printf.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #ifdef KOKKOS_ENABLE_CUDA
 #include <Cuda/Kokkos_Cuda_abort.hpp>
 #endif

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -136,7 +136,8 @@ KOKKOSCORE_EXPORT void finalize();
  */
 KOKKOSCORE_EXPORT void push_finalize_hook(std::function<void()> f);
 
-KOKKOSCORE_EXPORT void fence(const std::string& name /*= "Kokkos::fence: Unnamed Global Fence"*/);
+KOKKOSCORE_EXPORT void fence(
+    const std::string& name /*= "Kokkos::fence: Unnamed Global Fence"*/);
 
 /** \brief Print "Bill of Materials" */
 void print_configuration(std::ostream& os, bool verbose = false);

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -63,6 +63,7 @@
 #include <Kokkos_hwloc.hpp>
 #include <Kokkos_Timer.hpp>
 #include <Kokkos_Tuners.hpp>
+#include "kokkoscore_export.h"
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 #include <Kokkos_TaskScheduler.hpp>
 #endif
@@ -79,20 +80,20 @@
 
 namespace Kokkos {
 
-void initialize(int& argc, char* argv[]);
+KOKKOSCORE_EXPORT void initialize(int& argc, char* argv[]);
 
-void initialize(
+KOKKOSCORE_EXPORT void initialize(
     InitializationSettings const& settings = InitializationSettings());
 
 namespace Impl {
 
-void pre_initialize(const InitializationSettings& settings);
+KOKKOSCORE_EXPORT void pre_initialize(const InitializationSettings& settings);
 
-void post_initialize(const InitializationSettings& settings);
+KOKKOSCORE_EXPORT void post_initialize(const InitializationSettings& settings);
 
-void pre_finalize();
+KOKKOSCORE_EXPORT void pre_finalize();
 
-void post_finalize();
+KOKKOSCORE_EXPORT void post_finalize();
 
 void declare_configuration_metadata(const std::string& category,
                                     const std::string& key,
@@ -100,18 +101,18 @@ void declare_configuration_metadata(const std::string& category,
 
 }  // namespace Impl
 
-[[nodiscard]] bool is_initialized() noexcept;
-[[nodiscard]] bool is_finalized() noexcept;
+[[nodiscard]] KOKKOSCORE_EXPORT bool is_initialized() noexcept;
+[[nodiscard]] KOKKOSCORE_EXPORT bool is_finalized() noexcept;
 
-[[nodiscard]] int device_id() noexcept;
-[[nodiscard]] int num_devices() noexcept;
-[[nodiscard]] int num_threads() noexcept;
+[[nodiscard]] KOKKOSCORE_EXPORT int device_id() noexcept;
+[[nodiscard]] KOKKOSCORE_EXPORT int num_devices() noexcept;
+[[nodiscard]] KOKKOSCORE_EXPORT int num_threads() noexcept;
 
-bool show_warnings() noexcept;
-bool tune_internals() noexcept;
+KOKKOSCORE_EXPORT bool show_warnings() noexcept;
+KOKKOSCORE_EXPORT bool tune_internals() noexcept;
 
 /** \brief  Finalize the spaces that were initialized via Kokkos::initialize */
-void finalize();
+KOKKOSCORE_EXPORT void finalize();
 
 /**
  * \brief Push a user-defined function to be called in
@@ -133,9 +134,9 @@ void finalize();
  * just like std::atexit, if any of your functions throws but does not
  * catch an exception, Kokkos::finalize will call std::terminate.
  */
-void push_finalize_hook(std::function<void()> f);
+KOKKOSCORE_EXPORT void push_finalize_hook(std::function<void()> f);
 
-void fence(const std::string& name /*= "Kokkos::fence: Unnamed Global Fence"*/);
+KOKKOSCORE_EXPORT void fence(const std::string& name /*= "Kokkos::fence: Unnamed Global Fence"*/);
 
 /** \brief Print "Bill of Materials" */
 void print_configuration(std::ostream& os, bool verbose = false);

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -63,7 +63,7 @@
 #include <Kokkos_hwloc.hpp>
 #include <Kokkos_Timer.hpp>
 #include <Kokkos_Tuners.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 #include <Kokkos_TaskScheduler.hpp>
 #endif

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -63,7 +63,7 @@
 #include <Kokkos_hwloc.hpp>
 #include <Kokkos_Timer.hpp>
 #include <Kokkos_Tuners.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 #include <Kokkos_TaskScheduler.hpp>
 #endif

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -258,7 +258,8 @@ KOKKOS_FUNCTION void runtime_check_memory_access_violation(
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-KOKKOSCORE_EXPORT void fence(const std::string &name = "Kokkos::fence: Unnamed Global Fence");
+KOKKOSCORE_EXPORT void fence(
+    const std::string &name = "Kokkos::fence: Unnamed Global Fence");
 }  // namespace Kokkos
 
 //----------------------------------------------------------------------------

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -27,7 +27,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Printf.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Utilities.hpp>
 

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -27,7 +27,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Printf.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Utilities.hpp>
 

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -27,6 +27,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Printf.hpp>
+#include "kokkoscore_export.h"
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Utilities.hpp>
 
@@ -257,7 +258,7 @@ KOKKOS_FUNCTION void runtime_check_memory_access_violation(
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-void fence(const std::string &name = "Kokkos::fence: Unnamed Global Fence");
+KOKKOSCORE_EXPORT void fence(const std::string &name = "Kokkos::fence: Unnamed Global Fence");
 }  // namespace Kokkos
 
 //----------------------------------------------------------------------------

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -543,8 +543,8 @@ inline std::enable_if_t<!std::is_integral_v<iType>, int> extract_vector_length(
 
 }  // namespace Impl
 
-Impl::PerTeamValue PerTeam(const size_t& arg);
-Impl::PerThreadValue PerThread(const size_t& arg);
+KOKKOSCORE_EXPORT Impl::PerTeamValue PerTeam(const size_t& arg);
+KOKKOSCORE_EXPORT Impl::PerThreadValue PerThread(const size_t& arg);
 
 struct ScratchRequest {
   int level;
@@ -583,7 +583,7 @@ struct ScratchRequest {
 };
 
 // Causes abnormal program termination if level is not `0` or `1`
-void team_policy_check_valid_storage_level_argument(int level);
+KOKKOSCORE_EXPORT void team_policy_check_valid_storage_level_argument(int level);
 
 /** \brief  Execution policy for parallel work over a league of teams of
  * threads.

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -29,6 +29,7 @@ static_assert(false,
 #include <Kokkos_BitManipulation.hpp>
 #include <Kokkos_Concepts.hpp>
 #include <Kokkos_TypeInfo.hpp>
+#include "kokkoscore_export.h"
 #ifndef KOKKOS_ENABLE_IMPL_TYPEINFO
 #include <typeinfo>
 #endif

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -29,7 +29,7 @@ static_assert(false,
 #include <Kokkos_BitManipulation.hpp>
 #include <Kokkos_Concepts.hpp>
 #include <Kokkos_TypeInfo.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #ifndef KOKKOS_ENABLE_IMPL_TYPEINFO
 #include <typeinfo>
 #endif

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -29,7 +29,7 @@ static_assert(false,
 #include <Kokkos_BitManipulation.hpp>
 #include <Kokkos_Concepts.hpp>
 #include <Kokkos_TypeInfo.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #ifndef KOKKOS_ENABLE_IMPL_TYPEINFO
 #include <typeinfo>
 #endif

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -584,7 +584,8 @@ struct ScratchRequest {
 };
 
 // Causes abnormal program termination if level is not `0` or `1`
-KOKKOSCORE_EXPORT void team_policy_check_valid_storage_level_argument(int level);
+KOKKOSCORE_EXPORT void team_policy_check_valid_storage_level_argument(
+    int level);
 
 /** \brief  Execution policy for parallel work over a league of teams of
  * threads.

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -30,7 +30,7 @@ static_assert(false,
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_Concepts.hpp>
 #include <Kokkos_MemoryTraits.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #include <impl/Kokkos_Traits.hpp>
 #include <impl/Kokkos_Error.hpp>

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -30,6 +30,7 @@ static_assert(false,
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_Concepts.hpp>
 #include <Kokkos_MemoryTraits.hpp>
+#include "kokkoscore_export.h"
 
 #include <impl/Kokkos_Traits.hpp>
 #include <impl/Kokkos_Error.hpp>
@@ -103,13 +104,13 @@ class HostSpace {
                  const size_t arg_logical_size = 0) const {
     return allocate(arg_label, arg_alloc_size, arg_logical_size);
   }
-  void* allocate(const size_t arg_alloc_size) const;
-  void* allocate(const char* arg_label, const size_t arg_alloc_size,
+  KOKKOSCORE_EXPORT void* allocate(const size_t arg_alloc_size) const;
+  KOKKOSCORE_EXPORT void* allocate(const char* arg_label, const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;
 
   /**\brief  Deallocate untracked memory in the space */
-  void deallocate(void* const arg_alloc_ptr, const size_t arg_alloc_size) const;
-  void deallocate(const char* arg_label, void* const arg_alloc_ptr,
+  KOKKOSCORE_EXPORT void deallocate(void* const arg_alloc_ptr, const size_t arg_alloc_size) const;
+  KOKKOSCORE_EXPORT void deallocate(const char* arg_label, void* const arg_alloc_ptr,
                   const size_t arg_alloc_size,
                   const size_t arg_logical_size = 0) const;
 

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -105,14 +105,17 @@ class HostSpace {
     return allocate(arg_label, arg_alloc_size, arg_logical_size);
   }
   KOKKOSCORE_EXPORT void* allocate(const size_t arg_alloc_size) const;
-  KOKKOSCORE_EXPORT void* allocate(const char* arg_label, const size_t arg_alloc_size,
-                 const size_t arg_logical_size = 0) const;
+  KOKKOSCORE_EXPORT void* allocate(const char* arg_label,
+                                   const size_t arg_alloc_size,
+                                   const size_t arg_logical_size = 0) const;
 
   /**\brief  Deallocate untracked memory in the space */
-  KOKKOSCORE_EXPORT void deallocate(void* const arg_alloc_ptr, const size_t arg_alloc_size) const;
-  KOKKOSCORE_EXPORT void deallocate(const char* arg_label, void* const arg_alloc_ptr,
-                  const size_t arg_alloc_size,
-                  const size_t arg_logical_size = 0) const;
+  KOKKOSCORE_EXPORT void deallocate(void* const arg_alloc_ptr,
+                                    const size_t arg_alloc_size) const;
+  KOKKOSCORE_EXPORT void deallocate(const char* arg_label,
+                                    void* const arg_alloc_ptr,
+                                    const size_t arg_alloc_size,
+                                    const size_t arg_logical_size = 0) const;
 
   void* impl_allocate(const char* arg_label, const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -30,7 +30,7 @@ static_assert(false,
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_Concepts.hpp>
 #include <Kokkos_MemoryTraits.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #include <impl/Kokkos_Traits.hpp>
 #include <impl/Kokkos_Error.hpp>

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -25,6 +25,7 @@ static_assert(false,
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_Parallel.hpp>
 #include <Kokkos_Atomic.hpp>
+#include "kokkoscore_export.h"
 #include <impl/Kokkos_ConcurrentBitset.hpp>
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>
@@ -40,7 +41,7 @@ namespace Impl {
  *   min_superblock_size  <= min_block_alloc_size *
  *                           max_block_per_superblock
  */
-void memory_pool_bounds_verification(size_t min_block_alloc_size,
+KOKKOSCORE_EXPORT void memory_pool_bounds_verification(size_t min_block_alloc_size,
                                      size_t max_block_alloc_size,
                                      size_t min_superblock_size,
                                      size_t max_superblock_size,
@@ -53,7 +54,7 @@ namespace Kokkos {
 
 namespace Impl {
 
-void _print_memory_pool_state(std::ostream &s, uint32_t const *sb_state_ptr,
+KOKKOSCORE_EXPORT void _print_memory_pool_state(std::ostream &s, uint32_t const *sb_state_ptr,
                               int32_t sb_count, uint32_t sb_size_lg2,
                               uint32_t sb_state_size, uint32_t state_shift,
                               uint32_t state_used_mask);

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -41,12 +41,10 @@ namespace Impl {
  *   min_superblock_size  <= min_block_alloc_size *
  *                           max_block_per_superblock
  */
-KOKKOSCORE_EXPORT void memory_pool_bounds_verification(size_t min_block_alloc_size,
-                                     size_t max_block_alloc_size,
-                                     size_t min_superblock_size,
-                                     size_t max_superblock_size,
-                                     size_t max_block_per_superblock,
-                                     size_t min_total_alloc_size);
+KOKKOSCORE_EXPORT void memory_pool_bounds_verification(
+    size_t min_block_alloc_size, size_t max_block_alloc_size,
+    size_t min_superblock_size, size_t max_superblock_size,
+    size_t max_block_per_superblock, size_t min_total_alloc_size);
 }  // namespace Impl
 }  // namespace Kokkos
 
@@ -54,10 +52,10 @@ namespace Kokkos {
 
 namespace Impl {
 
-KOKKOSCORE_EXPORT void _print_memory_pool_state(std::ostream &s, uint32_t const *sb_state_ptr,
-                              int32_t sb_count, uint32_t sb_size_lg2,
-                              uint32_t sb_state_size, uint32_t state_shift,
-                              uint32_t state_used_mask);
+KOKKOSCORE_EXPORT void _print_memory_pool_state(
+    std::ostream &s, uint32_t const *sb_state_ptr, int32_t sb_count,
+    uint32_t sb_size_lg2, uint32_t sb_state_size, uint32_t state_shift,
+    uint32_t state_used_mask);
 
 }  // end namespace Impl
 

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -25,7 +25,7 @@ static_assert(false,
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_Parallel.hpp>
 #include <Kokkos_Atomic.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <impl/Kokkos_ConcurrentBitset.hpp>
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -25,7 +25,7 @@ static_assert(false,
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_Parallel.hpp>
 #include <Kokkos_Atomic.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <impl/Kokkos_ConcurrentBitset.hpp>
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>

--- a/core/src/Kokkos_hwloc.hpp
+++ b/core/src/Kokkos_hwloc.hpp
@@ -43,23 +43,23 @@ namespace Kokkos {
 namespace hwloc {
 
 /** \brief  Query if hwloc is available */
-bool available();
+KOKKOSCORE_EXPORT bool available();
 
 /** \brief  Query number of available NUMA regions.
  *          This will be less than the hardware capacity
  *          if the MPI process is pinned to a NUMA region.
  */
-unsigned get_available_numa_count();
+KOKKOSCORE_EXPORT unsigned get_available_numa_count();
 
 /** \brief  Query number of available cores per NUMA regions.
  *          This will be less than the hardware capacity
  *          if the MPI process is pinned to a set of cores.
  */
-unsigned get_available_cores_per_numa();
+KOKKOSCORE_EXPORT unsigned get_available_cores_per_numa();
 
 /** \brief  Query number of available "hard" threads per core; i.e.,
  * hyperthreads */
-unsigned get_available_threads_per_core();
+KOKKOSCORE_EXPORT unsigned get_available_threads_per_core();
 
 } /* namespace hwloc */
 } /* namespace Kokkos */

--- a/core/src/Kokkos_hwloc.hpp
+++ b/core/src/Kokkos_hwloc.hpp
@@ -23,7 +23,7 @@ static_assert(false,
 #define KOKKOS_HWLOC_HPP
 
 #include <Kokkos_Macros.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #include <utility>
 

--- a/core/src/Kokkos_hwloc.hpp
+++ b/core/src/Kokkos_hwloc.hpp
@@ -23,7 +23,7 @@ static_assert(false,
 #define KOKKOS_HWLOC_HPP
 
 #include <Kokkos_Macros.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #include <utility>
 

--- a/core/src/Kokkos_hwloc.hpp
+++ b/core/src/Kokkos_hwloc.hpp
@@ -23,6 +23,7 @@ static_assert(false,
 #define KOKKOS_HWLOC_HPP
 
 #include <Kokkos_Macros.hpp>
+#include "kokkoscore_export.h"
 
 #include <utility>
 

--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -87,7 +87,7 @@ SerialInternal& SerialInternal::singleton() {
 }
 
 // Resize thread team data scratch memory
-void SerialInternal::resize_thread_team_data(size_t pool_reduce_bytes,
+KOKKOSCORE_EXPORT void SerialInternal::resize_thread_team_data(size_t pool_reduce_bytes,
                                              size_t team_reduce_bytes,
                                              size_t team_shared_bytes,
                                              size_t thread_local_bytes) {
@@ -153,11 +153,11 @@ void SerialInternal::resize_thread_team_data(size_t pool_reduce_bytes,
 }
 }  // namespace Impl
 
-Serial::Serial()
+KOKKOSCORE_EXPORT Serial::Serial()
     : m_space_instance(&Impl::SerialInternal::singleton(),
                        [](Impl::SerialInternal*) {}) {}
 
-Serial::Serial(NewInstance)
+KOKKOSCORE_EXPORT Serial::Serial(NewInstance)
     : m_space_instance(new Impl::SerialInternal, [](Impl::SerialInternal* ptr) {
         ptr->finalize();
         delete ptr;
@@ -165,7 +165,7 @@ Serial::Serial(NewInstance)
   m_space_instance->initialize();
 }
 
-void Serial::print_configuration(std::ostream& os, bool /*verbose*/) const {
+KOKKOSCORE_EXPORT void Serial::print_configuration(std::ostream& os, bool /*verbose*/) const {
   os << "Host Serial Execution Space:\n";
   os << "  KOKKOS_ENABLE_SERIAL: yes\n";
 
@@ -176,7 +176,7 @@ void Serial::print_configuration(std::ostream& os, bool /*verbose*/) const {
   os << "\nSerial Runtime Configuration:\n";
 }
 
-bool Serial::impl_is_initialized() {
+KOKKOSCORE_EXPORT bool Serial::impl_is_initialized() {
   return Impl::SerialInternal::singleton().is_initialized();
 }
 
@@ -186,7 +186,7 @@ void Serial::impl_initialize(InitializationSettings const&) {
 
 void Serial::impl_finalize() { Impl::SerialInternal::singleton().finalize(); }
 
-const char* Serial::name() { return "Serial"; }
+KOKKOSCORE_EXPORT const char* Serial::name() { return "Serial"; }
 
 namespace Impl {
 

--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
+#include "kokkoscore_export.h"
 
 #include <Serial/Kokkos_Serial.hpp>
 #include <impl/Kokkos_Traits.hpp>

--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #include <Serial/Kokkos_Serial.hpp>
 #include <impl/Kokkos_Traits.hpp>

--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -88,10 +88,9 @@ SerialInternal& SerialInternal::singleton() {
 }
 
 // Resize thread team data scratch memory
-KOKKOSCORE_EXPORT void SerialInternal::resize_thread_team_data(size_t pool_reduce_bytes,
-                                             size_t team_reduce_bytes,
-                                             size_t team_shared_bytes,
-                                             size_t thread_local_bytes) {
+KOKKOSCORE_EXPORT void SerialInternal::resize_thread_team_data(
+    size_t pool_reduce_bytes, size_t team_reduce_bytes,
+    size_t team_shared_bytes, size_t thread_local_bytes) {
   if (pool_reduce_bytes < 512) pool_reduce_bytes = 512;
   if (team_reduce_bytes < 512) team_reduce_bytes = 512;
 
@@ -166,7 +165,8 @@ KOKKOSCORE_EXPORT Serial::Serial(NewInstance)
   m_space_instance->initialize();
 }
 
-KOKKOSCORE_EXPORT void Serial::print_configuration(std::ostream& os, bool /*verbose*/) const {
+KOKKOSCORE_EXPORT void Serial::print_configuration(std::ostream& os,
+                                                   bool /*verbose*/) const {
   os << "Host Serial Execution Space:\n";
   os << "  KOKKOS_ENABLE_SERIAL: yes\n";
 

--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -181,11 +181,13 @@ KOKKOSCORE_EXPORT bool Serial::impl_is_initialized() {
   return Impl::SerialInternal::singleton().is_initialized();
 }
 
-void Serial::impl_initialize(InitializationSettings const&) {
+KOKKOSCORE_EXPORT void Serial::impl_initialize(InitializationSettings const&) {
   Impl::SerialInternal::singleton().initialize();
 }
 
-void Serial::impl_finalize() { Impl::SerialInternal::singleton().finalize(); }
+KOKKOSCORE_EXPORT void Serial::impl_finalize() {
+  Impl::SerialInternal::singleton().finalize();
+}
 
 KOKKOSCORE_EXPORT const char* Serial::name() { return "Serial"; }
 

--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #include <Serial/Kokkos_Serial.hpp>
 #include <impl/Kokkos_Traits.hpp>

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -38,7 +38,7 @@ static_assert(false,
 #include <Kokkos_HostSpace.hpp>
 #include <Kokkos_ScratchSpace.hpp>
 #include <Kokkos_MemoryTraits.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <impl/Kokkos_HostThreadTeam.hpp>
 #include <impl/Kokkos_FunctorAnalysis.hpp>
 #include <impl/Kokkos_Tools.hpp>

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -67,9 +67,9 @@ class SerialInternal {
 
   // Resize thread team data scratch memory
   KOKKOSCORE_EXPORT void resize_thread_team_data(size_t pool_reduce_bytes,
-                               size_t team_reduce_bytes,
-                               size_t team_shared_bytes,
-                               size_t thread_local_bytes);
+                                                 size_t team_reduce_bytes,
+                                                 size_t team_shared_bytes,
+                                                 size_t thread_local_bytes);
 
   HostThreadTeamData m_thread_team_data;
   bool m_is_initialized = false;
@@ -200,7 +200,8 @@ class Serial {
 #endif
 
   //! Print configuration information to the given output stream.
-  KOKKOSCORE_EXPORT void print_configuration(std::ostream& os, bool verbose = false) const;
+  KOKKOSCORE_EXPORT void print_configuration(std::ostream& os,
+                                             bool verbose = false) const;
 
   static void impl_initialize(InitializationSettings const&);
 

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -38,6 +38,7 @@ static_assert(false,
 #include <Kokkos_HostSpace.hpp>
 #include <Kokkos_ScratchSpace.hpp>
 #include <Kokkos_MemoryTraits.hpp>
+#include "kokkoscore_export.h"
 #include <impl/Kokkos_HostThreadTeam.hpp>
 #include <impl/Kokkos_FunctorAnalysis.hpp>
 #include <impl/Kokkos_Tools.hpp>

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -38,7 +38,7 @@ static_assert(false,
 #include <Kokkos_HostSpace.hpp>
 #include <Kokkos_ScratchSpace.hpp>
 #include <Kokkos_MemoryTraits.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <impl/Kokkos_HostThreadTeam.hpp>
 #include <impl/Kokkos_FunctorAnalysis.hpp>
 #include <impl/Kokkos_Tools.hpp>

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -203,12 +203,12 @@ class Serial {
   KOKKOSCORE_EXPORT void print_configuration(std::ostream& os,
                                              bool verbose = false) const;
 
-  static void impl_initialize(InitializationSettings const&);
+  KOKKOSCORE_EXPORT static void impl_initialize(InitializationSettings const&);
 
   KOKKOSCORE_EXPORT static bool impl_is_initialized();
 
   //! Free any resources being consumed by the device.
-  static void impl_finalize();
+  KOKKOSCORE_EXPORT static void impl_finalize();
 
   //--------------------------------------------------------------------------
 

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -65,7 +65,7 @@ class SerialInternal {
   static std::mutex all_instances_mutex;
 
   // Resize thread team data scratch memory
-  void resize_thread_team_data(size_t pool_reduce_bytes,
+  KOKKOSCORE_EXPORT void resize_thread_team_data(size_t pool_reduce_bytes,
                                size_t team_reduce_bytes,
                                size_t team_shared_bytes,
                                size_t thread_local_bytes);
@@ -113,9 +113,9 @@ class Serial {
 
   //@}
 
-  Serial();
+  KOKKOSCORE_EXPORT Serial();
 
-  explicit Serial(NewInstance);
+  KOKKOSCORE_EXPORT explicit Serial(NewInstance);
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   template <typename T = void>
@@ -199,11 +199,11 @@ class Serial {
 #endif
 
   //! Print configuration information to the given output stream.
-  void print_configuration(std::ostream& os, bool verbose = false) const;
+  KOKKOSCORE_EXPORT void print_configuration(std::ostream& os, bool verbose = false) const;
 
   static void impl_initialize(InitializationSettings const&);
 
-  static bool impl_is_initialized();
+  KOKKOSCORE_EXPORT static bool impl_is_initialized();
 
   //! Free any resources being consumed by the device.
   static void impl_finalize();
@@ -224,7 +224,7 @@ class Serial {
 
   uint32_t impl_instance_id() const noexcept { return 1; }
 
-  static const char* name();
+  KOKKOSCORE_EXPORT static const char* name();
 
   Impl::SerialInternal* impl_internal_space_instance() const {
     return m_space_instance.get();

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -80,8 +80,9 @@ class Threads {
   /// device have completed.
   static void impl_static_fence(const std::string& name);
 
-  KOKKOSCORE_EXPORT void fence(const std::string& name =
-                 "Kokkos::Threads::fence: Unnamed Instance Fence") const;
+  KOKKOSCORE_EXPORT void fence(
+      const std::string& name =
+          "Kokkos::Threads::fence: Unnamed Instance Fence") const;
 
   /** \brief  Return the maximum amount of concurrency.  */
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -26,7 +26,7 @@ static_assert(false,
 #if defined(KOKKOS_ENABLE_THREADS)
 
 #include <Kokkos_Core_fwd.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #include <cstddef>
 #include <iosfwd>

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -26,7 +26,7 @@ static_assert(false,
 #if defined(KOKKOS_ENABLE_THREADS)
 
 #include <Kokkos_Core_fwd.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #include <cstddef>
 #include <iosfwd>

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -26,6 +26,7 @@ static_assert(false,
 #if defined(KOKKOS_ENABLE_THREADS)
 
 #include <Kokkos_Core_fwd.hpp>
+#include "kokkoscore_export.h"
 
 #include <cstddef>
 #include <iosfwd>
@@ -79,14 +80,14 @@ class Threads {
   /// device have completed.
   static void impl_static_fence(const std::string& name);
 
-  void fence(const std::string& name =
+  KOKKOSCORE_EXPORT void fence(const std::string& name =
                  "Kokkos::Threads::fence: Unnamed Instance Fence") const;
 
   /** \brief  Return the maximum amount of concurrency.  */
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  static int concurrency();
+  KOKKOSCORE_EXPORT static int concurrency();
 #else
-  int concurrency() const;
+  KOKKOSCORE_EXPORT int concurrency() const;
 #endif
 
   /// \brief Free any resources being consumed by the device.
@@ -108,9 +109,9 @@ class Threads {
 
   //----------------------------------------
 
-  static int impl_thread_pool_size(int depth = 0);
+  KOKKOSCORE_EXPORT static int impl_thread_pool_size(int depth = 0);
 
-  static int impl_thread_pool_rank_host();
+  KOKKOSCORE_EXPORT static int impl_thread_pool_rank_host();
 
   static KOKKOS_FUNCTION int impl_thread_pool_rank() {
     KOKKOS_IF_ON_HOST((return impl_thread_pool_rank_host();))
@@ -127,7 +128,7 @@ class Threads {
 
   uint32_t impl_instance_id() const noexcept { return 1; }
 
-  static const char* name();
+  KOKKOSCORE_EXPORT static const char* name();
   //@}
   //----------------------------------------
  private:

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -20,6 +20,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
+#include "kokkoscore_export.h"
 
 #include <utility>
 #include <iostream>
@@ -197,7 +198,7 @@ ThreadsInternal::~ThreadsInternal() {
   }
 }
 
-ThreadsInternal *ThreadsInternal::get_thread(const int init_thread_rank) {
+KOKKOSCORE_EXPORT ThreadsInternal *ThreadsInternal::get_thread(const int init_thread_rank) {
   ThreadsInternal *const th =
       init_thread_rank < s_thread_pool_size[0]
           ? s_threads_exec[s_thread_pool_size[0] - (init_thread_rank + 1)]
@@ -244,7 +245,7 @@ void ThreadsInternal::verify_is_process(const std::string &name,
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-KOKKOS_DEPRECATED int ThreadsInternal::in_parallel() {
+KOKKOSCORE_EXPORT KOKKOS_DEPRECATED int ThreadsInternal::in_parallel() {
   // A thread function is in execution and
   // the function argument is not the special threads process argument and
   // the master process is a worker or is not the master process.
@@ -252,10 +253,10 @@ KOKKOS_DEPRECATED int ThreadsInternal::in_parallel() {
          (s_threads_process.m_pool_base || !is_process());
 }
 #endif
-void ThreadsInternal::fence() {
+KOKKOSCORE_EXPORT void ThreadsInternal::fence() {
   fence("Kokkos::ThreadsInternal::fence: Unnamed Instance Fence");
 }
-void ThreadsInternal::fence(const std::string &name) {
+KOKKOSCORE_EXPORT void ThreadsInternal::fence(const std::string &name) {
   Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Threads>(
       name, Kokkos::Tools::Experimental::Impl::DirectFenceIDHandle{1},
       internal_fence);
@@ -278,7 +279,7 @@ void ThreadsInternal::internal_fence() {
 }
 
 /** \brief  Begin execution of the asynchronous functor */
-void ThreadsInternal::start(void (*func)(ThreadsInternal &, const void *),
+KOKKOSCORE_EXPORT void ThreadsInternal::start(void (*func)(ThreadsInternal &, const void *),
                             const void *arg) {
   verify_is_process("ThreadsInternal::start", true);
 
@@ -354,7 +355,7 @@ void ThreadsInternal::execute_resize_scratch_in_serial() {
 
 //----------------------------------------------------------------------------
 
-void *ThreadsInternal::root_reduce_scratch() {
+KOKKOSCORE_EXPORT void *ThreadsInternal::root_reduce_scratch() {
   return s_threads_process.reduce_memory();
 }
 
@@ -381,7 +382,7 @@ void ThreadsInternal::first_touch_allocate_thread_private_scratch(
   }
 }
 
-void *ThreadsInternal::resize_scratch(size_t reduce_size, size_t thread_size) {
+KOKKOSCORE_EXPORT void *ThreadsInternal::resize_scratch(size_t reduce_size, size_t thread_size) {
   enum { ALIGN_MASK = Kokkos::Impl::MEMORY_ALIGNMENT - 1 };
 
   fence();
@@ -413,7 +414,7 @@ void *ThreadsInternal::resize_scratch(size_t reduce_size, size_t thread_size) {
 
 //----------------------------------------------------------------------------
 
-void ThreadsInternal::print_configuration(std::ostream &s, const bool detail) {
+KOKKOSCORE_EXPORT void ThreadsInternal::print_configuration(std::ostream &s, const bool detail) {
   verify_is_process("ThreadsInternal::print_configuration", false);
 
   fence();
@@ -472,9 +473,9 @@ void ThreadsInternal::print_configuration(std::ostream &s, const bool detail) {
 
 //----------------------------------------------------------------------------
 
-int ThreadsInternal::is_initialized() { return nullptr != s_threads_exec[0]; }
+KOKKOSCORE_EXPORT int ThreadsInternal::is_initialized() { return nullptr != s_threads_exec[0]; }
 
-void ThreadsInternal::initialize(int thread_count_arg) {
+KOKKOSCORE_EXPORT void ThreadsInternal::initialize(int thread_count_arg) {
   unsigned thread_count = thread_count_arg == -1 ? 0 : thread_count_arg;
 
   const bool is_initialized = 0 != s_thread_pool_size[0];
@@ -622,7 +623,7 @@ void ThreadsInternal::initialize(int thread_count_arg) {
 
 //----------------------------------------------------------------------------
 
-void ThreadsInternal::finalize() {
+KOKKOSCORE_EXPORT void ThreadsInternal::finalize() {
   verify_is_process("ThreadsInternal::finalize", false);
 
   fence();
@@ -675,12 +676,12 @@ void ThreadsInternal::finalize() {
 namespace Kokkos {
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-int Threads::concurrency() { return impl_thread_pool_size(0); }
+KOKKOSCORE_EXPORT int Threads::concurrency() { return impl_thread_pool_size(0); }
 #else
-int Threads::concurrency() const { return impl_thread_pool_size(0); }
+KOKKOSCORE_EXPORT int Threads::concurrency() const { return impl_thread_pool_size(0); }
 #endif
 
-void Threads::fence(const std::string &name) const {
+KOKKOSCORE_EXPORT void Threads::fence(const std::string &name) const {
   Impl::ThreadsInternal::fence(name);
 }
 
@@ -689,7 +690,7 @@ Threads &Threads::impl_instance(int) {
   return t;
 }
 
-int Threads::impl_thread_pool_rank_host() {
+KOKKOSCORE_EXPORT int Threads::impl_thread_pool_rank_host() {
   const std::thread::id pid = std::this_thread::get_id();
   int i                     = 0;
   while ((i < Impl::s_thread_pool_size[0]) && (pid != Impl::s_threads_pid[i])) {
@@ -698,11 +699,11 @@ int Threads::impl_thread_pool_rank_host() {
   return i;
 }
 
-int Threads::impl_thread_pool_size(int depth) {
+KOKKOSCORE_EXPORT int Threads::impl_thread_pool_size(int depth) {
   return Impl::s_thread_pool_size[depth];
 }
 
-const char *Threads::name() { return "Threads"; }
+KOKKOSCORE_EXPORT const char *Threads::name() { return "Threads"; }
 
 namespace Impl {
 

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -20,7 +20,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #include <utility>
 #include <iostream>

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -20,7 +20,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #include <utility>
 #include <iostream>

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -198,7 +198,8 @@ ThreadsInternal::~ThreadsInternal() {
   }
 }
 
-KOKKOSCORE_EXPORT ThreadsInternal *ThreadsInternal::get_thread(const int init_thread_rank) {
+KOKKOSCORE_EXPORT ThreadsInternal *ThreadsInternal::get_thread(
+    const int init_thread_rank) {
   ThreadsInternal *const th =
       init_thread_rank < s_thread_pool_size[0]
           ? s_threads_exec[s_thread_pool_size[0] - (init_thread_rank + 1)]
@@ -279,8 +280,9 @@ void ThreadsInternal::internal_fence() {
 }
 
 /** \brief  Begin execution of the asynchronous functor */
-KOKKOSCORE_EXPORT void ThreadsInternal::start(void (*func)(ThreadsInternal &, const void *),
-                            const void *arg) {
+KOKKOSCORE_EXPORT void ThreadsInternal::start(void (*func)(ThreadsInternal &,
+                                                           const void *),
+                                              const void *arg) {
   verify_is_process("ThreadsInternal::start", true);
 
   if (s_current_function || s_current_function_arg) {
@@ -382,7 +384,8 @@ void ThreadsInternal::first_touch_allocate_thread_private_scratch(
   }
 }
 
-KOKKOSCORE_EXPORT void *ThreadsInternal::resize_scratch(size_t reduce_size, size_t thread_size) {
+KOKKOSCORE_EXPORT void *ThreadsInternal::resize_scratch(size_t reduce_size,
+                                                        size_t thread_size) {
   enum { ALIGN_MASK = Kokkos::Impl::MEMORY_ALIGNMENT - 1 };
 
   fence();
@@ -414,7 +417,8 @@ KOKKOSCORE_EXPORT void *ThreadsInternal::resize_scratch(size_t reduce_size, size
 
 //----------------------------------------------------------------------------
 
-KOKKOSCORE_EXPORT void ThreadsInternal::print_configuration(std::ostream &s, const bool detail) {
+KOKKOSCORE_EXPORT void ThreadsInternal::print_configuration(std::ostream &s,
+                                                            const bool detail) {
   verify_is_process("ThreadsInternal::print_configuration", false);
 
   fence();
@@ -473,7 +477,9 @@ KOKKOSCORE_EXPORT void ThreadsInternal::print_configuration(std::ostream &s, con
 
 //----------------------------------------------------------------------------
 
-KOKKOSCORE_EXPORT int ThreadsInternal::is_initialized() { return nullptr != s_threads_exec[0]; }
+KOKKOSCORE_EXPORT int ThreadsInternal::is_initialized() {
+  return nullptr != s_threads_exec[0];
+}
 
 KOKKOSCORE_EXPORT void ThreadsInternal::initialize(int thread_count_arg) {
   unsigned thread_count = thread_count_arg == -1 ? 0 : thread_count_arg;
@@ -676,9 +682,13 @@ KOKKOSCORE_EXPORT void ThreadsInternal::finalize() {
 namespace Kokkos {
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-KOKKOSCORE_EXPORT int Threads::concurrency() { return impl_thread_pool_size(0); }
+KOKKOSCORE_EXPORT int Threads::concurrency() {
+  return impl_thread_pool_size(0);
+}
 #else
-KOKKOSCORE_EXPORT int Threads::concurrency() const { return impl_thread_pool_size(0); }
+KOKKOSCORE_EXPORT int Threads::concurrency() const {
+  return impl_thread_pool_size(0);
+}
 #endif
 
 KOKKOSCORE_EXPORT void Threads::fence(const std::string &name) const {

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -246,7 +246,7 @@ void ThreadsInternal::verify_is_process(const std::string &name,
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-KOKKOSCORE_EXPORT KOKKOS_DEPRECATED int ThreadsInternal::in_parallel() {
+KOKKOS_DEPRECATED KOKKOSCORE_EXPORT int ThreadsInternal::in_parallel() {
   // A thread function is in execution and
   // the function argument is not the special threads process argument and
   // the master process is a worker or is not the master process.

--- a/core/src/Threads/Kokkos_Threads_Instance.hpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.hpp
@@ -90,7 +90,8 @@ class ThreadsInternal {
   KOKKOS_INLINE_FUNCTION int pool_rank() const { return m_pool_rank; }
   inline long team_work_index() const { return m_team_work_index; }
 
-  KOKKOSCORE_EXPORT static ThreadsInternal *get_thread(const int init_thread_rank);
+  KOKKOSCORE_EXPORT static ThreadsInternal *get_thread(
+      const int init_thread_rank);
 
   inline void *reduce_memory() const { return m_scratch; }
   KOKKOS_INLINE_FUNCTION void *scratch_memory() const {
@@ -107,7 +108,8 @@ class ThreadsInternal {
   ~ThreadsInternal();
   ThreadsInternal();
 
-  KOKKOSCORE_EXPORT static void *resize_scratch(size_t reduce_size, size_t thread_size);
+  KOKKOSCORE_EXPORT static void *resize_scratch(size_t reduce_size,
+                                                size_t thread_size);
 
   KOKKOSCORE_EXPORT static void *root_reduce_scratch();
 
@@ -121,7 +123,8 @@ class ThreadsInternal {
 
   KOKKOSCORE_EXPORT static void finalize();
 
-  KOKKOSCORE_EXPORT static void print_configuration(std::ostream &, const bool detail = false);
+  KOKKOSCORE_EXPORT static void print_configuration(std::ostream &,
+                                                    const bool detail = false);
 
   //------------------------------------
   // All-thread functions:
@@ -401,7 +404,8 @@ class ThreadsInternal {
    *          complete and release the Threads device.
    *          Acquire the Threads device and start this functor.
    */
-  KOKKOSCORE_EXPORT static void start(void (*)(ThreadsInternal &, const void *), const void *);
+  KOKKOSCORE_EXPORT static void start(void (*)(ThreadsInternal &, const void *),
+                                      const void *);
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOSCORE_EXPORT static int in_parallel();

--- a/core/src/Threads/Kokkos_Threads_Instance.hpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_THREADS_INSTANCE_HPP
 
 #include <Kokkos_Macros.hpp>
+#include "kokkoscore_export.h"
 
 #include <cstdio>
 #include <ostream>
@@ -89,7 +90,7 @@ class ThreadsInternal {
   KOKKOS_INLINE_FUNCTION int pool_rank() const { return m_pool_rank; }
   inline long team_work_index() const { return m_team_work_index; }
 
-  static ThreadsInternal *get_thread(const int init_thread_rank);
+  KOKKOSCORE_EXPORT static ThreadsInternal *get_thread(const int init_thread_rank);
 
   inline void *reduce_memory() const { return m_scratch; }
   KOKKOS_INLINE_FUNCTION void *scratch_memory() const {
@@ -106,21 +107,21 @@ class ThreadsInternal {
   ~ThreadsInternal();
   ThreadsInternal();
 
-  static void *resize_scratch(size_t reduce_size, size_t thread_size);
+  KOKKOSCORE_EXPORT static void *resize_scratch(size_t reduce_size, size_t thread_size);
 
-  static void *root_reduce_scratch();
+  KOKKOSCORE_EXPORT static void *root_reduce_scratch();
 
   static bool is_process();
 
   static void verify_is_process(const std::string &, const bool initialized);
 
-  static int is_initialized();
+  KOKKOSCORE_EXPORT static int is_initialized();
 
-  static void initialize(int thread_count);
+  KOKKOSCORE_EXPORT static void initialize(int thread_count);
 
-  static void finalize();
+  KOKKOSCORE_EXPORT static void finalize();
 
-  static void print_configuration(std::ostream &, const bool detail = false);
+  KOKKOSCORE_EXPORT static void print_configuration(std::ostream &, const bool detail = false);
 
   //------------------------------------
   // All-thread functions:
@@ -400,13 +401,13 @@ class ThreadsInternal {
    *          complete and release the Threads device.
    *          Acquire the Threads device and start this functor.
    */
-  static void start(void (*)(ThreadsInternal &, const void *), const void *);
+  KOKKOSCORE_EXPORT static void start(void (*)(ThreadsInternal &, const void *), const void *);
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  static int in_parallel();
+  KOKKOSCORE_EXPORT static int in_parallel();
 #endif
-  static void fence();
-  static void fence(const std::string &);
+  KOKKOSCORE_EXPORT static void fence();
+  KOKKOSCORE_EXPORT static void fence(const std::string &);
   static void internal_fence();
 
   /* Dynamic Scheduling related functionality */

--- a/core/src/Threads/Kokkos_Threads_Instance.hpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.hpp
@@ -18,7 +18,7 @@
 #define KOKKOS_THREADS_INSTANCE_HPP
 
 #include <Kokkos_Macros.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #include <cstdio>
 #include <ostream>

--- a/core/src/Threads/Kokkos_Threads_Instance.hpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.hpp
@@ -18,7 +18,7 @@
 #define KOKKOS_THREADS_INSTANCE_HPP
 
 #include <Kokkos_Macros.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #include <cstdio>
 #include <ostream>

--- a/core/src/Threads/Kokkos_Threads_Spinwait.cpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
+#include "kokkoscore_export.h"
 
 #include <Kokkos_Atomic.hpp>
 #include <Threads/Kokkos_Threads_Spinwait.hpp>
@@ -108,7 +109,7 @@ void host_thread_yield(const uint32_t i, const WaitMode mode) {
 #endif /* defined( KOKKOS_ENABLE_ASM ) */
 }
 
-void spinwait_while_equal(std::atomic<ThreadState> const& flag,
+KOKKOSCORE_EXPORT void spinwait_while_equal(std::atomic<ThreadState> const& flag,
                           ThreadState const value) {
   Kokkos::store_fence();
   uint32_t i = 0;

--- a/core/src/Threads/Kokkos_Threads_Spinwait.cpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #include <Kokkos_Atomic.hpp>
 #include <Threads/Kokkos_Threads_Spinwait.hpp>

--- a/core/src/Threads/Kokkos_Threads_Spinwait.cpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #include <Kokkos_Atomic.hpp>
 #include <Threads/Kokkos_Threads_Spinwait.hpp>

--- a/core/src/Threads/Kokkos_Threads_Spinwait.cpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.cpp
@@ -109,8 +109,8 @@ void host_thread_yield(const uint32_t i, const WaitMode mode) {
 #endif /* defined( KOKKOS_ENABLE_ASM ) */
 }
 
-KOKKOSCORE_EXPORT void spinwait_while_equal(std::atomic<ThreadState> const& flag,
-                          ThreadState const value) {
+KOKKOSCORE_EXPORT void spinwait_while_equal(
+    std::atomic<ThreadState> const& flag, ThreadState const value) {
   Kokkos::store_fence();
   uint32_t i = 0;
   while (value == flag) {

--- a/core/src/Threads/Kokkos_Threads_Spinwait.hpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.hpp
@@ -17,6 +17,8 @@
 #ifndef KOKKOS_THREADS_SPINWAIT_HPP
 #define KOKKOS_THREADS_SPINWAIT_HPP
 
+#include "kokkoscore_export.h"
+
 #include <Threads/Kokkos_Threads_State.hpp>
 
 #include <cstdint>
@@ -35,7 +37,7 @@ enum class WaitMode : int {
 
 void host_thread_yield(const uint32_t i, const WaitMode mode);
 
-void spinwait_while_equal(std::atomic<ThreadState> const& flag,
+KOKKOSCORE_EXPORT void spinwait_while_equal(std::atomic<ThreadState> const& flag,
                           ThreadState const value);
 
 }  // namespace Impl

--- a/core/src/Threads/Kokkos_Threads_Spinwait.hpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.hpp
@@ -37,8 +37,8 @@ enum class WaitMode : int {
 
 void host_thread_yield(const uint32_t i, const WaitMode mode);
 
-KOKKOSCORE_EXPORT void spinwait_while_equal(std::atomic<ThreadState> const& flag,
-                          ThreadState const value);
+KOKKOSCORE_EXPORT void spinwait_while_equal(
+    std::atomic<ThreadState> const& flag, ThreadState const value);
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/Threads/Kokkos_Threads_Spinwait.hpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_THREADS_SPINWAIT_HPP
 #define KOKKOS_THREADS_SPINWAIT_HPP
 
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #include <Threads/Kokkos_Threads_State.hpp>
 

--- a/core/src/Threads/Kokkos_Threads_Spinwait.hpp
+++ b/core/src/Threads/Kokkos_Threads_Spinwait.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_THREADS_SPINWAIT_HPP
 #define KOKKOS_THREADS_SPINWAIT_HPP
 
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #include <Threads/Kokkos_Threads_State.hpp>
 

--- a/core/src/fwd/Kokkos_Fwd_CUDA.hpp
+++ b/core/src/fwd/Kokkos_Fwd_CUDA.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_CUDA_FWD_HPP_
 #define KOKKOS_CUDA_FWD_HPP_
 #if defined(KOKKOS_ENABLE_CUDA)
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 namespace Kokkos {
 

--- a/core/src/fwd/Kokkos_Fwd_CUDA.hpp
+++ b/core/src/fwd/Kokkos_Fwd_CUDA.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_CUDA_FWD_HPP_
 #define KOKKOS_CUDA_FWD_HPP_
 #if defined(KOKKOS_ENABLE_CUDA)
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 namespace Kokkos {
 

--- a/core/src/fwd/Kokkos_Fwd_CUDA.hpp
+++ b/core/src/fwd/Kokkos_Fwd_CUDA.hpp
@@ -17,6 +17,8 @@
 #ifndef KOKKOS_CUDA_FWD_HPP_
 #define KOKKOS_CUDA_FWD_HPP_
 #if defined(KOKKOS_ENABLE_CUDA)
+#include "kokkoscore_export.h"
+
 namespace Kokkos {
 
 class CudaSpace;            ///< Memory space on Cuda GPU
@@ -30,7 +32,7 @@ template <class ExecSpace>
 void cuda_prefetch_pointer(const ExecSpace& /*space*/, const void* /*ptr*/,
                            size_t /*bytes*/, bool /*to_device*/) {}
 
-void cuda_prefetch_pointer(const Cuda& space, const void* ptr, size_t bytes,
+KOKKOSCORE_EXPORT void cuda_prefetch_pointer(const Cuda& space, const void* ptr, size_t bytes,
                            bool to_device);
 
 }  // namespace Impl

--- a/core/src/fwd/Kokkos_Fwd_CUDA.hpp
+++ b/core/src/fwd/Kokkos_Fwd_CUDA.hpp
@@ -32,8 +32,8 @@ template <class ExecSpace>
 void cuda_prefetch_pointer(const ExecSpace& /*space*/, const void* /*ptr*/,
                            size_t /*bytes*/, bool /*to_device*/) {}
 
-KOKKOSCORE_EXPORT void cuda_prefetch_pointer(const Cuda& space, const void* ptr, size_t bytes,
-                           bool to_device);
+KOKKOSCORE_EXPORT void cuda_prefetch_pointer(const Cuda& space, const void* ptr,
+                                             size_t bytes, bool to_device);
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_Abort.cpp
+++ b/core/src/impl/Kokkos_Abort.cpp
@@ -21,7 +21,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <Kokkos_Abort.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <impl/Kokkos_Stacktrace.hpp>
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_Abort.cpp
+++ b/core/src/impl/Kokkos_Abort.cpp
@@ -21,7 +21,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <Kokkos_Abort.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <impl/Kokkos_Stacktrace.hpp>
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_Abort.cpp
+++ b/core/src/impl/Kokkos_Abort.cpp
@@ -21,12 +21,13 @@
 #include <cstdlib>
 #include <iostream>
 #include <Kokkos_Abort.hpp>
+#include "kokkoscore_export.h"
 #include <impl/Kokkos_Stacktrace.hpp>
 
 namespace Kokkos {
 namespace Impl {
 
-void host_abort(const char *const message) {
+KOKKOSCORE_EXPORT void host_abort(const char *const message) {
   std::cerr << message;
 
 #ifdef KOKKOS_IMPL_ENABLE_STACKTRACE

--- a/core/src/impl/Kokkos_Command_Line_Parsing.cpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.cpp
@@ -18,7 +18,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE
 #endif
 
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <impl/Kokkos_Command_Line_Parsing.hpp>
 #include <impl/Kokkos_Error.hpp>
 

--- a/core/src/impl/Kokkos_Command_Line_Parsing.cpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.cpp
@@ -18,6 +18,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE
 #endif
 
+#include "kokkoscore_export.h"
 #include <impl/Kokkos_Command_Line_Parsing.hpp>
 #include <impl/Kokkos_Error.hpp>
 

--- a/core/src/impl/Kokkos_Command_Line_Parsing.cpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.cpp
@@ -246,7 +246,7 @@ std::vector<std::regex> do_not_warn_regular_expressions{
 };
 }
 
-void Kokkos::Impl::do_not_warn_not_recognized_command_line_argument(
+KOKKOSCORE_EXPORT void Kokkos::Impl::do_not_warn_not_recognized_command_line_argument(
     std::regex ignore) {
   do_not_warn_regular_expressions.push_back(std::move(ignore));
 }

--- a/core/src/impl/Kokkos_Command_Line_Parsing.cpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.cpp
@@ -18,7 +18,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE
 #endif
 
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <impl/Kokkos_Command_Line_Parsing.hpp>
 #include <impl/Kokkos_Error.hpp>
 

--- a/core/src/impl/Kokkos_Command_Line_Parsing.cpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.cpp
@@ -247,7 +247,8 @@ std::vector<std::regex> do_not_warn_regular_expressions{
 };
 }
 
-KOKKOSCORE_EXPORT void Kokkos::Impl::do_not_warn_not_recognized_command_line_argument(
+KOKKOSCORE_EXPORT void
+Kokkos::Impl::do_not_warn_not_recognized_command_line_argument(
     std::regex ignore) {
   do_not_warn_regular_expressions.push_back(std::move(ignore));
 }

--- a/core/src/impl/Kokkos_Command_Line_Parsing.hpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_COMMAND_LINE_PARSING_HPP
 #define KOKKOS_COMMAND_LINE_PARSING_HPP
 
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <string>
 #include <regex>
 

--- a/core/src/impl/Kokkos_Command_Line_Parsing.hpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.hpp
@@ -37,7 +37,8 @@ void warn_deprecated_command_line_argument(std::string deprecated);
 void warn_deprecated_command_line_argument(std::string deprecated,
                                            std::string use_instead);
 void warn_not_recognized_command_line_argument(std::string not_recognized);
-KOKKOSCORE_EXPORT void do_not_warn_not_recognized_command_line_argument(std::regex ignore);
+KOKKOSCORE_EXPORT void do_not_warn_not_recognized_command_line_argument(
+    std::regex ignore);
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Command_Line_Parsing.hpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_COMMAND_LINE_PARSING_HPP
 #define KOKKOS_COMMAND_LINE_PARSING_HPP
 
+#include "kokkoscore_export.h"
 #include <string>
 #include <regex>
 
@@ -36,7 +37,7 @@ void warn_deprecated_command_line_argument(std::string deprecated);
 void warn_deprecated_command_line_argument(std::string deprecated,
                                            std::string use_instead);
 void warn_not_recognized_command_line_argument(std::string not_recognized);
-void do_not_warn_not_recognized_command_line_argument(std::regex ignore);
+KOKKOSCORE_EXPORT void do_not_warn_not_recognized_command_line_argument(std::regex ignore);
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Command_Line_Parsing.hpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_COMMAND_LINE_PARSING_HPP
 #define KOKKOS_COMMAND_LINE_PARSING_HPP
 
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <string>
 #include <regex>
 

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
+#include "kokkoscore_export.h"
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Command_Line_Parsing.hpp>
 #include <impl/Kokkos_ParseCommandLineArgumentsAndEnvironmentVariables.hpp>
@@ -175,7 +176,7 @@ std::vector<int> const& Kokkos::Impl::get_visible_devices() {
 }
 
 // NOLINTNEXTLINE(bugprone-exception-escape)
-[[nodiscard]] int Kokkos::device_id() noexcept {
+[[nodiscard]] KOKKOSCORE_EXPORT int Kokkos::device_id() noexcept {
 #if defined(KOKKOS_ENABLE_CUDA)
   int device = Cuda().cuda_device();
 #elif defined(KOKKOS_ENABLE_HIP)
@@ -200,7 +201,7 @@ std::vector<int> const& Kokkos::Impl::get_visible_devices() {
   return -1;
 }
 
-[[nodiscard]] int Kokkos::num_devices() noexcept {
+[[nodiscard]] KOKKOSCORE_EXPORT int Kokkos::num_devices() noexcept {
   if constexpr (std::is_same_v<DefaultExecutionSpace,
                                DefaultHostExecutionSpace>) {
     return -1;  // no GPU backend enabled
@@ -209,7 +210,7 @@ std::vector<int> const& Kokkos::Impl::get_visible_devices() {
   }
 }
 
-[[nodiscard]] int Kokkos::num_threads() noexcept {
+[[nodiscard]] KOKKOSCORE_EXPORT int Kokkos::num_threads() noexcept {
   return DefaultHostExecutionSpace().concurrency();
 }
 
@@ -252,7 +253,7 @@ void Kokkos::Impl::ExecSpaceManager::print_configuration(std::ostream& os,
   }
 }
 
-int Kokkos::Impl::get_ctest_gpu(int local_rank) {
+KOKKOSCORE_EXPORT int Kokkos::Impl::get_ctest_gpu(int local_rank) {
   auto const* ctest_kokkos_device_type =
       std::getenv("CTEST_KOKKOS_DEVICE_TYPE");
   if (!ctest_kokkos_device_type) {
@@ -341,7 +342,7 @@ int Kokkos::Impl::get_ctest_gpu(int local_rank) {
   return std::stoi(id.c_str());
 }
 
-std::vector<int> Kokkos::Impl::get_visible_devices(int device_count) {
+KOKKOSCORE_EXPORT std::vector<int> Kokkos::Impl::get_visible_devices(int device_count) {
   std::vector<int> visible_devices;
   char* env_visible_devices = std::getenv("KOKKOS_VISIBLE_DEVICES");
   if (env_visible_devices) {
@@ -853,7 +854,7 @@ Kokkos is a Linux Foundation Project.
 
 }  // namespace
 
-void Kokkos::Impl::parse_command_line_arguments(
+KOKKOSCORE_EXPORT void Kokkos::Impl::parse_command_line_arguments(
     int& argc, char* argv[], InitializationSettings& settings) {
   Tools::InitArguments tools_init_arguments;
   combine(tools_init_arguments, settings);
@@ -952,7 +953,7 @@ void Kokkos::Impl::parse_command_line_arguments(
   }
 }
 
-void Kokkos::Impl::parse_environment_variables(
+KOKKOSCORE_EXPORT void Kokkos::Impl::parse_environment_variables(
     InitializationSettings& settings) {
   Tools::InitArguments tools_init_arguments;
   combine(tools_init_arguments, settings);
@@ -1052,19 +1053,19 @@ void Kokkos::initialize(InitializationSettings const& settings) {
   initialize_internal(tmp);
 }
 
-void Kokkos::Impl::pre_initialize(const InitializationSettings& settings) {
+KOKKOSCORE_EXPORT void Kokkos::Impl::pre_initialize(const InitializationSettings& settings) {
   pre_initialize_internal(settings);
 }
 
-void Kokkos::Impl::post_initialize(const InitializationSettings& settings) {
+KOKKOSCORE_EXPORT void Kokkos::Impl::post_initialize(const InitializationSettings& settings) {
   post_initialize_internal(settings);
 }
 
-void Kokkos::Impl::pre_finalize() { pre_finalize_internal(); }
+KOKKOSCORE_EXPORT void Kokkos::Impl::pre_finalize() { pre_finalize_internal(); }
 
-void Kokkos::Impl::post_finalize() { post_finalize_internal(); }
+KOKKOSCORE_EXPORT void Kokkos::Impl::post_finalize() { post_finalize_internal(); }
 
-void Kokkos::push_finalize_hook(std::function<void()> f) {
+KOKKOSCORE_EXPORT void Kokkos::push_finalize_hook(std::function<void()> f) {
   finalize_hooks.push(f);
 }
 
@@ -1117,12 +1118,12 @@ void Kokkos::print_configuration(std::ostream& os, bool verbose) {
   Impl::ExecSpaceManager::get_instance().print_configuration(os, verbose);
 }
 
-[[nodiscard]] bool Kokkos::is_initialized() noexcept {
+[[nodiscard]] KOKKOSCORE_EXPORT bool Kokkos::is_initialized() noexcept {
   return g_is_initialized;
 }
 
-[[nodiscard]] bool Kokkos::is_finalized() noexcept { return g_is_finalized; }
+[[nodiscard]] KOKKOSCORE_EXPORT bool Kokkos::is_finalized() noexcept { return g_is_finalized; }
 
-bool Kokkos::show_warnings() noexcept { return g_show_warnings; }
+KOKKOSCORE_EXPORT bool Kokkos::show_warnings() noexcept { return g_show_warnings; }
 
-bool Kokkos::tune_internals() noexcept { return g_tune_internals; }
+KOKKOSCORE_EXPORT bool Kokkos::tune_internals() noexcept { return g_tune_internals; }

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -342,7 +342,8 @@ KOKKOSCORE_EXPORT int Kokkos::Impl::get_ctest_gpu(int local_rank) {
   return std::stoi(id.c_str());
 }
 
-KOKKOSCORE_EXPORT std::vector<int> Kokkos::Impl::get_visible_devices(int device_count) {
+KOKKOSCORE_EXPORT std::vector<int> Kokkos::Impl::get_visible_devices(
+    int device_count) {
   std::vector<int> visible_devices;
   char* env_visible_devices = std::getenv("KOKKOS_VISIBLE_DEVICES");
   if (env_visible_devices) {
@@ -1053,17 +1054,21 @@ void Kokkos::initialize(InitializationSettings const& settings) {
   initialize_internal(tmp);
 }
 
-KOKKOSCORE_EXPORT void Kokkos::Impl::pre_initialize(const InitializationSettings& settings) {
+KOKKOSCORE_EXPORT void Kokkos::Impl::pre_initialize(
+    const InitializationSettings& settings) {
   pre_initialize_internal(settings);
 }
 
-KOKKOSCORE_EXPORT void Kokkos::Impl::post_initialize(const InitializationSettings& settings) {
+KOKKOSCORE_EXPORT void Kokkos::Impl::post_initialize(
+    const InitializationSettings& settings) {
   post_initialize_internal(settings);
 }
 
 KOKKOSCORE_EXPORT void Kokkos::Impl::pre_finalize() { pre_finalize_internal(); }
 
-KOKKOSCORE_EXPORT void Kokkos::Impl::post_finalize() { post_finalize_internal(); }
+KOKKOSCORE_EXPORT void Kokkos::Impl::post_finalize() {
+  post_finalize_internal();
+}
 
 KOKKOSCORE_EXPORT void Kokkos::push_finalize_hook(std::function<void()> f) {
   finalize_hooks.push(f);
@@ -1122,8 +1127,14 @@ void Kokkos::print_configuration(std::ostream& os, bool verbose) {
   return g_is_initialized;
 }
 
-[[nodiscard]] KOKKOSCORE_EXPORT bool Kokkos::is_finalized() noexcept { return g_is_finalized; }
+[[nodiscard]] KOKKOSCORE_EXPORT bool Kokkos::is_finalized() noexcept {
+  return g_is_finalized;
+}
 
-KOKKOSCORE_EXPORT bool Kokkos::show_warnings() noexcept { return g_show_warnings; }
+KOKKOSCORE_EXPORT bool Kokkos::show_warnings() noexcept {
+  return g_show_warnings;
+}
 
-KOKKOSCORE_EXPORT bool Kokkos::tune_internals() noexcept { return g_tune_internals; }
+KOKKOSCORE_EXPORT bool Kokkos::tune_internals() noexcept {
+  return g_tune_internals;
+}

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Command_Line_Parsing.hpp>
 #include <impl/Kokkos_ParseCommandLineArgumentsAndEnvironmentVariables.hpp>

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Command_Line_Parsing.hpp>
 #include <impl/Kokkos_ParseCommandLineArgumentsAndEnvironmentVariables.hpp>

--- a/core/src/impl/Kokkos_DeviceManagement.hpp
+++ b/core/src/impl/Kokkos_DeviceManagement.hpp
@@ -27,8 +27,9 @@ namespace Impl {
 std::optional<int> get_gpu(const Kokkos::InitializationSettings& settings);
 // This declaration is provided for testing purposes only
 KOKKOSCORE_EXPORT int get_ctest_gpu(int local_rank);
-KOKKOSCORE_EXPORT std::vector<int> get_visible_devices(int device_count);  // test-only
-std::vector<int> const& get_visible_devices();           // use this instead
+KOKKOSCORE_EXPORT std::vector<int> get_visible_devices(
+    int device_count);                          // test-only
+std::vector<int> const& get_visible_devices();  // use this instead
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_DeviceManagement.hpp
+++ b/core/src/impl/Kokkos_DeviceManagement.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_DEVICE_MANAGEMENT_HPP
 #define KOKKOS_DEVICE_MANAGEMENT_HPP
 
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <optional>
 #include <vector>
 

--- a/core/src/impl/Kokkos_DeviceManagement.hpp
+++ b/core/src/impl/Kokkos_DeviceManagement.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_DEVICE_MANAGEMENT_HPP
 #define KOKKOS_DEVICE_MANAGEMENT_HPP
 
+#include "kokkoscore_export.h"
 #include <optional>
 #include <vector>
 
@@ -25,8 +26,8 @@ class InitializationSettings;
 namespace Impl {
 std::optional<int> get_gpu(const Kokkos::InitializationSettings& settings);
 // This declaration is provided for testing purposes only
-int get_ctest_gpu(int local_rank);
-std::vector<int> get_visible_devices(int device_count);  // test-only
+KOKKOSCORE_EXPORT int get_ctest_gpu(int local_rank);
+KOKKOSCORE_EXPORT std::vector<int> get_visible_devices(int device_count);  // test-only
 std::vector<int> const& get_visible_devices();           // use this instead
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_DeviceManagement.hpp
+++ b/core/src/impl/Kokkos_DeviceManagement.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_DEVICE_MANAGEMENT_HPP
 #define KOKKOS_DEVICE_MANAGEMENT_HPP
 
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <optional>
 #include <vector>
 

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -23,7 +23,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <Kokkos_Core.hpp>  // show_warnings
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <impl/Kokkos_Error.hpp>
 
 KOKKOSCORE_EXPORT void Kokkos::Impl::throw_runtime_exception(const std::string &msg) {

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -26,7 +26,8 @@
 #include "Kokkos_Core_Export.h"
 #include <impl/Kokkos_Error.hpp>
 
-KOKKOSCORE_EXPORT void Kokkos::Impl::throw_runtime_exception(const std::string &msg) {
+KOKKOSCORE_EXPORT void Kokkos::Impl::throw_runtime_exception(
+    const std::string &msg) {
   throw std::runtime_error(msg);
 }
 

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -23,9 +23,10 @@
 #include <sstream>
 #include <stdexcept>
 #include <Kokkos_Core.hpp>  // show_warnings
+#include "kokkoscore_export.h"
 #include <impl/Kokkos_Error.hpp>
 
-void Kokkos::Impl::throw_runtime_exception(const std::string &msg) {
+KOKKOSCORE_EXPORT void Kokkos::Impl::throw_runtime_exception(const std::string &msg) {
   throw std::runtime_error(msg);
 }
 
@@ -38,7 +39,7 @@ void Kokkos::Impl::throw_bad_alloc(std::string_view memory_space_name,
   throw std::runtime_error(ss.str());
 }
 
-void Kokkos::Impl::log_warning(const std::string &msg) {
+KOKKOSCORE_EXPORT void Kokkos::Impl::log_warning(const std::string &msg) {
   if (show_warnings()) {
     std::cerr << msg << std::flush;
   }

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -23,7 +23,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <Kokkos_Core.hpp>  // show_warnings
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <impl/Kokkos_Error.hpp>
 
 KOKKOSCORE_EXPORT void Kokkos::Impl::throw_runtime_exception(

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -21,7 +21,7 @@
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Abort.hpp>
 #include <Kokkos_Assert.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 namespace Kokkos::Impl {
 

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -25,7 +25,8 @@
 
 namespace Kokkos::Impl {
 
-[[noreturn]] KOKKOSCORE_EXPORT void throw_runtime_exception(const std::string &msg);
+[[noreturn]] KOKKOSCORE_EXPORT void throw_runtime_exception(
+    const std::string &msg);
 [[noreturn]] void throw_bad_alloc(std::string_view memory_space_name,
                                   std::size_t size, std::string_view label);
 KOKKOSCORE_EXPORT void log_warning(const std::string &msg);

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -21,13 +21,14 @@
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Abort.hpp>
 #include <Kokkos_Assert.hpp>
+#include "kokkoscore_export.h"
 
 namespace Kokkos::Impl {
 
-[[noreturn]] void throw_runtime_exception(const std::string &msg);
+[[noreturn]] KOKKOSCORE_EXPORT void throw_runtime_exception(const std::string &msg);
 [[noreturn]] void throw_bad_alloc(std::string_view memory_space_name,
                                   std::size_t size, std::string_view label);
-void log_warning(const std::string &msg);
+KOKKOSCORE_EXPORT void log_warning(const std::string &msg);
 
 std::string human_memory_size(size_t bytes);
 

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -21,7 +21,7 @@
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Abort.hpp>
 #include <Kokkos_Assert.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 namespace Kokkos::Impl {
 

--- a/core/src/impl/Kokkos_ExecPolicy.cpp
+++ b/core/src/impl/Kokkos_ExecPolicy.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
+#include "kokkoscore_export.h"
 #include <sstream>
 
 namespace Kokkos {
@@ -28,15 +29,15 @@ PerTeamValue::PerTeamValue(size_t arg) : value(arg) {}
 PerThreadValue::PerThreadValue(size_t arg) : value(arg) {}
 }  // namespace Impl
 
-Impl::PerTeamValue PerTeam(const size_t& arg) {
+KOKKOSCORE_EXPORT Impl::PerTeamValue PerTeam(const size_t& arg) {
   return Impl::PerTeamValue(arg);
 }
 
-Impl::PerThreadValue PerThread(const size_t& arg) {
+KOKKOSCORE_EXPORT Impl::PerThreadValue PerThread(const size_t& arg) {
   return Impl::PerThreadValue(arg);
 }
 
-void team_policy_check_valid_storage_level_argument(int level) {
+KOKKOSCORE_EXPORT void team_policy_check_valid_storage_level_argument(int level) {
   if (!(level == 0 || level == 1)) {
     std::stringstream ss;
     ss << "TeamPolicy::set_scratch_size(/*level*/ " << level

--- a/core/src/impl/Kokkos_ExecPolicy.cpp
+++ b/core/src/impl/Kokkos_ExecPolicy.cpp
@@ -37,7 +37,8 @@ KOKKOSCORE_EXPORT Impl::PerThreadValue PerThread(const size_t& arg) {
   return Impl::PerThreadValue(arg);
 }
 
-KOKKOSCORE_EXPORT void team_policy_check_valid_storage_level_argument(int level) {
+KOKKOSCORE_EXPORT void team_policy_check_valid_storage_level_argument(
+    int level) {
   if (!(level == 0 || level == 1)) {
     std::stringstream ss;
     ss << "TeamPolicy::set_scratch_size(/*level*/ " << level

--- a/core/src/impl/Kokkos_ExecPolicy.cpp
+++ b/core/src/impl/Kokkos_ExecPolicy.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <sstream>
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_ExecPolicy.cpp
+++ b/core/src/impl/Kokkos_ExecPolicy.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <sstream>
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_HostBarrier.cpp
+++ b/core/src/impl/Kokkos_HostBarrier.cpp
@@ -35,7 +35,7 @@
 namespace Kokkos {
 namespace Impl {
 
-void HostBarrier::impl_backoff_wait_until_equal(
+KOKKOSCORE_EXPORT void HostBarrier::impl_backoff_wait_until_equal(
     int* ptr, const int v, const bool active_wait) noexcept {
   unsigned count = 0u;
 

--- a/core/src/impl/Kokkos_HostBarrier.cpp
+++ b/core/src/impl/Kokkos_HostBarrier.cpp
@@ -22,7 +22,7 @@
 
 #include <impl/Kokkos_HostBarrier.hpp>
 #include <Kokkos_BitManipulation.hpp>  // bit_width
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #include <thread>
 #if defined(_WIN32)

--- a/core/src/impl/Kokkos_HostBarrier.cpp
+++ b/core/src/impl/Kokkos_HostBarrier.cpp
@@ -22,7 +22,7 @@
 
 #include <impl/Kokkos_HostBarrier.hpp>
 #include <Kokkos_BitManipulation.hpp>  // bit_width
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #include <thread>
 #if defined(_WIN32)

--- a/core/src/impl/Kokkos_HostBarrier.cpp
+++ b/core/src/impl/Kokkos_HostBarrier.cpp
@@ -22,8 +22,7 @@
 
 #include <impl/Kokkos_HostBarrier.hpp>
 #include <Kokkos_BitManipulation.hpp>  // bit_width
-
-#include <impl/Kokkos_HostBarrier.hpp>
+#include "kokkoscore_export.h"
 
 #include <thread>
 #if defined(_WIN32)

--- a/core/src/impl/Kokkos_HostBarrier.hpp
+++ b/core/src/impl/Kokkos_HostBarrier.hpp
@@ -215,8 +215,8 @@ class HostBarrier {
     }
   }
 
-  KOKKOSCORE_EXPORT static void impl_backoff_wait_until_equal(int* ptr, const int v,
-                                            const bool active_wait) noexcept;
+  KOKKOSCORE_EXPORT static void impl_backoff_wait_until_equal(
+      int* ptr, const int v, const bool active_wait) noexcept;
 
  private:
   int m_size{0};

--- a/core/src/impl/Kokkos_HostBarrier.hpp
+++ b/core/src/impl/Kokkos_HostBarrier.hpp
@@ -19,7 +19,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Atomic.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/impl/Kokkos_HostBarrier.hpp
+++ b/core/src/impl/Kokkos_HostBarrier.hpp
@@ -19,6 +19,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Atomic.hpp>
+#include "kokkoscore_export.h"
 
 namespace Kokkos {
 namespace Impl {
@@ -214,7 +215,7 @@ class HostBarrier {
     }
   }
 
-  static void impl_backoff_wait_until_equal(int* ptr, const int v,
+  KOKKOSCORE_EXPORT static void impl_backoff_wait_until_equal(int* ptr, const int v,
                                             const bool active_wait) noexcept;
 
  private:

--- a/core/src/impl/Kokkos_HostBarrier.hpp
+++ b/core/src/impl/Kokkos_HostBarrier.hpp
@@ -19,7 +19,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Atomic.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #include <Kokkos_Atomic.hpp>
 #include <Kokkos_BitManipulation.hpp>

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
+#include "kokkoscore_export.h"
 
 #include <Kokkos_Atomic.hpp>
 #include <Kokkos_BitManipulation.hpp>
@@ -45,10 +46,10 @@ KOKKOS_DEPRECATED HostSpace::HostSpace(const HostSpace::AllocationMechanism &)
     : HostSpace() {}
 #endif
 
-void *HostSpace::allocate(const size_t arg_alloc_size) const {
+KOKKOSCORE_EXPORT void *HostSpace::allocate(const size_t arg_alloc_size) const {
   return allocate("[unlabeled]", arg_alloc_size);
 }
-void *HostSpace::allocate(const char *arg_label, const size_t arg_alloc_size,
+KOKKOSCORE_EXPORT void *HostSpace::allocate(const char *arg_label, const size_t arg_alloc_size,
                           const size_t
 
                               arg_logical_size) const {
@@ -85,12 +86,12 @@ void *HostSpace::impl_allocate(
   return ptr;
 }
 
-void HostSpace::deallocate(void *const arg_alloc_ptr,
+KOKKOSCORE_EXPORT void HostSpace::deallocate(void *const arg_alloc_ptr,
                            const size_t arg_alloc_size) const {
   deallocate("[unlabeled]", arg_alloc_ptr, arg_alloc_size);
 }
 
-void HostSpace::deallocate(const char *arg_label, void *const arg_alloc_ptr,
+KOKKOSCORE_EXPORT void HostSpace::deallocate(const char *arg_label, void *const arg_alloc_ptr,
                            const size_t arg_alloc_size,
                            const size_t arg_logical_size) const {
   if (arg_alloc_ptr) Kokkos::fence("HostSpace::impl_deallocate before free");

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -49,10 +49,11 @@ KOKKOS_DEPRECATED HostSpace::HostSpace(const HostSpace::AllocationMechanism &)
 KOKKOSCORE_EXPORT void *HostSpace::allocate(const size_t arg_alloc_size) const {
   return allocate("[unlabeled]", arg_alloc_size);
 }
-KOKKOSCORE_EXPORT void *HostSpace::allocate(const char *arg_label, const size_t arg_alloc_size,
-                          const size_t
+KOKKOSCORE_EXPORT void *HostSpace::allocate(const char *arg_label,
+                                            const size_t arg_alloc_size,
+                                            const size_t
 
-                              arg_logical_size) const {
+                                                arg_logical_size) const {
   return impl_allocate(arg_label, arg_alloc_size, arg_logical_size);
 }
 void *HostSpace::impl_allocate(
@@ -86,14 +87,14 @@ void *HostSpace::impl_allocate(
   return ptr;
 }
 
-KOKKOSCORE_EXPORT void HostSpace::deallocate(void *const arg_alloc_ptr,
-                           const size_t arg_alloc_size) const {
+KOKKOSCORE_EXPORT void HostSpace::deallocate(
+    void *const arg_alloc_ptr, const size_t arg_alloc_size) const {
   deallocate("[unlabeled]", arg_alloc_ptr, arg_alloc_size);
 }
 
-KOKKOSCORE_EXPORT void HostSpace::deallocate(const char *arg_label, void *const arg_alloc_ptr,
-                           const size_t arg_alloc_size,
-                           const size_t arg_logical_size) const {
+KOKKOSCORE_EXPORT void HostSpace::deallocate(
+    const char *arg_label, void *const arg_alloc_ptr,
+    const size_t arg_alloc_size, const size_t arg_logical_size) const {
   if (arg_alloc_ptr) Kokkos::fence("HostSpace::impl_deallocate before free");
   impl_deallocate(arg_label, arg_alloc_ptr, arg_alloc_size, arg_logical_size);
 }

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #include <Kokkos_Atomic.hpp>
 #include <Kokkos_BitManipulation.hpp>

--- a/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
+++ b/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
@@ -19,23 +19,24 @@
 #endif
 
 #include "Kokkos_Core.hpp"
+#include "kokkoscore_export.h"
 #include "Kokkos_HostSpace_deepcopy.hpp"
 
 namespace Kokkos {
 
 namespace Impl {
 
-void hostspace_fence(const DefaultHostExecutionSpace& exec) {
+KOKKOSCORE_EXPORT void hostspace_fence(const DefaultHostExecutionSpace& exec) {
   exec.fence("HostSpace fence");
 }
 
-void hostspace_parallel_deepcopy(void* dst, const void* src, ptrdiff_t n) {
+KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy(void* dst, const void* src, ptrdiff_t n) {
   Kokkos::DefaultHostExecutionSpace exec;
   hostspace_parallel_deepcopy_async(exec, dst, src, n);
 }
 
 // DeepCopy called with an execution space that can't access HostSpace
-void hostspace_parallel_deepcopy_async(void* dst, const void* src,
+KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(void* dst, const void* src,
                                        ptrdiff_t n) {
   Kokkos::DefaultHostExecutionSpace exec;
   hostspace_parallel_deepcopy_async(exec, dst, src, n);
@@ -44,7 +45,7 @@ void hostspace_parallel_deepcopy_async(void* dst, const void* src,
 }
 
 template <typename ExecutionSpace>
-void hostspace_parallel_deepcopy_async(const ExecutionSpace& exec, void* dst,
+KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(const ExecutionSpace& exec, void* dst,
                                        const void* src, ptrdiff_t n) {
   using policy_t = Kokkos::RangePolicy<ExecutionSpace>;
 
@@ -191,7 +192,7 @@ template void hostspace_parallel_zeromemset<DefaultHostExecutionSpace>(
      defined(KOKKOS_ENABLE_HPX))
 // Instantiate only if both the Serial backend and some other host parallel
 // backend are enabled
-template void hostspace_parallel_deepcopy_async<Kokkos::Serial>(
+template KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async<Kokkos::Serial>(
     const Kokkos::Serial&, void*, const void*, ptrdiff_t);
 #endif
 }  // namespace Impl

--- a/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
+++ b/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
@@ -30,14 +30,16 @@ KOKKOSCORE_EXPORT void hostspace_fence(const DefaultHostExecutionSpace& exec) {
   exec.fence("HostSpace fence");
 }
 
-KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy(void* dst, const void* src, ptrdiff_t n) {
+KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy(void* dst, const void* src,
+                                                   ptrdiff_t n) {
   Kokkos::DefaultHostExecutionSpace exec;
   hostspace_parallel_deepcopy_async(exec, dst, src, n);
 }
 
 // DeepCopy called with an execution space that can't access HostSpace
-KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(void* dst, const void* src,
-                                       ptrdiff_t n) {
+KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(void* dst,
+                                                         const void* src,
+                                                         ptrdiff_t n) {
   Kokkos::DefaultHostExecutionSpace exec;
   hostspace_parallel_deepcopy_async(exec, dst, src, n);
   exec.fence(
@@ -45,8 +47,8 @@ KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(void* dst, const void* 
 }
 
 template <typename ExecutionSpace>
-KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(const ExecutionSpace& exec, void* dst,
-                                       const void* src, ptrdiff_t n) {
+KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(
+    const ExecutionSpace& exec, void* dst, const void* src, ptrdiff_t n) {
   using policy_t = Kokkos::RangePolicy<ExecutionSpace>;
 
   // If the asynchronous HPX backend is enabled, do *not* copy anything
@@ -139,8 +141,8 @@ KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(const ExecutionSpace& e
 }
 
 template <typename ExecutionSpace>
-KOKKOSCORE_EXPORT void hostspace_parallel_zeromemset(const ExecutionSpace& exec, void* dst,
-                                   size_t n) {
+KOKKOSCORE_EXPORT void hostspace_parallel_zeromemset(const ExecutionSpace& exec,
+                                                     void* dst, size_t n) {
   constexpr uint8_t z_u8 = 0x00;
   using policy_t =
       Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<size_t>>;
@@ -192,8 +194,9 @@ template void hostspace_parallel_zeromemset<DefaultHostExecutionSpace>(
      defined(KOKKOS_ENABLE_HPX))
 // Instantiate only if both the Serial backend and some other host parallel
 // backend are enabled
-template KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async<Kokkos::Serial>(
-    const Kokkos::Serial&, void*, const void*, ptrdiff_t);
+template KOKKOSCORE_EXPORT void
+hostspace_parallel_deepcopy_async<Kokkos::Serial>(const Kokkos::Serial&, void*,
+                                                  const void*, ptrdiff_t);
 #endif
 }  // namespace Impl
 

--- a/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
+++ b/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include "Kokkos_Core.hpp"
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include "Kokkos_HostSpace_deepcopy.hpp"
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
+++ b/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include "Kokkos_Core.hpp"
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include "Kokkos_HostSpace_deepcopy.hpp"
 
 namespace Kokkos {
@@ -139,7 +139,7 @@ KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(const ExecutionSpace& e
 }
 
 template <typename ExecutionSpace>
-void hostspace_parallel_zeromemset(const ExecutionSpace& exec, void* dst,
+KOKKOSCORE_EXPORT void hostspace_parallel_zeromemset(const ExecutionSpace& exec, void* dst,
                                    size_t n) {
   constexpr uint8_t z_u8 = 0x00;
   using policy_t =

--- a/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
+++ b/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
@@ -47,8 +47,8 @@ KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(void* dst,
 }
 
 template <typename ExecutionSpace>
-KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(
-    const ExecutionSpace& exec, void* dst, const void* src, ptrdiff_t n) {
+void hostspace_parallel_deepcopy_async(const ExecutionSpace& exec, void* dst,
+                                       const void* src, ptrdiff_t n) {
   using policy_t = Kokkos::RangePolicy<ExecutionSpace>;
 
   // If the asynchronous HPX backend is enabled, do *not* copy anything
@@ -141,8 +141,8 @@ KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(
 }
 
 template <typename ExecutionSpace>
-KOKKOSCORE_EXPORT void hostspace_parallel_zeromemset(const ExecutionSpace& exec,
-                                                     void* dst, size_t n) {
+void hostspace_parallel_zeromemset(const ExecutionSpace& exec, void* dst,
+                                   size_t n) {
   constexpr uint8_t z_u8 = 0x00;
   using policy_t =
       Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<size_t>>;

--- a/core/src/impl/Kokkos_HostSpace_deepcopy.hpp
+++ b/core/src/impl/Kokkos_HostSpace_deepcopy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_IMPL_HOSTSPACE_DEEPCOPY_HPP
 #define KOKKOS_IMPL_HOSTSPACE_DEEPCOPY_HPP
 
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <cstdint>
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_HostSpace_deepcopy.hpp
+++ b/core/src/impl/Kokkos_HostSpace_deepcopy.hpp
@@ -26,15 +26,18 @@ namespace Impl {
 
 KOKKOSCORE_EXPORT void hostspace_fence(const DefaultHostExecutionSpace& exec);
 
-KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy(void* dst, const void* src, ptrdiff_t n);
+KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy(void* dst, const void* src,
+                                                   ptrdiff_t n);
 // DeepCopy called with an execution space that can't access HostSpace
-KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(void* dst, const void* src, ptrdiff_t n);
+KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(void* dst,
+                                                         const void* src,
+                                                         ptrdiff_t n);
 template <typename ExecutionSpace>
-KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(const ExecutionSpace& exec, void* dst,
-                                       const void* src, ptrdiff_t n);
+KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(
+    const ExecutionSpace& exec, void* dst, const void* src, ptrdiff_t n);
 template <typename ExecutionSpace>
-KOKKOSCORE_EXPORT void hostspace_parallel_zeromemset(const ExecutionSpace& exec, void* dst,
-                                   size_t n);
+KOKKOSCORE_EXPORT void hostspace_parallel_zeromemset(const ExecutionSpace& exec,
+                                                     void* dst, size_t n);
 }  // namespace Impl
 
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_HostSpace_deepcopy.hpp
+++ b/core/src/impl/Kokkos_HostSpace_deepcopy.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_IMPL_HOSTSPACE_DEEPCOPY_HPP
 #define KOKKOS_IMPL_HOSTSPACE_DEEPCOPY_HPP
 
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <cstdint>
 
 namespace Kokkos {
@@ -33,7 +33,7 @@ template <typename ExecutionSpace>
 KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(const ExecutionSpace& exec, void* dst,
                                        const void* src, ptrdiff_t n);
 template <typename ExecutionSpace>
-void hostspace_parallel_zeromemset(const ExecutionSpace& exec, void* dst,
+KOKKOSCORE_EXPORT void hostspace_parallel_zeromemset(const ExecutionSpace& exec, void* dst,
                                    size_t n);
 }  // namespace Impl
 

--- a/core/src/impl/Kokkos_HostSpace_deepcopy.hpp
+++ b/core/src/impl/Kokkos_HostSpace_deepcopy.hpp
@@ -17,19 +17,20 @@
 #ifndef KOKKOS_IMPL_HOSTSPACE_DEEPCOPY_HPP
 #define KOKKOS_IMPL_HOSTSPACE_DEEPCOPY_HPP
 
+#include "kokkoscore_export.h"
 #include <cstdint>
 
 namespace Kokkos {
 
 namespace Impl {
 
-void hostspace_fence(const DefaultHostExecutionSpace& exec);
+KOKKOSCORE_EXPORT void hostspace_fence(const DefaultHostExecutionSpace& exec);
 
-void hostspace_parallel_deepcopy(void* dst, const void* src, ptrdiff_t n);
+KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy(void* dst, const void* src, ptrdiff_t n);
 // DeepCopy called with an execution space that can't access HostSpace
-void hostspace_parallel_deepcopy_async(void* dst, const void* src, ptrdiff_t n);
+KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(void* dst, const void* src, ptrdiff_t n);
 template <typename ExecutionSpace>
-void hostspace_parallel_deepcopy_async(const ExecutionSpace& exec, void* dst,
+KOKKOSCORE_EXPORT void hostspace_parallel_deepcopy_async(const ExecutionSpace& exec, void* dst,
                                        const void* src, ptrdiff_t n);
 template <typename ExecutionSpace>
 void hostspace_parallel_zeromemset(const ExecutionSpace& exec, void* dst,

--- a/core/src/impl/Kokkos_MemoryPool.cpp
+++ b/core/src/impl/Kokkos_MemoryPool.cpp
@@ -39,12 +39,10 @@ namespace Impl {
  *   min_superblock_size  <= min_block_alloc_size *
  *                           max_block_per_superblock
  */
-KOKKOSCORE_EXPORT void memory_pool_bounds_verification(size_t min_block_alloc_size,
-                                     size_t max_block_alloc_size,
-                                     size_t min_superblock_size,
-                                     size_t max_superblock_size,
-                                     size_t max_block_per_superblock,
-                                     size_t min_total_alloc_size) {
+KOKKOSCORE_EXPORT void memory_pool_bounds_verification(
+    size_t min_block_alloc_size, size_t max_block_alloc_size,
+    size_t min_superblock_size, size_t max_superblock_size,
+    size_t max_block_per_superblock, size_t min_total_alloc_size) {
   const size_t max_superblock = min_block_alloc_size * max_block_per_superblock;
 
   if ((size_t(max_superblock_size) < min_superblock_size) ||
@@ -87,10 +85,10 @@ KOKKOSCORE_EXPORT void memory_pool_bounds_verification(size_t min_block_alloc_si
 
 // This has way too many parameters, but it is entirely for moving the iostream
 // inclusion out of the header file with as few changes as possible
-KOKKOSCORE_EXPORT void _print_memory_pool_state(std::ostream& s, uint32_t const* sb_state_ptr,
-                              int32_t sb_count, uint32_t sb_size_lg2,
-                              uint32_t sb_state_size, uint32_t state_shift,
-                              uint32_t state_used_mask) {
+KOKKOSCORE_EXPORT void _print_memory_pool_state(
+    std::ostream& s, uint32_t const* sb_state_ptr, int32_t sb_count,
+    uint32_t sb_size_lg2, uint32_t sb_state_size, uint32_t state_shift,
+    uint32_t state_used_mask) {
   s << "pool_size(" << (size_t(sb_count) << sb_size_lg2) << ")"
     << " superblock_size(" << (1LU << sb_size_lg2) << ")" << std::endl;
 

--- a/core/src/impl/Kokkos_MemoryPool.cpp
+++ b/core/src/impl/Kokkos_MemoryPool.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <impl/Kokkos_Error.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #include <ostream>
 #include <sstream>

--- a/core/src/impl/Kokkos_MemoryPool.cpp
+++ b/core/src/impl/Kokkos_MemoryPool.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <impl/Kokkos_Error.hpp>
+#include "kokkoscore_export.h"
 
 #include <ostream>
 #include <sstream>
@@ -38,7 +39,7 @@ namespace Impl {
  *   min_superblock_size  <= min_block_alloc_size *
  *                           max_block_per_superblock
  */
-void memory_pool_bounds_verification(size_t min_block_alloc_size,
+KOKKOSCORE_EXPORT void memory_pool_bounds_verification(size_t min_block_alloc_size,
                                      size_t max_block_alloc_size,
                                      size_t min_superblock_size,
                                      size_t max_superblock_size,
@@ -86,7 +87,7 @@ void memory_pool_bounds_verification(size_t min_block_alloc_size,
 
 // This has way too many parameters, but it is entirely for moving the iostream
 // inclusion out of the header file with as few changes as possible
-void _print_memory_pool_state(std::ostream& s, uint32_t const* sb_state_ptr,
+KOKKOSCORE_EXPORT void _print_memory_pool_state(std::ostream& s, uint32_t const* sb_state_ptr,
                               int32_t sb_count, uint32_t sb_size_lg2,
                               uint32_t sb_state_size, uint32_t state_shift,
                               uint32_t state_used_mask) {

--- a/core/src/impl/Kokkos_MemoryPool.cpp
+++ b/core/src/impl/Kokkos_MemoryPool.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <impl/Kokkos_Error.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #include <ostream>
 #include <sstream>

--- a/core/src/impl/Kokkos_ParseCommandLineArgumentsAndEnvironmentVariables.hpp
+++ b/core/src/impl/Kokkos_ParseCommandLineArgumentsAndEnvironmentVariables.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_PARSE_COMMAND_LINE_ARGUMENTS_AND_ENVIRONMENT_VARIABLES_HPP
 #define KOKKOS_PARSE_COMMAND_LINE_ARGUMENTS_AND_ENVIRONMENT_VARIABLES_HPP
 
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 // These declaration are only provided for testing purposes
 namespace Kokkos {

--- a/core/src/impl/Kokkos_ParseCommandLineArgumentsAndEnvironmentVariables.hpp
+++ b/core/src/impl/Kokkos_ParseCommandLineArgumentsAndEnvironmentVariables.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_PARSE_COMMAND_LINE_ARGUMENTS_AND_ENVIRONMENT_VARIABLES_HPP
 #define KOKKOS_PARSE_COMMAND_LINE_ARGUMENTS_AND_ENVIRONMENT_VARIABLES_HPP
 
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 // These declaration are only provided for testing purposes
 namespace Kokkos {

--- a/core/src/impl/Kokkos_ParseCommandLineArgumentsAndEnvironmentVariables.hpp
+++ b/core/src/impl/Kokkos_ParseCommandLineArgumentsAndEnvironmentVariables.hpp
@@ -23,9 +23,10 @@
 namespace Kokkos {
 class InitializationSettings;
 namespace Impl {
-KOKKOSCORE_EXPORT void parse_command_line_arguments(int& argc, char* argv[],
-                                  InitializationSettings& settings);
-KOKKOSCORE_EXPORT void parse_environment_variables(InitializationSettings& settings);
+KOKKOSCORE_EXPORT void parse_command_line_arguments(
+    int& argc, char* argv[], InitializationSettings& settings);
+KOKKOSCORE_EXPORT void parse_environment_variables(
+    InitializationSettings& settings);
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_ParseCommandLineArgumentsAndEnvironmentVariables.hpp
+++ b/core/src/impl/Kokkos_ParseCommandLineArgumentsAndEnvironmentVariables.hpp
@@ -17,13 +17,15 @@
 #ifndef KOKKOS_PARSE_COMMAND_LINE_ARGUMENTS_AND_ENVIRONMENT_VARIABLES_HPP
 #define KOKKOS_PARSE_COMMAND_LINE_ARGUMENTS_AND_ENVIRONMENT_VARIABLES_HPP
 
+#include "kokkoscore_export.h"
+
 // These declaration are only provided for testing purposes
 namespace Kokkos {
 class InitializationSettings;
 namespace Impl {
-void parse_command_line_arguments(int& argc, char* argv[],
+KOKKOSCORE_EXPORT void parse_command_line_arguments(int& argc, char* argv[],
                                   InitializationSettings& settings);
-void parse_environment_variables(InitializationSettings& settings);
+KOKKOSCORE_EXPORT void parse_environment_variables(InitializationSettings& settings);
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -23,7 +23,7 @@
 #include <Kokkos_Tuners.hpp>
 #endif
 
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <impl/Kokkos_Profiling.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>
 #include <impl/Kokkos_Command_Line_Parsing.hpp>

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -23,6 +23,7 @@
 #include <Kokkos_Tuners.hpp>
 #endif
 
+#include "kokkoscore_export.h"
 #include <impl/Kokkos_Profiling.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>
 #include <impl/Kokkos_Command_Line_Parsing.hpp>
@@ -79,7 +80,7 @@ const std::string InitArguments::unset_string_option = {
     "kokkos_tools_impl_unset_option"};
 
 namespace Impl {
-void parse_command_line_arguments(int& argc, char* argv[],
+KOKKOSCORE_EXPORT void parse_command_line_arguments(int& argc, char* argv[],
                                   InitArguments& arguments) {
   int iarg = 0;
   using Kokkos::Impl::check_arg;
@@ -141,7 +142,7 @@ void parse_command_line_arguments(int& argc, char* argv[],
       args = argv[0];
   }
 }
-Kokkos::Tools::Impl::InitializationStatus parse_environment_variables(
+KOKKOSCORE_EXPORT Kokkos::Tools::Impl::InitializationStatus parse_environment_variables(
     InitArguments& arguments) {
   auto& libs               = arguments.lib;
   auto& args               = arguments.args;
@@ -295,7 +296,7 @@ inline void invoke_kokkosp_callback(
   }
 }
 }  // namespace Experimental
-bool profileLibraryLoaded() {
+KOKKOSCORE_EXPORT bool profileLibraryLoaded() {
   return Kokkos::Tools::Experimental::isProfileLibraryLoaded;
 }
 
@@ -305,7 +306,7 @@ static void updateProfileLibraryState() {
                                     Experimental::no_profiling);
 }
 
-void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
+KOKKOSCORE_EXPORT void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
                       uint64_t* kernelID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
@@ -325,7 +326,7 @@ void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
 #endif
 }
 
-void endParallelFor(const uint64_t kernelID) {
+KOKKOSCORE_EXPORT void endParallelFor(const uint64_t kernelID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
       Experimental::current_callbacks.end_parallel_for, kernelID);
@@ -336,7 +337,7 @@ void endParallelFor(const uint64_t kernelID) {
 #endif
 }
 
-void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
+KOKKOSCORE_EXPORT void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
                        uint64_t* kernelID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
@@ -356,7 +357,7 @@ void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
 #endif
 }
 
-void endParallelScan(const uint64_t kernelID) {
+KOKKOSCORE_EXPORT void endParallelScan(const uint64_t kernelID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
       Experimental::current_callbacks.end_parallel_scan, kernelID);
@@ -367,7 +368,7 @@ void endParallelScan(const uint64_t kernelID) {
 #endif
 }
 
-void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
+KOKKOSCORE_EXPORT void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
                          uint64_t* kernelID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
@@ -387,7 +388,7 @@ void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
 #endif
 }
 
-void endParallelReduce(const uint64_t kernelID) {
+KOKKOSCORE_EXPORT void endParallelReduce(const uint64_t kernelID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
       Experimental::current_callbacks.end_parallel_reduce, kernelID);
@@ -398,13 +399,13 @@ void endParallelReduce(const uint64_t kernelID) {
 #endif
 }
 
-void pushRegion(const std::string& kName) {
+KOKKOSCORE_EXPORT void pushRegion(const std::string& kName) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
       Experimental::current_callbacks.push_region, kName.c_str());
 }
 
-void popRegion() {
+KOKKOSCORE_EXPORT void popRegion() {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
       Experimental::current_callbacks.pop_region);
@@ -426,7 +427,7 @@ void deallocateData(const SpaceHandle space, const std::string& label,
       ptr, size);
 }
 
-void beginDeepCopy(const SpaceHandle dst_space, const std::string& dst_label,
+KOKKOSCORE_EXPORT void beginDeepCopy(const SpaceHandle dst_space, const std::string& dst_label,
                    const void* dst_ptr, const SpaceHandle src_space,
                    const std::string& src_label, const void* src_ptr,
                    const uint64_t size) {
@@ -451,7 +452,7 @@ void beginDeepCopy(const SpaceHandle dst_space, const std::string& dst_label,
 #endif
 }
 
-void endDeepCopy() {
+KOKKOSCORE_EXPORT void endDeepCopy() {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.end_deep_copy);
@@ -464,7 +465,7 @@ void endDeepCopy() {
 #endif
 }
 
-void beginFence(const std::string& name, const uint32_t deviceId,
+KOKKOSCORE_EXPORT void beginFence(const std::string& name, const uint32_t deviceId,
                 uint64_t* handle) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
@@ -472,38 +473,38 @@ void beginFence(const std::string& name, const uint32_t deviceId,
       handle);
 }
 
-void endFence(const uint64_t handle) {
+KOKKOSCORE_EXPORT void endFence(const uint64_t handle) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.end_fence, handle);
 }
 
-void createProfileSection(const std::string& sectionName, uint32_t* secID) {
+KOKKOSCORE_EXPORT void createProfileSection(const std::string& sectionName, uint32_t* secID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.create_profile_section,
       sectionName.c_str(), secID);
 }
 
-void startSection(const uint32_t secID) {
+KOKKOSCORE_EXPORT void startSection(const uint32_t secID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.start_profile_section, secID);
 }
 
-void stopSection(const uint32_t secID) {
+KOKKOSCORE_EXPORT void stopSection(const uint32_t secID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.stop_profile_section, secID);
 }
 
-void destroyProfileSection(const uint32_t secID) {
+KOKKOSCORE_EXPORT void destroyProfileSection(const uint32_t secID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.destroy_profile_section, secID);
 }
 
-void markEvent(const std::string& eventName) {
+KOKKOSCORE_EXPORT void markEvent(const std::string& eventName) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.profile_event, eventName.c_str());
@@ -571,7 +572,7 @@ void parseArgs(const std::string& args) {
   delete[] _argv;
 }
 
-SpaceHandle make_space_handle(const char* space_name) {
+KOKKOSCORE_EXPORT SpaceHandle make_space_handle(const char* space_name) {
   SpaceHandle handle;
   strncpy(handle.name, space_name, 63);
   return handle;
@@ -823,14 +824,14 @@ void finalize() {
 #endif
 }
 
-void syncDualView(const std::string& label, const void* const ptr,
+KOKKOSCORE_EXPORT void syncDualView(const std::string& label, const void* const ptr,
                   bool to_device) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.sync_dual_view, label.c_str(), ptr,
       to_device);
 }
-void modifyDualView(const std::string& label, const void* const ptr,
+KOKKOSCORE_EXPORT void modifyDualView(const std::string& label, const void* const ptr,
                     bool on_device) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
@@ -838,7 +839,7 @@ void modifyDualView(const std::string& label, const void* const ptr,
       on_device);
 }
 
-void declareMetadata(const std::string& key, const std::string& value) {
+KOKKOSCORE_EXPORT void declareMetadata(const std::string& key, const std::string& value) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.declare_metadata, key.c_str(),
@@ -849,11 +850,11 @@ void declareMetadata(const std::string& key, const std::string& value) {
 
 namespace Tools {
 namespace Experimental {
-void set_init_callback(initFunction callback) {
+KOKKOSCORE_EXPORT void set_init_callback(initFunction callback) {
   current_callbacks.init = callback;
   updateProfileLibraryState();
 }
-void set_finalize_callback(finalizeFunction callback) {
+KOKKOSCORE_EXPORT void set_finalize_callback(finalizeFunction callback) {
   current_callbacks.finalize = callback;
   updateProfileLibraryState();
 }
@@ -865,127 +866,127 @@ void set_print_help_callback(printHelpFunction callback) {
   current_callbacks.print_help = callback;
   updateProfileLibraryState();
 }
-void set_begin_parallel_for_callback(beginFunction callback) {
+KOKKOSCORE_EXPORT void set_begin_parallel_for_callback(beginFunction callback) {
   current_callbacks.begin_parallel_for = callback;
   updateProfileLibraryState();
 }
-void set_end_parallel_for_callback(endFunction callback) {
+KOKKOSCORE_EXPORT void set_end_parallel_for_callback(endFunction callback) {
   current_callbacks.end_parallel_for = callback;
   updateProfileLibraryState();
 }
-void set_begin_parallel_reduce_callback(beginFunction callback) {
+KOKKOSCORE_EXPORT void set_begin_parallel_reduce_callback(beginFunction callback) {
   current_callbacks.begin_parallel_reduce = callback;
   updateProfileLibraryState();
 }
-void set_end_parallel_reduce_callback(endFunction callback) {
+KOKKOSCORE_EXPORT void set_end_parallel_reduce_callback(endFunction callback) {
   current_callbacks.end_parallel_reduce = callback;
   updateProfileLibraryState();
 }
-void set_begin_parallel_scan_callback(beginFunction callback) {
+KOKKOSCORE_EXPORT void set_begin_parallel_scan_callback(beginFunction callback) {
   current_callbacks.begin_parallel_scan = callback;
   updateProfileLibraryState();
 }
-void set_end_parallel_scan_callback(endFunction callback) {
+KOKKOSCORE_EXPORT void set_end_parallel_scan_callback(endFunction callback) {
   current_callbacks.end_parallel_scan = callback;
   updateProfileLibraryState();
 }
-void set_push_region_callback(pushFunction callback) {
+KOKKOSCORE_EXPORT void set_push_region_callback(pushFunction callback) {
   current_callbacks.push_region = callback;
   updateProfileLibraryState();
 }
-void set_pop_region_callback(popFunction callback) {
+KOKKOSCORE_EXPORT void set_pop_region_callback(popFunction callback) {
   current_callbacks.pop_region = callback;
   updateProfileLibraryState();
 }
-void set_allocate_data_callback(allocateDataFunction callback) {
+KOKKOSCORE_EXPORT void set_allocate_data_callback(allocateDataFunction callback) {
   current_callbacks.allocate_data = callback;
   updateProfileLibraryState();
 }
-void set_deallocate_data_callback(deallocateDataFunction callback) {
+KOKKOSCORE_EXPORT void set_deallocate_data_callback(deallocateDataFunction callback) {
   current_callbacks.deallocate_data = callback;
   updateProfileLibraryState();
 }
-void set_create_profile_section_callback(
+KOKKOSCORE_EXPORT void set_create_profile_section_callback(
     createProfileSectionFunction callback) {
   current_callbacks.create_profile_section = callback;
   updateProfileLibraryState();
 }
-void set_start_profile_section_callback(startProfileSectionFunction callback) {
+KOKKOSCORE_EXPORT void set_start_profile_section_callback(startProfileSectionFunction callback) {
   current_callbacks.start_profile_section = callback;
   updateProfileLibraryState();
 }
-void set_stop_profile_section_callback(stopProfileSectionFunction callback) {
+KOKKOSCORE_EXPORT void set_stop_profile_section_callback(stopProfileSectionFunction callback) {
   current_callbacks.stop_profile_section = callback;
   updateProfileLibraryState();
 }
-void set_destroy_profile_section_callback(
+KOKKOSCORE_EXPORT void set_destroy_profile_section_callback(
     destroyProfileSectionFunction callback) {
   current_callbacks.destroy_profile_section = callback;
   updateProfileLibraryState();
 }
-void set_profile_event_callback(profileEventFunction callback) {
+KOKKOSCORE_EXPORT void set_profile_event_callback(profileEventFunction callback) {
   current_callbacks.profile_event = callback;
   updateProfileLibraryState();
 }
-void set_begin_deep_copy_callback(beginDeepCopyFunction callback) {
+KOKKOSCORE_EXPORT void set_begin_deep_copy_callback(beginDeepCopyFunction callback) {
   current_callbacks.begin_deep_copy = callback;
   updateProfileLibraryState();
 }
-void set_end_deep_copy_callback(endDeepCopyFunction callback) {
+KOKKOSCORE_EXPORT void set_end_deep_copy_callback(endDeepCopyFunction callback) {
   current_callbacks.end_deep_copy = callback;
   updateProfileLibraryState();
 }
-void set_begin_fence_callback(beginFenceFunction callback) {
+KOKKOSCORE_EXPORT void set_begin_fence_callback(beginFenceFunction callback) {
   current_callbacks.begin_fence = callback;
   updateProfileLibraryState();
 }
-void set_end_fence_callback(endFenceFunction callback) {
+KOKKOSCORE_EXPORT void set_end_fence_callback(endFenceFunction callback) {
   current_callbacks.end_fence = callback;
   updateProfileLibraryState();
 }
 
-void set_dual_view_sync_callback(dualViewSyncFunction callback) {
+KOKKOSCORE_EXPORT void set_dual_view_sync_callback(dualViewSyncFunction callback) {
   current_callbacks.sync_dual_view = callback;
   updateProfileLibraryState();
 }
-void set_dual_view_modify_callback(dualViewModifyFunction callback) {
+KOKKOSCORE_EXPORT void set_dual_view_modify_callback(dualViewModifyFunction callback) {
   current_callbacks.modify_dual_view = callback;
   updateProfileLibraryState();
 }
-void set_declare_metadata_callback(declareMetadataFunction callback) {
+KOKKOSCORE_EXPORT void set_declare_metadata_callback(declareMetadataFunction callback) {
   current_callbacks.declare_metadata = callback;
   updateProfileLibraryState();
 }
-void set_request_tool_settings_callback(requestToolSettingsFunction callback) {
+KOKKOSCORE_EXPORT void set_request_tool_settings_callback(requestToolSettingsFunction callback) {
   current_callbacks.request_tool_settings = callback;
   updateProfileLibraryState();
 }
-void set_provide_tool_programming_interface_callback(
+KOKKOSCORE_EXPORT void set_provide_tool_programming_interface_callback(
     provideToolProgrammingInterfaceFunction callback) {
   current_callbacks.provide_tool_programming_interface = callback;
   updateProfileLibraryState();
 }
 
-void set_declare_output_type_callback(
+KOKKOSCORE_EXPORT void set_declare_output_type_callback(
     Experimental::outputTypeDeclarationFunction callback) {
   current_callbacks.declare_output_type = callback;
   updateProfileLibraryState();
 }
-void set_declare_input_type_callback(
+KOKKOSCORE_EXPORT void set_declare_input_type_callback(
     Experimental::inputTypeDeclarationFunction callback) {
   current_callbacks.declare_input_type = callback;
   updateProfileLibraryState();
 }
-void set_request_output_values_callback(
+KOKKOSCORE_EXPORT void set_request_output_values_callback(
     Experimental::requestValueFunction callback) {
   current_callbacks.request_output_values = callback;
   updateProfileLibraryState();
 }
-void set_end_context_callback(Experimental::contextEndFunction callback) {
+KOKKOSCORE_EXPORT void set_end_context_callback(Experimental::contextEndFunction callback) {
   current_callbacks.end_tuning_context = callback;
   updateProfileLibraryState();
 }
-void set_begin_context_callback(Experimental::contextBeginFunction callback) {
+KOKKOSCORE_EXPORT void set_begin_context_callback(Experimental::contextBeginFunction callback) {
   current_callbacks.begin_tuning_context = callback;
   updateProfileLibraryState();
 }
@@ -995,7 +996,7 @@ void set_declare_optimization_goal_callback(
   updateProfileLibraryState();
 }
 
-void pause_tools() {
+KOKKOSCORE_EXPORT void pause_tools() {
   isProfileLibraryLoaded = false;
   backup_callbacks       = current_callbacks;
   current_callbacks      = no_profiling;
@@ -1006,7 +1007,7 @@ void resume_tools() {
   updateProfileLibraryState();
 }
 
-Kokkos::Tools::Experimental::EventSet get_callbacks() {
+KOKKOSCORE_EXPORT Kokkos::Tools::Experimental::EventSet get_callbacks() {
   return current_callbacks;
 }
 void set_callbacks(Kokkos::Tools::Experimental::EventSet new_events) {

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -81,7 +81,7 @@ const std::string InitArguments::unset_string_option = {
 
 namespace Impl {
 KOKKOSCORE_EXPORT void parse_command_line_arguments(int& argc, char* argv[],
-                                  InitArguments& arguments) {
+                                                    InitArguments& arguments) {
   int iarg = 0;
   using Kokkos::Impl::check_arg;
   using Kokkos::Impl::check_arg_str;
@@ -142,8 +142,8 @@ KOKKOSCORE_EXPORT void parse_command_line_arguments(int& argc, char* argv[],
       args = argv[0];
   }
 }
-KOKKOSCORE_EXPORT Kokkos::Tools::Impl::InitializationStatus parse_environment_variables(
-    InitArguments& arguments) {
+KOKKOSCORE_EXPORT Kokkos::Tools::Impl::InitializationStatus
+parse_environment_variables(InitArguments& arguments) {
   auto& libs               = arguments.lib;
   auto& args               = arguments.args;
   auto env_profile_library = std::getenv("KOKKOS_PROFILE_LIBRARY");
@@ -306,8 +306,9 @@ static void updateProfileLibraryState() {
                                     Experimental::no_profiling);
 }
 
-KOKKOSCORE_EXPORT void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
-                      uint64_t* kernelID) {
+KOKKOSCORE_EXPORT void beginParallelFor(const std::string& kernelPrefix,
+                                        const uint32_t devID,
+                                        uint64_t* kernelID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
       Experimental::current_callbacks.begin_parallel_for, kernelPrefix.c_str(),
@@ -337,8 +338,9 @@ KOKKOSCORE_EXPORT void endParallelFor(const uint64_t kernelID) {
 #endif
 }
 
-KOKKOSCORE_EXPORT void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
-                       uint64_t* kernelID) {
+KOKKOSCORE_EXPORT void beginParallelScan(const std::string& kernelPrefix,
+                                         const uint32_t devID,
+                                         uint64_t* kernelID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
       Experimental::current_callbacks.begin_parallel_scan, kernelPrefix.c_str(),
@@ -368,8 +370,9 @@ KOKKOSCORE_EXPORT void endParallelScan(const uint64_t kernelID) {
 #endif
 }
 
-KOKKOSCORE_EXPORT void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
-                         uint64_t* kernelID) {
+KOKKOSCORE_EXPORT void beginParallelReduce(const std::string& kernelPrefix,
+                                           const uint32_t devID,
+                                           uint64_t* kernelID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
       Experimental::current_callbacks.begin_parallel_reduce,
@@ -427,10 +430,12 @@ void deallocateData(const SpaceHandle space, const std::string& label,
       ptr, size);
 }
 
-KOKKOSCORE_EXPORT void beginDeepCopy(const SpaceHandle dst_space, const std::string& dst_label,
-                   const void* dst_ptr, const SpaceHandle src_space,
-                   const std::string& src_label, const void* src_ptr,
-                   const uint64_t size) {
+KOKKOSCORE_EXPORT void beginDeepCopy(const SpaceHandle dst_space,
+                                     const std::string& dst_label,
+                                     const void* dst_ptr,
+                                     const SpaceHandle src_space,
+                                     const std::string& src_label,
+                                     const void* src_ptr, const uint64_t size) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.begin_deep_copy, dst_space,
@@ -465,8 +470,8 @@ KOKKOSCORE_EXPORT void endDeepCopy() {
 #endif
 }
 
-KOKKOSCORE_EXPORT void beginFence(const std::string& name, const uint32_t deviceId,
-                uint64_t* handle) {
+KOKKOSCORE_EXPORT void beginFence(const std::string& name,
+                                  const uint32_t deviceId, uint64_t* handle) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.begin_fence, name.c_str(), deviceId,
@@ -479,7 +484,8 @@ KOKKOSCORE_EXPORT void endFence(const uint64_t handle) {
       Experimental::current_callbacks.end_fence, handle);
 }
 
-KOKKOSCORE_EXPORT void createProfileSection(const std::string& sectionName, uint32_t* secID) {
+KOKKOSCORE_EXPORT void createProfileSection(const std::string& sectionName,
+                                            uint32_t* secID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.create_profile_section,
@@ -824,22 +830,23 @@ void finalize() {
 #endif
 }
 
-KOKKOSCORE_EXPORT void syncDualView(const std::string& label, const void* const ptr,
-                  bool to_device) {
+KOKKOSCORE_EXPORT void syncDualView(const std::string& label,
+                                    const void* const ptr, bool to_device) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.sync_dual_view, label.c_str(), ptr,
       to_device);
 }
-KOKKOSCORE_EXPORT void modifyDualView(const std::string& label, const void* const ptr,
-                    bool on_device) {
+KOKKOSCORE_EXPORT void modifyDualView(const std::string& label,
+                                      const void* const ptr, bool on_device) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.modify_dual_view, label.c_str(), ptr,
       on_device);
 }
 
-KOKKOSCORE_EXPORT void declareMetadata(const std::string& key, const std::string& value) {
+KOKKOSCORE_EXPORT void declareMetadata(const std::string& key,
+                                       const std::string& value) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.declare_metadata, key.c_str(),
@@ -874,7 +881,8 @@ KOKKOSCORE_EXPORT void set_end_parallel_for_callback(endFunction callback) {
   current_callbacks.end_parallel_for = callback;
   updateProfileLibraryState();
 }
-KOKKOSCORE_EXPORT void set_begin_parallel_reduce_callback(beginFunction callback) {
+KOKKOSCORE_EXPORT void set_begin_parallel_reduce_callback(
+    beginFunction callback) {
   current_callbacks.begin_parallel_reduce = callback;
   updateProfileLibraryState();
 }
@@ -882,7 +890,8 @@ KOKKOSCORE_EXPORT void set_end_parallel_reduce_callback(endFunction callback) {
   current_callbacks.end_parallel_reduce = callback;
   updateProfileLibraryState();
 }
-KOKKOSCORE_EXPORT void set_begin_parallel_scan_callback(beginFunction callback) {
+KOKKOSCORE_EXPORT void set_begin_parallel_scan_callback(
+    beginFunction callback) {
   current_callbacks.begin_parallel_scan = callback;
   updateProfileLibraryState();
 }
@@ -898,11 +907,13 @@ KOKKOSCORE_EXPORT void set_pop_region_callback(popFunction callback) {
   current_callbacks.pop_region = callback;
   updateProfileLibraryState();
 }
-KOKKOSCORE_EXPORT void set_allocate_data_callback(allocateDataFunction callback) {
+KOKKOSCORE_EXPORT void set_allocate_data_callback(
+    allocateDataFunction callback) {
   current_callbacks.allocate_data = callback;
   updateProfileLibraryState();
 }
-KOKKOSCORE_EXPORT void set_deallocate_data_callback(deallocateDataFunction callback) {
+KOKKOSCORE_EXPORT void set_deallocate_data_callback(
+    deallocateDataFunction callback) {
   current_callbacks.deallocate_data = callback;
   updateProfileLibraryState();
 }
@@ -911,11 +922,13 @@ KOKKOSCORE_EXPORT void set_create_profile_section_callback(
   current_callbacks.create_profile_section = callback;
   updateProfileLibraryState();
 }
-KOKKOSCORE_EXPORT void set_start_profile_section_callback(startProfileSectionFunction callback) {
+KOKKOSCORE_EXPORT void set_start_profile_section_callback(
+    startProfileSectionFunction callback) {
   current_callbacks.start_profile_section = callback;
   updateProfileLibraryState();
 }
-KOKKOSCORE_EXPORT void set_stop_profile_section_callback(stopProfileSectionFunction callback) {
+KOKKOSCORE_EXPORT void set_stop_profile_section_callback(
+    stopProfileSectionFunction callback) {
   current_callbacks.stop_profile_section = callback;
   updateProfileLibraryState();
 }
@@ -924,15 +937,18 @@ KOKKOSCORE_EXPORT void set_destroy_profile_section_callback(
   current_callbacks.destroy_profile_section = callback;
   updateProfileLibraryState();
 }
-KOKKOSCORE_EXPORT void set_profile_event_callback(profileEventFunction callback) {
+KOKKOSCORE_EXPORT void set_profile_event_callback(
+    profileEventFunction callback) {
   current_callbacks.profile_event = callback;
   updateProfileLibraryState();
 }
-KOKKOSCORE_EXPORT void set_begin_deep_copy_callback(beginDeepCopyFunction callback) {
+KOKKOSCORE_EXPORT void set_begin_deep_copy_callback(
+    beginDeepCopyFunction callback) {
   current_callbacks.begin_deep_copy = callback;
   updateProfileLibraryState();
 }
-KOKKOSCORE_EXPORT void set_end_deep_copy_callback(endDeepCopyFunction callback) {
+KOKKOSCORE_EXPORT void set_end_deep_copy_callback(
+    endDeepCopyFunction callback) {
   current_callbacks.end_deep_copy = callback;
   updateProfileLibraryState();
 }
@@ -945,19 +961,23 @@ KOKKOSCORE_EXPORT void set_end_fence_callback(endFenceFunction callback) {
   updateProfileLibraryState();
 }
 
-KOKKOSCORE_EXPORT void set_dual_view_sync_callback(dualViewSyncFunction callback) {
+KOKKOSCORE_EXPORT void set_dual_view_sync_callback(
+    dualViewSyncFunction callback) {
   current_callbacks.sync_dual_view = callback;
   updateProfileLibraryState();
 }
-KOKKOSCORE_EXPORT void set_dual_view_modify_callback(dualViewModifyFunction callback) {
+KOKKOSCORE_EXPORT void set_dual_view_modify_callback(
+    dualViewModifyFunction callback) {
   current_callbacks.modify_dual_view = callback;
   updateProfileLibraryState();
 }
-KOKKOSCORE_EXPORT void set_declare_metadata_callback(declareMetadataFunction callback) {
+KOKKOSCORE_EXPORT void set_declare_metadata_callback(
+    declareMetadataFunction callback) {
   current_callbacks.declare_metadata = callback;
   updateProfileLibraryState();
 }
-KOKKOSCORE_EXPORT void set_request_tool_settings_callback(requestToolSettingsFunction callback) {
+KOKKOSCORE_EXPORT void set_request_tool_settings_callback(
+    requestToolSettingsFunction callback) {
   current_callbacks.request_tool_settings = callback;
   updateProfileLibraryState();
 }
@@ -982,11 +1002,13 @@ KOKKOSCORE_EXPORT void set_request_output_values_callback(
   current_callbacks.request_output_values = callback;
   updateProfileLibraryState();
 }
-KOKKOSCORE_EXPORT void set_end_context_callback(Experimental::contextEndFunction callback) {
+KOKKOSCORE_EXPORT void set_end_context_callback(
+    Experimental::contextEndFunction callback) {
   current_callbacks.end_tuning_context = callback;
   updateProfileLibraryState();
 }
-KOKKOSCORE_EXPORT void set_begin_context_callback(Experimental::contextBeginFunction callback) {
+KOKKOSCORE_EXPORT void set_begin_context_callback(
+    Experimental::contextBeginFunction callback) {
   current_callbacks.begin_tuning_context = callback;
   updateProfileLibraryState();
 }

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -23,7 +23,7 @@
 #include <Kokkos_Tuners.hpp>
 #endif
 
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <impl/Kokkos_Profiling.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>
 #include <impl/Kokkos_Command_Line_Parsing.hpp>

--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -70,9 +70,9 @@ InitializationStatus initialize_tools_subsystem(
     const Kokkos::Tools::InitArguments& args);
 
 KOKKOSCORE_EXPORT void parse_command_line_arguments(int& narg, char* arg[],
-                                  InitArguments& arguments);
-KOKKOSCORE_EXPORT Kokkos::Tools::Impl::InitializationStatus parse_environment_variables(
-    InitArguments& arguments);
+                                                    InitArguments& arguments);
+KOKKOSCORE_EXPORT Kokkos::Tools::Impl::InitializationStatus
+parse_environment_variables(InitArguments& arguments);
 
 template <typename PolicyType, typename Functor>
 struct ToolResponse {
@@ -83,20 +83,24 @@ struct ToolResponse {
 
 KOKKOSCORE_EXPORT bool profileLibraryLoaded();
 
-KOKKOSCORE_EXPORT void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
-                      uint64_t* kernelID);
+KOKKOSCORE_EXPORT void beginParallelFor(const std::string& kernelPrefix,
+                                        const uint32_t devID,
+                                        uint64_t* kernelID);
 KOKKOSCORE_EXPORT void endParallelFor(const uint64_t kernelID);
-KOKKOSCORE_EXPORT void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
-                       uint64_t* kernelID);
+KOKKOSCORE_EXPORT void beginParallelScan(const std::string& kernelPrefix,
+                                         const uint32_t devID,
+                                         uint64_t* kernelID);
 KOKKOSCORE_EXPORT void endParallelScan(const uint64_t kernelID);
-KOKKOSCORE_EXPORT void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
-                         uint64_t* kernelID);
+KOKKOSCORE_EXPORT void beginParallelReduce(const std::string& kernelPrefix,
+                                           const uint32_t devID,
+                                           uint64_t* kernelID);
 KOKKOSCORE_EXPORT void endParallelReduce(const uint64_t kernelID);
 
 KOKKOSCORE_EXPORT void pushRegion(const std::string& kName);
 KOKKOSCORE_EXPORT void popRegion();
 
-KOKKOSCORE_EXPORT void createProfileSection(const std::string& sectionName, uint32_t* secID);
+KOKKOSCORE_EXPORT void createProfileSection(const std::string& sectionName,
+                                            uint32_t* secID);
 KOKKOSCORE_EXPORT void startSection(const uint32_t secID);
 KOKKOSCORE_EXPORT void stopSection(const uint32_t secID);
 KOKKOSCORE_EXPORT void destroyProfileSection(const uint32_t secID);
@@ -108,13 +112,15 @@ void allocateData(const SpaceHandle space, const std::string& label,
 void deallocateData(const SpaceHandle space, const std::string& label,
                     const void* ptr, const uint64_t size);
 
-KOKKOSCORE_EXPORT void beginDeepCopy(const SpaceHandle dst_space, const std::string& dst_label,
-                   const void* dst_ptr, const SpaceHandle src_space,
-                   const std::string& src_label, const void* src_ptr,
-                   const uint64_t size);
+KOKKOSCORE_EXPORT void beginDeepCopy(const SpaceHandle dst_space,
+                                     const std::string& dst_label,
+                                     const void* dst_ptr,
+                                     const SpaceHandle src_space,
+                                     const std::string& src_label,
+                                     const void* src_ptr, const uint64_t size);
 KOKKOSCORE_EXPORT void endDeepCopy();
-KOKKOSCORE_EXPORT void beginFence(const std::string& name, const uint32_t deviceId,
-                uint64_t* handle);
+KOKKOSCORE_EXPORT void beginFence(const std::string& name,
+                                  const uint32_t deviceId, uint64_t* handle);
 KOKKOSCORE_EXPORT void endFence(const uint64_t handle);
 
 /**
@@ -128,8 +134,8 @@ KOKKOSCORE_EXPORT void endFence(const uint64_t handle);
  * to_device: true if the data is being synchronized to the device
  * 		false otherwise
  */
-KOKKOSCORE_EXPORT void syncDualView(const std::string& label, const void* const ptr,
-                  bool to_device);
+KOKKOSCORE_EXPORT void syncDualView(const std::string& label,
+                                    const void* const ptr, bool to_device);
 /**
  * modifyDualView declares to the tool that a given DualView
  * has been modified. Note: this means that somebody *called*
@@ -143,10 +149,11 @@ KOKKOSCORE_EXPORT void syncDualView(const std::string& label, const void* const 
  * on_device: true if the data is being modified on the device
  * 		false otherwise
  */
-KOKKOSCORE_EXPORT void modifyDualView(const std::string& label, const void* const ptr,
-                    bool on_device);
+KOKKOSCORE_EXPORT void modifyDualView(const std::string& label,
+                                      const void* const ptr, bool on_device);
 
-KOKKOSCORE_EXPORT void declareMetadata(const std::string& key, const std::string& value);
+KOKKOSCORE_EXPORT void declareMetadata(const std::string& key,
+                                       const std::string& value);
 void initialize(
     const std::string& = {});  // should rename to impl_initialize ASAP
 void initialize(const Kokkos::Tools::InitArguments&);
@@ -155,7 +162,8 @@ void finalize();
 bool printHelp(const std::string&);
 void parseArgs(const std::string&);
 
-KOKKOSCORE_EXPORT Kokkos_Profiling_SpaceHandle make_space_handle(const char* space_name);
+KOKKOSCORE_EXPORT Kokkos_Profiling_SpaceHandle
+make_space_handle(const char* space_name);
 
 namespace Experimental {
 
@@ -221,37 +229,53 @@ void set_parse_args_callback(parseArgsFunction callback);
 void set_print_help_callback(printHelpFunction callback);
 KOKKOSCORE_EXPORT void set_begin_parallel_for_callback(beginFunction callback);
 KOKKOSCORE_EXPORT void set_end_parallel_for_callback(endFunction callback);
-KOKKOSCORE_EXPORT void set_begin_parallel_reduce_callback(beginFunction callback);
+KOKKOSCORE_EXPORT void set_begin_parallel_reduce_callback(
+    beginFunction callback);
 KOKKOSCORE_EXPORT void set_end_parallel_reduce_callback(endFunction callback);
 KOKKOSCORE_EXPORT void set_begin_parallel_scan_callback(beginFunction callback);
 KOKKOSCORE_EXPORT void set_end_parallel_scan_callback(endFunction callback);
 KOKKOSCORE_EXPORT void set_push_region_callback(pushFunction callback);
 KOKKOSCORE_EXPORT void set_pop_region_callback(popFunction callback);
-KOKKOSCORE_EXPORT void set_allocate_data_callback(allocateDataFunction callback);
-KOKKOSCORE_EXPORT void set_deallocate_data_callback(deallocateDataFunction callback);
-KOKKOSCORE_EXPORT void set_create_profile_section_callback(createProfileSectionFunction callback);
-KOKKOSCORE_EXPORT void set_start_profile_section_callback(startProfileSectionFunction callback);
-KOKKOSCORE_EXPORT void set_stop_profile_section_callback(stopProfileSectionFunction callback);
+KOKKOSCORE_EXPORT void set_allocate_data_callback(
+    allocateDataFunction callback);
+KOKKOSCORE_EXPORT void set_deallocate_data_callback(
+    deallocateDataFunction callback);
+KOKKOSCORE_EXPORT void set_create_profile_section_callback(
+    createProfileSectionFunction callback);
+KOKKOSCORE_EXPORT void set_start_profile_section_callback(
+    startProfileSectionFunction callback);
+KOKKOSCORE_EXPORT void set_stop_profile_section_callback(
+    stopProfileSectionFunction callback);
 KOKKOSCORE_EXPORT void set_destroy_profile_section_callback(
     destroyProfileSectionFunction callback);
-KOKKOSCORE_EXPORT void set_profile_event_callback(profileEventFunction callback);
-KOKKOSCORE_EXPORT void set_begin_deep_copy_callback(beginDeepCopyFunction callback);
+KOKKOSCORE_EXPORT void set_profile_event_callback(
+    profileEventFunction callback);
+KOKKOSCORE_EXPORT void set_begin_deep_copy_callback(
+    beginDeepCopyFunction callback);
 KOKKOSCORE_EXPORT void set_end_deep_copy_callback(endDeepCopyFunction callback);
 KOKKOSCORE_EXPORT void set_begin_fence_callback(beginFenceFunction callback);
 KOKKOSCORE_EXPORT void set_end_fence_callback(endFenceFunction callback);
-KOKKOSCORE_EXPORT void set_dual_view_sync_callback(dualViewSyncFunction callback);
-KOKKOSCORE_EXPORT void set_dual_view_modify_callback(dualViewModifyFunction callback);
-KOKKOSCORE_EXPORT void set_declare_metadata_callback(declareMetadataFunction callback);
-KOKKOSCORE_EXPORT void set_request_tool_settings_callback(requestToolSettingsFunction callback);
+KOKKOSCORE_EXPORT void set_dual_view_sync_callback(
+    dualViewSyncFunction callback);
+KOKKOSCORE_EXPORT void set_dual_view_modify_callback(
+    dualViewModifyFunction callback);
+KOKKOSCORE_EXPORT void set_declare_metadata_callback(
+    declareMetadataFunction callback);
+KOKKOSCORE_EXPORT void set_request_tool_settings_callback(
+    requestToolSettingsFunction callback);
 KOKKOSCORE_EXPORT void set_provide_tool_programming_interface_callback(
     provideToolProgrammingInterfaceFunction callback);
-KOKKOSCORE_EXPORT void set_declare_output_type_callback(outputTypeDeclarationFunction callback);
-KOKKOSCORE_EXPORT void set_declare_input_type_callback(inputTypeDeclarationFunction callback);
-KOKKOSCORE_EXPORT void set_request_output_values_callback(requestValueFunction callback);
+KOKKOSCORE_EXPORT void set_declare_output_type_callback(
+    outputTypeDeclarationFunction callback);
+KOKKOSCORE_EXPORT void set_declare_input_type_callback(
+    inputTypeDeclarationFunction callback);
+KOKKOSCORE_EXPORT void set_request_output_values_callback(
+    requestValueFunction callback);
 void set_declare_optimization_goal_callback(
     optimizationGoalDeclarationFunction callback);
 KOKKOSCORE_EXPORT void set_end_context_callback(contextEndFunction callback);
-KOKKOSCORE_EXPORT void set_begin_context_callback(contextBeginFunction callback);
+KOKKOSCORE_EXPORT void set_begin_context_callback(
+    contextBeginFunction callback);
 
 KOKKOSCORE_EXPORT void pause_tools();
 void resume_tools();

--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -24,7 +24,7 @@
 
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_ExecPolicy.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Tuners.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>

--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -24,7 +24,7 @@
 
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_ExecPolicy.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Tuners.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>

--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -24,6 +24,7 @@
 
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_ExecPolicy.hpp>
+#include "kokkoscore_export.h"
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Tuners.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>
@@ -37,8 +38,8 @@
 namespace Kokkos {
 
 // forward declaration
-bool show_warnings() noexcept;
-bool tune_internals() noexcept;
+KOKKOSCORE_EXPORT bool show_warnings() noexcept;
+KOKKOSCORE_EXPORT bool tune_internals() noexcept;
 
 namespace Tools {
 
@@ -68,9 +69,9 @@ struct InitializationStatus {
 InitializationStatus initialize_tools_subsystem(
     const Kokkos::Tools::InitArguments& args);
 
-void parse_command_line_arguments(int& narg, char* arg[],
+KOKKOSCORE_EXPORT void parse_command_line_arguments(int& narg, char* arg[],
                                   InitArguments& arguments);
-Kokkos::Tools::Impl::InitializationStatus parse_environment_variables(
+KOKKOSCORE_EXPORT Kokkos::Tools::Impl::InitializationStatus parse_environment_variables(
     InitArguments& arguments);
 
 template <typename PolicyType, typename Functor>
@@ -80,41 +81,41 @@ struct ToolResponse {
 
 }  // namespace Impl
 
-bool profileLibraryLoaded();
+KOKKOSCORE_EXPORT bool profileLibraryLoaded();
 
-void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
+KOKKOSCORE_EXPORT void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
                       uint64_t* kernelID);
-void endParallelFor(const uint64_t kernelID);
-void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
+KOKKOSCORE_EXPORT void endParallelFor(const uint64_t kernelID);
+KOKKOSCORE_EXPORT void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
                        uint64_t* kernelID);
-void endParallelScan(const uint64_t kernelID);
-void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
+KOKKOSCORE_EXPORT void endParallelScan(const uint64_t kernelID);
+KOKKOSCORE_EXPORT void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
                          uint64_t* kernelID);
-void endParallelReduce(const uint64_t kernelID);
+KOKKOSCORE_EXPORT void endParallelReduce(const uint64_t kernelID);
 
-void pushRegion(const std::string& kName);
-void popRegion();
+KOKKOSCORE_EXPORT void pushRegion(const std::string& kName);
+KOKKOSCORE_EXPORT void popRegion();
 
-void createProfileSection(const std::string& sectionName, uint32_t* secID);
-void startSection(const uint32_t secID);
-void stopSection(const uint32_t secID);
-void destroyProfileSection(const uint32_t secID);
+KOKKOSCORE_EXPORT void createProfileSection(const std::string& sectionName, uint32_t* secID);
+KOKKOSCORE_EXPORT void startSection(const uint32_t secID);
+KOKKOSCORE_EXPORT void stopSection(const uint32_t secID);
+KOKKOSCORE_EXPORT void destroyProfileSection(const uint32_t secID);
 
-void markEvent(const std::string& evName);
+KOKKOSCORE_EXPORT void markEvent(const std::string& evName);
 
 void allocateData(const SpaceHandle space, const std::string& label,
                   const void* ptr, const uint64_t size);
 void deallocateData(const SpaceHandle space, const std::string& label,
                     const void* ptr, const uint64_t size);
 
-void beginDeepCopy(const SpaceHandle dst_space, const std::string& dst_label,
+KOKKOSCORE_EXPORT void beginDeepCopy(const SpaceHandle dst_space, const std::string& dst_label,
                    const void* dst_ptr, const SpaceHandle src_space,
                    const std::string& src_label, const void* src_ptr,
                    const uint64_t size);
-void endDeepCopy();
-void beginFence(const std::string& name, const uint32_t deviceId,
+KOKKOSCORE_EXPORT void endDeepCopy();
+KOKKOSCORE_EXPORT void beginFence(const std::string& name, const uint32_t deviceId,
                 uint64_t* handle);
-void endFence(const uint64_t handle);
+KOKKOSCORE_EXPORT void endFence(const uint64_t handle);
 
 /**
  * syncDualView declares to the tool that a given DualView
@@ -127,7 +128,7 @@ void endFence(const uint64_t handle);
  * to_device: true if the data is being synchronized to the device
  * 		false otherwise
  */
-void syncDualView(const std::string& label, const void* const ptr,
+KOKKOSCORE_EXPORT void syncDualView(const std::string& label, const void* const ptr,
                   bool to_device);
 /**
  * modifyDualView declares to the tool that a given DualView
@@ -142,10 +143,10 @@ void syncDualView(const std::string& label, const void* const ptr,
  * on_device: true if the data is being modified on the device
  * 		false otherwise
  */
-void modifyDualView(const std::string& label, const void* const ptr,
+KOKKOSCORE_EXPORT void modifyDualView(const std::string& label, const void* const ptr,
                     bool on_device);
 
-void declareMetadata(const std::string& key, const std::string& value);
+KOKKOSCORE_EXPORT void declareMetadata(const std::string& key, const std::string& value);
 void initialize(
     const std::string& = {});  // should rename to impl_initialize ASAP
 void initialize(const Kokkos::Tools::InitArguments&);
@@ -154,7 +155,7 @@ void finalize();
 bool printHelp(const std::string&);
 void parseArgs(const std::string&);
 
-Kokkos_Profiling_SpaceHandle make_space_handle(const char* space_name);
+KOKKOSCORE_EXPORT Kokkos_Profiling_SpaceHandle make_space_handle(const char* space_name);
 
 namespace Experimental {
 
@@ -214,48 +215,48 @@ void profile_fence_event(
   Kokkos::Tools::endFence(handle);
 }
 }  // namespace Impl
-void set_init_callback(initFunction callback);
-void set_finalize_callback(finalizeFunction callback);
+KOKKOSCORE_EXPORT void set_init_callback(initFunction callback);
+KOKKOSCORE_EXPORT void set_finalize_callback(finalizeFunction callback);
 void set_parse_args_callback(parseArgsFunction callback);
 void set_print_help_callback(printHelpFunction callback);
-void set_begin_parallel_for_callback(beginFunction callback);
-void set_end_parallel_for_callback(endFunction callback);
-void set_begin_parallel_reduce_callback(beginFunction callback);
-void set_end_parallel_reduce_callback(endFunction callback);
-void set_begin_parallel_scan_callback(beginFunction callback);
-void set_end_parallel_scan_callback(endFunction callback);
-void set_push_region_callback(pushFunction callback);
-void set_pop_region_callback(popFunction callback);
-void set_allocate_data_callback(allocateDataFunction callback);
-void set_deallocate_data_callback(deallocateDataFunction callback);
-void set_create_profile_section_callback(createProfileSectionFunction callback);
-void set_start_profile_section_callback(startProfileSectionFunction callback);
-void set_stop_profile_section_callback(stopProfileSectionFunction callback);
-void set_destroy_profile_section_callback(
+KOKKOSCORE_EXPORT void set_begin_parallel_for_callback(beginFunction callback);
+KOKKOSCORE_EXPORT void set_end_parallel_for_callback(endFunction callback);
+KOKKOSCORE_EXPORT void set_begin_parallel_reduce_callback(beginFunction callback);
+KOKKOSCORE_EXPORT void set_end_parallel_reduce_callback(endFunction callback);
+KOKKOSCORE_EXPORT void set_begin_parallel_scan_callback(beginFunction callback);
+KOKKOSCORE_EXPORT void set_end_parallel_scan_callback(endFunction callback);
+KOKKOSCORE_EXPORT void set_push_region_callback(pushFunction callback);
+KOKKOSCORE_EXPORT void set_pop_region_callback(popFunction callback);
+KOKKOSCORE_EXPORT void set_allocate_data_callback(allocateDataFunction callback);
+KOKKOSCORE_EXPORT void set_deallocate_data_callback(deallocateDataFunction callback);
+KOKKOSCORE_EXPORT void set_create_profile_section_callback(createProfileSectionFunction callback);
+KOKKOSCORE_EXPORT void set_start_profile_section_callback(startProfileSectionFunction callback);
+KOKKOSCORE_EXPORT void set_stop_profile_section_callback(stopProfileSectionFunction callback);
+KOKKOSCORE_EXPORT void set_destroy_profile_section_callback(
     destroyProfileSectionFunction callback);
-void set_profile_event_callback(profileEventFunction callback);
-void set_begin_deep_copy_callback(beginDeepCopyFunction callback);
-void set_end_deep_copy_callback(endDeepCopyFunction callback);
-void set_begin_fence_callback(beginFenceFunction callback);
-void set_end_fence_callback(endFenceFunction callback);
-void set_dual_view_sync_callback(dualViewSyncFunction callback);
-void set_dual_view_modify_callback(dualViewModifyFunction callback);
-void set_declare_metadata_callback(declareMetadataFunction callback);
-void set_request_tool_settings_callback(requestToolSettingsFunction callback);
-void set_provide_tool_programming_interface_callback(
+KOKKOSCORE_EXPORT void set_profile_event_callback(profileEventFunction callback);
+KOKKOSCORE_EXPORT void set_begin_deep_copy_callback(beginDeepCopyFunction callback);
+KOKKOSCORE_EXPORT void set_end_deep_copy_callback(endDeepCopyFunction callback);
+KOKKOSCORE_EXPORT void set_begin_fence_callback(beginFenceFunction callback);
+KOKKOSCORE_EXPORT void set_end_fence_callback(endFenceFunction callback);
+KOKKOSCORE_EXPORT void set_dual_view_sync_callback(dualViewSyncFunction callback);
+KOKKOSCORE_EXPORT void set_dual_view_modify_callback(dualViewModifyFunction callback);
+KOKKOSCORE_EXPORT void set_declare_metadata_callback(declareMetadataFunction callback);
+KOKKOSCORE_EXPORT void set_request_tool_settings_callback(requestToolSettingsFunction callback);
+KOKKOSCORE_EXPORT void set_provide_tool_programming_interface_callback(
     provideToolProgrammingInterfaceFunction callback);
-void set_declare_output_type_callback(outputTypeDeclarationFunction callback);
-void set_declare_input_type_callback(inputTypeDeclarationFunction callback);
-void set_request_output_values_callback(requestValueFunction callback);
+KOKKOSCORE_EXPORT void set_declare_output_type_callback(outputTypeDeclarationFunction callback);
+KOKKOSCORE_EXPORT void set_declare_input_type_callback(inputTypeDeclarationFunction callback);
+KOKKOSCORE_EXPORT void set_request_output_values_callback(requestValueFunction callback);
 void set_declare_optimization_goal_callback(
     optimizationGoalDeclarationFunction callback);
-void set_end_context_callback(contextEndFunction callback);
-void set_begin_context_callback(contextBeginFunction callback);
+KOKKOSCORE_EXPORT void set_end_context_callback(contextEndFunction callback);
+KOKKOSCORE_EXPORT void set_begin_context_callback(contextBeginFunction callback);
 
-void pause_tools();
+KOKKOSCORE_EXPORT void pause_tools();
 void resume_tools();
 
-EventSet get_callbacks();
+KOKKOSCORE_EXPORT EventSet get_callbacks();
 void set_callbacks(EventSet new_events);
 }  // namespace Experimental
 

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
+#include "kokkoscore_export.h"
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -27,7 +28,7 @@ namespace Kokkos {
 namespace Impl {
 
 #ifdef KOKKOS_ENABLE_DEBUG
-bool SharedAllocationRecord<void, void>::is_sane(
+KOKKOSCORE_EXPORT bool SharedAllocationRecord<void, void>::is_sane(
     SharedAllocationRecord<void, void>* arg_record) {
   SharedAllocationRecord* const root =
       arg_record ? arg_record->m_root : nullptr;
@@ -95,7 +96,7 @@ bool SharedAllocationRecord<void, void>::is_sane(
 
 #else
 
-bool SharedAllocationRecord<void, void>::is_sane(
+KOKKOSCORE_EXPORT bool SharedAllocationRecord<void, void>::is_sane(
     SharedAllocationRecord<void, void>*) {
   Kokkos::abort(
       "Kokkos::Impl::SharedAllocationRecord::is_sane only works with "
@@ -147,7 +148,7 @@ SharedAllocationRecord<void, void>* SharedAllocationRecord<void, void>::find(
 /**\brief  Construct and insert into 'arg_root' tracking set.
  *         use_count is zero.
  */
-SharedAllocationRecord<void, void>::SharedAllocationRecord(
+KOKKOSCORE_EXPORT SharedAllocationRecord<void, void>::SharedAllocationRecord(
 #ifdef KOKKOS_ENABLE_DEBUG
     SharedAllocationRecord<void, void>* arg_root,
 #endif
@@ -198,7 +199,7 @@ SharedAllocationRecord<void, void>::SharedAllocationRecord(
   }
 }
 
-void SharedAllocationRecord<void, void>::increment(
+KOKKOSCORE_EXPORT void SharedAllocationRecord<void, void>::increment(
     SharedAllocationRecord<void, void>* arg_record) {
   const int old_count = Kokkos::atomic_fetch_add(&arg_record->m_count, 1);
 
@@ -207,7 +208,7 @@ void SharedAllocationRecord<void, void>::increment(
   }
 }
 
-SharedAllocationRecord<void, void>* SharedAllocationRecord<
+KOKKOSCORE_EXPORT SharedAllocationRecord<void, void>* SharedAllocationRecord<
     void, void>::decrement(SharedAllocationRecord<void, void>* arg_record) {
   const int old_count = Kokkos::atomic_fetch_sub(&arg_record->m_count, 1);
 
@@ -320,7 +321,7 @@ void SharedAllocationRecord<void, void>::print_host_accessible_records(
 }
 #endif
 
-void fill_host_accessible_header_info(
+KOKKOSCORE_EXPORT void fill_host_accessible_header_info(
     SharedAllocationRecord<void, void>* arg_record,
     SharedAllocationHeader& arg_header, std::string const& arg_label) {
   // Fill in the Header information, directly accessible on the host

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <iomanip>
 #include <iostream>
 #include <sstream>

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include <Kokkos_Core.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <iomanip>
 #include <iostream>
 #include <sstream>

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_SHARED_ALLOC_HPP
 
 #include <Kokkos_Macros.hpp>
+#include "kokkoscore_export.h"
 #include <Kokkos_Core_fwd.hpp>
 #include <impl/Kokkos_Error.hpp>  // Impl::throw_runtime_exception
 
@@ -51,7 +52,7 @@ class SharedAllocationHeader {
   friend class SharedAllocationRecordCommon;
   template <class>
   friend class HostInaccessibleSharedAllocationRecordCommon;
-  friend void fill_host_accessible_header_info(
+  KOKKOSCORE_EXPORT friend void fill_host_accessible_header_info(
       SharedAllocationRecord<void, void>*, SharedAllocationHeader&,
       std::string const&);
 
@@ -109,7 +110,7 @@ class SharedAllocationRecord<void, void> {
   /**\brief  Construct and insert into 'arg_root' tracking set.
    *         use_count is zero.
    */
-  SharedAllocationRecord(
+  KOKKOSCORE_EXPORT SharedAllocationRecord(
 #ifdef KOKKOS_ENABLE_DEBUG
       SharedAllocationRecord* arg_root,
 #endif
@@ -119,7 +120,7 @@ class SharedAllocationRecord<void, void> {
   static inline thread_local int t_tracking_enabled = 1;
 
  public:
-  virtual std::string get_label() const { return std::string("Unmanaged"); }
+  KOKKOSCORE_EXPORT virtual std::string get_label() const { return std::string("Unmanaged"); }
 
 #if defined(__EDG__)
 #pragma push
@@ -174,11 +175,11 @@ class SharedAllocationRecord<void, void> {
   int use_count() const { return *static_cast<const volatile int*>(&m_count); }
 
   /* Increment use count */
-  static void increment(SharedAllocationRecord*);
+  KOKKOSCORE_EXPORT static void increment(SharedAllocationRecord*);
 
   /* Decrement use count. If 1->0 then remove from the tracking list and invoke
    * m_dealloc */
-  static SharedAllocationRecord* decrement(SharedAllocationRecord*);
+  KOKKOSCORE_EXPORT static SharedAllocationRecord* decrement(SharedAllocationRecord*);
 
   /* Given a root record and data pointer find the record */
   static SharedAllocationRecord* find(SharedAllocationRecord* const,
@@ -188,7 +189,7 @@ class SharedAllocationRecord<void, void> {
    * belongs. Locks the set's insert/erase operations until the sanity check is
    * complete.
    */
-  static bool is_sane(SharedAllocationRecord*);
+  KOKKOSCORE_EXPORT static bool is_sane(SharedAllocationRecord*);
 
   /*  Print host-accessible records */
   static void print_host_accessible_records(
@@ -234,7 +235,7 @@ class SharedAllocationRecordCommon : public SharedAllocationRecord<void, void> {
   static void deallocate(record_base_t* arg_rec);
 
  public:
-  ~SharedAllocationRecordCommon();
+  KOKKOSCORE_EXPORT ~SharedAllocationRecordCommon();
   template <class ExecutionSpace>
   SharedAllocationRecordCommon(
       ExecutionSpace const& exec, MemorySpace const& space,
@@ -250,19 +251,19 @@ class SharedAllocationRecordCommon : public SharedAllocationRecord<void, void> {
     auto& header = *SharedAllocationRecord<void, void>::m_alloc_ptr;
     fill_host_accessible_header_info(this, header, label);
   }
-  SharedAllocationRecordCommon(
+  KOKKOSCORE_EXPORT SharedAllocationRecordCommon(
       MemorySpace const& space, std::string const& label, std::size_t size,
       record_base_t::function_type dealloc = &deallocate);
 
-  static auto allocate(MemorySpace const& arg_space,
+  KOKKOSCORE_EXPORT static auto allocate(MemorySpace const& arg_space,
                        std::string const& arg_label, size_t arg_alloc_size)
       -> derived_t*;
   /**\brief  Allocate tracked memory in the space */
-  static void* allocate_tracked(MemorySpace const& arg_space,
+  KOKKOSCORE_EXPORT static void* allocate_tracked(MemorySpace const& arg_space,
                                 std::string const& arg_alloc_label,
                                 size_t arg_alloc_size);
   /**\brief  Deallocate tracked memory in the space */
-  static void deallocate_tracked(void* arg_alloc_ptr);
+  KOKKOSCORE_EXPORT static void deallocate_tracked(void* arg_alloc_ptr);
   /**\brief  Reallocate tracked memory in the space
    * \note The ExecutionSpace template parameter is used to force
    * templatization of the method to delay its definition. Otherwise, the
@@ -270,8 +271,8 @@ class SharedAllocationRecordCommon : public SharedAllocationRecord<void, void> {
    */
   template <class ExecutionSpace = typename MemorySpace::execution_space>
   static void* reallocate_tracked(void* arg_alloc_ptr, size_t arg_alloc_size);
-  static auto get_record(void* alloc_ptr) -> derived_t*;
-  std::string get_label() const override;
+  KOKKOSCORE_EXPORT static auto get_record(void* alloc_ptr) -> derived_t*;
+  KOKKOSCORE_EXPORT std::string get_label() const override;
   static void print_records(std::ostream& s, MemorySpace const&,
                             bool detail = false);
 };
@@ -318,7 +319,7 @@ class HostInaccessibleSharedAllocationRecordCommon
   static void deallocate(record_base_t* arg_rec);
 
  public:
-  ~HostInaccessibleSharedAllocationRecordCommon();
+  KOKKOSCORE_EXPORT ~HostInaccessibleSharedAllocationRecordCommon();
   template <class ExecutionSpace>
   HostInaccessibleSharedAllocationRecordCommon(
       ExecutionSpace const& exec, MemorySpace const& space,
@@ -339,19 +340,19 @@ class HostInaccessibleSharedAllocationRecordCommon
         exec, SharedAllocationRecord<void, void>::m_alloc_ptr, &header,
         sizeof(SharedAllocationHeader));
   }
-  HostInaccessibleSharedAllocationRecordCommon(
+  KOKKOSCORE_EXPORT HostInaccessibleSharedAllocationRecordCommon(
       MemorySpace const& space, std::string const& label, std::size_t size,
       record_base_t::function_type dealloc = &deallocate);
 
-  static auto allocate(MemorySpace const& arg_space,
+  KOKKOSCORE_EXPORT static auto allocate(MemorySpace const& arg_space,
                        std::string const& arg_label, size_t arg_alloc_size)
       -> derived_t*;
   /**\brief  Allocate tracked memory in the space */
-  static void* allocate_tracked(MemorySpace const& arg_space,
+  KOKKOSCORE_EXPORT static void* allocate_tracked(MemorySpace const& arg_space,
                                 std::string const& arg_alloc_label,
                                 size_t arg_alloc_size);
   /**\brief  Deallocate tracked memory in the space */
-  static void deallocate_tracked(void* arg_alloc_ptr);
+  KOKKOSCORE_EXPORT static void deallocate_tracked(void* arg_alloc_ptr);
   /**\brief  Reallocate tracked memory in the space
    * \note The ExecutionSpace template parameter is used to force
    * templatization of the method to delay its definition. Otherwise, the
@@ -368,8 +369,8 @@ class HostInaccessibleSharedAllocationRecordCommon
   template <class ExecutionSpace = Kokkos::DefaultHostExecutionSpace>
   static void print_records(std::ostream& s, MemorySpace const&,
                             bool detail = false);
-  static auto get_record(void* alloc_ptr) -> derived_t*;
-  std::string get_label() const override;
+  KOKKOSCORE_EXPORT static auto get_record(void* alloc_ptr) -> derived_t*;
+  KOKKOSCORE_EXPORT std::string get_label() const override;
 };
 
 /**
@@ -481,7 +482,7 @@ class SharedAllocationRecord
             &Kokkos::Impl::deallocate<MemorySpace, DestroyFunctor>),
         m_destroy() {}
 
-  SharedAllocationRecord()                                         = delete;
+  KOKKOSCORE_EXPORT SharedAllocationRecord()                       = delete;
   SharedAllocationRecord(const SharedAllocationRecord&)            = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;
 

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -120,7 +120,9 @@ class SharedAllocationRecord<void, void> {
   static inline thread_local int t_tracking_enabled = 1;
 
  public:
-  KOKKOSCORE_EXPORT virtual std::string get_label() const { return std::string("Unmanaged"); }
+  KOKKOSCORE_EXPORT virtual std::string get_label() const {
+    return std::string("Unmanaged");
+  }
 
 #if defined(__EDG__)
 #pragma push
@@ -179,7 +181,8 @@ class SharedAllocationRecord<void, void> {
 
   /* Decrement use count. If 1->0 then remove from the tracking list and invoke
    * m_dealloc */
-  KOKKOSCORE_EXPORT static SharedAllocationRecord* decrement(SharedAllocationRecord*);
+  KOKKOSCORE_EXPORT static SharedAllocationRecord* decrement(
+      SharedAllocationRecord*);
 
   /* Given a root record and data pointer find the record */
   static SharedAllocationRecord* find(SharedAllocationRecord* const,
@@ -256,12 +259,12 @@ class SharedAllocationRecordCommon : public SharedAllocationRecord<void, void> {
       record_base_t::function_type dealloc = &deallocate);
 
   KOKKOSCORE_EXPORT static auto allocate(MemorySpace const& arg_space,
-                       std::string const& arg_label, size_t arg_alloc_size)
-      -> derived_t*;
+                                         std::string const& arg_label,
+                                         size_t arg_alloc_size) -> derived_t*;
   /**\brief  Allocate tracked memory in the space */
-  KOKKOSCORE_EXPORT static void* allocate_tracked(MemorySpace const& arg_space,
-                                std::string const& arg_alloc_label,
-                                size_t arg_alloc_size);
+  KOKKOSCORE_EXPORT static void* allocate_tracked(
+      MemorySpace const& arg_space, std::string const& arg_alloc_label,
+      size_t arg_alloc_size);
   /**\brief  Deallocate tracked memory in the space */
   KOKKOSCORE_EXPORT static void deallocate_tracked(void* arg_alloc_ptr);
   /**\brief  Reallocate tracked memory in the space
@@ -345,12 +348,12 @@ class HostInaccessibleSharedAllocationRecordCommon
       record_base_t::function_type dealloc = &deallocate);
 
   KOKKOSCORE_EXPORT static auto allocate(MemorySpace const& arg_space,
-                       std::string const& arg_label, size_t arg_alloc_size)
-      -> derived_t*;
+                                         std::string const& arg_label,
+                                         size_t arg_alloc_size) -> derived_t*;
   /**\brief  Allocate tracked memory in the space */
-  KOKKOSCORE_EXPORT static void* allocate_tracked(MemorySpace const& arg_space,
-                                std::string const& arg_alloc_label,
-                                size_t arg_alloc_size);
+  KOKKOSCORE_EXPORT static void* allocate_tracked(
+      MemorySpace const& arg_space, std::string const& arg_alloc_label,
+      size_t arg_alloc_size);
   /**\brief  Deallocate tracked memory in the space */
   KOKKOSCORE_EXPORT static void deallocate_tracked(void* arg_alloc_ptr);
   /**\brief  Reallocate tracked memory in the space

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -18,7 +18,7 @@
 #define KOKKOS_SHARED_ALLOC_HPP
 
 #include <Kokkos_Macros.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <Kokkos_Core_fwd.hpp>
 #include <impl/Kokkos_Error.hpp>  // Impl::throw_runtime_exception
 

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -485,7 +485,7 @@ class SharedAllocationRecord
             &Kokkos::Impl::deallocate<MemorySpace, DestroyFunctor>),
         m_destroy() {}
 
-  KOKKOSCORE_EXPORT SharedAllocationRecord()                       = delete;
+  SharedAllocationRecord()                                         = delete;
   SharedAllocationRecord(const SharedAllocationRecord&)            = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;
 

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -18,7 +18,7 @@
 #define KOKKOS_SHARED_ALLOC_HPP
 
 #include <Kokkos_Macros.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <Kokkos_Core_fwd.hpp>
 #include <impl/Kokkos_Error.hpp>  // Impl::throw_runtime_exception
 

--- a/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
@@ -19,6 +19,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Core_fwd.hpp>
+#include "kokkoscore_export.h"
 
 #include <impl/Kokkos_SharedAlloc.hpp>
 
@@ -33,7 +34,7 @@ namespace Impl {
 
 // NOLINTBEGIN(bugprone-exception-escape)
 template <class MemorySpace>
-SharedAllocationRecordCommon<MemorySpace>::~SharedAllocationRecordCommon() {
+KOKKOSCORE_EXPORT SharedAllocationRecordCommon<MemorySpace>::~SharedAllocationRecordCommon() {
   auto alloc_ptr  = SharedAllocationRecord<void, void>::m_alloc_ptr;
   auto alloc_size = SharedAllocationRecord<void, void>::m_alloc_size;
   auto label      = SharedAllocationRecord<void, void>::m_label;
@@ -41,7 +42,7 @@ SharedAllocationRecordCommon<MemorySpace>::~SharedAllocationRecordCommon() {
                      alloc_size - sizeof(SharedAllocationHeader));
 }
 template <class MemorySpace>
-HostInaccessibleSharedAllocationRecordCommon<
+KOKKOSCORE_EXPORT HostInaccessibleSharedAllocationRecordCommon<
     MemorySpace>::~HostInaccessibleSharedAllocationRecordCommon() {
   auto alloc_ptr  = SharedAllocationRecord<void, void>::m_alloc_ptr;
   auto alloc_size = SharedAllocationRecord<void, void>::m_alloc_size;
@@ -52,7 +53,7 @@ HostInaccessibleSharedAllocationRecordCommon<
 // NOLINTEND(bugprone-exception-escape)
 
 template <class MemorySpace>
-SharedAllocationRecordCommon<MemorySpace>::SharedAllocationRecordCommon(
+KOKKOSCORE_EXPORT SharedAllocationRecordCommon<MemorySpace>::SharedAllocationRecordCommon(
     MemorySpace const& space, std::string const& label, std::size_t alloc_size,
     SharedAllocationRecord<void, void>::function_type dealloc)
     : SharedAllocationRecord<void, void>(
@@ -94,14 +95,14 @@ HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::
 }
 
 template <class MemorySpace>
-auto SharedAllocationRecordCommon<MemorySpace>::allocate(
+KOKKOSCORE_EXPORT auto SharedAllocationRecordCommon<MemorySpace>::allocate(
     MemorySpace const& arg_space, std::string const& arg_label,
     size_t arg_alloc_size) -> derived_t* {
   return new derived_t(arg_space, arg_label, arg_alloc_size);
 }
 
 template <class MemorySpace>
-void* SharedAllocationRecordCommon<MemorySpace>::allocate_tracked(
+KOKKOSCORE_EXPORT void* SharedAllocationRecordCommon<MemorySpace>::allocate_tracked(
     const MemorySpace& arg_space, const std::string& arg_alloc_label,
     size_t arg_alloc_size) {
   if (!arg_alloc_size) return nullptr;
@@ -121,7 +122,7 @@ void SharedAllocationRecordCommon<MemorySpace>::deallocate(
 }
 
 template <class MemorySpace>
-void SharedAllocationRecordCommon<MemorySpace>::deallocate_tracked(
+KOKKOSCORE_EXPORT void SharedAllocationRecordCommon<MemorySpace>::deallocate_tracked(
     void* arg_alloc_ptr) {
   if (arg_alloc_ptr != nullptr) {
     SharedAllocationRecord* const r = derived_t::get_record(arg_alloc_ptr);
@@ -130,14 +131,14 @@ void SharedAllocationRecordCommon<MemorySpace>::deallocate_tracked(
 }
 
 template <class MemorySpace>
-auto HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::allocate(
+KOKKOSCORE_EXPORT auto HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::allocate(
     MemorySpace const& arg_space, std::string const& arg_label,
     size_t arg_alloc_size) -> derived_t* {
   return new derived_t(arg_space, arg_label, arg_alloc_size);
 }
 
 template <class MemorySpace>
-void* HostInaccessibleSharedAllocationRecordCommon<
+KOKKOSCORE_EXPORT void* HostInaccessibleSharedAllocationRecordCommon<
     MemorySpace>::allocate_tracked(const MemorySpace& arg_space,
                                    const std::string& arg_alloc_label,
                                    size_t arg_alloc_size) {
@@ -158,7 +159,7 @@ void HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::deallocate(
 }
 
 template <class MemorySpace>
-void HostInaccessibleSharedAllocationRecordCommon<
+KOKKOSCORE_EXPORT void HostInaccessibleSharedAllocationRecordCommon<
     MemorySpace>::deallocate_tracked(void* arg_alloc_ptr) {
   if (arg_alloc_ptr != nullptr) {
     SharedAllocationRecord* const r = derived_t::get_record(arg_alloc_ptr);
@@ -167,7 +168,7 @@ void HostInaccessibleSharedAllocationRecordCommon<
 }
 
 template <class MemorySpace>
-auto SharedAllocationRecordCommon<MemorySpace>::get_record(void* alloc_ptr)
+KOKKOSCORE_EXPORT auto SharedAllocationRecordCommon<MemorySpace>::get_record(void* alloc_ptr)
     -> derived_t* {
   using Header = SharedAllocationHeader;
 
@@ -184,7 +185,7 @@ auto SharedAllocationRecordCommon<MemorySpace>::get_record(void* alloc_ptr)
 }
 
 template <class MemorySpace>
-std::string SharedAllocationRecordCommon<MemorySpace>::get_label() const {
+KOKKOSCORE_EXPORT std::string SharedAllocationRecordCommon<MemorySpace>::get_label() const {
   return record_base_t::m_label;
 }
 
@@ -294,7 +295,7 @@ void HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::print_records(
 }
 
 template <class MemorySpace>
-auto HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::get_record(
+KOKKOSCORE_EXPORT auto HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::get_record(
     void* alloc_ptr) -> derived_t* {
   // Copy the header from the allocation
   SharedAllocationHeader head;
@@ -325,7 +326,7 @@ auto HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::get_record(
 }
 
 template <class MemorySpace>
-std::string
+KOKKOSCORE_EXPORT std::string
 HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::get_label() const {
   return record_base_t::m_label;
 }

--- a/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
@@ -19,7 +19,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Core_fwd.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #include <impl/Kokkos_SharedAlloc.hpp>
 

--- a/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
@@ -19,7 +19,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Core_fwd.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #include <impl/Kokkos_SharedAlloc.hpp>
 

--- a/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
@@ -34,7 +34,8 @@ namespace Impl {
 
 // NOLINTBEGIN(bugprone-exception-escape)
 template <class MemorySpace>
-KOKKOSCORE_EXPORT SharedAllocationRecordCommon<MemorySpace>::~SharedAllocationRecordCommon() {
+KOKKOSCORE_EXPORT
+    SharedAllocationRecordCommon<MemorySpace>::~SharedAllocationRecordCommon() {
   auto alloc_ptr  = SharedAllocationRecord<void, void>::m_alloc_ptr;
   auto alloc_size = SharedAllocationRecord<void, void>::m_alloc_size;
   auto label      = SharedAllocationRecord<void, void>::m_label;
@@ -53,7 +54,8 @@ KOKKOSCORE_EXPORT HostInaccessibleSharedAllocationRecordCommon<
 // NOLINTEND(bugprone-exception-escape)
 
 template <class MemorySpace>
-KOKKOSCORE_EXPORT SharedAllocationRecordCommon<MemorySpace>::SharedAllocationRecordCommon(
+KOKKOSCORE_EXPORT
+SharedAllocationRecordCommon<MemorySpace>::SharedAllocationRecordCommon(
     MemorySpace const& space, std::string const& label, std::size_t alloc_size,
     SharedAllocationRecord<void, void>::function_type dealloc)
     : SharedAllocationRecord<void, void>(
@@ -102,7 +104,8 @@ KOKKOSCORE_EXPORT auto SharedAllocationRecordCommon<MemorySpace>::allocate(
 }
 
 template <class MemorySpace>
-KOKKOSCORE_EXPORT void* SharedAllocationRecordCommon<MemorySpace>::allocate_tracked(
+KOKKOSCORE_EXPORT void*
+SharedAllocationRecordCommon<MemorySpace>::allocate_tracked(
     const MemorySpace& arg_space, const std::string& arg_alloc_label,
     size_t arg_alloc_size) {
   if (!arg_alloc_size) return nullptr;
@@ -122,7 +125,8 @@ void SharedAllocationRecordCommon<MemorySpace>::deallocate(
 }
 
 template <class MemorySpace>
-KOKKOSCORE_EXPORT void SharedAllocationRecordCommon<MemorySpace>::deallocate_tracked(
+KOKKOSCORE_EXPORT void
+SharedAllocationRecordCommon<MemorySpace>::deallocate_tracked(
     void* arg_alloc_ptr) {
   if (arg_alloc_ptr != nullptr) {
     SharedAllocationRecord* const r = derived_t::get_record(arg_alloc_ptr);
@@ -131,17 +135,18 @@ KOKKOSCORE_EXPORT void SharedAllocationRecordCommon<MemorySpace>::deallocate_tra
 }
 
 template <class MemorySpace>
-KOKKOSCORE_EXPORT auto HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::allocate(
+KOKKOSCORE_EXPORT auto
+HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::allocate(
     MemorySpace const& arg_space, std::string const& arg_label,
     size_t arg_alloc_size) -> derived_t* {
   return new derived_t(arg_space, arg_label, arg_alloc_size);
 }
 
 template <class MemorySpace>
-KOKKOSCORE_EXPORT void* HostInaccessibleSharedAllocationRecordCommon<
-    MemorySpace>::allocate_tracked(const MemorySpace& arg_space,
-                                   const std::string& arg_alloc_label,
-                                   size_t arg_alloc_size) {
+KOKKOSCORE_EXPORT void*
+HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::allocate_tracked(
+    const MemorySpace& arg_space, const std::string& arg_alloc_label,
+    size_t arg_alloc_size) {
   if (!arg_alloc_size) return nullptr;
 
   SharedAllocationRecord* const r =
@@ -159,8 +164,9 @@ void HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::deallocate(
 }
 
 template <class MemorySpace>
-KOKKOSCORE_EXPORT void HostInaccessibleSharedAllocationRecordCommon<
-    MemorySpace>::deallocate_tracked(void* arg_alloc_ptr) {
+KOKKOSCORE_EXPORT void
+HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::deallocate_tracked(
+    void* arg_alloc_ptr) {
   if (arg_alloc_ptr != nullptr) {
     SharedAllocationRecord* const r = derived_t::get_record(arg_alloc_ptr);
     record_base_t::decrement(r);
@@ -168,8 +174,8 @@ KOKKOSCORE_EXPORT void HostInaccessibleSharedAllocationRecordCommon<
 }
 
 template <class MemorySpace>
-KOKKOSCORE_EXPORT auto SharedAllocationRecordCommon<MemorySpace>::get_record(void* alloc_ptr)
-    -> derived_t* {
+KOKKOSCORE_EXPORT auto SharedAllocationRecordCommon<MemorySpace>::get_record(
+    void* alloc_ptr) -> derived_t* {
   using Header = SharedAllocationHeader;
 
   Header const* const h = alloc_ptr ? Header::get_header(alloc_ptr) : nullptr;
@@ -185,7 +191,8 @@ KOKKOSCORE_EXPORT auto SharedAllocationRecordCommon<MemorySpace>::get_record(voi
 }
 
 template <class MemorySpace>
-KOKKOSCORE_EXPORT std::string SharedAllocationRecordCommon<MemorySpace>::get_label() const {
+KOKKOSCORE_EXPORT std::string
+SharedAllocationRecordCommon<MemorySpace>::get_label() const {
   return record_base_t::m_label;
 }
 
@@ -295,7 +302,8 @@ void HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::print_records(
 }
 
 template <class MemorySpace>
-KOKKOSCORE_EXPORT auto HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::get_record(
+KOKKOSCORE_EXPORT auto
+HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::get_record(
     void* alloc_ptr) -> derived_t* {
   // Copy the header from the allocation
   SharedAllocationHeader head;

--- a/core/src/impl/Kokkos_Stacktrace.cpp
+++ b/core/src/impl/Kokkos_Stacktrace.cpp
@@ -20,7 +20,7 @@
 
 #include "Kokkos_Macros.hpp"
 #include "Kokkos_Stacktrace.hpp"
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #ifdef KOKKOS_IMPL_ENABLE_STACKTRACE
 // backtrace() function for retrieving the stacktrace

--- a/core/src/impl/Kokkos_Stacktrace.cpp
+++ b/core/src/impl/Kokkos_Stacktrace.cpp
@@ -20,6 +20,7 @@
 
 #include "Kokkos_Macros.hpp"
 #include "Kokkos_Stacktrace.hpp"
+#include "kokkoscore_export.h"
 
 #ifdef KOKKOS_IMPL_ENABLE_STACKTRACE
 // backtrace() function for retrieving the stacktrace
@@ -112,7 +113,7 @@ class Stacktrace {
 int Stacktrace::length = 0;
 void* Stacktrace::buffer[Stacktrace::capacity];
 
-void save_stacktrace() {
+KOKKOSCORE_EXPORT void save_stacktrace() {
   Stacktrace::length = backtrace(Stacktrace::buffer, Stacktrace::capacity);
 }
 
@@ -208,14 +209,14 @@ void demangle_and_print_traceback(std::ostream& out,
   }
 }
 
-void print_saved_stacktrace(std::ostream& out) {
+KOKKOSCORE_EXPORT void print_saved_stacktrace(std::ostream& out) {
   auto lines = Stacktrace::lines();
   for (auto&& entry : lines) {
     out << entry << std::endl;
   }
 }
 
-void print_demangled_saved_stacktrace(std::ostream& out) {
+KOKKOSCORE_EXPORT void print_demangled_saved_stacktrace(std::ostream& out) {
   demangle_and_print_traceback(out, Stacktrace::lines());
 }
 
@@ -239,7 +240,7 @@ void kokkos_terminate_handler() {
   }
 }
 
-void set_kokkos_terminate_handler(std::function<void()> user_post) {
+KOKKOSCORE_EXPORT void set_kokkos_terminate_handler(std::function<void()> user_post) {
   user_terminate_handler_post_ = user_post;
   std::set_terminate(kokkos_terminate_handler);
 }

--- a/core/src/impl/Kokkos_Stacktrace.cpp
+++ b/core/src/impl/Kokkos_Stacktrace.cpp
@@ -20,7 +20,7 @@
 
 #include "Kokkos_Macros.hpp"
 #include "Kokkos_Stacktrace.hpp"
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #ifdef KOKKOS_IMPL_ENABLE_STACKTRACE
 // backtrace() function for retrieving the stacktrace

--- a/core/src/impl/Kokkos_Stacktrace.cpp
+++ b/core/src/impl/Kokkos_Stacktrace.cpp
@@ -240,7 +240,8 @@ void kokkos_terminate_handler() {
   }
 }
 
-KOKKOSCORE_EXPORT void set_kokkos_terminate_handler(std::function<void()> user_post) {
+KOKKOSCORE_EXPORT void set_kokkos_terminate_handler(
+    std::function<void()> user_post) {
   user_terminate_handler_post_ = user_post;
   std::set_terminate(kokkos_terminate_handler);
 }

--- a/core/src/impl/Kokkos_Stacktrace.hpp
+++ b/core/src/impl/Kokkos_Stacktrace.hpp
@@ -54,7 +54,8 @@ KOKKOSCORE_EXPORT void print_demangled_saved_stacktrace(std::ostream& out);
 /// without including their header file, and Kokkos does not depend on
 /// MPI, so there's no way for Kokkos to depend on MPI_Abort in a
 /// portable way.
-KOKKOSCORE_EXPORT void set_kokkos_terminate_handler(std::function<void()> user_post = nullptr);
+KOKKOSCORE_EXPORT void set_kokkos_terminate_handler(
+    std::function<void()> user_post = nullptr);
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_Stacktrace.hpp
+++ b/core/src/impl/Kokkos_Stacktrace.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOS_STACKTRACE_HPP
 #define KOKKOS_STACKTRACE_HPP
 
+#include "kokkoscore_export.h"
 #include <functional>
 #include <ostream>
 #include <string>
@@ -33,17 +34,17 @@ std::string demangle(const std::string& name);
 /// You may only save one stacktrace at a time.  If you call this
 /// twice, the second call will overwrite the result of the first
 /// call.
-void save_stacktrace();
+KOKKOSCORE_EXPORT void save_stacktrace();
 
 /// \brief Print the raw form of the currently saved stacktrace, if
 ///   any, to the given output stream.
-void print_saved_stacktrace(std::ostream& out);
+KOKKOSCORE_EXPORT void print_saved_stacktrace(std::ostream& out);
 
 /// \brief Print the currently saved, demangled stacktrace, if any, to
 ///   the given output stream.
 ///
 /// Demangling is best effort only.
-void print_demangled_saved_stacktrace(std::ostream& out);
+KOKKOSCORE_EXPORT void print_demangled_saved_stacktrace(std::ostream& out);
 
 /// \brief Set the std::terminate handler so that it prints the
 ///   currently saved stack trace, then calls user_post.
@@ -53,7 +54,7 @@ void print_demangled_saved_stacktrace(std::ostream& out);
 /// without including their header file, and Kokkos does not depend on
 /// MPI, so there's no way for Kokkos to depend on MPI_Abort in a
 /// portable way.
-void set_kokkos_terminate_handler(std::function<void()> user_post = nullptr);
+KOKKOSCORE_EXPORT void set_kokkos_terminate_handler(std::function<void()> user_post = nullptr);
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_Stacktrace.hpp
+++ b/core/src/impl/Kokkos_Stacktrace.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STACKTRACE_HPP
 #define KOKKOS_STACKTRACE_HPP
 
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <functional>
 #include <ostream>
 #include <string>

--- a/core/src/impl/Kokkos_Stacktrace.hpp
+++ b/core/src/impl/Kokkos_Stacktrace.hpp
@@ -17,7 +17,7 @@
 #ifndef KOKKOS_STACKTRACE_HPP
 #define KOKKOS_STACKTRACE_HPP
 
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <functional>
 #include <ostream>
 #include <string>

--- a/core/src/impl/Kokkos_TaskQueue.hpp
+++ b/core/src/impl/Kokkos_TaskQueue.hpp
@@ -133,14 +133,13 @@ class TaskQueue : public TaskQueueBase {
   //   Postcondition:
   //     task->m_wait == LockTag  =>  task is complete
   //     task->m_wait != LockTag  =>  task is waiting
-  KOKKOSCORE_EXPORT KOKKOS_FUNCTION
-  void complete(task_root_type*);
+  KOKKOSCORE_EXPORT KOKKOS_FUNCTION void complete(task_root_type*);
 
   KOKKOS_FUNCTION
   static bool push_task(task_root_type* volatile* const, task_root_type* const);
 
-  KOKKOSCORE_EXPORT KOKKOS_FUNCTION
-  static task_root_type* pop_ready_task(task_root_type* volatile* const);
+  KOKKOSCORE_EXPORT KOKKOS_FUNCTION static task_root_type* pop_ready_task(
+      task_root_type* volatile* const);
 
   KOKKOSCORE_EXPORT KOKKOS_FUNCTION static void decrement(task_root_type* task);
 
@@ -185,11 +184,11 @@ class TaskQueue : public TaskQueueBase {
   KOKKOS_FUNCTION
   size_t allocate_block_size(size_t n);  ///< Actual block size allocated
 
-  KOKKOSCORE_EXPORT KOKKOS_FUNCTION
-  void* allocate(size_t n);  ///< Allocate from the memory pool
+  KOKKOSCORE_EXPORT KOKKOS_FUNCTION void* allocate(
+      size_t n);  ///< Allocate from the memory poo
 
-  KOKKOSCORE_EXPORT KOKKOS_FUNCTION
-  void deallocate(void* p, size_t n);  ///< Deallocate to the memory pool
+  KOKKOSCORE_EXPORT KOKKOS_FUNCTION void deallocate(
+      void* p, size_t n);  ///< Deallocate to the memory pool
 
   //----------------------------------------
   /**\brief  Allocation size for a spawned task */

--- a/core/src/impl/Kokkos_TaskQueue.hpp
+++ b/core/src/impl/Kokkos_TaskQueue.hpp
@@ -29,6 +29,7 @@
 
 #include <Kokkos_TaskScheduler_fwd.hpp>
 #include <Kokkos_Core_fwd.hpp>
+#include <Kokkos_Core_Export.h>
 
 #include <Kokkos_MemoryPool.hpp>
 
@@ -77,7 +78,7 @@ class TaskQueue : public TaskQueueBase {
 
   struct Destroy {
     TaskQueue* m_queue;
-    void destroy_shared_allocation();
+    KOKKOSCORE_EXPORT void destroy_shared_allocation();
   };
 
   //----------------------------------------
@@ -96,14 +97,14 @@ class TaskQueue : public TaskQueueBase {
 
   //----------------------------------------
 
-  ~TaskQueue();
+  KOKKOSCORE_EXPORT ~TaskQueue();
   TaskQueue()                            = delete;
   TaskQueue(TaskQueue&&)                 = delete;
   TaskQueue(TaskQueue const&)            = delete;
   TaskQueue& operator=(TaskQueue&&)      = delete;
   TaskQueue& operator=(TaskQueue const&) = delete;
 
-  TaskQueue(const memory_pool& arg_memory_pool);
+  KOKKOSCORE_EXPORT TaskQueue(const memory_pool& arg_memory_pool);
 
   // Schedule a task
   //   Precondition:
@@ -111,8 +112,8 @@ class TaskQueue : public TaskQueueBase {
   //     task->m_next is the dependence or zero
   //   Postcondition:
   //     task->m_next is linked list membership
-  KOKKOS_FUNCTION void schedule_runnable(task_root_type*);
-  KOKKOS_FUNCTION void schedule_aggregate(task_root_type*);
+  KOKKOSCORE_EXPORT KOKKOS_FUNCTION void schedule_runnable(task_root_type*);
+  KOKKOSCORE_EXPORT KOKKOS_FUNCTION void schedule_aggregate(task_root_type*);
 
   // Reschedule a task
   //   Precondition:
@@ -132,16 +133,16 @@ class TaskQueue : public TaskQueueBase {
   //   Postcondition:
   //     task->m_wait == LockTag  =>  task is complete
   //     task->m_wait != LockTag  =>  task is waiting
-  KOKKOS_FUNCTION
+  KOKKOSCORE_EXPORT KOKKOS_FUNCTION
   void complete(task_root_type*);
 
   KOKKOS_FUNCTION
   static bool push_task(task_root_type* volatile* const, task_root_type* const);
 
-  KOKKOS_FUNCTION
+  KOKKOSCORE_EXPORT KOKKOS_FUNCTION
   static task_root_type* pop_ready_task(task_root_type* volatile* const);
 
-  KOKKOS_FUNCTION static void decrement(task_root_type* task);
+  KOKKOSCORE_EXPORT KOKKOS_FUNCTION static void decrement(task_root_type* task);
 
  public:
   KOKKOS_INLINE_FUNCTION
@@ -184,10 +185,10 @@ class TaskQueue : public TaskQueueBase {
   KOKKOS_FUNCTION
   size_t allocate_block_size(size_t n);  ///< Actual block size allocated
 
-  KOKKOS_FUNCTION
+  KOKKOSCORE_EXPORT KOKKOS_FUNCTION
   void* allocate(size_t n);  ///< Allocate from the memory pool
 
-  KOKKOS_FUNCTION
+  KOKKOSCORE_EXPORT KOKKOS_FUNCTION
   void deallocate(void* p, size_t n);  ///< Deallocate to the memory pool
 
   //----------------------------------------

--- a/core/src/impl/Kokkos_TaskQueue_impl.hpp
+++ b/core/src/impl/Kokkos_TaskQueue_impl.hpp
@@ -32,14 +32,15 @@ namespace Impl {
 //----------------------------------------------------------------------------
 
 template <typename ExecSpace, typename MemorySpace>
-void TaskQueue<ExecSpace, MemorySpace>::Destroy::destroy_shared_allocation() {
+KOKKOSCORE_EXPORT void
+TaskQueue<ExecSpace, MemorySpace>::Destroy::destroy_shared_allocation() {
   m_queue->~TaskQueue();
 }
 
 //----------------------------------------------------------------------------
 
 template <typename ExecSpace, typename MemorySpace>
-TaskQueue<ExecSpace, MemorySpace>::TaskQueue(
+KOKKOSCORE_EXPORT TaskQueue<ExecSpace, MemorySpace>::TaskQueue(
     typename TaskQueue<ExecSpace, MemorySpace>::memory_pool const
         &arg_memory_pool)
     : m_memory(arg_memory_pool),
@@ -58,7 +59,7 @@ TaskQueue<ExecSpace, MemorySpace>::TaskQueue(
 //----------------------------------------------------------------------------
 
 template <typename ExecSpace, typename MemorySpace>
-TaskQueue<ExecSpace, MemorySpace>::~TaskQueue() {
+KOKKOSCORE_EXPORT TaskQueue<ExecSpace, MemorySpace>::~TaskQueue() {
   // Verify that queues are empty and ready count is zero
 
   for (int i = 0; i < NumQueue; ++i) {
@@ -77,7 +78,8 @@ TaskQueue<ExecSpace, MemorySpace>::~TaskQueue() {
 //----------------------------------------------------------------------------
 
 template <typename ExecSpace, typename MemorySpace>
-KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::decrement(
+KOKKOSCORE_EXPORT KOKKOS_FUNCTION void
+TaskQueue<ExecSpace, MemorySpace>::decrement(
     TaskQueue<ExecSpace, MemorySpace>::task_root_type *task) {
   task_root_type volatile &t = *task;
 
@@ -120,7 +122,8 @@ TaskQueue<ExecSpace, MemorySpace>::allocate_block_size(size_t n) {
 }
 
 template <typename ExecSpace, typename MemorySpace>
-KOKKOS_FUNCTION void *TaskQueue<ExecSpace, MemorySpace>::allocate(size_t n) {
+KOKKOSCORE_EXPORT KOKKOS_FUNCTION void *
+TaskQueue<ExecSpace, MemorySpace>::allocate(size_t n) {
   void *const p = m_memory.allocate(n);
 
   if (p) {
@@ -135,8 +138,8 @@ KOKKOS_FUNCTION void *TaskQueue<ExecSpace, MemorySpace>::allocate(size_t n) {
 }
 
 template <typename ExecSpace, typename MemorySpace>
-KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::deallocate(void *p,
-                                                                   size_t n) {
+KOKKOSCORE_EXPORT KOKKOS_FUNCTION void
+TaskQueue<ExecSpace, MemorySpace>::deallocate(void *p,size_t n) {
   m_memory.deallocate(p, n);
   desul::atomic_dec(&m_count_alloc, desul::MemoryOrderSeqCst(),
                     desul::MemoryScopeDevice());  // TODO? memory_order_relaxed
@@ -211,8 +214,9 @@ KOKKOS_FUNCTION bool TaskQueue<ExecSpace, MemorySpace>::push_task(
 //----------------------------------------------------------------------------
 
 template <typename ExecSpace, typename MemorySpace>
-KOKKOS_FUNCTION typename TaskQueue<ExecSpace, MemorySpace>::task_root_type *
-TaskQueue<ExecSpace, MemorySpace>::pop_ready_task(
+KOKKOSCORE_EXPORT KOKKOS_FUNCTION
+    typename TaskQueue<ExecSpace, MemorySpace>::task_root_type *
+    TaskQueue<ExecSpace, MemorySpace>::pop_ready_task(
     TaskQueue<ExecSpace, MemorySpace>::task_root_type *volatile *const queue) {
   // Pop task from a concurrently pushed and popped ready task queue.
   // The queue is a linked list where 'task->m_next' form the links.
@@ -289,7 +293,8 @@ TaskQueue<ExecSpace, MemorySpace>::pop_ready_task(
 //----------------------------------------------------------------------------
 
 template <typename ExecSpace, typename MemorySpace>
-KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::schedule_runnable(
+KOKKOSCORE_EXPORT KOKKOS_FUNCTION void
+TaskQueue<ExecSpace, MemorySpace>::schedule_runnable(
     TaskQueue<ExecSpace, MemorySpace>::task_root_type *const task) {
   // Schedule a runnable task upon construction / spawn
   // and upon completion of other tasks that 'task' is waiting on.
@@ -413,7 +418,8 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::schedule_runnable(
 }
 
 template <typename ExecSpace, typename MemorySpace>
-KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::schedule_aggregate(
+KOKKOSCORE_EXPORT KOKKOS_FUNCTION void
+TaskQueue<ExecSpace, MemorySpace>::schedule_aggregate(
     TaskQueue<ExecSpace, MemorySpace>::task_root_type *const task) {
   // Schedule an aggregate task upon construction
   // and upon completion of other tasks that 'task' is waiting on.
@@ -552,7 +558,8 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::reschedule(
 //----------------------------------------------------------------------------
 
 template <typename ExecSpace, typename MemorySpace>
-KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::complete(
+KOKKOSCORE_EXPORT KOKKOS_FUNCTION void
+TaskQueue<ExecSpace, MemorySpace>::complete(
     TaskQueue<ExecSpace, MemorySpace>::task_root_type *task) {
   // Complete a runnable task that has finished executing
   // or a when_all task when all of its dependeneces are complete.

--- a/core/src/impl/Kokkos_TaskQueue_impl.hpp
+++ b/core/src/impl/Kokkos_TaskQueue_impl.hpp
@@ -139,7 +139,7 @@ TaskQueue<ExecSpace, MemorySpace>::allocate(size_t n) {
 
 template <typename ExecSpace, typename MemorySpace>
 KOKKOSCORE_EXPORT KOKKOS_FUNCTION void
-TaskQueue<ExecSpace, MemorySpace>::deallocate(void *p,size_t n) {
+TaskQueue<ExecSpace, MemorySpace>::deallocate(void *p, size_t n) {
   m_memory.deallocate(p, n);
   desul::atomic_dec(&m_count_alloc, desul::MemoryOrderSeqCst(),
                     desul::MemoryScopeDevice());  // TODO? memory_order_relaxed
@@ -217,7 +217,8 @@ template <typename ExecSpace, typename MemorySpace>
 KOKKOSCORE_EXPORT KOKKOS_FUNCTION
     typename TaskQueue<ExecSpace, MemorySpace>::task_root_type *
     TaskQueue<ExecSpace, MemorySpace>::pop_ready_task(
-    TaskQueue<ExecSpace, MemorySpace>::task_root_type *volatile *const queue) {
+        TaskQueue<ExecSpace, MemorySpace>::task_root_type *volatile
+            *const queue) {
   // Pop task from a concurrently pushed and popped ready task queue.
   // The queue is a linked list where 'task->m_next' form the links.
 

--- a/core/src/impl/Kokkos_hwloc.cpp
+++ b/core/src/impl/Kokkos_hwloc.cpp
@@ -27,7 +27,7 @@
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_hwloc.hpp>
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include <impl/Kokkos_Error.hpp>
 
 /*--------------------------------------------------------------------------*/

--- a/core/src/impl/Kokkos_hwloc.cpp
+++ b/core/src/impl/Kokkos_hwloc.cpp
@@ -27,6 +27,7 @@
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_hwloc.hpp>
+#include "kokkoscore_export.h"
 #include <impl/Kokkos_Error.hpp>
 
 /*--------------------------------------------------------------------------*/
@@ -514,19 +515,19 @@ Sentinel::Sentinel() {
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-bool available() { return true; }
+KOKKOSCORE_EXPORT bool available() { return true; }
 
-unsigned get_available_numa_count() {
+KOKKOSCORE_EXPORT unsigned get_available_numa_count() {
   sentinel();
   return s_core_topology.first;
 }
 
-unsigned get_available_cores_per_numa() {
+KOKKOSCORE_EXPORT unsigned get_available_cores_per_numa() {
   sentinel();
   return s_core_topology.second;
 }
 
-unsigned get_available_threads_per_core() {
+KOKKOSCORE_EXPORT unsigned get_available_threads_per_core() {
   sentinel();
   return s_core_capacity;
 }
@@ -694,12 +695,12 @@ std::pair<unsigned, unsigned> get_this_thread_coordinate() {
 namespace Kokkos {
 namespace hwloc {
 
-bool available() { return false; }
+KOKKOSCORE_EXPORT bool available() { return false; }
 bool can_bind_threads() { return false; }
 
-unsigned get_available_numa_count() { return 1; }
-unsigned get_available_cores_per_numa() { return 1; }
-unsigned get_available_threads_per_core() { return 1; }
+KOKKOSCORE_EXPORT unsigned get_available_numa_count() { return 1; }
+KOKKOSCORE_EXPORT unsigned get_available_cores_per_numa() { return 1; }
+KOKKOSCORE_EXPORT unsigned get_available_threads_per_core() { return 1; }
 
 unsigned bind_this_thread(const unsigned, std::pair<unsigned, unsigned>[]) {
   return ~0;

--- a/core/src/impl/Kokkos_hwloc.cpp
+++ b/core/src/impl/Kokkos_hwloc.cpp
@@ -27,7 +27,7 @@
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_hwloc.hpp>
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include <impl/Kokkos_Error.hpp>
 
 /*--------------------------------------------------------------------------*/

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT GTest_FOUND) # fallback to internal gtest
   set(GTEST_SOURCE_DIR ${Kokkos_SOURCE_DIR}/tpls/gtest)
 
   kokkos_add_test_library(
-    kokkos_gtest HEADERS ${GTEST_SOURCE_DIR}/gtest/gtest.h SOURCES ${GTEST_SOURCE_DIR}/gtest/gtest-all.cc
+    kokkos_gtest STATIC HEADERS ${GTEST_SOURCE_DIR}/gtest/gtest.h SOURCES ${GTEST_SOURCE_DIR}/gtest/gtest-all.cc
   )
 
   target_include_directories(kokkos_gtest SYSTEM PUBLIC ${GTEST_SOURCE_DIR})

--- a/simd/src/CMakeLists.txt
+++ b/simd/src/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SIMD_MODULES Kokkos_SIMD.cppm)
 # These will get ignored for standalone CMake and a true interface library made
 kokkos_add_library(
   kokkossimd
+  STATIC
   SOURCES
   ${SIMD_SOURCES}
   HEADERS

--- a/simd/src/CMakeLists.txt
+++ b/simd/src/CMakeLists.txt
@@ -22,7 +22,7 @@ set(SIMD_MODULES Kokkos_SIMD.cppm)
 # These will get ignored for standalone CMake and a true interface library made
 kokkos_add_library(
   kokkossimd
-  INTERFACE
+  STATIC
   SOURCES
   ${SIMD_SOURCES}
   HEADERS
@@ -34,7 +34,7 @@ kokkos_lib_include_directories(
   kokkossimd ${KOKKOS_TOP_BUILD_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-kokkos_link_internal_library(kokkossimd INTERFACE kokkoscore)
+kokkos_link_internal_library(kokkossimd kokkoscore)
 
 # If ARM-SVE, check and warn for available arm_neon_sve_bridge.h
 if(KOKKOS_ARCH_ARM_SVE)

--- a/simd/src/CMakeLists.txt
+++ b/simd/src/CMakeLists.txt
@@ -22,7 +22,7 @@ set(SIMD_MODULES Kokkos_SIMD.cppm)
 # These will get ignored for standalone CMake and a true interface library made
 kokkos_add_library(
   kokkossimd
-  STATIC
+  INTERFACE
   SOURCES
   ${SIMD_SOURCES}
   HEADERS
@@ -34,7 +34,7 @@ kokkos_lib_include_directories(
   kokkossimd ${KOKKOS_TOP_BUILD_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-kokkos_link_internal_library(kokkossimd kokkoscore)
+kokkos_link_internal_library(kokkossimd INTERFACE kokkoscore)
 
 # If ARM-SVE, check and warn for available arm_neon_sve_bridge.h
 if(KOKKOS_ARCH_ARM_SVE)

--- a/tpls/desul/Config.hpp.cmake.in
+++ b/tpls/desul/Config.hpp.cmake.in
@@ -18,4 +18,6 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #cmakedefine DESUL_ATOMICS_ENABLE_OPENACC
 #cmakedefine DESUL_ATOMICS_ENABLE_OPENMP
 
+#cmakedefine DESUL_BUILD_SHARED_LIBS
+
 #endif

--- a/tpls/desul/include/desul/atomics/Lock_Array_CUDA.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Array_CUDA.hpp
@@ -12,7 +12,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <cstdint>
 
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 #include "desul/atomics/Common.hpp"
 #include "desul/atomics/Macros.hpp"
 

--- a/tpls/desul/include/desul/atomics/Lock_Array_CUDA.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Array_CUDA.hpp
@@ -12,7 +12,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <cstdint>
 
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 #include "desul/atomics/Common.hpp"
 #include "desul/atomics/Macros.hpp"
 

--- a/tpls/desul/include/desul/atomics/Lock_Array_CUDA.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Array_CUDA.hpp
@@ -6,11 +6,13 @@ Source: https://github.com/desul/desul
 SPDX-License-Identifier: (BSD-3-Clause)
 */
 
+
 #ifndef DESUL_ATOMICS_LOCK_ARRAY_CUDA_HPP_
 #define DESUL_ATOMICS_LOCK_ARRAY_CUDA_HPP_
 
 #include <cstdint>
 
+#include "kokkoscore_export.h"
 #include "desul/atomics/Common.hpp"
 #include "desul/atomics/Macros.hpp"
 
@@ -19,8 +21,8 @@ namespace Impl {
 
 /// \brief This global variable in Host space is the central definition
 ///        of these arrays.
-extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h;
-extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE_h;
+KOKKOSCORE_EXPORT extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h;
+KOKKOSCORE_EXPORT extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE_h;
 
 /// \brief After this call, the g_host_cuda_lock_arrays variable has
 ///        valid, initialized arrays.

--- a/tpls/desul/include/desul/atomics/Lock_Array_CUDA.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Array_CUDA.hpp
@@ -12,7 +12,6 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <cstdint>
 
-#include <Kokkos_Core_Export.h>
 #include "desul/atomics/Common.hpp"
 #include "desul/atomics/Macros.hpp"
 
@@ -21,8 +20,8 @@ namespace Impl {
 
 /// \brief This global variable in Host space is the central definition
 ///        of these arrays.
-KOKKOSCORE_EXPORT extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h;
-KOKKOSCORE_EXPORT extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE_h;
+DESUL_EXPORT extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h;
+DESUL_EXPORT extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE_h;
 
 /// \brief After this call, the g_host_cuda_lock_arrays variable has
 ///        valid, initialized arrays.

--- a/tpls/desul/include/desul/atomics/Macros.hpp
+++ b/tpls/desul/include/desul/atomics/Macros.hpp
@@ -167,4 +167,14 @@ static constexpr bool desul_impl_omp_on_host() { return false; }
 #endif
 #endif
 
+#if defined(DESUL_BUILD_SHARED_LIBS) && defined(_WIN32)
+#ifdef DESUL_EXPORT_SYMBOLS
+#define DESUL_EXPORT __declspec(dllexport)
+#else
+#define DESUL_EXPORT __declspec(dllimport)
+#endif
+#else
+#define DESUL_EXPORT
+#endif
+
 #endif  // DESUL_ATOMICS_MACROS_HPP_

--- a/tpls/desul/src/Lock_Array_CUDA.cpp
+++ b/tpls/desul/src/Lock_Array_CUDA.cpp
@@ -11,7 +11,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #include <sstream>
 #include <string>
 
-#include "Kokkos_Core_Export.h"
+#include <Kokkos_Core_Export.h>
 
 #ifdef DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION
 namespace desul {

--- a/tpls/desul/src/Lock_Array_CUDA.cpp
+++ b/tpls/desul/src/Lock_Array_CUDA.cpp
@@ -11,7 +11,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #include <sstream>
 #include <string>
 
-#include "kokkoscore_export.h"
+#include "Kokkos_Core_Export.h"
 
 #ifdef DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION
 namespace desul {

--- a/tpls/desul/src/Lock_Array_CUDA.cpp
+++ b/tpls/desul/src/Lock_Array_CUDA.cpp
@@ -11,6 +11,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #include <sstream>
 #include <string>
 
+#include "kokkoscore_export.h"
+
 #ifdef DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION
 namespace desul {
 namespace Impl {
@@ -36,8 +38,8 @@ __global__ void init_lock_arrays_cuda_kernel() {
 
 namespace Impl {
 
-int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
-int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
+KOKKOSCORE_EXPORT int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
+KOKKOSCORE_EXPORT int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
 
 // Putting this into anonymous namespace so we don't have multiple defined symbols
 // When linking in more than one copy of the object file

--- a/tpls/desul/src/Lock_Array_CUDA.cpp
+++ b/tpls/desul/src/Lock_Array_CUDA.cpp
@@ -11,8 +11,6 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #include <sstream>
 #include <string>
 
-#include <Kokkos_Core_Export.h>
-
 #ifdef DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION
 namespace desul {
 namespace Impl {
@@ -38,8 +36,8 @@ __global__ void init_lock_arrays_cuda_kernel() {
 
 namespace Impl {
 
-KOKKOSCORE_EXPORT int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
-KOKKOSCORE_EXPORT int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
+int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
+int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
 
 // Putting this into anonymous namespace so we don't have multiple defined symbols
 // When linking in more than one copy of the object file


### PR DESCRIPTION
Fixes #8259 and a few issues that came up when trying to build kokkos as a DLL on windows.

## DLL Fix
CMake's [GenerateExportHeader](https://cmake.org/cmake/help/latest/module/GenerateExportHeader.html) was used to create 2 header files during configure time, one for containers/src/ (Kokkos_Containers_Export.h) and another for core/src/ (Kokkos_Core_Export.h), which allows for KOKKOSCONTAINER_EXPORT or KOKKOSCORE_EXPORT macros to be used for symbols. Theses macros translate to no-ops on linux version.

Unit tests all compiled and linked on windows and linux version.  

**IMPORTANT**
**I also used KOKKOSCORE_EXPORT to export 2 symbols on desul files (Lock_Array_CUDA.hpp/.cpp), I include this in the commit but I am unsure how you all would like this to be properly handled, at the moment this will allow for proper export and linkage of the needed symbols.**

### Minor changes 
For my machine to properly build the unit tests on windows I needed to add the following:
```
if(Kokkos_ENABLE_TESTS)
  find_package(GTest QUIET)
  if (WIN32)
    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/bigobj>)
    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=/bigobj")
  endif()
endif()
```
This was added to avoid error [C1128 ](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/fatal-error-c1128?view=msvc-170). Potentially instead of if (WIN32) it should probably be changed to if (MSVC) in case someone tries to build with GCC/Clang. To avoid conflicts with nvcc I needed to add the language check.

When BUILD_SHARED_LIBS is ON, windows only generates kokkos_gtest.dll which leads to a linking error as it tries to find 'core\unit_test\kokkos_gtest.lib'. Adding the keyword STATIC fixes this:
```
kokkos_add_test_library(
  kokkos_gtest STATIC HEADERS ${GTEST_SOURCE_DIR}/gtest/gtest.h SOURCES ${GTEST_SOURCE_DIR}/gtest/gtest-all.cc
)
```



