### PR TITLE
Fix macro guards to skip reduction identity min/max test

### DIFF
--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -716,6 +716,7 @@ class TestReductionOverInfiniteFloat {
   }
 };
 
+KOKKOS_IMPL_DISABLE_UNREACHABLE_WARNINGS_PUSH()
 TEST(TEST_CATEGORY, reduction_identity_min_max_floating_point_types) {
 #if __FINITE_MATH_ONLY__
   GTEST_SKIP() << "skipping when compiling with -ffinite-math-only";
@@ -737,5 +738,6 @@ TEST(TEST_CATEGORY, reduction_identity_min_max_floating_point_types) {
   TestReductionOverInfiniteFloat<long double>();
 #endif
 }
+KOKKOS_IMPL_DISABLE_UNREACHABLE_WARNINGS_POP()
 
 }  // namespace Test

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -720,11 +720,12 @@ TEST(TEST_CATEGORY, reduction_identity_min_max_floating_point_types) {
 #if __FINITE_MATH_ONLY__
   GTEST_SKIP() << "skipping when compiling with -ffinite-math-only";
 #endif
-// nvhpc on device doesn't use the correct neutral value for the min and max
-// reducers
-#if !(defined(KOKKOS_COMPILER_NVHPC) && defined(KOKKOS_ENABLE_OPENACC))
+// FIXME_OPENACC nvhpc on device doesn't use the correct neutral value for the
+// min and max reducers
+#if defined(KOKKOS_COMPILER_NVHPC) && defined(KOKKOS_ENABLE_OPENACC)
   GTEST_SKIP() << "skipping for NVHPC and OPENACC due to wrong neutral value";
-#else
+#endif
+
   TestReductionOverInfiniteFloat<Kokkos::Experimental::half_t>();
   TestReductionOverInfiniteFloat<Kokkos::Experimental::bhalf_t>();
   TestReductionOverInfiniteFloat<float>();
@@ -734,7 +735,6 @@ TEST(TEST_CATEGORY, reduction_identity_min_max_floating_point_types) {
     !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_OPENMPTARGET) && \
     !defined(KOKKOS_ENABLE_OPENACC)
   TestReductionOverInfiniteFloat<long double>();
-#endif
 #endif
 }
 


### PR DESCRIPTION
The OpenACC build is failing since the merge of #8302 
```
3: [ RUN      ] serial.reduction_identity_min_max_floating_point_types
3: /var/jenkins/workspace/Kokkos_PR-8294/core/unit_test/TestReduce.hpp:701: Failure
3: Expected equality of these values:
3:   inf
3:   min
3:     Which is: 3.40282e+38
3: For type float
3: 
3: /var/jenkins/workspace/Kokkos_PR-8294/core/unit_test/TestReduce.hpp:714: Failure
3: Expected equality of these values:
3:   -inf
3:   max
3:     Which is: -3.40282e+38
3: For type float
3: 
3: /var/jenkins/workspace/Kokkos_PR-8294/core/unit_test/TestReduce.hpp:701: Failure
3: Expected equality of these values:
3:   inf
3:   min
3:     Which is: 3.40282e+38
3: For type float
3: 
3: /var/jenkins/workspace/Kokkos_PR-8294/core/unit_test/TestReduce.hpp:714: Failure
3: Expected equality of these values:
3:   -inf
3:   max
3:     Which is: -3.40282e+38
3: For type float
3: 
3: /var/jenkins/workspace/Kokkos_PR-8294/core/unit_test/TestReduce.hpp:701: Failure
3: Expected equality of these values:
3:   inf
3:   min
3:     Which is: 3.40282e+38
3: For type float
3: 
3: /var/jenkins/workspace/Kokkos_PR-8294/core/unit_test/TestReduce.hpp:714: Failure
3: Expected equality of these values:
3:   -inf
3:   max
3:     Which is: -3.40282e+38
3: For type float
3: 
3: /var/jenkins/workspace/Kokkos_PR-8294/core/unit_test/TestReduce.hpp:701: Failure
3: Expected equality of these values:
3:   inf
3:   min
3:     Which is: 1.79769e+308
3: For type double
3: 
3: /var/jenkins/workspace/Kokkos_PR-8294/core/unit_test/TestReduce.hpp:714: Failure
3: Expected equality of these values:
3:   -inf
3:   max
3:     Which is: -1.79769e+308
3: For type double
3: 
3: [  FAILED  ] serial.reduction_identity_min_max_floating_point_types (2 ms)
```
The macro guards to skip the test are clearly wrong.
https://github.com/kokkos/kokkos/blob/52aedeb34768d0661e04137e11bc620b09c38d4e/core/unit_test/TestReduce.hpp#L723-L727

The test was introduced in #8244 