### PR TITLE
[4.7.1] Cherry pick 8292: Make compile check use our linker flags

### DIFF
--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -962,7 +962,7 @@ endfunction()
 #       FLAGS       --> flags to check
 #
 function(kokkos_check_flags)
-  cmake_parse_arguments(INP "COMPILER;LINKER" "LANGUAGE" "FLAGS" ${ARGN})
+  cmake_parse_arguments(INP "COMPILER;LINKER" "LANGUAGE" "FLAGS;LINKER_FLAGS" ${ARGN})
 
   # do nothing if no flags are given
   if(NOT INP_FLAGS)
@@ -982,6 +982,11 @@ function(kokkos_check_flags)
     include(CheckCompilerFlag)
     #delete cache so we always do the check
     unset(KOKKOS_COMPILE_OPTIONS_CHECK CACHE)
+    if(INP_LINKER_FLAGS)
+      # icpx adds "-device ..." options that need quotes (which CMake removes). We need to add them here again.
+      string(REGEX REPLACE "(-device [A-Za-z0-9_\\\\.]*)" "\"\\1\"" QUOTED_LINKER_FLAGS "${INP_LINKER_FLAGS}")
+      set(CMAKE_REQUIRED_LINK_OPTIONS "${QUOTED_LINKER_FLAGS}")
+    endif()
     check_compiler_flag(${INP_LANGUAGE} "${QUOTED_FLAGS}" KOKKOS_COMPILE_OPTIONS_CHECK)
     if(NOT KOKKOS_COMPILE_OPTIONS_CHECK)
       message(

--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -322,7 +322,15 @@ function(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
        AND (NOT (KOKKOS_ENABLE_CUDA) OR ("${CMAKE_CXX_COMPILER}" MATCHES "nvcc_wrapper") OR (${KOKKOS_CXX_COMPILER_ID}
                                                                                              STREQUAL Clang))
     )
-      kokkos_check_flags(COMPILER LANGUAGE ${KOKKOS_COMPILE_LANGUAGE} FLAGS ${ALL_KOKKOS_COMPILER_FLAGS})
+      kokkos_check_flags(
+        COMPILER
+        LANGUAGE
+        ${KOKKOS_COMPILE_LANGUAGE}
+        FLAGS
+        ${ALL_KOKKOS_COMPILER_FLAGS}
+        LINKER_FLAGS
+        ${KOKKOS_LINK_OPTIONS}
+      )
     endif()
   endif()
 


### PR DESCRIPTION
Cherry pick of #8292

Changelog:
Use Kokkos' linker flags for build system checking in CMake