### PR TITLE
Deprecate `KOKKOS_ATTRIBUTE_NODISCARD` macro

### DIFF
--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -254,12 +254,9 @@ inline std::string scopeguard_destruct_after_finalize_warning() {
 
 }  // namespace Impl
 
-class KOKKOS_ATTRIBUTE_NODISCARD ScopeGuard {
+class [[nodiscard]] ScopeGuard {
  public:
   template <class... Args>
-#if defined(__has_cpp_attribute) && __has_cpp_attribute(nodiscard) >= 201907
-  [[nodiscard]]
-#endif
   ScopeGuard(Args&&... args) {
     if (is_initialized()) {
       Kokkos::abort(

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -668,7 +668,7 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 #endif
 // clang-format on
 
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 #define KOKKOS_ATTRIBUTE_NODISCARD [[nodiscard]]
 #endif
 

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -668,8 +668,6 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 #endif
 // clang-format on
 
-#define KOKKOS_ATTRIBUTE_NODISCARD [[nodiscard]]
-
 #if (defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG) ||         \
      defined(KOKKOS_COMPILER_INTEL_LLVM) || defined(KOKKOS_COMPILER_NVHPC)) && \
     !defined(_WIN32) && !defined(__ANDROID__)

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -668,6 +668,10 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 #endif
 // clang-format on
 
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#define KOKKOS_ATTRIBUTE_NODISCARD [[nodiscard]]
+#endif
+
 #if (defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG) ||         \
      defined(KOKKOS_COMPILER_INTEL_LLVM) || defined(KOKKOS_COMPILER_NVHPC)) && \
     !defined(_WIN32) && !defined(__ANDROID__)


### PR DESCRIPTION
I propose to guard it for deprecated code 4.  We never intended to provide this to users.

It was introduced in #2409 at a time where we were not as careful with "symbol visibility" and marking with "impl".
When we cleaned things up for 4.0 with the C++17 requirement, in #5295, we had decided to keep it.  As far as I can tell I had objected against outright removal but I suppose it was folded into so many other things that no one suggested to deprecate it.