### PR TITLE
Cleanup suspicious `__CUDA_ARCH__` macro guards

### DIFF
--- a/core/unit_test/TestViewMapping_subview.hpp
+++ b/core/unit_test/TestViewMapping_subview.hpp
@@ -52,24 +52,20 @@ struct TestViewMappingSubview {
   using DLT  = Kokkos::View<int*** [13][14], Kokkos::LayoutLeft, ExecSpace>;
   using DLS1 = Kokkos::Subview<DLT, range, int, int, int, int>;
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
   static_assert(
       DLS1::rank == 1 &&
           std::is_same<typename DLS1::array_layout, Kokkos::LayoutLeft>::value,
       "Subview layout error for rank 1 subview of left-most range of "
       "LayoutLeft");
-#endif
 
   using DRT  = Kokkos::View<int*** [13][14], Kokkos::LayoutRight, ExecSpace>;
   using DRS1 = Kokkos::Subview<DRT, int, int, int, int, range>;
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
   static_assert(
       DRS1::rank == 1 &&
           std::is_same<typename DRS1::array_layout, Kokkos::LayoutRight>::value,
       "Subview layout error for rank 1 subview of right-most range of "
       "LayoutRight");
-#endif
 
   AT Aa;
   AS Ab;

--- a/core/unit_test/TestViewMapping_subview.hpp
+++ b/core/unit_test/TestViewMapping_subview.hpp
@@ -54,7 +54,7 @@ struct TestViewMappingSubview {
 
   static_assert(
       DLS1::rank == 1 &&
-          std::is_same<typename DLS1::array_layout, Kokkos::LayoutLeft>::value,
+          std::is_same_v<typename DLS1::array_layout, Kokkos::LayoutLeft>,
       "Subview layout error for rank 1 subview of left-most range of "
       "LayoutLeft");
 
@@ -63,7 +63,7 @@ struct TestViewMappingSubview {
 
   static_assert(
       DRS1::rank == 1 &&
-          std::is_same<typename DRS1::array_layout, Kokkos::LayoutRight>::value,
+          std::is_same_v<typename DRS1::array_layout, Kokkos::LayoutRight>,
       "Subview layout error for rank 1 subview of right-most range of "
       "LayoutRight");
 


### PR DESCRIPTION
It looks like an oversight in https://github.com/kokkos/kokkos/pull/4138

The previous macro guard was `#ifndef
KOKKOS_IMPL_CUDA_VERSION_9_WORKAROUND` which clearly refers to the CUDA version not the GPU architecture.