### PR TITLE
[4.7.1] Add missing KOKKOS_FUNCTION annotations on View constructor from nullptr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bug Fixes
 * Add missing const qualifier to `View::to_mdspan` and `View` to `mdspan` conversion [\#8333](https://github.com/kokkos/kokkos/pull/8333)
 * Fix configure-time check of compilation and linker flags [\#8292](https://github.com/kokkos/kokkos/pull/8292)
+* Add missing `KOKKOS_FUNCTION` annotation on `View(std::nullptr_t, ...)` constructor [\#8436](https://github.com/kokkos/kokkos/pull/8436) 
 
 ## 4.7.00
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### Bug Fixes
 * Add missing const qualifier to `View::to_mdspan` and `View` to `mdspan` conversion [\#8333](https://github.com/kokkos/kokkos/pull/8333)
 * Fix configure-time check of compilation and linker flags [\#8292](https://github.com/kokkos/kokkos/pull/8292)
-* Add missing `KOKKOS_FUNCTION` annotation on `View(std::nullptr_t, ...)` constructor [\#8436](https://github.com/kokkos/kokkos/pull/8436) 
+* Add missing `KOKKOS_FUNCTION` annotation on `View(std::nullptr_t, ...)` constructor [\#8436](https://github.com/kokkos/kokkos/pull/8436)
 
 ## 4.7.00
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -724,7 +724,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   // Special function to be preferred over the above for passing in 0, NULL or
   // nullptr when pointer type is char*
   template <class... Args>
-  explicit View(decltype(nullptr), Args... args)
+  KOKKOS_FUNCTION explicit View(std::nullptr_t, Args... args)
       : View(Kokkos::view_wrap(pointer_type(nullptr)), args...) {}
 #endif
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -688,7 +688,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   // Special function to be preferred over the above for passing in 0, NULL or
   // nullptr when pointer type is char*
   template <class... Args>
-  explicit View(decltype(nullptr), Args... args)
+  KOKKOS_FUNCTION explicit View(std::nullptr_t, Args... args)
       : View(Kokkos::view_wrap(pointer_type(nullptr)), args...) {}
 #else
   // FIXME: The std::is_null_pointer_v<P> condition is to workaround a GCC8 bug

--- a/core/src/impl/Kokkos_Abort.cpp
+++ b/core/src/impl/Kokkos_Abort.cpp
@@ -18,6 +18,9 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE
 #endif
 
+// include cstddef to deal with internal system header issue on some builds
+// where our CI complained about missing definition of std::size_t
+#include <cstddef>
 #include <cstdlib>
 #include <iostream>
 #include <Kokkos_Abort.hpp>

--- a/core/src/impl/Kokkos_Abort.cpp
+++ b/core/src/impl/Kokkos_Abort.cpp
@@ -18,9 +18,6 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE
 #endif
 
-// include cstddef to deal with internal system header issue on some builds
-// where our CI complained about missing definition of std::size_t
-#include <cstddef>
 #include <cstdlib>
 #include <iostream>
 #include <Kokkos_Abort.hpp>

--- a/core/unit_test/TestViewEmptyRuntimeUnmanaged.hpp
+++ b/core/unit_test/TestViewEmptyRuntimeUnmanaged.hpp
@@ -21,29 +21,44 @@
 namespace {
 
 template <class T>
-void test_empty_view_runtime_unmanaged() {
-  T d{};
-  auto* p = reinterpret_cast<T*>(0xABADBABE);
+struct TestEmptyViewRuntimeUnmanaged {
+  template <class ExecutionSpace>
+  TestEmptyViewRuntimeUnmanaged(ExecutionSpace const& exec) {
+    Kokkos::parallel_for(Kokkos::RangePolicy(exec, 0, 1), *this);
+  }
 
-  (void)Kokkos::View<T*>(p, 0);
-  (void)Kokkos::View<T*>(&d, 0);
-  (void)Kokkos::View<T*>(nullptr, 0);
-  (void)Kokkos::View<T*>(NULL, 0);  // NOLINT(modernize-use-nullptr)
-  (void)Kokkos::View<T*>(0, 0);     // NOLINT(modernize-use-nullptr)
+  KOKKOS_FUNCTION void operator()(int) const {
+    T d{};
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4312)
+#endif
+    auto* p = reinterpret_cast<T*>(0xABADBABE);
+#if defined(_MSC_VER)
+#pragma warning(push)
+#endif
 
-  (void)Kokkos::View<T**>(p, 0, 0);
-  (void)Kokkos::View<T**>(&d, 0, 0);
-  (void)Kokkos::View<T**>(nullptr, 0, 0);
-  (void)Kokkos::View<T**>(NULL, 0, 0);  // NOLINT(modernize-use-nullptr)
-  (void)Kokkos::View<T**>(0, 0, 0);     // NOLINT(modernize-use-nullptr)
-}
+    (void)Kokkos::View<T*>(p, 0);
+    (void)Kokkos::View<T*>(&d, 0);
+    (void)Kokkos::View<T*>(nullptr, 0);
+    (void)Kokkos::View<T*>(NULL, 0);  // NOLINT(modernize-use-nullptr)
+    (void)Kokkos::View<T*>(0, 0);     // NOLINT(modernize-use-nullptr)
+
+    (void)Kokkos::View<T**>(p, 0, 0);
+    (void)Kokkos::View<T**>(&d, 0, 0);
+    (void)Kokkos::View<T**>(nullptr, 0, 0);
+    (void)Kokkos::View<T**>(NULL, 0, 0);  // NOLINT(modernize-use-nullptr)
+    (void)Kokkos::View<T**>(0, 0, 0);     // NOLINT(modernize-use-nullptr)
+  }
+};
 
 TEST(TEST_CATEGORY, view_empty_runtime_unmanaged) {
-  test_empty_view_runtime_unmanaged<float>();
-  test_empty_view_runtime_unmanaged<const double>();
-  test_empty_view_runtime_unmanaged<int>();
-  test_empty_view_runtime_unmanaged<char>();
-  test_empty_view_runtime_unmanaged<const char>();
+  TEST_EXECSPACE exec;
+  (void)TestEmptyViewRuntimeUnmanaged<float>(exec);
+  (void)TestEmptyViewRuntimeUnmanaged<const double>(exec);
+  (void)TestEmptyViewRuntimeUnmanaged<int>(exec);
+  (void)TestEmptyViewRuntimeUnmanaged<char>(exec);
+  (void)TestEmptyViewRuntimeUnmanaged<const char>(exec);
 }
 
 }  // namespace

--- a/core/unit_test/TestViewEmptyRuntimeUnmanaged.hpp
+++ b/core/unit_test/TestViewEmptyRuntimeUnmanaged.hpp
@@ -24,7 +24,8 @@ template <class T>
 struct TestEmptyViewRuntimeUnmanaged {
   template <class ExecutionSpace>
   TestEmptyViewRuntimeUnmanaged(ExecutionSpace const& exec) {
-    Kokkos::parallel_for(Kokkos::RangePolicy(exec, 0, 1), *this);
+    Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(exec, 0, 1),
+                         *this);
   }
 
   KOKKOS_FUNCTION void operator()(int) const {


### PR DESCRIPTION
Cherry-picking #8436 into RC 4.7.1 branch