### PR TITLE
Add tests for int8 and int16

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -150,6 +150,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       AtomicOperations_complexfloat
       AtomicOperations_double
       AtomicOperations_float
+      AtomicOperations_int8
+      AtomicOperations_int16
       AtomicOperations_int
       AtomicOperations_longint
       AtomicOperations_longlongint

--- a/core/unit_test/TestAtomicOperations_int16.hpp
+++ b/core/unit_test/TestAtomicOperations_int16.hpp
@@ -1,0 +1,33 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <TestAtomicOperations.hpp>
+
+namespace Test {
+TEST(TEST_CATEGORY, atomic_operations_int16) {
+  // FIXME_OPENMPTARGET - causes runtime failure with CrayClang compiler
+#if defined(KOKKOS_COMPILER_CRAY_LLVM) && defined(KOKKOS_ENABLE_OPENMPTARGET)
+  GTEST_SKIP() << "known to fail with OpenMPTarget+Cray LLVM";
+#endif
+  const int16_t start = -5;
+  const int16_t end   = 11;
+  for (int16_t i = start; i < end; ++i) {
+    for (int16_t t = 0; t < 16; t++)
+      ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestIntegralType<
+                   int16_t, TEST_EXECSPACE>(i, end - i + start, t)));
+  }
+}
+}  // namespace Test

--- a/core/unit_test/TestAtomicOperations_int8.hpp
+++ b/core/unit_test/TestAtomicOperations_int8.hpp
@@ -1,0 +1,33 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <TestAtomicOperations.hpp>
+
+namespace Test {
+TEST(TEST_CATEGORY, atomic_operations_int8) {
+  // FIXME_OPENMPTARGET - causes runtime failure with CrayClang compiler
+#if defined(KOKKOS_COMPILER_CRAY_LLVM) && defined(KOKKOS_ENABLE_OPENMPTARGET)
+  GTEST_SKIP() << "known to fail with OpenMPTarget+Cray LLVM";
+#endif
+  const int8_t start = -5;
+  const int8_t end   = 11;
+  for (int8_t i = start; i < end; ++i) {
+    for (int8_t t = 0; t < 16; t++)
+      ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestIntegralType<
+                   int8_t, TEST_EXECSPACE>(i, end - i + start, t)));
+  }
+}
+}  // namespace Test


### PR DESCRIPTION
On Slack a user described having a deadlock with a RTX3080 with Clang+Cuda that was not there with NVCC.
This is likely due to the lack of forward-progress guarantee that can lead to issues if users do synchronization with atomics.
Nevertheless, to increase our test coverage this PR adds tests for `int8` and `int16` that should hit the fallback implementation in desul.

The files are copied from the test for `int` and adapted