### PR TITLE
core(cuda): remove unused `show_warnings`

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -43,8 +43,6 @@
 
 namespace Kokkos {
 
-extern bool show_warnings() noexcept;
-
 namespace Impl {
 
 template <class... Properties>


### PR DESCRIPTION
As discussed in:
- https://github.com/kokkos/kokkos/pull/8387/files#r2342011640