### PR TITLE
Remove c++17 jobs from the cea nightly

### DIFF
--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -18,13 +18,12 @@ jobs:
         build_type:
           - Release
         cxx_standard:
-          - 17
           - 20
         backend:
-          - name: OpenMP-x86_64-GCC/10.3-Shared
+          - name: OpenMP-x86_64-GCC/11.2-Shared
             configure: -DKokkos_ENABLE_OPENMP=ON -DBUILD_SHARED_LIBS=ON
             test: -e cpu OMP_PROC_BIND=spread OMP_PLACES=threads
-            modules: gcc/10.3.0/gcc-4.8.5 cmake/3.28.3/gcc-11.2.0
+            modules: gcc/11.2.0/gcc-4.8.5 cmake/3.28.3/gcc-11.2.0
 
           - name: Cuda-A100-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE
             configure: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON -DKokkos_ENABLE_CUDA_CONSTEXPR=ON -DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON
@@ -45,11 +44,6 @@ jobs:
             configure: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_CUDA_UVM=ON -DKokkos_ENABLE_CUDA_CONSTEXPR=ON -DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON
             test: -e gpu -g v100
             modules: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
-        exclude:
-          # note: GCC 10.3 does not support C++ 20 well enough
-          - backend:
-              name: OpenMP-x86_64-GCC/10.3-Shared
-            cxx_standard: 20
 
     runs-on: [self-hosted, cuda]
 

--- a/.github/workflows/nightly-cea.yml
+++ b/.github/workflows/nightly-cea.yml
@@ -30,18 +30,8 @@ jobs:
             test: -e gpu -g a100
             modules: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
 
-          - name: Cuda-A100-UVM-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE
-            configure: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_AMPERE80=ON -DKokkos_ENABLE_CUDA_UVM=ON -DKokkos_ENABLE_CUDA_CONSTEXPR=ON -DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON
-            test: -e gpu -g a100
-            modules: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
-
           - name: Cuda-V100-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE
             configure: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_CUDA_CONSTEXPR=ON -DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON
-            test: -e gpu -g v100
-            modules: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
-
-          - name: Cuda-V100-UVM-GCC/11.2.0-Cuda/12.2.1-Static-CUDA_CONSTEXPR-CUDA_RELOCATABLE_DEVICE_CODE
-            configure: -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_CUDA_UVM=ON -DKokkos_ENABLE_CUDA_CONSTEXPR=ON -DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON
             test: -e gpu -g v100
             modules: gcc/11.2.0/gcc-4.8.5 cuda/12.2.1/gcc-11.2.0 cmake/3.28.3/gcc-11.2.0
 


### PR DESCRIPTION
This PR removes the c++17 jobs in the cea nightly, as kokkos now requires c++20. It also updates the OpenMP job's gcc version from 10.3.0 to 11.2.0 to meet the new minimum requirements. The UVM builds (with `Kokkos_ENABLE_CUDA_UVM`) are removed as this feature is now deprecated.