### PR TITLE
core(graph): add vendor node

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -10,12 +10,14 @@
 
 #include <Kokkos_Graph_fwd.hpp>
 
+#include <impl/Kokkos_DeviceHandle.hpp>
 #include <impl/Kokkos_GraphImpl.hpp>  // GraphAccess needs to be complete
 
 #include <Kokkos_Parallel.hpp>
 #include <Kokkos_Parallel_Reduce.hpp>
 
 #include <Cuda/Kokkos_Cuda.hpp>
+#include <Cuda/Kokkos_Cuda_Instance.hpp>
 
 namespace Kokkos {
 namespace Impl {
@@ -39,6 +41,24 @@ struct GraphNodeThenHostImpl<Kokkos::Cuda, Functor> {
 
     KOKKOS_IMPL_CUDA_SAFE_CALL(
         cudaGraphAddHostNode(&m_node, graph, nullptr, 0, &params));
+  }
+};
+
+template <typename Functor>
+struct GraphNodeThenNativeImpl<Kokkos::Cuda, Functor> {
+  Functor m_functor;
+  cudaGraphNode_t m_node = nullptr;
+
+  explicit GraphNodeThenNativeImpl(Functor functor)
+      : m_functor(std::move(functor)) {}
+
+  void add_to_graph(
+      const Kokkos::Impl::DeviceHandle<Kokkos::Cuda>& device_handle,
+      cudaGraph_t graph) {
+    cudaGraphNodeParams params = m_functor();
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        device_handle.m_exec.impl_internal_space_instance()
+            ->cuda_graph_add_node_wrapper(&m_node, graph, nullptr, 0, &params));
   }
 };
 

