### PR TITLE
[skip-ci]: olcf-nightly: Set FF_ENABLE_JOB_CLEANUP variable

### DIFF
--- a/.gitlab/olcf-gitlab-ci.yml
+++ b/.gitlab/olcf-gitlab-ci.yml
@@ -1,3 +1,6 @@
+variables:
+  FF_ENABLE_JOB_CLEANUP: 1
+
 stages:
   - test
   - clean_up


### PR DESCRIPTION
This PR sets the `FF_ENABLE_JOB_CLEANUP` variable for the nightly OLCF tests. This was recommended by OLCF to fix our disk-space issue.