### PR TITLE
core(policy): delegating constructor for binding iteration domain with new execution space instance [impl]

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -293,6 +293,12 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
       : TeamPolicyInternal(typename traits::execution_space(), league_size_,
                            team_size_request, vector_length_request) {}
 
+  TeamPolicyInternal(const PolicyUpdate, const TeamPolicyInternal& other,
+                     typename traits::execution_space space)
+      : TeamPolicyInternal(other) {
+    this->m_space = std::move(space);
+  }
+
   inline int chunk_size() const { return m_chunk_size; }
 
   /** \brief set chunk_size to a discrete value*/

--- a/core/src/HIP/Kokkos_HIP_TeamPolicyInternal.hpp
+++ b/core/src/HIP/Kokkos_HIP_TeamPolicyInternal.hpp
@@ -266,6 +266,12 @@ class TeamPolicyInternal<HIP, Properties...>
       : TeamPolicyInternal(typename traits::execution_space(), league_size_, -1,
                            -1) {}
 
+  TeamPolicyInternal(const PolicyUpdate, const TeamPolicyInternal& other,
+                     typename traits::execution_space space)
+      : TeamPolicyInternal(other) {
+    this->m_space = std::move(space);
+  }
+
   int chunk_size() const { return m_chunk_size; }
 
   TeamPolicyInternal& set_chunk_size(typename traits::index_type chunk_size_) {

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -928,6 +928,12 @@ class TeamPolicyInternal<Kokkos::Experimental::HPX, Properties...>
     init(league_size_request, 1);
   }
 
+  TeamPolicyInternal(const PolicyUpdate, const TeamPolicyInternal &other,
+                     typename traits::execution_space space)
+      : TeamPolicyInternal(other) {
+    this->m_space = std::move(space);
+  }
+
   inline int chunk_size() const { return m_chunk_size; }
 
   inline TeamPolicyInternal &set_chunk_size(

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -306,6 +306,12 @@ struct MDRangePolicy<P, Properties...>
             Impl::to_array_potentially_narrowing<index_type, decltype(m_tile)>(
                 tile)) {}
 
+  MDRangePolicy(const Impl::PolicyUpdate, const MDRangePolicy& other,
+                typename traits::execution_space space)
+      : MDRangePolicy(other) {
+    this->m_space = std::move(space);
+  }
+
   template <class... OtherProperties>
   MDRangePolicy(const MDRangePolicy<OtherProperties...> p)
       : traits(p),  // base class may contain data such as desired occupancy

--- a/core/src/Kokkos_Core_Impl.cppm
+++ b/core/src/Kokkos_Core_Impl.cppm
@@ -79,6 +79,7 @@ export {
   using ::Kokkos::Impl::get_tile_size_properties;
   using ::Kokkos::Impl::ParallelConstructName;
   using ::Kokkos::Impl::PolicyTraits;
+  using ::Kokkos::Impl::PolicyUpdate;
   using ::Kokkos::Impl::WorkTagTrait;
   }  // namespace Impl
 

--- a/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
@@ -346,6 +346,13 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
         m_chunk_size(0) {
     init(league_size_request, team_size_request, 1);
   }
+
+  TeamPolicyInternal(const PolicyUpdate, const TeamPolicyInternal& other,
+                     Kokkos::Experimental::OpenACC space)
+      : TeamPolicyInternal(other) {
+    this->m_space = std::move(space);
+  }
+
   static int vector_length_max() {
     return 32; /* TODO: this is bad. Need logic that is compiler and backend
                   aware */

--- a/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
@@ -251,6 +251,12 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
     init(league_size_request, team_size_request);
   }
 
+  TeamPolicyInternal(const PolicyUpdate, const TeamPolicyInternal& other,
+                     typename traits::execution_space space)
+      : TeamPolicyInternal(other) {
+    this->m_space = std::move(space);
+  }
+
   inline int team_alloc() const { return m_team_alloc; }
   inline int team_iter() const { return m_team_iter; }
 

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -493,6 +493,12 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenMPTarget, Properties...>
         m_chunk_size(0) {
     init(league_size_request, team_size_request, 1);
   }
