### PR TITLE
[4.7.1] Cherry-Pick of #8304,  #8322, #8358, #8338 and #8370: fixes to get Trilinos working with the new View

### DIFF
--- a/cmake/kokkos_configure_trilinos.cmake
+++ b/cmake/kokkos_configure_trilinos.cmake
@@ -33,8 +33,6 @@ if(CMAKE_PROJECT_NAME STREQUAL "Trilinos")
 
   set(Kokkos_ENABLE_COMPLEX_ALIGN OFF CACHE BOOL "Whether to align Kokkos::complex to 2*alignof(RealType)")
 
-  set(Kokkos_ENABLE_IMPL_VIEW_LEGACY ON CACHE BOOL "Whether to use the legacy implementation of View" FORCE)
-
   # FIXME_TRILINOS We run into problems when trying to use an external GTest in Trilinos CI
   set(CMAKE_DISABLE_FIND_PACKAGE_GTest ON)
 endif()

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -809,6 +809,23 @@ class DynRankView : private View<DataType*******, Properties...> {
   KOKKOS_FUNCTION DynRankView(const DynRankView<RT, RP...>& rhs)
       : view_type(rhs), m_rank(rhs.m_rank) {}
 
+  KOKKOS_INLINE_FUNCTION DynRankView(view_type rhs, size_t new_rank)
+      : view_type(rhs), m_rank(new_rank) {
+    if (new_rank > view_type::rank())
+      Kokkos::abort(
+          "Attempting to construct DynRankView from View and new rank, with "
+          "the new rank being too large.");
+
+    bool invalid_extent = false;
+    for (size_t r = new_rank; r < view_type::rank(); r++)
+      if (rhs.extent(r) != 1) invalid_extent = true;
+    if (invalid_extent)
+      Kokkos::abort(
+          "Attempting to construct DynRankView from View with incompatible "
+          "extents. (Extents for dimensions larger than the provided rank are "
+          "not equal to 1).");
+  }
+
   template <class RT, class... RP>
   KOKKOS_FUNCTION DynRankView& operator=(const DynRankView<RT, RP...>& rhs) {
     view_type::operator=(rhs);

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -499,6 +499,11 @@ class DynRankView : private View<DataType*******, Properties...> {
   using reference        = reference_type;
   using data_handle_type = pointer_type;
 
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+  using accessor_type = typename view_type::accessor_type;
+  using mapping_type  = typename view_type::mapping_type;
+#endif
+
   KOKKOS_FUNCTION
   view_type& DownCast() const { return (view_type&)(*this); }
 
@@ -905,7 +910,8 @@ class DynRankView : private View<DataType*******, Properties...> {
       std::enable_if_t<((!std::is_same_v<P, std::string>)&&...),
                        const typename traits::array_layout&>
           layout) {
-    if constexpr (traits::impl_is_customized) {
+    if constexpr (traits::impl_is_customized &&
+                  !Impl::ViewCtorProp<P...>::has_accessor_arg) {
       int r = 0;
       while (r < 7 && layout.dimension[r] != KOKKOS_INVALID_INDEX) r++;
 
@@ -1602,23 +1608,16 @@ namespace Impl {
 template <class T, class... P, class... ViewCtorArgs>
 inline auto create_mirror(const DynRankView<T, P...>& src,
                           const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop) {
-  check_view_ctor_args_create_mirror<ViewCtorArgs...>();
-
-  auto prop_copy = Impl::with_properties_if_unset(
-      arg_prop, std::string(src.label()).append("_mirror"));
-
   if constexpr (Impl::ViewCtorProp<ViewCtorArgs...>::has_memory_space) {
     using dst_type = typename Impl::MirrorDRViewType<
         typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
         P...>::dest_view_type;
-    return dst_type(prop_copy,
-                    Impl::reconstructLayout(src.layout(), src.rank()));
+    return dst_type(create_mirror(arg_prop, src.DownCast()), src.rank());
   } else {
     using src_type = DynRankView<T, P...>;
     using dst_type = typename src_type::HostMirror;
 
-    return dst_type(prop_copy,
-                    Impl::reconstructLayout(src.layout(), src.rank()));
+    return dst_type(create_mirror(arg_prop, src.DownCast()), src.rank());
   }
 #if defined(KOKKOS_COMPILER_NVCC) && KOKKOS_COMPILER_NVCC >= 1130 && \
     !defined(KOKKOS_COMPILER_MSVC)

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -119,7 +119,7 @@ struct DynRankDimTraits {
       (std::is_same_v<Layout, Kokkos::LayoutRight> ||
        std::is_same_v<Layout, Kokkos::LayoutLeft>),
       Layout>
-  createLayout(const Layout& layout) {
+  createLayout(const Layout& layout, [[maybe_unused]] int new_rank = -1) {
     Layout new_layout(
         layout.dimension[0] != unspecified ? layout.dimension[0] : 1,
         layout.dimension[1] != unspecified ? layout.dimension[1] : 1,
@@ -146,6 +146,10 @@ struct DynRankDimTraits {
     } else
 #endif
       new_layout.stride = layout.stride;
+    if constexpr (std::is_same_v<Layout, Kokkos::LayoutRight>) {
+      if (new_rank != -1 && layout.dimension[new_rank - 1] == layout.stride)
+        new_layout.stride = unspecified;
+    }
     return new_layout;
   }
 
@@ -153,7 +157,7 @@ struct DynRankDimTraits {
   template <typename Layout>
   KOKKOS_INLINE_FUNCTION static std::enable_if_t<
       (std::is_same_v<Layout, Kokkos::LayoutStride>), Layout>
-  createLayout(const Layout& layout) {
+  createLayout(const Layout& layout, [[maybe_unused]] int new_rank = -1) {
     return Layout(
         layout.dimension[0] != unspecified ? layout.dimension[0] : 1,
         layout.stride[0],
@@ -853,7 +857,7 @@ class DynRankView : private View<DataType*******, Properties...> {
       : view_type(rhs.data_handle(),
                   Impl::mapping_from_array_layout<
                       typename view_type::mdspan_type::mapping_type>(
-                      drdtraits::createLayout(rhs.layout())),
+                      drdtraits::createLayout(rhs.layout(), new_rank)),
                   rhs.accessor()),
         m_rank(new_rank) {
     if (new_rank > View<RT, RP...>::rank())
@@ -868,7 +872,7 @@ class DynRankView : private View<DataType*******, Properties...> {
         view_type(rhs.data_handle(),
                   Impl::mapping_from_array_layout<
                       typename view_type::mdspan_type::mapping_type>(
-                      drdtraits::createLayout(rhs.layout())),
+                      drdtraits::createLayout(rhs.layout(), rhs.rank())),
                   rhs.accessor()));
     m_rank = rhs.rank();
     return *this;

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -65,31 +65,10 @@ struct DynRankDimTraits {
   KOKKOS_INLINE_FUNCTION
   static size_t computeRank(const size_t N0, const size_t N1, const size_t N2,
                             const size_t N3, const size_t N4, const size_t N5,
-                            const size_t N6, const size_t /* N7 */) {
-    return (
-        (N6 == unspecified && N5 == unspecified && N4 == unspecified &&
-         N3 == unspecified && N2 == unspecified && N1 == unspecified &&
-         N0 == unspecified)
-            ? 0
-            : ((N6 == unspecified && N5 == unspecified && N4 == unspecified &&
-                N3 == unspecified && N2 == unspecified && N1 == unspecified)
-                   ? 1
-                   : ((N6 == unspecified && N5 == unspecified &&
-                       N4 == unspecified && N3 == unspecified &&
-                       N2 == unspecified)
-                          ? 2
-                          : ((N6 == unspecified && N5 == unspecified &&
-                              N4 == unspecified && N3 == unspecified)
-                                 ? 3
-                                 : ((N6 == unspecified && N5 == unspecified &&
-                                     N4 == unspecified)
-                                        ? 4
-                                        : ((N6 == unspecified &&
-                                            N5 == unspecified)
-                                               ? 5
-                                               : ((N6 == unspecified)
-                                                      ? 6
-                                                      : 7)))))));
+                            const size_t N6, const size_t N7) {
+    return (N0 != unspecified) + (N1 != unspecified) + (N2 != unspecified) +
+           (N3 != unspecified) + (N4 != unspecified) + (N5 != unspecified) +
+           (N6 != unspecified) + (N7 != unspecified);
   }
 
   // Compute the rank of the view from the nonzero layout arguments.
@@ -934,7 +913,7 @@ class DynRankView : private View<DataType*******, Properties...> {
     if constexpr (traits::impl_is_customized &&
                   !Impl::ViewCtorProp<P...>::has_accessor_arg) {
       int r = 0;
-      while (r < 7 && layout.dimension[r] != KOKKOS_INVALID_INDEX) r++;
+      while (r < 8 && layout.dimension[r] != KOKKOS_INVALID_INDEX) r++;
 
       // Can't use with_properties_if_unset since its a host only function!
       return view_wrap(
@@ -953,7 +932,7 @@ class DynRankView : private View<DataType*******, Properties...> {
     if constexpr (traits::impl_is_customized &&
                   !Impl::ViewCtorProp<P...>::has_accessor_arg) {
       int r = 0;
-      while (r < 7 && layout.dimension[r] != KOKKOS_INVALID_INDEX) r++;
+      while (r < 8 && layout.dimension[r] != KOKKOS_INVALID_INDEX) r++;
       // Could use with_properties_if_unset, but rather keep same as above.
       return view_alloc(
           static_cast<const Impl::ViewCtorProp<void, P>&>(arg_prop).value...,

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -21,6 +21,7 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
       DynViewAPI_rank12345
       DynViewAPI_rank67
       DynRankView_Ctors
+      DynRankView_LayoutMember
       DynRankView_TeamScratch
       DynRankView_ViewCustomization
       ErrorReporter

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -20,6 +20,7 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
       DynViewAPI_generic
       DynViewAPI_rank12345
       DynViewAPI_rank67
+      DynRankView_Ctors
       DynRankView_TeamScratch
       DynRankView_ViewCustomization
       ErrorReporter

--- a/containers/unit_tests/TestDynRankViewTypedefs.cpp
+++ b/containers/unit_tests/TestDynRankViewTypedefs.cpp
@@ -56,7 +56,7 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::data_type, DataType>);
   static_assert(std::is_same_v<typename ViewType::const_data_type, typename data_analysis<DataType>::const_data_type>);
   static_assert(std::is_same_v<typename ViewType::non_const_data_type, typename data_analysis<DataType>::non_const_data_type>);
-  
+
   // FIXME: these should be deprecated and for proper testing (I.e. where this is different from data_type)
   // we would need ensemble types which use the hidden View dimension facility of View (i.e. which make
   // "specialize" not void)
@@ -84,12 +84,12 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::memory_traits, MemoryTraitsType>);
   static_assert(std::is_same_v<typename ViewType::host_mirror_space, HostMirrorSpace>);
   static_assert(std::is_same_v<typename ViewType::size_type, typename ViewType::memory_space::size_type>);
- 
+
   // FIXME: should be deprecated in favor of reference
   static_assert(std::is_same_v<typename ViewType::reference_type, ReferenceType>);
   // FIXME: should be deprecated in favor of data_handle_type
   static_assert(std::is_same_v<typename ViewType::pointer_type, ValueType*>);
- 
+
   // =========================================
   // in Legacy View: some helper View variants
   // =========================================
@@ -173,6 +173,14 @@ constexpr bool test_view_typedefs_impl() {
   // FIXME: should come from accessor_type
   static_assert(std::is_same_v<typename ViewType::data_handle_type, typename ViewType::pointer_type>);
   static_assert(std::is_same_v<typename ViewType::reference, typename ViewType::reference_type>);
+
+  #ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+  using base_view_type = typename ViewType::view_type;
+  static_assert(
+      std::is_same_v<typename ViewType::accessor_type, typename base_view_type::accessor_type>);
+  static_assert(
+      std::is_same_v<typename ViewType::mapping_type, typename base_view_type::mapping_type>);
+  #endif
   return true;
 }
 

--- a/containers/unit_tests/TestDynRankView_Ctors.hpp
+++ b/containers/unit_tests/TestDynRankView_Ctors.hpp
@@ -1,0 +1,110 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_DynRankView.hpp>
+
+namespace {
+
+void test_dyn_rank_view_ctor_from_members() {
+  using drview_t = Kokkos::DynRankView<double, TEST_EXECSPACE>;
+  using view_t   = typename drview_t::view_type;
+
+  {
+    view_t data("data", 2, 3, 4, 5, 6, 7, 8);
+    drview_t drv(data, 7);
+
+    ASSERT_EQ(drv.rank(), 7lu);
+    for (size_t r = 0; r < drv.rank(); r++)
+      ASSERT_EQ(static_cast<size_t>(drv.extent(r)), r + 2);
+    ASSERT_EQ(data.use_count(), 2);
+    ASSERT_EQ(data.data(), drv.data());
+  }
+  {
+    view_t data("data", 2, 3, 4, 1, 1, 1, 1);
+    drview_t drv(data, 3);
+
+    ASSERT_EQ(drv.rank(), 3lu);
+    for (size_t r = 0; r < drv.rank(); r++)
+      ASSERT_EQ(static_cast<size_t>(drv.extent(r)), r + 2);
+    ASSERT_EQ(data.use_count(), 2);
+    ASSERT_EQ(data.data(), drv.data());
+  }
+  {
+    view_t data("data", 1, 1, 1, 1, 1, 1, 1);
+    drview_t drv(data, 0);
+
+    ASSERT_EQ(drv.rank(), 0lu);
+    ASSERT_EQ(data.use_count(), 2);
+    ASSERT_EQ(data.data(), drv.data());
+  }
+}
+
+TEST(TEST_CATEGORY, dyn_rank_view_ctor_from_members) {
+  test_dyn_rank_view_ctor_from_members();
+}
+
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+void test_dyn_rank_view_ctor_from_layout_stride() {
+  using drview_t =
+      Kokkos::DynRankView<double, Kokkos::LayoutStride, TEST_EXECSPACE>;
+  using view_t = typename drview_t::view_type;
+  {
+    typename view_t::mapping_type map(
+        Kokkos::dextents<int, 7>(2, 3, 4, 5, 6, 7, 8),
+        std::array{1, 2, 6, 24, 120, 720, 5040});
+    view_t data("data", map);
+    drview_t drv(data, 7);
+
+    ASSERT_EQ(drv.rank(), 7lu);
+    for (size_t r = 0; r < drv.rank(); r++)
+      ASSERT_EQ(static_cast<size_t>(drv.extent(r)), r + 2);
+    ASSERT_EQ(data.use_count(), 2);
+    ASSERT_EQ(data.data(), drv.data());
+  }
+  {
+    typename view_t::mapping_type map(
+        Kokkos::dextents<int, 7>(2, 3, 4, 1, 1, 1, 1),
+        std::array{1, 2, 6, 1, 1, 1, 1});
+    view_t data("data", map);
+    drview_t drv(data, 3);
+
+    ASSERT_EQ(drv.rank(), 3lu);
+    for (size_t r = 0; r < drv.rank(); r++)
+      ASSERT_EQ(static_cast<size_t>(drv.extent(r)), r + 2);
+    ASSERT_EQ(data.use_count(), 2);
+    ASSERT_EQ(data.data(), drv.data());
+  }
+  {
+    typename view_t::mapping_type map(
+        Kokkos::dextents<int, 7>(1, 1, 1, 1, 1, 1, 1),
+        std::array{1, 1, 1, 1, 1, 1, 1});
+    view_t data("data", map);
+    drview_t drv(data, 0);
+
+    ASSERT_EQ(drv.rank(), 0lu);
+    ASSERT_EQ(data.use_count(), 2);
+    ASSERT_EQ(data.data(), drv.data());
+  }
+}
+
+TEST(TEST_CATEGORY, dyn_rank_view_ctor_from_layout_stride) {
+  test_dyn_rank_view_ctor_from_layout_stride();
+}
+#endif
+
+}  // namespace

--- a/containers/unit_tests/TestDynRankView_LayoutMember.hpp
+++ b/containers/unit_tests/TestDynRankView_LayoutMember.hpp
@@ -1,0 +1,51 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_DynRankView.hpp>
+
+namespace {
+
+template <class Layout>
+void test_dyn_rank_view_layout_member() {
+  bool is_ll = std::is_same_v<Layout, Kokkos::LayoutLeft>;
+  {
+    Kokkos::DynRankView<int, Layout> a(
+        Kokkos::View<int***, Layout>("A", 11, 7, 5));
+    auto l = a.layout();
+    ASSERT_EQ(l.dimension[0], 11lu);
+    ASSERT_EQ(l.dimension[1], 7lu);
+    ASSERT_EQ(l.dimension[2], 5lu);
+    ASSERT_TRUE(
+        (l.stride == is_ll ? 11lu : 5lu || static_cast<int>(l.stride) == -1));
+  }
+  {
+    Kokkos::DynRankView<int, Layout> a(Kokkos::View<int**, Layout>("A", 7, 5));
+    auto l = a.layout();
+    ASSERT_EQ(l.dimension[0], 7lu);
+    ASSERT_EQ(l.dimension[1], 5lu);
+    ASSERT_TRUE(
+        (l.stride == is_ll ? 7lu : 5lu || static_cast<int>(l.stride) == -1));
+  }
+}
+
+}  // namespace
+
+TEST(TEST_CATEGORY, dyn_rank_view_layout_member) {
+  test_dyn_rank_view_layout_member<Kokkos::LayoutRight>();
+  test_dyn_rank_view_layout_member<Kokkos::LayoutLeft>();
+}

--- a/containers/unit_tests/TestDynRankView_ViewCustomization.hpp
+++ b/containers/unit_tests/TestDynRankView_ViewCustomization.hpp
@@ -204,6 +204,36 @@ TEST(TEST_CATEGORY, view_customization_extra_int_arg) {
         sizeof(double);
     ASSERT_EQ(shmem, expected_shmem_size);
   }
+  // Rank 7
+  {
+    view_t a("A", 2, 3, 2, 7, 2, 11, 2, 5);
+    ASSERT_EQ(a.rank(), 7lu);
+    ASSERT_EQ(a.extent(0), 2lu);
+    ASSERT_EQ(a.extent(1), 3lu);
+    ASSERT_EQ(a.extent(2), 2lu);
+    ASSERT_EQ(a.extent(3), 7lu);
+    ASSERT_EQ(a.extent(4), 2lu);
+    ASSERT_EQ(a.extent(5), 11lu);
+    ASSERT_EQ(a.extent(2), 2lu);
+    ASSERT_EQ(a.accessor().size, 5lu);
+    ASSERT_EQ(a.accessor().stride, size_t(16 * 3 * 7 * 11));
+    view_t b(a.data(), 2, 3, 2, 7, 2, 11, 2, 5);
+    ASSERT_EQ(b.rank(), 7lu);
+    ASSERT_EQ(b.extent(0), 2lu);
+    ASSERT_EQ(b.extent(1), 3lu);
+    ASSERT_EQ(b.extent(2), 2lu);
+    ASSERT_EQ(b.extent(3), 7lu);
+    ASSERT_EQ(b.extent(4), 2lu);
+    ASSERT_EQ(b.extent(5), 11lu);
+    ASSERT_EQ(b.extent(6), 2lu);
+    ASSERT_EQ(b.accessor().size, 5lu);
+    ASSERT_EQ(b.accessor().stride, size_t(16 * 3 * 7 * 11));
+    size_t shmem = view_t::shmem_size(2, 3, 2, 7, 2, 11, 2, 5);
+    size_t expected_shmem_size =
+        2lu * 3lu * 2lu * 7lu * 2lu * 11lu * 2lu * 5lu * sizeof(double) +
+        sizeof(double);
+    ASSERT_EQ(shmem, expected_shmem_size);
+  }
   // With accessor arg and no label
   {
     // This should not interpret the last argument (11) as an accessor arg since

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -302,7 +302,14 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 1, iType> {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const iType& i0) const { a(i0) = b(i0); }
+  void operator()(const iType& i0) const {
+    // backwards compatible fix for allowing deep_copy between
+    // non-assignable types for rank 0-3
+    if constexpr (std::is_assignable_v<decltype(a(i0)), decltype(b(i0))>)
+      a(i0) = b(i0);
+    else
+      a(i0) = static_cast<value_type>(b(i0));
+  }
 };
 
 template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
@@ -332,7 +339,13 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 2, iType> {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const iType& i0, const iType& i1) const {
-    a(i0, i1) = b(i0, i1);
+    // backwards compatible fix for allowing deep_copy between
+    // non-assignable types for rank 0-3
+    if constexpr (std::is_assignable_v<decltype(a(i0, i1)),
+                                       decltype(b(i0, i1))>)
+      a(i0, i1) = b(i0, i1);
+    else
+      a(i0, i1) = static_cast<value_type>(b(i0, i1));
   }
 };
 
@@ -365,7 +378,13 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 3, iType> {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const iType& i0, const iType& i1, const iType& i2) const {
-    a(i0, i1, i2) = b(i0, i1, i2);
+    // backwards compatible fix for allowing deep_copy between
+    // non-assignable types for rank 0-3
+    if constexpr (std::is_assignable_v<decltype(a(i0, i1, i2)),
+                                       decltype(b(i0, i1, i2))>)
+      a(i0, i1, i2) = b(i0, i1, i2);
+    else
+      a(i0, i1, i2) = static_cast<value_type>(b(i0, i1, i2));
   }
 };
 

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -56,11 +56,27 @@ namespace Impl {
 
 template <class ViewType, class Layout, class ExecSpace, typename iType>
 struct ViewFill<ViewType, Layout, ExecSpace, 0, iType> {
+  ViewType a;
+  typename ViewType::const_value_type val;
   using ST = typename ViewType::non_const_value_type;
-  ViewFill(const ViewType& a, const ST& val, const ExecSpace& space) {
-    Kokkos::Impl::DeepCopy<typename ViewType::memory_space, Kokkos::HostSpace,
-                           ExecSpace>(space, a.data(), &val, sizeof(ST));
+  ViewFill(const ViewType& a_, const ST& val_, const ExecSpace& space)
+      : a(a_), val(val_) {
+    // If the View is not customized and uses one of the trivial accessors
+    // we can deep_copy, otherwise we need to run a kernel so the accessor
+    // side effects take place.
+    if constexpr (!ViewType::traits::impl_is_customized) {
+      Kokkos::Impl::DeepCopy<typename ViewType::memory_space, Kokkos::HostSpace,
+                             ExecSpace>(space, a.data(), &val, sizeof(ST));
+    } else {
+      using policy_type =
+          Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<iType>>;
+      Kokkos::parallel_for("Kokkos::ViewFill-1D", policy_type(space, 0, 1),
+                           *this);
+    }
   }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const iType&) const { a() = val; }
 };
 
 template <class ViewType, class Layout, class ExecSpace, typename iType>
@@ -1043,9 +1059,9 @@ inline void deep_copy(
   using dst_memory_space = typename dst_type::memory_space;
   using src_memory_space = typename src_type::memory_space;
 
-  static_assert(std::is_same_v<typename dst_type::value_type,
-                               typename src_type::non_const_value_type>,
-                "deep_copy requires matching non-const destination type");
+  static_assert(
+      std::is_same_v<value_type, typename src_type::non_const_value_type>,
+      "deep_copy requires matching non-const destination type");
 
   if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
     Kokkos::Profiling::beginDeepCopy(
@@ -1067,8 +1083,16 @@ inline void deep_copy(
 
   Kokkos::fence("Kokkos::deep_copy: scalar to scalar copy, pre copy fence");
   if (dst.data() != src.data()) {
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+    using dst_ptr_type  = decltype(dst.data());
+    const size_t nbytes = allocation_size_from_mapping_and_accessor(
+                              src.mapping(), src.accessor()) *
+                          sizeof(std::remove_pointer_t<dst_ptr_type>);
+#else
+    const size_t nbytes = sizeof(value_type);
+#endif
     Kokkos::Impl::DeepCopy<dst_memory_space, src_memory_space>(
-        dst.data(), src.data(), sizeof(value_type));
+        dst.data(), src.data(), nbytes);
     Kokkos::fence("Kokkos::deep_copy: scalar to scalar copy, post copy fence");
   }
   if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -302,9 +302,7 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 1, iType> {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const iType& i0) const {
-    a(i0) = static_cast<value_type>(b(i0));
-  }
+  void operator()(const iType& i0) const { a(i0) = b(i0); }
 };
 
 template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
@@ -334,7 +332,7 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 2, iType> {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const iType& i0, const iType& i1) const {
-    a(i0, i1) = static_cast<value_type>(b(i0, i1));
+    a(i0, i1) = b(i0, i1);
   }
 };
 
@@ -367,7 +365,7 @@ struct ViewCopy<ViewTypeA, ViewTypeB, Layout, ExecSpace, 3, iType> {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const iType& i0, const iType& i1, const iType& i2) const {
-    a(i0, i1, i2) = static_cast<value_type>(b(i0, i1, i2));
+    a(i0, i1, i2) = b(i0, i1, i2);
   }
 };
 
@@ -1044,6 +1042,16 @@ inline void deep_copy(
 
 //----------------------------------------------------------------------------
 /** \brief  A deep copy between views of compatible type, and rank zero.  */
+
+namespace Impl {
+template <class ExecSpace, class DstView, class SrcView>
+void deep_copy_rank0(ExecSpace exec_space, DstView dst, SrcView src) {
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<ExecSpace>(exec_space, 0, 1),
+      KOKKOS_LAMBDA(int) { dst() = src(); });
+}
+}  // namespace Impl
+
 template <class DT, class... DP, class ST, class... SP>
 inline void deep_copy(
     const View<DT, DP...>& dst, const View<ST, SP...>& src,
@@ -1055,13 +1063,8 @@ inline void deep_copy(
   using dst_type = View<DT, DP...>;
   using src_type = View<ST, SP...>;
 
-  using value_type       = typename dst_type::value_type;
   using dst_memory_space = typename dst_type::memory_space;
   using src_memory_space = typename src_type::memory_space;
-
-  static_assert(
-      std::is_same_v<value_type, typename src_type::non_const_value_type>,
-      "deep_copy requires matching non-const destination type");
 
   if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
     Kokkos::Profiling::beginDeepCopy(
@@ -1082,17 +1085,37 @@ inline void deep_copy(
   }
 
   Kokkos::fence("Kokkos::deep_copy: scalar to scalar copy, pre copy fence");
-  if (dst.data() != src.data()) {
+
+  if constexpr (std::is_same_v<
+                    typename ViewTraits<DT, DP...>::value_type,
+                    typename ViewTraits<ST, SP...>::non_const_value_type>) {
+    if (dst.data() != src.data()) {
 #ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
-    using dst_ptr_type  = decltype(dst.data());
-    const size_t nbytes = allocation_size_from_mapping_and_accessor(
-                              src.mapping(), src.accessor()) *
-                          sizeof(std::remove_pointer_t<dst_ptr_type>);
+      using dst_ptr_type  = decltype(dst.data());
+      const size_t nbytes = allocation_size_from_mapping_and_accessor(
+                                src.mapping(), src.accessor()) *
+                            sizeof(std::remove_pointer_t<dst_ptr_type>);
 #else
-    const size_t nbytes = sizeof(value_type);
+      const size_t nbytes = sizeof(typename dst_type::value_type);
 #endif
-    Kokkos::Impl::DeepCopy<dst_memory_space, src_memory_space>(
-        dst.data(), src.data(), nbytes);
+      Kokkos::Impl::DeepCopy<dst_memory_space, src_memory_space>(
+          dst.data(), src.data(), nbytes);
+      Kokkos::fence(
+          "Kokkos::deep_copy: scalar to scalar copy, post copy fence");
+    }
+  } else {
+    using exec_space = std::conditional_t<
+        Kokkos::SpaceAccessibility<typename dst_memory_space::execution_space,
+                                   src_memory_space>::accessible,
+        typename dst_memory_space::execution_space,
+        typename src_memory_space::execution_space>;
+
+    static_assert(
+        SpaceAccessibility<exec_space, dst_memory_space>::accessible &&
+            SpaceAccessibility<exec_space, src_memory_space>::accessible,
+        "deep_copy between different value types requires common accessibility "
+        "of Views");
+    Impl::deep_copy_rank0(exec_space(), dst, src);
     Kokkos::fence("Kokkos::deep_copy: scalar to scalar copy, post copy fence");
   }
   if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
@@ -2283,9 +2306,6 @@ inline void deep_copy(
 
   using src_memory_space = typename src_traits::memory_space;
   using dst_memory_space = typename dst_traits::memory_space;
-  static_assert(std::is_same_v<typename dst_traits::value_type,
-                               typename src_traits::non_const_value_type>,
-                "deep_copy requires matching non-const destination type");
 
   if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
     Kokkos::Profiling::beginDeepCopy(
@@ -2304,10 +2324,21 @@ inline void deep_copy(
     return;
   }
 
-  if (dst.data() != src.data()) {
-    Kokkos::Impl::DeepCopy<dst_memory_space, src_memory_space, ExecSpace>(
-        exec_space, dst.data(), src.data(),
-        sizeof(typename dst_traits::value_type));
+  if constexpr (std::is_same_v<
+                    typename ViewTraits<DT, DP...>::value_type,
+                    typename ViewTraits<ST, SP...>::non_const_value_type>) {
+    if (dst.data() != src.data()) {
+      Kokkos::Impl::DeepCopy<dst_memory_space, src_memory_space, ExecSpace>(
+          exec_space, dst.data(), src.data(),
+          sizeof(typename dst_traits::value_type));
+    }
+  } else {
+    static_assert(
+        SpaceAccessibility<ExecSpace, dst_memory_space>::accessible &&
+            SpaceAccessibility<ExecSpace, src_memory_space>::accessible,
+        "deep_copy between different value types requires common accessibility "
+        "of Views");
+    Impl::deep_copy_rank0(exec_space, dst, src);
   }
   if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
     Kokkos::Profiling::endDeepCopy();

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -907,16 +907,17 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   }
 
   template <class... Args>
-  View(std::enable_if_t<
+  KOKKOS_FUNCTION View(
+      std::enable_if_t<
 #ifndef KOKKOS_COMPILER_MSVC
-           ((sizeof...(Args)) == rank() + 1) &&
-               (std::is_constructible_v<size_t, Args> && ... && true),
+          ((sizeof...(Args)) == rank() + 1) &&
+              (std::is_constructible_v<size_t, Args> && ... && true),
 #else
            msvc_workaround_ctor_condition_2<Args...>(),
 #endif
-           const pointer_type&>
-           arg_ptr,
-       const Args... args)
+          const pointer_type&>
+          arg_ptr,
+      const Args... args)
       : View(
             Kokkos::view_wrap(arg_ptr,
                               Kokkos::Impl::AccessorArg_t{

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -166,6 +166,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       Complex
       Concepts
       Crs
+      DeepCopy_Assignment
+      DeepCopy_Narrowing
       DeepCopyAlignment
       ExecSpacePartitioning
       ExecSpaceThreadSafety

--- a/core/unit_test/TestDeepCopy.hpp
+++ b/core/unit_test/TestDeepCopy.hpp
@@ -1,0 +1,70 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+#include <cstddef>
+
+namespace {
+struct Foo {
+  KOKKOS_FUNCTION Foo& operator=(double val_) {
+    val = val_;
+    return *this;
+  }
+  float val;
+  KOKKOS_FUNCTION bool operator==(double val_) {
+    return val_ == static_cast<double>(val);
+  }
+};
+
+template <class D1, class D2, class... Extents>
+void test_deep_copy_assignable_types(Extents... exts) {
+  Kokkos::View<D1, TEST_EXECSPACE> a("A", exts...);
+  Kokkos::deep_copy(a, 1.5);
+
+  Kokkos::View<D2, TEST_EXECSPACE> b("B", exts...);
+  Kokkos::deep_copy(b, a);
+
+  auto h_b = Kokkos::create_mirror_view(b);
+  Kokkos::deep_copy(h_b, b);
+  ASSERT_TRUE(h_b((exts - 1)...) == 1.5);
+
+  // Check that
+  Kokkos::deep_copy(TEST_EXECSPACE(), a, 2.5);
+  Kokkos::deep_copy(TEST_EXECSPACE(), b, a);
+  Kokkos::deep_copy(TEST_EXECSPACE(), h_b, b);
+  TEST_EXECSPACE().fence();
+
+  ASSERT_TRUE(h_b((exts - 1)...) == 2.5);
+
+#ifdef KOKKOS_HAS_SHARED_SPACE
+  Kokkos::View<D1, Kokkos::SharedSpace> s("S", exts...);
+  Kokkos::deep_copy(s, 1.5);
+
+  Kokkos::deep_copy(b, s);
+  Kokkos::deep_copy(h_b, b);
+  ASSERT_TRUE(h_b((exts - 1)...) == 1.5);
+#endif
+
+#ifdef KOKKOS_HAS_SHARED_HOST_PINNED_SPACE
+  Kokkos::View<D1, Kokkos::SharedHostPinnedSpace> sp("S", exts...);
+  Kokkos::deep_copy(sp, 2.5);
+
+  Kokkos::deep_copy(b, sp);
+  Kokkos::deep_copy(h_b, b);
+  ASSERT_TRUE(h_b((exts - 1)...) == 2.5);
+#endif
+}
+}  // namespace

--- a/core/unit_test/TestDeepCopy_Assignment.hpp
+++ b/core/unit_test/TestDeepCopy_Assignment.hpp
@@ -1,0 +1,55 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "TestDeepCopy.hpp"
+
+TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_0) {
+  test_deep_copy_assignable_types<double, Foo>();
+}
+
+TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_1) {
+  test_deep_copy_assignable_types<double*, Foo*>(1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_2) {
+  test_deep_copy_assignable_types<double**, Foo**>(1, 1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_3) {
+  test_deep_copy_assignable_types<double***, Foo***>(1, 1, 1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_4) {
+  test_deep_copy_assignable_types<double****, Foo****>(1, 1, 1, 1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_5) {
+  test_deep_copy_assignable_types<double*****, Foo*****>(1, 1, 1, 1, 1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_6) {
+  test_deep_copy_assignable_types<double******, Foo******>(1, 1, 1, 1, 1, 1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_7) {
+  test_deep_copy_assignable_types<double*******, Foo*******>(1, 1, 1, 1, 1, 1,
+                                                             1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_8) {
+  test_deep_copy_assignable_types<double********, Foo********>(1, 1, 1, 1, 1, 1,
+                                                               1, 1);
+}

--- a/core/unit_test/TestDeepCopy_Assignment.hpp
+++ b/core/unit_test/TestDeepCopy_Assignment.hpp
@@ -53,3 +53,18 @@ TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_8) {
   test_deep_copy_assignable_types<double********, Foo********>(1, 1, 1, 1, 1, 1,
                                                                1, 1);
 }
+
+// Half types used to work just for rank 1-3
+TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_1_half) {
+  test_deep_copy_assignable_types<double*, Kokkos::Experimental::half_t*>(1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_2_half) {
+  test_deep_copy_assignable_types<double**, Kokkos::Experimental::half_t**>(1,
+                                                                            1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_assignable_types_rank_3_half) {
+  test_deep_copy_assignable_types<double***, Kokkos::Experimental::half_t***>(
+      1, 1, 1);
+}

--- a/core/unit_test/TestDeepCopy_Narrowing.hpp
+++ b/core/unit_test/TestDeepCopy_Narrowing.hpp
@@ -1,0 +1,55 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "TestDeepCopy.hpp"
+
+TEST(TEST_CATEGORY, deep_copy_narrowing_rank_0) {
+  test_deep_copy_assignable_types<float, double>();
+}
+
+TEST(TEST_CATEGORY, deep_copy_narrowing_rank_1) {
+  test_deep_copy_assignable_types<float*, double*>(1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_narrowing_rank_2) {
+  test_deep_copy_assignable_types<float**, double**>(1, 1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_narrowing_rank_3) {
+  test_deep_copy_assignable_types<float***, double***>(1, 1, 1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_narrowing_rank_4) {
+  test_deep_copy_assignable_types<float****, double****>(1, 1, 1, 1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_narrowing_rank_5) {
+  test_deep_copy_assignable_types<float*****, double*****>(1, 1, 1, 1, 1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_narrowing_rank_6) {
+  test_deep_copy_assignable_types<float******, double******>(1, 1, 1, 1, 1, 1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_narrowing_rank_7) {
+  test_deep_copy_assignable_types<float*******, double*******>(1, 1, 1, 1, 1, 1,
+                                                               1);
+}
+
+TEST(TEST_CATEGORY, deep_copy_narrowing_rank_8) {
+  test_deep_copy_assignable_types<float********, double********>(1, 1, 1, 1, 1,
+                                                                 1, 1, 1);
+}


### PR DESCRIPTION
This cherry picks 5 fixes from develop, which are required to make Trilinos work: #8304, #8322, #8358, #8338 and #8370