### PR TITLE
Update OLCF CI

### DIFF
--- a/.gitlab/olcf-gitlab-ci.yml
+++ b/.gitlab/olcf-gitlab-ci.yml
@@ -9,7 +9,7 @@ hipcc:
     OLCF_ID_TOKEN:
       aud: https://code.olcf.ornl.gov
   script:
-    - module load rocm/6.0
+    - module load rocm/6.3.1
     - export CMAKE_BUILD_PARALLEL_LEVEL=48
     - export CRAYPE_LINK_TYPE=dynamic
     - export ENV_CMAKE_OPTIONS=""
@@ -18,7 +18,7 @@ hipcc:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_HIP=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_COMPILER_WARNINGS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_TESTS=ON"
-    - ctest -VV -E Kokkos_CoreUnitTest_DeviceAndThreads -D CDASH_MODEL="Nightly" -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}" -S scripts/CTestRun.cmake -D CTEST_SITE="frontier" -D CTEST_BUILD_NAME="hipcc-rocm/6.0"
+    - ctest -VV -E Kokkos_CoreUnitTest_DeviceAndThreads -D CDASH_MODEL="Nightly" -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}" -S scripts/CTestRun.cmake -D CTEST_SITE="frontier" -D CTEST_BUILD_NAME="hipcc-rocm/6.3.1"
 
 amdclang:
   stage: test
@@ -46,8 +46,8 @@ crayclang:
     OLCF_ID_TOKEN:
       aud: https://code.olcf.ornl.gov
   script:
-    - module load rocm/6.3.1
-    - module load cce/18.0.1
+    - module load rocm/6.4.1
+    - module load cce/19.0.0
     - export CMAKE_BUILD_PARALLEL_LEVEL=48
     - export CRAYPE_LINK_TYPE=dynamic
     - export ENV_CMAKE_OPTIONS=""
@@ -56,7 +56,7 @@ crayclang:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_HIP=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_COMPILER_WARNINGS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_TESTS=ON"
-    - ctest -VV -E Kokkos_CoreUnitTest_DeviceAndThreads -D CDASH_MODEL="Nightly" -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}" -S scripts/CTestRun.cmake -D CTEST_SITE="frontier" -D CTEST_BUILD_NAME="crayclang/18.0.1-rocm/6.3.1"
+    - ctest -VV -E Kokkos_CoreUnitTest_DeviceAndThreads -D CDASH_MODEL="Nightly" -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}" -S scripts/CTestRun.cmake -D CTEST_SITE="frontier" -D CTEST_BUILD_NAME="crayclang/19.0.0-rocm/6.4.1"
 
 include:
 - project: ci/resources/templates


### PR DESCRIPTION
Since we will drop support for ROCm 6.1 and earlier, update the ROCm 6.0 build to 6.3.1. I also update the Cray compiler, though I don't expect any improvements.