+
+  // FIXME_OPENMPTARGET https://github.com/kokkos/kokkos/issues/8510
+  TeamPolicyInternal(const PolicyUpdate, const TeamPolicyInternal& other,
+                     typename traits::execution_space)
+      : TeamPolicyInternal(other) {}
+
   inline static size_t vector_length_max() {
     return 32; /* TODO: this is bad. Need logic that is compiler and backend
                   aware */

--- a/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
@@ -229,6 +229,12 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
       : TeamPolicyInternal(typename traits::execution_space(), league_size_, -1,
                            -1) {}
 
+  TeamPolicyInternal(const PolicyUpdate, const TeamPolicyInternal& other,
+                     typename traits::execution_space space)
+      : TeamPolicyInternal(other) {
+    this->m_space = std::move(space);
+  }
+
   int chunk_size() const { return m_chunk_size; }
 
   TeamPolicyInternal& set_chunk_size(typename traits::index_type chunk_size_) {

--- a/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
@@ -157,6 +157,12 @@ class TeamPolicyInternal<Kokkos::Serial, Properties...>
                            league_size_request, team_size_request,
                            vector_length_request) {}
 
+  TeamPolicyInternal(const PolicyUpdate, const TeamPolicyInternal& other,
+                     typename traits::execution_space space)
+      : TeamPolicyInternal(other) {
+    this->m_space = std::move(space);
+  }
+
   inline int chunk_size() const { return m_chunk_size; }
 
   /** \brief set chunk_size to a discrete value*/

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -559,7 +559,6 @@ class TeamPolicyInternal<Kokkos::Threads, Properties...>
 
  public:
   //! Tag this class as a kokkos execution policy
-  //! Tag this class as a kokkos execution policy
   using execution_policy = TeamPolicyInternal;
 
   using traits = PolicyTraits<Properties...>;
@@ -715,6 +714,11 @@ class TeamPolicyInternal<Kokkos::Threads, Properties...>
                      const Kokkos::AUTO_t& /* vector_length_request */)
       : TeamPolicyInternal(typename traits::execution_space(),
                            league_size_request, team_size_request, -1) {}
+
+  // FIXME_THREADS https://github.com/kokkos/kokkos/issues/8510
+  TeamPolicyInternal(const PolicyUpdate, const TeamPolicyInternal& other,
+                     const typename traits::execution_space&)
+      : TeamPolicyInternal(other) {}
 
   inline int chunk_size() const { return m_chunk_size; }
 

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -193,4 +193,29 @@ TEST(TEST_CATEGORY, policy_get_tile_size) {
   }
 }
 
+// The execution space is defaulted if not given to the constructor.
+TEST(TEST_CATEGORY, md_range_policy_default_space) {
+  using policy_t = Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>;
+
+  policy_t defaulted({42, 47}, {666, 999});
+
+  ASSERT_EQ(defaulted.space(), TEST_EXECSPACE{});
+}
+
+// The execution space instance can be updated.
+TEST(TEST_CATEGORY, md_range_policy_impl_set_space) {
+  using policy_t = Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>;
+
+  const auto [exec_old, exec_new] =
+      Kokkos::Experimental::partition_space(TEST_EXECSPACE{}, 1, 1);
+
+  const policy_t policy_old(exec_old, {42, 47}, {666, 999});
+  ASSERT_EQ(policy_old.space(), exec_old);
+
+  const policy_t policy_new(Kokkos::Impl::PolicyUpdate{}, policy_old, exec_new);
+  ASSERT_EQ(policy_new.space(), exec_new);
+  ASSERT_EQ(policy_new.m_lower, (typename policy_t::point_type{42, 47}));
+  ASSERT_EQ(policy_new.m_upper, (typename policy_t::point_type{666, 999}));
+}
+
 }  // namespace

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -6,6 +6,7 @@
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
+import kokkos.core_impl;
 #else
 #include <Kokkos_Core.hpp>
 #endif
@@ -330,5 +331,30 @@ constexpr bool test_chunk_size_explicit() {
 }
 
 static_assert(test_chunk_size_explicit());
