### PR TITLE
Make Timer test more robust

### DIFF
--- a/core/unit_test/TestTimer.hpp
+++ b/core/unit_test/TestTimer.hpp
@@ -28,21 +28,24 @@ TEST(TEST_CATEGORY, timer) {
   using namespace std::chrono_literals;
 
   Kokkos::Timer t;
-  std::this_thread::sleep_for(50ms);
+  std::this_thread::sleep_for(5ms);
   auto elapsed = t.seconds();
-  EXPECT_GE(elapsed, .05);
+  EXPECT_GE(elapsed, .005);
   EXPECT_LT(elapsed, 1.);
 
-  std::this_thread::sleep_for(50ms);
+  std::this_thread::sleep_for(10ms);
   auto elapsed2 = std::as_const(t).seconds();
-  EXPECT_GE(elapsed2, .1);
+  EXPECT_GE(elapsed2, .015);
   EXPECT_GT(elapsed2, elapsed);
 
   t.reset();
-  std::this_thread::sleep_for(50ms);
+  std::this_thread::sleep_for(5ms);
   auto elapsed3 = t.seconds();
-  EXPECT_GE(elapsed3, .05);
-  EXPECT_LT(elapsed3, elapsed2);
+  EXPECT_GE(elapsed3, .005);
+  // Using the line below turned out to be problematic since there is no
+  // guaranteed upper bound for the time std::this_thread::sleep_for is
+  // blocking for.
+  // EXPECT_LT(elapsed3, elapsed2);
 }
 
 static_assert(!std::is_copy_constructible_v<Kokkos::Timer>);

--- a/core/unit_test/TestTimer.hpp
+++ b/core/unit_test/TestTimer.hpp
@@ -28,20 +28,20 @@ TEST(TEST_CATEGORY, timer) {
   using namespace std::chrono_literals;
 
   Kokkos::Timer t;
-  std::this_thread::sleep_for(5ms);
+  std::this_thread::sleep_for(50ms);
   auto elapsed = t.seconds();
-  EXPECT_GE(elapsed, .005);
+  EXPECT_GE(elapsed, .05);
   EXPECT_LT(elapsed, 1.);
 
-  std::this_thread::sleep_for(10ms);
+  std::this_thread::sleep_for(50ms);
   auto elapsed2 = std::as_const(t).seconds();
-  EXPECT_GE(elapsed2, .015);
+  EXPECT_GE(elapsed2, .01);
   EXPECT_GT(elapsed2, elapsed);
 
   t.reset();
-  std::this_thread::sleep_for(5ms);
+  std::this_thread::sleep_for(50ms);
   auto elapsed3 = t.seconds();
-  EXPECT_GE(elapsed3, .005);
+  EXPECT_GE(elapsed3, .05);
   EXPECT_LT(elapsed3, elapsed2);
 }
 

--- a/core/unit_test/TestTimer.hpp
+++ b/core/unit_test/TestTimer.hpp
@@ -35,7 +35,7 @@ TEST(TEST_CATEGORY, timer) {
 
   std::this_thread::sleep_for(50ms);
   auto elapsed2 = std::as_const(t).seconds();
-  EXPECT_GE(elapsed2, .01);
+  EXPECT_GE(elapsed2, .1);
   EXPECT_GT(elapsed2, elapsed);
 
   t.reset();


### PR DESCRIPTION
The timer test fails on a regular basis with something like
```
[ RUN      ] serial.timer
/Users/runner/work/kokkos/kokkos/core/unit_test/TestTimer.hpp:45: Failure
Expected: (elapsed3) < (elapsed2), actual: 0.0367204 vs 0.0325606
[  FAILED  ] serial.timer (69 ms)
```
This pull request tries making that a little more robust by making the thread sleep for a longer time.