### PR TITLE
Proposed fixes for intel 2025 SYCL

### DIFF
--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -855,7 +855,8 @@ if(KOKKOS_ENABLE_HIP)
 endif()
 
 if(KOKKOS_ENABLE_SYCL)
-  compiler_specific_flags(DEFAULT -fsycl -fno-sycl-id-queries-fit-in-int -fsycl-dead-args-optimization)
+  # extra flags needed for intel 2025, probably not the right place to put them but...
+  compiler_specific_flags(DEFAULT -fsycl -fno-sycl-id-queries-fit-in-int -fsycl-dead-args-optimization -fsycl-targets=spir64_gen -Xs "-device pvc")
   compiler_specific_options(DEFAULT -fsycl-unnamed-lambda)
   if(KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM AND KOKKOS_CXX_COMPILER_VERSION VERSION_LESS 2024.1.0)
     # Before oneAPI 2024.1.0 passing -fno-sycl didn't work properly
@@ -865,7 +866,8 @@ if(KOKKOS_ENABLE_SYCL)
   elseif(KOKKOS_ENABLE_SYCL_RELOCATABLE_DEVICE_CODE)
     compiler_specific_options(DEFAULT -fsycl-rdc)
   else()
-    compiler_specific_options(DEFAULT -fno-sycl-rdc)
+    # intel-oneapi 2025 compiler crashes with this flag defined, comment out
+    #compiler_specific_options(DEFAULT -fno-sycl-rdc)
   endif()
 endif()
 


### PR DESCRIPTION
I've been trying to compile kokkos with the intel 2025 compilers for SYCL backend. I've tried every version of the 2025 intel oneapi containers - analogous to what kokkos uses for testing and always get a compiler failure. Also got the same failure with the spack installs of oneapi. The main issue was the flag "-fno-sycl-rdc". This caused the internal compiler failure.

Also ended up with link failures that are directly addressed at the bottom of this page on intel's site:
https://oneapi-src.github.io/ishmem/compiling_and_running_programs.html

The error is:
```
icpx: warning: linked binaries do not contain expected 'spir64-unknown-unknown' target; found targets: 'spir64_gen-unknown-unknown' [-Wsycl-target]
```

This PR shows what worked for me to get a build going. It's probably not how kokkos wants to fix long term, but maybe this saves you some debug effort.

Another issue: When I try to build with either "-g" or "-O0" on SYCL, the link of the kokkos-kernels library fails as it passes the 2GB limit. There were lots of suggestions online, but none of them worked. One suggestion I could not try required static libraries, but it looks like kokkos-kernels does not allow static libs for the SYCL backend. Will this requirement be removed anytime soon? RDC requires static libs (unless SYCL is different than cuda and hip) and would block porting to SYCL for some applications. Not something we need anytime soon, but was curious about timeline for this.

@ndellingwood @crtrott 