### PR TITLE
Fixup for DynRankView of FAD type of rank-7

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -65,31 +65,10 @@ struct DynRankDimTraits {
   KOKKOS_INLINE_FUNCTION
   static size_t computeRank(const size_t N0, const size_t N1, const size_t N2,
                             const size_t N3, const size_t N4, const size_t N5,
-                            const size_t N6, const size_t /* N7 */) {
-    return (
-        (N6 == unspecified && N5 == unspecified && N4 == unspecified &&
-         N3 == unspecified && N2 == unspecified && N1 == unspecified &&
-         N0 == unspecified)
-            ? 0
-            : ((N6 == unspecified && N5 == unspecified && N4 == unspecified &&
-                N3 == unspecified && N2 == unspecified && N1 == unspecified)
-                   ? 1
-                   : ((N6 == unspecified && N5 == unspecified &&
-                       N4 == unspecified && N3 == unspecified &&
-                       N2 == unspecified)
-                          ? 2
-                          : ((N6 == unspecified && N5 == unspecified &&
-                              N4 == unspecified && N3 == unspecified)
-                                 ? 3
-                                 : ((N6 == unspecified && N5 == unspecified &&
-                                     N4 == unspecified)
-                                        ? 4
-                                        : ((N6 == unspecified &&
-                                            N5 == unspecified)
-                                               ? 5
-                                               : ((N6 == unspecified)
-                                                      ? 6
-                                                      : 7)))))));
+                            const size_t N6, const size_t N7) {
+    return (N0 != unspecified) + (N1 != unspecified) + (N2 != unspecified) +
+           (N3 != unspecified) + (N4 != unspecified) + (N5 != unspecified) +
+           (N6 != unspecified) + (N7 != unspecified);
   }
 
   // Compute the rank of the view from the nonzero layout arguments.
@@ -937,7 +916,7 @@ class DynRankView : private View<DataType*******, Properties...> {
     if constexpr (traits::impl_is_customized &&
                   !Impl::ViewCtorProp<P...>::has_accessor_arg) {
       int r = 0;
-      while (r < 7 && layout.dimension[r] != KOKKOS_INVALID_INDEX) r++;
+      while (r < 8 && layout.dimension[r] != KOKKOS_INVALID_INDEX) r++;
 
       // Can't use with_properties_if_unset since its a host only function!
       return view_wrap(
@@ -956,7 +935,7 @@ class DynRankView : private View<DataType*******, Properties...> {
     if constexpr (traits::impl_is_customized &&
                   !Impl::ViewCtorProp<P...>::has_accessor_arg) {
       int r = 0;
-      while (r < 7 && layout.dimension[r] != KOKKOS_INVALID_INDEX) r++;
+      while (r < 8 && layout.dimension[r] != KOKKOS_INVALID_INDEX) r++;
       // Could use with_properties_if_unset, but rather keep same as above.
       return view_alloc(
           static_cast<const Impl::ViewCtorProp<void, P>&>(arg_prop).value...,

--- a/containers/unit_tests/TestDynRankView_ViewCustomization.hpp
+++ b/containers/unit_tests/TestDynRankView_ViewCustomization.hpp
@@ -204,6 +204,36 @@ TEST(TEST_CATEGORY, view_customization_extra_int_arg) {
         sizeof(double);
     ASSERT_EQ(shmem, expected_shmem_size);
   }
+  // Rank 7
+  {
+    view_t a("A", 2, 3, 2, 7, 2, 11, 2, 5);
+    ASSERT_EQ(a.rank(), 7lu);
+    ASSERT_EQ(a.extent(0), 2lu);
+    ASSERT_EQ(a.extent(1), 3lu);
+    ASSERT_EQ(a.extent(2), 2lu);
+    ASSERT_EQ(a.extent(3), 7lu);
+    ASSERT_EQ(a.extent(4), 2lu);
+    ASSERT_EQ(a.extent(5), 11lu);
+    ASSERT_EQ(a.extent(2), 2lu);
+    ASSERT_EQ(a.accessor().size, 5lu);
+    ASSERT_EQ(a.accessor().stride, size_t(16 * 3 * 7 * 11));
+    view_t b(a.data(), 2, 3, 2, 7, 2, 11, 2, 5);
+    ASSERT_EQ(b.rank(), 7lu);
+    ASSERT_EQ(b.extent(0), 2lu);
+    ASSERT_EQ(b.extent(1), 3lu);
+    ASSERT_EQ(b.extent(2), 2lu);
+    ASSERT_EQ(b.extent(3), 7lu);
+    ASSERT_EQ(b.extent(4), 2lu);
+    ASSERT_EQ(b.extent(5), 11lu);
+    ASSERT_EQ(b.extent(6), 2lu);
+    ASSERT_EQ(b.accessor().size, 5lu);
+    ASSERT_EQ(b.accessor().stride, size_t(16 * 3 * 7 * 11));
+    size_t shmem = view_t::shmem_size(2, 3, 2, 7, 2, 11, 2, 5);
+    size_t expected_shmem_size =
+        2lu * 3lu * 2lu * 7lu * 2lu * 11lu * 2lu * 5lu * sizeof(double) +
+        sizeof(double);
+    ASSERT_EQ(shmem, expected_shmem_size);
+  }
   // With accessor arg and no label
   {
     // This should not interpret the last argument (11) as an accessor arg since


### PR DESCRIPTION
This wasn't behaving correctly for Rank-7 DynRankView of Fad. Exposed in Intrepid2 testing. 