### PR TITLE
SYCL: Check for device global support on Nvidia and AMD gpus

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -313,7 +313,7 @@ pipeline {
                                 -DKokkos_ENABLE_EXAMPLES=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_BENCHMARKS=ON \
-                                -DoneDPL_ROOT=/opt/intel/oneapi/dpl/2022.7 \
+                                -DoneDPL_ROOT=/opt/intel/oneapi/dpl/2022.8 \
                                 -DKokkos_ENABLE_SYCL=ON \
                                 -DKokkos_ENABLE_SYCL_RELOCATABLE_DEVICE_CODE=ON \
                                 -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON \

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -869,12 +869,17 @@ endif()
 #   implementation. Otherwise, the feature is not supported when building shared
 #   libraries. Thus, we don't even check for support if shared libraries are
 #   requested and SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined.
-#   As of oneAPI 2025.0.0, this feature only works well for Intel GPUs.
-#   For simplicity only test for JIT and PVC
+#   As of oneAPI 2025.0.0, the codeplay documentation indicates support
+#   for device_global on Nvidia and AMD GPUs. However, testing suggested
+#   that the feature only works well as of oneAPI 2025.1.1.
+#   Otherwise, for simplicity we only test for JIT and PVC.
 if(KOKKOS_ENABLE_SYCL)
   string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${KOKKOS_COMPILE_OPTIONS}")
   include(CheckCXXSymbolExists)
-  if(Kokkos_ARCH_INTEL_PVC OR Kokkos_ARCH_INTEL_GEN)
+  if(Kokkos_ARCH_INTEL_PVC OR Kokkos_ARCH_INTEL_GEN
+     OR (KOKKOS_ENABLE_UNSUPPORTED_ARCHS AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM
+         AND KOKKOS_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 2025.1.1)
+  )
     check_cxx_symbol_exists(
       SYCL_EXT_ONEAPI_DEVICE_GLOBAL "sycl/sycl.hpp" KOKKOS_IMPL_HAVE_SYCL_EXT_ONEAPI_DEVICE_GLOBAL
     )

--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -47,17 +47,17 @@ RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRO
     | tee /etc/apt/sources.list.d/oneAPI.list
 
 RUN apt-get update && apt-get install -y \
-        intel-oneapi-compiler-dpcpp-cpp-2025.0 \
+        intel-oneapi-compiler-dpcpp-cpp-2025.1 \
         curl \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -LOJ "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2025.0.0&filters[]=12.0&filters[]=linux" && \
-    chmod +x oneapi-for-nvidia-gpus-2025.0.0-cuda-12.0-linux.sh && \
-    ./oneapi-for-nvidia-gpus-2025.0.0-cuda-12.0-linux.sh
+RUN curl -LOJ "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&version=2025.1.1&filters[]=linux" && \
+    chmod +x oneapi-for-nvidia-gpus-2025.1.1-rocm-all-linux.sh && \
+    ./oneapi-for-nvidia-gpus-2025.1.1-rocm-all-linux.sh
 
 # sycl-ls, icpx
-ENV PATH=/opt/intel/oneapi/compiler/2025.0/bin/:$PATH
+ENV PATH=/opt/intel/oneapi/compiler/2025.1/bin/:$PATH
 # libsycl, libsvml
-ENV LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/2025.0/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/2025.1/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
Addresses:
- https://github.com/kokkos/kokkos/issues/8482

As of OneAPI 2025.0.0, the Codeplay documentation lists support for `device_global` on Nvidia and AMD gpus:
- https://developer.codeplay.com/products/oneapi/nvidia/2025.0.0/guides/features-nvidia.html#extensions
- https://developer.codeplay.com/products/oneapi/amd/2025.0.0/guides/features-amd

Drive-by: We expect the `SYCL` build from `continuous.groovy` to be a build that will check this feature. Looking at the details of this build, we noticed one of the CMake variables referring to OneAPI 2022 even though the build appears to be on version 2025:

https://github.com/kokkos/kokkos/blob/fb6aa7bff5dccac703ad1b3ba6ccbb3d9206c6af/.jenkins/continuous.groovy#L316

@masterleinad, do you know whether this CMake variable is an oversight that we should update or whether it is right that it refers to OneAPI 2022? Looking at build logs in the Kokkos CI, it appears `CMake` finds OneDPL even with this variable set as it is.

