### PR TITLE
ROCm 6.4: Disable -Wpass-failed warnings for some tests

### DIFF
--- a/core/unit_test/TestMathematicalSpecialFunctions.hpp
+++ b/core/unit_test/TestMathematicalSpecialFunctions.hpp
@@ -1609,7 +1609,15 @@ struct TestComplexBesselH1Function {
 #else
     using Property = Kokkos::Experimental::WorkItemProperty::None_t;
 #endif
+
+#if (HIP_VERSION_MAJOR == 6) && (HIP_VERSION_MINOR == 4)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpass-failed"
+#endif
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, Property>(0, N), *this);
+#if (HIP_VERSION_MAJOR == 6) && (HIP_VERSION_MINOR == 4)
+#pragma clang diagnostic pop
+#endif
     Kokkos::fence();
 
     Kokkos::deep_copy(h_ch10, d_ch10);
@@ -1801,7 +1809,14 @@ struct TestComplexBesselH2Function {
     Kokkos::deep_copy(d_z, h_z);
 
     // Call Hankel functions
+#if (HIP_VERSION_MAJOR == 6) && (HIP_VERSION_MINOR == 4)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpass-failed"
+#endif
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0, N), *this);
+#if (HIP_VERSION_MAJOR == 6) && (HIP_VERSION_MINOR == 4)
+#pragma clang diagnostic pop
+#endif
     Kokkos::fence();
 
     Kokkos::deep_copy(h_ch20, d_ch20);

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -464,7 +464,14 @@ KOKKOS_INLINE_FUNCTION void device_check_all_math_ops(
     device_check_math_op_all_loaders<Abi>(erf_op(), n, first_args);
     device_check_math_op_all_loaders<Abi>(erfc_op(), n, first_args);
     device_check_math_op_all_loaders<Abi>(tgamma_op(), n, first_args);
+#if (HIP_VERSION_MAJOR == 6) && (HIP_VERSION_MINOR == 4)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpass-failed"
+#endif
     device_check_math_op_all_loaders<Abi>(lgamma_op(), n, first_args);
+#if (HIP_VERSION_MAJOR == 6) && (HIP_VERSION_MINOR == 4)
+#pragma clang diagnostic pop
+#endif
 
     device_check_math_op_all_loaders<Abi>(pow_op(), n, first_args, second_args);
     device_check_math_op_all_loaders<Abi>(hypot_op(), n, first_args,


### PR DESCRIPTION
This PR fixes the nightly by disabling warnings of the kind:
```
/home/kokkos/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp:75:1: error: failed to meet occupancy target given by 'amdgpu-waves-per-eu' in '_ZN6Kokkos4ImplL32hip_parallel_launch_local_memoryINS0_11ParallelForI28simd_d
evice_math_ops_functorNS_11RangePolicyIJNS_3HIPEEEES5_EEEEvT_': desired occupancy was 4, final occupancy is 3 [-Werror,-Wpass-failed]                                                                              
   75 |     const DriverType driver) {                                                                                                                                                                             
      | ^                                                                                                                                                                                                          
1 error generated when compiling for gfx90a
```

I can reproduce the warnings on Frontier with ROCm 6.4.1 and ROCm 6.4.3. There are no warnings with ROCm 6.3. Since the MI210 have been offline for a while, I also checked older versions of Kokkos. They also trigger the warning.

The warnings are from the Hankel functions `ch_10` and `ch_20` when using complex numbers and from `lgamma_op` in SIMD.