### PR TITLE
core(graph): submit on default `exec` by default to align with `Kokkos` semantics

### DIFF
--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -109,12 +109,10 @@ struct [[nodiscard]] Graph {
 
   auto root_node() const { return root_t{m_impl_ptr, m_root}; }
 
-  void submit(const execution_space& exec) const {
+  void submit(const execution_space& exec = execution_space{}) const {
     KOKKOS_EXPECTS(bool(m_impl_ptr))
     (*m_impl_ptr).submit(exec);
   }
-
-  void submit() const { submit(get_execution_space()); }
 
   decltype(auto) native_graph();
 


### PR DESCRIPTION
By default, a `Kokkos` parallel region submitted without passing an execution space instance explicitly will default to using the default execution space instance.

This PR aligns the `graph.submit()` behavior such that it also uses the default execution space instance, instead of the graph's one.