### PR TITLE
Add hardware limit information for tile sizes in `TileSizeProperties`

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_MDRangePolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_MDRangePolicy.hpp
@@ -40,11 +40,14 @@ template <>
 inline TileSizeProperties get_tile_size_properties<Kokkos::Cuda>(
     const Kokkos::Cuda& space) {
   TileSizeProperties properties;
-  properties.max_threads = space.impl_internal_space_instance()
-                               ->m_deviceProp.maxThreadsPerMultiProcessor;
+  const auto& device_prop = space.impl_internal_space_instance()->m_deviceProp;
+  properties.max_threads  = device_prop.maxThreadsPerMultiProcessor;
   properties.default_largest_tile_size = 16;
   properties.default_tile_size         = 2;
   properties.max_total_tile_size       = 512;
+  properties.max_threads_dimensions[0] = device_prop.maxThreadsDim[0];
+  properties.max_threads_dimensions[1] = device_prop.maxThreadsDim[1];
+  properties.max_threads_dimensions[2] = device_prop.maxThreadsDim[2];
   return properties;
 }
 

--- a/core/src/Cuda/Kokkos_Cuda_MDRangePolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_MDRangePolicy.hpp
@@ -40,7 +40,7 @@ template <>
 inline TileSizeProperties get_tile_size_properties<Kokkos::Cuda>(
     const Kokkos::Cuda& space) {
   TileSizeProperties properties;
-  const auto& device_prop = space.impl_internal_space_instance()->m_deviceProp;
+  const auto& device_prop = space.cuda_device_prop();
   properties.max_threads  = device_prop.maxThreadsPerMultiProcessor;
   properties.default_largest_tile_size = 16;
   properties.default_tile_size         = 2;

--- a/core/src/HIP/Kokkos_HIP_MDRangePolicy.hpp
+++ b/core/src/HIP/Kokkos_HIP_MDRangePolicy.hpp
@@ -39,11 +39,14 @@ namespace Impl {
 template <>
 inline TileSizeProperties get_tile_size_properties<HIP>(const HIP& space) {
   TileSizeProperties properties;
-  properties.max_threads =
-      space.impl_internal_space_instance()->m_maxThreadsPerSM;
+  const auto& device_prop = space.impl_internal_space_instance()->m_deviceProp;
+  properties.max_threads  = device_prop.maxThreadsPerBlock;
   properties.default_largest_tile_size = 16;
   properties.default_tile_size         = 4;
   properties.max_total_tile_size       = HIPTraits::MaxThreadsPerBlock;
+  properties.max_threads_dimensions[0] = device_prop.maxThreadsDim[0];
+  properties.max_threads_dimensions[1] = device_prop.maxThreadsDim[1];
+  properties.max_threads_dimensions[2] = device_prop.maxThreadsDim[2];
   return properties;
 }
 

--- a/core/src/HIP/Kokkos_HIP_MDRangePolicy.hpp
+++ b/core/src/HIP/Kokkos_HIP_MDRangePolicy.hpp
@@ -39,8 +39,8 @@ namespace Impl {
 template <>
 inline TileSizeProperties get_tile_size_properties<HIP>(const HIP& space) {
   TileSizeProperties properties;
-  const auto& device_prop = space.hip_device_prop();
-  properties.max_threads  = device_prop.maxThreadsPerBlock;
+  const auto& device_prop              = space.hip_device_prop();
+  properties.max_threads               = device_prop.maxThreadsPerBlock;
   properties.default_largest_tile_size = 16;
   properties.default_tile_size         = 4;
   properties.max_total_tile_size       = HIPTraits::MaxThreadsPerBlock;

--- a/core/src/HIP/Kokkos_HIP_MDRangePolicy.hpp
+++ b/core/src/HIP/Kokkos_HIP_MDRangePolicy.hpp
@@ -39,7 +39,7 @@ namespace Impl {
 template <>
 inline TileSizeProperties get_tile_size_properties<HIP>(const HIP& space) {
   TileSizeProperties properties;
-  const auto& device_prop = space.impl_internal_space_instance()->m_deviceProp;
+  const auto& device_prop = space.hip_device_prop();
   properties.max_threads  = device_prop.maxThreadsPerBlock;
   properties.default_largest_tile_size = 16;
   properties.default_tile_size         = 4;

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -135,10 +135,12 @@ constexpr NVCC_WONT_LET_ME_CALL_YOU_Array to_array_potentially_narrowing(
 }
 
 struct TileSizeProperties {
-  int max_threads;
+  int max_threads;  // (per SM, CU)
   int default_largest_tile_size;
   int default_tile_size;
   int max_total_tile_size;
+  // For GPU backends: hardware limits for block dimensions
+  Kokkos::Array<int, 3> max_threads_dimensions;
 };
 
 template <typename ExecutionSpace>
@@ -149,6 +151,9 @@ TileSizeProperties get_tile_size_properties(const ExecutionSpace&) {
   properties.default_largest_tile_size = 0;
   properties.default_tile_size         = 2;
   properties.max_total_tile_size       = std::numeric_limits<int>::max();
+  for (int i = 0; i < 3; ++i) {
+    properties.max_threads_dimensions[i] = std::numeric_limits<int>::max();
+  }
   return properties;
 }
 

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -30,6 +30,7 @@ static_assert(false,
 #include <impl/KokkosExp_Host_IterateTile.hpp>
 #include <Kokkos_ExecPolicy.hpp>
 #include <type_traits>
+#include <array>
 #include <cmath>
 
 namespace Kokkos {
@@ -140,7 +141,7 @@ struct TileSizeProperties {
   int default_tile_size;
   int max_total_tile_size;
   // For GPU backends: hardware limits for block dimensions
-  Kokkos::Array<int, 3> max_threads_dimensions;
+  std::array<int, 3> max_threads_dimensions;
 };
 
 template <typename ExecutionSpace>

--- a/core/src/SYCL/Kokkos_SYCL_MDRangePolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_MDRangePolicy.hpp
@@ -49,7 +49,6 @@ inline TileSizeProperties get_tile_size_properties<Kokkos::SYCL>(
   auto device = space.sycl_queue().get_device();
   auto max_work_item_sizes =
       device.get_info<sycl::info::device::max_work_item_sizes<3>>();
-  properties.max_threads_dimensions    = Kokkos::Array<int, 3>{1, 1, 1};
   properties.max_threads_dimensions[0] = max_work_item_sizes[0];
   properties.max_threads_dimensions[1] = max_work_item_sizes[1];
   properties.max_threads_dimensions[2] = max_work_item_sizes[2];

--- a/core/src/SYCL/Kokkos_SYCL_MDRangePolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_MDRangePolicy.hpp
@@ -45,6 +45,14 @@ inline TileSizeProperties get_tile_size_properties<Kokkos::SYCL>(
   properties.default_largest_tile_size = 16;
   properties.default_tile_size         = 2;
   properties.max_total_tile_size       = properties.max_threads;
+
+  auto device = space.sycl_queue().get_device();
+  auto max_work_item_sizes =
+      device.get_info<sycl::info::device::max_work_item_sizes<3>>();
+  properties.max_threads_dimensions    = Kokkos::Array<int, 3>{1, 1, 1};
+  properties.max_threads_dimensions[0] = max_work_item_sizes[0];
+  properties.max_threads_dimensions[1] = max_work_item_sizes[1];
+  properties.max_threads_dimensions[2] = max_work_item_sizes[2];
   return properties;
 }
 


### PR DESCRIPTION
## Description
This PR enhances the `TileSizeProperties` struct by adding hardware limit information for tile sizes. The implementation queries the maximum number of threads per dimension from the device properties of the execution space.

### Motivation

Thread limit information per dimension is essential for:
- Enabling the tuner to respect hardware constraints and facilitating the removal of the `clampZ` function from `Kokkos_Cuda_Parallel_MDRange` (see #8264)
- Facilitate testing capabilities for tile size validation (see #8189)