### PR TITLE
[OpenMPTarget] Get rid of outdated macro guards

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsMinMaxElementOps.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsMinMaxElementOps.cpp
@@ -436,8 +436,7 @@ TEST_F(std_algorithms_min_max_element_test,
 }
 #endif
 
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_COMPILER_CLANG) && \
-    (KOKKOS_COMPILER_CLANG >= 1300)
+#if defined(KOKKOS_ENABLE_OPENMPTARGET)
 TEST_F(std_algorithms_min_max_element_test, minmax_element_empty_range) {
   test_minmax_element_empty_range(m_static_view);
   test_minmax_element_empty_range(m_dynamic_view);

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -512,11 +512,7 @@ class TestReduceDynamicView {
 }  // namespace
 
 // FIXME_SYCL
-// FIXME_OPENMPTARGET : The feature works with LLVM/13 on NVIDIA
-// architectures. The jenkins currently tests with LLVM/12.
-#if !defined(KOKKOS_ENABLE_SYCL) &&          \
-    (!defined(KOKKOS_ENABLE_OPENMPTARGET) || \
-     defined(KOKKOS_COMPILER_CLANG) && (KOKKOS_COMPILER_CLANG >= 1300))
+#if !defined(KOKKOS_ENABLE_SYCL)
 TEST(TEST_CATEGORY, int64_t_reduce) {
   TestReduce<int64_t, TEST_EXECSPACE>(0);
   TestReduce<int64_t, TEST_EXECSPACE>(1000000);
@@ -654,10 +650,6 @@ struct FunctorReductionWithLargeIterationCount {
 };
 
 TEST(TEST_CATEGORY, reduction_with_large_iteration_count) {
-  // FIXME_OPENMPTARGET - causes runtime failure with CrayClang compiler
-#if defined(KOKKOS_COMPILER_CRAY_LLVM) && defined(KOKKOS_ENABLE_OPENMPTARGET)
-  GTEST_SKIP() << "known to fail with OpenMPTarget+Cray LLVM";
-#endif
   if constexpr (std::is_same_v<typename TEST_EXECSPACE::memory_space,
                                Kokkos::HostSpace>) {
     GTEST_SKIP() << "Disabling for host backends";

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -1584,16 +1584,8 @@ struct TestReducers {
 #endif
 // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
 #if !defined(KOKKOS_ENABLE_OPENACC)
-// FIXME_OPENMPTARGET - The minmaxloc test fails llvm < 13 version,
-// test_minmaxloc_2d requires custom reductions
-#if defined(KOKKOS_ENABLE_OPENMPTARGET)
-#if defined(KOKKOS_COMPILER_CLANG) && (KOKKOS_COMPILER_CLANG >= 1300) && \
-    (KOKKOS_COMPILER_CLANG <= 1700)
+#if defined(KOKKOS_ENABLE_OPENMPTARGET)  // FIXME_OPENMPTARGET custom reducers
     test_minmaxloc(10007);
-#else
-    if (!std::is_same_v<ExecSpace, Kokkos::Experimental::OpenMPTarget>)
-      test_minmaxloc(10007);
-#endif
 #else
     test_minmaxloc(10007);
     test_minmaxloc_loc_init(3);
@@ -1640,15 +1632,8 @@ struct TestReducers {
 #endif
 // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
 #if !defined(KOKKOS_ENABLE_OPENACC)
-// FIXME_OPENMPTARGET - The minmaxloc test fails llvm < 13 version,
-// the minmaxloc_2d test requires custom reductions.
-#if defined(KOKKOS_ENABLE_OPENMPTARGET)
-#if defined(KOKKOS_COMPILER_CLANG) && (KOKKOS_COMPILER_CLANG >= 1300)
+#if defined(KOKKOS_ENABLE_OPENMPTARGET)  // FIXME_OPENMPTARGET custom reducers
     test_minmaxloc(10007);
-#else
-    if (!std::is_same_v<ExecSpace, Kokkos::Experimental::OpenMPTarget>)
-      test_minmaxloc(10007);
-#endif
 #else
     test_minmaxloc(10007);
     test_minmaxloc_loc_init(3);


### PR DESCRIPTION
We only support recent LLVM/Clang versions