### PR TITLE
Cleanup Timer class and add tests

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -260,6 +260,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         TeamScratch
         TeamTeamSize
         TeamVectorRange
+        Timer
         UniqueToken
         View_64bit
         ViewAPI_a

--- a/core/unit_test/TestTimer.hpp
+++ b/core/unit_test/TestTimer.hpp
@@ -18,7 +18,6 @@
 
 #include <Kokkos_Timer.hpp>
 
-#include <chrono>
 #include <thread>
 #include <type_traits>
 

--- a/core/unit_test/TestTimer.hpp
+++ b/core/unit_test/TestTimer.hpp
@@ -30,18 +30,15 @@ TEST(TEST_CATEGORY, timer) {
   std::this_thread::sleep_for(5ms);
   auto elapsed = t.seconds();
   EXPECT_GE(elapsed, .005);
-  EXPECT_LE(elapsed, .01);
 
   std::this_thread::sleep_for(10ms);
   auto elapsed2 = t.seconds();
   EXPECT_GE(elapsed2, .015);
-  EXPECT_LE(elapsed2, .02);
 
   t.reset();
   std::this_thread::sleep_for(5ms);
   auto elapsed3 = t.seconds();
   EXPECT_GE(elapsed3, .005);
-  EXPECT_LE(elapsed3, .01);
 }
 
 static_assert(!std::is_copy_constructible_v<Kokkos::Timer>);

--- a/core/unit_test/TestTimer.hpp
+++ b/core/unit_test/TestTimer.hpp
@@ -20,6 +20,7 @@
 
 #include <thread>
 #include <type_traits>
+#include <utility>
 
 namespace {
 
@@ -30,15 +31,18 @@ TEST(TEST_CATEGORY, timer) {
   std::this_thread::sleep_for(5ms);
   auto elapsed = t.seconds();
   EXPECT_GE(elapsed, .005);
+  EXPECT_LT(elapsed, 1.);
 
   std::this_thread::sleep_for(10ms);
-  auto elapsed2 = t.seconds();
+  auto elapsed2 = std::as_const(t).seconds();
   EXPECT_GE(elapsed2, .015);
+  EXPECT_GT(elapsed2, elapsed);
 
   t.reset();
   std::this_thread::sleep_for(5ms);
   auto elapsed3 = t.seconds();
   EXPECT_GE(elapsed3, .005);
+  EXPECT_LT(elapsed3, elapsed2);
 }
 
 static_assert(!std::is_copy_constructible_v<Kokkos::Timer>);

--- a/core/unit_test/TestTimer.hpp
+++ b/core/unit_test/TestTimer.hpp
@@ -1,0 +1,53 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Timer.hpp>
+
+#include <chrono>
+#include <thread>
+#include <type_traits>
+
+namespace {
+
+TEST(TEST_CATEGORY, timer) {
+  using namespace std::chrono_literals;
+
+  Kokkos::Timer t;
+  std::this_thread::sleep_for(5ms);
+  auto elapsed = t.seconds();
+  EXPECT_GE(elapsed, .005);
+  EXPECT_LE(elapsed, .01);
+
+  std::this_thread::sleep_for(10ms);
+  auto elapsed2 = t.seconds();
+  EXPECT_GE(elapsed2, .015);
+  EXPECT_LE(elapsed2, .02);
+
+  t.reset();
+  std::this_thread::sleep_for(5ms);
+  auto elapsed3 = t.seconds();
+  EXPECT_GE(elapsed3, .005);
+  EXPECT_LE(elapsed3, .01);
+}
+
+static_assert(!std::is_copy_constructible_v<Kokkos::Timer>);
+static_assert(!std::is_move_constructible_v<Kokkos::Timer>);
+static_assert(!std::is_copy_assignable_v<Kokkos::Timer>);
+static_assert(!std::is_move_assignable_v<Kokkos::Timer>);
+
+}  // namespace


### PR DESCRIPTION
* Get rid of the GCC 10.3 workaround.
* Fix copy semantics (broken in https://github.com/kokkos/kokkos/pull/4348, giving a link time error instead of compile time)
* Modernize the implementation
* Add test coverage