### PR TITLE
Fix Layout Creation in DynRankView when there is a stride

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -159,7 +159,7 @@ struct DynRankDimTraits {
   template <typename Layout>
   KOKKOS_INLINE_FUNCTION static std::enable_if_t<
       (std::is_same_v<Layout, Kokkos::LayoutStride>), Layout>
-  createLayout(const Layout& layout, [[maybe_unused]] size_t new_rank = -1) {
+  createLayout(const Layout& layout, [[maybe_unused]] size_t new_rank = unspecified) {
     return Layout(
         layout.dimension[0] != unspecified ? layout.dimension[0] : 1,
         layout.stride[0],

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -159,7 +159,8 @@ struct DynRankDimTraits {
   template <typename Layout>
   KOKKOS_INLINE_FUNCTION static std::enable_if_t<
       (std::is_same_v<Layout, Kokkos::LayoutStride>), Layout>
-  createLayout(const Layout& layout, [[maybe_unused]] size_t new_rank = unspecified) {
+  createLayout(const Layout& layout,
+               [[maybe_unused]] size_t new_rank = unspecified) {
     return Layout(
         layout.dimension[0] != unspecified ? layout.dimension[0] : 1,
         layout.stride[0],

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -119,7 +119,8 @@ struct DynRankDimTraits {
       (std::is_same_v<Layout, Kokkos::LayoutRight> ||
        std::is_same_v<Layout, Kokkos::LayoutLeft>),
       Layout>
-  createLayout(const Layout& layout) {
+  createLayout(const Layout& layout,
+               [[maybe_unused]] size_t new_rank = unspecified) {
     Layout new_layout(
         layout.dimension[0] != unspecified ? layout.dimension[0] : 1,
         layout.dimension[1] != unspecified ? layout.dimension[1] : 1,
@@ -146,6 +147,11 @@ struct DynRankDimTraits {
     } else
 #endif
       new_layout.stride = layout.stride;
+    if constexpr (std::is_same_v<Layout, Kokkos::LayoutRight>) {
+      if (new_rank != unspecified && new_rank > 0 &&
+          layout.dimension[new_rank - 1] == layout.stride)
+        new_layout.stride = unspecified;
+    }
     return new_layout;
   }
 
@@ -153,7 +159,7 @@ struct DynRankDimTraits {
   template <typename Layout>
   KOKKOS_INLINE_FUNCTION static std::enable_if_t<
       (std::is_same_v<Layout, Kokkos::LayoutStride>), Layout>
-  createLayout(const Layout& layout) {
+  createLayout(const Layout& layout, [[maybe_unused]] size_t new_rank = -1) {
     return Layout(
         layout.dimension[0] != unspecified ? layout.dimension[0] : 1,
         layout.stride[0],
@@ -860,7 +866,7 @@ class DynRankView : private View<DataType*******, Properties...> {
       : view_type(rhs.data_handle(),
                   Impl::mapping_from_array_layout<
                       typename view_type::mdspan_type::mapping_type>(
-                      drdtraits::createLayout(rhs.layout())),
+                      drdtraits::createLayout(rhs.layout(), new_rank)),
                   rhs.accessor()),
         m_rank(new_rank) {
     if (new_rank > View<RT, RP...>::rank())
@@ -875,7 +881,7 @@ class DynRankView : private View<DataType*******, Properties...> {
         view_type(rhs.data_handle(),
                   Impl::mapping_from_array_layout<
                       typename view_type::mdspan_type::mapping_type>(
-                      drdtraits::createLayout(rhs.layout())),
+                      drdtraits::createLayout(rhs.layout(), rhs.rank())),
                   rhs.accessor()));
     m_rank = rhs.rank();
     return *this;

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -21,6 +21,7 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
       DynViewAPI_rank12345
       DynViewAPI_rank67
       DynRankView_Ctors
+      DynRankView_LayoutMember
       DynRankView_TeamScratch
       DynRankView_ViewCustomization
       ErrorReporter

--- a/containers/unit_tests/TestDynRankView_LayoutMember.hpp
+++ b/containers/unit_tests/TestDynRankView_LayoutMember.hpp
@@ -1,0 +1,51 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_DynRankView.hpp>
+
+namespace {
+
+template <class Layout>
+void test_dyn_rank_view_layout_member() {
+  bool is_ll = std::is_same_v<Layout, Kokkos::LayoutLeft>;
+  {
+    Kokkos::DynRankView<int, Layout> a(
+        Kokkos::View<int***, Layout>("A", 11, 7, 5));
+    auto l = a.layout();
+    ASSERT_EQ(l.dimension[0], 11lu);
+    ASSERT_EQ(l.dimension[1], 7lu);
+    ASSERT_EQ(l.dimension[2], 5lu);
+    ASSERT_TRUE(
+        (l.stride == is_ll ? 11lu : 5lu || l.stride == KOKKOS_INVALID_INDEX));
+  }
+  {
+    Kokkos::DynRankView<int, Layout> a(Kokkos::View<int**, Layout>("A", 7, 5));
+    auto l = a.layout();
+    ASSERT_EQ(l.dimension[0], 7lu);
+    ASSERT_EQ(l.dimension[1], 5lu);
+    ASSERT_TRUE(
+        (l.stride == is_ll ? 7lu : 5lu || l.stride == KOKKOS_INVALID_INDEX));
+  }
+}
+
+}  // namespace
+
+TEST(TEST_CATEGORY, dyn_rank_view_layout_member) {
+  test_dyn_rank_view_layout_member<Kokkos::LayoutRight>();
+  test_dyn_rank_view_layout_member<Kokkos::LayoutLeft>();
+}


### PR DESCRIPTION
The problem here was an invalid handling of the stride member in the layout struct (not the mapping) for LayoutRight when converting View to DynRankView in particular. This did not happen for everything (e.g. rank-3 was fine, but rank-2 failed ...). 