### PR TITLE
Compare to standard algorithms in tests

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsAdjacentFind.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsAdjacentFind.cpp
@@ -25,33 +25,6 @@ namespace AdjacentFind {
 
 namespace KE = Kokkos::Experimental;
 
-// impl is here for std because it is only avail from c++>=17
-template <class InputIterator, class OutputIterator, class BinaryPredicate>
-auto my_unique_copy(InputIterator first, InputIterator last,
-                    OutputIterator result, BinaryPredicate pred) {
-  if (first != last) {
-    typename OutputIterator::value_type t(*first);
-    *result = t;
-    ++result;
-    while (++first != last) {
-      if (!pred(t, *first)) {
-        t       = *first;
-        *result = t;
-        ++result;
-      }
-    }
-  }
-  return result;
-}
-
-template <class InputIterator, class OutputIterator>
-auto my_unique_copy(InputIterator first, InputIterator last,
-                    OutputIterator result) {
-  using value_type = typename OutputIterator::value_type;
-  using func_t     = IsEqualFunctor<value_type>;
-  return my_unique_copy(first, last, result, func_t());
-}
-
 template <class ValueType>
 struct UnifDist;
 
@@ -181,28 +154,6 @@ void fill_view(ViewType dest_view, const std::string& name) {
   Kokkos::parallel_for("copy", dest_view.extent(0), F1);
 }
 
-template <class IteratorType, class BinaryPredicate>
-IteratorType my_std_adjacent_find(IteratorType first, IteratorType last,
-                                  BinaryPredicate p) {
-  if (first == last) {
-    return last;
-  }
-  IteratorType next = first;
-  ++next;
-  for (; next != last; ++next, ++first) {
-    if (p(*first, *next)) {
-      return first;
-    }
-  }
-  return last;
-}
-
-template <class IteratorType>
-IteratorType my_std_adjacent_find(IteratorType first, IteratorType last) {
-  using value_type = typename IteratorType::value_type;
-  return my_std_adjacent_find(first, last, IsEqualFunctor<value_type>());
-}
-
 std::string value_type_to_string(int) { return "int"; }
 std::string value_type_to_string(double) { return "double"; }
 
@@ -226,7 +177,7 @@ void verify(DiffType my_diff, ViewType view, Args... args) {
   auto view_dc = create_deep_copyable_compatible_clone(view);
   auto view_h  = create_mirror_view_and_copy(Kokkos::HostSpace(), view_dc);
   auto std_r =
-      my_std_adjacent_find(KE::cbegin(view_h), KE::cend(view_h), args...);
+      std::adjacent_find(KE::cbegin(view_h), KE::cend(view_h), args...);
   const auto std_diff = std_r - KE::cbegin(view_h);
 
   ASSERT_EQ(my_diff, std_diff);

--- a/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCommon.hpp
@@ -28,9 +28,10 @@ import kokkos.std_algorithms;
 #endif
 #include <Kokkos_Core.hpp>
 #include <TestStdAlgorithmsHelperFunctors.hpp>
-#include <utility>
+#include <algorithm>
 #include <numeric>
 #include <random>
+#include <utility>
 
 namespace Test {
 namespace stdalgos {

--- a/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
@@ -121,21 +121,6 @@ void fill_view(ViewType dest_view, const std::string& name) {
   Kokkos::parallel_for("copy", dest_view.extent(0), F1);
 }
 
-// I had to write my own because std::exclusive_scan is ONLY found with
-// std=c++17
-template <class it1, class it2, class ValType, class BopType>
-void my_host_exclusive_scan(it1 first, it1 last, it2 dest, ValType init,
-                            BopType bop) {
-  const auto num_elements = last - first;
-  if (num_elements > 0) {
-    while (first < last - 1) {
-      *(dest++) = init;
-      init      = bop(*first++, init);
-    }
-    *dest = init;
-  }
-}
-
 template <class ValueType>
 struct MultiplyFunctor {
   KOKKOS_INLINE_FUNCTION
@@ -166,8 +151,8 @@ struct VerifyData {
     using gold_view_value_type = typename ViewType2::value_type;
     Kokkos::View<gold_view_value_type*, Kokkos::HostSpace> gold_h(
         "goldh", data_view.extent(0));
-    my_host_exclusive_scan(KE::cbegin(data_view_h), KE::cend(data_view_h),
-                           KE::begin(gold_h), init_value, bop);
+    std::exclusive_scan(KE::cbegin(data_view_h), KE::cend(data_view_h),
+                        KE::begin(gold_h), init_value, bop);
 
     auto test_view_dc = create_deep_copyable_compatible_clone(test_view);
     auto test_view_h =

--- a/algorithms/unit_tests/TestStdAlgorithmsFindEnd.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsFindEnd.cpp
@@ -184,59 +184,6 @@ auto create_seq(ViewType data_view, std::size_t seq_extent) {
   return seq_view;
 }
 
-// search is only avai from c++17, so I have to put it here
-template <class ForwardIt1, class ForwardIt2, class BinaryPredicate>
-ForwardIt1 my_std_search(ForwardIt1 first, ForwardIt1 last, ForwardIt2 s_first,
-                         ForwardIt2 s_last, BinaryPredicate p) {
-  for (;; ++first) {
-    ForwardIt1 it = first;
-    for (ForwardIt2 s_it = s_first;; ++it, ++s_it) {
-      if (s_it == s_last) {
-        return first;
-      }
-      if (it == last) {
-        return last;
-      }
-      if (!p(*it, *s_it)) {
-        break;
-      }
-    }
-  }
-}
-
-// only avai from c++17, so I have to put it here
-template <class ForwardIt1, class ForwardIt2, class BinaryPredicate>
-ForwardIt1 my_std_find_end(ForwardIt1 first, ForwardIt1 last,
-                           ForwardIt2 s_first, ForwardIt2 s_last,
-                           BinaryPredicate p) {
-  if (s_first == s_last) {
-    return last;
-  }
-
-  ForwardIt1 result = last;
-  while (true) {
-    ForwardIt1 new_result = my_std_search(first, last, s_first, s_last, p);
-    if (new_result == last) {
-      break;
-    } else {
-      result = new_result;
-      first  = result;
-      ++first;
-    }
-  }
-  return result;
-}
-
-template <class ForwardIt1, class ForwardIt2>
-ForwardIt1 my_std_find_end(ForwardIt1 first, ForwardIt1 last,
-                           ForwardIt2 s_first, ForwardIt2 s_last) {
-  using value_type1 = typename ForwardIt1::value_type;
-  using value_type2 = typename ForwardIt2::value_type;
-
-  using pred_t = IsEqualFunctor<value_type1, value_type2>;
-  return my_std_find_end(first, last, s_first, s_last, pred_t());
-}
-
 std::string value_type_to_string(int) { return "int"; }
 std::string value_type_to_string(double) { return "double"; }
 
@@ -273,8 +220,8 @@ void run_single_scenario(const InfoType& scenario_info, std::size_t seq_ext,
   auto view_h   = create_host_space_copy(view);
   auto s_view_h = create_host_space_copy(s_view);
   auto stdrit =
-      my_std_find_end(KE::cbegin(view_h), KE::cend(view_h),
-                      KE::cbegin(s_view_h), KE::cend(s_view_h), args...);
+      std::find_end(KE::cbegin(view_h), KE::cend(view_h), KE::cbegin(s_view_h),
+                    KE::cend(s_view_h), args...);
 
   {
     auto myrit = KE::find_end(exespace(), KE::cbegin(view), KE::cend(view),

--- a/algorithms/unit_tests/TestStdAlgorithmsReplaceIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsReplaceIf.cpp
@@ -104,17 +104,6 @@ void fill_view(ViewType dest_view, const std::string& name) {
   Kokkos::parallel_for("copy", dest_view.extent(0), F1);
 }
 
-// my own because std::replace_if is ONLY found with std=c++20
-template <class ForwardIt, class UnaryPredicate, class T>
-void my_host_replace_if(ForwardIt first, ForwardIt last, UnaryPredicate p,
-                        const T& new_value) {
-  for (; first != last; ++first) {
-    if (p(*first)) {
-      *first = new_value;
-    }
-  }
-}
-
 template <class ViewType1, class ViewType2, class ValueType,
           class PredicateType>
 void verify_data(ViewType1 data_view,  // contains data
@@ -125,8 +114,8 @@ void verify_data(ViewType1 data_view,  // contains data
   auto data_view_dc = create_deep_copyable_compatible_clone(data_view);
   auto data_view_h =
       create_mirror_view_and_copy(Kokkos::HostSpace(), data_view_dc);
-  my_host_replace_if(KE::begin(data_view_h), KE::end(data_view_h), pred,
-                     new_value);
+  std::replace_if(KE::begin(data_view_h), KE::end(data_view_h), pred,
+                  new_value);
 
   auto test_view_dc = create_deep_copyable_compatible_clone(test_view);
   auto test_view_h =

--- a/algorithms/unit_tests/TestStdAlgorithmsSearch.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsSearch.cpp
@@ -184,37 +184,6 @@ auto create_seq_to_search(ViewType data_view, std::size_t seq_extent) {
   return seq_view;
 }
 
-// search is only avai from c++17, so I have to put it here
-template <class ForwardIt1, class ForwardIt2, class BinaryPredicate>
-ForwardIt1 my_std_search(ForwardIt1 first, ForwardIt1 last, ForwardIt2 s_first,
-                         ForwardIt2 s_last, BinaryPredicate p) {
-  for (;; ++first) {
-    ForwardIt1 it = first;
-    for (ForwardIt2 s_it = s_first;; ++it, ++s_it) {
-      if (s_it == s_last) {
-        return first;
-      }
-      if (it == last) {
-        return last;
-      }
-      if (!p(*it, *s_it)) {
-        break;
-      }
-    }
-  }
-}
-
-// search is only avai from c++17, so I have to put it here
-template <class ForwardIt1, class ForwardIt2>
-ForwardIt1 my_std_search(ForwardIt1 first, ForwardIt1 last, ForwardIt2 s_first,
-                         ForwardIt2 s_last) {
-  using value_type1 = typename ForwardIt1::value_type;
-  using value_type2 = typename ForwardIt2::value_type;
-
-  using pred_t = IsEqualFunctor<value_type1, value_type2>;
-  return my_std_search(first, last, s_first, s_last, pred_t());
-}
-
 std::string value_type_to_string(int) { return "int"; }
 std::string value_type_to_string(double) { return "double"; }
 
@@ -250,9 +219,8 @@ void run_single_scenario(const InfoType& scenario_info, std::size_t seq_ext,
   // run std
   auto view_h   = create_host_space_copy(view);
   auto s_view_h = create_host_space_copy(s_view);
-  auto stdrit =
-      my_std_search(KE::cbegin(view_h), KE::cend(view_h), KE::cbegin(s_view_h),
-                    KE::cend(s_view_h), args...);
+  auto stdrit   = std::search(KE::cbegin(view_h), KE::cend(view_h),
+                              KE::cbegin(s_view_h), KE::cend(s_view_h), args...);
 
   {
     auto myrit        = KE::search(exespace(), KE::cbegin(view), KE::cend(view),

--- a/algorithms/unit_tests/TestStdAlgorithmsSearch_n.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsSearch_n.cpp
@@ -23,50 +23,6 @@ namespace Search_n {
 
 namespace KE = Kokkos::Experimental;
 
-// search_n is only available from c++20, so I have to put it here
-template <class ForwardIt, class Size, class T, class BinaryPredicate>
-ForwardIt my_std_search_n(ForwardIt first, ForwardIt last, Size count,
-                          const T& value, BinaryPredicate p) {
-  if (count <= 0) {
-    return first;
-  }
-  for (; first != last; ++first) {
-    if (!p(*first, value)) {
-      continue;
-    }
-
-    ForwardIt candidate = first;
-    Size cur_count      = 0;
-
-    while (true) {
-      ++cur_count;
-      if (cur_count >= count) {
-        // success
-        return candidate;
-      }
-      ++first;
-      if (first == last) {
-        // exhausted the list
-        return last;
-      }
-      if (!p(*first, value)) {
-        // too few in a row
-        break;
-      }
-    }
-  }
-
-  return last;
-}
-
-template <class ForwardIt, class Size, class T>
-ForwardIt my_std_search_n(ForwardIt first, ForwardIt last, Size count,
-                          const T& value) {
-  using iter_value_type = typename ForwardIt::value_type;
-  using p_type          = IsEqualFunctor<iter_value_type, T>;
-  return my_std_search_n(first, last, count, value, p_type());
-}
-
 std::string value_type_to_string(int) { return "int"; }
 std::string value_type_to_string(double) { return "double"; }
 
@@ -195,8 +151,8 @@ void run_single_scenario(const InfoType& scenario_info, std::size_t count,
 
   // run std
   auto view_h = create_host_space_copy(view);
-  auto stdrit = my_std_search_n(KE::cbegin(view_h), KE::cend(view_h), count,
-                                value, args...);
+  auto stdrit = std::search_n(KE::cbegin(view_h), KE::cend(view_h), count,
+                              value, args...);
   const auto stddiff = stdrit - KE::cbegin(view_h);
 
   {

--- a/algorithms/unit_tests/TestStdAlgorithmsShiftRight.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsShiftRight.cpp
@@ -73,30 +73,11 @@ void fill_view(ViewType dest_view, const std::string& name) {
   Kokkos::parallel_for("copy", dest_view.extent(0), F1);
 }
 
-template <class ForwardIterator>
-ForwardIterator my_std_shift_right(
-    ForwardIterator first, ForwardIterator last,
-    typename std::iterator_traits<ForwardIterator>::difference_type n) {
-  // copied from
-  // https://github.com/llvm/llvm-project/blob/main/libcxx/include/__algorithm/shift_right.h
-
-  if (n == 0) {
-    return first;
-  }
-
-  decltype(n) d = last - first;
-  if (n >= d) {
-    return last;
-  }
-  ForwardIterator m = first + (d - n);
-  return std::move_backward(first, m, last);
-}
-
 template <class ViewType, class ResultIt, class ViewHostType>
 void verify_data(ResultIt result_it, ViewType view, ViewHostType data_view_host,
                  std::size_t shift_value) {
-  auto std_rit = my_std_shift_right(KE::begin(data_view_host),
-                                    KE::end(data_view_host), shift_value);
+  auto std_rit = std::shift_right(KE::begin(data_view_host),
+                                  KE::end(data_view_host), shift_value);
 
   // make sure results match
   const auto my_diff  = KE::end(view) - result_it;

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamShiftRight.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamShiftRight.cpp
@@ -71,25 +71,6 @@ struct TestFunctorA {
   }
 };
 
-// shift_right is only supported starting from C++20,
-// so put here a working version of the std algo copied from
-// https://github.com/llvm/llvm-project/blob/main/libcxx/include/__algorithm/shift_right.h
-template <class ForwardIterator>
-ForwardIterator my_std_shift_right(
-    ForwardIterator first, ForwardIterator last,
-    typename std::iterator_traits<ForwardIterator>::difference_type n) {
-  if (n == 0) {
-    return first;
-  }
-
-  decltype(n) d = last - first;
-  if (n >= d) {
-    return last;
-  }
-  ForwardIterator m = first + (d - n);
-  return std::move_backward(first, m, last);
-}
-
 template <class LayoutTag, class ValueType>
 void test_A(std::size_t numTeams, std::size_t numCols, std::size_t shift,
             int apiId) {
@@ -136,7 +117,7 @@ void test_A(std::size_t numTeams, std::size_t numCols, std::size_t shift,
   auto intraTeamSentinelView_h = create_host_space_copy(intraTeamSentinelView);
   for (std::size_t i = 0; i < cloneOfDataViewBeforeOp_h.extent(0); ++i) {
     auto myRow = Kokkos::subview(cloneOfDataViewBeforeOp_h, i, Kokkos::ALL());
-    auto it    = my_std_shift_right(KE::begin(myRow), KE::end(myRow), shift);
+    auto it    = std::shift_right(KE::begin(myRow), KE::end(myRow), shift);
     const std::size_t stdDistance = KE::distance(KE::begin(myRow), it);
     ASSERT_EQ(stdDistance, distancesView_h(i));
     ASSERT_TRUE(intraTeamSentinelView_h(i));

--- a/algorithms/unit_tests/TestStdAlgorithmsTransformExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTransformExclusiveScan.cpp
@@ -127,21 +127,6 @@ void fill_view(ViewType dest_view, const std::string& name) {
   Kokkos::parallel_for("copy", dest_view.extent(0), F1);
 }
 
-// I had to write my own because std::transform_exclusive_scan is ONLY found
-// with std=c++17
-template <class it1, class it2, class ValType, class BopType, class UopType>
-void my_host_transform_exclusive_scan(it1 first, it1 last, it2 dest,
-                                      ValType init, BopType bop, UopType uop) {
-  const auto num_elements = last - first;
-  if (num_elements > 0) {
-    while (first < last - 1) {
-      *(dest++) = init;
-      init      = bop(uop(*(first++)), init);
-    }
-    *dest = init;
-  }
-}
-
 template <class ViewType1, class ViewType2, class ValueType, class BinaryOp,
           class UnaryOp>
 void verify_data(ViewType1 data_view,  // contains data
@@ -156,9 +141,8 @@ void verify_data(ViewType1 data_view,  // contains data
   using gold_view_value_type = typename ViewType2::value_type;
   Kokkos::View<gold_view_value_type*, Kokkos::HostSpace> gold_h(
       "goldh", data_view.extent(0));
-  my_host_transform_exclusive_scan(KE::cbegin(data_view_h),
-                                   KE::cend(data_view_h), KE::begin(gold_h),
-                                   init_value, bop, uop);
+  std::transform_exclusive_scan(KE::cbegin(data_view_h), KE::cend(data_view_h),
+                                KE::begin(gold_h), init_value, bop, uop);
 
   auto test_view_dc = create_deep_copyable_compatible_clone(test_view);
   auto test_view_h =

--- a/algorithms/unit_tests/TestStdAlgorithmsUniqueCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsUniqueCopy.cpp
@@ -23,33 +23,6 @@ namespace UniqueCopy {
 
 namespace KE = Kokkos::Experimental;
 
-// impl is here for std because it is only avail from c++>=17
-template <class InputIterator, class OutputIterator, class BinaryPredicate>
-auto my_unique_copy(InputIterator first, InputIterator last,
-                    OutputIterator result, BinaryPredicate pred) {
-  if (first != last) {
-    typename OutputIterator::value_type t(*first);
-    *result = t;
-    ++result;
-    while (++first != last) {
-      if (!pred(t, *first)) {
-        t       = *first;
-        *result = t;
-        ++result;
-      }
-    }
-  }
-  return result;
-}
-
-template <class InputIterator, class OutputIterator>
-auto my_unique_copy(InputIterator first, InputIterator last,
-                    OutputIterator result) {
-  using value_type = typename OutputIterator::value_type;
-  using func_t     = IsEqualFunctor<value_type>;
-  return my_unique_copy(first, last, result, func_t());
-}
-
 template <class ValueType>
 struct UnifDist;
 
@@ -141,7 +114,7 @@ std::size_t fill_view(ViewType dest_view, const std::string& name) {
     std::fill(tmp.begin(), tmp.end(), static_cast<value_type>(0));
     using func_t = IsEqualFunctor<value_type>;
     auto std_r =
-        my_unique_copy(KE::cbegin(v_h), KE::cend(v_h), tmp.begin(), func_t());
+        std::unique_copy(KE::cbegin(v_h), KE::cend(v_h), tmp.begin(), func_t());
     count = (std::size_t)(std_r - tmp.begin());
   }
 
@@ -225,8 +198,8 @@ void verify_data(const std::string& name, ViewTypeFrom view_from,
     std::vector<value_type> tmp(view_test_h.extent(0));
     std::fill(tmp.begin(), tmp.end(), static_cast<value_type>(0));
 
-    auto std_r = my_unique_copy(KE::cbegin(view_from_h), KE::cend(view_from_h),
-                                tmp.begin(), args...);
+    auto std_r = std::unique_copy(KE::cbegin(view_from_h),
+                                  KE::cend(view_from_h), tmp.begin(), args...);
     (void)std_r;
 
     for (std::size_t i = 0; i < view_from_h.extent(0); ++i) {


### PR DESCRIPTION
Yet another cleanup PR...

Following up on #8382
We were not very consistent in our annotations and I had originally searched for C++20 case sensitive.

This is not exhaustive, some (e.g. https://github.com/kokkos/kokkos/blob/ceca2f7c9e3fb7ff2992e05c5d332e118f51f190/algorithms/unit_tests/TestStdAlgorithmsForEach.cpp#L83-L85) can also be simplified by comparing against running the standard algorithms.
I did not tackle them because this turns out being more work than I anticipated and the PR is getting quite big.