### PR TITLE
Fix: deprecate profiling library warning

### DIFF
--- a/cmake/fake_tribits.cmake
+++ b/cmake/fake_tribits.cmake
@@ -84,9 +84,7 @@ function(KOKKOS_ADD_TEST)
   endif()
   if(TEST_TOOL)
     add_dependencies(${EXE} ${TEST_TOOL}) #make sure the exe has to build the tool
-    set_property(
-      TEST ${TEST_NAME} APPEND_STRING PROPERTY ENVIRONMENT "KOKKOS_PROFILE_LIBRARY=$<TARGET_FILE:${TEST_TOOL}>"
-    )
+    set_property(TEST ${TEST_NAME} APPEND_STRING PROPERTY ENVIRONMENT "KOKKOS_TOOLS_LIBS=$<TARGET_FILE:${TEST_TOOL}>")
   endif()
   verify_empty(KOKKOS_ADD_TEST ${TEST_UNPARSED_ARGUMENTS})
 endfunction()


### PR DESCRIPTION
Minor fix to avoid deprecation warning.

The message that this PR intends to solve is:

```
Warning: environment variable 'KOKKOS_PROFILE_LIBRARY' is deprecated. Use 'KOKKOS_TOOLS_LIBS' instead. Raised by Kokkos::initialize().
```

https://github.com/kokkos/kokkos-tools/blob/1c843f3b38f8f4aa8c3f865d54744151d523f724/common/kokkos-sampler/kp_sampler_skip.cpp#L101-L112