--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -144,6 +144,22 @@ struct GraphImpl<Kokkos::Cuda> {
 
   template <class NodeImpl>
   std::enable_if_t<
+      Kokkos::Impl::is_graph_then_native_v<typename NodeImpl::kernel_type>>
+  add_node(const device_handle_t& device_handle,
+           std::shared_ptr<NodeImpl> arg_node_ptr) {
+    static_assert(
+        Kokkos::Impl::is_specialization_of_v<NodeImpl, GraphNodeImpl>);
+    KOKKOS_EXPECTS(bool(arg_node_ptr));
+
+    auto& kernel = arg_node_ptr->get_kernel();
+    kernel.add_to_graph(device_handle, m_graph);
+    static_cast<node_details_t*>(arg_node_ptr.get())->node = kernel.m_node;
+
+    m_nodes.push_back(std::move(arg_node_ptr));
+  }
+
+  template <class NodeImpl>
+  std::enable_if_t<
       Kokkos::Impl::is_graph_then_host_v<typename NodeImpl::kernel_type>>
   add_node(std::shared_ptr<NodeImpl> arg_node_ptr) {
     static_assert(

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -217,6 +217,20 @@ class CudaInternal {
                                   numDependencies, pNodeParams);
   }
 
+  cudaError_t cuda_graph_add_node_wrapper(
+      cudaGraphNode_t* pGraphNode, cudaGraph_t graph,
+      const cudaGraphNode_t* pDependencies, size_t numDependencies,
+      cudaGraphNodeParams* pNodeParams) const {
+    set_cuda_device();
+#if CUDART_VERSION >= 13000
+    return cudaGraphAddNode(pGraphNode, graph, pDependencies, nullptr,
+                            numDependencies, pNodeParams);
+#else
+    return cudaGraphAddNode(pGraphNode, graph, pDependencies, numDependencies,
+                            pNodeParams);
+#endif
+  }
+
   cudaError_t cuda_graph_create_wrapper(cudaGraph_t* pGraph,
                                         unsigned int flags) const {
     set_cuda_device();

--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -6,12 +6,14 @@
 
 #include <Kokkos_Graph_fwd.hpp>
 
+#include <impl/Kokkos_DeviceHandle.hpp>
 #include <impl/Kokkos_GraphImpl.hpp>
 
 #include <Kokkos_Parallel.hpp>
 #include <Kokkos_Parallel_Reduce.hpp>
 
 #include <HIP/Kokkos_HIP_GraphNode_Impl.hpp>
+#include <HIP/Kokkos_HIP_Instance.hpp>
 
 namespace Kokkos {
 namespace Impl {
@@ -35,6 +37,24 @@ struct GraphNodeThenHostImpl<Kokkos::HIP, Functor> {
 
     KOKKOS_IMPL_HIP_SAFE_CALL(
         hipGraphAddHostNode(&m_node, graph, nullptr, 0, &params));
+  }
+};
+
+template <typename Functor>
+struct GraphNodeThenNativeImpl<Kokkos::HIP, Functor> {
+  Functor m_functor;
+  hipGraphNode_t m_node = nullptr;
+
+  explicit GraphNodeThenNativeImpl(Functor functor)
+      : m_functor(std::move(functor)) {}
+
+  void add_to_graph(
+      const Kokkos::Impl::DeviceHandle<Kokkos::HIP>& device_handle,
+      hipGraph_t graph) {
+    hipGraphNodeParams params = m_functor();
+    KOKKOS_IMPL_HIP_SAFE_CALL(
+        device_handle.m_exec.impl_internal_space_instance()
+            ->hip_graph_add_node_wrapper(&m_node, graph, nullptr, 0, &params));
   }
 };
 

--- a/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
@@ -55,6 +55,12 @@ class GraphImpl<Kokkos::HIP> {
 
   template <class NodeImpl>
   std::enable_if_t<
+      Kokkos::Impl::is_graph_then_native_v<typename NodeImpl::kernel_type>>
+  add_node(const device_handle_t& device_handle,
+           std::shared_ptr<NodeImpl> arg_node_ptr);
+
+  template <class NodeImpl>
+  std::enable_if_t<
       Kokkos::Impl::is_graph_then_host_v<typename NodeImpl::kernel_type>>
   add_node(std::shared_ptr<NodeImpl> arg_node_ptr);
 
@@ -161,6 +167,21 @@ GraphImpl<Kokkos::HIP>::add_node(const Kokkos::HIP& exec,
 
   auto& kernel = arg_node_ptr->get_kernel();
   kernel.capture(exec, m_graph);
+  static_cast<node_details_t*>(arg_node_ptr.get())->node = kernel.m_node;
+
+  m_nodes.push_back(std::move(arg_node_ptr));
+}
+
+template <class NodeImpl>
+inline std::enable_if_t<
+    Kokkos::Impl::is_graph_then_native_v<typename NodeImpl::kernel_type>>
+GraphImpl<Kokkos::HIP>::add_node(const device_handle_t& device_handle,
+                                 std::shared_ptr<NodeImpl> arg_node_ptr) {
+  static_assert(Kokkos::Impl::is_specialization_of_v<NodeImpl, GraphNodeImpl>);
+  KOKKOS_EXPECTS(bool(arg_node_ptr));
+
+  auto& kernel = arg_node_ptr->get_kernel();
+  kernel.add_to_graph(device_handle, m_graph);
   static_cast<node_details_t*>(arg_node_ptr.get())->node = kernel.m_node;
 
   m_nodes.push_back(std::move(arg_node_ptr));

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -249,6 +249,16 @@ class HIPInternal {
                                  numDependencies, pNodeParams);
   }
 
+  hipError_t hip_graph_add_node_wrapper(hipGraphNode_t *pGraphNode,
+                                        hipGraph_t graph,
+                                        const hipGraphNode_t *pDependencies,
+                                        size_t numDependencies,
+                                        hipGraphNodeParams *pNodeParams) const {
+    set_hip_device();
+    return hipGraphAddNode(pGraphNode, graph, pDependencies, numDependencies,
+                           pNodeParams);
+  }
+
   hipError_t hip_graph_create_wrapper(hipGraph_t *pGraph,
                                       unsigned int flags) const {
     set_hip_device();

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -55,7 +55,8 @@ class GraphNodeRef {
   static_assert(std::is_same_v<Predecessor, TypeErasedTag> ||
                     Kokkos::Impl::is_graph_kernel<Kernel>::value ||
                     Kokkos::Impl::is_graph_capture_v<Kernel> ||
-                    Kokkos::Impl::is_graph_then_host_v<Kernel>,
+                    Kokkos::Impl::is_graph_then_host_v<Kernel> ||
+                    Kokkos::Impl::is_graph_then_native_v<Kernel>,
                 "Invalid kernel template parameter given to GraphNodeRef");
 
   static_assert(!Kokkos::Impl::is_more_type_erased<Kernel, Predecessor>::value,
@@ -347,6 +348,58 @@ class GraphNodeRef {
         std::static_pointer_cast<node_details_t>(m_node_impl)->node;
     KOKKOS_EXPECTS(impl.has_value());
     return *impl;  // NOLINT(bugprone-unchecked-optional-access)
+  }
+#endif
+
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
+    (defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_SYCL_GRAPH_SUPPORT))
+  template <typename Props, typename Functor>
+    requires Kokkos::Impl::NodeProperties<std::remove_cvref_t<Props>>
+#if defined(KOKKOS_ENABLE_CUDA)
+  auto then_cuda_node(Props&& props, Functor&& functor) const {
+    if constexpr (std::same_as<ExecutionSpace, Kokkos::Cuda>) {
+      static_assert(std::is_invocable_r_v<cudaGraphNodeParams,
+                                          const std::remove_cvref_t<Functor>>);
+#elif defined(KOKKOS_ENABLE_HIP)
+  auto then_hip_node(Props&& props, Functor&& functor) const {
+    if constexpr (std::same_as<ExecutionSpace, Kokkos::HIP>) {
+      static_assert(std::is_invocable_r_v<hipGraphNodeParams,
+                                          const std::remove_cvref_t<Functor>>);
+#elif defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_SYCL_GRAPH_SUPPORT)
+  auto then_sycl_node(Props&& props, Functor&& functor) const {
+    if constexpr (std::same_as<ExecutionSpace, Kokkos::SYCL>) {
+      static_assert(requires(const std::remove_cvref_t<Functor>& func) {
+        { func() } -> std::invocable<sycl::handler&>;
+      });
+#endif
+      using then_native_t =
+          Kokkos::Impl::GraphNodeThenNativeImpl<ExecutionSpace,
+                                                std::remove_cvref_t<Functor>>;
+      using return_t =
+          GraphNodeRef<ExecutionSpace, then_native_t, GraphNodeRef>;
+      auto graph_ptr = m_graph_impl.lock();
+      KOKKOS_EXPECTS(bool(graph_ptr))
+
+      auto rv = Kokkos::Impl::GraphAccess::make_graph_node_ref(
+          m_graph_impl,
+          Kokkos::Impl::GraphAccess::make_node_shared_ptr<
+              typename return_t::node_impl_t>(
+              m_node_impl->get_device_handle(),
+              Kokkos::Impl::_graph_node_native_ctor_tag{},
+              std::forward<Functor>(functor),
+              Kokkos::Impl::_graph_node_predecessor_ctor_tag{}, *this));
+
+      // Add the node itself to the backend's graph data structure, now that
+      // everything is set up.
+      graph_ptr->add_node(Kokkos::Impl::extract_property_or<device_handle_t>(
+                              props, graph_ptr->get_device_handle()),
+                          rv.m_node_impl);
+      // Add the predecessor we stored in the constructor above in the
+      // backend's data structure, now that everything is set up.
+      graph_ptr->add_predecessor(rv.m_node_impl, *this);
+      KOKKOS_ENSURES(bool(rv.m_node_impl))
+      return rv;
+    }
   }
 #endif
 

--- a/core/src/Kokkos_Graph_fwd.hpp
+++ b/core/src/Kokkos_Graph_fwd.hpp
@@ -28,6 +28,7 @@ enum class GraphNodeKind : std::uint8_t {
   Aggregate,
   Host,
   Capture,
+  Native
 };
 
 template <Kokkos::ExecutionSpace ExecutionSpace, class Kernel = TypeErasedTag,

--- a/core/src/SYCL/Kokkos_SYCL_GraphNodeKernel.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_GraphNodeKernel.hpp
@@ -6,6 +6,7 @@
 
 #include <Kokkos_Graph_fwd.hpp>
 
+#include <impl/Kokkos_DeviceHandle.hpp>
 #include <impl/Kokkos_GraphImpl.hpp>
 
 #include <Kokkos_Parallel.hpp>
@@ -32,14 +33,32 @@ struct GraphNodeThenHostImpl<Kokkos::SYCL, Functor> {
       : m_functor{std::move(functor)} {}
 
   void add_to_graph(sycl_graph_t& graph) {
-    KOKKOS_ENSURES(!m_node);
-    KOKKOS_ENSURES(m_functor.has_value());
+    KOKKOS_EXPECTS(!m_node.has_value());
+    KOKKOS_EXPECTS(m_functor.has_value());
     m_node = graph.add([&](sycl::handler& cgh) {
       // The functor is passed through as universal reference and can thus be
       // moved. See also
       // https://github.com/intel/llvm/blob/d33426f92e885dce30700b7327a44e039d656962/sycl/include/sycl/handler.hpp#L1942-L1949.
       cgh.host_task(*std::exchange(m_functor, std::nullopt));
     });
+  }
+};
+
+// Inspired by
+// https://github.com/intel/llvm/blob/1d5eac36b4b696aaf6d0842cc05ae36be09f99bc/sycl/include/sycl/ext/oneapi/experimental/graph/modifiable_graph.hpp#L90.
+template <typename Functor>
+struct GraphNodeThenNativeImpl<Kokkos::SYCL, Functor> {
+  using sycl_graph_t = sycl::ext::oneapi::experimental::command_graph<
+      sycl::ext::oneapi::experimental::graph_state::modifiable>;
+
+  Functor m_functor;
+  std::optional<sycl::ext::oneapi::experimental::node> m_node = std::nullopt;
+
+  // FIXME_SYCL Use the device handle for device selection.
+  void add_to_graph(const Kokkos::Impl::DeviceHandle<Kokkos::SYCL>&,
+                    sycl_graph_t& graph) {
+    KOKKOS_EXPECTS(!m_node.has_value());
+    m_node = graph.add(m_functor());
   }
 };
 
@@ -171,12 +190,11 @@ void sycl_attach_kernel_to_node(Kernel& kernel, const Lambda& lambda) {
       Impl::get_sycl_graph_from_kernel(kernel);
   std::optional<sycl::ext::oneapi::experimental::node>& graph_node =
       Impl::get_sycl_graph_node_from_kernel(kernel);
-  KOKKOS_ENSURES(!graph_node);
+  KOKKOS_EXPECTS(!graph_node);
   graph_node = graph.add(lambda);
   KOKKOS_ENSURES(graph_node);
-  // FIXME_SYCL_GRAPH not yet implemented in the compiler
-  //   KOKKOS_ENSURES(graph_node.get_type() ==
-  //   sycl::ext::oneapi::experimental::node_type::kernel)
+  KOKKOS_ENSURES(graph_node->get_type() ==
+                 sycl::ext::oneapi::experimental::node_type::kernel);
 }
 
 }  // namespace Impl

--- a/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
@@ -57,6 +57,12 @@ class GraphImpl<Kokkos::SYCL> {
 
   template <class NodeImpl>
   std::enable_if_t<
+      Kokkos::Impl::is_graph_then_native_v<typename NodeImpl::kernel_type>>
+  add_node(const device_handle_t& device_handle,
+           std::shared_ptr<NodeImpl> arg_node_ptr);
+
+  template <class NodeImpl>
+  std::enable_if_t<
       Kokkos::Impl::is_graph_then_host_v<typename NodeImpl::kernel_type>>
   add_node(std::shared_ptr<NodeImpl> arg_node_ptr);
 
@@ -128,6 +134,21 @@ GraphImpl<Kokkos::SYCL>::add_node(std::shared_ptr<NodeImpl> arg_node_ptr) {
   kernel.set_sycl_graph_node_ptr(&node);
   kernel.execute();
   KOKKOS_ENSURES(node);
+  m_nodes.push_back(std::move(arg_node_ptr));
+}
+
+template <class NodeImpl>
+inline std::enable_if_t<
+    Kokkos::Impl::is_graph_then_native_v<typename NodeImpl::kernel_type>>
+GraphImpl<Kokkos::SYCL>::add_node(const device_handle_t& device_handle,
+                                  std::shared_ptr<NodeImpl> arg_node_ptr) {
+  static_assert(Kokkos::Impl::is_specialization_of_v<NodeImpl, GraphNodeImpl>);
+  KOKKOS_EXPECTS(bool(arg_node_ptr));
+
+  auto& kernel = arg_node_ptr->get_kernel();
+  kernel.add_to_graph(device_handle, m_graph);
+  static_cast<node_details_t*>(arg_node_ptr.get())->node = kernel.m_node;
+
   m_nodes.push_back(std::move(arg_node_ptr));
 }
 

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -39,6 +39,12 @@ struct is_graph_then_host<
            Kokkos::Impl::is_specialization_of_v<T, GraphNodeThenHostImpl>>>
     : public std::true_type {};
 
+template <typename T>
+struct is_graph_then_native<
+    T, std::enable_if_t<
+           Kokkos::Impl::is_specialization_of_v<T, GraphNodeThenNativeImpl>>>
+    : public std::true_type {};
+
 struct GraphAccess {
   template <class NodeType, class... Args>
   static auto make_node_shared_ptr(Args&&... args) {

--- a/core/src/impl/Kokkos_GraphImpl_fwd.hpp
+++ b/core/src/impl/Kokkos_GraphImpl_fwd.hpp
@@ -34,17 +34,27 @@ inline constexpr bool is_graph_capture_v = is_graph_capture<T>::value;
 template <typename ExecutionSpace, typename Functor>
 struct GraphNodeThenHostImpl;
 
+template <typename ExecutionSpace, typename Functor>
+struct GraphNodeThenNativeImpl;
+
 template <typename T, class Enable = void>
 struct is_graph_then_host : public std::false_type {};
 
 template <typename T>
 inline constexpr bool is_graph_then_host_v = is_graph_then_host<T>::value;
 
+template <typename T, class Enable = void>
+struct is_graph_then_native : public std::false_type {};
+
+template <typename T>
+inline constexpr bool is_graph_then_native_v = is_graph_then_native<T>::value;
+
 struct _graph_node_kernel_ctor_tag {};
 struct _graph_node_capture_ctor_tag {};
 struct _graph_node_predecessor_ctor_tag {};
 struct _graph_node_is_root_ctor_tag {};
 struct _graph_node_host_ctor_tag {};
+struct _graph_node_native_ctor_tag {};
 
 struct GraphAccess;
 

--- a/core/src/impl/Kokkos_GraphNodeCtorProps.hpp
+++ b/core/src/impl/Kokkos_GraphNodeCtorProps.hpp
@@ -90,6 +90,20 @@ has<Prop> [[nodiscard]] constexpr decltype(auto) extract_property(
   return std::move(static_cast<NodeCtorProp<Prop>&>(props).m_value);
 }
 
+template <typename Prop, NodeProperties Props>
+  requires Props::template
+has<Prop> [[nodiscard]] constexpr decltype(auto) extract_property_or(
+    Props& props, const Prop&) {
+  return extract_property<Prop>(props);
+}
+
+template <typename Prop, NodeProperties Props, typename T>
+  requires(!Props::template has<std::remove_cvref_t<Prop>> &&
+           std::convertible_to<T, Prop>)
+[[nodiscard]] constexpr decltype(auto) extract_property_or(Props&, T&& prop) {
+  return std::forward<T>(prop);
+}
+
 struct WithProperty {
   template <typename... Props, typename Property>
     requires(sizeof...(Props) > 0)

--- a/core/src/impl/Kokkos_GraphNodeImpl.hpp
+++ b/core/src/impl/Kokkos_GraphNodeImpl.hpp
@@ -134,7 +134,8 @@ struct GraphNodeImpl<ExecutionSpace, Kernel,
             typename = std::enable_if_t<
                 std::is_same_v<Tag, _graph_node_kernel_ctor_tag> ||
                 std::is_same_v<Tag, _graph_node_capture_ctor_tag> ||
-                std::is_same_v<Tag, _graph_node_host_ctor_tag>>>
+                std::same_as<Tag, _graph_node_host_ctor_tag> ||
+                std::same_as<Tag, _graph_node_native_ctor_tag>>>
   GraphNodeImpl(device_handle_t const& device_handle, Tag,
                 KernelDeduced&& arg_kernel)
       : base_t(device_handle), m_kernel{(KernelDeduced&&)arg_kernel} {}
@@ -179,6 +180,8 @@ struct GraphNodeImpl<ExecutionSpace, Kernel,
       return Experimental::GraphNodeKind::Capture;
     } else if constexpr (is_graph_then_host_v<kernel_type>) {
       return Experimental::GraphNodeKind::Host;
+    } else if constexpr (is_graph_then_native_v<kernel_type>) {
+      return Experimental::GraphNodeKind::Native;
     } else {
       return Experimental::GraphNodeKind::Aggregate;
     }
@@ -249,7 +252,8 @@ struct GraphNodeImpl
             typename = std::enable_if_t<
                 std::is_same_v<Tag, _graph_node_kernel_ctor_tag> ||
                 std::is_same_v<Tag, _graph_node_capture_ctor_tag> ||
-                std::is_same_v<Tag, _graph_node_host_ctor_tag>>>
+                std::same_as<Tag, _graph_node_host_ctor_tag> ||
+                std::same_as<Tag, _graph_node_native_ctor_tag>>>
   GraphNodeImpl(device_handle_t const& device_handle, Tag,
                 KernelDeduced&& arg_kernel, _graph_node_predecessor_ctor_tag,
                 PredecessorPtrDeduced&& arg_predecessor)

--- a/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
@@ -213,6 +213,64 @@ TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), interact_with_cuda_node) {
   ASSERT_EQ(data(), 5);
 #endif
 }
+
+template <typename ViewType>
+struct CheckValue {
+  typename ViewType::const_type data;
+  typename ViewType::non_const_value_type value;
+
+  KOKKOS_FUNCTION
+  void operator()() const {
+    if (data() != value) Kokkos::abort("Wrong value.");
+  }
+};
+
+template <typename ViewType>
+struct CustomCudaNode {
+  typename ViewType::const_type data;
+
+  auto operator()() const noexcept {
+    cudaGraphNodeParams params = {};
+    params.type                = cudaGraphNodeTypeMemset;
+    params.memset.dst =
+        const_cast<void*>(static_cast<const void*>(this->data.data()));
+    params.memset.pitch       = 0;
+    params.memset.value       = 42;
+    params.memset.elementSize = 4;
+    params.memset.width       = 1;
+    params.memset.height      = 1;
+    return params;
+  }
+};
+
+// Add a CUDA memset node using the CUDA graph node interoperability
+// feature.
+TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), then_cuda_node) {
+  graph_t graph_with_cuda_node{
+      Kokkos::Experimental::get_device_handle(this->exec)};
+
+  const auto node_check_zero = graph_with_cuda_node.root_node().then(
+      Kokkos::Experimental::node_props("check it is zero"),
+      CheckValue<view_t>{.data = this->data, .value = 0});
+
+  ASSERT_EQ(this->data.use_count(), 2);
+  const auto node_memset = node_check_zero.then_cuda_node(
+      Kokkos::Experimental::node_props("nice interop"),
+      CustomCudaNode<view_t>{.data = data});
+  ASSERT_EQ(this->data.use_count(), 3);
+
+  ASSERT_EQ(node_memset.get_node_kind(),
+            Kokkos::Experimental::GraphNodeKind::Native);
+
+  const auto node_incr = node_memset.then_parallel_for(
+      Kokkos::RangePolicy(this->exec, 0, 1), Increment{.data = this->data});
+
+  graph_with_cuda_node.submit(exec);
+
+  exec.fence();
+
+  ASSERT_EQ(data(), 43);
+}
 // NOLINTEND(bugprone-unchecked-optional-access)
 
 }  // namespace

--- a/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
@@ -164,4 +164,68 @@ TEST(TEST_CATEGORY, interact_with_hip_node) {
   ASSERT_EQ(data(), 2);
 }
 
+template <typename ViewType>
+struct CheckValue {
+  typename ViewType::const_type data;
+  typename ViewType::non_const_value_type value;
+
+  KOKKOS_FUNCTION
+  void operator()() const {
+    if (data() != value) Kokkos::abort("Wrong value.");
+  }
+};
+
+template <typename ViewType>
+struct CustomHIPNode {
+  typename ViewType::const_type data;
+
+  auto operator()() const noexcept {
+    hipGraphNodeParams params = {};
+    params.type               = hipGraphNodeTypeMemset;
+    params.memset.dst =
+        const_cast<void*>(static_cast<const void*>(this->data.data()));
+    params.memset.pitch       = 0;
+    params.memset.value       = 42;
+    params.memset.elementSize = 4;
+    params.memset.width       = 1;
+    params.memset.height      = 1;
+    return params;
+  }
+};
+
+// Add a HIP memset node using the HIP graph node interoperability
+// feature.
+TEST(TEST_CATEGORY, graph_then_hip_node) {
+  const Kokkos::HIP exec{};
+
+  using view_t = Kokkos::View<int, Kokkos::HIPManagedSpace>;
+
+  const view_t data(Kokkos::view_alloc(exec, "witness"));
+
+  Kokkos::Experimental::Graph graph_with_hip_node{
+      Kokkos::Experimental::get_device_handle(exec)};
+
+  const auto node_check_zero = graph_with_hip_node.root_node().then(
+      Kokkos::Experimental::node_props("check it is zero"),
+      CheckValue<view_t>{.data = data, .value = 0});
+
+  ASSERT_EQ(data.use_count(), 2);
+  const auto node_memset = node_check_zero.then_hip_node(
+      Kokkos::Experimental::node_props("nice interop"),
+      CustomHIPNode<view_t>{.data = data});
+  ASSERT_EQ(data.use_count(), 3);
+
+  ASSERT_EQ(node_memset.get_node_kind(),
+            Kokkos::Experimental::GraphNodeKind::Native);
+
+  const auto node_incr = node_memset.then_parallel_for(
+      Kokkos::RangePolicy(exec, 0, 1), Increment{.data = data});
+
+  graph_with_hip_node.submit(exec);
+
+  exec.fence();
+
+  ASSERT_EQ(data(), 43);
+}
+
 }  // namespace

--- a/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
@@ -192,4 +192,60 @@ TEST(TEST_CATEGORY, interact_with_sycl_node) {
 #endif
 }
 
+template <typename ViewType>
+struct CheckValue {
+  typename ViewType::const_type data;
+  typename ViewType::non_const_value_type value;
+
+  KOKKOS_FUNCTION
+  void operator()() const {
+    if (data() != value) Kokkos::abort("Wrong value.");
+  }
+};
+
+template <typename ViewType>
+struct CustomSYCLNode {
+  typename ViewType::non_const_type data;
+
+  auto operator()() const noexcept {
+    return [ptr = data.data()](sycl::handler& cgh) {
+      cgh.parallel_for(sycl::range<1>(1), [=](int) { *ptr = 42; });
+    };
+  }
+};
+
+// Add a SYCL node using the SYCL graph node interoperability feature.
+TEST(TEST_CATEGORY, then_sycl_node) {
+  using view_t = Kokkos::View<int, Kokkos::SYCLSharedUSMSpace>;
+
+  const Kokkos::SYCL exec{};
+
+  const view_t data(Kokkos::view_alloc(exec, "witness"));
+
+  Kokkos::Experimental::Graph graph_with_sycl_node{
+      Kokkos::Experimental::get_device_handle(exec)};
+
+  const auto node_check_zero = graph_with_sycl_node.root_node().then(
+      Kokkos::Experimental::node_props("check it is zero"),
+      CheckValue<view_t>{.data = data, .value = 0});
+
+  ASSERT_EQ(data.use_count(), 2);
+  const auto node_memset = node_check_zero.then_sycl_node(
+      Kokkos::Experimental::node_props("nice interop"),
+      CustomSYCLNode<view_t>{.data = data});
+  ASSERT_EQ(data.use_count(), 3);
+
+  ASSERT_EQ(node_memset.get_node_kind(),
+            Kokkos::Experimental::GraphNodeKind::Native);
+
+  const auto node_incr = node_memset.then_parallel_for(
+      Kokkos::RangePolicy(exec, 0, 1), Increment{.data = data});
+
+  graph_with_sycl_node.submit(exec);
+
+  exec.fence();
+
+  ASSERT_EQ(data(), 43);
+}
+
 }  // namespace


### PR DESCRIPTION
This PR adds a new interoperability feature for `Kokkos::Graph`, allowing users to add a vendor-based node to a `Kokkos::Graph`.

For instance, `Kokkos::Graph` does not yet surface a `deep_copy` node or equivalent. Yet, setting device memory to a given value from within the graph is now feasible with `CUDA` memset node (instead of writing a kernel node for this operation).

1. It is an interoperability feature, so the naming is `then_<backend>_node`.
2. I've kept `Native` in the `GraphNodeType` enum to avoid weirdness of some `#ifdef` within the definition of the enum. Though we now prefer to avoid "native", we need a value in the `GraphNodeKind` to represent "this is a backend node". `Native` was the "less worst" choice.
3. The node stores a functor, much like the capture node. The call operator of this functor has to provide either the CUDA/HIP node parameters, or for SYCL returns the command group function. This functor allows users to attach data to the node to extend their lifetime to the one of the graph.