### PR TITLE
[4.7.1] Cherry-pick of #8298: Fix incompatibilities with CUDA 13 runtime API

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -571,13 +571,13 @@ pipeline {
                         }
                     }
                 }
-                stage('CUDA-11.6-NVCC-DEBUG') {
+                stage('CUDA-13.0-NVCC-DEBUG') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.nvcc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=nvcr.io/nvidia/cuda:11.6.2-devel-ubuntu20.04@sha256:d95d54bc231f8aea7fda79f60da620324584b20ed31a8ebdb0686cffd34dd405'
-                            label 'nvidia-docker && (volta || ampere)'
+                            additionalBuildArgs '--build-arg BASE=nvcr.io/nvidia/cuda:13.0.0-devel-ubuntu24.04@sha256:435220c0fef35cbf712e11999f8670a83835ef3cdd18564e5e8122f83078c88c'
+                            label 'nvidia-docker && ampere && cuda-13-driver'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }
                     }

--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -11,11 +11,10 @@
 # example, you may have have two different wrappers with either icpc
 # or g++ as their back-end compiler.  The defaults can be overwritten
 # by using the usual arguments (e.g., -arch=sm_80 -ccbin icpc).
-# sm_70 is supported by every CUDA version from 9-12 and is thus
+# sm_80 is supported by every CUDA version from 11-13 and is thus
 # chosen as default
 
-default_arch="sm_70"
-#default_arch="sm_80"
+default_arch="sm_80"
 
 #
 # The default C++ compiler.

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -222,7 +222,11 @@ class CudaInternal {
       cudaGraph_t graph, const cudaGraphNode_t* from, const cudaGraphNode_t* to,
       size_t numDependencies) const {
     set_cuda_device();
+#if CUDART_VERSION >= 13000
+    return cudaGraphAddDependencies(graph, from, to, NULL, numDependencies);
+#else
     return cudaGraphAddDependencies(graph, from, to, numDependencies);
+#endif
   }
 
   cudaError_t cuda_graph_add_empty_node_wrapper(
@@ -276,7 +280,12 @@ class CudaInternal {
   cudaError_t cuda_mem_prefetch_async_wrapper(const void* devPtr, size_t count,
                                               int dstDevice) const {
     set_cuda_device();
+#if CUDART_VERSION >= 13000
+    cudaMemLocation loc = {cudaMemLocationTypeDevice, dstDevice};
+    return cudaMemPrefetchAsync(devPtr, count, loc, 0, m_stream);
+#else
     return cudaMemPrefetchAsync(devPtr, count, dstDevice, m_stream);
+#endif
   }
 
   cudaError_t cuda_memcpy_wrapper(void* dst, const void* src, size_t count,


### PR DESCRIPTION
* Fix incompatibilities with CUDA 13 runtime API



* Test with Cuda-13 in Jenkins

* Use sm_80 by default for nvcc_wrapper

* Fix CI label

---------