### PR TITLE
OpenMPTarget: Remove obsolete code for non-clang compilers.

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
@@ -105,13 +105,8 @@ void OpenMPTargetInternal::impl_initialize() {
   m_is_initialized = true;
 
   // FIXME_OPENMPTARGET:  Only fix the number of teams for NVIDIA architectures
-  // from Pascal and upwards.
-  // FIXME_OPENMPTARGTE: Cray compiler did not yet implement omp_set_num_teams.
-#if !defined(KOKKOS_COMPILER_CRAY_LLVM)
-#if defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU) && defined(KOKKOS_COMPILER_CLANG) && \
-    (KOKKOS_COMPILER_CLANG >= 1300)
+#if defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
   omp_set_num_teams(512);
-#endif
 #endif
 }
 int OpenMPTargetInternal::impl_is_initialized() {
@@ -172,10 +167,7 @@ void OpenMPTargetInternal::resize_scratch(int64_t team_size,
   // max_active_teams is the number of active teams on the given hardware.
   // We set the number of teams to be twice the number of max_active_teams for
   // the compiler to pick the right number in its case.
-  // FIXME_OPENMPTARGET: Cray compiler did not yet implement omp_set_num_teams.
-#if !defined(KOKKOS_COMPILER_CRAY_LLVM)
   omp_set_num_teams(max_active_teams * 2);
-#endif
 
   // Total amount of scratch memory allocated is depenedent
   // on the maximum number of in-flight teams possible.

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_Team.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_Team.hpp
@@ -117,14 +117,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     // mode but works in the Debug mode.
 
     // Maximum active teams possible.
-    // FIXME_OPENMPTARGET: Cray compiler did not yet implement
-    // omp_get_max_teams.
-#if !defined(KOKKOS_COMPILER_CRAY_LLVM)
     int max_active_teams = omp_get_max_teams();
-#else
-    int max_active_teams =
-        std::min(m_policy.space().concurrency() / team_size, league_size);
-#endif
 
     // FIXME_OPENMPTARGET: Although the maximum number of teams is set using the
     // omp_set_num_teams in the resize_scratch routine, the call is not

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp
@@ -356,14 +356,7 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
     ValueType result = ValueType();
 
     // Maximum active teams possible.
-    // FIXME_OPENMPTARGET: Cray compiler did not yet implement
-    // omp_get_max_teams.
-#if !defined(KOKKOS_COMPILER_CRAY_LLVM)
     int max_active_teams = omp_get_max_teams();
-#else
-    int max_active_teams =
-        std::min(p.space().concurrency() / team_size, league_size);
-#endif
 
     // If the league size is <=0, do not launch the kernel.
     if (max_active_teams <= 0) return;
@@ -423,14 +416,7 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
         p.space().impl_internal_space_instance()->get_scratch_ptr();
 
     // Maximum active teams possible.
-    // FIXME_OPENMPTARGET: Cray compiler did not yet implement
-    // omp_get_max_teams.
-#if !defined(KOKKOS_COMPILER_CRAY_LLVM)
     int max_active_teams = omp_get_max_teams();
-#else
-    int max_active_teams =
-        std::min(p.space().concurrency() / team_size, league_size);
-#endif
 
     // If the league size is <=0, do not launch the kernel.
     if (max_active_teams <= 0) return;


### PR DESCRIPTION
The PR is an extension to #8407 . 
The PR is also dependent on the fix in #8420 