### PR TITLE
Remove workaround for old version of ROCm

### DIFF
--- a/cmake/Modules/FindTPLROCM.cmake
+++ b/cmake/Modules/FindTPLROCM.cmake
@@ -3,37 +3,12 @@ include(FindPackageHandleStandardArgs)
 find_library(AMD_HIP_LIBRARY amdhip64 PATHS ENV ROCM_PATH PATH_SUFFIXES lib)
 find_library(HSA_RUNTIME_LIBRARY hsa-runtime64 PATHS ENV ROCM_PATH PATH_SUFFIXES lib)
 
-# FIXME_HIP Starting with ROCm 5.5 it is not necessary to link againt clang_rt.
-# We keep the code as is for now because it is hard to find the version of ROCM
-# found.
-# clang_rt.builtins is necessary to use half precision. The following code to
-# find clang_rt.buitins is based on
-# https://github.com/ROCm-Developer-Tools/hipamd/blob/d1e0ee98a0f3d79f7bf43295f82d0053a69ec742/hip-config.cmake.in#L241
-# NOTE: Per the above, we still search for the clang-rt library,
-# but use the user's specified compiler to find the library to avoid use of
-# environment variables / relative paths.
-execute_process(
-  COMMAND ${CMAKE_CXX_COMPILER} -print-libgcc-file-name --rtlib=compiler-rt
-  OUTPUT_VARIABLE CLANG_RT_LIBRARY
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  RESULT_VARIABLE CLANG_RT_CHECK
-)
-
-if(NOT "${CLANG_RT_CHECK}" STREQUAL "0")
-  # if the above failed, we delete CLANG_RT_LIBRARY to make the args check
-  # below fail
-  unset(CLANG_RT_LIBRARY)
-endif()
-
-find_package_handle_standard_args(TPLROCM DEFAULT_MSG AMD_HIP_LIBRARY HSA_RUNTIME_LIBRARY CLANG_RT_LIBRARY)
-
 kokkos_create_imported_tpl(
   ROCM
   INTERFACE
   LINK_LIBRARIES
   ${HSA_RUNTIME_LIBRARY}
   ${AMD_HIP_LIBRARY}
-  ${CLANG_RT_LIBRARY}
   COMPILE_DEFINITIONS
   __HIP_ROCclr__
 )

--- a/cmake/Modules/FindTPLROCM.cmake
+++ b/cmake/Modules/FindTPLROCM.cmake
@@ -3,6 +3,8 @@ include(FindPackageHandleStandardArgs)
 find_library(AMD_HIP_LIBRARY amdhip64 PATHS ENV ROCM_PATH PATH_SUFFIXES lib)
 find_library(HSA_RUNTIME_LIBRARY hsa-runtime64 PATHS ENV ROCM_PATH PATH_SUFFIXES lib)
 
+find_package_handle_standard_args(TPLROCM DEFAULT_MSG AMD_HIP_LIBRARY HSA_RUNTIME_LIBRARY)
+
 kokkos_create_imported_tpl(
   ROCM
   INTERFACE

--- a/cmake/Modules/FindTPLROCTHRUST.cmake
+++ b/cmake/Modules/FindTPLROCTHRUST.cmake
@@ -1,13 +1,3 @@
-# ROCm 5.6 and earlier set AMDGPU_TARGETS and GPU_TARGETS to all the supported
-# architectures. Therefore, we end up compiling Kokkos for all the supported
-# architecture. Starting with ROCm 5.7 AMDGPU_TARGETS and GPU_TARGETS are empty.
-# It is the user's job to set the variables. Since we are injecting the
-# architecture flag ourselves, we can let the variables empty. To replicate the
-# behavior of ROCm 5.7 and later for earlier version of ROCm we set
-# AMDGPU_TARGETS and GPU_TARGETS to empty and set the values in the cache. If
-# the values are not cached, FIND_PACKAGE(rocthrust) will overwrite them.
-set(AMDGPU_TARGETS "" CACHE STRING "AMD GPU targets to compile for")
-set(GPU_TARGETS "" CACHE STRING "GPU targets to compile for")
 find_package(rocthrust REQUIRED)
 kokkos_create_imported_tpl(ROCTHRUST INTERFACE LINK_LIBRARIES roc::rocthrust)
 

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -189,17 +189,7 @@ void HIPInternal::initialize(hipStream_t stream) {
   if (was_finalized)
     Kokkos::abort("Calling HIP::initialize after HIP::finalize is illegal\n");
 
-    // Get the device ID. If this is ROCm 5.6 or later, we can query this from
-    // the provided stream and potentially use multiple GPU devices. For
-    // ROCm 5.5 or earlier, we must use the singleton device id and there are no
-    // checks possible for the device id matching the device the stream was
-    // created on.
-#if (HIP_VERSION_MAJOR > 5 || \
-     (HIP_VERSION_MAJOR == 5 && HIP_VERSION_MINOR >= 6))
   KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamGetDevice(stream, &m_hipDev));
