### PR TITLE
Update OpenACC parallel_scan() to support RangePolicy with non-zero begin index

### DIFF
--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelScan_Range.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelScan_Range.hpp
@@ -117,11 +117,11 @@ KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang vector_length(chunk_size) KOKKOS_IMPL_
       IndexType temp;
 #pragma acc loop vector
       for (IndexType thread_id = 0; thread_id < chunk_size; ++thread_id) {
-        const IndexType local_offset = team_id * chunk_size;
+        const IndexType local_offset = team_id * chunk_size + begin;
         const IndexType idx          = local_offset + thread_id;
         ValueType update;
         final_reducer.init(&update);
-        if ((idx > 0) && (idx < N)) functor(idx - 1, update, false);
+        if ((idx > begin) && (idx < end)) functor(idx - 1, update, false);
         KOKKOS_IMPL_ACC_ACCESS_ELEMENTS(thread_id) = update;
       }
       for (IndexType step_size = 1; step_size < chunk_size; step_size *= 2) {
@@ -172,14 +172,14 @@ KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang vector_length(chunk_size) KOKKOS_IMPL_
       IndexType temp;
 #pragma acc loop vector
       for (IndexType thread_id = 0; thread_id < chunk_size; ++thread_id) {
-        const IndexType local_offset = team_id * chunk_size;
+        const IndexType local_offset = team_id * chunk_size + begin;
         const IndexType idx          = local_offset + thread_id;
         ValueType update;
         final_reducer.init(&update);
         if (thread_id == 0) {
           final_reducer.join(&update, &offset_values(team_id));
         }
-        if ((idx > 0) && (idx < N)) functor(idx - 1, update, false);
+        if ((idx > begin) && (idx < end)) functor(idx - 1, update, false);
         KOKKOS_IMPL_ACC_ACCESS_ELEMENTS(thread_id) = update;
       }
       for (IndexType step_size = 1; step_size < chunk_size; step_size *= 2) {
@@ -206,12 +206,12 @@ KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang vector_length(chunk_size) KOKKOS_IMPL_
       }
 #pragma acc loop vector
       for (IndexType thread_id = 0; thread_id < chunk_size; ++thread_id) {
-        const IndexType local_offset = team_id * chunk_size;
+        const IndexType local_offset = team_id * chunk_size + begin;
         const IndexType idx          = local_offset + thread_id;
         ValueType update             = KOKKOS_IMPL_ACC_ACCESS_ELEMENTS(
             current_step * chunk_size + thread_id);
-        if (idx < N) functor(idx, update, true);
-        if (idx == N - 1) {
+        if (idx < end) functor(idx, update, true);
+        if (idx == end - 1) {
           if (m_result_ptr_device_accessible) {
             *m_result_ptr = update;
           } else {

--- a/core/unit_test/TestParallelScanRangePolicy.hpp
+++ b/core/unit_test/TestParallelScanRangePolicy.hpp
@@ -87,6 +87,7 @@ struct TestParallelScanRangePolicy {
       Kokkos::deep_copy(postfix_results, 0);
     };
 
+#ifndef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET
     // Lambda for checking errors from stored value at each index
     // starting from 2.
     auto check_scan_results_start2 = [&]() {
@@ -111,6 +112,7 @@ struct TestParallelScanRangePolicy {
       Kokkos::deep_copy(prefix_results, 0);
       Kokkos::deep_copy(postfix_results, 0);
     };
+#endif
 
     // If policy template args are not given, call parallel_scan()
     // with work_size input, if args are given, call

--- a/core/unit_test/TestParallelScanRangePolicy.hpp
+++ b/core/unit_test/TestParallelScanRangePolicy.hpp
@@ -226,7 +226,7 @@ struct TestParallelScanRangePolicy {
                   return_val);  // sum( 0 .. N-1 )
       }
 
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET
       // FIXME_OPENMPTARGET - does not support partial scan.
       if (work_size >= 2) {
         // Construct another RangePolicy for parallel_scan

--- a/core/unit_test/TestParallelScanRangePolicy.hpp
+++ b/core/unit_test/TestParallelScanRangePolicy.hpp
@@ -115,7 +115,7 @@ struct TestParallelScanRangePolicy {
     // If policy template args are not given, call parallel_scan()
     // with work_size input, if args are given, call
     // parallel_scan() with RangePolicy<Args...>(0, work_size)
-    // and RangePolicy<Args...>(1, work_size).
+    // and RangePolicy<Args...>(2, work_size).
     // For each case, call parallel_scan() with all possible
     // function signatures.
     if (sizeof...(Args) == 0) {

--- a/core/unit_test/TestParallelScanRangePolicy.hpp
+++ b/core/unit_test/TestParallelScanRangePolicy.hpp
@@ -226,6 +226,8 @@ struct TestParallelScanRangePolicy {
                   return_val);  // sum( 0 .. N-1 )
       }
 
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
+      // FIXME_OPENMPTARGET - does not support partial scan.
       if (work_size >= 2) {
         // Construct another RangePolicy for parallel_scan
         // whose range starts from 2.
@@ -297,6 +299,7 @@ struct TestParallelScanRangePolicy {
               return_val);  // sum( 2 .. N-1 )
         }
       }
+#endif
     }
   }
 

--- a/core/unit_test/TestParallelScanRangePolicy.hpp
+++ b/core/unit_test/TestParallelScanRangePolicy.hpp
@@ -87,9 +87,35 @@ struct TestParallelScanRangePolicy {
       Kokkos::deep_copy(postfix_results, 0);
     };
 
+    // Lambda for checking errors from stored value at each index
+    // starting from 2.
+    auto check_scan_results_start2 = [&]() {
+      auto const prefix_h = Kokkos::create_mirror_view_and_copy(
+          Kokkos::HostSpace(), prefix_results);
+      auto const postfix_h = Kokkos::create_mirror_view_and_copy(
+          Kokkos::HostSpace(), postfix_results);
+
+      for (size_t i = 2; i < work_size; ++i) {
+        // Check prefix sum
+        ASSERT_EQ(static_cast<ValueType>(
+                      (static_cast<ValueType>(i + 1) * (i - 2)) / 2),
+                  prefix_h(i));
+
+        // Check postfix sum
+        ASSERT_EQ(static_cast<ValueType>(
+                      (static_cast<ValueType>(i + 2) * (i - 1)) / 2),
+                  postfix_h(i));
+      }
+
+      // Reset results
+      Kokkos::deep_copy(prefix_results, 0);
+      Kokkos::deep_copy(postfix_results, 0);
+    };
+
     // If policy template args are not given, call parallel_scan()
     // with work_size input, if args are given, call
-    // parallel_scan() with RangePolicy<Args...>(0, work_size).
+    // parallel_scan() with RangePolicy<Args...>(0, work_size)
+    // and RangePolicy<Args...>(1, work_size).
     // For each case, call parallel_scan() with all possible
     // function signatures.
     if (sizeof...(Args) == 0) {
@@ -198,6 +224,78 @@ struct TestParallelScanRangePolicy {
         ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
                                          (work_size - 1) / 2),
                   return_val);  // sum( 0 .. N-1 )
+      }
+
+      if (work_size >= 2) {
+        // Construct another RangePolicy for parallel_scan
+        // whose range starts from 2.
+        Kokkos::RangePolicy<execution_space, Args...> policy2(2, work_size);
+
+        // Input: label, work_count, functor
+        Kokkos::parallel_scan("TestWithStrArg5", policy2, *this);
+        check_scan_results_start2();
+
+        // Input: work_count, functor
+        Kokkos::parallel_scan(policy2, *this);
+        check_scan_results_start2();
+
+        {
+          // Input: label, work_count, functor
+          // Input/Output: return_value
+          ValueType return_val = 0;
+          Kokkos::parallel_scan("TestWithStrArg6", policy2, *this, return_val);
+          check_scan_results_start2();
+          ASSERT_EQ(
+              static_cast<ValueType>(static_cast<ValueType>(work_size + 1) *
+                                     (work_size - 2) / 2),
+              return_val);  // sum( 2 .. N-1 )
+        }
+
+        // Input: work_count, functor
+        // Input/Output: return_value
+        {
+          ValueType return_val = 0;
+          Kokkos::parallel_scan(policy2, *this, return_val);
+          check_scan_results_start2();
+          ASSERT_EQ(
+              static_cast<ValueType>(static_cast<ValueType>(work_size + 1) *
+                                     (work_size - 2) / 2),
+              return_val);  // sum( 2 .. N-1 )
+        }
+
+        // Input: work_count, functor
+        // Input/Output: return_view (Device)
+        {
+          Kokkos::View<ValueType, execution_space> return_view("return_view");
+          Kokkos::parallel_scan(policy2, *this, return_view);
+          check_scan_results_start2();
+
+          ValueType total;
+          Kokkos::deep_copy(total, return_view);
+          ASSERT_EQ(
+              static_cast<ValueType>(static_cast<ValueType>(work_size + 1) *
+                                     (work_size - 2) / 2),
+              total);  // sum( 2 .. N-1 )
+        }
+
+        // Check Kokkos::Experimental::require()
+        // for one of the signatures.
+        {
+          using Property =
+              Kokkos::Experimental::WorkItemProperty::HintLightWeight_t;
+          const auto policy_with_require2 =
+              Kokkos::Experimental::require(policy2, Property());
+
+          // Input: work_count, functor
+          // Input/Output: return_value
+          ValueType return_val = 0;
+          Kokkos::parallel_scan(policy_with_require2, *this, return_val);
+          check_scan_results_start2();
+          ASSERT_EQ(
+              static_cast<ValueType>(static_cast<ValueType>(work_size + 1) *
+                                     (work_size - 2) / 2),
+              return_val);  // sum( 2 .. N-1 )
+        }
       }
     }
   }


### PR DESCRIPTION
This PR updates the OpenACC backend implementation of `parallel_scan(RangePolicy)` to support `RangePolicy` with non-zero `begin` argument. (Previous implementation assumed that `RangePolicy` starts from `0`.)