### PR TITLE
spack_test: avoid C and CXX dependency in utility CMake script

### DIFF
--- a/scripts/spack_test/CMakeLists.txt
+++ b/scripts/spack_test/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(SpackTestGen)
+project(SpackTestGen LANGUAGES NONE)
 set(TEST_LIST_DEF ${CMAKE_CURRENT_SOURCE_DIR}/test_list.def)
 file(STRINGS ${TEST_LIST_DEF} TEST_FILES)
 


### PR DESCRIPTION
This utility script causes Spack builds to depend on a `C` compiler. Since it only copies around files, it should not depend on any compiler.