### PR TITLE
MemoryRandomAccess does not imply Unmanaged

### DIFF
--- a/core/src/Kokkos_MemoryTraits.hpp
+++ b/core/src/Kokkos_MemoryTraits.hpp
@@ -74,8 +74,12 @@ namespace Kokkos {
 using MemoryManaged KOKKOS_DEPRECATED = Kokkos::MemoryTraits<>;
 #endif
 using MemoryUnmanaged = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 using MemoryRandomAccess =
     Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>;
+#else
+using MemoryRandomAccess = Kokkos::MemoryTraits<Kokkos::RandomAccess>;
+#endif
 
 }  // namespace Kokkos
 


### PR DESCRIPTION
In #8066, as we deprecated the memory trait `MemoryManaged` alias, we had discussed that the definition of `MemoryRandomAccess` was unfortunate and that it shouldn't be setting `Unmanaged` but we fell through the cracks and we never got around to implementing it.

There is no known use in ArborX, Cabana, nor LAMMPS.
In Trilinos, all uses I could find were in STK
```
packages/stk/stk_search/stk_search/morton_lbvh/MortonLBVH_CommonTypes.hpp:83:  using local_ordinal_scl_tmt = Kokkos::View<const LocalOrdinal, memory_space, Kokkos::MemoryRandomAccess>;
packages/stk/stk_search/stk_search/morton_lbvh/MortonLBVH_CommonTypes.hpp:88:  using local_ordinals_tmt = Kokkos::View<LocalOrdinal *, memory_space, Kokkos::MemoryRandomAccess>;
packages/stk/stk_search/stk_search/morton_lbvh/MortonLBVH_CommonTypes.hpp:93:  using local_ordinal_pairs_tmt = Kokkos::View<LocalOrdinal * [2], memory_space, Kokkos::MemoryRandomAccess>;
packages/stk/stk_search/stk_search/morton_lbvh/MortonLBVH_CommonTypes.hpp:97:  using aabb_morton_codes_tmt = Kokkos::View<const morton_code_t *, ExecutionSpace, Kokkos::MemoryRandomAccess>;
packages/stk/stk_search/stk_search/morton_lbvh/MortonLBVH_CommonTypes.hpp:109:  using aabb_const_points_tmt = Kokkos::View<const RealType * [3], memory_space, Kokkos::MemoryRandomAccess>;
```

Arguing that this is an oversight, I propose to change the definition in 5.0 and guard it against deprecated code 4 (and not deprecated code 5).