### PR TITLE
Add COPYRIGHT notice file with contributors

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,206 @@
+# Copyright Contributors to the Kokkos Project
+
+This file contains a (partial) list of people who contributed to the Kokkos Project
+and retain applicable copyrights to their contributions.
+
+For each contributor, we list their organization (if known) and the email
+address associated with their commits.
+
+Contributors are listed for specific date ranges reflecting major Kokkos versions.
+These lists are generated using `git shortlog -sne --since="YYYY-MM-DD" --until="YYYY-MM-DD"`
+commands.
+
+## Kokkos 5
+
+Date Range: present -- 2025-08-11
+
+### Sandia National Laboratories (SNL)
+
+Under the terms of Contract DE-NA0003525 with NTESS,
+the U.S. Government retains certain rights in this software.
+
+Christian Trott; SNL; crtrott@sandia.gov
+Nathan Ellingwood; SNL; ndellin@sandia.gov
+Dong Hun Lee; SNL; donlee@sandia.gov
+Nicolas Morales; SNL; nmmoral@sandia.gov
+Thomas Conrad; SNL; Clevenger tccleve@sandia.gov tccleve@kokkos-dev-2.sandia.gov
+Carl Pearson; SNL; cwpears@sandia.gov
+Jan Ciesko; SNL; jan.ciesko@gmail.com
+
+### Oak Ridge National Laboratories (ORNL)
+
+Damien Lebrun-Grandie; ORNL; dalg24@gmail.com dalg24+github@gmail.com
+Daniel Arndt; ORNL; arndtd@ornl.gov
+Bruno Turcksin; ORNL; bruno.turcksin@gmail.com
+Jakob Bludau; ORNL; bludauj@ornl.gov 104908666+JBludau@users.noreply.github.com
+Seyong Lee; ORNL; lees2@ornl.gov
+
+### Commissariat à l’Energie Atomique et aux Energies Alternatives (CEA)
+
+Paul Zehner; CEA; paul.zehner@cea.fr
+Trévis Morvany; CEA; trevis.morvany@cea.fr
+Paul Gannay; CEA; paul.gannay@cea.fr
+Thomas Padioleau; CEA; thomas.padioleau@cea.fr
+Cédric Chevalier; CEA; cedric.chevalier@cea.fr
+
+### Individual Contributors (OTHER)
+
+Romin Tomasetti; OTHER; romin.tomasetti@gmail.com
+Maarten Arnst; OTHER; maarten.arnst@uliege.be
+
+## Kokkos 4
+
+Date Range: 2025-08-11 -- 2022-09-20
+
+### Sandia National Laboratories (SNL)
+
+                        Kokkos v. 4.0
+      Copyright (2022) National Technology & Engineering
+              Solutions of Sandia, LLC (NTESS).
+
+Under the terms of Contract DE-NA0003525 with NTESS,
+the U.S. Government retains certain rights in this software.
+
+Christian Trott; SNL; crtrott@sandia.gov
+Francesco Rizzi; SNL; fnrizzi@sandia.gov
+Nathan Ellingwood; SNL; ndellin@sandia.gov
+Dong Hun Lee; SNL; donlee@sandia.gov
+Nicolas Morales; SNL; nmmoral@sandia.gov
+Thomas Conrad; SNL; Clevenger tccleve@sandia.gov tccleve@kokkos-dev-2.sandia.gov
+Carl Pearson; SNL; cwpears@sandia.gov
+Jan Ciesko; SNL; jan.ciesko@gmail.com
+Cezary Skrzyński; SNL; cezary.skrzynski@ng-analytics.com
+Arkadiusz Szczepkowicz; SNL; arek.szczepkowicz@ng-analytics.com
+Dan Ibanez; SNL; ibaned@users.noreply.github.com
+Evan Harvey; SNL; 57234914+e10harvey@users.noreply.github.com
+
+### Oak Ridge National Laboratories (ORNL)
+
+Damien Lebrun-Grandie; ORNL; dalg24@gmail.com dalg24+github@gmail.com
+Daniel Arndt; ORNL; arndtd@ornl.gov
+Bruno Turcksin; ORNL; bruno.turcksin@gmail.com
+Jakob Bludau; ORNL; bludauj@ornl.gov 104908666+JBludau@users.noreply.github.com
+Seyong Lee; ORNL; lees2@ornl.gov
+Andrey Prokopenko; ORNL; prokopenkoav@ornl.gov
+
+### Commissariat à l’Energie Atomique et aux Energies Alternatives (CEA)
+
+Paul Zehner; CEA; paul.zehner@cea.fr
+Thomas Padioleau; CEA; thomas.padioleau@cea.fr
+Trévis Morvany; CEA; trevis.morvany@cea.fr
+Cédric Chevalier; CEA; cedric.chevalier@cea.fr
+Paul Gannay; CEA; paul.gannay@cea.fr
+
+### Individual Contributors (OTHER)
+
+Rahulkumar Gayatri; OTHER; rahulgayatri84@gmail.com rgayatri@lbl.gov rahulkgayatri@gmail.com
+Romin Tomasetti; OTHER; romin.tomasetti@gmail.com
+Mikael Simberg; OTHER; mikael.simberg@iki.fi
+Nevin ":-)" Liber; OTHER; nliber+github@gmail.com nliber@anl.gov
+Maarten Arnst; OTHER; maarten.arnst@uliege.be
+Christoph Junghans; OTHER; junghans@votca.org
+Timo Heister; OTHER; timo.heister@gmail.com
+
+## Kokkos 3
+
+Date Range: 2022-09-20 -- 2019-06-24
+
+### Sandia National Laboratories (SNL)
+
+                       Kokkos v. 3.0
+      Copyright (2020) National Technology & Engineering
+              Solutions of Sandia, LLC (NTESS).
+
+Under the terms of Contract DE-NA0003525 with NTESS,
+the U.S. Government retains certain rights in this software.
+
+Christian Trott; SNL; crtrott@sandia.gov
+D. S. Hollman; SNL; dshollm@sandia.gov
+David Poliakoff; SNL; david.poliakoff@gmail.com
+Nathan Ellingwood; SNL; ndellin@sandia.gov
+Dan Ibanez; SNL; daibane@sandia.gov
+Francesco Rizzi; SNL; fnrizzi@sandia.gov
+Dong Hun Lee; SNL; donlee@sandia.gov
+Evan Harvey; SNL; eharvey@sandia.gov
+Phil Miller; SNL; pbmille@sandia.gov
+Jeff Miles; SNL; jsmiles@sandia.gov jsmiles@kokkos-dev-2.sandia.gov jsmiles@apollo.sandia.gov
+Nicolas Morales; SNL; nmmoral@sandia.gov
+Jeremiah Wilke; SNL; jjwilke@sandia.gov
+Jan Ciesko; SNL; jan.ciesko@gmail.com
+Cezary Skrzyński; SNL; cezary.skrzynski@ng-analytics.com
+Brian Kelley; SNL; bmkelle@sandia.gov
+Jonathan Lifflander; SNL; jliffla@sandia.gov
+Vinh Dang; SNL; vqdang@sandia.gov
+CA Lewis; SNL; canlewi@sandia.gov
+Amy Powell; SNL; ajpowel@sandia.gov
+Eric Phipps; SNL; etphipp@sandia.gov
+Samuel Browne; SNL; sebrown@sandia.gov
+Si Hammond; SNL; sdhammo@compton1.(none)
+
+### Oak Ridge National Laboratories (ORNL)
+
+Damien Lebrun-Grandie; ORNL; dalg24@gmail.com dalg24+github@gmail.com
+Daniel Arndt; ORNL; arndtd@ornl.gov
+Bruno Turcksin; ORNL; bruno.turcksin@gmail.com
+Seyong Lee; ORNL; lees2@ornl.gov
+
+### Individual Contributors (OTHER)
+
+Rahul Gayatri; OTHER; rgayatri@lbl.gov rahulgayatri84@gmail.com
+Nick Curtis; OTHER; nicholas.curtis@amd.com nicurtis@amd.com
+Jonathan R. Madsen; OTHER; jonathanrmadsen@gmail.com jrmadsen@users.noreply.github.com
+Christoph Junghans; OTHER; junghans@votca.org junghans@lanl.gov
+Mikael Simberg; OTHER; simberg@cscs.ch mikael.simberg@iki.fi
+J Todd; OTHER; joeatodd@gmail.com
+Jakob Bludau; OTHER; jakob.bludau@tum.de
+Matt Stack; OTHER; 36867242+matt-stack@users.noreply.github.com
+Jeff Hammond; OTHER; jeff.r.hammond@intel.com
+Cameron Smith; OTHER; smithc11@rpi.edu
+
+## Kokkos 2
+
+### Sandia National Laboratories (SNL)
+
+                       Kokkos v. 2.0
+             Copyright (2014) Sandia Corporation
+
+Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+the U.S. Government retains certain rights in this software.
+
+Christian Trott; SNL; crtrott@sandia.gov
+Carter Edwards; SNL; hcedwar@sandia.gov
+Dan Ibanez; SNL; daibane@sandia.gov
+Nathan Ellingwood; SNL; ndellin@sandia.gov
+David Hollman; SNL; dshollm@sandia.gov
+Dan Sunderland; SNL; dsunder@sandia.gov
+James Foucar; SNL; jgfouca@sandia.gov
+Steve Bova; SNL; swbova@sandia.gov
+Vinh Dang; SNL; vqdang@sandia.gov
+Greg Mackey; SNL; gemacke@sandia.gov
+Si Hammond; SNL; sdhammo@sandia.gov
+James David Stevens; SNL; jdsteve@kokkos-dev.sandia.gov
+Mark Hoemmen; SNL; mhoemme@sandia.gov
+Jeremiah Wilke; SNL; jjwilke@sandia.gov
+Jeff Miles; SNL; jsmiles@sandia.gov jsmiles@kokkos-dev-2.sandia.gov jsmiles@apollo.sandia.gov
+Stan Moore; SNL; stamoor@sandia.gov
+James Elliott; SNL; jjellio@sandia.gov
+Eric Phipps; SNL; etphipp@sandia.gov
+Kyungjoo Kim; SNL; kyukim@sandia.gov
+Steven W. Bova; SNL; swbova@kokkos-dev.sandia.gov
+
+### Oak Ridge National Laboratories (ORNL)
+
+Damien Lebrun-Grandie; ORNL; qdi@ornl.gov
+
+### Commissariat à l’Energie Atomique et aux Energies Alternatives (CEA)
+
+Pierre Kestener; CEA; pierre.kestener@cea.fr
+
+### Individual Contributors (OTHER)
+
+Mikael Simberg; OTHER; simberg@cscs.ch mikael.simberg@iki.fi
+Chip Freitag; OTHER; chip.freitag@amd.com
+Scott Kruger; OTHER; scott.e.kruger@gmail.com
+Christoph Junghans; OTHER; junghans@votca.org
+Daniel Holladay; OTHER; dholladay00@.lanl.gov
+


### PR DESCRIPTION
This adds a file for listing contributors and have a place to put institutional copyrights.

It is structured by major version as headings, and institutions as sub headings.
The organization tags can be used to grep for just contributors and the ";" are used as field separators.