### PR TITLE
core(graph): an aggregate node is awaitable

### DIFF
--- a/core/src/impl/Kokkos_Default_GraphNode_Impl.hpp
+++ b/core/src/impl/Kokkos_Default_GraphNode_Impl.hpp
@@ -91,10 +91,9 @@ struct GraphNodeBackendSpecificDetails {
     m_is_aggregate = true;
   }
 
-  // A node is awaitable if it can execute a kernel.
-  // A root node or an aggregate node cannot be waited for, because it does
-  // not launch anything.
-  bool awaitable() const { return (!m_is_root) && (!m_is_aggregate); }
+  // A node is awaitable if it is not a root node.
+  // Note that an aggregate node is a when_all event that may be waited for.
+  bool awaitable() const { return !m_is_root; }
 
   // Retrieve the execution space instance that has been passed to
   // the kernel at construction phase.


### PR DESCRIPTION
The goal of this PR is to ensure that in the default implementation of the `Kokkos::Graph`, fencing occurs as needed to ensure that dependencies are met when using an aggregate node.

The default implementation fences when the predecessor is awaitable and not on the same execution space instance. Currently, the default implementation considers that an aggregate node is *not* awaitable. However, if an aggregate doesn't fence because of equality of execution space instances, a child node of the aggregate actually may have to fence if it is on a different execution space instance. And so it appears that aggregate nodes must in fact be considered "awaitable".

This PR thus modifies the `awaitable` function so that aggregate nodes are awaitable. The new test illustrates a case in which a child node of an aggregate node needs to fence.

EDIT: Motivated by a failing test seen in our downstream code on HPX. 

Joint work with @romintomasetti. 

