### PR TITLE
More cleanup enabled by the newer gcc requirement

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -161,8 +161,8 @@
 #define KOKKOS_COMPILER_GNU \
   __GNUC__ * 100 + __GNUC_MINOR__ * 10 + __GNUC_PATCHLEVEL__
 
-#if (820 > KOKKOS_COMPILER_GNU)
-#error "Compiling with GCC version earlier than 8.2.0 is not supported."
+#if (1040 > KOKKOS_COMPILER_GNU)
+#error "Compiling with GCC version earlier than 10.4.0 is not supported."
 #endif
 
 #elif defined(_MSC_VER)

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -34,7 +34,6 @@
 #include <cstdlib>
 #include <stack>
 #include <functional>
-#include <list>
 #include <cerrno>
 #include <random>
 #include <regex>
@@ -51,17 +50,9 @@ bool g_is_initialized      = false;
 bool g_is_finalized        = false;
 bool g_show_warnings       = true;
 bool g_tune_internals      = false;
-// When compiling with clang/LLVM and using the GNU (GCC) C++ Standard Library
-// (any recent version between GCC 7.3 and GCC 9.2), std::deque SEGV's during
-// the unwinding of the atexit(3C) handlers at program termination.  However,
-// this bug is not observable when building with GCC.
-// As an added bonus, std::list<T> provides constant insertion and
-// deletion time complexity, which translates to better run-time performance. As
-// opposed to std::deque<T> which does not provide the same constant time
-// complexity for inserts/removals, since std::deque<T> is implemented as a
-// segmented array.
+
 using hook_function_type = std::function<void()>;
-std::stack<hook_function_type, std::list<hook_function_type>> finalize_hooks;
+std::stack<hook_function_type> finalize_hooks;
 
 /**
  * The category is only used in printing, tools

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -99,13 +99,7 @@ KOKKOS_FUNCTION constexpr bool test_array_aggregate_initialization() {
 
 static_assert(test_array_aggregate_initialization());
 
-// A few compilers, such as GCC 8.4, were erroring out when the function below
-// appeared in a constant expression because
-// Kokkos::Array<T, 0, Proxy>::operator[] is non-constexpr.  The issue
-// disappears with GCC 9.1 (https://godbolt.org/z/TG4TEef1b).  As a workaround,
-// the static_assert was dropped and the [[maybe_unused]] is used as an attempt
-// to silent warnings that the function is never used.
-[[maybe_unused]] KOKKOS_FUNCTION void test_array_zero_sized() {
+KOKKOS_FUNCTION constexpr bool test_array_zero_sized() {
   using T = float;
 
   // The code below must compile for zero-sized arrays.
@@ -114,7 +108,11 @@ static_assert(test_array_aggregate_initialization());
   for (int i = 0; i < N; ++i) {
     a[i] = T();
   }
+
+  return true;
 }
+
+static_assert(test_array_zero_sized());
 
 constexpr bool test_array_const_qualified_element_type() {
   Kokkos::Array<int const, 1> a{255};

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -412,15 +412,9 @@ TEST(TEST_CATEGORY, complex_special_funtions) {
 
 TEST(TEST_CATEGORY, complex_io) { testComplexIO(); }
 
-TEST(TEST_CATEGORY, complex_trivially_copyable) {
-  // Kokkos::complex<RealType> is trivially copyable when RealType is
-  // trivially copyable
-  using RealType = double;
-  // clang claims compatibility with gcc 4.2.1 but all versions tested know
-  // about std::is_trivially_copyable.
-  ASSERT_TRUE(std::is_trivially_copyable_v<Kokkos::complex<RealType>> ||
-              !std::is_trivially_copyable_v<RealType>);
-}
+static_assert(std::is_trivially_copyable_v<Kokkos::complex<float>>);
+static_assert(std::is_trivially_copyable_v<Kokkos::complex<double>>);
+static_assert(std::is_trivially_copyable_v<Kokkos::complex<long double>>);
 
 template <class ExecSpace>
 struct TestBugPowAndLogComplex {

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -414,7 +414,10 @@ TEST(TEST_CATEGORY, complex_io) { testComplexIO(); }
 
 static_assert(std::is_trivially_copyable_v<Kokkos::complex<float>>);
 static_assert(std::is_trivially_copyable_v<Kokkos::complex<double>>);
+#ifndef KOKKOS_IMPL_32BIT  // FIXME_32BIT
+// error: requested alignment '24' is not a positive power of 2
 static_assert(std::is_trivially_copyable_v<Kokkos::complex<long double>>);
+#endif
 
 template <class ExecSpace>
 struct TestBugPowAndLogComplex {

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -342,8 +342,7 @@ struct TestComplexSpecialFunctions {
     ASSERT_FLOAT_EQ(h_results(13).real(), r.real());
     ASSERT_FLOAT_EQ(h_results(13).imag(), r.imag());
     // atanh
-    // Work around a bug in gcc 5.3.1 where the compiler cannot compute atanh
-    r = {0.163481616851666003, 1.27679502502111284};
+    r = std::atanh(a);
     ASSERT_FLOAT_EQ(h_results(14).real(), r.real());
     ASSERT_FLOAT_EQ(h_results(14).imag(), r.imag());
     r = std::asin(a);
@@ -353,8 +352,7 @@ struct TestComplexSpecialFunctions {
     ASSERT_FLOAT_EQ(h_results(16).real(), r.real());
     ASSERT_FLOAT_EQ(h_results(16).imag(), r.imag());
     // atan
-    // Work around a bug in gcc 5.3.1 where the compiler cannot compute atan
-    r = {1.380543138238714, 0.2925178131625636};
+    r = std::atan(a);
     ASSERT_FLOAT_EQ(h_results(17).real(), r.real());
     ASSERT_FLOAT_EQ(h_results(17).imag(), r.imag());
     // log10


### PR DESCRIPTION
Get rid of workarounds that I could find that had comments indicated they were for older GCC versions that we don't support any more