### PR TITLE
core(typelist): new features (size and contains)

### DIFF
--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -175,6 +175,9 @@ template <template <class> class UnaryPred, class... Ts>
 struct type_list_any<UnaryPred, type_list<Ts...>>
     : std::bool_constant<(UnaryPred<Ts>::value || ...)> {};
 
+template <template <class> class UnaryPred, class... Ts>
+constexpr bool type_list_any_v = type_list_any<UnaryPred, Ts...>::value;
+
 // </editor-fold> end type_list_any }}}2
 //------------------------------------------------------------------------------
 
@@ -224,6 +227,36 @@ using filter_type_list_t =
     typename filter_type_list<PredicateT, T, ValueT>::type;
 
 // </editor-fold> end filter_type_list }}}2
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// <editor-fold desc="type_list_contains"> {{{2
+//  type_list_contains checks if a type is contained in the list.
+template <typename, typename...>
+struct type_list_contains;
+
+template <typename U, typename... Ts>
+struct type_list_contains<U, type_list<Ts...>>
+    : std::disjunction<std::is_same<U, Ts>...> {};
+
+template <typename U, typename... Ts>
+constexpr bool type_list_contains_v = type_list_contains<U, Ts...>::value;
+// </editor-fold> end type_list_contains }}}2
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// <editor-fold desc="type_list_size"> {{{2
+//  type_list_size returns the size of a type list.
+template <typename>
+struct type_list_size;
+
+template <typename... Ts>
+struct type_list_size<type_list<Ts...>>
+    : std::integral_constant<std::size_t, sizeof...(Ts)> {};
+
+template <typename T>
+constexpr std::size_t type_list_size_v = type_list_size<T>::value;
+// </editor-fold> end type_list_size }}}2
 //------------------------------------------------------------------------------
 
 // </editor-fold> end type_list }}}1

--- a/core/unit_test/TestTypeList.cpp
+++ b/core/unit_test/TestTypeList.cpp
@@ -16,6 +16,8 @@
 
 #include <impl/Kokkos_Utilities.hpp>
 
+using type_list_empty_t = Kokkos::Impl::type_list<>;
+
 using TypeList2 = Kokkos::Impl::type_list<void, bool>;
 using TypeList3 = Kokkos::Impl::type_list<char, short, int>;
 using TypeList223 =
@@ -43,3 +45,43 @@ using FilterTypeList223NoVoid =
     Kokkos::Impl::filter_type_list_t<std::is_void, TypeList223, false>;
 static_assert(std::is_same_v<TypeList223NoVoid, FilterTypeList223NoVoid>,
               "filter_type_list with predicate value==false failed");
+
+constexpr bool test_type_list_any() {
+  using Kokkos::Impl::type_list;
+  using Kokkos::Impl::type_list_any_v;
+
+  static_assert(!type_list_any_v<std::is_enum, type_list_empty_t>);
+  static_assert(type_list_any_v<std::is_floating_point,
+                                type_list<float, double, char, int>>);
+  static_assert(type_list_any_v<std::is_integral,
+                                type_list<float, char, int, std::size_t>>);
+  static_assert(!type_list_any_v<std::is_enum, type_list<float, char, int>>);
+
+  return true;
+}
+static_assert(test_type_list_any());
+
+constexpr bool test_type_list_size() {
+  using Kokkos::Impl::type_list_size_v;
+
+  static_assert(type_list_size_v<type_list_empty_t> == 0);
+  static_assert(type_list_size_v<TypeList2> == 2);
+  static_assert(type_list_size_v<TypeList3> == 3);
+
+  return true;
+}
+static_assert(test_type_list_size());
+
+constexpr bool test_type_list_contains() {
+  using Kokkos::Impl::type_list_contains_v;
+
+  static_assert(!type_list_contains_v<int, type_list_empty_t>);
+
+  static_assert(type_list_contains_v<char, TypeList3>);
+  static_assert(type_list_contains_v<short, TypeList3>);
+  static_assert(type_list_contains_v<int, TypeList3>);
+  static_assert(!type_list_contains_v<double, TypeList3>);
+
+  return true;
+}
+static_assert(test_type_list_contains());


### PR DESCRIPTION
This PR adds 2 new helpers for `Kokkos::Impl::type_list`:
1. `type_list_size_v` to get its size.
2. `type_list_contains_v` to know if it contains a type.

Related to:
- #8191 