+
+// The execution space is defaulted if not given to the constructor.
+TEST(TEST_CATEGORY, range_policy_default_space) {
+  using policy_t = Kokkos::RangePolicy<TEST_EXECSPACE>;
+
+  policy_t defaulted(42, 666);
+
+  ASSERT_EQ(defaulted.space(), TEST_EXECSPACE{});
+}
+
+// The execution space instance can be updated.
+TEST(TEST_CATEGORY, range_policy_impl_set_space) {
+  using policy_t = Kokkos::RangePolicy<TEST_EXECSPACE>;
+
+  const auto [exec_old, exec_new] =
+      Kokkos::Experimental::partition_space(TEST_EXECSPACE{}, 1, 1);
+
+  const policy_t policy_old(exec_old, 42, 666);
+  ASSERT_EQ(policy_old.space(), exec_old);
+
+  const policy_t policy_new(Kokkos::Impl::PolicyUpdate{}, policy_old, exec_new);
+  ASSERT_EQ(policy_new.space(), exec_new);
+  ASSERT_EQ(policy_new.begin(), 42);
+  ASSERT_EQ(policy_new.end(), 666);
+}
 
 }  // namespace

--- a/core/unit_test/TestTeamPolicyConstructors.hpp
+++ b/core/unit_test/TestTeamPolicyConstructors.hpp
@@ -6,6 +6,7 @@
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
+import kokkos.core_impl;
 #else
 #include <Kokkos_Core.hpp>
 #endif
@@ -159,6 +160,31 @@ TEST(TEST_CATEGORY, team_policy_runtime_parameters) {
   test_run_time_parameters<Kokkos::TeamPolicy<LongIndex,       TestExecSpace,   DynamicSchedule         >>();
   test_run_time_parameters<Kokkos::TeamPolicy<DynamicSchedule, LongIndex,       TestExecSpace,   SomeTag>>();
   // clang-format on
+}
+
+// The execution space is defaulted if not given to the constructor.
+TEST(TEST_CATEGORY, team_policy_default_space) {
+  using policy_t = Kokkos::TeamPolicy<TEST_EXECSPACE>;
+
+  policy_t defaulted(42, Kokkos::AUTO);
+
+  ASSERT_EQ(defaulted.space(), TEST_EXECSPACE{});
+}
+
+// The execution space instance can be updated.
+TEST(TEST_CATEGORY, team_policy_impl_set_space) {
+  using policy_t = Kokkos::TeamPolicy<TEST_EXECSPACE>;
+
+  const auto [exec_old, exec_new] =
+      Kokkos::Experimental::partition_space(TEST_EXECSPACE{}, 1, 1);
+
+  const policy_t policy_old(exec_old, 42, Kokkos::AUTO);
+  ASSERT_EQ(policy_old.space(), exec_old);
+
+  const policy_t policy_new(Kokkos::Impl::PolicyUpdate{}, policy_old, exec_new);
+
+  ASSERT_EQ(policy_new.space(), exec_new);
+  ASSERT_EQ(policy_new.league_size(), 42);
 }
 
 }  // namespace


### PR DESCRIPTION
Add a delegating constructor allowing to update the execution space instance of an execution policy.

This is reserved for internal usage, hence the `Impl::PolicyUpdate` tag. 

```c++
Policy(const Impl::PolicyUpdate, const Policy& other, execution_space exec);
```

It will be used in the graph later on. The scenario is that the user *has to* pass an execution policy with a defaulted execution space instance when adding a node, and the graph will internally update the execution space instance.

Note that *in fine*, we'll probably want the user to provide a "bare policy", *i.e.* without the execution space instance member. Very much like:
https://github.com/kokkos/kokkos/blob/7b74f54bf504bcfbc81ae919f8394feca825c86b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp#L45-L54

<details>

<summary>
Old PR description.
</summary>

This is for internal use only, hence the `impl` prefix.

It may be necessary to update the execution space instance stored by an execution policy, all other members unchanged.

Other patterns considered:
* Attorney-Client, but judged "too easy to break code invariants"
* Constructor like `RangePolicy(RangePolicy&& other, Exec exec)` but judged overkill for a single member update.
</details>