### PR TITLE
Don't try finding libdl on MacOS X

### DIFF
--- a/cmake/Modules/FindTPLLIBDL.cmake
+++ b/cmake/Modules/FindTPLLIBDL.cmake
@@ -1,1 +1,5 @@
-kokkos_find_imported(LIBDL HEADER dlfcn.h INTERFACE LIBRARIES ${CMAKE_DL_LIBS})
+# Finding dlfcn.h includes a problematic path on MacOS X using homebrew's clang
+# Mac OS X doesn't require extra libraries for using dlopen
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  kokkos_find_imported(LIBDL HEADER dlfcn.h INTERFACE LIBRARIES ${CMAKE_DL_LIBS})
+endif()

--- a/cmake/kokkos_tpls.cmake
+++ b/cmake/kokkos_tpls.cmake
@@ -81,7 +81,11 @@ kokkos_tpl_option(LIBQUADMATH ${LIBQUADMATH_DEFAULT} TRIBITS quadmath)
 kokkos_import_tpl(HPX INTERFACE)
 kokkos_import_tpl(CUDA INTERFACE)
 kokkos_import_tpl(HWLOC)
-kokkos_import_tpl(LIBDL)
+# Finding dlfcn.h includes a problematic path on MacOS X using homebrew's clang
+# Mac OS X doesn't require extra libraries for using dlopen
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  kokkos_import_tpl(LIBDL)
+endif()
 if(NOT WIN32)
   kokkos_import_tpl(THREADS INTERFACE)
 endif()

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -170,7 +170,11 @@ endif()
 kokkos_link_tpl(kokkoscore PUBLIC HWLOC)
 kokkos_link_tpl(kokkoscore PUBLIC CUDA)
 kokkos_link_tpl(kokkoscore PUBLIC HPX)
-kokkos_link_tpl(kokkoscore PUBLIC LIBDL)
+# Finding dlfcn.h includes a problematic path on MacOS X using homebrew's clang
+# Mac OS X doesn't require extra libraries for using dlopen
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  kokkos_link_tpl(kokkoscore PUBLIC LIBDL)
+endif()
 # On *nix-like systems (Linux, macOS) we need pthread for C++ std::thread
 if(NOT WIN32)
   kokkos_link_tpl(kokkoscore PUBLIC THREADS)


### PR DESCRIPTION
When trying to find `dlfcn.h` we are including `/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include` in the header file paths which leads to errors such as
```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_types/_wint_t.h:32:9: error: unknown type name '__darwin_wint_t'
   32 | typedef __darwin_wint_t wint_t;
      |         ^
```
when using `homebrew`'s `clang++`. Since explicit linking with libdl isn't necessary for MacOS X, this pull request avoids finding in linking `libdl`.

It's not clear if we ever need to find an include path for `dlfcn.h`. If not, we could just directly link `kokkoscore` with `${CMAKE_DL_LIBS}` (publically) and avoid defining an extra TPL.