### PR TITLE
Add DynRankView ctor from constructor

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -815,6 +815,23 @@ class DynRankView : private View<DataType*******, Properties...> {
   KOKKOS_FUNCTION DynRankView(const DynRankView<RT, RP...>& rhs)
       : view_type(rhs), m_rank(rhs.m_rank) {}
 
+  KOKKOS_INLINE_FUNCTION DynRankView(view_type rhs, size_t new_rank)
+      : view_type(rhs), m_rank(new_rank) {
+    if (new_rank > view_type::rank())
+      Kokkos::abort(
+          "Attempting to construct DynRankView from View and new rank, with "
+          "the new rank being too large.");
+
+    bool invalid_extent = false;
+    for (size_t r = new_rank; r < view_type::rank(); r++)
+      if (rhs.extent(r) != 1) invalid_extent = true;
+    if (invalid_extent)
+      Kokkos::abort(
+          "Attempting to construct DynRankView from View with incompatible "
+          "extents. (Extents for dimensions larger than the provided rank are "
+          "not equal to 1).");
+  }
+
   template <class RT, class... RP>
   KOKKOS_FUNCTION DynRankView& operator=(const DynRankView<RT, RP...>& rhs) {
     view_type::operator=(rhs);

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -20,6 +20,7 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
       DynViewAPI_generic
       DynViewAPI_rank12345
       DynViewAPI_rank67
+      DynRankView_Ctors
       DynRankView_TeamScratch
       DynRankView_ViewCustomization
       ErrorReporter

--- a/containers/unit_tests/TestDynRankView_Ctors.hpp
+++ b/containers/unit_tests/TestDynRankView_Ctors.hpp
@@ -1,0 +1,110 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_DynRankView.hpp>
+
+namespace {
+
+void test_dyn_rank_view_ctor_from_members() {
+  using drview_t = Kokkos::DynRankView<double, TEST_EXECSPACE>;
+  using view_t   = typename drview_t::view_type;
+
+  {
+    view_t data("data", 2, 3, 4, 5, 6, 7, 8);
+    drview_t drv(data, 7);
+
+    ASSERT_EQ(drv.rank(), 7lu);
+    for (size_t r = 0; r < drv.rank(); r++)
+      ASSERT_EQ(static_cast<size_t>(drv.extent(r)), r + 2);
+    ASSERT_EQ(data.use_count(), 2);
+    ASSERT_EQ(data.data(), drv.data());
+  }
+  {
+    view_t data("data", 2, 3, 4, 1, 1, 1, 1);
+    drview_t drv(data, 3);
+
+    ASSERT_EQ(drv.rank(), 3lu);
+    for (size_t r = 0; r < drv.rank(); r++)
+      ASSERT_EQ(static_cast<size_t>(drv.extent(r)), r + 2);
+    ASSERT_EQ(data.use_count(), 2);
+    ASSERT_EQ(data.data(), drv.data());
+  }
+  {
+    view_t data("data", 1, 1, 1, 1, 1, 1, 1);
+    drview_t drv(data, 0);
+
+    ASSERT_EQ(drv.rank(), 0lu);
+    ASSERT_EQ(data.use_count(), 2);
+    ASSERT_EQ(data.data(), drv.data());
+  }
+}
+
+TEST(TEST_CATEGORY, dyn_rank_view_ctor_from_members) {
+  test_dyn_rank_view_ctor_from_members();
+}
+
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+void test_dyn_rank_view_ctor_from_layout_stride() {
+  using drview_t =
+      Kokkos::DynRankView<double, Kokkos::LayoutStride, TEST_EXECSPACE>;
+  using view_t = typename drview_t::view_type;
+  {
+    typename view_t::mapping_type map(
+        Kokkos::dextents<int, 7>(2, 3, 4, 5, 6, 7, 8),
+        std::array{1, 2, 6, 24, 120, 720, 5040});
+    view_t data("data", map);
+    drview_t drv(data, 7);
+
+    ASSERT_EQ(drv.rank(), 7lu);
+    for (size_t r = 0; r < drv.rank(); r++)
+      ASSERT_EQ(static_cast<size_t>(drv.extent(r)), r + 2);
+    ASSERT_EQ(data.use_count(), 2);
+    ASSERT_EQ(data.data(), drv.data());
+  }
+  {
+    typename view_t::mapping_type map(
+        Kokkos::dextents<int, 7>(2, 3, 4, 1, 1, 1, 1),
+        std::array{1, 2, 6, 1, 1, 1, 1});
+    view_t data("data", map);
+    drview_t drv(data, 3);
+
+    ASSERT_EQ(drv.rank(), 3lu);
+    for (size_t r = 0; r < drv.rank(); r++)
+      ASSERT_EQ(static_cast<size_t>(drv.extent(r)), r + 2);
+    ASSERT_EQ(data.use_count(), 2);
+    ASSERT_EQ(data.data(), drv.data());
+  }
+  {
+    typename view_t::mapping_type map(
+        Kokkos::dextents<int, 7>(1, 1, 1, 1, 1, 1, 1),
+        std::array{1, 1, 1, 1, 1, 1, 1});
+    view_t data("data", map);
+    drview_t drv(data, 0);
+
+    ASSERT_EQ(drv.rank(), 0lu);
+    ASSERT_EQ(data.use_count(), 2);
+    ASSERT_EQ(data.data(), drv.data());
+  }
+}
+
+TEST(TEST_CATEGORY, dyn_rank_view_ctor_from_layout_stride) {
+  test_dyn_rank_view_ctor_from_layout_stride();
+}
+#endif
+
+}  // namespace


### PR DESCRIPTION
This constructor enables direct construction from the member view and the rank, without going through the view converting constructor.

Incidentally this makes it unnecessary to implement in Sacado a "Kokkos::Impl::mapping_from_array_layout" functionality for Sacado's `LayoutContiguous`. 