### PR TITLE
Deprecate `Experimental::ErrorReporter`

### DIFF
--- a/containers/src/Kokkos_ErrorReporter.hpp
+++ b/containers/src/Kokkos_ErrorReporter.hpp
@@ -26,11 +26,13 @@
 #include <Kokkos_View.hpp>
 #include <Kokkos_DualView.hpp>
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+
 namespace Kokkos {
 namespace Experimental {
 
 template <typename ReportType, typename DeviceType>
-class ErrorReporter {
+class KOKKOS_DEPRECATED ErrorReporter {
  public:
   using report_type     = ReportType;
   using device_type     = DeviceType;
@@ -167,6 +169,8 @@ void ErrorReporter<ReportType, DeviceType>::resize(const size_t new_size) {
 
 }  // namespace Experimental
 }  // namespace Kokkos
+
+#endif  // KOKKOS_ENABLE_DEPRECATED_CODE_4
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_ERRORREPORTER
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE

--- a/containers/src/Kokkos_ErrorReporter.hpp
+++ b/containers/src/Kokkos_ErrorReporter.hpp
@@ -90,6 +90,12 @@ class KOKKOS_DEPRECATED ErrorReporter {
   Kokkos::DualView<int *, device_type> m_reporters;
 };
 
+#ifdef KOKKOS_COMPILER_GNU
+// g++ raises deprecated declaration warnings on the out-of-class
+// implementations of the various member functions below
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
+#endif
+
 template <typename ReportType, typename DeviceType>
 inline int ErrorReporter<ReportType, DeviceType>::getNumReports() {
   int num_reports = 0;
@@ -166,6 +172,10 @@ void ErrorReporter<ReportType, DeviceType>::resize(const size_t new_size) {
   typename DeviceType::execution_space().fence(
       "Kokkos::Experimental::ErrorReporter::resize: fence after resizing");
 }
+
+#ifdef KOKKOS_COMPILER_GNU
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+#endif
 
 }  // namespace Experimental
 }  // namespace Kokkos

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -11,7 +11,7 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
     set(UnitTestSources UnitTestMain.cpp)
     set(dir ${CMAKE_CURRENT_BINARY_DIR}/${dir})
     file(MAKE_DIRECTORY ${dir})
-    set(DeprecatedTests Vector StaticCrsGraph)
+    set(DeprecatedTests ErrorReporter Vector StaticCrsGraph)
     foreach(
       Name
       Bitset

--- a/containers/unit_tests/TestErrorReporter.hpp
+++ b/containers/unit_tests/TestErrorReporter.hpp
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 #include <iostream>
 #include <Kokkos_Core.hpp>
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
 #include <Kokkos_ErrorReporter.hpp>
 
 namespace Test {


### PR DESCRIPTION
I propose to deprecate on the grounds that it is a somewhat obscure experimental feature, that it is a misfit in the Containers sub package and that the only known downstream usage is in Trilinos/STK which means we are able to reach out and help find a transition path.
It is mentioned in the documentation https://kokkos.org/kokkos-core-wiki/API/alphabetical.html#containers but there is no entry for it.

I searched for "Experimental::ErrorReporter" on GH and could only find one use in Trilinos, as a utility in the STK unit tests.
https://github.com/trilinos/Trilinos/blob/6cc989ed39a87da3990d10fca611b69b7e91c4ef/packages/stk/stk_ngp_test/stk_ngp_test/Reporter.hpp#L84
