### PR TITLE
Cleanup `reduction_identity<complex<T>>` specialization

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -1030,15 +1030,8 @@ std::istream& operator>>(std::istream& is, complex<RealType>& x) {
 
 template <class T>
 struct reduction_identity<Kokkos::complex<T>> {
-  using t_red_ident = reduction_identity<T>;
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static Kokkos::complex<T>
-  sum() noexcept {
-    return Kokkos::complex<T>(t_red_ident::sum(), t_red_ident::sum());
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static Kokkos::complex<T>
-  prod() noexcept {
-    return Kokkos::complex<T>(t_red_ident::prod(), t_red_ident::sum());
-  }
+  KOKKOS_FUNCTION static Kokkos::complex<T> sum() noexcept { return 0; }
+  KOKKOS_FUNCTION static Kokkos::complex<T> prod() noexcept { return 1; }
 };
 
 }  // namespace Kokkos


### PR DESCRIPTION
There was really no good reason to defer to `reduction_identity<T>` and if we really cared about symbol visibility (see https://github.com/kokkos/kokkos/pull/8329#discussion_r2285638978) then we also get rid of a stray public member type.