### PR TITLE
core(allocation): avoid copying shared allocation header on device if not needed

### DIFF
--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -335,9 +335,11 @@ class HostInaccessibleSharedAllocationRecordCommon
 
     fill_host_accessible_header_info(this, header, label);
 
+#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
     Kokkos::Impl::DeepCopy<MemorySpace, HostSpace>(
         exec, SharedAllocationRecord<void, void>::m_alloc_ptr, &header,
         sizeof(SharedAllocationHeader));
+#endif
   }
   HostInaccessibleSharedAllocationRecordCommon(
       MemorySpace const& space, std::string const& label, std::size_t size,

--- a/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
@@ -83,6 +83,7 @@ HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::
 
   fill_host_accessible_header_info(this, header, label);
 
+#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
   typename MemorySpace::execution_space exec;
   Kokkos::Impl::DeepCopy<MemorySpace, HostSpace>(
       exec, SharedAllocationRecord<void, void>::m_alloc_ptr, &header,
@@ -91,6 +92,7 @@ HostInaccessibleSharedAllocationRecordCommon<MemorySpace>::
              MemorySpace::name() +
              "Space, void>::SharedAllocationRecord(): "
              "fence after copying header from HostSpace");
+#endif
 }
 
 template <class MemorySpace>


### PR DESCRIPTION
Addressing #8441.