### PR TITLE
Fix namespace lookup for symbols in Kokkos_MDSpan_Layout.hpp

### DIFF
--- a/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
@@ -40,14 +40,14 @@ template <class>
 struct IsLayoutRightPadded : std::false_type {};
 
 template <size_t Pad>
-struct IsLayoutRightPadded<Experimental::layout_right_padded<Pad>>
+struct IsLayoutRightPadded<::Kokkos::Experimental::layout_right_padded<Pad>>
     : std::true_type {};
 
 template <class>
 struct IsLayoutLeftPadded : std::false_type {};
 
 template <size_t Pad>
-struct IsLayoutLeftPadded<Experimental::layout_left_padded<Pad>>
+struct IsLayoutLeftPadded<::Kokkos::Experimental::layout_left_padded<Pad>>
     : std::true_type {};
 
 template <class ArrayLayout>
@@ -57,12 +57,12 @@ struct LayoutFromArrayLayout {
 
 template <>
 struct LayoutFromArrayLayout<LayoutLeft> {
-  using type = Experimental::layout_left_padded<dynamic_extent>;
+  using type = ::Kokkos::Experimental::layout_left_padded<dynamic_extent>;
 };
 
 template <>
 struct LayoutFromArrayLayout<LayoutRight> {
-  using type = Experimental::layout_right_padded<dynamic_extent>;
+  using type = ::Kokkos::Experimental::layout_right_padded<dynamic_extent>;
 };
 
 template <>


### PR DESCRIPTION
Extracted from https://github.com/kokkos/kokkos/pull/8222/files/e50bf570b05bbd2d7daa1424cdb1454034067944#r2182969639.
Depending on the inclusion order, these symbols were attempted to be found in the `Kokkos::Impl::Experimental` namespace that exists for the `ScatterView` implementation.