### PR TITLE
snl-ci: set KOKKOS_NUM_THREADS=64 in hpx job

### DIFF
--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -277,5 +277,5 @@ jobs:
 
       - name: test_kokkos
         working-directory: kokkos/build
-        run: ctest --output-on-failure --timeout 3600
+        run: KOKKOS_NUM_THREADS=64 ctest --output-on-failure --timeout 3600
 


### PR DESCRIPTION
Avoid periodic failures in
`Kokkos_CoreUnitTest_HPX_IndependentInstances` unit test