### PR TITLE
Fix compiling with OpenMPTarget

### DIFF
--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -530,7 +530,7 @@ class MemoryPool {
 #else
     const uint32_t block_id_hint =
         (uint32_t)(Kokkos::Impl::clock_tic()
-#ifdef __CUDA_ARCH__  // FIXME_CUDA
+#if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
                    // Spread out potentially concurrent access
                    // by threads within a warp or thread block.
                    + (threadIdx.x + blockDim.x * threadIdx.y)


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/002a63f937d91c0aad192f2d4997317fb277b32a added `__CUDA_ARCH__` also for OpenMPTarget but threadIdx isn't defined leading to compilation errors like
```
In file included from /var/jenkins/workspace/Kokkos_PR-8417/core/src/Kokkos_Core.hpp:58:
/var/jenkins/workspace/Kokkos_PR-8417/core/src/Kokkos_MemoryPool.hpp:536:23: error: use of undeclared identifier 'threadIdx'
  536 |                    + (threadIdx.x + blockDim.x * threadIdx.y)
      |                       ^
/var/jenkins/workspace/Kokkos_PR-8417/core/src/Kokkos_MemoryPool.hpp:536:37: error: use of undeclared identifier 'blockDim'
  536 |                    + (threadIdx.x + blockDim.x * threadIdx.y)
      |                                     ^
/var/jenkins/workspace/Kokkos_PR-8417/core/src/Kokkos_MemoryPool.hpp:536:50: error: use of undeclared identifier 'threadIdx'
  536 |                    + (threadIdx.x + blockDim.x * threadIdx.y)
      |                              
```
see, e.g., https://cloud1.cees.ornl.gov/jenkins-ci/job/Kokkos/job/PR-8417/1/pipeline-overview/?selected-node=327.