### PR TITLE
Fix LegacyView to_mdspan and mdspan conversion for const

### DIFF
--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -1344,8 +1344,9 @@ class View : public ViewTraits<DataType, Properties...> {
                 std::is_assignable<mdspan<OtherElementType, OtherExtents,
                                           OtherLayoutPolicy, OtherAccessor>,
                                    ImplNaturalMDSpanType>>::value>>
-  KOKKOS_INLINE_FUNCTION constexpr operator mdspan<
-      OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>() {
+  KOKKOS_INLINE_FUNCTION constexpr
+  operator mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy,
+                  OtherAccessor>() const {
     using mdspan_type = typename Impl::MDSpanViewTraits<traits>::mdspan_type;
     return mdspan_type{data(),
                        Impl::mapping_from_view_mapping<mdspan_type>(m_map)};
@@ -1359,7 +1360,7 @@ class View : public ViewTraits<DataType, Properties...> {
                 typename OtherAccessorType::data_handle_type>>>
   KOKKOS_INLINE_FUNCTION constexpr auto to_mdspan(
       const OtherAccessorType& other_accessor =
-          typename Impl::MDSpanViewTraits<traits>::accessor_type()) {
+          typename Impl::MDSpanViewTraits<traits>::accessor_type()) const {
     using mdspan_type = typename Impl::MDSpanViewTraits<traits>::mdspan_type;
     using ret_mdspan_type =
         mdspan<typename mdspan_type::element_type,

--- a/core/unit_test/TestMDSpanConversion.hpp
+++ b/core/unit_test/TestMDSpanConversion.hpp
@@ -91,7 +91,7 @@ struct TestViewMDSpanConversion {
 
   template <class MDSpanLayoutMapping, class ViewType>
   static void test_conversion_to_mdspan(
-      const MDSpanLayoutMapping &ref_layout_mapping, ViewType v) {
+      const MDSpanLayoutMapping &ref_layout_mapping, const ViewType v) {
     using view_type           = ViewType;
     using natural_mdspan_type = typename Kokkos::Impl::MDSpanViewTraits<
         typename view_type::traits>::mdspan_type;


### PR DESCRIPTION
This tests that const View to mdspan works. This fixes #8330 