### PR TITLE
Revert "ROCm 6.4: Disable -Wpass-failed warnings for some tests"

### DIFF
--- a/core/unit_test/TestMathematicalSpecialFunctions.hpp
+++ b/core/unit_test/TestMathematicalSpecialFunctions.hpp
@@ -1609,15 +1609,7 @@ struct TestComplexBesselH1Function {
 #else
     using Property = Kokkos::Experimental::WorkItemProperty::None_t;
 #endif
-
-#if (HIP_VERSION_MAJOR == 6) && (HIP_VERSION_MINOR == 4)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpass-failed"
-#endif
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, Property>(0, N), *this);
-#if (HIP_VERSION_MAJOR == 6) && (HIP_VERSION_MINOR == 4)
-#pragma clang diagnostic pop
-#endif
     Kokkos::fence();
 
     Kokkos::deep_copy(h_ch10, d_ch10);
@@ -1809,14 +1801,7 @@ struct TestComplexBesselH2Function {
     Kokkos::deep_copy(d_z, h_z);
 
     // Call Hankel functions
-#if (HIP_VERSION_MAJOR == 6) && (HIP_VERSION_MINOR == 4)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpass-failed"
-#endif
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0, N), *this);
-#if (HIP_VERSION_MAJOR == 6) && (HIP_VERSION_MINOR == 4)
-#pragma clang diagnostic pop
-#endif
     Kokkos::fence();
 
     Kokkos::deep_copy(h_ch20, d_ch20);

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -464,14 +464,7 @@ KOKKOS_INLINE_FUNCTION void device_check_all_math_ops(
     device_check_math_op_all_loaders<Abi>(erf_op(), n, first_args);
     device_check_math_op_all_loaders<Abi>(erfc_op(), n, first_args);
     device_check_math_op_all_loaders<Abi>(tgamma_op(), n, first_args);
-#if (HIP_VERSION_MAJOR == 6) && (HIP_VERSION_MINOR == 4)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpass-failed"
-#endif
     device_check_math_op_all_loaders<Abi>(lgamma_op(), n, first_args);
-#if (HIP_VERSION_MAJOR == 6) && (HIP_VERSION_MINOR == 4)
-#pragma clang diagnostic pop
-#endif
 
     device_check_math_op_all_loaders<Abi>(pow_op(), n, first_args, second_args);
     device_check_math_op_all_loaders<Abi>(hypot_op(), n, first_args,


### PR DESCRIPTION
Reverts kokkos/kokkos#8347

Per https://github.com/kokkos/kokkos/pull/8347#issuecomment-3214753455