### PR TITLE
Deprecate `{Owning,Observing}RawPtr` aliases 

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -98,8 +98,8 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
   // These are really functioning as optional references, though I'm not sure
   // that the cudaGraph_t one needs to be since it's a pointer under the
   // covers and we're not modifying it
-  Kokkos::ObservingRawPtr<const cudaGraph_t> m_graph_ptr    = nullptr;
-  Kokkos::ObservingRawPtr<cudaGraphNode_t> m_graph_node_ptr = nullptr;
+  cudaGraph_t const* m_graph_ptr    = nullptr;
+  cudaGraphNode_t* m_graph_node_ptr = nullptr;
   // Basically, we have to make this mutable for the same reasons that the
   // global kernel buffers in the Cuda instance are mutable...
   mutable std::shared_ptr<base_t> m_driver_storage = nullptr;
@@ -137,8 +137,7 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
   cudaGraphNode_t* get_cuda_graph_node_ptr() const { return m_graph_node_ptr; }
   cudaGraph_t const* get_cuda_graph_ptr() const { return m_graph_ptr; }
 
-  Kokkos::ObservingRawPtr<base_t> allocate_driver_memory_buffer(
-      const CudaSpace& mem) const {
+  base_t* allocate_driver_memory_buffer(const CudaSpace& mem) const {
     KOKKOS_EXPECTS(m_driver_storage == nullptr)
     std::string alloc_label =
         label + " - GraphNodeKernel global memory functor storage";

--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -111,8 +111,7 @@ class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
 
   hipGraph_t const* get_hip_graph_ptr() const { return m_graph_ptr; }
 
-  Kokkos::ObservingRawPtr<base_t> allocate_driver_memory_buffer(
-      const HIP& exec) const {
+  base_t* allocate_driver_memory_buffer(const HIP& exec) const {
     KOKKOS_EXPECTS(m_driver_storage == nullptr);
     std::string alloc_label =
         label + " - GraphNodeKernel global memory functor storage";
@@ -130,9 +129,9 @@ class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
   auto get_driver_storage() const { return m_driver_storage; }
 
  private:
-  Kokkos::ObservingRawPtr<const hipGraph_t> m_graph_ptr    = nullptr;
-  Kokkos::ObservingRawPtr<hipGraphNode_t> m_graph_node_ptr = nullptr;
-  mutable std::shared_ptr<base_t> m_driver_storage         = nullptr;
+  hipGraph_t const* m_graph_ptr                    = nullptr;
+  hipGraphNode_t* m_graph_node_ptr                 = nullptr;
+  mutable std::shared_ptr<base_t> m_driver_storage = nullptr;
   std::string label;
 };
 

--- a/core/src/Kokkos_PointerOwnership.hpp
+++ b/core/src/Kokkos_PointerOwnership.hpp
@@ -31,17 +31,19 @@ static_assert(false,
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 namespace Kokkos {
 
 /// Trivial wrapper for raw pointers that express ownership.
 template <class T>
-using OwningRawPtr = T*;
+using OwningRawPtr KOKKOS_DEPRECATED = T*;
 
 /// Trivial wrapper for raw pointers that do not express ownership.
 template <class T>
-using ObservingRawPtr = T*;
+using ObservingRawPtr KOKKOS_DEPRECATED = T*;
 
 }  // end namespace Kokkos
+#endif
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/core/src/SYCL/Kokkos_SYCL_GraphNodeKernel.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_GraphNodeKernel.hpp
@@ -131,11 +131,11 @@ class GraphNodeKernelImpl<Kokkos::SYCL, PolicyType, Functor, PatternTag,
   }
 
  private:
-  Kokkos::ObservingRawPtr<sycl::ext::oneapi::experimental::command_graph<
-      sycl::ext::oneapi::experimental::graph_state::modifiable>>
-      m_graph_ptr = nullptr;
-  Kokkos::ObservingRawPtr<std::optional<sycl::ext::oneapi::experimental::node>>
-      m_graph_node_ptr = nullptr;
+  sycl::ext::oneapi::experimental::command_graph<
+      sycl::ext::oneapi::experimental::graph_state::modifiable>* m_graph_ptr =
+      nullptr;
+  std::optional<sycl::ext::oneapi::experimental::node>* m_graph_node_ptr =
+      nullptr;
 };
 
 struct SYCLGraphNodeAggregate {};

--- a/core/src/impl/Kokkos_Default_GraphNode_Impl.hpp
+++ b/core/src/impl/Kokkos_Default_GraphNode_Impl.hpp
@@ -43,7 +43,7 @@ struct GraphNodeBackendSpecificDetails {
   std::vector<std::shared_ptr<GraphNodeBackendSpecificDetails<ExecutionSpace>>>
       m_predecessors = {};
 
-  Kokkos::ObservingRawPtr<default_kernel_impl_t> m_kernel_ptr = nullptr;
+  default_kernel_impl_t* m_kernel_ptr = nullptr;
 
   bool m_has_executed = false;
   bool m_is_aggregate = false;


### PR DESCRIPTION
No known usage downstream.
These were never documented and were mostly used in Tasking.
There was marginal use in the Graph implementation details where I suggest to use old-fashioned pointers instead but I am open to have an `Impl::` alias if reviewers really want it.