### PR TITLE
Drop Spack workaround overwriting the cxx compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,19 +101,6 @@ if(Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE AND Kokkos_ENABLE_HIP)
   set(KOKKOS_COMPILE_LANGUAGE HIP)
 endif()
 
-if(Spack_WORKAROUND)
-  if(Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE)
-    message(FATAL_ERROR "Can't currently use Kokkos_ENABLE_COMPILER_AS_CMAKE_LANGUAGE in a spack installation!")
-  endif()
-
-  #if we are explicitly using Spack for development,
-  #nuke the Spack compiler
-  set(SPACK_CXX $ENV{SPACK_CXX})
-  if(SPACK_CXX)
-    set(CMAKE_CXX_COMPILER ${SPACK_CXX} CACHE STRING "the C++ compiler" FORCE)
-    set(ENV{CXX} ${SPACK_CXX})
-  endif()
-endif()
 # Always call the project command to define Kokkos_ variables
 # and to make sure that C++ is an enabled language
 project(Kokkos ${KOKKOS_COMPILE_LANGUAGE} ${KOKKOS_INTERNAL_EXTRA_COMPILE_LANGUAGE})


### PR DESCRIPTION
Per discussion on the build and packaging working group channel, this is not wired in on the Spack side and we want to get rid of it.