-#else
-  m_hipDev = singleton().m_hipDev;
-#endif
   KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(m_hipDev));
   hip_devices.insert(m_hipDev);
 

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -22,13 +22,10 @@
 #if defined(__HIPCC__)
 
 #include <HIP/Kokkos_HIP_Error.hpp>
+#include <HIP/Kokkos_HIP_GraphNodeKernel.hpp>
 #include <HIP/Kokkos_HIP_Instance.hpp>
 #include <HIP/Kokkos_HIP_Space.hpp>
-
-#ifdef KOKKOS_IMPL_HIP_NATIVE_GRAPH
-#include <HIP/Kokkos_HIP_GraphNodeKernel.hpp>
 #include <impl/Kokkos_GraphImpl_fwd.hpp>
-#endif
 
 // Must use global variable on the device with HIP-Clang
 #ifdef __HIP__
@@ -383,7 +380,6 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
         driver);
   }
 
-#ifdef KOKKOS_IMPL_HIP_NATIVE_GRAPH
   static void create_parallel_launch_graph_node(
       DriverType const &driver, dim3 const &grid, dim3 const &block, int shmem,
       HIPInternal const *hip_instance) {
@@ -418,7 +414,6 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
     }
     KOKKOS_ENSURES(graph_node);
   }
-#endif
 };
 
 // HIPLaunchMechanism::GlobalMemory specialization
@@ -445,7 +440,6 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
         driver_ptr);
   }
 
-#ifdef KOKKOS_IMPL_HIP_NATIVE_GRAPH
   static void create_parallel_launch_graph_node(
       DriverType const &driver, dim3 const &grid, dim3 const &block, int shmem,
       HIPInternal const *hip_instance) {
@@ -494,7 +488,6 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
     }
     KOKKOS_ENSURES(bool(graph_node))
   }
-#endif
 };
 
 // HIPLaunchMechanism::ConstantMemory specializations
@@ -615,16 +608,13 @@ void hip_parallel_launch(const DriverType &driver, const dim3 &grid,
     desul::ensure_hip_lock_arrays_on_device();
   }
 
