### PR TITLE
Unset CMAKE_REQUIRED* variables after use

### DIFF
--- a/cmake/Modules/FindTPLLIBQUADMATH.cmake
+++ b/cmake/Modules/FindTPLLIBQUADMATH.cmake
@@ -13,6 +13,8 @@ check_cxx_source_compiles(
   }"
   KOKKOS_QUADMATH_COMPILER_SUPPORT
 )
+unset(CMAKE_REQUIRED_LIBRARIES)
+
 if(KOKKOS_QUADMATH_COMPILER_SUPPORT)
   kokkos_create_imported_tpl(LIBQUADMATH INTERFACE LINK_LIBRARIES quadmath)
 else()

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -773,7 +773,6 @@ if(KOKKOS_ARCH_NATIVE)
     check_cxx_symbol_exists(__ARM_NEON "" KOKKOS_COMPILER_HAS_ARM_NEON)
     unset(KOKKOS_COMPILER_HAS_AVX CACHE)
     check_cxx_symbol_exists(__AVX__ "" KOKKOS_COMPILER_HAS_AVX)
-    set(CMAKE_REQUIRED_FLAGS "${KOKKOS_COMPILE_OPTIONS}")
 
     unset(CMAKE_REQUIRED_QUIET)
     unset(CMAKE_REQUIRED_FLAGS)
@@ -918,6 +917,7 @@ if(KOKKOS_ENABLE_SYCL)
   endif()
 
   check_cxx_symbol_exists(SYCL_EXT_ONEAPI_GRAPH "sycl/sycl.hpp" KOKKOS_IMPL_HAVE_SYCL_EXT_ONEAPI_GRAPH)
+  unset(CMAKE_REQUIRED_FLAGS)
 endif()
 
 set(CUDA_ARCH_ALREADY_SPECIFIED "")


### PR DESCRIPTION
CMAKE_REQUIRED*  variables are used in a bunch of different CMake checks and we should make sure to reset them when done using. This fixes the duplicated flags in https://github.com/kokkos/kokkos/pull/8292#issuecomment-3185164477.