### PR TITLE
[4.7] Disable graph_capture test for cuda/11.4 + all gcc/10 versions

### DIFF
--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -840,7 +840,8 @@ struct GraphNodeTypes {
 
 #if defined(KOKKOS_ENABLE_CUDA)
 // TODO check range of problematic nvcc/11.4 and gcc/10.x combos
-#if (defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU == 1030)) && \
+#if (defined(KOKKOS_COMPILER_GNU) &&                                 \
+     (KOKKOS_COMPILER_GNU >= 1000 && KOKKOS_COMPILER_GNU < 1100)) && \
     (defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC == 1140))
   static constexpr bool support_capture = false;
 #else


### PR DESCRIPTION
Cherry-pick https://github.com/kokkos/kokkos/pull/8309