-#ifdef KOKKOS_IMPL_HIP_NATIVE_GRAPH
   if constexpr (DoGraph) {
     // Graph launch
     using base_t = HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
                                                   LaunchMechanism>;
     base_t::create_parallel_launch_graph_node(driver, grid, block, shmem,
                                               hip_instance);
-  } else
-#endif
-  {
+  } else {
     // Regular kernel launch
 #ifndef KOKKOS_ENABLE_HIP_MULTIPLE_KERNEL_INSTANTIATIONS
     HIPParallelLaunch<DriverType, LaunchBounds, LaunchMechanism>(

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -96,9 +96,7 @@ void* HIPSpace::impl_allocate(const int device_id,
                               const size_t arg_logical_size,
                               [[maybe_unused]] bool stream_sync_only) const {
   void* ptr = nullptr;
-  // ROCm 5.5 and earlier throw an error when using hipMallocAsync and
-  // arg_alloc_size is zero. Instead of trying to allocate memory, just return
-  // early.
+  // Instead of trying to allocate zero memory, return early.
   if (arg_alloc_size == 0) return ptr;
 
   KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(device_id));

--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -187,7 +187,7 @@ decltype(auto) Graph<ExecutionSpace>::native_graph() {
   if constexpr (std::is_same_v<ExecutionSpace, Kokkos::Cuda>) {
     return m_impl_ptr->cuda_graph();
   }
-#elif defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
+#elif defined(KOKKOS_ENABLE_HIP)
   if constexpr (std::is_same_v<ExecutionSpace, Kokkos::HIP>) {
     return m_impl_ptr->hip_graph();
   }
@@ -205,7 +205,7 @@ decltype(auto) Graph<ExecutionSpace>::native_graph_exec() {
   if constexpr (std::is_same_v<ExecutionSpace, Kokkos::Cuda>) {
     return m_impl_ptr->cuda_graph_exec();
   }
-#elif defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
+#elif defined(KOKKOS_ENABLE_HIP)
   if constexpr (std::is_same_v<ExecutionSpace, Kokkos::HIP>) {
     return m_impl_ptr->hip_graph_exec();
   }
@@ -228,10 +228,7 @@ decltype(auto) Graph<ExecutionSpace>::native_graph_exec() {
 #include <impl/Kokkos_Default_Graph_Impl.hpp>
 #include <Cuda/Kokkos_Cuda_Graph_Impl.hpp>
 #if defined(KOKKOS_ENABLE_HIP)
-// The implementation of hipGraph in ROCm 5.2 is bugged, so we cannot use it.
-#if defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
 #include <HIP/Kokkos_HIP_Graph_Impl.hpp>
-#endif
 #endif
 #ifdef KOKKOS_IMPL_SYCL_GRAPH_SUPPORT
 #include <SYCL/Kokkos_SYCL_Graph_Impl.hpp>

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -319,8 +319,7 @@ class GraphNodeRef {
     return rv;
   }
 
-#if defined(KOKKOS_ENABLE_CUDA) ||                                           \
-    (defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)) || \
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
     (defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_SYCL_GRAPH_SUPPORT))
   template <
       class Functor,
@@ -329,7 +328,7 @@ class GraphNodeRef {
 #if defined(KOKKOS_ENABLE_CUDA)
   auto cuda_capture(const ExecutionSpace& exec, Functor&& functor) const {
     if constexpr (std::is_same_v<ExecutionSpace, Kokkos::Cuda>) {
-#elif defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
+#elif defined(KOKKOS_ENABLE_HIP)
   auto hip_capture(const ExecutionSpace& exec, Functor&& functor) const {
     if constexpr (std::is_same_v<ExecutionSpace, Kokkos::HIP>) {
 #elif defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_SYCL_GRAPH_SUPPORT)

--- a/core/src/setup/Kokkos_Setup_HIP.hpp
+++ b/core/src/setup/Kokkos_Setup_HIP.hpp
@@ -49,11 +49,6 @@ static_assert(false,
 #endif
 // clang-format on
 
-// The implementation of hipGraph in ROCm 5.2 is bugged, so we cannot use it.
-#if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 2))
-#define KOKKOS_IMPL_HIP_NATIVE_GRAPH
-#endif
-
 #ifdef KOKKOS_ARCH_AMD_GFX942_APU
 #define KOKKOS_IMPL_HIP_UNIFIED_MEMORY
 #endif

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -438,13 +438,12 @@ struct SizedFunctor {
 TEST_F(TEST_CATEGORY_FIXTURE(graph), force_global_launch) {
 #if defined(KOKKOS_ENABLE_CUDA)
   if constexpr (!std::is_same_v<TEST_EXECSPACE, Kokkos::Cuda>) {
-#elif defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
+#elif defined(KOKKOS_ENABLE_HIP)
   if constexpr (!std::is_same_v<TEST_EXECSPACE, Kokkos::HIP>) {
 #endif
     GTEST_SKIP() << "This execution space does not support global launch.";
 
-#if defined(KOKKOS_ENABLE_CUDA) || \
-    (defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH))
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   }
 
   using value_t   = int;
@@ -852,7 +851,7 @@ struct GraphNodeTypes {
 #else
   static constexpr bool support_capture = std::is_same_v<Exec, Kokkos::Cuda>;
 #endif
-#elif defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
+#elif defined(KOKKOS_ENABLE_HIP)
     static constexpr bool support_capture = std::is_same_v<Exec, Kokkos::HIP>;
 #elif defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_SYCL_GRAPH_SUPPORT)
   static constexpr bool support_capture = std::is_same_v<Exec, Kokkos::SYCL>;
@@ -970,8 +969,7 @@ __global__ void set_to(DstType* const dst, const SrcTypes* const... srcs) {
 
 template <typename Exec>
 struct ExternalCapture {
-#if defined(KOKKOS_ENABLE_CUDA) ||                                           \
-    (defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)) || \
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
     (defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_SYCL_GRAPH_SUPPORT))
   // clang-format off
   template <typename Pred, typename DstType, typename... SrcTypes>
@@ -1000,7 +998,7 @@ struct ExternalCapture {
         <<<dim3(1, 1, 1), dim3(1, 1, 1), 0, exec.cuda_stream()>>>(dst, srcs...);
   }
 #endif
-#if defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
+#if defined(KOKKOS_ENABLE_HIP)
   template <typename DstType, typename... SrcTypes>
   static void compute(const Kokkos::HIP& exec, DstType* const dst,
                       const SrcTypes* const... srcs) {
@@ -1178,8 +1176,7 @@ struct ThenIncrementAndCombineFunctor
 template <typename T>
 struct GraphIsDefaulted : std::true_type {};
 
-#if defined(KOKKOS_ENABLE_CUDA) ||                                           \
-    (defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)) || \
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
     (defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_SYCL_GRAPH_SUPPORT))
 template <>
 struct GraphIsDefaulted<

--- a/core/unit_test/TestMathematicalSpecialFunctions.hpp
+++ b/core/unit_test/TestMathematicalSpecialFunctions.hpp
@@ -505,12 +505,7 @@ struct TestComplexBesselJ0Y0Function {
     Kokkos::deep_copy(d_z, h_z);
 
     // Call Bessel functions
-#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 4)
-    using Property =
-        Kokkos::Experimental::WorkItemProperty::ImplForceGlobalLaunch_t;
-#else
     using Property = Kokkos::Experimental::WorkItemProperty::None_t;
-#endif
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, Property>(0, N), *this);
     Kokkos::fence();
 
@@ -801,12 +796,7 @@ struct TestComplexBesselJ1Y1Function {
     Kokkos::deep_copy(d_z, h_z);
 
     // Call Bessel functions
-#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 4)
-    using Property =
-        Kokkos::Experimental::WorkItemProperty::ImplForceGlobalLaunch_t;
-#else
     using Property = Kokkos::Experimental::WorkItemProperty::None_t;
-#endif
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, Property>(0, N), *this);
     Kokkos::fence();
 
@@ -1101,12 +1091,7 @@ struct TestComplexBesselI0K0Function {
     Kokkos::deep_copy(d_z, h_z);
 
     // Call Bessel functions
-#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 4)
-    using Property =
-        Kokkos::Experimental::WorkItemProperty::ImplForceGlobalLaunch_t;
-#else
     using Property = Kokkos::Experimental::WorkItemProperty::None_t;
-#endif
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, Property>(0, N), *this);
     Kokkos::fence();
 
@@ -1204,11 +1189,6 @@ struct TestComplexBesselI0K0Function {
         Kokkos::complex<double>(1.413897840559108e-27, -1.851678917759592e+25);
     h_ref_cbk0(25) = Kokkos::complex<double>(9.5496636116079915979, 0.);
 
-    // FIXME_HIP Disable the test when using ROCm 5.5 and 5.6 due to a known
-    // compiler bug
-#if !defined(KOKKOS_ENABLE_HIP) || (HIP_VERSION_MAJOR != 5) || \
-    ((HIP_VERSION_MAJOR == 5) &&                               \
-     !((HIP_VERSION_MINOR == 5) || (HIP_VERSION_MINOR == 6)))
     for (int i = 0; i < N; i++) {
       EXPECT_LE(Kokkos::abs(h_cbi0(i) - h_ref_cbi0(i)),
                 Kokkos::abs(h_ref_cbi0(i)) * 1e-13);
@@ -1224,7 +1204,6 @@ struct TestComplexBesselI0K0Function {
                 Kokkos::abs(h_ref_cbk0(i)) * 1e-13)
           << "at index " << i;
     }
-#endif
 #endif
 
     ////Test large arguments
@@ -1356,12 +1335,7 @@ struct TestComplexBesselI1K1Function {
     Kokkos::deep_copy(d_z, h_z);
 
     // Call Bessel functions
-#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 4)
-    using Property =
-        Kokkos::Experimental::WorkItemProperty::ImplForceGlobalLaunch_t;
-#else
     using Property = Kokkos::Experimental::WorkItemProperty::None_t;
-#endif
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, Property>(0, N), *this);
     Kokkos::fence();
 
@@ -1603,12 +1577,7 @@ struct TestComplexBesselH1Function {
     Kokkos::deep_copy(d_z, h_z);
 
     // Call Hankel functions
-#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 4)
-    using Property =
-        Kokkos::Experimental::WorkItemProperty::ImplForceGlobalLaunch_t;
-#else
     using Property = Kokkos::Experimental::WorkItemProperty::None_t;
-#endif
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, Property>(0, N), *this);
     Kokkos::fence();
 
@@ -1908,12 +1877,9 @@ struct TestComplexBesselH2Function {
     h_ref_ch21(24) =
         Kokkos::complex<double>(1.629136145471347e-01, +1.530182458039000e-02);
 
-    // FIXME_HIP Disable the test when using ROCm 5.5, 5.6, and 6.2 due to a
-    // known compiler bug
-#if !(defined(KOKKOS_ENABLE_HIP) ||                          \
-      ((HIP_VERSION_MAJOR == 5 && HIP_VERSION_MINOR == 5) || \
-       (HIP_VERSION_MAJOR == 5 && HIP_VERSION_MINOR == 6) || \
-       (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR == 2)))
+    // FIXME_HIP Disable the test when 6.2 due to a known compiler bug
+#if !(defined(KOKKOS_ENABLE_HIP) || \
+      (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR == 2))
     EXPECT_EQ(h_ref_ch20(0), h_ch20(0));
     // FIXME_SYCL Failing for Intel GPUs highly dependent on optimization flags
 #if !(defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_ARCH_INTEL_GPU)) || \
@@ -1976,13 +1942,6 @@ TEST(TEST_CATEGORY, mathspecialfunc_cbesselj0y0) {
 }
 
 TEST(TEST_CATEGORY, mathspecialfunc_cbesselj1y1) {
-#if defined(KOKKOS_ENABLE_HIP) &&                         \
-    (HIP_VERSION_MAJOR == 5 && HIP_VERSION_MINOR == 3) && \
-    defined(KOKKOS_ARCH_AMD_GFX908)
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::HIP>)
-    GTEST_SKIP()
-        << "skipping since test is known to fail on MI100 with ROCm 5.3";
-#endif
 #if __FINITE_MATH_ONLY__
   GTEST_SKIP() << "skipping when compiling with -ffinite-math-only";
 #endif
@@ -2007,12 +1966,10 @@ TEST(TEST_CATEGORY, mathspecialfunc_cbesseli1k1) {
 }
 
 TEST(TEST_CATEGORY, mathspecialfunc_cbesselh1stkind) {
-  // Disable the test when using ROCm 5.5, 5.6, and 6.2 due to a
-  // known compiler bug. The test always fails on MI100.
-#if defined(KOKKOS_ENABLE_HIP) &&                            \
-    (((HIP_VERSION_MAJOR == 5 && HIP_VERSION_MINOR == 5) ||  \
-      (HIP_VERSION_MAJOR == 5 && HIP_VERSION_MINOR == 6) ||  \
-      (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR == 2)) || \
+  // Disable the test when using 6.2 due to a known compiler bug. The test
+  // always fails on MI100.
+#if defined(KOKKOS_ENABLE_HIP) &&                          \
+    ((HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR == 2) || \
      defined(KOKKOS_ARCH_AMD_GFX908))
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::HIP>)
     GTEST_SKIP() << "skipping since test is known to fail on MI100 and for "

--- a/core/unit_test/TestNonTrivialScalarTypes.hpp
+++ b/core/unit_test/TestNonTrivialScalarTypes.hpp
@@ -140,11 +140,7 @@ struct array_reduce {
 
   KOKKOS_INLINE_FUNCTION
   array_reduce &operator=(const array_reduce &src) {
-    // ROCm 5.5 and earlier returns the wrong result when early return is enable
-#if !defined(KOKKOS_ENABLE_HIP) || (HIP_VERSION_MAJOR > 5) || \
-    ((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR >= 6))
     if (&src == this) return *this;
-#endif
     for (int i = 0; i < N; i++) data[i] = src.data[i];
     return *this;
   }

--- a/core/unit_test/TestViewBadAlloc.hpp
+++ b/core/unit_test/TestViewBadAlloc.hpp
@@ -54,12 +54,6 @@ TEST(TEST_CATEGORY, view_bad_alloc) {
   }
 #endif
 #endif
-#if ((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR < 7))
-  if (std::is_same_v<ExecutionSpace, Kokkos::HIP>) {
-    GTEST_SKIP() << "ROCm 5.6 and earlier segfaults when trying to allocate "
-                    "too much memory";
-  }
-#endif
 #if defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC
   if (std::is_same_v<ExecutionSpace, Kokkos::Experimental::OpenACC>) {
     GTEST_SKIP() << "acc_malloc() not properly returning nullptr";

--- a/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
@@ -37,9 +37,6 @@ struct Increment {
 // This test checks the promises of Kokkos::Graph against its
 // underlying HIP native objects.
 TEST(TEST_CATEGORY, graph_promises_on_native_objects) {
-#if !defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
-  GTEST_SKIP() << "This test will not work without native graph support";
-#else
   Kokkos::Experimental::Graph<Kokkos::HIP> graph{};
   // Before instantiation, the HIP graph is valid, but the HIP executable
   // graph is still null.
@@ -61,14 +58,11 @@ TEST(TEST_CATEGORY, graph_promises_on_native_objects) {
 
   ASSERT_EQ(graph.native_graph(), hip_graph);
   ASSERT_EQ(graph.native_graph_exec(), hip_graph_exec);
-#endif
 }
 
 // Use native HIP graph to generate a DOT representation.
 TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
-#if !defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
-  GTEST_SKIP() << "This test will not work without native graph support";
-#elif defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 9
+#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 9
   GTEST_SKIP()
       << "The GNU C++ Library (libstdc++) versions less than 9.1 "
          "require linking with `-lstdc++fs` when using std::filesystem";
@@ -96,9 +90,6 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 
   ASSERT_EQ(num_nodes, 2u);
 
-  // hipGraphDebugDotPrint was introduced in ROCm 5.5
-#if (HIP_VERSION_MAJOR > 5) || \
-    ((HIP_VERSION_MAJOR > 5) && (HIP_VERSION_MINOR >= 5))
   const auto dot = std::filesystem::temp_directory_path() / "hip_graph.dot";
 
   KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphDebugDotPrint(
@@ -120,14 +111,10 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
       << "Could not find expected signature regex " << std::quoted(expected)
       << " in " << dot;
 #endif
-#endif
 }
 
 // Build a Kokkos::Graph from an existing hipGraph_t.
 TEST(TEST_CATEGORY, graph_construct_from_native) {
-#if !defined(KOKKOS_IMPL_HIP_NATIVE_GRAPH)
-  GTEST_SKIP() << "This test will not work without native graph support";
-#else
   using view_t = Kokkos::View<int, Kokkos::HIPManagedSpace>;
 
   hipGraph_t native_graph = nullptr;
@@ -148,7 +135,6 @@ TEST(TEST_CATEGORY, graph_construct_from_native) {
   exec.fence();
 
   ASSERT_EQ(data(), 1);
-#endif
 }
 
 }  // namespace

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -30,14 +30,6 @@
     "Kokkos_SIMD_AVX2.hpp must be included before Kokkos_SIMD_Common_Math.hpp!"
 #endif
 
-// FIXME_HIP ROCm 5.6, 5.7, and 6.0 can't compile with the intrinsic used here.
-#if defined(__HIPCC__) &&                                        \
-    (((HIP_VERSION_MAJOR == 5) &&                                \
-      ((HIP_VERSION_MINOR == 6) || (HIP_VERSION_MINOR == 7))) || \
-     ((HIP_VERSION_MAJOR == 6) && ((HIP_VERSION_MINOR == 0))))
-#define KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-#endif
-
 namespace Kokkos {
 
 namespace Experimental {
@@ -1615,22 +1607,11 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
-    // FIXME_HIP ROCm 5.6, 5.7, and 6.0 can't compile with the intrinsic used
-    // here.
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    m_value = _mm_loadu_si128(reinterpret_cast<__m128i const*>(ptr));
-#else
     m_value = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask_type(true)));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        vector_aligned_tag) {
-    // FIXME_HIP ROCm 5.6 can't compile with the intrinsic used here.
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    m_value = _mm_load_si128(reinterpret_cast<__m128i const*>(ptr));
-#else
     m_value = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask_type(true)));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
@@ -1844,23 +1825,11 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
-    // FIXME_HIP ROCm 5.6, 5.7, and 6.0 can't compile with the intrinsic used
-    // here.
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    m_value = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(ptr));
-#else
     m_value = _mm256_maskload_epi32(ptr, static_cast<__m256i>(mask_type(true)));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        vector_aligned_tag) {
-    // FIXME_HIP ROCm 5.6, 5.7, and 6.0 can't compile with the intrinsic used
-    // here.
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    m_value = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(ptr));
-#else
     m_value = _mm256_maskload_epi32(ptr, static_cast<__m256i>(mask_type(true)));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
@@ -2077,21 +2046,13 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    m_value = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(ptr));
-#else
     m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                     static_cast<__m256i>(mask_type(true)));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        vector_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    m_value = _mm256_load_si256(reinterpret_cast<__m256i const*>(ptr));
-#else
     m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                     static_cast<__m256i>(mask_type(true)));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
@@ -2317,21 +2278,13 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    m_value = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(ptr));
-#else
     m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                     static_cast<__m256i>(mask_type(true)));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        vector_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    m_value = _mm256_load_si256(reinterpret_cast<__m256i const*>(ptr));
-#else
     m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                     static_cast<__m256i>(mask_type(true)));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
@@ -2594,23 +2547,13 @@ class where_expression<basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, element_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    __m256d tmp = _mm256_loadu_pd(mem);
-    m_value = value_type(_mm256_and_si256(tmp, static_cast<__m256d>(m_mask)));
-#else
     m_value = value_type(_mm256_maskload_pd(
         mem, _mm256_castpd_si256(static_cast<__m256d>(m_mask))));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, vector_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    __m256d tmp = _mm256_load_pd(mem);
-    m_value = value_type(_mm256_and_si256(tmp, static_cast<__m256d>(m_mask)));
-#else
     m_value = value_type(_mm256_maskload_pd(
         mem, _mm256_castpd_si256(static_cast<__m256d>(m_mask))));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
@@ -2694,23 +2637,13 @@ class where_expression<basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    __m128 tmp = _mm_loadu_ps(mem);
-    m_value    = value_type(_mm_and_ps(tmp, static_cast<__m128>(m_mask)));
-#else
     m_value = value_type(
         _mm_maskload_ps(mem, _mm_castps_si128(static_cast<__m128>(m_mask))));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, vector_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    __m128 tmp = _mm_load_ps(mem);
-    m_value    = value_type(_mm_and_ps(tmp, static_cast<__m128>(m_mask)));
-#else
     m_value = value_type(
         _mm_maskload_ps(mem, _mm_castps_si128(static_cast<__m128>(m_mask))));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
@@ -2794,22 +2727,12 @@ class where_expression<basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    __m256 tmp = _mm256_loadu_ps(mem);
-    m_value    = value_type(_mm256_and_ps(tmp, static_cast<__m256>(m_mask)));
-#else
     m_value = value_type(_mm256_maskload_ps(
         mem, _mm256_castps_si256(static_cast<__m256>(m_mask))));
-#endif
   }
   void copy_from(float const* mem, vector_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    __m256 tmp = _mm256_load_ps(mem);
-    m_value    = value_type(_mm256_and_ps(tmp, static_cast<__m256>(m_mask)));
-#else
     m_value = value_type(_mm256_maskload_ps(
         mem, _mm256_castps_si256(static_cast<__m256>(m_mask))));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
@@ -2896,21 +2819,11 @@ class where_expression<
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    __m128i tmp = _mm_loadu_si128(reinterpret_cast<__m128i const*>(mem));
-    m_value     = value_type(_mm_and_si128(tmp, static_cast<__m128i>(m_mask)));
-#else
     m_value = value_type(_mm_maskload_epi32(mem, static_cast<__m128i>(m_mask)));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, vector_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    __m128i tmp = _mm_load_si128(reinterpret_cast<__m128i const*>(mem));
-    m_value     = value_type(_mm_and_si128(tmp, static_cast<__m128i>(m_mask)));
-#else
     m_value = value_type(_mm_maskload_epi32(mem, static_cast<__m128i>(m_mask)));
-#endif
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -2999,23 +2912,13 @@ class where_expression<
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    __m256i tmp = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(mem));
-    m_value = value_type(_mm256_and_si256(tmp, static_cast<__m256i>(m_mask)));
-#else
     m_value =
         value_type(_mm256_maskload_epi32(mem, static_cast<__m256i>(m_mask)));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, vector_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    __m256i tmp = _mm256_load_si256(reinterpret_cast<__m256i const*>(mem));
-    m_value = value_type(_mm256_and_si256(tmp, static_cast<__m256i>(m_mask)));
-#else
     m_value =
         value_type(_mm256_maskload_epi32(mem, static_cast<__m256i>(m_mask)));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
@@ -3106,23 +3009,13 @@ class where_expression<
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(std::int64_t const* mem,
                                                        element_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    __m256i tmp = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(mem));
-    m_value = value_type(_mm256_and_si256(tmp, static_cast<__m256i>(m_mask)));
-#else
     m_value = value_type(_mm256_maskload_epi64(
         reinterpret_cast<long long const*>(mem), static_cast<__m256i>(m_mask)));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(std::int64_t const* mem,
                                                        vector_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    __m256i tmp = _mm256_load_si256(reinterpret_cast<__m256i const*>(mem));
-    m_value = value_type(_mm256_and_si256(tmp, static_cast<__m256i>(m_mask)));
-#else
     m_value = value_type(_mm256_maskload_epi64(
         reinterpret_cast<long long const*>(mem), static_cast<__m256i>(m_mask)));
-#endif
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -3214,23 +3107,13 @@ class where_expression<
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(std::uint64_t const* mem,
                                                        element_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    __m256i tmp = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(mem));
-    m_value = value_type(_mm256_and_si256(tmp, static_cast<__m256i>(m_mask)));
-#else
     m_value = value_type(_mm256_maskload_epi64(
         reinterpret_cast<long long const*>(mem), static_cast<__m256i>(m_mask)));
-#endif
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(std::uint64_t const* mem,
                                                        vector_aligned_tag) {
-#ifdef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
-    __m256i tmp = _mm256_load_si256(reinterpret_cast<__m256i const*>(mem));
-    m_value = value_type(_mm256_and_si256(tmp, static_cast<__m256i>(m_mask)));
-#else
     m_value = value_type(_mm256_maskload_epi64(
         reinterpret_cast<long long const*>(mem), static_cast<__m256i>(m_mask)));
-#endif
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -3260,7 +3143,5 @@ class where_expression<
 
 }  // namespace Experimental
 }  // namespace Kokkos
-
-#undef KOKKOS_IMPL_WORKAROUND_ROCM_AVX2_ISSUE
 
 #endif


### PR DESCRIPTION
This PR removes all the workarounds we have for ROCM 6.1 and earlier