### PR TITLE
simd: fix a "missing return statement" warning with cuda 13

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1635,6 +1635,11 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       case 3: return _mm_extract_epi32(m_value, 0x3);
       default: Kokkos::abort("Index out of bound"); break;
     }
+// missing return statement warning with cuda 13
+#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC >= 1300) && \
+    defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+    return value_type{};
+#endif
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
@@ -2074,6 +2079,10 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       case 3: return _mm256_extract_epi64(m_value, 0x3);
       default: Kokkos::abort("Index out of bound"); break;
     }
+#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC >= 1300) && \
+    defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+    return value_type{};
+#endif
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
@@ -2306,6 +2315,10 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
       case 3: return _mm256_extract_epi64(m_value, 0x3);
       default: Kokkos::abort("Index out of bound"); break;
     }
+#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC >= 1300) && \
+    defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+    return value_type{};
+#endif
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -452,6 +452,7 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
       case 1: return vgetq_lane_f64(m_value, 1);
       default: Kokkos::abort("Index out of bound"); break;
     }
+// missing return statement warning with cuda 13
 #if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC >= 1300) && \
     defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
     return value_type{};

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -452,6 +452,10 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
       case 1: return vgetq_lane_f64(m_value, 1);
       default: Kokkos::abort("Index out of bound"); break;
     }
+#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC >= 1300) && \
+    defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+    return value_type{};
+#endif
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
@@ -715,6 +719,10 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
       case 1: return vget_lane_f32(m_value, 1);
       default: Kokkos::abort("Index out of bound"); break;
     }
+#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC >= 1300) && \
+    defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+    return value_type{};
+#endif
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
@@ -972,6 +980,10 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
       case 3: return vgetq_lane_f32(m_value, 3);
       default: Kokkos::abort("Index out of bound"); break;
     }
+#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC >= 1300) && \
+    defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+    return value_type{};
+#endif
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
@@ -1228,6 +1240,10 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
       case 1: return vget_lane_s32(m_value, 1);
       default: Kokkos::abort("Index out of bound"); break;
     }
+#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC >= 1300) && \
+    defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+    return value_type{};
+#endif
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
@@ -1442,6 +1458,10 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
       case 3: return vgetq_lane_s32(m_value, 3);
       default: Kokkos::abort("Index out of bound"); break;
     }
+#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC >= 1300) && \
+    defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+    return value_type{};
+#endif
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
@@ -1654,6 +1674,10 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
       case 1: return vgetq_lane_s64(m_value, 1);
       default: Kokkos::abort("Index out of bound"); break;
     }
+#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC >= 1300) && \
+    defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+    return value_type{};
+#endif
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
@@ -1865,6 +1889,10 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
       case 1: return vgetq_lane_u64(m_value, 1);
       default: Kokkos::abort("Index out of bound"); break;
     }
+#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC >= 1300) && \
+    defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+    return value_type{};
+#endif
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(


### PR DESCRIPTION
This PR fixes a missing return statement warnings in the AVX2 and NEON backends' `operator[]`, this warning (see https://kokkosteam.slack.com/archives/G5CBLMFLP/p1757079354689919) appears with cuda 13 when `Kokkos_ENABLE_DEBUG_BOUNDS_CHECK` is enabled, because it removes the `[[noreturn]]` attribute from `Kokkos::abort` which is used in the default branch of a switch in some of the `operator[]` implementations.

To silence this, I conditionally add a `return value_type{};` at the end of the function.