### PR TITLE
enable view hooks for new mdspan-based view implementation

### DIFF
--- a/core/src/Kokkos_Core.cppm
+++ b/core/src/Kokkos_Core.cppm
@@ -130,8 +130,6 @@ export {
   using ::Kokkos::WithoutInitializing;
   namespace Experimental {
   using ::Kokkos::Experimental::AppendExtent;
-  using ::Kokkos::Experimental::DefaultViewHooks;
-  using ::Kokkos::Experimental::EmptyViewHooks;
   using ::Kokkos::Experimental::Extents;
   using ::Kokkos::Experimental::is_hooks_policy;
   using ::Kokkos::Experimental::is_hooks_policy_v;

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -679,7 +679,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
-#if defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
   KOKKOS_FUNCTION
   View(const View& other) : base_t{other} {
     if constexpr (has_hooks_policy) {
@@ -703,7 +703,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
-#if defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
   KOKKOS_FUNCTION
   View(View&& other) : base_t{std::move(static_cast<base_t&&>(other))} {
     if constexpr (has_hooks_policy) {
@@ -727,7 +727,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
-#if defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
   KOKKOS_FUNCTION
   View& operator=(const View& other) {
     base_t::operator=(other);
@@ -760,7 +760,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
-#if defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
   KOKKOS_FUNCTION
   View& operator=(View&& other) {
     base_t::operator=(std::move(static_cast<base_t&&>(other)));

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -195,6 +195,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 
  private:
   using raw_allocation_value_type = std::remove_pointer_t<pointer_type>;
+  using hooks_policy = typename Impl::ViewHooksFromTraits<DataType, Properties...>::type;
 
  public:
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
@@ -673,17 +674,33 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   KOKKOS_DEFAULTED_FUNCTION
   View() = default;
 
-  KOKKOS_DEFAULTED_FUNCTION
-  View(const View& other) = default;
+  KOKKOS_FUNCTION
+  View(const View& other)
+    : base_t{ other } {
+    KOKKOS_IF_ON_HOST((hooks_policy::copy_construct(*this, other);))
+  }
 
-  KOKKOS_DEFAULTED_FUNCTION
-  View(View&& other) = default;
+  KOKKOS_FUNCTION
+  View(View&& other)
+    : base_t{ std::move( other ) } {
+    KOKKOS_IF_ON_HOST((hooks_policy::move_construct(*this, other);))
+  }
 
-  KOKKOS_DEFAULTED_FUNCTION
-  View& operator=(const View& other) = default;
+  KOKKOS_FUNCTION
+  View& operator=(const View& other) {
+    base_t::operator=(other);
+    KOKKOS_IF_ON_HOST((if (&other != this ) { hooks_policy::copy_assign(*this, other); }))
 
-  KOKKOS_DEFAULTED_FUNCTION
-  View& operator=(View&& other) = default;
+    return *this;
+  }
+
+  KOKKOS_FUNCTION
+  View& operator=(View&& other) {
+    base_t::operator=(other);
+    KOKKOS_IF_ON_HOST((if (&other != this ) { hooks_policy::move_assign(*this, other); }))
+
+    return *this;
+  }
 
   KOKKOS_FUNCTION
   View(typename base_t::data_handle_type p,

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -693,7 +693,8 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
+#define KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
+#if KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
   KOKKOS_FUNCTION
   View(const View& other) : base_t{other} {
     if constexpr (has_hooks_policy) {
@@ -714,10 +715,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   }
 #endif
 
-// FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
-// exclusive requirements clauses. 12.6 Also has some issues though it manifests
-// differently
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
+#if KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
   KOKKOS_FUNCTION
   View(View&& other) : base_t{std::move(static_cast<base_t&&>(other))} {
     if constexpr (has_hooks_policy) {
@@ -738,10 +736,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   }
 #endif
 
-// FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
-// exclusive requirements clauses. 12.6 Also has some issues though it manifests
-// differently
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
+#if KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
   KOKKOS_FUNCTION
   View& operator=(const View& other) {
     base_t::operator=(other);
@@ -774,7 +769,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
+#if KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
   KOKKOS_FUNCTION
   View& operator=(View&& other) {
     base_t::operator=(std::move(static_cast<base_t&&>(other)));
@@ -803,6 +798,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     return *this;
   }
 #endif
+#undef KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
 
   KOKKOS_FUNCTION
   View(typename base_t::data_handle_type p,

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -197,7 +197,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   using raw_allocation_value_type = std::remove_pointer_t<pointer_type>;
   using hooks_policy =
       typename Impl::ViewHooksFromTraits<DataType, Properties...>::type;
-  static constexpr bool has_empty_hooks_policy = std::same_as<hooks_policy, Experimental::EmptyViewHooks>;
+  static constexpr bool has_empty_hooks_policy = std::is_void_v<hooks_policy>;
 
  public:
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -693,8 +693,10 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
-#define KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
-#if KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
+#define KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND 1
+#endif
+#ifdef KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
   KOKKOS_FUNCTION
   View(const View& other) : base_t{other} {
     if constexpr (has_hooks_policy) {
@@ -715,7 +717,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   }
 #endif
 
-#if KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
+#ifdef KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
   KOKKOS_FUNCTION
   View(View&& other) : base_t{std::move(static_cast<base_t&&>(other))} {
     if constexpr (has_hooks_policy) {
@@ -736,7 +738,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   }
 #endif
 
-#if KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
+#ifdef KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
   KOKKOS_FUNCTION
   View& operator=(const View& other) {
     base_t::operator=(other);
@@ -769,7 +771,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
-#if KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
+#ifdef KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
   KOKKOS_FUNCTION
   View& operator=(View&& other) {
     base_t::operator=(std::move(static_cast<base_t&&>(other)));

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -679,7 +679,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
-#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC)
+#if defined(KOKKOS_ENABLE_CUDA)
   KOKKOS_FUNCTION
   View(const View& other) : base_t{other} {
     if constexpr (has_hooks_policy) {
@@ -703,7 +703,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
-#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC)
+#if defined(KOKKOS_ENABLE_CUDA)
   KOKKOS_FUNCTION
   View(View&& other) : base_t{std::move(static_cast<base_t&&>(other))} {
     if constexpr (has_hooks_policy) {
@@ -727,7 +727,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
-#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC)
+#if defined(KOKKOS_ENABLE_CUDA)
   KOKKOS_FUNCTION
   View& operator=(const View& other) {
     base_t::operator=(other);
@@ -760,7 +760,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
-#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC)
+#if defined(KOKKOS_ENABLE_CUDA)
   KOKKOS_FUNCTION
   View& operator=(View&& other) {
     base_t::operator=(std::move(static_cast<base_t&&>(other)));

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -195,7 +195,8 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 
  private:
   using raw_allocation_value_type = std::remove_pointer_t<pointer_type>;
-  using hooks_policy = typename Impl::ViewHooksFromTraits<DataType, Properties...>::type;
+  using hooks_policy =
+      typename Impl::ViewHooksFromTraits<DataType, Properties...>::type;
 
  public:
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
@@ -675,21 +676,20 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   View() = default;
 
   KOKKOS_FUNCTION
-  View(const View& other)
-    : base_t{ other } {
+  View(const View& other) : base_t{other} {
     KOKKOS_IF_ON_HOST((hooks_policy::copy_construct(*this, other);))
   }
 
   KOKKOS_FUNCTION
-  View(View&& other)
-    : base_t{ std::move( other ) } {
+  View(View&& other) : base_t{std::move(other)} {
     KOKKOS_IF_ON_HOST((hooks_policy::move_construct(*this, other);))
   }
 
   KOKKOS_FUNCTION
   View& operator=(const View& other) {
     base_t::operator=(other);
-    KOKKOS_IF_ON_HOST((if (&other != this ) { hooks_policy::copy_assign(*this, other); }))
+    KOKKOS_IF_ON_HOST(
+        (if (&other != this) { hooks_policy::copy_assign(*this, other); }))
 
     return *this;
   }
@@ -697,7 +697,8 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   KOKKOS_FUNCTION
   View& operator=(View&& other) {
     base_t::operator=(other);
-    KOKKOS_IF_ON_HOST((if (&other != this ) { hooks_policy::move_assign(*this, other); }))
+    KOKKOS_IF_ON_HOST(
+        (if (&other != this) { hooks_policy::move_assign(*this, other); }))
 
     return *this;
   }

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -217,9 +217,10 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   //----------------------------------------
   // Compatible view of a data type
   using type = std::conditional_t<
-      has_hooks_policy, View<typename traits::data_type, typename traits::array_layout,
-                    typename traits::device_type, typename traits::hooks_policy,
-                    typename traits::memory_traits>,
+      has_hooks_policy,
+      View<typename traits::data_type, typename traits::array_layout,
+           typename traits::device_type, typename traits::hooks_policy,
+           typename traits::memory_traits>,
       View<typename traits::data_type, typename traits::array_layout,
            typename traits::device_type, typename traits::memory_traits> >;
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -197,7 +197,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   using raw_allocation_value_type = std::remove_pointer_t<pointer_type>;
   using hooks_policy =
       typename Impl::ViewHooksFromTraits<DataType, Properties...>::type;
-  static constexpr bool has_empty_hooks_policy = std::is_void_v<hooks_policy>;
+  static constexpr bool has_hooks_policy = !std::is_void_v<hooks_policy>;
 
  public:
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
@@ -682,19 +682,19 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC)
   KOKKOS_FUNCTION
   View(const View& other) : base_t{other} {
-    if constexpr (!has_empty_hooks_policy) {
+    if constexpr (has_hooks_policy) {
       KOKKOS_IF_ON_HOST((hooks_policy::copy_construct(*this, other);))
     }
   }
 #else
   KOKKOS_DEFAULTED_FUNCTION
   View(const View&)
-    requires(has_empty_hooks_policy)
+    requires(!has_hooks_policy)
   = default;
 
   KOKKOS_FUNCTION
   View(const View& other)
-    requires(!has_empty_hooks_policy)
+    requires(has_hooks_policy)
       : base_t{other} {
     KOKKOS_IF_ON_HOST((hooks_policy::copy_construct(*this, other);))
   }
@@ -706,19 +706,19 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC)
   KOKKOS_FUNCTION
   View(View&& other) : base_t{std::move(static_cast<base_t&&>(other))} {
-    if constexpr (!has_empty_hooks_policy) {
+    if constexpr (has_hooks_policy) {
       KOKKOS_IF_ON_HOST((hooks_policy::move_construct(*this, other);))
     }
   }
 #else
   KOKKOS_DEFAULTED_FUNCTION
   View(View&&)
-    requires(has_empty_hooks_policy)
+    requires(!has_hooks_policy)
   = default;
 
   KOKKOS_FUNCTION
   View(View&& other)
-    requires(!has_empty_hooks_policy)
+    requires(has_hooks_policy)
       : base_t{std::move(static_cast<base_t&&>(other))} {
     KOKKOS_IF_ON_HOST((hooks_policy::move_construct(*this, other);))
   }
@@ -732,7 +732,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   View& operator=(const View& other) {
     base_t::operator=(other);
 
-    if constexpr (!has_empty_hooks_policy) {
+    if constexpr (has_hooks_policy) {
       KOKKOS_IF_ON_HOST(
           (if (&other != this) { hooks_policy::copy_assign(*this, other); }))
     }
@@ -742,12 +742,12 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 #else
   KOKKOS_DEFAULTED_FUNCTION
   View& operator=(const View&)
-    requires(has_empty_hooks_policy)
+    requires(!has_hooks_policy)
   = default;
 
   KOKKOS_FUNCTION
   View& operator=(const View& other)
-    requires(!has_empty_hooks_policy)
+    requires(has_hooks_policy)
   {
     base_t::operator=(other);
     KOKKOS_IF_ON_HOST(
@@ -765,7 +765,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   View& operator=(View&& other) {
     base_t::operator=(std::move(static_cast<base_t&&>(other)));
 
-    if constexpr (!has_empty_hooks_policy) {
+    if constexpr (has_hooks_policy) {
       KOKKOS_IF_ON_HOST(
           (if (&other != this) { hooks_policy::move_assign(*this, other); }))
     }
@@ -775,12 +775,12 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 #else
   KOKKOS_DEFAULTED_FUNCTION
   View& operator=(View&&)
-    requires(has_empty_hooks_policy)
+    requires(!has_hooks_policy)
   = default;
 
   KOKKOS_FUNCTION
   View& operator=(View&& other)
-    requires(!has_empty_hooks_policy)
+    requires(has_hooks_policy)
   {
     base_t::operator=(std::move(static_cast<base_t&&>(other)));
     KOKKOS_IF_ON_HOST(

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -216,9 +216,12 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 
   //----------------------------------------
   // Compatible view of a data type
-  using type = View<typename traits::data_type, typename traits::array_layout,
+  using type = std::conditional_t<
+      has_hooks_policy, View<typename traits::data_type, typename traits::array_layout,
                     typename traits::device_type, typename traits::hooks_policy,
-                    typename traits::memory_traits>;
+                    typename traits::memory_traits>,
+      View<typename traits::data_type, typename traits::array_layout,
+           typename traits::device_type, typename traits::memory_traits> >;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   //----------------------------------------
@@ -227,23 +230,33 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 #endif
 
   // Compatible view of const data type
-  using const_type =
+  using const_type = std::conditional_t<
+      has_hooks_policy,
       View<typename traits::const_data_type, typename traits::array_layout,
            typename traits::device_type, typename traits::hooks_policy,
-           typename traits::memory_traits>;
+           typename traits::memory_traits>,
+      View<typename traits::const_data_type, typename traits::array_layout,
+           typename traits::device_type, typename traits::memory_traits> >;
 
   // Compatible view of non-const data type
-  using non_const_type =
+  using non_const_type = std::conditional_t<
+      has_hooks_policy,
       View<typename traits::non_const_data_type, typename traits::array_layout,
            typename traits::device_type, typename traits::hooks_policy,
-           typename traits::memory_traits>;
+           typename traits::memory_traits>,
+      View<typename traits::non_const_data_type, typename traits::array_layout,
+           typename traits::device_type, typename traits::memory_traits> >;
 
   // Compatible host mirror view
-  using host_mirror_type =
+  using host_mirror_type = std::conditional_t<
+      has_hooks_policy,
       View<typename traits::non_const_data_type, typename traits::array_layout,
            Device<DefaultHostExecutionSpace,
                   typename traits::host_mirror_space::memory_space>,
-           typename traits::hooks_policy>;
+           typename traits::hooks_policy>,
+      View<typename traits::non_const_data_type, typename traits::array_layout,
+           Device<DefaultHostExecutionSpace,
+                  typename traits::host_mirror_space::memory_space> > >;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   /** \brief  Compatible HostMirror view */

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -676,6 +676,17 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   KOKKOS_DEFAULTED_FUNCTION
   View() = default;
 
+// FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
+// exclusive requirements clauses
+#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC) && \
+    KOKKOS_COMPILER_NVCC >= 1220 && KOKKOS_COMPILER_NVCC < 1240
+  KOKKOS_FUNCTION
+  View(const View& other) : base_t{other} {
+    if constexpr (!has_empty_hooks_policy) {
+      KOKKOS_IF_ON_HOST((hooks_policy::copy_construct(*this, other);))
+    }
+  }
+#else
   KOKKOS_DEFAULTED_FUNCTION
   View(const View&)
     requires(has_empty_hooks_policy)
@@ -687,7 +698,19 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
       : base_t{other} {
     KOKKOS_IF_ON_HOST((hooks_policy::copy_construct(*this, other);))
   }
+#endif
 
+// FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
+// exclusive requirements clauses
+#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC) && \
+    KOKKOS_COMPILER_NVCC >= 1220 && KOKKOS_COMPILER_NVCC < 1240
+  KOKKOS_FUNCTION
+  View(View&& other) : base_t{std::move(static_cast<base_t&&>(other))} {
+    if constexpr (!has_empty_hooks_policy) {
+      KOKKOS_IF_ON_HOST((hooks_policy::move_construct(*this, other);))
+    }
+  }
+#else
   KOKKOS_DEFAULTED_FUNCTION
   View(View&&)
     requires(has_empty_hooks_policy)
@@ -699,7 +722,24 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
       : base_t{std::move(static_cast<base_t&&>(other))} {
     KOKKOS_IF_ON_HOST((hooks_policy::move_construct(*this, other);))
   }
+#endif
 
+// FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
+// exclusive requirements clauses
+#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC) && \
+    KOKKOS_COMPILER_NVCC >= 1220 && KOKKOS_COMPILER_NVCC < 1240
+  KOKKOS_FUNCTION
+  View& operator=(const View& other) {
+    base_t::operator=(other);
+
+    if constexpr (!has_empty_hooks_policy) {
+      KOKKOS_IF_ON_HOST(
+          (if (&other != this) { hooks_policy::copy_assign(*this, other); }))
+    }
+
+    return *this;
+  }
+#else
   KOKKOS_DEFAULTED_FUNCTION
   View& operator=(const View&)
     requires(has_empty_hooks_policy)
@@ -715,7 +755,24 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 
     return *this;
   }
+#endif
 
+// FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
+// exclusive requirements clauses
+#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC) && \
+    KOKKOS_COMPILER_NVCC >= 1220 && KOKKOS_COMPILER_NVCC < 1240
+  KOKKOS_FUNCTION
+  View& operator=(View&& other) {
+    base_t::operator=(std::move(static_cast<base_t&&>(other)));
+
+    if constexpr (!has_empty_hooks_policy) {
+      KOKKOS_IF_ON_HOST(
+          (if (&other != this) { hooks_policy::move_assign(*this, other); }))
+    }
+
+    return *this;
+  }
+#else
   KOKKOS_DEFAULTED_FUNCTION
   View& operator=(View&&)
     requires(has_empty_hooks_policy)
@@ -731,6 +788,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 
     return *this;
   }
+#endif
 
   KOKKOS_FUNCTION
   View(typename base_t::data_handle_type p,

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -197,6 +197,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   using raw_allocation_value_type = std::remove_pointer_t<pointer_type>;
   using hooks_policy =
       typename Impl::ViewHooksFromTraits<DataType, Properties...>::type;
+  static constexpr bool has_empty_hooks_policy = std::same_as<hooks_policy, Experimental::EmptyViewHooks>;
 
  public:
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
@@ -675,18 +676,27 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   KOKKOS_DEFAULTED_FUNCTION
   View() = default;
 
+  KOKKOS_DEFAULTED_FUNCTION
+  View(const View&) requires(has_empty_hooks_policy) = default;
+
   KOKKOS_FUNCTION
-  View(const View& other) : base_t{other} {
+  View(const View& other) requires(!has_empty_hooks_policy) : base_t{other} {
     KOKKOS_IF_ON_HOST((hooks_policy::copy_construct(*this, other);))
   }
 
+  KOKKOS_DEFAULTED_FUNCTION
+  View(View&&) requires(has_empty_hooks_policy) = default;
+
   KOKKOS_FUNCTION
-  View(View&& other) : base_t{std::move(static_cast<base_t &&>(other))} {
+  View(View&& other) requires(!has_empty_hooks_policy) : base_t{std::move(static_cast<base_t &&>(other))} {
     KOKKOS_IF_ON_HOST((hooks_policy::move_construct(*this, other);))
   }
 
+  KOKKOS_DEFAULTED_FUNCTION
+  View& operator=(const View&) requires(has_empty_hooks_policy) = default;
+
   KOKKOS_FUNCTION
-  View& operator=(const View& other) {
+  View& operator=(const View& other) requires(!has_empty_hooks_policy) {
     base_t::operator=(other);
     KOKKOS_IF_ON_HOST(
         (if (&other != this) { hooks_policy::copy_assign(*this, other); }))
@@ -694,8 +704,11 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     return *this;
   }
 
+  KOKKOS_DEFAULTED_FUNCTION
+  View& operator=(View&&) requires(has_empty_hooks_policy) = default;
+
   KOKKOS_FUNCTION
-  View& operator=(View&& other) {
+  View& operator=(View&& other) requires(!has_empty_hooks_policy) {
     base_t::operator=(std::move(static_cast<base_t &&>(other)));
     KOKKOS_IF_ON_HOST(
         (if (&other != this) { hooks_policy::move_assign(*this, other); }))

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -681,7 +681,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   }
 
   KOKKOS_FUNCTION
-  View(View&& other) : base_t{std::move(other)} {
+  View(View&& other) : base_t{std::move(static_cast<base_t &&>(other))} {
     KOKKOS_IF_ON_HOST((hooks_policy::move_construct(*this, other);))
   }
 
@@ -696,7 +696,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 
   KOKKOS_FUNCTION
   View& operator=(View&& other) {
-    base_t::operator=(other);
+    base_t::operator=(std::move(static_cast<base_t &&>(other)));
     KOKKOS_IF_ON_HOST(
         (if (&other != this) { hooks_policy::move_assign(*this, other); }))
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -677,9 +677,9 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   View() = default;
 
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
-// exclusive requirements clauses
-#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC) && \
-    KOKKOS_COMPILER_NVCC >= 1220 && KOKKOS_COMPILER_NVCC < 1240
+// exclusive requirements clauses. 12.6 Also has some issues though it manifests
+// differently
+#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC)
   KOKKOS_FUNCTION
   View(const View& other) : base_t{other} {
     if constexpr (!has_empty_hooks_policy) {
@@ -701,9 +701,9 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 #endif
 
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
-// exclusive requirements clauses
-#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC) && \
-    KOKKOS_COMPILER_NVCC >= 1220 && KOKKOS_COMPILER_NVCC < 1240
+// exclusive requirements clauses. 12.6 Also has some issues though it manifests
+// differently
+#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC)
   KOKKOS_FUNCTION
   View(View&& other) : base_t{std::move(static_cast<base_t&&>(other))} {
     if constexpr (!has_empty_hooks_policy) {
@@ -725,9 +725,9 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 #endif
 
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
-// exclusive requirements clauses
-#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC) && \
-    KOKKOS_COMPILER_NVCC >= 1220 && KOKKOS_COMPILER_NVCC < 1240
+// exclusive requirements clauses. 12.6 Also has some issues though it manifests
+// differently
+#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC)
   KOKKOS_FUNCTION
   View& operator=(const View& other) {
     base_t::operator=(other);
@@ -758,9 +758,9 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 #endif
 
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
-// exclusive requirements clauses
-#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC) && \
-    KOKKOS_COMPILER_NVCC >= 1220 && KOKKOS_COMPILER_NVCC < 1240
+// exclusive requirements clauses. 12.6 Also has some issues though it manifests
+// differently
+#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC)
   KOKKOS_FUNCTION
   View& operator=(View&& other) {
     base_t::operator=(std::move(static_cast<base_t&&>(other)));

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -677,26 +677,38 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   View() = default;
 
   KOKKOS_DEFAULTED_FUNCTION
-  View(const View&) requires(has_empty_hooks_policy) = default;
+  View(const View&)
+    requires(has_empty_hooks_policy)
+  = default;
 
   KOKKOS_FUNCTION
-  View(const View& other) requires(!has_empty_hooks_policy) : base_t{other} {
+  View(const View& other)
+    requires(!has_empty_hooks_policy)
+      : base_t{other} {
     KOKKOS_IF_ON_HOST((hooks_policy::copy_construct(*this, other);))
   }
 
   KOKKOS_DEFAULTED_FUNCTION
-  View(View&&) requires(has_empty_hooks_policy) = default;
+  View(View&&)
+    requires(has_empty_hooks_policy)
+  = default;
 
   KOKKOS_FUNCTION
-  View(View&& other) requires(!has_empty_hooks_policy) : base_t{std::move(static_cast<base_t &&>(other))} {
+  View(View&& other)
+    requires(!has_empty_hooks_policy)
+      : base_t{std::move(static_cast<base_t&&>(other))} {
     KOKKOS_IF_ON_HOST((hooks_policy::move_construct(*this, other);))
   }
 
   KOKKOS_DEFAULTED_FUNCTION
-  View& operator=(const View&) requires(has_empty_hooks_policy) = default;
+  View& operator=(const View&)
+    requires(has_empty_hooks_policy)
+  = default;
 
   KOKKOS_FUNCTION
-  View& operator=(const View& other) requires(!has_empty_hooks_policy) {
+  View& operator=(const View& other)
+    requires(!has_empty_hooks_policy)
+  {
     base_t::operator=(other);
     KOKKOS_IF_ON_HOST(
         (if (&other != this) { hooks_policy::copy_assign(*this, other); }))
@@ -705,11 +717,15 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   }
 
   KOKKOS_DEFAULTED_FUNCTION
-  View& operator=(View&&) requires(has_empty_hooks_policy) = default;
+  View& operator=(View&&)
+    requires(has_empty_hooks_policy)
+  = default;
 
   KOKKOS_FUNCTION
-  View& operator=(View&& other) requires(!has_empty_hooks_policy) {
-    base_t::operator=(std::move(static_cast<base_t &&>(other)));
+  View& operator=(View&& other)
+    requires(!has_empty_hooks_policy)
+  {
+    base_t::operator=(std::move(static_cast<base_t&&>(other)));
     KOKKOS_IF_ON_HOST(
         (if (&other != this) { hooks_policy::move_assign(*this, other); }))
 

--- a/core/src/View/Hooks/Kokkos_ViewHooks.hpp
+++ b/core/src/View/Hooks/Kokkos_ViewHooks.hpp
@@ -63,19 +63,6 @@ struct move_assignment_operator_invoker {
 };
 }  // namespace Impl
 
-struct EmptyViewHooks {
-  using hooks_policy = EmptyViewHooks;
-
-  template <typename View>
-  static constexpr void copy_construct(View &, const View &) {}
-  template <typename View>
-  static constexpr void copy_assign(View &, const View &) {}
-  template <typename View>
-  static constexpr void move_construct(View &, const View &) {}
-  template <typename View>
-  static constexpr void move_assign(View &, const View &) {}
-};
-
 template <class... Subscribers>
 struct SubscribableViewHooks {
   using hooks_policy = SubscribableViewHooks<Subscribers...>;
@@ -101,8 +88,6 @@ struct SubscribableViewHooks {
                                  Subscribers...>::invoke(self, other);
   }
 };
-
-using DefaultViewHooks = EmptyViewHooks;
 
 }  // namespace Experimental
 }  // namespace Kokkos

--- a/core/src/View/Hooks/Kokkos_ViewHooks.hpp
+++ b/core/src/View/Hooks/Kokkos_ViewHooks.hpp
@@ -67,13 +67,13 @@ struct EmptyViewHooks {
   using hooks_policy = EmptyViewHooks;
 
   template <typename View>
-  static void copy_construct(View &, const View &) {}
+  static constexpr void copy_construct(View &, const View &) {}
   template <typename View>
-  static void copy_assign(View &, const View &) {}
+  static constexpr void copy_assign(View &, const View &) {}
   template <typename View>
-  static void move_construct(View &, const View &) {}
+  static constexpr void move_construct(View &, const View &) {}
   template <typename View>
-  static void move_assign(View &, const View &) {}
+  static constexpr void move_assign(View &, const View &) {}
 };
 
 template <class... Subscribers>

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -227,7 +227,7 @@ class View : public ViewTraits<DataType, Properties...> {
       Kokkos::Impl::ViewMapping<traits, typename traits::specialize>;
   template <typename V>
   friend struct Kokkos::Impl::ViewTracker;
-  using hooks_policy                           = typename traits::hooks_policy;
+  using hooks_policy                     = typename traits::hooks_policy;
   static constexpr bool has_hooks_policy = !std::is_void_v<hooks_policy>;
 
   view_tracker_type m_track;
@@ -886,8 +886,7 @@ class View : public ViewTraits<DataType, Properties...> {
 // differently
 #if defined(KOKKOS_ENABLE_CUDA)
   KOKKOS_FUNCTION
-  View(const View& other)
-      : m_track(other.m_track), m_map(other.m_map) {
+  View(const View& other) : m_track(other.m_track), m_map(other.m_map) {
     if constexpr (has_hooks_policy) {
       KOKKOS_IF_ON_HOST((hooks_policy::copy_construct(*this, other);))
     }
@@ -905,7 +904,6 @@ class View : public ViewTraits<DataType, Properties...> {
     KOKKOS_IF_ON_HOST((hooks_policy::copy_construct(*this, other);))
   }
 #endif
-
 
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -227,7 +227,8 @@ class View : public ViewTraits<DataType, Properties...> {
       Kokkos::Impl::ViewMapping<traits, typename traits::specialize>;
   template <typename V>
   friend struct Kokkos::Impl::ViewTracker;
-  using hooks_policy = typename traits::hooks_policy;
+  using hooks_policy                           = typename traits::hooks_policy;
+  static constexpr bool has_empty_hooks_policy = std::is_void_v<hooks_policy>;
 
   view_tracker_type m_track;
   map_type m_map;
@@ -880,19 +881,39 @@ class View : public ViewTraits<DataType, Properties...> {
   KOKKOS_DEFAULTED_FUNCTION
   View() = default;
 
+  KOKKOS_DEFAULTED_FUNCTION
+  View(const View&)
+    requires(has_empty_hooks_policy)
+  = default;
+
   KOKKOS_FUNCTION
-  View(const View& other) : m_track(other.m_track), m_map(other.m_map) {
+  View(const View& other)
+    requires(!has_empty_hooks_policy)
+      : m_track(other.m_track), m_map(other.m_map) {
     KOKKOS_IF_ON_HOST((hooks_policy::copy_construct(*this, other);))
   }
 
+  KOKKOS_DEFAULTED_FUNCTION
+  View(View&&)
+    requires(has_empty_hooks_policy)
+  = default;
+
   KOKKOS_FUNCTION
   View(View&& other)
+    requires(!has_empty_hooks_policy)
       : m_track{std::move(other.m_track)}, m_map{std::move(other.m_map)} {
     KOKKOS_IF_ON_HOST((hooks_policy::move_construct(*this, other);))
   }
 
+  KOKKOS_DEFAULTED_FUNCTION
+  View& operator=(const View&)
+    requires(has_empty_hooks_policy)
+  = default;
+
   KOKKOS_FUNCTION
-  View& operator=(const View& other) {
+  View& operator=(const View& other)
+    requires(!has_empty_hooks_policy)
+  {
     m_map   = other.m_map;
     m_track = other.m_track;
 
@@ -901,8 +922,15 @@ class View : public ViewTraits<DataType, Properties...> {
     return *this;
   }
 
+  KOKKOS_DEFAULTED_FUNCTION
+  View& operator=(View&&)
+    requires(has_empty_hooks_policy)
+  = default;
+
   KOKKOS_FUNCTION
-  View& operator=(View&& other) {
+  View& operator=(View&& other)
+    requires(!has_empty_hooks_policy)
+  {
     m_map   = std::move(other.m_map);
     m_track = std::move(other.m_track);
 

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -884,7 +884,7 @@ class View : public ViewTraits<DataType, Properties...> {
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
-#if defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
   KOKKOS_FUNCTION
   View(const View& other) : m_track(other.m_track), m_map(other.m_map) {
     if constexpr (has_hooks_policy) {
@@ -908,7 +908,7 @@ class View : public ViewTraits<DataType, Properties...> {
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
-#if defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
   KOKKOS_FUNCTION
   View(View&& other)
       : m_track{std::move(other.m_track)}, m_map{std::move(other.m_map)} {
@@ -933,7 +933,7 @@ class View : public ViewTraits<DataType, Properties...> {
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
-#if defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
   KOKKOS_FUNCTION
   View& operator=(const View& other) {
     m_map   = other.m_map;
@@ -968,7 +968,7 @@ class View : public ViewTraits<DataType, Properties...> {
 // FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
-#if defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
   KOKKOS_FUNCTION
   View& operator=(View&& other) {
     m_map   = std::move(other.m_map);

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -236,9 +236,12 @@ class View : public ViewTraits<DataType, Properties...> {
  public:
   //----------------------------------------
   /** \brief  Compatible view of data type */
-  using type = View<typename traits::data_type, typename traits::array_layout,
+  using type = std::conditional_t<
+      has_hooks_policy, View<typename traits::data_type, typename traits::array_layout,
                     typename traits::device_type, typename traits::hooks_policy,
-                    typename traits::memory_traits>;
+                    typename traits::memory_traits>,
+      View<typename traits::data_type, typename traits::array_layout,
+           typename traits::device_type, typename traits::memory_traits>>;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   /** \brief  Compatible view of array of data types */
@@ -246,23 +249,33 @@ class View : public ViewTraits<DataType, Properties...> {
 #endif
 
   /** \brief  Compatible view of const data type */
-  using const_type =
+  using const_type = std::conditional_t<
+      has_hooks_policy,
       View<typename traits::const_data_type, typename traits::array_layout,
            typename traits::device_type, typename traits::hooks_policy,
-           typename traits::memory_traits>;
+           typename traits::memory_traits>,
+      View<typename traits::const_data_type, typename traits::array_layout,
+           typename traits::device_type, typename traits::memory_traits>>;
 
   /** \brief  Compatible view of non-const data type */
-  using non_const_type =
+  using non_const_type = std::conditional_t<
+      has_hooks_policy,
       View<typename traits::non_const_data_type, typename traits::array_layout,
            typename traits::device_type, typename traits::hooks_policy,
-           typename traits::memory_traits>;
+           typename traits::memory_traits>,
+      View<typename traits::non_const_data_type, typename traits::array_layout,
+           typename traits::device_type, typename traits::memory_traits>>;
 
   /** \brief  Compatible host mirror view */
-  using host_mirror_type =
+  using host_mirror_type = std::conditional_t<
+      has_hooks_policy,
       View<typename traits::non_const_data_type, typename traits::array_layout,
            Device<DefaultHostExecutionSpace,
                   typename traits::host_mirror_space::memory_space>,
-           typename traits::hooks_policy>;
+           typename traits::hooks_policy>,
+      View<typename traits::non_const_data_type, typename traits::array_layout,
+           Device<DefaultHostExecutionSpace,
+                  typename traits::host_mirror_space::memory_space>>>;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   /** \brief  Compatible host mirror view */

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -237,9 +237,10 @@ class View : public ViewTraits<DataType, Properties...> {
   //----------------------------------------
   /** \brief  Compatible view of data type */
   using type = std::conditional_t<
-      has_hooks_policy, View<typename traits::data_type, typename traits::array_layout,
-                    typename traits::device_type, typename traits::hooks_policy,
-                    typename traits::memory_traits>,
+      has_hooks_policy,
+      View<typename traits::data_type, typename traits::array_layout,
+           typename traits::device_type, typename traits::hooks_policy,
+           typename traits::memory_traits>,
       View<typename traits::data_type, typename traits::array_layout,
            typename traits::device_type, typename traits::memory_traits>>;
 

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -899,6 +899,9 @@ class View : public ViewTraits<DataType, Properties...> {
 // exclusive requirements clauses. 12.6 Also has some issues though it manifests
 // differently
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
+#define KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND 1
+#endif
+#ifdef KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
   KOKKOS_FUNCTION
   View(const View& other) : m_track(other.m_track), m_map(other.m_map) {
     if constexpr (has_hooks_policy) {
@@ -919,10 +922,7 @@ class View : public ViewTraits<DataType, Properties...> {
   }
 #endif
 
-// FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
-// exclusive requirements clauses. 12.6 Also has some issues though it manifests
-// differently
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
+#ifdef KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
   KOKKOS_FUNCTION
   View(View&& other)
       : m_track{std::move(other.m_track)}, m_map{std::move(other.m_map)} {
@@ -944,10 +944,7 @@ class View : public ViewTraits<DataType, Properties...> {
   }
 #endif
 
-// FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
-// exclusive requirements clauses. 12.6 Also has some issues though it manifests
-// differently
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
+#ifdef KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
   KOKKOS_FUNCTION
   View& operator=(const View& other) {
     m_map   = other.m_map;
@@ -979,10 +976,7 @@ class View : public ViewTraits<DataType, Properties...> {
   }
 #endif
 
-// FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
-// exclusive requirements clauses. 12.6 Also has some issues though it manifests
-// differently
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_COMPILER_NVHPC)
+#ifdef KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
   KOKKOS_FUNCTION
   View& operator=(View&& other) {
     m_map   = std::move(other.m_map);
@@ -1013,6 +1007,7 @@ class View : public ViewTraits<DataType, Properties...> {
     return *this;
   }
 #endif
+#undef KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND
 
   //----------------------------------------
   // Compatible view copy constructor and assignment

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -228,7 +228,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename V>
   friend struct Kokkos::Impl::ViewTracker;
   using hooks_policy                           = typename traits::hooks_policy;
-  static constexpr bool has_empty_hooks_policy = std::is_void_v<hooks_policy>;
+  static constexpr bool has_hooks_policy = !std::is_void_v<hooks_policy>;
 
   view_tracker_type m_track;
   map_type m_map;
@@ -881,38 +881,82 @@ class View : public ViewTraits<DataType, Properties...> {
   KOKKOS_DEFAULTED_FUNCTION
   View() = default;
 
+// FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
+// exclusive requirements clauses. 12.6 Also has some issues though it manifests
+// differently
+#if defined(KOKKOS_ENABLE_CUDA)
+  KOKKOS_FUNCTION
+  View(const View& other)
+      : m_track(other.m_track), m_map(other.m_map) {
+    if constexpr (has_hooks_policy) {
+      KOKKOS_IF_ON_HOST((hooks_policy::copy_construct(*this, other);))
+    }
+  }
+#else
   KOKKOS_DEFAULTED_FUNCTION
   View(const View&)
-    requires(has_empty_hooks_policy)
+    requires(!has_hooks_policy)
   = default;
 
   KOKKOS_FUNCTION
   View(const View& other)
-    requires(!has_empty_hooks_policy)
+    requires(has_hooks_policy)
       : m_track(other.m_track), m_map(other.m_map) {
     KOKKOS_IF_ON_HOST((hooks_policy::copy_construct(*this, other);))
   }
+#endif
 
+
+// FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
+// exclusive requirements clauses. 12.6 Also has some issues though it manifests
+// differently
+#if defined(KOKKOS_ENABLE_CUDA)
+  KOKKOS_FUNCTION
+  View(View&& other)
+      : m_track{std::move(other.m_track)}, m_map{std::move(other.m_map)} {
+    if constexpr (has_hooks_policy) {
+      KOKKOS_IF_ON_HOST((hooks_policy::move_construct(*this, other);))
+    }
+  }
+#else
   KOKKOS_DEFAULTED_FUNCTION
   View(View&&)
-    requires(has_empty_hooks_policy)
+    requires(!has_hooks_policy)
   = default;
 
   KOKKOS_FUNCTION
   View(View&& other)
-    requires(!has_empty_hooks_policy)
+    requires(has_hooks_policy)
       : m_track{std::move(other.m_track)}, m_map{std::move(other.m_map)} {
     KOKKOS_IF_ON_HOST((hooks_policy::move_construct(*this, other);))
   }
+#endif
 
+// FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
+// exclusive requirements clauses. 12.6 Also has some issues though it manifests
+// differently
+#if defined(KOKKOS_ENABLE_CUDA)
+  KOKKOS_FUNCTION
+  View& operator=(const View& other) {
+    m_map   = other.m_map;
+    m_track = other.m_track;
+
+    if constexpr (has_hooks_policy) {
+      KOKKOS_IF_ON_HOST(
+          (if (&other != this) { hooks_policy::copy_assign(*this, other); }))
+    }
+
+    return *this;
+  }
+#else
   KOKKOS_DEFAULTED_FUNCTION
   View& operator=(const View&)
-    requires(has_empty_hooks_policy)
+    requires(!has_hooks_policy)
   = default;
 
   KOKKOS_FUNCTION
   View& operator=(const View& other)
-    requires(!has_empty_hooks_policy)
+    requires(has_hooks_policy)
   {
     m_map   = other.m_map;
     m_track = other.m_track;
@@ -921,15 +965,33 @@ class View : public ViewTraits<DataType, Properties...> {
 
     return *this;
   }
+#endif
 
+// FIXME_NVCC: nvcc 12.2 and 12.3 view these as ambiguous even though they have
+// exclusive requirements clauses. 12.6 Also has some issues though it manifests
+// differently
+#if defined(KOKKOS_ENABLE_CUDA)
+  KOKKOS_FUNCTION
+  View& operator=(View&& other) {
+    m_map   = std::move(other.m_map);
+    m_track = std::move(other.m_track);
+
+    if constexpr (has_hooks_policy) {
+      KOKKOS_IF_ON_HOST(
+          (if (&other != this) { hooks_policy::move_assign(*this, other); }))
+    }
+
+    return *this;
+  }
+#else
   KOKKOS_DEFAULTED_FUNCTION
   View& operator=(View&&)
-    requires(has_empty_hooks_policy)
+    requires(!has_hooks_policy)
   = default;
 
   KOKKOS_FUNCTION
   View& operator=(View&& other)
-    requires(!has_empty_hooks_policy)
+    requires(has_hooks_policy)
   {
     m_map   = std::move(other.m_map);
     m_track = std::move(other.m_track);
@@ -938,6 +1000,7 @@ class View : public ViewTraits<DataType, Properties...> {
 
     return *this;
   }
+#endif
 
   //----------------------------------------
   // Compatible view copy constructor and assignment

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -590,7 +590,7 @@ struct RemoveAlignedMemoryTrait {
 template <class DataType, class... Properties>
 constexpr auto customize_view_hooks() {
   using traits_type = ViewTraits<DataType, Properties...>;
-  if constexpr ( !std::is_void_v<typename traits_type::hooks_policy> ) {
+  if constexpr (!std::is_void_v<typename traits_type::hooks_policy>) {
     return typename traits_type::hooks_policy{};
   }
 }

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -590,15 +590,14 @@ struct RemoveAlignedMemoryTrait {
 // Customization point for view hooks; default is to use the explicit template
 // parameter, but this can be customized to get the view hook from a special
 // memory space for example
-template< class DataType, class... Properties >
+template <class DataType, class... Properties>
 constexpr auto customize_view_hooks() {
   using traits_type = ViewTraits<DataType, Properties...>;
   return typename traits_type::hooks_policy{};
 }
 
-template<class DataType, class... Properties>
-struct ViewHooksFromTraits
-{
+template <class DataType, class... Properties>
+struct ViewHooksFromTraits {
   using type = decltype(customize_view_hooks<DataType, Properties...>());
 };
 }  // namespace Impl

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -586,6 +586,21 @@ struct RemoveAlignedMemoryTrait {
  public:
   using type = typename TypeListToViewTraits<D, new_type_list>::type;
 };
+
+// Customization point for view hooks; default is to use the explicit template
+// parameter, but this can be customized to get the view hook from a special
+// memory space for example
+template< class DataType, class... Properties >
+constexpr auto customize_view_hooks() {
+  using traits_type = ViewTraits<DataType, Properties...>;
+  return typename traits_type::hooks_policy{};
+}
+
+template<class DataType, class... Properties>
+struct ViewHooksFromTraits
+{
+  using type = decltype(customize_view_hooks<DataType, Properties...>());
+};
 }  // namespace Impl
 
 } /* namespace Kokkos */

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -590,7 +590,9 @@ struct RemoveAlignedMemoryTrait {
 template <class DataType, class... Properties>
 constexpr auto customize_view_hooks() {
   using traits_type = ViewTraits<DataType, Properties...>;
-  return typename traits_type::hooks_policy{};
+  if constexpr ( !std::is_void_v<typename traits_type::hooks_policy> ) {
+    return typename traits_type::hooks_policy{};
+  }
 }
 
 template <class DataType, class... Properties>

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -479,10 +479,7 @@ struct ViewTraits {
                          typename prop::memory_traits,
                          typename Kokkos::MemoryTraits<>>;
 
-  using HooksPolicy =
-      std::conditional_t<!std::is_void_v<typename prop::hooks_policy>,
-                         typename prop::hooks_policy,
-                         Kokkos::Experimental::DefaultViewHooks>;
+  using HooksPolicy = typename prop::hooks_policy;
 
   // Analyze data type's properties,
   // May be specialized based upon the layout and value type

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -290,11 +290,6 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
     if(KOKKOS_CXX_COMPILER_ID STREQUAL Intel)
       list(REMOVE_ITEM ${Tag}_TESTNAMES2A ViewCopy_c)
     endif()
-    # FIXME: we will eventually likely remove ViewHooks entirely, but for now
-    # ViewHooks are not compatible
-    if(NOT Kokkos_ENABLE_IMPL_VIEW_LEGACY)
-      list(REMOVE_ITEM ${Tag}_TESTNAMES2A ViewHooks)
-    endif()
     foreach(Name IN LISTS ${Tag}_TESTNAMES2A)
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid

--- a/core/unit_test/TestInterOp.cpp
+++ b/core/unit_test/TestInterOp.cpp
@@ -15,10 +15,9 @@ import kokkos.dyn_rank_view;
 static_assert(
     std::is_same_v<
         Kokkos::Experimental::python_view_type_t<Kokkos::View<double*>>,
-        Kokkos::View<double*,
-                     typename Kokkos::DefaultExecutionSpace::array_layout,
-                     typename Kokkos::DefaultExecutionSpace::memory_space,
-                     void>>,
+        Kokkos::View<
+            double*, typename Kokkos::DefaultExecutionSpace::array_layout,
+            typename Kokkos::DefaultExecutionSpace::memory_space, void>>,
     "Error! Unexpected python_view_type for: View");
 
 // DynRankView
@@ -35,10 +34,9 @@ static_assert(
     std::is_same_v<
         Kokkos::Experimental::python_view_type_t<
             Kokkos::View<double*, Kokkos::DefaultExecutionSpace>>,
-        Kokkos::View<double*,
-                     typename Kokkos::DefaultExecutionSpace::array_layout,
-                     typename Kokkos::DefaultExecutionSpace::memory_space,
-                     void>>,
+        Kokkos::View<
+            double*, typename Kokkos::DefaultExecutionSpace::array_layout,
+            typename Kokkos::DefaultExecutionSpace::memory_space, void>>,
     "Error! Unexpected python_view_type for: View + Execution Space");
 
 // DynRankView + Execution Space
@@ -52,11 +50,10 @@ static_assert(
     "Error! Unexpected python_view_type for: DynRankView + Execution Space");
 
 // View + Memory space
-static_assert(std::is_same_v<
-                  Kokkos::Experimental::python_view_type_t<
-                      Kokkos::View<int64_t*, Kokkos::HostSpace>>,
-                  Kokkos::View<int64_t*, Kokkos::LayoutRight, Kokkos::HostSpace,
-                               void>>,
+static_assert(std::is_same_v<Kokkos::Experimental::python_view_type_t<
+                                 Kokkos::View<int64_t*, Kokkos::HostSpace>>,
+                             Kokkos::View<int64_t*, Kokkos::LayoutRight,
+                                          Kokkos::HostSpace, void>>,
               "Error! Unexpected python_view_type for: View + Memory space");
 
 // DynRankView + Memory space
@@ -92,8 +89,7 @@ static_assert(
     std::is_same_v<
         Kokkos::Experimental::python_view_type_t<
             Kokkos::View<uint32_t**, Kokkos::LayoutLeft, Kokkos::HostSpace>>,
-        Kokkos::View<uint32_t**, Kokkos::LayoutLeft, Kokkos::HostSpace,
-                     void>>,
+        Kokkos::View<uint32_t**, Kokkos::LayoutLeft, Kokkos::HostSpace, void>>,
     "Error! Unexpected python_view_type for: View + Layout + Memory Space");
 
 // DynRankView + Layout + Memory Space
@@ -113,8 +109,7 @@ static_assert(
             Kokkos::MemoryTraits<Kokkos::RandomAccess>>>,
         Kokkos::View<float***, Kokkos::LayoutLeft,
                      typename Kokkos::DefaultHostExecutionSpace::memory_space,
-                     void,
-                     Kokkos::MemoryTraits<Kokkos::RandomAccess>>>,
+                     void, Kokkos::MemoryTraits<Kokkos::RandomAccess>>>,
     "Error! Unexpected python_view_type for: View + Layout + Execution space + "
     "Memory Trait");
 

--- a/core/unit_test/TestInterOp.cpp
+++ b/core/unit_test/TestInterOp.cpp
@@ -15,9 +15,9 @@ import kokkos.dyn_rank_view;
 static_assert(
     std::is_same_v<
         Kokkos::Experimental::python_view_type_t<Kokkos::View<double*>>,
-        Kokkos::View<
-            double*, typename Kokkos::DefaultExecutionSpace::array_layout,
-            typename Kokkos::DefaultExecutionSpace::memory_space, void>>,
+        Kokkos::View<double*,
+                     typename Kokkos::DefaultExecutionSpace::array_layout,
+                     typename Kokkos::DefaultExecutionSpace::memory_space>>,
     "Error! Unexpected python_view_type for: View");
 
 // DynRankView
@@ -34,9 +34,9 @@ static_assert(
     std::is_same_v<
         Kokkos::Experimental::python_view_type_t<
             Kokkos::View<double*, Kokkos::DefaultExecutionSpace>>,
-        Kokkos::View<
-            double*, typename Kokkos::DefaultExecutionSpace::array_layout,
-            typename Kokkos::DefaultExecutionSpace::memory_space, void>>,
+        Kokkos::View<double*,
+                     typename Kokkos::DefaultExecutionSpace::array_layout,
+                     typename Kokkos::DefaultExecutionSpace::memory_space>>,
     "Error! Unexpected python_view_type for: View + Execution Space");
 
 // DynRankView + Execution Space
@@ -53,7 +53,7 @@ static_assert(
 static_assert(std::is_same_v<Kokkos::Experimental::python_view_type_t<
                                  Kokkos::View<int64_t*, Kokkos::HostSpace>>,
                              Kokkos::View<int64_t*, Kokkos::LayoutRight,
-                                          Kokkos::HostSpace, void>>,
+                                          Kokkos::HostSpace>>,
               "Error! Unexpected python_view_type for: View + Memory space");
 
 // DynRankView + Memory space
@@ -70,8 +70,7 @@ static_assert(
         Kokkos::Experimental::python_view_type_t<Kokkos::View<
             int**, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace>>,
         Kokkos::View<int**, Kokkos::LayoutLeft,
-                     typename Kokkos::DefaultExecutionSpace::memory_space,
-                     void>>,
+                     typename Kokkos::DefaultExecutionSpace::memory_space>>,
     "Error! Unexpected python_view_type for: View + Layout + Execution space");
 
 // DynRankView + Layout + Execution space
@@ -89,7 +88,7 @@ static_assert(
     std::is_same_v<
         Kokkos::Experimental::python_view_type_t<
             Kokkos::View<uint32_t**, Kokkos::LayoutLeft, Kokkos::HostSpace>>,
-        Kokkos::View<uint32_t**, Kokkos::LayoutLeft, Kokkos::HostSpace, void>>,
+        Kokkos::View<uint32_t**, Kokkos::LayoutLeft, Kokkos::HostSpace>>,
     "Error! Unexpected python_view_type for: View + Layout + Memory Space");
 
 // DynRankView + Layout + Memory Space
@@ -109,7 +108,7 @@ static_assert(
             Kokkos::MemoryTraits<Kokkos::RandomAccess>>>,
         Kokkos::View<float***, Kokkos::LayoutLeft,
                      typename Kokkos::DefaultHostExecutionSpace::memory_space,
-                     void, Kokkos::MemoryTraits<Kokkos::RandomAccess>>>,
+                     Kokkos::MemoryTraits<Kokkos::RandomAccess>>>,
     "Error! Unexpected python_view_type for: View + Layout + Execution space + "
     "Memory Trait");
 

--- a/core/unit_test/TestInterOp.cpp
+++ b/core/unit_test/TestInterOp.cpp
@@ -18,7 +18,7 @@ static_assert(
         Kokkos::View<double*,
                      typename Kokkos::DefaultExecutionSpace::array_layout,
                      typename Kokkos::DefaultExecutionSpace::memory_space,
-                     Kokkos::Experimental::DefaultViewHooks>>,
+                     void>>,
     "Error! Unexpected python_view_type for: View");
 
 // DynRankView
@@ -38,7 +38,7 @@ static_assert(
         Kokkos::View<double*,
                      typename Kokkos::DefaultExecutionSpace::array_layout,
                      typename Kokkos::DefaultExecutionSpace::memory_space,
-                     Kokkos::Experimental::DefaultViewHooks>>,
+                     void>>,
     "Error! Unexpected python_view_type for: View + Execution Space");
 
 // DynRankView + Execution Space
@@ -56,7 +56,7 @@ static_assert(std::is_same_v<
                   Kokkos::Experimental::python_view_type_t<
                       Kokkos::View<int64_t*, Kokkos::HostSpace>>,
                   Kokkos::View<int64_t*, Kokkos::LayoutRight, Kokkos::HostSpace,
-                               Kokkos::Experimental::DefaultViewHooks>>,
+                               void>>,
               "Error! Unexpected python_view_type for: View + Memory space");
 
 // DynRankView + Memory space
@@ -74,7 +74,7 @@ static_assert(
             int**, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace>>,
         Kokkos::View<int**, Kokkos::LayoutLeft,
                      typename Kokkos::DefaultExecutionSpace::memory_space,
-                     Kokkos::Experimental::DefaultViewHooks>>,
+                     void>>,
     "Error! Unexpected python_view_type for: View + Layout + Execution space");
 
 // DynRankView + Layout + Execution space
@@ -93,7 +93,7 @@ static_assert(
         Kokkos::Experimental::python_view_type_t<
             Kokkos::View<uint32_t**, Kokkos::LayoutLeft, Kokkos::HostSpace>>,
         Kokkos::View<uint32_t**, Kokkos::LayoutLeft, Kokkos::HostSpace,
-                     Kokkos::Experimental::DefaultViewHooks>>,
+                     void>>,
     "Error! Unexpected python_view_type for: View + Layout + Memory Space");
 
 // DynRankView + Layout + Memory Space
@@ -113,7 +113,7 @@ static_assert(
             Kokkos::MemoryTraits<Kokkos::RandomAccess>>>,
         Kokkos::View<float***, Kokkos::LayoutLeft,
                      typename Kokkos::DefaultHostExecutionSpace::memory_space,
-                     Kokkos::Experimental::DefaultViewHooks,
+                     void,
                      Kokkos::MemoryTraits<Kokkos::RandomAccess>>>,
     "Error! Unexpected python_view_type for: View + Layout + Execution space + "
     "Memory Trait");

--- a/core/unit_test/TestViewHooks.hpp
+++ b/core/unit_test/TestViewHooks.hpp
@@ -20,15 +20,17 @@ struct TestSubscriber {
                    Kokkos::Experimental::SubscribableViewHooks<TestSubscriber>,
                    DeviceType>,
       Kokkos::View<double **, DeviceType>>;
-  inline static test_view_type *self_ptr = nullptr;
+  inline static test_view_type *self_ptr        = nullptr;
   inline static const test_view_type *other_ptr = nullptr;
 
-  static void copy_constructed(test_view_type &self, const test_view_type &other) {
+  static void copy_constructed(test_view_type &self,
+                               const test_view_type &other) {
     self_ptr  = &self;
     other_ptr = &other;
   }
 
-  static void move_constructed(test_view_type &self, const test_view_type &other) {
+  static void move_constructed(test_view_type &self,
+                               const test_view_type &other) {
     self_ptr  = &self;
     other_ptr = &other;
   }
@@ -48,36 +50,37 @@ struct TestSubscriber {
     other_ptr = nullptr;
   }
 };
+}  // namespace Test
+
+namespace TestADLViewHookCustomization {
+template <typename DeviceType>
+class TestMemSpace : public DeviceType::memory_space {};
+
+template <typename DeviceType>
+using TestDevice = Kokkos::Device<typename DeviceType::execution_space,
+                                  TestMemSpace<DeviceType>>;
+
+template <class DataType, class... Properties>
+constexpr auto customize_view_hooks() {
+  using traits_type = Kokkos::ViewTraits<DataType, Properties...>;
+  return Test::TestSubscriber<typename traits_type::device_type, false>{};
 }
-
-namespace TestADLViewHookCustomization
-{
-  template< typename DeviceType >
-  class TestMemSpace : public DeviceType::memory_space
-  {};
-
-  template< typename DeviceType >
-  using TestDevice = Kokkos::Device<typename DeviceType::execution_space, TestMemSpace<DeviceType>>;
-
-  template <class DataType, class... Properties>
-  constexpr auto customize_view_hooks() {
-    using traits_type = Kokkos::ViewTraits<DataType, Properties...>;
-    return Test::TestSubscriber<typename traits_type::device_type, false>{};
-  }
-}
+}  // namespace TestADLViewHookCustomization
 
 namespace Test {
 template <class DeviceType>
 struct TestViewHooks {
   using subscriber_type = TestSubscriber<DeviceType, true>;
-  using test_view_type = typename subscriber_type::test_view_type;
+  using test_view_type  = typename subscriber_type::test_view_type;
 
-  using adl_subscriber_type = TestSubscriber<TestADLViewHookCustomization::TestMemSpace<DeviceType>, false>;
+  using adl_subscriber_type =
+      TestSubscriber<TestADLViewHookCustomization::TestMemSpace<DeviceType>,
+                     false>;
   using adl_test_view_type = typename adl_subscriber_type::test_view_type;
 
   static_assert(
       Kokkos::Experimental::is_hooks_policy<
-          Kokkos::Experimental::SubscribableViewHooks<subscriber_type> >::value,
+          Kokkos::Experimental::SubscribableViewHooks<subscriber_type>>::value,
       "Must be a hooks policy");
 
   static void testViewHooksCopyConstruct() {

--- a/core/unit_test/TestViewHooks.hpp
+++ b/core/unit_test/TestViewHooks.hpp
@@ -12,104 +12,125 @@ import kokkos.core;
 #endif
 
 namespace Test {
+template <class DeviceType, bool ExplicitSubscriber>
+struct TestSubscriber {
+  using test_view_type = std::conditional_t<
+      ExplicitSubscriber,
+      Kokkos::View<double **,
+                   Kokkos::Experimental::SubscribableViewHooks<TestSubscriber>,
+                   DeviceType>,
+      Kokkos::View<double **, DeviceType>>;
+  inline static test_view_type *self_ptr = nullptr;
+  inline static const test_view_type *other_ptr = nullptr;
+
+  static void copy_constructed(test_view_type &self, const test_view_type &other) {
+    self_ptr  = &self;
+    other_ptr = &other;
+  }
+
+  static void move_constructed(test_view_type &self, const test_view_type &other) {
+    self_ptr  = &self;
+    other_ptr = &other;
+  }
+
+  static void copy_assigned(test_view_type &self, const test_view_type &other) {
+    self_ptr  = &self;
+    other_ptr = &other;
+  }
+
+  static void move_assigned(test_view_type &self, const test_view_type &other) {
+    self_ptr  = &self;
+    other_ptr = &other;
+  }
+
+  static void reset() {
+    self_ptr  = nullptr;
+    other_ptr = nullptr;
+  }
+};
+}
+
+namespace TestADLViewHookCustomization
+{
+  template< typename DeviceType >
+  class TestMemSpace : public DeviceType::memory_space
+  {};
+
+  template< typename DeviceType >
+  using TestDevice = Kokkos::Device<typename DeviceType::execution_space, TestMemSpace<DeviceType>>;
+
+  template <class DataType, class... Properties>
+  constexpr auto customize_view_hooks() {
+    using traits_type = Kokkos::ViewTraits<DataType, Properties...>;
+    return Test::TestSubscriber<typename traits_type::device_type, false>{};
+  }
+}
+
+namespace Test {
 template <class DeviceType>
 struct TestViewHooks {
-  struct TestSubscriber;
+  using subscriber_type = TestSubscriber<DeviceType, true>;
+  using test_view_type = typename subscriber_type::test_view_type;
+
+  using adl_subscriber_type = TestSubscriber<TestADLViewHookCustomization::TestMemSpace<DeviceType>, false>;
+  using adl_test_view_type = typename adl_subscriber_type::test_view_type;
 
   static_assert(
       Kokkos::Experimental::is_hooks_policy<
-          Kokkos::Experimental::SubscribableViewHooks<TestSubscriber> >::value,
+          Kokkos::Experimental::SubscribableViewHooks<subscriber_type> >::value,
       "Must be a hooks policy");
 
-  using test_view_type =
-      Kokkos::View<double **,
-                   Kokkos::Experimental::SubscribableViewHooks<TestSubscriber>,
-                   DeviceType>;
-
-  struct TestSubscriber {
-    static test_view_type *self_ptr;
-    static const test_view_type *other_ptr;
-
-    template <typename View>
-    static void copy_constructed(View &self, const View &other) {
-      self_ptr  = &self;
-      other_ptr = &other;
-    }
-
-    template <typename View>
-    static void move_constructed(View &self, const View &other) {
-      self_ptr  = &self;
-      other_ptr = &other;
-    }
-
-    template <typename View>
-    static void copy_assigned(View &self, const View &other) {
-      self_ptr  = &self;
-      other_ptr = &other;
-    }
-
-    template <typename View>
-    static void move_assigned(View &self, const View &other) {
-      self_ptr  = &self;
-      other_ptr = &other;
-    }
-
-    static void reset() {
-      self_ptr  = nullptr;
-      other_ptr = nullptr;
-    }
-  };
-
   static void testViewHooksCopyConstruct() {
-    TestSubscriber::reset();
+    subscriber_type::reset();
     test_view_type testa;
 
     test_view_type testb(testa);
-    EXPECT_EQ(TestSubscriber::self_ptr, &testb);
-    EXPECT_EQ(TestSubscriber::other_ptr, &testa);
+    EXPECT_EQ(subscriber_type::self_ptr, &testb);
+    EXPECT_EQ(subscriber_type::other_ptr, &testa);
   }
 
   static void testViewHooksMoveConstruct() {
-    TestSubscriber::reset();
+    subscriber_type::reset();
     test_view_type testa;
 
     test_view_type testb(std::move(testa));
-    EXPECT_EQ(TestSubscriber::self_ptr, &testb);
+    EXPECT_EQ(subscriber_type::self_ptr, &testb);
 
     // This is valid, even if the view is moved-from
-    EXPECT_EQ(TestSubscriber::other_ptr, &testa);
+    EXPECT_EQ(subscriber_type::other_ptr, &testa);
   }
 
   static void testViewHooksCopyAssign() {
-    TestSubscriber::reset();
+    subscriber_type::reset();
     test_view_type testa;
 
     test_view_type testb;
     testb = testa;
-    EXPECT_EQ(TestSubscriber::self_ptr, &testb);
-    EXPECT_EQ(TestSubscriber::other_ptr, &testa);
+    EXPECT_EQ(subscriber_type::self_ptr, &testb);
+    EXPECT_EQ(subscriber_type::other_ptr, &testa);
   }
 
   static void testViewHooksMoveAssign() {
-    TestSubscriber::reset();
+    subscriber_type::reset();
     test_view_type testa;
 
     test_view_type testb;
     testb = std::move(testa);
-    EXPECT_EQ(TestSubscriber::self_ptr, &testb);
+    EXPECT_EQ(subscriber_type::self_ptr, &testb);
 
     // This is valid, even if the view is moved-from
-    EXPECT_EQ(TestSubscriber::other_ptr, &testa);
+    EXPECT_EQ(subscriber_type::other_ptr, &testa);
+  }
+
+  static void testViewHooksCopyConstructWithADL() {
+    adl_subscriber_type::reset();
+    adl_test_view_type testa;
+
+    adl_test_view_type testb(testa);
+    EXPECT_EQ(adl_subscriber_type::self_ptr, &testb);
+    EXPECT_EQ(adl_subscriber_type::other_ptr, &testa);
   }
 };
-
-template <class DeviceType>
-typename TestViewHooks<DeviceType>::test_view_type
-    *TestViewHooks<DeviceType>::TestSubscriber::self_ptr = nullptr;
-
-template <class DeviceType>
-const typename TestViewHooks<DeviceType>::test_view_type
-    *TestViewHooks<DeviceType>::TestSubscriber::other_ptr = nullptr;
 
 TEST(TEST_CATEGORY, view_hooks) {
   using ExecSpace = TEST_EXECSPACE;

--- a/core/unit_test/TestViewHooks.hpp
+++ b/core/unit_test/TestViewHooks.hpp
@@ -89,8 +89,8 @@ struct TestViewHooks {
           Kokkos::Experimental::SubscribableViewHooks<subscriber_type>>::value,
       "Must be a hooks policy");
   static_assert(
-      std::same_as<typename test_view_type::array_type,
-                   Kokkos::View<typename test_view_type::scalar_array_type,
+      std::same_as<typename test_view_type::type,
+                   Kokkos::View<typename test_view_type::data_type,
                                 typename test_view_type::array_layout,
                                 typename test_view_type::device_type,
                                 Kokkos::Experimental::SubscribableViewHooks<

--- a/core/unit_test/TestViewHooks.hpp
+++ b/core/unit_test/TestViewHooks.hpp
@@ -54,7 +54,10 @@ struct TestSubscriber {
 
 namespace TestADLViewHookCustomization {
 template <typename DeviceType>
-class TestMemSpace : public DeviceType::memory_space {};
+class TestMemSpace : public DeviceType::memory_space {
+ public:
+  using memory_space = TestMemSpace;
+};
 
 template <typename DeviceType>
 using TestDevice = Kokkos::Device<typename DeviceType::execution_space,
@@ -63,13 +66,16 @@ using TestDevice = Kokkos::Device<typename DeviceType::execution_space,
 template <class DataType, class... Properties>
 constexpr auto customize_view_hooks() {
   using traits_type = Kokkos::ViewTraits<DataType, Properties...>;
-  return Test::TestSubscriber<typename traits_type::device_type, false>{};
+  return Kokkos::Experimental::SubscribableViewHooks<
+      Test::TestSubscriber<typename traits_type::device_type, false>>{};
 }
 }  // namespace TestADLViewHookCustomization
 
 namespace Test {
 template <class DeviceType>
 struct TestViewHooks {
+  static_assert(Kokkos::is_memory_space_v<
+                TestADLViewHookCustomization::TestMemSpace<DeviceType>>);
   using subscriber_type = TestSubscriber<DeviceType, true>;
   using test_view_type  = typename subscriber_type::test_view_type;
 
@@ -82,6 +88,14 @@ struct TestViewHooks {
       Kokkos::Experimental::is_hooks_policy<
           Kokkos::Experimental::SubscribableViewHooks<subscriber_type>>::value,
       "Must be a hooks policy");
+  static_assert(
+      std::same_as<typename test_view_type::array_type,
+                   Kokkos::View<typename test_view_type::scalar_array_type,
+                                typename test_view_type::array_layout,
+                                typename test_view_type::device_type,
+                                Kokkos::Experimental::SubscribableViewHooks<
+                                    subscriber_type>,
+                                typename test_view_type::memory_traits>>);
 
   static void testViewHooksCopyConstruct() {
     subscriber_type::reset();

--- a/core/unit_test/TestViewTypedefs.cpp
+++ b/core/unit_test/TestViewTypedefs.cpp
@@ -54,6 +54,7 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::const_data_type, typename data_analysis<DataType>::const_data_type>);
   static_assert(std::is_same_v<typename ViewType::non_const_data_type, typename data_analysis<DataType>::non_const_data_type>);
 
+
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   // FIXME: these should be deprecated and for proper testing (I.e. where this is different from data_type)
   // we would need ensemble types which use the hidden View dimension facility of View (i.e. which make
@@ -87,12 +88,12 @@ constexpr bool test_view_typedefs_impl() {
   static_assert(std::is_same_v<typename ViewType::memory_traits, MemoryTraitsType>);
   static_assert(std::is_same_v<typename ViewType::host_mirror_space, HostMirrorSpace>);
   static_assert(std::is_same_v<typename ViewType::size_type, typename ViewType::memory_space::size_type>);
- 
+
   // FIXME: should be deprecated in favor of reference
   static_assert(std::is_same_v<typename ViewType::reference_type, ReferenceType>);
   // FIXME: should be deprecated in favor of data_handle_type
   static_assert(std::is_same_v<typename ViewType::pointer_type, ValueType*>);
- 
+
   // =========================================
   // in Legacy View: some helper View variants
   // =========================================
@@ -107,21 +108,18 @@ KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 #endif
   static_assert(std::is_same_v<typename ViewType::type,
                                Kokkos::View<typename ViewType::data_type, typename ViewType::array_layout,
-                                            typename ViewType::device_type, typename ViewTraitsType::hooks_policy,
+                                            typename ViewType::device_type,
                                             typename ViewType::memory_traits>>);
   static_assert(std::is_same_v<typename ViewType::const_type,
                                Kokkos::View<typename ViewType::const_data_type, typename ViewType::array_layout,
-                                            typename ViewType::device_type, typename ViewTraitsType::hooks_policy,
-                                            typename ViewType::memory_traits>>);
+                                            typename ViewType::device_type, typename ViewType::memory_traits>>);
   static_assert(std::is_same_v<typename ViewType::non_const_type,
                                Kokkos::View<typename ViewType::non_const_data_type, typename ViewType::array_layout,
-                                            typename ViewType::device_type, typename ViewTraitsType::hooks_policy,
-                                            typename ViewType::memory_traits>>);
+                                            typename ViewType::device_type, typename ViewType::memory_traits>>);
   static_assert(std::is_same_v<typename ViewType::host_mirror_type,
                                Kokkos::View<typename ViewType::non_const_data_type, typename ViewType::array_layout,
                                             Kokkos::Device<Kokkos::DefaultHostExecutionSpace,
-                                                           typename ViewType::host_mirror_space::memory_space>,
-                                            typename ViewTraitsType::hooks_policy>>);
+                                                           typename ViewType::host_mirror_space::memory_space>>>);
 
   using uniform_layout_type = std::conditional_t<ViewType::rank()==0 || (ViewType::rank()==0 &&
                                                  std::is_same_v<Layout, Kokkos::LayoutRight>),

--- a/core/unit_test/TestViewTypedefs.cpp
+++ b/core/unit_test/TestViewTypedefs.cpp
@@ -102,7 +102,7 @@ constexpr bool test_view_typedefs_impl() {
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
   static_assert(std::is_same_v<typename ViewType::array_type,
                                Kokkos::View<typename ViewType::scalar_array_type, typename ViewType::array_layout,
-                                            typename ViewType::device_type, typename ViewTraitsType::hooks_policy,
+                                            typename ViewType::device_type,
                                             typename ViewType::memory_traits>>);
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 #endif


### PR DESCRIPTION
This PR also adds additional capabilities to the view hooks; `customize_view_hooks` is ADL-found and can be customized to change the behavior of which view hook is used (default is to just use the view hook template argument)

Additionally, the lack of `constexpr` on the empty view hook was likely an oversight previously, so this also fixes that.

This PR removes `Kokkos::Experimental::DefaultViewHooks` and `Kokkos::Experimental::EmptyViewHooks` and replaces them with a `void` type as it is more idiomatic with the rest of our code and works well with the constraints Christian suggested.