### PR TITLE
Reenable static_cast use in deep_copy rank-123

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -302,7 +302,14 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 1, iType> {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const iType& i0) const { a(i0) = b(i0); }
+  void operator()(const iType& i0) const {
+    // backwards compatible fix for allowing deep_copy between
+    // non-assignable types for rank 0-3
+    if constexpr (std::is_assignable_v<decltype(a(i0)), decltype(b(i0))>)
+      a(i0) = b(i0);
+    else
+      a(i0) = static_cast<value_type>(b(i0));
+  }
 };
 
 template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
@@ -332,7 +339,13 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 2, iType> {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const iType& i0, const iType& i1) const {
-    a(i0, i1) = b(i0, i1);
+    // backwards compatible fix for allowing deep_copy between
+    // non-assignable types for rank 0-3
+    if constexpr (std::is_assignable_v<decltype(a(i0, i1)),
+                                       decltype(b(i0, i1))>)
+      a(i0, i1) = b(i0, i1);
+    else
+      a(i0, i1) = static_cast<value_type>(b(i0, i1));
   }
 };
 
@@ -365,7 +378,13 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 3, iType> {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const iType& i0, const iType& i1, const iType& i2) const {
-    a(i0, i1, i2) = b(i0, i1, i2);
+    // backwards compatible fix for allowing deep_copy between
+    // non-assignable types for rank 0-3
+    if constexpr (std::is_assignable_v<decltype(a(i0, i1, i2)),
+                                       decltype(b(i0, i1, i2))>)
+      a(i0, i1, i2) = b(i0, i1, i2);
+    else
+      a(i0, i1, i2) = static_cast<value_type>(b(i0, i1, i2));
   }
 };
 

--- a/core/unit_test/TestDeepCopy_Assignment.hpp
+++ b/core/unit_test/TestDeepCopy_Assignment.hpp
@@ -53,3 +53,18 @@ TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_8) {
   test_deep_copy_assignable_types<double********, Foo********>(1, 1, 1, 1, 1, 1,
                                                                1, 1);
 }
+
+// Half types used to work just for rank 1-3
+TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_1_half) {
+  test_deep_copy_assignable_types<double*, Kokkos::Experimental::half_t*>(1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_2_half) {
+  test_deep_copy_assignable_types<double**, Kokkos::Experimental::half_t**>(1,
+                                                                            1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_3_half) {
+  test_deep_copy_assignable_types<double***, Kokkos::Experimental::half_t***>(
+      1, 1, 1);
+}


### PR DESCRIPTION
Kokkos kernels does a deep_copy from half_t to double. And half_t can only be explicitly cast to double.

So this doesn't work right now, and for rank 0 and rank > 3 it never did:
```c++
  Kokkos::View<double*> a("A",10);
  Kokkos::View<Kokkos::Experimental::half_t*> b("B",10);
  Kokkos::deep_copy(a,b);
```

Note `deep_copy` the other way around works.