### PR TITLE
Make `reduction_identity<[b]half_t>::fun()` return `[b]half_t` instead of `float`

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
@@ -26,8 +26,7 @@
 #include <cuda_bf16.h>
 #endif
 
-namespace Kokkos {
-namespace Experimental {
+namespace Kokkos::Experimental {
 
 /************************** half conversions **********************************/
 KOKKOS_INLINE_FUNCTION
@@ -472,44 +471,27 @@ cast_from_bhalf(bhalf_t val) {
 #endif  // CUDA_VERSION >= 11010
 
 #undef KOKKOS_IMPL_NVIDIA_GPU_ARCH_SUPPORT_BHALF
-}  // namespace Experimental
+}  // namespace Kokkos::Experimental
 
 #if (CUDA_VERSION >= 11000)
 template <>
-struct reduction_identity<Kokkos::Experimental::bhalf_t> {
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float sum() noexcept {
-    return 0.0F;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float prod() noexcept {
-    return 1.0F;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float max() noexcept {
-    return -Kokkos::Experimental::infinity_v<float>;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float min() noexcept {
-    return Kokkos::Experimental::infinity_v<float>;
-  }
+struct Kokkos::reduction_identity<Kokkos::Experimental::bhalf_t> {
+  static constexpr auto inf = Experimental::infinity_v<float>;
+  KOKKOS_FUNCTION static Experimental::bhalf_t sum() noexcept { return 0; }
+  KOKKOS_FUNCTION static Experimental::bhalf_t prod() noexcept { return 1; }
+  KOKKOS_FUNCTION static Experimental::bhalf_t max() noexcept { return -inf; }
+  KOKKOS_FUNCTION static Experimental::bhalf_t min() noexcept { return inf; }
 };
 #endif  // CUDA_VERSION >= 11000
 
-// use float as the return type for sum and prod since cuda_fp16.h
-// has no constexpr functions for casting to __half
 template <>
-struct reduction_identity<Kokkos::Experimental::half_t> {
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float sum() noexcept {
-    return 0.0F;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float prod() noexcept {
-    return 1.0F;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float max() noexcept {
-    return -Kokkos::Experimental::infinity_v<float>;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float min() noexcept {
-    return Kokkos::Experimental::infinity_v<float>;
-  }
+struct Kokkos::reduction_identity<Kokkos::Experimental::half_t> {
+  static constexpr auto inf = Experimental::infinity_v<float>;
+  KOKKOS_FUNCTION static Experimental::half_t sum() noexcept { return 0; }
+  KOKKOS_FUNCTION static Experimental::half_t prod() noexcept { return 1; }
+  KOKKOS_FUNCTION static Experimental::half_t max() noexcept { return -inf; }
+  KOKKOS_FUNCTION static Experimental::half_t min() noexcept { return inf; }
 };
 
-}  // namespace Kokkos
 #endif  // KOKKOS_IMPL_CUDA_HALF_TYPE_DEFINED
 #endif

--- a/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
@@ -20,7 +20,6 @@
 #ifdef KOKKOS_IMPL_CUDA_HALF_TYPE_DEFINED
 
 #include <Kokkos_Half.hpp>
-#include <Kokkos_ReductionIdentity.hpp>
 
 #if CUDA_VERSION >= 11000
 #include <cuda_bf16.h>
@@ -472,26 +471,6 @@ cast_from_bhalf(bhalf_t val) {
 
 #undef KOKKOS_IMPL_NVIDIA_GPU_ARCH_SUPPORT_BHALF
 }  // namespace Kokkos::Experimental
-
-#if (CUDA_VERSION >= 11000)
-template <>
-struct Kokkos::reduction_identity<Kokkos::Experimental::bhalf_t> {
-  static constexpr auto inf = Experimental::infinity_v<float>;
-  KOKKOS_FUNCTION static Experimental::bhalf_t sum() noexcept { return 0; }
-  KOKKOS_FUNCTION static Experimental::bhalf_t prod() noexcept { return 1; }
-  KOKKOS_FUNCTION static Experimental::bhalf_t max() noexcept { return -inf; }
-  KOKKOS_FUNCTION static Experimental::bhalf_t min() noexcept { return inf; }
-};
-#endif  // CUDA_VERSION >= 11000
-
-template <>
-struct Kokkos::reduction_identity<Kokkos::Experimental::half_t> {
-  static constexpr auto inf = Experimental::infinity_v<float>;
-  KOKKOS_FUNCTION static Experimental::half_t sum() noexcept { return 0; }
-  KOKKOS_FUNCTION static Experimental::half_t prod() noexcept { return 1; }
-  KOKKOS_FUNCTION static Experimental::half_t max() noexcept { return -inf; }
-  KOKKOS_FUNCTION static Experimental::half_t min() noexcept { return inf; }
-};
 
 #endif  // KOKKOS_IMPL_CUDA_HALF_TYPE_DEFINED
 #endif

--- a/core/src/HIP/Kokkos_HIP_Half_Conversion.hpp
+++ b/core/src/HIP/Kokkos_HIP_Half_Conversion.hpp
@@ -22,8 +22,7 @@
 #include <Kokkos_Half.hpp>
 #include <Kokkos_ReductionIdentity.hpp>
 
-namespace Kokkos {
-namespace Experimental {
+namespace Kokkos::Experimental {
 
 /************************** half conversions **********************************/
 KOKKOS_INLINE_FUNCTION
@@ -193,26 +192,16 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, unsigned long>, T>
 cast_from_half(half_t val) {
   return static_cast<T>(cast_from_half<unsigned long long>(val));
 }
-}  // namespace Experimental
+}  // namespace Kokkos::Experimental
 
-// use float as the return type for sum and prod since hip_fp16.h
-// has no constexpr functions for casting to __half
 template <>
-struct reduction_identity<Kokkos::Experimental::half_t> {
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float sum() noexcept {
-    return 0.0F;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float prod() noexcept {
-    return 1.0F;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float max() noexcept {
-    return -Kokkos::Experimental::infinity_v<float>;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float min() noexcept {
-    return Kokkos::Experimental::infinity_v<float>;
-  }
+struct Kokkos::reduction_identity<Kokkos::Experimental::half_t> {
+  static constexpr auto inf = Experimental::infinity_v<float>;
+  KOKKOS_FUNCTION static float sum() noexcept { return 0; }
+  KOKKOS_FUNCTION static float prod() noexcept { return 1; }
+  KOKKOS_FUNCTION static float max() noexcept { return -inf; }
+  KOKKOS_FUNCTION static float min() noexcept { return inf; }
 };
 
-}  // namespace Kokkos
 #endif
 #endif

--- a/core/src/HIP/Kokkos_HIP_Half_Conversion.hpp
+++ b/core/src/HIP/Kokkos_HIP_Half_Conversion.hpp
@@ -20,7 +20,6 @@
 #ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
 
 #include <Kokkos_Half.hpp>
-#include <Kokkos_ReductionIdentity.hpp>
 
 namespace Kokkos::Experimental {
 
@@ -193,15 +192,6 @@ cast_from_half(half_t val) {
   return static_cast<T>(cast_from_half<unsigned long long>(val));
 }
 }  // namespace Kokkos::Experimental
-
-template <>
-struct Kokkos::reduction_identity<Kokkos::Experimental::half_t> {
-  static constexpr auto inf = Experimental::infinity_v<float>;
-  KOKKOS_FUNCTION static float sum() noexcept { return 0; }
-  KOKKOS_FUNCTION static float prod() noexcept { return 1; }
-  KOKKOS_FUNCTION static float max() noexcept { return -inf; }
-  KOKKOS_FUNCTION static float min() noexcept { return inf; }
-};
 
 #endif
 #endif

--- a/core/src/Kokkos_Half.hpp
+++ b/core/src/Kokkos_Half.hpp
@@ -23,6 +23,7 @@
 
 #include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
 #include <impl/Kokkos_Half_NumericTraits.hpp>
+#include <impl/Kokkos_Half_ReductionIdentity.hpp>
 #include <impl/Kokkos_Half_MathematicalFunctions.hpp>
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_HALF

--- a/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
@@ -134,8 +134,7 @@ struct reduction_identity<Kokkos::Experimental::half_t> {
 
 #ifdef KOKKOS_IMPL_SYCL_BHALF_TYPE_DEFINED
 
-namespace Kokkos {
-namespace Experimental {
+namespace Kokkos::Experimental {
 
 /************************** bhalf conversions *********************************/
 KOKKOS_INLINE_FUNCTION
@@ -215,26 +214,17 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, unsigned long>, T>
 cast_from_bhalf(bhalf_t val) {
   return static_cast<T>(bhalf_t::impl_type(val));
 }
-}  // namespace Experimental
+}  // namespace Kokkos::Experimental
 
-// sycl::bfloat16 doesn't have constexpr constructors so we return float
 template <>
-struct reduction_identity<Kokkos::Experimental::bhalf_t> {
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float sum() noexcept {
-    return 0.f;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float prod() noexcept {
-    return 1.0f;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float max() noexcept {
-    return -Kokkos::Experimental::infinity_v<float>;
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static float min() noexcept {
-    return Kokkos::Experimental::infinity_v<float>;
-  }
+struct Kokkos::reduction_identity<Kokkos::Experimental::bhalf_t> {
+  static constexpr auto inf = Experimental::infinity_v<float>;
+  KOKKOS_FUNCTION static Experimental::bhalf_t sum() { return 0; }
+  KOKKOS_FUNCTION static Experimental::bhalf_t prod() { return 1; }
+  KOKKOS_FUNCTION static Experimental::bhalf_t max() { return -inf; }
+  KOKKOS_FUNCTION static Experimental::bhalf_t min() { return inf; }
 };
 
-}  // namespace Kokkos
 #endif  // KOKKOS_IMPL_SYCL_BHALF_TYPE_DEFINED
 
 #endif

--- a/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
@@ -21,11 +21,8 @@
 
 #include <SYCL/Kokkos_SYCL_Half_Impl_Type.hpp>
 #include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
-#include <Kokkos_ReductionIdentity.hpp>
-#include <impl/Kokkos_Half_NumericTraits.hpp>
 
-namespace Kokkos {
-namespace Experimental {
+namespace Kokkos::Experimental {
 
 /************************** half conversions **********************************/
 KOKKOS_INLINE_FUNCTION
@@ -103,33 +100,8 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, unsigned long>, T>
 cast_from_half(half_t val) {
   return static_cast<T>(half_t::impl_type(val));
 }
-}  // namespace Experimental
 
-template <>
-struct reduction_identity<Kokkos::Experimental::half_t> {
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static Kokkos::Experimental::half_t
-  sum() noexcept {
-    return Kokkos::Experimental::half_t::impl_type(0.0F);
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static Kokkos::Experimental::half_t
-  prod() noexcept {
-    return Kokkos::Experimental::half_t::impl_type(1.0F);
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static auto max() noexcept {
-    // sycl::half doesn't have constexpr constructors so we return
-    // bit_comparison_type which doesn't have a unitary minus operator.
-    // -inf
-    return Kokkos::Experimental::half_t::bit_comparison_type{
-        0b1'11111'0000000000};
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static auto min() noexcept {
-    // sycl::half doesn't have constexpr constructors so we return
-    // bit_comparison_type
-    return Kokkos::Experimental::infinity_v<Kokkos::Experimental::half_t>;
-  }
-};
-
-}  // namespace Kokkos
+}  // namespace Kokkos::Experimental
 #endif  // KOKKOS_IMPL_SYCL_HALF_TYPE_DEFINED
 
 #ifdef KOKKOS_IMPL_SYCL_BHALF_TYPE_DEFINED
@@ -215,15 +187,6 @@ cast_from_bhalf(bhalf_t val) {
   return static_cast<T>(bhalf_t::impl_type(val));
 }
 }  // namespace Kokkos::Experimental
-
-template <>
-struct Kokkos::reduction_identity<Kokkos::Experimental::bhalf_t> {
-  static constexpr auto inf = Experimental::infinity_v<float>;
-  KOKKOS_FUNCTION static Experimental::bhalf_t sum() { return 0; }
-  KOKKOS_FUNCTION static Experimental::bhalf_t prod() { return 1; }
-  KOKKOS_FUNCTION static Experimental::bhalf_t max() { return -inf; }
-  KOKKOS_FUNCTION static Experimental::bhalf_t min() { return inf; }
-};
 
 #endif  // KOKKOS_IMPL_SYCL_BHALF_TYPE_DEFINED
 

--- a/core/src/impl/Kokkos_Half_ReductionIdentity.hpp
+++ b/core/src/impl/Kokkos_Half_ReductionIdentity.hpp
@@ -22,7 +22,10 @@
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
 template <>
 struct Kokkos::reduction_identity<Kokkos::Experimental::half_t> {
+ private:
   static constexpr auto inf = Experimental::infinity_v<float>;
+
+ public:
   KOKKOS_FUNCTION static Experimental::half_t sum() noexcept { return 0; }
   KOKKOS_FUNCTION static Experimental::half_t prod() noexcept { return 1; }
   KOKKOS_FUNCTION static Experimental::half_t max() noexcept { return -inf; }
@@ -33,7 +36,10 @@ struct Kokkos::reduction_identity<Kokkos::Experimental::half_t> {
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
 template <>
 struct Kokkos::reduction_identity<Kokkos::Experimental::bhalf_t> {
+ private:
   static constexpr auto inf = Experimental::infinity_v<float>;
+
+ public:
   KOKKOS_FUNCTION static Experimental::bhalf_t sum() noexcept { return 0; }
   KOKKOS_FUNCTION static Experimental::bhalf_t prod() noexcept { return 1; }
   KOKKOS_FUNCTION static Experimental::bhalf_t max() noexcept { return -inf; }

--- a/core/src/impl/Kokkos_Half_ReductionIdentity.hpp
+++ b/core/src/impl/Kokkos_Half_ReductionIdentity.hpp
@@ -1,0 +1,44 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_HALF_REDUCTION_IDENTITY_HPP_
+#define KOKKOS_HALF_REDUCTION_IDENTITY_HPP_
+
+#include <Kokkos_ReductionIdentity.hpp>
+
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+template <>
+struct Kokkos::reduction_identity<Kokkos::Experimental::half_t> {
+  static constexpr auto inf = Experimental::infinity_v<float>;
+  KOKKOS_FUNCTION static Experimental::half_t sum() noexcept { return 0; }
+  KOKKOS_FUNCTION static Experimental::half_t prod() noexcept { return 1; }
+  KOKKOS_FUNCTION static Experimental::half_t max() noexcept { return -inf; }
+  KOKKOS_FUNCTION static Experimental::half_t min() noexcept { return inf; }
+};
+#endif
+
+#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+template <>
+struct Kokkos::reduction_identity<Kokkos::Experimental::bhalf_t> {
+  static constexpr auto inf = Experimental::infinity_v<float>;
+  KOKKOS_FUNCTION static Experimental::bhalf_t sum() noexcept { return 0; }
+  KOKKOS_FUNCTION static Experimental::bhalf_t prod() noexcept { return 1; }
+  KOKKOS_FUNCTION static Experimental::bhalf_t max() noexcept { return -inf; }
+  KOKKOS_FUNCTION static Experimental::bhalf_t min() noexcept { return inf; }
+};
+#endif
+
+#endif


### PR DESCRIPTION
Drop the constexpr and the pointless forceinline.
Merge Cuda, HIP, and SYCL implementations into a single common header for half types to guarantee all are in sync.
Intended as a preliminary cleanup to merge before #8302