### PR TITLE
Disable unsupported OpenACC atomic tests (int8_t and int16_t types)

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -612,6 +612,8 @@ if(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_double.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_float.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_int.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_int8.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_int16.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_longint.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_longlongint.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_AtomicOperations_shared.cpp

--- a/core/unit_test/TestAtomicOperations_int16.hpp
+++ b/core/unit_test/TestAtomicOperations_int16.hpp
@@ -17,10 +17,15 @@
 #include <TestAtomicOperations.hpp>
 
 namespace Test {
+KOKKOS_IMPL_DISABLE_UNREACHABLE_WARNINGS_PUSH()
 TEST(TEST_CATEGORY, atomic_operations_int16) {
   // FIXME_OPENMPTARGET - causes runtime failure with CrayClang compiler
 #if defined(KOKKOS_COMPILER_CRAY_LLVM) && defined(KOKKOS_ENABLE_OPENMPTARGET)
   GTEST_SKIP() << "known to fail with OpenMPTarget+Cray LLVM";
+#endif
+  // FIXME_OPENACC - does not support atomic operations on int16_t data
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  GTEST_SKIP() << "unsupported atomic data type for OpenACC+NVHPC";
 #endif
   const int16_t start = -5;
   const int16_t end   = 11;
@@ -30,4 +35,5 @@ TEST(TEST_CATEGORY, atomic_operations_int16) {
                    int16_t, TEST_EXECSPACE>(i, end - i + start, t)));
   }
 }
+KOKKOS_IMPL_DISABLE_UNREACHABLE_WARNINGS_POP()
 }  // namespace Test

--- a/core/unit_test/TestAtomicOperations_int8.hpp
+++ b/core/unit_test/TestAtomicOperations_int8.hpp
@@ -17,10 +17,15 @@
 #include <TestAtomicOperations.hpp>
 
 namespace Test {
+KOKKOS_IMPL_DISABLE_UNREACHABLE_WARNINGS_PUSH()
 TEST(TEST_CATEGORY, atomic_operations_int8) {
   // FIXME_OPENMPTARGET - causes runtime failure with CrayClang compiler
 #if defined(KOKKOS_COMPILER_CRAY_LLVM) && defined(KOKKOS_ENABLE_OPENMPTARGET)
   GTEST_SKIP() << "known to fail with OpenMPTarget+Cray LLVM";
+#endif
+  // FIXME_OPENACC - does not support atomic operations on int8_t data
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  GTEST_SKIP() << "unsupported atomic data type for OpenACC+NVHPC";
 #endif
   const int8_t start = -5;
   const int8_t end   = 11;
@@ -30,4 +35,5 @@ TEST(TEST_CATEGORY, atomic_operations_int8) {
                    int8_t, TEST_EXECSPACE>(i, end - i + start, t)));
   }
 }
+KOKKOS_IMPL_DISABLE_UNREACHABLE_WARNINGS_POP()
 }  // namespace Test


### PR DESCRIPTION
This PR addresses the issue on too much DESUL error messages in OpenACC CI build log: 
    `DESUL error in device_atomic_fetch_oper(): …`

1) Skip unsupported OpenACC atomic tests (int8_t and int16_t types) for NVHPC OpenACC.
2) For Clacc OpenACC, all the atomic tests are disabled due to a known Clacc compiler bug.