### PR TITLE
Drop `Impl::{type_identity,remove_cvref}[_t]`

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_Reduce.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Reduce.hpp
@@ -124,7 +124,7 @@ ValueType reduce_default_functors_exespace_impl(
   Impl::static_assert_is_not_openmptarget(ex);
   Impl::expect_valid_range(first, last);
 
-  using value_type = Kokkos::Impl::remove_cvref_t<ValueType>;
+  using value_type = std::remove_cvref_t<ValueType>;
 
   if (::Kokkos::is_detected<has_reduction_identity_sum_t, value_type>::value) {
     if (first == last) {
@@ -199,7 +199,7 @@ KOKKOS_FUNCTION ValueType reduce_default_functors_team_impl(
   Impl::static_assert_is_not_openmptarget(teamHandle);
   Impl::expect_valid_range(first, last);
 
-  using value_type = Kokkos::Impl::remove_cvref_t<ValueType>;
+  using value_type = std::remove_cvref_t<ValueType>;
 
   if (::Kokkos::is_detected<has_reduction_identity_sum_t, value_type>::value) {
     if (first == last) {

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -67,7 +67,7 @@ namespace Impl {
 template <typename ViewType, typename... P, typename... Args>
 auto allocate_without_initializing_if_possible(
     const Impl::ViewCtorProp<P...> &alloc_prop, Args &&...args) {
-  using alloc_prop_t = Impl::remove_cvref_t<decltype(alloc_prop)>;
+  using alloc_prop_t = std::remove_cvref_t<decltype(alloc_prop)>;
 
   // if incompatible we don't add the property
   if constexpr (alloc_prop_t::sequential_host_init)
@@ -373,7 +373,7 @@ class UnorderedMap {
         m_hasher(hasher),
         m_equal_to(equal_to),
         m_sequential_host_init(
-            Impl::remove_cvref_t<decltype(arg_prop)>::sequential_host_init) {
+            std::remove_cvref_t<decltype(arg_prop)>::sequential_host_init) {
     if (!is_insertable_map) {
       Kokkos::Impl::throw_runtime_exception(
           "Cannot construct a non-insertable (i.e. const key_type) "
@@ -381,7 +381,7 @@ class UnorderedMap {
     }
 
     //! Ensure that allocation properties are consistent.
-    using alloc_prop_t = Impl::remove_cvref_t<decltype(arg_prop)>;
+    using alloc_prop_t = std::remove_cvref_t<decltype(arg_prop)>;
     static_assert(alloc_prop_t::initialize,
                   "Allocation property 'initialize' should be true.");
     static_assert(

--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -160,12 +160,12 @@ template <class KernelType,
           class Tag =
               typename PatternTagFromImplSpecialization<KernelType>::type>
 struct get_graph_node_kernel_type
-    : type_identity<
+    : std::type_identity<
           GraphNodeKernelImpl<Kokkos::Cuda, typename KernelType::Policy,
                               typename KernelType::functor_type, Tag>> {};
 template <class KernelType>
 struct get_graph_node_kernel_type<KernelType, Kokkos::ParallelReduceTag>
-    : type_identity<GraphNodeKernelImpl<
+    : std::type_identity<GraphNodeKernelImpl<
           Kokkos::Cuda, typename KernelType::Policy,
           CombinedFunctorReducer<typename KernelType::functor_type,
                                  typename KernelType::reducer_type>,

--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -142,13 +142,13 @@ template <typename KernelType,
           typename Tag =
               typename PatternTagFromImplSpecialization<KernelType>::type>
 struct get_graph_node_kernel_type
-    : type_identity<
+    : std::type_identity<
           GraphNodeKernelImpl<Kokkos::HIP, typename KernelType::Policy,
                               typename KernelType::functor_type, Tag>> {};
 
 template <typename KernelType>
 struct get_graph_node_kernel_type<KernelType, Kokkos::ParallelReduceTag>
-    : type_identity<GraphNodeKernelImpl<
+    : std::type_identity<GraphNodeKernelImpl<
           Kokkos::HIP, typename KernelType::Policy,
           CombinedFunctorReducer<typename KernelType::functor_type,
                                  typename KernelType::reducer_type>,

--- a/core/src/Kokkos_Atomics_Desul_Wrapper.hpp
+++ b/core/src/Kokkos_Atomics_Desul_Wrapper.hpp
@@ -21,11 +21,13 @@ static_assert(false,
 #endif
 #ifndef KOKKOS_DESUL_ATOMICS_WRAPPER_HPP_
 #define KOKKOS_DESUL_ATOMICS_WRAPPER_HPP_
+
 #include <Kokkos_Macros.hpp>
 #include <desul/atomics.hpp>
 
-#include <impl/Kokkos_Utilities.hpp>  // identity_type
 #include <impl/Kokkos_Volatile_Load.hpp>
+
+#include <type_traits>
 
 namespace Kokkos {
 
@@ -60,7 +62,7 @@ KOKKOS_DEPRECATED inline const char* atomic_query_version() {
 namespace Impl {
 template <class T>
 using not_deduced_atomic_t =
-    std::add_const_t<std::remove_volatile_t<type_identity_t<T>>>;
+    std::add_const_t<std::remove_volatile_t<std::type_identity_t<T>>>;
 
 template <class T, class R>
 using enable_if_atomic_t =

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -33,6 +33,7 @@ static_assert(false,
 #include <typeinfo>
 #endif
 #include <limits>
+#include <type_traits>
 
 //----------------------------------------------------------------------------
 
@@ -1277,30 +1278,30 @@ struct PatternImplSpecializationFromTag;
 
 template <class... Args>
 struct PatternImplSpecializationFromTag<Kokkos::ParallelForTag, Args...>
-    : type_identity<ParallelFor<Args...>> {};
+    : std::type_identity<ParallelFor<Args...>> {};
 
 template <class... Args>
 struct PatternImplSpecializationFromTag<Kokkos::ParallelReduceTag, Args...>
-    : type_identity<ParallelReduce<Args...>> {};
+    : std::type_identity<ParallelReduce<Args...>> {};
 
 template <class... Args>
 struct PatternImplSpecializationFromTag<Kokkos::ParallelScanTag, Args...>
-    : type_identity<ParallelScan<Args...>> {};
+    : std::type_identity<ParallelScan<Args...>> {};
 
 template <class PatternImpl>
 struct PatternTagFromImplSpecialization;
 
 template <class... Args>
 struct PatternTagFromImplSpecialization<ParallelFor<Args...>>
-    : type_identity<ParallelForTag> {};
+    : std::type_identity<ParallelForTag> {};
 
 template <class... Args>
 struct PatternTagFromImplSpecialization<ParallelReduce<Args...>>
-    : type_identity<ParallelReduceTag> {};
+    : std::type_identity<ParallelReduceTag> {};
 
 template <class... Args>
 struct PatternTagFromImplSpecialization<ParallelScan<Args...>>
-    : type_identity<ParallelScanTag> {};
+    : std::type_identity<ParallelScanTag> {};
 
 }  // end namespace Impl
 

--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -171,9 +171,8 @@ Graph<ExecutionSpace> create_graph(ExecutionSpace ex, Closure&& arg_closure) {
 template <
     class ExecutionSpace = DefaultExecutionSpace,
     class Closure = Kokkos::Impl::DoNotExplicitlySpecifyThisTemplateParameter>
-std::enable_if_t<
-    !Kokkos::is_execution_space_v<Kokkos::Impl::remove_cvref_t<Closure>>,
-    Graph<ExecutionSpace>>
+std::enable_if_t<!Kokkos::is_execution_space_v<std::remove_cvref_t<Closure>>,
+                 Graph<ExecutionSpace>>
 create_graph(Closure&& arg_closure) {
   return create_graph(ExecutionSpace{}, (Closure&&)arg_closure);
 }

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -134,14 +134,14 @@ class GraphNodeRef {
 
   template <class NextKernelDeduced>
   auto _then_kernel(NextKernelDeduced&& arg_kernel) const {
-    static_assert(Kokkos::Impl::is_graph_kernel_v<
-                      Kokkos::Impl::remove_cvref_t<NextKernelDeduced>>,
-                  "Kokkos internal error");
+    static_assert(
+        Kokkos::Impl::is_graph_kernel_v<std::remove_cvref_t<NextKernelDeduced>>,
+        "Kokkos internal error");
 
     auto graph_ptr = m_graph_impl.lock();
     KOKKOS_EXPECTS(bool(graph_ptr))
 
-    using next_kernel_t = Kokkos::Impl::remove_cvref_t<NextKernelDeduced>;
+    using next_kernel_t = std::remove_cvref_t<NextKernelDeduced>;
 
     using return_t = GraphNodeRef<ExecutionSpace, next_kernel_t, GraphNodeRef>;
 
@@ -230,41 +230,39 @@ class GraphNodeRef {
 
   // TODO We should do better than a p-for (that uses registers, heavier).
   //      This should "just" launch the function on device with our driver.
-  template <typename Label, typename Policy, typename Functor,
-            std::enable_if_t<
-                std::is_invocable_r_v<
-                    void, const Kokkos::Impl::remove_cvref_t<Functor>> &&
-                    Kokkos::Impl::is_view_label_v<
-                        Kokkos::Impl::remove_cvref_t<Label>> &&
-                    Kokkos::Impl::is_specialization_of_v<Policy, ThenPolicy>,
-                int> = 0>
+  template <
+      typename Label, typename Policy, typename Functor,
+      std::enable_if_t<
+          std::is_invocable_r_v<void, const std::remove_cvref_t<Functor>> &&
+              Kokkos::Impl::is_view_label_v<std::remove_cvref_t<Label>> &&
+              Kokkos::Impl::is_specialization_of_v<Policy, ThenPolicy>,
+          int> = 0>
   auto then(Label&& label, const ExecutionSpace& exec, Policy&& policy,
             Functor&& functor) const {
     using next_kernel_t =
         Kokkos::Impl::GraphNodeThenImpl<ExecutionSpace,
-                                        Kokkos::Impl::remove_cvref_t<Policy>,
-                                        Kokkos::Impl::remove_cvref_t<Functor>>;
+                                        std::remove_cvref_t<Policy>,
+                                        std::remove_cvref_t<Functor>>;
     return this->_then_kernel(next_kernel_t(std::forward<Label>(label), exec,
                                             std::forward<Policy>(policy),
                                             std::forward<Functor>(functor)));
   }
 
   // Overload for a label.
-  template <typename Label, typename Functor,
-            std::enable_if_t<Kokkos::Impl::is_view_label_v<
-                                 Kokkos::Impl::remove_cvref_t<Label>>,
-                             int> = 0>
+  template <
+      typename Label, typename Functor,
+      std::enable_if_t<
+          Kokkos::Impl::is_view_label_v<std::remove_cvref_t<Label>>, int> = 0>
   auto then(Label&& label, Functor&& functor) const {
     return this->then(std::forward<Label>(label), ExecutionSpace{},
                       ThenPolicy{}, std::forward<Functor>(functor));
   }
 
   // Overload for a policy.
-  template <
-      typename Policy, typename Functor,
-      std::enable_if_t<Kokkos::Impl::is_specialization_of_v<
-                           Kokkos::Impl::remove_cvref_t<Policy>, ThenPolicy>,
-                       int> = 0>
+  template <typename Policy, typename Functor,
+            std::enable_if_t<Kokkos::Impl::is_specialization_of_v<
+                                 std::remove_cvref_t<Policy>, ThenPolicy>,
+                             int> = 0>
   auto then(Policy&& policy, Functor&& functor) const {
     return this->then(std::string{}, ExecutionSpace{},
                       std::forward<Policy>(policy),
@@ -289,8 +287,9 @@ class GraphNodeRef {
 
   template <typename Label, typename Functor>
   auto then_host(Label&&, Functor&& functor) const {
-    using host_t = Kokkos::Impl::GraphNodeThenHostImpl<
-        ExecutionSpace, Kokkos::Impl::remove_cvref_t<Functor>>;
+    using host_t =
+        Kokkos::Impl::GraphNodeThenHostImpl<ExecutionSpace,
+                                            std::remove_cvref_t<Functor>>;
     using return_t = GraphNodeRef<ExecutionSpace, host_t, GraphNodeRef>;
 
     auto graph_ptr = m_graph_impl.lock();
@@ -318,10 +317,10 @@ class GraphNodeRef {
 #if defined(KOKKOS_ENABLE_CUDA) ||                                           \
     (defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)) || \
     (defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_SYCL_GRAPH_SUPPORT))
-  template <class Functor,
-            typename = std::enable_if_t<std::is_invocable_r_v<
-                void, const Kokkos::Impl::remove_cvref_t<Functor>,
-                const ExecutionSpace&>>>
+  template <
+      class Functor,
+      typename = std::enable_if_t<std::is_invocable_r_v<
+          void, const std::remove_cvref_t<Functor>, const ExecutionSpace&>>>
 #if defined(KOKKOS_ENABLE_CUDA)
   auto cuda_capture(const ExecutionSpace& exec, Functor&& functor) const {
     if constexpr (std::is_same_v<ExecutionSpace, Kokkos::Cuda>) {
@@ -332,8 +331,9 @@ class GraphNodeRef {
   auto sycl_capture(const ExecutionSpace& exec, Functor&& functor) const {
     if constexpr (std::is_same_v<ExecutionSpace, Kokkos::SYCL>) {
 #endif
-      using capture_t = Kokkos::Impl::GraphNodeCaptureImpl<
-          ExecutionSpace, Kokkos::Impl::remove_cvref_t<Functor>>;
+      using capture_t =
+          Kokkos::Impl::GraphNodeCaptureImpl<ExecutionSpace,
+                                             std::remove_cvref_t<Functor>>;
       using return_t = GraphNodeRef<ExecutionSpace, capture_t, GraphNodeRef>;
 
       auto graph_ptr = m_graph_impl.lock();
@@ -360,14 +360,13 @@ class GraphNodeRef {
   }
 #endif
 
-  template <
-      class Policy, class Functor,
-      std::enable_if_t<
-          // equivalent to:
-          //   requires Kokkos::ExecutionPolicy<remove_cvref_t<Policy>>
-          is_execution_policy<Kokkos::Impl::remove_cvref_t<Policy>>::value,
-          // --------------------
-          int> = 0>
+  template <class Policy, class Functor,
+            std::enable_if_t<
+                // equivalent to:
+                //   requires Kokkos::ExecutionPolicy<remove_cvref_t<Policy>>
+                is_execution_policy<std::remove_cvref_t<Policy>>::value,
+                // --------------------
+                int> = 0>
   auto then_parallel_for(std::string arg_name, Policy&& arg_policy,
                          Functor&& functor) const {
     //----------------------------------------
@@ -380,7 +379,7 @@ class GraphNodeRef {
 
     // needs to static assert constraint: DataParallelFunctor<Functor>
 
-    using policy_t = Kokkos::Impl::remove_cvref_t<Policy>;
+    using policy_t = std::remove_cvref_t<Policy>;
     // constraint check: same execution space type (or defaulted, maybe?)
     static_assert(
         std::is_same_v<typename policy_t::execution_space, execution_space>,
@@ -401,14 +400,13 @@ class GraphNodeRef {
                                             (Policy&&)policy});
   }
 
-  template <
-      class Policy, class Functor,
-      std::enable_if_t<
-          // equivalent to:
-          //   requires Kokkos::ExecutionPolicy<remove_cvref_t<Policy>>
-          is_execution_policy<Kokkos::Impl::remove_cvref_t<Policy>>::value,
-          // --------------------
-          int> = 0>
+  template <class Policy, class Functor,
+            std::enable_if_t<
+                // equivalent to:
+                //   requires Kokkos::ExecutionPolicy<remove_cvref_t<Policy>>
+                is_execution_policy<std::remove_cvref_t<Policy>>::value,
+                // --------------------
+                int> = 0>
   auto then_parallel_for(Policy&& policy, Functor&& functor) const {
     // needs to static assert constraint: DataParallelFunctor<Functor>
     return this->then_parallel_for("", (Policy&&)policy, (Functor&&)functor);
@@ -445,14 +443,13 @@ class GraphNodeRef {
       return static_cast<T2&&>(v2);
   }
 
-  template <
-      class Policy, class Functor, class ReturnType,
-      std::enable_if_t<
-          // equivalent to:
-          //   requires Kokkos::ExecutionPolicy<remove_cvref_t<Policy>>
-          is_execution_policy<Kokkos::Impl::remove_cvref_t<Policy>>::value,
-          // --------------------
-          int> = 0>
+  template <class Policy, class Functor, class ReturnType,
+            std::enable_if_t<
+                // equivalent to:
+                //   requires Kokkos::ExecutionPolicy<remove_cvref_t<Policy>>
+                is_execution_policy<std::remove_cvref_t<Policy>>::value,
+                // --------------------
+                int> = 0>
   auto then_parallel_reduce(std::string arg_name, Policy&& arg_policy,
                             Functor&& functor,
                             ReturnType&& return_value) const {
@@ -520,7 +517,7 @@ class GraphNodeRef {
         std::conditional_t<Kokkos::is_reducer<return_type_remove_cvref>::value,
                            return_type_remove_cvref,
                            const return_type_remove_cvref>;
-    using functor_type = Kokkos::Impl::remove_cvref_t<Functor>;
+    using functor_type = std::remove_cvref_t<Functor>;
     // see Kokkos_Parallel_Reduce.hpp for how these details are used there;
     // we're just doing the same thing here
     using return_value_adapter =
@@ -562,14 +559,13 @@ class GraphNodeRef {
         return_value_adapter::return_value(return_value, functor)});
   }
 
-  template <
-      class Policy, class Functor, class ReturnType,
-      std::enable_if_t<
-          // equivalent to:
-          //   requires Kokkos::ExecutionPolicy<remove_cvref_t<Policy>>
-          is_execution_policy<Kokkos::Impl::remove_cvref_t<Policy>>::value,
-          // --------------------
-          int> = 0>
+  template <class Policy, class Functor, class ReturnType,
+            std::enable_if_t<
+                // equivalent to:
+                //   requires Kokkos::ExecutionPolicy<remove_cvref_t<Policy>>
+                is_execution_policy<std::remove_cvref_t<Policy>>::value,
+                // --------------------
+                int> = 0>
   auto then_parallel_reduce(Policy&& arg_policy, Functor&& functor,
                             ReturnType&& return_value) const {
     return this->then_parallel_reduce("", (Policy&&)arg_policy,

--- a/core/src/SYCL/Kokkos_SYCL_GraphNodeKernel.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_GraphNodeKernel.hpp
@@ -144,13 +144,13 @@ template <typename KernelType,
           typename Tag =
               typename PatternTagFromImplSpecialization<KernelType>::type>
 struct get_graph_node_kernel_type
-    : type_identity<
+    : std::type_identity<
           GraphNodeKernelImpl<Kokkos::SYCL, typename KernelType::Policy,
                               typename KernelType::functor_type, Tag>> {};
 
 template <typename KernelType>
 struct get_graph_node_kernel_type<KernelType, Kokkos::ParallelReduceTag>
-    : type_identity<GraphNodeKernelImpl<
+    : std::type_identity<GraphNodeKernelImpl<
           Kokkos::SYCL, typename KernelType::Policy,
           CombinedFunctorReducer<typename KernelType::FunctorType,
                                  typename KernelType::ReducerType>,

--- a/core/src/View/Kokkos_ViewCtor.hpp
+++ b/core/src/View/Kokkos_ViewCtor.hpp
@@ -499,7 +499,7 @@ inline constexpr Kokkos::Impl::AllowPadding_t AllowPadding{};
 template <class... Args>
 auto view_alloc(Args &&...args) {
   using return_type = Impl::ViewCtorProp<
-      typename Impl::ViewCtorProp<void, std:: ::remove_cvref_t<Args>>::type...>;
+      typename Impl::ViewCtorProp<void, std::remove_cvref_t<Args>>::type...>;
 
   static_assert(!return_type::has_pointer,
                 "Cannot give pointer-to-memory for view allocation");

--- a/core/src/View/Kokkos_ViewCtor.hpp
+++ b/core/src/View/Kokkos_ViewCtor.hpp
@@ -498,8 +498,8 @@ inline constexpr Kokkos::Impl::AllowPadding_t AllowPadding{};
  */
 template <class... Args>
 auto view_alloc(Args &&...args) {
-  using return_type = Impl::ViewCtorProp<typename Impl::ViewCtorProp<
-      void, Kokkos::Impl::remove_cvref_t<Args>>::type...>;
+  using return_type = Impl::ViewCtorProp<
+      typename Impl::ViewCtorProp<void, std:: ::remove_cvref_t<Args>>::type...>;
 
   static_assert(!return_type::has_pointer,
                 "Cannot give pointer-to-memory for view allocation");

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -369,7 +369,7 @@ struct CombinedReductionFunctorWrapperImpl<
   template <class... IdxOrMemberTypes, class IdxOrMemberType1,
             class... IdxOrMemberTypesThenValueType>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      !std::is_same_v<remove_cvref_t<IdxOrMemberType1>, value_type>>
+      !std::is_same_v<std::remove_cvref_t<IdxOrMemberType1>, value_type>>
   _call_op_impl(IdxOrMemberTypes&&... idxs, IdxOrMemberType1&& idx,
                 IdxOrMemberTypesThenValueType&&... args) const {
     this->template _call_op_impl<IdxOrMemberTypes&&..., IdxOrMemberType1&&>(

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -72,7 +72,7 @@ struct GraphAccess {
   template <class NodeRef>
   static auto get_node_ptr(NodeRef&& node_ref) {
     static_assert(
-        is_specialization_of<remove_cvref_t<NodeRef>,
+        is_specialization_of<std::remove_cvref_t<NodeRef>,
                              Kokkos::Experimental::GraphNodeRef>::value,
         "Kokkos Internal Implementation error (bad argument to "
         "`GraphAccess::get_node_ptr()`)");
@@ -82,7 +82,7 @@ struct GraphAccess {
   template <class NodeRef>
   static auto get_graph_weak_ptr(NodeRef&& node_ref) {
     static_assert(
-        is_specialization_of<remove_cvref_t<NodeRef>,
+        is_specialization_of<std::remove_cvref_t<NodeRef>,
                              Kokkos::Experimental::GraphNodeRef>::value,
         "Kokkos Internal Implementation error (bad argument to "
         "`GraphAccess::get_graph_weak_ptr()`)");

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -56,34 +56,6 @@ struct always_false : std::false_type {};
 
 //==============================================================================
 
-#if defined(__cpp_lib_type_identity)
-// since C++20
-using std::type_identity;
-using std::type_identity_t;
-#else
-template <typename T>
-struct type_identity {
-  using type = T;
-};
-
-template <typename T>
-using type_identity_t = typename type_identity<T>::type;
-#endif
-
-#if defined(__cpp_lib_remove_cvref)
-// since C++20
-using std::remove_cvref;
-using std::remove_cvref_t;
-#else
-template <class T>
-struct remove_cvref {
-  using type = std::remove_cv_t<std::remove_reference_t<T>>;
-};
-
-template <class T>
-using remove_cvref_t = typename remove_cvref<T>::type;
-#endif
-
 // same as C++23 std::to_underlying but with __host__ __device__ annotations
 template <typename E>
 KOKKOS_FUNCTION constexpr std::underlying_type_t<E> to_underlying(

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -128,7 +128,7 @@ struct _type_list_remove_first_impl<Entry, type_list<Entry, Ts...>,
 
 template <class Entry, class... OutTs>
 struct _type_list_remove_first_impl<Entry, type_list<>, type_list<OutTs...>>
-    : type_identity<type_list<OutTs...>> {};
+    : std::type_identity<type_list<OutTs...>> {};
 
 template <class Entry, class List>
 struct type_list_remove_first

--- a/core/unit_test/TestConcepts.hpp
+++ b/core/unit_test/TestConcepts.hpp
@@ -53,12 +53,6 @@ static_assert(!Kokkos::is_space<DeviceType &>{});
 static_assert(Kokkos::is_execution_space_v<ExecutionSpace>);
 static_assert(!Kokkos::is_execution_space_v<ExecutionSpace &>);
 
-static_assert(
-    std::is_same<float, Kokkos::Impl::remove_cvref_t<float const &>>{});
-static_assert(std::is_same<int, Kokkos::Impl::remove_cvref_t<int &>>{});
-static_assert(std::is_same<int, Kokkos::Impl::remove_cvref_t<int const>>{});
-static_assert(std::is_same<float, Kokkos::Impl::remove_cvref_t<float>>{});
-
 /*-------------------------------------------------
   begin test for team_handle concept
 


### PR DESCRIPTION
Use the facility from the C++20 standard library instead